### PR TITLE
Track navigation timestamp on CacheNode

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -171,9 +171,12 @@ const pendingActionQueue: Promise<AppRouterActionQueue> = new Promise(
         // and before any components have hydrated.
         setAppBuildId(initialRSCPayload.b)
 
+        const initialTimestamp = Date.now()
+
         resolve(
           createMutableActionQueue(
             createInitialRouterState({
+              navigatedAt: initialTimestamp,
               initialFlightData: initialRSCPayload.f,
               initialCanonicalUrlParts: initialRSCPayload.c,
               initialParallelRoutes: new Map(),

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -149,6 +149,7 @@ export function createEmptyCacheNode(): CacheNode {
     prefetchHead: null,
     parallelRoutes: new Map(),
     loading: null,
+    navigatedAt: -1,
   }
 }
 

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -381,6 +381,7 @@ function InnerLayoutRouter({
       // TODO-APP: remove ''
       const refetchTree = walkAddRefetch(['', ...segmentPath], fullTree)
       const includeNextUrl = hasInterceptionRouteInCurrentTree(fullTree)
+      const navigatedAt = Date.now()
       cacheNode.lazyData = lazyData = fetchServerResponse(
         new URL(url, location.origin),
         {
@@ -393,6 +394,7 @@ function InnerLayoutRouter({
             type: ACTION_SERVER_PATCH,
             previousTree: fullTree,
             serverResponse,
+            navigatedAt,
           })
         })
 
@@ -565,6 +567,7 @@ export default function OuterLayoutRouter({
       prefetchHead: null,
       parallelRoutes: new Map(),
       loading: null,
+      navigatedAt: -1,
     }
 
     // Flight data fetch kicked off during render and put into the cache.

--- a/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
@@ -24,6 +24,7 @@ import type { Mutable, ReadonlyReducerState } from './router-reducer-types'
  * more granular segment map and so the router will be able to simply re-use the loading segment for the new navigation.
  */
 export function handleAliasedPrefetchEntry(
+  navigatedAt: number,
   state: ReadonlyReducerState,
   flightData: string | NormalizedFlightData[],
   url: URL,
@@ -85,6 +86,7 @@ export function handleAliasedPrefetchEntry(
 
       // Construct a new tree and apply the aliased loading state for each parallel route
       fillNewTreeWithOnlyLoadingSegments(
+        navigatedAt,
         newCache,
         currentCache,
         treePatch,
@@ -99,6 +101,7 @@ export function handleAliasedPrefetchEntry(
 
       // copy the loading state only into the leaf node (the part that changed)
       fillCacheWithNewSubTreeDataButOnlyLoading(
+        navigatedAt,
         newCache,
         currentCache,
         normalizedFlightData
@@ -146,6 +149,7 @@ function hasLoadingComponentInSeedData(seedData: CacheNodeSeedData | null) {
 }
 
 function fillNewTreeWithOnlyLoadingSegments(
+  navigatedAt: number,
   newCache: CacheNode,
   existingCache: CacheNode,
   routerState: FlightRouterState,
@@ -180,6 +184,7 @@ function fillNewTreeWithOnlyLoadingSegments(
         prefetchHead: null,
         parallelRoutes: new Map(),
         loading,
+        navigatedAt,
       }
     } else {
       // No data available for this node. This will trigger a lazy fetch
@@ -192,6 +197,7 @@ function fillNewTreeWithOnlyLoadingSegments(
         prefetchHead: null,
         parallelRoutes: new Map(),
         loading: null,
+        navigatedAt: -1,
       }
     }
 
@@ -203,6 +209,7 @@ function fillNewTreeWithOnlyLoadingSegments(
     }
 
     fillNewTreeWithOnlyLoadingSegments(
+      navigatedAt,
       newCacheNode,
       existingCache,
       parallelRouteState,

--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -5,6 +5,7 @@ import type { PrefetchCacheEntry } from './router-reducer-types'
 import type { NormalizedFlightData } from '../../flight-data-helpers'
 
 export function applyFlightData(
+  navigatedAt: number,
   existingCache: CacheNode,
   cache: CacheNode,
   flightData: NormalizedFlightData,
@@ -30,6 +31,7 @@ export function applyFlightData(
     // old behavior — no PPR value.
     cache.prefetchRsc = null
     fillLazyItemsTillLeafWithHead(
+      navigatedAt,
       cache,
       existingCache,
       treePatch,
@@ -47,7 +49,13 @@ export function applyFlightData(
     cache.parallelRoutes = new Map(existingCache.parallelRoutes)
     cache.loading = existingCache.loading
     // Create a copy of the existing cache with the rsc applied.
-    fillCacheWithNewSubTreeData(cache, existingCache, flightData, prefetchEntry)
+    fillCacheWithNewSubTreeData(
+      navigatedAt,
+      cache,
+      existingCache,
+      flightData,
+      prefetchEntry
+    )
   }
 
   return true

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { clearCacheNodeDataForSegmentPath } from './clear-cache-node-data-for-segment-path'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 
+const navigatedAt = -1
+
 describe('clearCacheNodeDataForSegmentPath', () => {
   it('should clear the data property', () => {
     const pathname = '/dashboard/settings'
@@ -13,6 +15,7 @@ describe('clearCacheNodeDataForSegmentPath', () => {
       .flat()
 
     const cache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -22,6 +25,7 @@ describe('clearCacheNodeDataForSegmentPath', () => {
       loading: null,
     }
     const existingCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
@@ -35,6 +39,7 @@ describe('clearCacheNodeDataForSegmentPath', () => {
             [
               'linking',
               {
+                navigatedAt,
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
@@ -48,6 +53,7 @@ describe('clearCacheNodeDataForSegmentPath', () => {
                       [
                         '',
                         {
+                          navigatedAt,
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
@@ -74,18 +80,21 @@ describe('clearCacheNodeDataForSegmentPath', () => {
        "head": null,
        "lazyData": null,
        "loading": null,
+       "navigatedAt": -1,
        "parallelRoutes": Map {
          "children" => Map {
            "linking" => {
              "head": null,
              "lazyData": null,
              "loading": null,
+             "navigatedAt": -1,
              "parallelRoutes": Map {
                "children" => Map {
                  "" => {
                    "head": null,
                    "lazyData": null,
                    "loading": null,
+                   "navigatedAt": -1,
                    "parallelRoutes": Map {},
                    "prefetchHead": null,
                    "prefetchRsc": null,
@@ -105,6 +114,7 @@ describe('clearCacheNodeDataForSegmentPath', () => {
              "head": null,
              "lazyData": null,
              "loading": null,
+             "navigatedAt": -1,
              "parallelRoutes": Map {},
              "prefetchHead": null,
              "prefetchRsc": null,

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
@@ -44,6 +44,7 @@ export function clearCacheNodeDataForSegmentPath(
         prefetchHead: null,
         parallelRoutes: new Map(),
         loading: null,
+        navigatedAt: -1,
       })
     }
     return
@@ -60,6 +61,7 @@ export function clearCacheNodeDataForSegmentPath(
         prefetchHead: null,
         parallelRoutes: new Map(),
         loading: null,
+        navigatedAt: -1,
       })
     }
     return

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -19,6 +19,8 @@ const getInitialRouterStateTree = (): FlightRouterState => [
   true,
 ]
 
+const navigatedAt = Date.now()
+
 describe('createInitialRouterState', () => {
   it('should return the correct initial router state', () => {
     const initialTree = getInitialRouterStateTree()
@@ -32,6 +34,7 @@ describe('createInitialRouterState', () => {
     const initialParallelRoutes: CacheNode['parallelRoutes'] = new Map()
 
     const state = createInitialRouterState({
+      navigatedAt,
       initialFlightData: [[initialTree, ['', children, {}, null]]],
       initialCanonicalUrlParts: initialCanonicalUrl.split('/'),
       initialParallelRoutes,
@@ -42,6 +45,7 @@ describe('createInitialRouterState', () => {
     })
 
     const state2 = createInitialRouterState({
+      navigatedAt,
       initialFlightData: [[initialTree, ['', children, {}, null]]],
       initialCanonicalUrlParts: initialCanonicalUrl.split('/'),
       initialParallelRoutes,
@@ -52,6 +56,7 @@ describe('createInitialRouterState', () => {
     })
 
     const expectedCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: children,
       prefetchRsc: null,
@@ -65,6 +70,7 @@ describe('createInitialRouterState', () => {
             [
               'linking',
               {
+                navigatedAt,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -72,6 +78,7 @@ describe('createInitialRouterState', () => {
                       [
                         '',
                         {
+                          navigatedAt,
                           lazyData: null,
                           rsc: null,
                           prefetchRsc: null,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -10,6 +10,7 @@ import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-par
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
 
 export interface InitialRouterStateParameters {
+  navigatedAt: number
   initialCanonicalUrlParts: string[]
   initialParallelRoutes: CacheNode['parallelRoutes']
   initialFlightData: FlightDataPath[]
@@ -20,6 +21,7 @@ export interface InitialRouterStateParameters {
 }
 
 export function createInitialRouterState({
+  navigatedAt,
   initialFlightData,
   initialCanonicalUrlParts,
   initialParallelRoutes,
@@ -52,6 +54,7 @@ export function createInitialRouterState({
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.
     parallelRoutes: initialParallelRoutes,
     loading,
+    navigatedAt,
   }
 
   const canonicalUrl =
@@ -69,6 +72,7 @@ export function createInitialRouterState({
   // When the cache hasn't been seeded yet we fill the cache with the head.
   if (initialParallelRoutes === null || initialParallelRoutes.size === 0) {
     fillLazyItemsTillLeafWithHead(
+      navigatedAt,
       cache,
       undefined,
       initialTree,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -20,6 +20,7 @@ const getFlightData = (): NormalizedFlightData[] => {
 describe('fillCacheWithNewSubtreeData', () => {
   it('should apply rsc and head property', () => {
     const cache: CacheNode = {
+      navigatedAt: -1,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -29,6 +30,7 @@ describe('fillCacheWithNewSubtreeData', () => {
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
+      navigatedAt: -1,
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
@@ -42,6 +44,7 @@ describe('fillCacheWithNewSubtreeData', () => {
             [
               'linking',
               {
+                navigatedAt: -1,
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
@@ -55,6 +58,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                       [
                         '',
                         {
+                          navigatedAt: -1,
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
@@ -83,9 +87,16 @@ describe('fillCacheWithNewSubtreeData', () => {
     // Mirrors the way router-reducer values are passed in.
     const normalizedFlightData = flightData[0]
 
-    fillCacheWithNewSubTreeData(cache, existingCache, normalizedFlightData)
+    const navigatedAt = -1
+    fillCacheWithNewSubTreeData(
+      navigatedAt,
+      cache,
+      existingCache,
+      normalizedFlightData
+    )
 
     const expectedCache: CacheNode = {
+      navigatedAt: -1,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -99,6 +110,7 @@ describe('fillCacheWithNewSubtreeData', () => {
             [
               'linking',
               {
+                navigatedAt: -1,
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
@@ -113,6 +125,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                       [
                         '',
                         {
+                          navigatedAt: -1,
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
@@ -125,6 +138,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                       [
                         'about',
                         {
+                          navigatedAt: -1,
                           lazyData: null,
                           head: null,
                           prefetchHead: null,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -11,6 +11,7 @@ import type { NormalizedFlightData } from '../../flight-data-helpers'
  * Common logic for filling cache with new sub tree data.
  */
 function fillCacheHelper(
+  navigatedAt: number,
   newCache: CacheNode,
   existingCache: CacheNode,
   flightData: NormalizedFlightData,
@@ -78,6 +79,7 @@ function fillCacheHelper(
             fillLazyItems && existingChildCacheNode
               ? new Map(existingChildCacheNode.parallelRoutes)
               : new Map(),
+          navigatedAt,
         }
 
         if (existingChildCacheNode && fillLazyItems) {
@@ -89,6 +91,7 @@ function fillCacheHelper(
         }
         if (fillLazyItems) {
           fillLazyItemsTillLeafWithHead(
+            navigatedAt,
             childCacheNode,
             existingChildCacheNode,
             treePatch,
@@ -132,19 +135,35 @@ function fillCacheHelper(
  * Fill cache with rsc based on flightDataPath
  */
 export function fillCacheWithNewSubTreeData(
+  navigatedAt: number,
   newCache: CacheNode,
   existingCache: CacheNode,
   flightData: NormalizedFlightData,
   prefetchEntry?: PrefetchCacheEntry
 ): void {
-  fillCacheHelper(newCache, existingCache, flightData, prefetchEntry, true)
+  fillCacheHelper(
+    navigatedAt,
+    newCache,
+    existingCache,
+    flightData,
+    prefetchEntry,
+    true
+  )
 }
 
 export function fillCacheWithNewSubTreeDataButOnlyLoading(
+  navigatedAt: number,
   newCache: CacheNode,
   existingCache: CacheNode,
   flightData: NormalizedFlightData,
   prefetchEntry?: PrefetchCacheEntry
 ): void {
-  fillCacheHelper(newCache, existingCache, flightData, prefetchEntry, false)
+  fillCacheHelper(
+    navigatedAt,
+    newCache,
+    existingCache,
+    flightData,
+    prefetchEntry,
+    false
+  )
 }

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -33,9 +33,12 @@ const getFlightData = (): FlightData => {
   ]
 }
 
+const navigatedAt = Date.now()
+
 describe('fillLazyItemsTillLeafWithHead', () => {
   it('should fill lazy items till leaf with head', () => {
     const cache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -45,6 +48,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       loading: null,
     }
     const existingCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
@@ -58,6 +62,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
             [
               'linking',
               {
+                navigatedAt,
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
@@ -71,6 +76,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                       [
                         '',
                         {
+                          navigatedAt,
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
@@ -102,6 +108,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       flightDataPath.slice(-4)
 
     fillLazyItemsTillLeafWithHead(
+      navigatedAt,
       cache,
       existingCache,
       treePatch,
@@ -111,6 +118,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
     )
 
     const expectedCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -124,6 +132,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
             [
               'linking',
               {
+                navigatedAt,
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
@@ -137,6 +146,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                       [
                         'about',
                         {
+                          navigatedAt,
                           lazyData: null,
                           loading: null,
                           parallelRoutes: new Map([
@@ -146,6 +156,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                                 [
                                   '',
                                   {
+                                    navigatedAt,
                                     lazyData: null,
                                     rsc: null,
                                     prefetchRsc: null,
@@ -167,6 +178,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                       [
                         '',
                         {
+                          navigatedAt,
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -10,6 +10,7 @@ import {
 } from './router-reducer-types'
 
 export function fillLazyItemsTillLeafWithHead(
+  navigatedAt: number,
   newCache: CacheNode,
   existingCache: CacheNode | undefined,
   routerState: FlightRouterState,
@@ -70,6 +71,7 @@ export function fillLazyItemsTillLeafWithHead(
             prefetchHead: null,
             loading,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
+            navigatedAt,
           }
         } else if (hasReusablePrefetch && existingCacheNode) {
           // No new data was sent from the server, but the existing cache node
@@ -97,6 +99,7 @@ export function fillLazyItemsTillLeafWithHead(
             prefetchHead: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
             loading: null,
+            navigatedAt,
           }
         }
 
@@ -104,6 +107,7 @@ export function fillLazyItemsTillLeafWithHead(
         parallelRouteCacheNode.set(cacheKey, newCacheNode)
         // Traverse deeper to apply the head / fill lazy items till the head.
         fillLazyItemsTillLeafWithHead(
+          navigatedAt,
           newCacheNode,
           existingCacheNode,
           parallelRouteState,
@@ -130,6 +134,7 @@ export function fillLazyItemsTillLeafWithHead(
         prefetchHead: null,
         parallelRoutes: new Map(),
         loading,
+        navigatedAt,
       }
     } else {
       // No data available for this node. This will trigger a lazy fetch
@@ -142,6 +147,7 @@ export function fillLazyItemsTillLeafWithHead(
         prefetchHead: null,
         parallelRoutes: new Map(),
         loading: null,
+        navigatedAt,
       }
     }
 
@@ -153,6 +159,7 @@ export function fillLazyItemsTillLeafWithHead(
     }
 
     fillLazyItemsTillLeafWithHead(
+      navigatedAt,
       newCacheNode,
       undefined,
       parallelRouteState,

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -19,9 +19,12 @@ const getFlightData = (): NormalizedFlightData[] => {
   ]
 }
 
+const navigatedAt = Date.now()
+
 describe('invalidateCacheBelowFlightSegmentPath', () => {
   it('should invalidate cache below flight segment path', () => {
     const cache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -31,6 +34,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
@@ -44,6 +48,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
             [
               'linking',
               {
+                navigatedAt,
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
@@ -57,6 +62,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                       [
                         '',
                         {
+                          navigatedAt,
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
@@ -89,7 +95,12 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
     cache.rsc = existingCache.rsc
     cache.prefetchRsc = existingCache.prefetchRsc
     // Create a copy of the existing cache with the rsc applied.
-    fillCacheWithNewSubTreeData(cache, existingCache, normalizedFlightData)
+    fillCacheWithNewSubTreeData(
+      navigatedAt,
+      cache,
+      existingCache,
+      normalizedFlightData
+    )
 
     // Invalidate the cache below the flight segment path. This should remove the 'about' node.
     invalidateCacheBelowFlightSegmentPath(
@@ -99,6 +110,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
     )
 
     const expectedCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       head: null,
       prefetchHead: null,
@@ -110,6 +122,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
             [
               'linking',
               {
+                navigatedAt,
                 lazyData: null,
                 head: null,
                 prefetchHead: null,
@@ -121,6 +134,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                       [
                         '',
                         {
+                          navigatedAt,
                           lazyData: null,
                           loading: null,
                           parallelRoutes: new Map(),

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -2,9 +2,12 @@ import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { FlightRouterState } from '../../../server/app-render/types'
 
+const navigatedAt = -1
+
 describe('invalidateCacheByRouterState', () => {
   it('should invalidate the cache by router state', () => {
     const cache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -14,6 +17,7 @@ describe('invalidateCacheByRouterState', () => {
       parallelRoutes: new Map(),
     }
     const existingCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
@@ -27,6 +31,7 @@ describe('invalidateCacheByRouterState', () => {
             [
               'linking',
               {
+                navigatedAt,
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
@@ -40,6 +45,7 @@ describe('invalidateCacheByRouterState', () => {
                       [
                         '',
                         {
+                          navigatedAt,
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
@@ -82,6 +88,7 @@ describe('invalidateCacheByRouterState', () => {
     invalidateCacheByRouterState(cache, existingCache, routerState)
 
     const expectedCache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -394,7 +394,7 @@ export function prunePrefetchCache(
 
 // These values are set by `define-env-plugin` (based on `nextConfig.experimental.staleTimes`)
 // and default to 5 minutes (static) / 0 seconds (dynamic)
-const DYNAMIC_STALETIME_MS =
+export const DYNAMIC_STALETIME_MS =
   Number(process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME) * 1000
 
 export const STATIC_STALETIME_MS =

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -2,6 +2,8 @@ import type { FlightRouterState } from '../../../../server/app-render/types'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { findHeadInCache } from './find-head-in-cache'
 
+const navigatedAt = -1
+
 describe('findHeadInCache', () => {
   it('should find the head', () => {
     const routerTree: FlightRouterState = [
@@ -25,6 +27,7 @@ describe('findHeadInCache', () => {
     ]
 
     const cache: CacheNode = {
+      navigatedAt,
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
@@ -38,6 +41,7 @@ describe('findHeadInCache', () => {
             [
               'linking',
               {
+                navigatedAt,
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
@@ -51,6 +55,7 @@ describe('findHeadInCache', () => {
                       [
                         'about',
                         {
+                          navigatedAt,
                           lazyData: null,
                           head: null,
                           prefetchHead: null,
@@ -62,6 +67,7 @@ describe('findHeadInCache', () => {
                                 [
                                   '',
                                   {
+                                    navigatedAt,
                                     lazyData: null,
                                     rsc: null,
                                     prefetchRsc: null,

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -34,6 +34,7 @@ function hmrRefreshReducerImpl(
 
   // TODO-APP: verify that `href` is not an external url.
   // Fetch data from the root of the tree.
+  const navigatedAt = Date.now()
   cache.lazyData = fetchServerResponse(new URL(href, origin), {
     flightRouterState: [state.tree[0], state.tree[1], state.tree[2], 'refetch'],
     nextUrl: includeNextUrl ? state.nextUrl : null,
@@ -95,6 +96,7 @@ function hmrRefreshReducerImpl(
           mutable.canonicalUrl = canonicalUrlOverrideHref
         }
         const applied = applyFlightData(
+          navigatedAt,
           currentCache,
           cache,
           normalizedFlightData

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -226,16 +226,19 @@ export function navigateReducer(
 
   return data.then(
     ({ flightData, canonicalUrl: canonicalUrlOverride, postponed }) => {
+      const navigatedAt = Date.now()
+
       let isFirstRead = false
       // we only want to mark this once
       if (!prefetchValues.lastUsedTime) {
         // important: we should only mark the cache node as dirty after we unsuspend from the call above
-        prefetchValues.lastUsedTime = Date.now()
+        prefetchValues.lastUsedTime = navigatedAt
         isFirstRead = true
       }
 
       if (prefetchValues.aliased) {
         const result = handleAliasedPrefetchEntry(
+          navigatedAt,
           state,
           flightData,
           url,
@@ -328,6 +331,7 @@ export function navigateReducer(
             postponed
           ) {
             const task = startPPRNavigation(
+              navigatedAt,
               currentCache,
               currentTree,
               treePatch,
@@ -427,9 +431,10 @@ export function navigateReducer(
               )
               // since we re-used the stale cache's loading state & refreshed the data,
               // update the `lastUsedTime` so that it can continue to be re-used for the next 30s
-              prefetchValues.lastUsedTime = Date.now()
+              prefetchValues.lastUsedTime = navigatedAt
             } else {
               applied = applyFlightData(
+                navigatedAt,
                 currentCache,
                 cache,
                 normalizedFlightData,

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -48,6 +48,7 @@ export function refreshReducer(
     nextUrl: includeNextUrl ? state.nextUrl : null,
   })
 
+  const navigatedAt = Date.now()
   return cache.lazyData.then(
     async ({ flightData, canonicalUrl: canonicalUrlOverride }) => {
       // Handle case when navigating to page in `pages` from `app`
@@ -114,6 +115,7 @@ export function refreshReducer(
           cache.prefetchRsc = null
           cache.loading = loading
           fillLazyItemsTillLeafWithHead(
+            navigatedAt,
             cache,
             // Existing cache is not passed in as `router.refresh()` has to invalidate the entire cache.
             undefined,
@@ -130,6 +132,7 @@ export function refreshReducer(
         }
 
         await refreshInactiveParallelSegments({
+          navigatedAt,
           state,
           updatedTree: newTree,
           updatedCache: cache,

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -222,6 +222,8 @@ export function serverActionReducer(
       ? state.nextUrl
       : null
 
+  const navigatedAt = Date.now()
+
   return fetchServerAction(state, nextUrl, action).then(
     async ({
       actionResult,
@@ -329,6 +331,7 @@ export function serverActionReducer(
           cache.prefetchRsc = null
           cache.loading = cacheNodeSeedData[3]
           fillLazyItemsTillLeafWithHead(
+            navigatedAt,
             cache,
             // Existing cache is not passed in as server actions have to invalidate the entire cache.
             undefined,
@@ -346,6 +349,7 @@ export function serverActionReducer(
           }
           if (actionRevalidated) {
             await refreshInactiveParallelSegments({
+              navigatedAt,
               state,
               updatedTree: newTree,
               updatedCache: cache,

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -19,6 +19,7 @@ export function serverPatchReducer(
 ): ReducerState {
   const {
     serverResponse: { flightData, canonicalUrl: canonicalUrlOverride },
+    navigatedAt,
   } = action
 
   const mutable: Mutable = {}
@@ -77,7 +78,7 @@ export function serverPatchReducer(
     }
 
     const cache: CacheNode = createEmptyCacheNode()
-    applyFlightData(currentCache, cache, normalizedFlightData)
+    applyFlightData(navigatedAt, currentCache, cache, normalizedFlightData)
 
     mutable.patchedTree = newTree
     mutable.cache = cache

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -6,6 +6,7 @@ import { fetchServerResponse } from './fetch-server-response'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 
 interface RefreshInactiveParallelSegments {
+  navigatedAt: number
   state: AppRouterState
   updatedTree: FlightRouterState
   updatedCache: CacheNode
@@ -36,6 +37,7 @@ export async function refreshInactiveParallelSegments(
 }
 
 async function refreshInactiveParallelSegmentsImpl({
+  navigatedAt,
   state,
   updatedTree,
   updatedCache,
@@ -76,7 +78,12 @@ async function refreshInactiveParallelSegmentsImpl({
           // we only pass the new cache as this function is called after clearing the router cache
           // and filling in the new page data from the server. Meaning the existing cache is actually the cache that's
           // just been created & has been written to, but hasn't been "committed" yet.
-          applyFlightData(updatedCache, updatedCache, flightDataPath)
+          applyFlightData(
+            navigatedAt,
+            updatedCache,
+            updatedCache,
+            flightDataPath
+          )
         }
       } else {
         // When flightData is a string, it suggests that the server response should have triggered an MPA navigation
@@ -90,6 +97,7 @@ async function refreshInactiveParallelSegmentsImpl({
 
   for (const key in parallelRoutes) {
     const parallelFetchPromise = refreshInactiveParallelSegmentsImpl({
+      navigatedAt,
       state,
       updatedTree: parallelRoutes[key],
       updatedCache,

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -14,9 +14,11 @@ export const ACTION_HMR_REFRESH = 'hmr-refresh'
 export const ACTION_SERVER_ACTION = 'server-action'
 
 export type RouterChangeByServerResponse = ({
+  navigatedAt,
   previousTree,
   serverResponse,
 }: {
+  navigatedAt: number
   previousTree: FlightRouterState
   serverResponse: FetchServerResponseResult
 }) => void
@@ -131,6 +133,7 @@ export interface RestoreAction {
  */
 export interface ServerPatchAction {
   type: typeof ACTION_SERVER_PATCH
+  navigatedAt: number
   serverResponse: FetchServerResponseResult
   previousTree: FlightRouterState
 }

--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -123,6 +123,7 @@ export function navigate(
     const isPrefetchHeadPartial = route.isHeadPartial
     const newCanonicalUrl = route.canonicalUrl
     return navigateUsingPrefetchedRouteTree(
+      now,
       url,
       nextUrl,
       isSamePageNavigation,
@@ -141,6 +142,7 @@ export function navigate(
   return {
     tag: NavigationResultTag.Async,
     data: navigateDynamicallyWithNoPrefetch(
+      now,
       url,
       nextUrl,
       isSamePageNavigation,
@@ -153,6 +155,7 @@ export function navigate(
 }
 
 function navigateUsingPrefetchedRouteTree(
+  now: number,
   url: URL,
   nextUrl: string | null,
   isSamePageNavigation: boolean,
@@ -174,6 +177,7 @@ function navigateUsingPrefetchedRouteTree(
   // so we can share code with the old prefetching implementation.
   const scrollableSegments: Array<FlightSegmentPath> = []
   const task = startPPRNavigation(
+    now,
     currentCacheNode,
     currentFlightRouterState,
     prefetchFlightRouterState,
@@ -339,6 +343,7 @@ function readRenderSnapshotFromCache(
 }
 
 async function navigateDynamicallyWithNoPrefetch(
+  now: number,
   url: URL,
   nextUrl: string | null,
   isSamePageNavigation: boolean,
@@ -398,6 +403,7 @@ async function navigateDynamicallyWithNoPrefetch(
   // Now we proceed exactly as we would for normal navigation.
   const scrollableSegments: Array<FlightSegmentPath> = []
   const task = startPPRNavigation(
+    now,
     currentCacheNode,
     currentFlightRouterState,
     prefetchFlightRouterState,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1058,6 +1058,9 @@ function App<T>({
   )
 
   const initialState = createInitialRouterState({
+    // This is not used during hydration, so we don't have to pass a
+    // real timestamp.
+    navigatedAt: -1,
     initialFlightData: response.f,
     initialCanonicalUrlParts: response.c,
     initialParallelRoutes: new Map(),
@@ -1122,6 +1125,9 @@ function ErrorApp<T>({
   )
 
   const initialState = createInitialRouterState({
+    // This is not used during hydration, so we don't have to pass a
+    // real timestamp.
+    navigatedAt: -1,
     initialFlightData: response.f,
     initialCanonicalUrlParts: response.c,
     initialParallelRoutes: new Map(),

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -65,6 +65,13 @@ export type LazyCacheNode = {
    * Child parallel routes.
    */
   parallelRoutes: Map<string, ChildSegmentMap>
+
+  /**
+   * The timestamp of the navigation that last updated the CacheNode's data. If
+   * a CacheNode is reused from a previous navigation, this value is not
+   * updated. Used to track the staleness of the data.
+   */
+  navigatedAt: number
 }
 
 export type ReadyCacheNode = {
@@ -105,6 +112,8 @@ export type ReadyCacheNode = {
   loading: LoadingModuleData | Promise<LoadingModuleData>
 
   parallelRoutes: Map<string, ChildSegmentMap>
+
+  navigatedAt: number
 }
 
 export interface NavigateOptions {

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -45,8 +45,8 @@ describe('error-ignored-frames', () => {
        at processFullStringRow ()
        at processFullBinaryRow ()
        at progress ()
-       at InnerLayoutRouter (../src/client/components/layout-router.tsx (413:5))
-       at OuterLayoutRouter (../src/client/components/layout-router.tsx (612:19))"
+       at InnerLayoutRouter (../src/client/components/layout-router.tsx (415:5))
+       at OuterLayoutRouter (../src/client/components/layout-router.tsx (615:19))"
       `)
     }
   })

--- a/test/e2e/app-dir/segment-cache/staleness/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/dynamic/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function Content() {
+  await connection()
+  return <div id="dynamic-content">Dynamic content</div>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
@@ -20,6 +20,9 @@ export default function Page() {
             Page with stale time of 10 minutes
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/dynamic">Page with dynamic data</LinkAccordion>
+        </li>
       </ul>
     </>
   )

--- a/test/e2e/app-dir/segment-cache/staleness/next.config.js
+++ b/test/e2e/app-dir/segment-cache/staleness/next.config.js
@@ -6,6 +6,9 @@ const nextConfig = {
     ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
+    staleTimes: {
+      dynamic: 30,
+    },
   },
 }
 


### PR DESCRIPTION
Adds a field `navigatedAt` to the CacheNode type. It represents the timestamp of the navigation that last updated the CacheNode's data.

This will be used to implement the `staleTimes.dynamic` configuration option, which allows dynamic data to be stale in the UI up to the given threshold. This first PR adds the field without changing any behavior.

Originally I was going to call this `requestedAt`, but I have intentionally chosen not to distinguish between whether the data was fetched from the network or from the prefetch cache. This means that even fully static data will respect the `staleTimes.dynamic` configuration option. In practice, this only matters if the dynamic stale time is longer than the static one, although usually static stale times will be larger anyway.