### PR TITLE
[bundle] bundle dependency of dependency

### DIFF
--- a/packages/next/src/build/get-package-name.test.ts
+++ b/packages/next/src/build/get-package-name.test.ts
@@ -1,0 +1,255 @@
+import { getPackageName } from './get-package-name'
+
+describe('getPackageName', () => {
+  describe('npm/yarn standard paths', () => {
+    it('should extract regular package names', () => {
+      expect(getPackageName('node_modules/react/index.js')).toBe('react')
+      expect(getPackageName('node_modules/lodash/lib/index.js')).toBe('lodash')
+      expect(getPackageName('node_modules/express/lib/express.js')).toBe(
+        'express'
+      )
+    })
+
+    it('should extract scoped package names', () => {
+      expect(getPackageName('node_modules/@babel/core/lib/index.js')).toBe(
+        '@babel/core'
+      )
+      expect(getPackageName('node_modules/@types/node/index.d.ts')).toBe(
+        '@types/node'
+      )
+      expect(getPackageName('node_modules/@next/swc-darwin-x64/index.js')).toBe(
+        '@next/swc-darwin-x64'
+      )
+    })
+
+    it('should handle nested paths', () => {
+      expect(getPackageName('/Users/project/node_modules/react/index.js')).toBe(
+        'react'
+      )
+      expect(
+        getPackageName('project/src/node_modules/@babel/core/lib/index.js')
+      ).toBe('@babel/core')
+    })
+  })
+
+  describe('pnpm .pnpm directory structure', () => {
+    it('should extract from pnpm nested node_modules', () => {
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/react@18.0.0/node_modules/react/index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/index.js'
+        )
+      ).toBe('lodash')
+    })
+
+    it('should extract scoped packages from pnpm paths', () => {
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/@babel+core@7.22.5/node_modules/@babel/core/lib/index.js'
+        )
+      ).toBe('@babel/core')
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/@types+node@20.0.0/node_modules/@types/node/index.d.ts'
+        )
+      ).toBe('@types/node')
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/@next+swc-darwin-x64@13.4.0/node_modules/@next/swc-darwin-x64/index.js'
+        )
+      ).toBe('@next/swc-darwin-x64')
+    })
+
+    it('should handle deep pnpm registry paths', () => {
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/registry.npmjs.org/react/18.0.0/node_modules/react/index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/registry.npmjs.org/@babel+core/7.22.5/node_modules/@babel/core/lib/index.js'
+        )
+      ).toBe('@babel/core')
+    })
+
+    it('should handle pnpm paths with complex versions', () => {
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/react@18.0.0_react-dom@18.0.0/node_modules/react/index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/@babel+core@7.22.5_@babel+types@7.22.5/node_modules/@babel/core/lib/index.js'
+        )
+      ).toBe('@babel/core')
+    })
+  })
+
+  describe('multiple nested node_modules', () => {
+    it('should use the last node_modules in the path', () => {
+      expect(
+        getPackageName(
+          'project/node_modules/some-package/node_modules/react/index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          'node_modules/workspace/node_modules/@babel/core/lib/index.js'
+        )
+      ).toBe('@babel/core')
+    })
+
+    it('should handle deep nesting with pnpm', () => {
+      expect(
+        getPackageName(
+          'project/node_modules/.pnpm/workspace@1.0.0/node_modules/workspace/node_modules/react/index.js'
+        )
+      ).toBe('react')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should return null for paths without node_modules', () => {
+      expect(getPackageName('src/components/Button.tsx')).toBe(null)
+      expect(getPackageName('/Users/project/src/index.js')).toBe(null)
+      expect(getPackageName('')).toBe(null)
+    })
+
+    it('should return null for malformed paths', () => {
+      expect(getPackageName('node_modules/')).toBe(null)
+      expect(getPackageName('node_modules/.pnpm/')).toBe(null)
+      expect(getPackageName('node_modules/@')).toBe(null)
+      expect(getPackageName('node_modules/@babel')).toBe(null)
+    })
+
+    it('should handle paths ending with node_modules', () => {
+      expect(getPackageName('project/node_modules')).toBe(null)
+    })
+
+    it('should handle complex real-world pnpm paths', () => {
+      // Real pnpm path examples
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/next@14.0.0_@babel+core@7.22.5_react-dom@18.0.0_react@18.0.0/node_modules/next/dist/lib/index.js'
+        )
+      ).toBe('next')
+      expect(
+        getPackageName(
+          'node_modules/.pnpm/@swc+helpers@0.5.1/node_modules/@swc/helpers/lib/index.js'
+        )
+      ).toBe('@swc/helpers')
+    })
+  })
+
+  describe('yarn pnp and other variations', () => {
+    it('should handle yarn berry virtual paths', () => {
+      // Yarn berry sometimes uses virtual paths but still has node_modules structure
+      expect(
+        getPackageName(
+          '.yarn/cache/react-npm-18.0.0-virtual-abc123/node_modules/react/index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          '.yarn/cache/@babel-core-npm-7.22.5-virtual-def456/node_modules/@babel/core/lib/index.js'
+        )
+      ).toBe('@babel/core')
+    })
+  })
+
+  describe('Windows path support', () => {
+    it('should extract regular package names from Windows paths', () => {
+      expect(getPackageName('node_modules\\react\\index.js')).toBe('react')
+      expect(getPackageName('node_modules\\lodash\\lib\\index.js')).toBe(
+        'lodash'
+      )
+      expect(
+        getPackageName('C:\\project\\node_modules\\express\\lib\\express.js')
+      ).toBe('express')
+    })
+
+    it('should extract scoped package names from Windows paths', () => {
+      expect(getPackageName('node_modules\\@babel\\core\\lib\\index.js')).toBe(
+        '@babel/core'
+      )
+      expect(getPackageName('node_modules\\@types\\node\\index.d.ts')).toBe(
+        '@types/node'
+      )
+      expect(
+        getPackageName(
+          'C:\\Users\\project\\node_modules\\@next\\swc-win32-x64\\index.js'
+        )
+      ).toBe('@next/swc-win32-x64')
+    })
+
+    it('should handle pnpm paths on Windows', () => {
+      expect(
+        getPackageName(
+          'node_modules\\.pnpm\\react@18.0.0\\node_modules\\react\\index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          'node_modules\\.pnpm\\@babel+core@7.22.5\\node_modules\\@babel\\core\\lib\\index.js'
+        )
+      ).toBe('@babel/core')
+      expect(
+        getPackageName(
+          'C:\\project\\node_modules\\.pnpm\\lodash@4.17.21\\node_modules\\lodash\\index.js'
+        )
+      ).toBe('lodash')
+    })
+
+    it('should handle mixed path separators', () => {
+      // Mixed separators can happen in some environments
+      expect(getPackageName('C:\\project/node_modules\\react/index.js')).toBe(
+        'react'
+      )
+      expect(
+        getPackageName(
+          'node_modules/.pnpm\\@babel+core@7.22.5/node_modules\\@babel/core\\lib/index.js'
+        )
+      ).toBe('@babel/core')
+    })
+
+    it('should handle nested Windows paths', () => {
+      expect(
+        getPackageName(
+          'C:\\project\\node_modules\\some-package\\node_modules\\react\\index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          'D:\\workspace\\node_modules\\.pnpm\\workspace@1.0.0\\node_modules\\workspace\\node_modules\\@babel\\core\\lib\\index.js'
+        )
+      ).toBe('@babel/core')
+    })
+
+    it('should return null for Windows paths without node_modules', () => {
+      expect(getPackageName('C:\\project\\src\\components\\Button.tsx')).toBe(
+        null
+      )
+      expect(getPackageName('D:\\workspace\\src\\index.js')).toBe(null)
+    })
+
+    it('should handle Windows UNC paths', () => {
+      // Universal Naming Convention paths
+      expect(
+        getPackageName(
+          '\\\\server\\share\\project\\node_modules\\react\\index.js'
+        )
+      ).toBe('react')
+      expect(
+        getPackageName(
+          '\\\\network\\drive\\node_modules\\@babel\\core\\lib\\index.js'
+        )
+      ).toBe('@babel/core')
+    })
+  })
+})

--- a/packages/next/src/build/get-package-name.ts
+++ b/packages/next/src/build/get-package-name.ts
@@ -1,0 +1,61 @@
+export function getPackageName(filePath: string): string | null {
+  // Normalize path separators for cross-platform compatibility
+  const normalizedPath = filePath.replace(/\\/g, '/')
+
+  // Find the last occurrence of node_modules to handle nested cases
+  const nodeModulesIndex = normalizedPath.lastIndexOf('node_modules/')
+  if (nodeModulesIndex === -1) {
+    return null
+  }
+
+  // Get the path after the last node_modules/
+  const afterNodeModules = normalizedPath.substring(
+    nodeModulesIndex + 'node_modules/'.length
+  )
+
+  // Handle pnpm .pnpm directory structure
+  // Example: .pnpm/react@18.0.0/node_modules/react/index.js
+  // Example: .pnpm/@babel+core@7.0.0/node_modules/@babel/core/lib/index.js
+  if (afterNodeModules.startsWith('.pnpm/')) {
+    // Find the nested node_modules within .pnpm structure
+    const nestedNodeModulesIndex = afterNodeModules.indexOf('/node_modules/')
+    if (nestedNodeModulesIndex !== -1) {
+      const afterNestedNodeModules = afterNodeModules.substring(
+        nestedNodeModulesIndex + '/node_modules/'.length
+      )
+      return extractPackageNameFromPath(afterNestedNodeModules)
+    }
+    // Fallback: try to extract from .pnpm path directly
+    const pnpmPath = afterNodeModules.substring('.pnpm/'.length)
+    const firstSlash = pnpmPath.indexOf('/')
+    if (firstSlash !== -1) {
+      const packageSpec = pnpmPath.substring(0, firstSlash)
+      // Handle scoped packages like @babel+core@7.0.0 → @babel/core
+      return packageSpec.replace(/\+/g, '/').replace(/@[^@]*$/, '')
+    }
+  }
+
+  // Handle regular npm/yarn structure
+  return extractPackageNameFromPath(afterNodeModules)
+}
+
+function extractPackageNameFromPath(path: string): string | null {
+  if (!path) return null
+
+  const parts = path.split('/')
+  const packagePart = parts[0]
+
+  // Return null for empty or special directory names
+  if (!packagePart || packagePart.startsWith('.')) {
+    return null
+  }
+
+  // Handle scoped packages (start with @)
+  if (packagePart.startsWith('@')) {
+    if (parts.length < 2 || !parts[1]) return null
+    return `${parts[0]}/${parts[1]}`
+  }
+
+  // Handle regular packages
+  return packagePart
+}

--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -10,8 +10,14 @@ import {
   NODE_ESM_RESOLVE_OPTIONS,
   NODE_RESOLVE_OPTIONS,
 } from './webpack-config'
-import { isWebpackBundledLayer, shouldUseReactServerCondition } from './utils'
+import {
+  isWebpackBundledLayer,
+  isWebpackPagesRouterPagesLayer,
+  shouldUseReactServerCondition,
+} from './utils'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
+import { getPackageName } from './get-package-name'
+
 const reactPackagesRegex = /^(react|react-dom|react-server-dom-webpack)($|\/)/
 
 const pathSeparators = '[/\\\\]'
@@ -25,6 +31,13 @@ const externalPattern = new RegExp(
 
 const nodeModulesRegex = /node_modules[/\\].*\.[mc]?js$/
 
+// Determine if a resource is in a package
+// 1st case:
+//   resource is in a package that is in the list of packages
+//   e.g. resource is foo/* and packageNames is ['foo']
+// 2nd case:
+//   resource is in a package that is in the list of packages
+//   e.g. resource is */node_modules/foo/* and packageNames is ['foo']
 export function isResourceInPackages(
   resource: string,
   packageNames?: string[],
@@ -149,6 +162,7 @@ export function makeExternalHandler({
     request: string,
     dependencyType: string,
     layer: WebpackLayerName | null,
+    issuer: string,
     getResolve: (
       options: any
     ) => (
@@ -282,6 +296,19 @@ export function makeExternalHandler({
     // If the request cannot be resolved we need to have
     // webpack "bundle" it so it surfaces the not found error.
     if (!res) {
+      return
+    }
+
+    // When bundling pages router page, we need to recursively bundle dependencies of dependencies.
+    // If the package is required to be transpiled, then all its dependencies should also
+    // be transpiled.
+    if (
+      isWebpackPagesRouterPagesLayer(layer) &&
+      isResourceInPackages(issuer, transpiledPackages)
+    ) {
+      const packageName = getPackageName(res)
+      if (packageName) transpiledPackages.push(packageName)
+
       return
     }
 

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1886,6 +1886,14 @@ export function isWebpackAppPagesLayer(
   return Boolean(layer && WEBPACK_LAYERS.GROUP.appPages.includes(layer as any))
 }
 
+export function isWebpackPagesRouterPagesLayer(
+  layer: WebpackLayerName | null | undefined
+): boolean {
+  return Boolean(
+    layer && WEBPACK_LAYERS.GROUP.pagesRouterPages.includes(layer as any)
+  )
+}
+
 export function collectMeta({
   status,
   headers,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1016,6 +1016,7 @@ export default async function getBaseWebpackConfig(
                 request,
                 dependencyType,
                 contextInfo.issuerLayer as WebpackLayerName,
+                contextInfo.issuer,
                 (options) => {
                   const resolveFunction = getResolve(options)
                   return (resolveContext: string, requestToResolve: string) =>

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -201,6 +201,11 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.appPagesBrowser,
       WEBPACK_LAYERS_NAMES.actionBrowser,
     ],
+    pagesRouterPages: [
+      WEBPACK_LAYERS_NAMES.pagesDirBrowser,
+      WEBPACK_LAYERS_NAMES.pagesDirNode,
+      WEBPACK_LAYERS_NAMES.pagesDirEdge,
+    ],
   },
 }
 

--- a/test/e2e/barrel-optimization-recurrsive-bundle/barrel-optimization-recurrsive-bundle.test.ts
+++ b/test/e2e/barrel-optimization-recurrsive-bundle/barrel-optimization-recurrsive-bundle.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('barrel-optimization-recurrsive-bundle', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    packageManager: 'yarn',
+    dependencies: {
+      antd: '5.23.4',
+    },
+  })
+
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('button').text()).toBe('Click')
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('button').text()).toBe('Click')
+  })
+})

--- a/test/e2e/barrel-optimization-recurrsive-bundle/pages/index.tsx
+++ b/test/e2e/barrel-optimization-recurrsive-bundle/pages/index.tsx
@@ -1,0 +1,11 @@
+import { Button } from 'antd'
+
+function Page() {
+  return (
+    <div>
+      <Button type="primary">Click</Button>
+    </div>
+  )
+}
+
+export default Page

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -10,7 +10,7 @@ const { linkPackages } =
 const PREFER_OFFLINE = process.env.NEXT_TEST_PREFER_OFFLINE === '1'
 const useRspack = process.env.NEXT_TEST_USE_RSPACK === '1'
 
-async function installDependencies(cwd, tmpDir) {
+async function installDependencies(packageManager, cwd, tmpDir) {
   const args = [
     'install',
     '--strict-peer-dependencies=false',
@@ -24,7 +24,7 @@ async function installDependencies(cwd, tmpDir) {
     args.push('--prefer-offline')
   }
 
-  await execa('pnpm', args, {
+  await execa(packageManager, args, {
     cwd,
     stdio: ['ignore', 'inherit', 'inherit'],
     env: process.env,
@@ -39,6 +39,7 @@ async function installDependencies(cwd, tmpDir) {
  * @param {object | null} [param0.resolutions]
  * @param { ((ctx: { dependencies: { [key: string]: string } }) => string) | string | null} [param0.installCommand]
  * @param {object} [param0.packageJson]
+ * @param {string} [param0.packageManager]
  * @param {string} [param0.dirSuffix]
  * @param {boolean} [param0.keepRepoDir]
  * @param {(span: import('@next/telemetry').Span, installDir: string) => Promise<void>} param0.beforeInstall
@@ -49,6 +50,7 @@ async function createNextInstall({
   dependencies = {},
   resolutions = null,
   installCommand = null,
+  packageManager = 'pnpm',
   packageJson = {},
   dirSuffix = '',
   keepRepoDir = false,
@@ -215,7 +217,9 @@ async function createNextInstall({
       } else {
         await rootSpan
           .traceChild('run generic install command', combinedDependencies)
-          .traceAsyncFn(() => installDependencies(installDir, tmpDir))
+          .traceAsyncFn(() =>
+            installDependencies(packageManager, installDir, tmpDir)
+          )
       }
 
       if (useRspack) {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -39,6 +39,8 @@ export interface NextInstanceOpts {
   buildArgs?: string[]
   startCommand?: string
   startArgs?: string[]
+  startOptions?: string[]
+  packageManager?: 'yarn' | 'pnpm' | string
   env?: Record<string, string>
   dirSuffix?: string
   turbo?: boolean
@@ -71,6 +73,8 @@ export class NextInstance {
   public buildArgs?: string[]
   protected startCommand?: string
   protected startArgs?: string[]
+  protected startOptions?: string[]
+  protected packageManager?: 'yarn' | 'pnpm' | string
   protected dependencies?: PackageJson['dependencies'] = {}
   protected resolutions?: PackageJson['resolutions']
   protected events: { [eventName: string]: Set<any> } = {}
@@ -92,6 +96,8 @@ export class NextInstance {
 
   constructor(opts: NextInstanceOpts) {
     this.env = {}
+    // set default package manager to pnpm
+    opts.packageManager = opts.packageManager || 'pnpm'
     Object.assign(this, opts)
 
     if (!isNextDeploy) {
@@ -272,6 +278,7 @@ export class NextInstance {
               dependencies: finalDependencies,
               resolutions: this.resolutions ?? null,
               installCommand: this.installCommand,
+              packageManager: this.packageManager!,
               packageJson: this.packageJson,
               dirSuffix: this.dirSuffix,
               keepRepoDir: true,

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -31,7 +31,7 @@ export class NextDevInstance extends NextInstance {
       ((this as any).turbo || (this as any).experimentalTurbo)
 
     let startArgs = [
-      'pnpm',
+      this.packageManager,
       'next',
       useTurbo ? getTurbopackFlag() : undefined,
     ].filter(Boolean) as string[]

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -63,8 +63,8 @@ export class NextStartInstance extends NextInstance {
       },
     }
 
-    let buildArgs = ['pnpm', 'next', 'build']
-    let startArgs = ['pnpm', 'next', 'start']
+    let buildArgs = [this.packageManager!, 'next', 'build']
+    let startArgs = [this.packageManager!, 'next', 'start']
 
     if (this.buildCommand) {
       buildArgs = this.buildCommand.split(' ')
@@ -205,7 +205,7 @@ export class NextStartInstance extends NextInstance {
       cliOutput: string
     }>((resolve) => {
       const curOutput = this._cliOutput.length
-      const buildArgs = ['pnpm', 'next', 'build']
+      const buildArgs = [this.packageManager!, 'next', 'build']
 
       if (this.buildArgs) {
         buildArgs.push(...this.buildArgs)


### PR DESCRIPTION
### What

pnpm and yarn has different filesystem layout, where pnpm is using a nested layout but yarn (non PnP) is using a flat layout when hoisting is disabled. This will lead [this line](https://github.com/vercel/next.js/blob/ca210eb3888421e62b5e1e42be8257c751d2b597/packages/next/src/build/handle-externals.ts#L282-L286) behaves differently while resolving nested dependencies.

For example, `antd` has a lot of dependencies, one of them is `rc-util` which is the deep dependency. With pnpm, it's not directly resolved by webpack since it's deep dependency. With yarn it can be resolved and our external handling didn't treat it as external dependency.

In yarn, it's flat dependencies in the file system so it can be resolved by module resolver. Resolving result:
```
rc-util/es/omit -> /../repros/next-antd-demo/node_modules/rc-util/es/omit.js
```

In pnpm, the dependency of dependency is nested, it can't not be resolved directly. Resolving result:
```
rc-util/es/omit -> null
```

If the dependency is included into `transpiledPackages`, like `antd` is included by default due to barrel optimization. We should still bundle the dependencies of it. This is only needed for Pages Router since Page. So we introduce a extra checking for Pages Rouer that when we check external we'll include the dependencies of transpiled packages also into the transpiled list, this will grow recursively to ensure all the dependencies are included.

Fixes #75783