### PR TITLE
feat: added component stack debugging environment variable

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -155,6 +155,10 @@ export function getDefineEnv({
     // variable to the client.
     'process.env.__NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING':
       process.env.__NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING || false,
+    // Propagates the `__NEXT_COMPONENT_STACK_DEBUGGING` environment variable to
+    // the client.
+    'process.env.__NEXT_COMPONENT_STACK_DEBUGGING':
+      process.env.__NEXT_COMPONENT_STACK_DEBUGGING || false,
     'process.env.__NEXT_FETCH_CACHE_KEY_PREFIX': fetchCacheKeyPrefix ?? '',
     ...(isTurbopack
       ? {}

--- a/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
+++ b/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
@@ -80,6 +80,12 @@ export function onCaughtError(
     originConsoleError('%o\n\n%s', err, errorLocation)
 
     handleClientError(stitchedError, [])
+  } else if (process.env.__NEXT_COMPONENT_STACK_DEBUGGING === '1') {
+    if (errorInfo.componentStack) {
+      ;(err as any)._componentStack = errorInfo.componentStack
+    }
+
+    originConsoleError(err)
   } else {
     originConsoleError(err)
   }
@@ -99,6 +105,13 @@ export function onUncaughtError(err: unknown, errorInfo: React.ErrorInfo) {
 
     // TODO: Add an adendum to the overlay telling people about custom error boundaries.
     reportGlobalError(stitchedError)
+  } else if (process.env.__NEXT_COMPONENT_STACK_DEBUGGING === '1') {
+    if (errorInfo.componentStack) {
+      ;(err as any)._componentStack = errorInfo.componentStack
+    }
+
+    // TODO: Add an adendum to the overlay telling people about custom error boundaries.
+    reportGlobalError(err)
   } else {
     reportGlobalError(err)
   }

--- a/packages/next/src/client/react-client-callbacks/on-recoverable-error.ts
+++ b/packages/next/src/client/react-client-callbacks/on-recoverable-error.ts
@@ -13,10 +13,16 @@ export const onRecoverableError: HydrationOptions['onRecoverableError'] = (
   // x-ref: https://github.com/facebook/react/pull/28736
   const cause = isError(error) && 'cause' in error ? error.cause : error
   const stitchedError = getReactStitchedError(cause)
+
   // In development mode, pass along the component stack to the error
-  if (process.env.NODE_ENV === 'development' && errorInfo.componentStack) {
+  if (
+    (process.env.NODE_ENV === 'development' ||
+      process.env.__NEXT_COMPONENT_STACK_DEBUGGING === '1') &&
+    errorInfo.componentStack
+  ) {
     ;(stitchedError as any)._componentStack = errorInfo.componentStack
   }
+
   // Skip certain custom errors which are not expected to be reported on client
   if (isBailoutToCSRError(cause)) return
 


### PR DESCRIPTION
This adds a new environment variable `__NEXT_COMPONENT_STACK_DEBUGGING=1` which when provided, enables printing component stack information along with error logs in the server console and in the browser. This is only enabled by default in development, but this allows it to be enabled also in production environments.

This is a prefixed environment variable (it starts with `__NEXT_`), so it should be considered unstable until a more formal flag has been added to enable this behaviour.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
