### PR TITLE
Alternate bundler: show state in app info message

### DIFF
--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -23,10 +23,19 @@ export function logStartInfo({
   experimentalFeatures?: ConfiguredExperimentalFeature[]
   maxExperimentalFeatures?: number
 }) {
+  let bundlerSuffix
+  if (process.env.TURBOPACK) {
+    bundlerSuffix = ' (Turbopack)'
+  } else if (process.env.NEXT_RSPACK) {
+    bundlerSuffix = ' (Rspack)'
+  } else {
+    bundlerSuffix = ''
+  }
+
   Log.bootstrap(
     `${bold(
       purple(`${Log.prefixes.ready} Next.js ${process.env.__NEXT_VERSION}`)
-    )}${process.env.TURBOPACK ? ' (Turbopack)' : ''}`
+    )}${bundlerSuffix}`
   )
   if (appUrl) {
     Log.bootstrap(`- Local:        ${appUrl}`)


### PR DESCRIPTION
When next starts, in either `next dev` or `next start`, we log a message
that includes Turbopack state (`▲ Next.js 15.3.0-canary.12
(Turbopack)`). This implements it for rspack as well.

Test Plan:

Configure the rspack plugin and start `next dev`. Confirm `▲ Next.js
15.3.0-canary.12 (rspack)` is shown.

Run `next dev --turbopack`. Verify Turbopack is shown instead.


Closes PACK-4195