### PR TITLE
fix: pass telemetry plugin rspack tests

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -893,7 +893,6 @@ export default async function getBaseWebpackConfig(
   }
 
   const telemetryPlugin =
-    !isRspack &&
     !dev &&
     isClient &&
     new (
@@ -2056,8 +2055,7 @@ export default async function getBaseWebpackConfig(
         config.experimental.cssChunking &&
         new CssChunkingPlugin(config.experimental.cssChunking === 'strict'),
       telemetryPlugin,
-      !isRspack &&
-        !dev &&
+      !dev &&
         isNodeServer &&
         new (
           require('./webpack/plugins/telemetry-plugin/telemetry-plugin') as typeof import('./webpack/plugins/telemetry-plugin/telemetry-plugin')

--- a/packages/next/src/build/webpack/plugins/telemetry-plugin/telemetry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/telemetry-plugin/telemetry-plugin.ts
@@ -1,5 +1,4 @@
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
-import { NormalModule } from 'next/dist/compiled/webpack/webpack'
 import {
   createUseCacheTracker,
   type UseCacheTrackerKey,
@@ -127,7 +126,8 @@ function findFeatureInModule(module: webpack.Module): Feature | undefined {
   }
 
   for (const [feature, path] of FEATURE_MODULE_MAP) {
-    if ((module as webpack.NormalModule).resource.endsWith(path)) {
+    // imports like "http" will be undefined resource in rspack
+    if ((module as webpack.NormalModule).resource?.endsWith(path)) {
       return feature
     }
   }
@@ -238,7 +238,8 @@ export class TelemetryPlugin implements webpack.WebpackPluginInstance {
       compiler.hooks.thisCompilation.tap(
         TelemetryPlugin.name,
         (compilation) => {
-          const moduleHooks = NormalModule.getCompilationHooks(compilation)
+          const moduleHooks =
+            compiler.webpack.NormalModule.getCompilationHooks(compilation)
           moduleHooks.loader.tap(TelemetryPlugin.name, (loaderContext) => {
             ;(loaderContext as TelemetryLoaderContext).eliminatedPackages =
               eliminatedPackages


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Support Telemetry Plugin in Rspack and fixes the following test(s):

`integration/telemetry/test/config.test.js`
`test/e2e/next-config-warnings/esm-externals-false/esm-externals-false.test.ts`
`test/production/next-font/telemetry.test.ts`