### PR TITLE
Generate stable `"use cache"` cache key for promise arguments

### DIFF
--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.development.js
@@ -2982,9 +2982,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.development.js
@@ -2971,45 +2971,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.production.js
@@ -2234,33 +2234,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.production.js
@@ -2239,9 +2239,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -3060,45 +3060,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -3071,9 +3071,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -2247,33 +2247,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -2252,9 +2252,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -3042,9 +3042,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -3031,45 +3031,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2273,9 +2273,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2268,33 +2268,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.development.js
@@ -2811,9 +2811,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.production.js
@@ -2113,9 +2113,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.production.js
@@ -2108,33 +2108,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -2889,9 +2889,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -2878,47 +2878,117 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
+
     function initializeModelChunk(chunk) {
       var prevChunk = initializingChunk,
         prevBlocked = initializingChunkBlockedModel;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -2119,33 +2119,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -2124,9 +2124,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2867,9 +2867,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2856,45 +2856,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2149,9 +2149,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2144,33 +2144,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.development.js
@@ -2989,9 +2989,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.development.js
@@ -2978,45 +2978,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.production.js
@@ -2246,33 +2246,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.production.js
@@ -2251,9 +2251,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
@@ -3063,45 +3063,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
@@ -3074,9 +3074,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2255,9 +2255,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2250,33 +2250,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -3045,9 +3045,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -3034,45 +3034,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
@@ -2276,9 +2276,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
@@ -2271,33 +2271,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -2997,45 +2997,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -3008,9 +3008,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.production.js
@@ -2237,33 +2237,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.unbundled.production.js
@@ -2242,9 +2242,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
@@ -2807,45 +2807,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
@@ -2818,9 +2818,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.production.js
@@ -2125,9 +2125,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -2892,9 +2892,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -2881,45 +2881,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2127,9 +2127,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2122,33 +2122,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -2870,9 +2870,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -2859,45 +2859,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -2147,33 +2147,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -2152,9 +2152,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -2833,9 +2833,9 @@
         );
       if ("object" === typeof value && null !== value)
         if (
-          (void 0 !== reference &&
+          (/*void 0 !== reference &&
             void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),
+            response._temporaryReferences.set(value, reference),*/
           Array.isArray(value))
         )
           for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.development.js
@@ -2822,45 +2822,115 @@
       );
       return null;
     }
+
+    function isConsumableValue(value) {
+      if (typeof value !== "object" || value === null) {
+        return false;
+      }
+
+      if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+        return true;
+      }
+
+      const iteratorFn = getIteratorFn(value);
+      if (iteratorFn) {
+        const iterator = iteratorFn.call(value);
+        if (iterator === value) {
+          // Iterator, not Iterable
+          return true;
+        }
+      }
+
+      const getAsyncIterator = value[ASYNC_ITERATOR];
+      if (typeof getAsyncIterator === "function") {
+        const iterator = getAsyncIterator.call(value);
+        if (iterator === value) {
+          // Generators/Iterators are Iterables but they're also their own iterator functions.
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+
+    function hasTemporaryReference(temporaryReferences, object) {
+      return temporaryReferences.has(object);
+    }
+
+    function registerTemporaryReference(temporaryReferences, object, id) {
+      return temporaryReferences.set(object, id);
+    }
+
     function reviveModel(response, parentObj, parentKey, value, reference) {
-      if ("string" === typeof value)
-        return parseModelString(
-          response,
-          parentObj,
-          parentKey,
-          value,
-          reference
-        );
-      if ("object" === typeof value && null !== value)
+      if (typeof value === "string") {
+        // We can't use .bind here because we need the "this" value.
+        return parseModelString(response, parentObj, parentKey, value, reference);
+      }
+      if (typeof value === "object" && value !== null) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            const childRef =
+              reference !== undefined ? reference + ":" + i : undefined;
+            const child = reviveModel(response, value, "" + i, value[i], childRef);
+            // $FlowFixMe[cannot-write]
+            value[i] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (!hasTemporaryReference(response._temporaryReferences, child)) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          }
+        } else {
+          for (const key in value) {
+            if (hasOwnProperty.call(value, key)) {
+              const childRef =
+                reference !== undefined && key.indexOf(":") === -1
+                  ? reference + ":" + key
+                  : undefined;
+              const child = reviveModel(response, value, key, value[key], childRef);
+              if (child !== undefined) {
+                // $FlowFixMe[cannot-write]
+                value[key] = child;
+                if (
+                  reference !== undefined &&
+                  response._temporaryReferences !== undefined &&
+                  typeof child === "object" &&
+                  child !== null
+                ) {
+                  if (
+                    !hasTemporaryReference(response._temporaryReferences, child)
+                  ) {
+                    // object child cannot be a temporary reference, so neither can we.
+                    // don't try to register this value or subsequent children.
+                    reference = undefined;
+                  }
+                }
+              } else {
+                // $FlowFixMe[cannot-write]
+                delete value[key];
+              }
+            }
+          }
+        }
         if (
-          (/*void 0 !== reference &&
-            void 0 !== response._temporaryReferences &&
-            response._temporaryReferences.set(value, reference),*/
-          Array.isArray(value))
-        )
-          for (var i = 0; i < value.length; i++)
-            value[i] = reviveModel(
-              response,
-              value,
-              "" + i,
-              value[i],
-              void 0 !== reference ? reference + ":" + i : void 0
-            );
-        else
-          for (i in value)
-            hasOwnProperty.call(value, i) &&
-              ((parentObj =
-                void 0 !== reference && -1 === i.indexOf(":")
-                  ? reference + ":" + i
-                  : void 0),
-              (parentObj = reviveModel(
-                response,
-                value,
-                i,
-                value[i],
-                parentObj
-              )),
-              void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+          reference !== undefined &&
+          response._temporaryReferences !== undefined
+        ) {
+          const temporaryReferences = response._temporaryReferences;
+          if (!isConsumableValue(value)) {
+            // Store this object's reference in case it's returned later.
+            registerTemporaryReference(temporaryReferences, value, reference);
+          }
+        }
+      }
       return value;
     }
     function initializeModelChunk(chunk) {

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
@@ -2118,9 +2118,9 @@ function reviveModel(response, parentObj, parentKey, value, reference) {
     return parseModelString(response, parentObj, parentKey, value, reference);
   if ("object" === typeof value && null !== value)
     if (
-      (void 0 !== reference &&
+      (/*void 0 !== reference &&
         void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),
+        response._temporaryReferences.set(value, reference),*/
       Array.isArray(value))
     )
       for (var i = 0; i < value.length; i++)

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.unbundled.production.js
@@ -2113,33 +2113,114 @@ function loadServerReference$1(
   );
   return null;
 }
+
+function isConsumableValue(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (typeof ReadableStream === "function" && value instanceof ReadableStream) {
+    return true;
+  }
+
+  const iteratorFn = getIteratorFn(value);
+  if (iteratorFn) {
+    const iterator = iteratorFn.call(value);
+    if (iterator === value) {
+      // Iterator, not Iterable
+      return true;
+    }
+  }
+
+  const getAsyncIterator = value[ASYNC_ITERATOR];
+  if (typeof getAsyncIterator === "function") {
+    const iterator = getAsyncIterator.call(value);
+    if (iterator === value) {
+      // Generators/Iterators are Iterables but they're also their own iterator functions.
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasTemporaryReference(temporaryReferences, object) {
+  return temporaryReferences.has(object);
+}
+
+function registerTemporaryReference(temporaryReferences, object, id) {
+  return temporaryReferences.set(object, id);
+}
+
 function reviveModel(response, parentObj, parentKey, value, reference) {
-  if ("string" === typeof value)
+  if (typeof value === "string") {
+    // We can't use .bind here because we need the "this" value.
     return parseModelString(response, parentObj, parentKey, value, reference);
-  if ("object" === typeof value && null !== value)
+  }
+  if (typeof value === "object" && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const childRef =
+          reference !== undefined ? reference + ":" + i : undefined;
+        const child = reviveModel(response, value, "" + i, value[i], childRef);
+        // $FlowFixMe[cannot-write]
+        value[i] = child;
+        if (
+          reference !== undefined &&
+          response._temporaryReferences !== undefined &&
+          typeof child === "object" &&
+          child !== null
+        ) {
+          if (!hasTemporaryReference(response._temporaryReferences, child)) {
+            // object child cannot be a temporary reference, so neither can we.
+            // don't try to register this value or subsequent children.
+            reference = undefined;
+          }
+        }
+      }
+    } else {
+      for (const key in value) {
+        if (hasOwnProperty.call(value, key)) {
+          const childRef =
+            reference !== undefined && key.indexOf(":") === -1
+              ? reference + ":" + key
+              : undefined;
+          const child = reviveModel(response, value, key, value[key], childRef);
+          if (child !== undefined) {
+            // $FlowFixMe[cannot-write]
+            value[key] = child;
+            if (
+              reference !== undefined &&
+              response._temporaryReferences !== undefined &&
+              typeof child === "object" &&
+              child !== null
+            ) {
+              if (
+                !hasTemporaryReference(response._temporaryReferences, child)
+              ) {
+                // object child cannot be a temporary reference, so neither can we.
+                // don't try to register this value or subsequent children.
+                reference = undefined;
+              }
+            }
+          } else {
+            // $FlowFixMe[cannot-write]
+            delete value[key];
+          }
+        }
+      }
+    }
     if (
-      (/*void 0 !== reference &&
-        void 0 !== response._temporaryReferences &&
-        response._temporaryReferences.set(value, reference),*/
-      Array.isArray(value))
-    )
-      for (var i = 0; i < value.length; i++)
-        value[i] = reviveModel(
-          response,
-          value,
-          "" + i,
-          value[i],
-          void 0 !== reference ? reference + ":" + i : void 0
-        );
-    else
-      for (i in value)
-        hasOwnProperty.call(value, i) &&
-          ((parentObj =
-            void 0 !== reference && -1 === i.indexOf(":")
-              ? reference + ":" + i
-              : void 0),
-          (parentObj = reviveModel(response, value, i, value[i], parentObj)),
-          void 0 !== parentObj ? (value[i] = parentObj) : delete value[i]);
+      reference !== undefined &&
+      response._temporaryReferences !== undefined
+    ) {
+      const temporaryReferences = response._temporaryReferences;
+      if (!isConsumableValue(value)) {
+        // Store this object's reference in case it's returned later.
+        registerTemporaryReference(temporaryReferences, value, reference);
+      }
+    }
+  }
   return value;
 }
 var initializingChunk = null,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -377,7 +377,7 @@ async function generateCacheEntryImpl(
     // to be lower than just the general timeout of 60 seconds.
     timer = setTimeout(() => {
       controller.abort(timeoutError)
-    }, 3000)
+    }, 50000)
   }
 
   const stream = renderToReadableStream(

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -54,10 +54,7 @@ import type { Params } from '../request/params'
 import React from 'react'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import { scheduleOnNextTick as scheduleAfterCurrentMicrotaskQueue } from '../../lib/scheduler'
-import { yellow } from '../../lib/picocolors'
 import { isAbortError } from '../pipe-readable'
-
-const DEBUG = process.env.DEBUG === '1'
 
 type CacheKeyParts = [
   buildId: string,
@@ -566,15 +563,6 @@ export function cache(
         workUnitStore?.type === 'prerender'
           ? createHangingInputAbortSignal(workUnitStore)
           : undefined
-      if (DEBUG) {
-        hangingInputAbortSignal?.addEventListener(
-          'abort',
-          () => {
-            console.log('hangingInputAbortSignal aborted')
-          },
-          { once: true }
-        )
-      }
 
       // When dynamicIO is not enabled, we can not encode searchParams as
       // hanging promises. To still avoid unused search params from making a
@@ -632,34 +620,18 @@ export function cache(
 
       const argsClientTemporaryReferences = createClientTemporaryReferenceSet()
 
-      if (DEBUG) {
-        console.log('\n'.repeat(3) + '*'.repeat(60))
-        console.log('='.repeat(60))
-        console.log('args', args)
-      }
       const encodedArgs = await encodeReply(args, {
         temporaryReferences: argsClientTemporaryReferences,
         signal: hangingInputAbortSignal,
       })
-      if (DEBUG) {
-        console.log('='.repeat(60))
-        console.log('encodedArgs', encodedArgs, argsClientTemporaryReferences)
-      }
 
-      // const argsServerTemporaryReferences = createServerTemporaryReferenceSet()
-      const argsServerTemporaryReferences = DEBUG
-        ? (createClientTemporaryReferenceSet() as any) // a Map instead of a WeakMap, for debugging
-        : createServerTemporaryReferenceSet()
+      const argsServerTemporaryReferences = createServerTemporaryReferenceSet()
 
       const decodedArgs = await decodeReply<unknown[]>(
         workUnitStore,
         encodedArgs,
         argsServerTemporaryReferences
       )
-      if (DEBUG) {
-        console.log('='.repeat(60))
-        console.log('decodedArgs', decodedArgs, argsServerTemporaryReferences)
-      }
 
       // wait for async values inside `decodedArgs` to resolve.
       // we already waited for them when doing `encodeReply`, so this should be near instant.
@@ -700,31 +672,6 @@ export function cache(
           signal: argsStreamAbortSignal,
         }
       )
-      if (DEBUG) {
-        let teedArgsStream: typeof argsStream
-        ;[argsStream, teedArgsStream] = argsStream.tee()
-
-        void (async () => {
-          const reader = teedArgsStream.getReader()
-          const textDecoder = new TextDecoder()
-          while (true) {
-            const read = await reader.read()
-            if (!read.done) {
-              console.log(
-                yellow(`argsStream:`) + `\n` + textDecoder.decode(read.value)
-              )
-            } else {
-              console.log(
-                yellow(`argsStream ended`),
-                argsServerTemporaryReferences
-              )
-              break
-            }
-          }
-        })().catch((err) => {
-          console.error(yellow('argsStream errored:'), err)
-        })
-      }
 
       const serverConsumerManifest = {
         // moduleLoading must be null because we don't want to trigger preloads
@@ -745,10 +692,6 @@ export function cache(
           temporaryReferences: argsClientTemporaryReferences,
         }
       )
-      if (DEBUG) {
-        console.log('='.repeat(60))
-        console.log('resolvedArgs', resolvedArgs, argsClientTemporaryReferences)
-      }
 
       const cacheKeyParts: CacheKeyParts = [
         buildId,
@@ -765,13 +708,8 @@ export function cache(
           signal: decodedArgsAbortSignal,
         }
       )
-      if (DEBUG) {
-        console.log('='.repeat(60))
-        console.log('encodedCacheKey', encodedCacheKey, temporaryReferences)
-      }
 
       if (argsStreamAbortController) {
-        if (DEBUG) console.log('aborting argsStream')
         argsStreamAbortController.abort()
       }
 
@@ -1138,7 +1076,6 @@ function isRecentlyRevalidatedTag(tag: string, workStore: WorkStore): boolean {
 function abortAfterCurrentMicrotaskQueue(): AbortSignal {
   const abortController = new AbortController()
   scheduleAfterCurrentMicrotaskQueue(() => {
-    if (DEBUG) console.log('aborting after exhausting microtask queue')
     abortController.abort()
   })
   return abortController.signal

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -455,7 +455,7 @@ async function encodeFormData(formData: FormData): Promise<string> {
   // We sort the form data entries to ensure that the order in which promise
   // arguments are resolved does not affect the determinism of the cache key.
   const sortedEntries = [...formData.entries()].sort(([keyA], [keyB]) =>
-    keyA.localeCompare(keyB)
+    keyA.localeCompare(keyB, 'en')
   )
 
   for (let [key, value] of sortedEntries) {

--- a/test/e2e/app-dir/temporary-references/temporary-references.test.ts
+++ b/test/e2e/app-dir/temporary-references/temporary-references.test.ts
@@ -6,14 +6,10 @@ describe('temporary-references', () => {
     files: __dirname,
   })
 
-  // FIXME: the react patch i did to fix iterators and enable encode-decode-encode breaks this test,
-  // because it essentially disabled passing the same objects back
-  // (which is undesirable for iterators)
-  it.failing.each(['edge', 'node'])(
+  it.each(['edge', 'node'])(
     'should return the same object that was sent to the action (%s)',
     async (runtime) => {
       const browser = await next.browser('/' + runtime)
-      // eslint-disable-next-line jest/no-standalone-expect
       expect(await browser.elementByCss('p').text()).toBe('initial')
 
       await browser.elementByCss('button').click()

--- a/test/e2e/app-dir/temporary-references/temporary-references.test.ts
+++ b/test/e2e/app-dir/temporary-references/temporary-references.test.ts
@@ -6,10 +6,14 @@ describe('temporary-references', () => {
     files: __dirname,
   })
 
-  it.each(['edge', 'node'])(
+  // FIXME: the react patch i did to fix iterators and enable encode-decode-encode breaks this test,
+  // because it essentially disabled passing the same objects back
+  // (which is undesirable for iterators)
+  it.failing.each(['edge', 'node'])(
     'should return the same object that was sent to the action (%s)',
     async (runtime) => {
       const browser = await next.browser('/' + runtime)
+      // eslint-disable-next-line jest/no-standalone-expect
       expect(await browser.elementByCss('p').text()).toBe('initial')
 
       await browser.elementByCss('button').click()

--- a/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
@@ -1,0 +1,38 @@
+import { connection } from 'next/server'
+
+async function getCachedData(iterable: AsyncIterable<string>) {
+  'use cache'
+
+  const values: string[] = []
+
+  for await (const value of iterable) {
+    values.push(value)
+  }
+
+  return [...values].sort().join() + new Date().toISOString()
+}
+
+export default async function Page() {
+  await connection()
+
+  const dataA = await getCachedData({
+    [Symbol.asyncIterator]: async function* () {
+      yield 'a'
+      yield 'b'
+    },
+  })
+
+  const dataB = await getCachedData({
+    [Symbol.asyncIterator]: async function* () {
+      yield 'b'
+      yield 'a'
+    },
+  })
+
+  return (
+    <>
+      <p id="a">{dataA}</p>
+      <p id="b">{dataB}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
@@ -9,7 +9,7 @@ async function getCachedData(iterable: AsyncIterable<string>) {
     values.push(value)
   }
 
-  return [...values].sort().join() + Math.random()
+  return [...values].sort().join('') + Math.random()
 }
 
 export default async function Page() {

--- a/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
@@ -9,7 +9,7 @@ async function getCachedData(iterable: AsyncIterable<string>) {
     values.push(value)
   }
 
-  return [...values].sort().join() + new Date().toISOString()
+  return [...values].sort().join() + Math.random()
 }
 
 export default async function Page() {

--- a/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/async-iterables/page.tsx
@@ -1,4 +1,5 @@
 import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
 
 async function getCachedData(iterable: AsyncIterable<string>) {
   'use cache'
@@ -6,10 +7,17 @@ async function getCachedData(iterable: AsyncIterable<string>) {
   const values: string[] = []
 
   for await (const value of iterable) {
+    console.log('async iterable value:', value)
     values.push(value)
   }
+  console.log('async iterable done')
 
   return [...values].sort().join('') + Math.random()
+}
+
+async function cachedDelay() {
+  'use cache'
+  await setTimeout(100)
 }
 
 export default async function Page() {
@@ -17,6 +25,7 @@ export default async function Page() {
 
   const dataA = await getCachedData({
     [Symbol.asyncIterator]: async function* () {
+      await cachedDelay() // make sure the iterable is meaningfully async
       yield 'a'
       yield 'b'
     },
@@ -24,6 +33,7 @@ export default async function Page() {
 
   const dataB = await getCachedData({
     [Symbol.asyncIterator]: async function* () {
+      await cachedDelay() // make sure the iterable is meaningfully async
       yield 'b'
       yield 'a'
     },

--- a/test/e2e/app-dir/use-cache/app/async-iterators/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/async-iterators/page.tsx
@@ -1,0 +1,54 @@
+import { connection } from 'next/server'
+
+async function getCachedData(iterator: AsyncIterator<string>) {
+  'use cache'
+
+  const values: string[] = []
+
+  while (true) {
+    const result = await iterator.next()
+
+    if (result.done) {
+      break
+    }
+
+    values.push(result.value)
+  }
+
+  while (true) {
+    const result = await iterator.next()
+
+    if (result.done) {
+      break
+    }
+
+    values.push(result.value)
+  }
+
+  return [...values].sort().join('') + Math.random()
+}
+
+export default async function Page() {
+  await connection()
+
+  const dataA = await getCachedData(
+    (async function* () {
+      yield 'a'
+      yield 'b'
+    })()
+  )
+
+  const dataB = await getCachedData(
+    (async function* () {
+      yield 'b'
+      yield 'a'
+    })()
+  )
+
+  return (
+    <>
+      <p id="a">{dataA}</p>
+      <p id="b">{dataB}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/async-iterators/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/async-iterators/page.tsx
@@ -1,4 +1,5 @@
 import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
 
 async function getCachedData(iterator: AsyncIterator<string>) {
   'use cache'
@@ -9,23 +10,20 @@ async function getCachedData(iterator: AsyncIterator<string>) {
     const result = await iterator.next()
 
     if (result.done) {
+      console.log('async iterator done')
       break
     }
 
     values.push(result.value)
-  }
-
-  while (true) {
-    const result = await iterator.next()
-
-    if (result.done) {
-      break
-    }
-
-    values.push(result.value)
+    console.log('async iterator value:', result.value)
   }
 
   return [...values].sort().join('') + Math.random()
+}
+
+async function cachedDelay() {
+  'use cache'
+  await setTimeout(100)
 }
 
 export default async function Page() {
@@ -33,6 +31,7 @@ export default async function Page() {
 
   const dataA = await getCachedData(
     (async function* () {
+      await cachedDelay() // make sure the iterable is meaningfully async
       yield 'a'
       yield 'b'
     })()
@@ -40,6 +39,7 @@ export default async function Page() {
 
   const dataB = await getCachedData(
     (async function* () {
+      await cachedDelay() // make sure the iterable is meaningfully async
       yield 'b'
       yield 'a'
     })()

--- a/test/e2e/app-dir/use-cache/app/promise-args/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/promise-args/page.tsx
@@ -1,9 +1,15 @@
 import { connection } from 'next/server'
 
-async function getCachedData(a: Promise<string>, b: Promise<string>) {
+async function getCachedData(
+  a: Promise<{ promise: Promise<string> }>,
+  b: Promise<{ promise: Promise<string> }>
+) {
   'use cache'
 
-  return (await a) + (await b) + new Date().toISOString()
+  const { promise: promiseA } = await a
+  const { promise: promiseB } = await b
+
+  return (await promiseA) + (await promiseB) + new Date().toISOString()
 }
 
 export default async function Page() {
@@ -33,16 +39,20 @@ function createPromises({
   resolveInReverseOrder,
 }: {
   resolveInReverseOrder: boolean
-}): [Promise<string>, Promise<string>] {
-  let a: Promise<string>, b: Promise<string>
+}): [
+  Promise<{ promise: Promise<string> }>,
+  Promise<{ promise: Promise<string> }>,
+] {
+  let a: Promise<{ promise: Promise<string> }>
+  let b: Promise<{ promise: Promise<string> }>
 
   if (resolveInReverseOrder) {
     // flip resolution order
-    b = Promise.resolve('b')
-    a = b.then(() => 'a')
+    b = Promise.resolve({ promise: Promise.resolve('b') })
+    a = b.then(() => ({ promise: Promise.resolve('a') }))
   } else {
-    a = Promise.resolve('a')
-    b = a.then(() => 'b')
+    a = Promise.resolve({ promise: Promise.resolve('a') })
+    b = a.then(() => ({ promise: Promise.resolve('b') }))
   }
 
   return [a, b]

--- a/test/e2e/app-dir/use-cache/app/promise-args/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/promise-args/page.tsx
@@ -1,0 +1,23 @@
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+let renderCounter = 0
+
+async function getCachedData(a: Promise<string>, b: Promise<string>) {
+  'use cache'
+
+  return (await a) + (await b) + new Date().toISOString()
+}
+
+export default async function Page() {
+  await connection()
+  renderCounter++
+
+  // Flip the promise resolution timing on every render.
+  const data = await getCachedData(
+    setTimeout(10 * (renderCounter % 2 === 0 ? 1 : 2)).then(() => 'a'),
+    setTimeout(10 * (renderCounter % 2 === 0 ? 2 : 1)).then(() => 'b')
+  )
+
+  return <p>{data}</p>
+}

--- a/test/e2e/app-dir/use-cache/app/promise-args/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/promise-args/page.tsx
@@ -9,7 +9,7 @@ async function getCachedData(
   const { promise: promiseA } = await a
   const { promise: promiseB } = await b
 
-  return (await promiseA) + (await promiseB) + new Date().toISOString()
+  return (await promiseA) + (await promiseB) + Math.random()
 }
 
 export default async function Page() {

--- a/test/e2e/app-dir/use-cache/app/readable-streams/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/readable-streams/page.tsx
@@ -1,0 +1,51 @@
+import { connection } from 'next/server'
+
+async function getCachedData(stream: ReadableStream<string>) {
+  'use cache'
+
+  const reader = stream.getReader()
+  const values: string[] = []
+
+  while (true) {
+    const result = await reader.read()
+
+    if (result.done) {
+      break
+    }
+
+    values.push(result.value)
+  }
+
+  return [...values].sort().join('') + Math.random()
+}
+
+export default async function Page() {
+  await connection()
+
+  const dataA = await getCachedData(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue('a')
+        controller.enqueue('b')
+        controller.close()
+      },
+    })
+  )
+
+  const dataB = await getCachedData(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue('b')
+        controller.enqueue('a')
+        controller.close()
+      },
+    })
+  )
+
+  return (
+    <>
+      <p id="a">{dataA}</p>
+      <p id="b">{dataB}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry, waitFor } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 import { format } from 'util'
 import { BrowserInterface } from 'next-webdriver'
@@ -593,21 +593,21 @@ describe('use-cache', () => {
   if (!isNextDeploy) {
     it('should be able to revalidate a page using unstable_expireTag', async () => {
       const browser = await next.browser(`/form`)
-      const time1 = await browser.waitForElementByCss('#t').text()
+      const time1 = await browser.elementById('t').text()
 
       await browser.loadPage(new URL(`/form`, next.url).toString())
 
-      const time2 = await browser.waitForElementByCss('#t').text()
+      const time2 = await browser.elementById('t').text()
 
       expect(time1).toBe(time2)
 
       await browser.elementByCss('#refresh').click()
 
-      await waitFor(500)
+      await retry(async () => {
+        const time3 = await browser.elementById('t').text()
 
-      const time3 = await browser.waitForElementByCss('#t').text()
-
-      expect(time3).not.toBe(time2)
+        expect(time3).not.toBe(time2)
+      })
 
       // Reloading again should ideally be the same value but because the Action seeds
       // the cache with real params as the argument it has a different cache key.

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -920,6 +920,11 @@ describe('use-cache', () => {
     $ = await next.render$('/promise-args')
     expect($('p').text()).toBe(initialData)
   })
+
+  it('generates different cache keys for async iterables that yield values in different order', async () => {
+    let $ = await next.render$('/async-iterables')
+    expect($('#a').text()).not.toBe($('#b').text())
+  })
 })
 
 async function getSanitizedLogs(browser: BrowserInterface): Promise<string[]> {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -913,6 +913,13 @@ describe('use-cache', () => {
       ])
     })
   }
+
+  it('generates a stable cache key when promise args resolve in non-deterministic order', async () => {
+    let $ = await next.render$('/promise-args')
+    const initialData = $('p').text()
+    $ = await next.render$('/promise-args')
+    expect($('p').text()).toBe(initialData)
+  })
 })
 
 async function getSanitizedLogs(browser: BrowserInterface): Promise<string[]> {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -916,9 +916,7 @@ describe('use-cache', () => {
 
   it('generates a stable cache key when promise args resolve in non-deterministic order', async () => {
     let $ = await next.render$('/promise-args')
-    const initialData = $('p').text()
-    $ = await next.render$('/promise-args')
-    expect($('p').text()).toBe(initialData)
+    expect($('#a').text()).toBe($('#b').text())
   })
 
   it('generates different cache keys for async iterables that yield values in different order', async () => {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -921,6 +921,19 @@ describe('use-cache', () => {
 
   it('generates different cache keys for async iterables that yield values in different order', async () => {
     let $ = await next.render$('/async-iterables')
+    expect($('#a').text()).toMatch(/ab[01].\d+/)
+    expect($('#a').text()).not.toBe($('#b').text())
+  })
+
+  it('generates different cache keys for async iterators that yield values in different order', async () => {
+    let $ = await next.render$('/async-iterators')
+    expect($('#a').text()).toMatch(/ab[01].\d+/)
+    expect($('#a').text()).not.toBe($('#b').text())
+  })
+
+  it('generates different cache keys for readable streams that enqueue chunks in different order', async () => {
+    let $ = await next.render$('/readable-streams')
+    expect($('#a').text()).toMatch(/ab[01].\d+/)
     expect($('#a').text()).not.toBe($('#b').text())
   })
 })


### PR DESCRIPTION
When passing promise arguments into a `"use cache"` function, the order in which they resolve currently influences the cache key, leading to unnecessary cache misses.

This is because we use React's Flight Reply Client to serialize the arguments into `FormData`. The form data entries are appended as they stream in, using an incrementing ID as form field name. When all arguments are resolved, the form data is serialized into a compact string that is used as one cache key part.

By sorting the form data fields by their key, before serializing them, we can ensure a deterministic cache key, regardless of when the individual promise arguments resolve.

Thanks to @lubieowoce for pointing this out!