### PR TITLE
[metadata] fix the metadata route like pages and refactor utils

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
@@ -1,7 +1,10 @@
 import path from 'path'
 import { stringify } from 'querystring'
 import { WEBPACK_RESOURCE_QUERIES } from '../../../../lib/constants'
-import { isMetadataRoute } from '../../../../lib/metadata/is-metadata-route'
+import {
+  DEFAULT_METADATA_ROUTE_EXTENSIONS,
+  isMetadataRouteFile,
+} from '../../../../lib/metadata/is-metadata-route'
 import type { NextConfig } from '../../../../server/config-shared'
 import { AppBundlePathNormalizer } from '../../../../server/normalizers/built/app/app-bundle-path-normalizer'
 import { AppPathnameNormalizer } from '../../../../server/normalizers/built/app/app-pathname-normalizer'
@@ -10,6 +13,7 @@ import type { PageExtensions } from '../../../page-extensions-type'
 import { getFilenameAndExtension } from '../next-metadata-route-loader'
 
 export async function createAppRouteCode({
+  appDir,
   name,
   page,
   pagePath,
@@ -17,6 +21,7 @@ export async function createAppRouteCode({
   pageExtensions,
   nextConfigOutput,
 }: {
+  appDir: string
   name: string
   page: string
   pagePath: string
@@ -39,10 +44,18 @@ export async function createAppRouteCode({
     )
   }
 
-  // If this is a metadata route, then we need to use the metadata loader for
-  // the route to ensure that the route is generated.
+  // If this is a metadata route file, then we need to use the metadata-loader
+  // for the route to ensure that the route is generated.
   const fileBaseName = path.parse(resolvedPagePath).name
-  if (isMetadataRoute(name) && fileBaseName !== 'route') {
+  const appDirRelativePath = resolvedPagePath.slice(appDir.length)
+
+  if (
+    isMetadataRouteFile(
+      appDirRelativePath,
+      DEFAULT_METADATA_ROUTE_EXTENSIONS,
+      true
+    )
+  ) {
     const { ext } = getFilenameAndExtension(resolvedPagePath)
     const isDynamicRouteExtension = pageExtensions.includes(ext)
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
@@ -48,14 +48,12 @@ export async function createAppRouteCode({
   // for the route to ensure that the route is generated.
   const fileBaseName = path.parse(resolvedPagePath).name
   const appDirRelativePath = resolvedPagePath.slice(appDir.length)
-
-  if (
-    isMetadataRouteFile(
-      appDirRelativePath,
-      DEFAULT_METADATA_ROUTE_EXTENSIONS,
-      true
-    )
-  ) {
+  const isMetadataEntryFile = isMetadataRouteFile(
+    appDirRelativePath,
+    DEFAULT_METADATA_ROUTE_EXTENSIONS,
+    true
+  )
+  if (isMetadataEntryFile) {
     const { ext } = getFilenameAndExtension(resolvedPagePath)
     const isDynamicRouteExtension = pageExtensions.includes(ext)
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -666,6 +666,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
 
   if (isAppRouteRoute(name)) {
     return createAppRouteCode({
+      appDir,
       // TODO: investigate if the local `page` is the same as the loaderOptions.page
       page: loaderOptions.page,
       name,

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -47,6 +47,7 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
     const buildInfo = getModuleBuildInfo(this._module)
 
     buildInfo.nextEdgeSSR = {
+      // TODO: replace with isMetadataRouteFile
       isServerComponent: !isMetadataRoute(page), // Needed for 'use cache'.
       page: page,
       isAppDir: true,

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -47,7 +47,6 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
     const buildInfo = getModuleBuildInfo(this._module)
 
     buildInfo.nextEdgeSSR = {
-      // TODO: replace with isMetadataRouteFile
       isServerComponent: !isMetadataRoute(page), // Needed for 'use cache'.
       page: page,
       isAppDir: true,

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -347,23 +347,25 @@ export class FlightClientEntryPlugin {
         const relativeRequest = isAbsoluteRequest
           ? path.relative(compilation.options.context!, entryRequest)
           : entryRequest
+        const appDirRelativeRequest = relativeRequest
+          .replace(/^src[\\/]/, '')
+          .replace(/^app[\\/]/, '/')
 
         // Replace file suffix as `.js` will be added.
         let bundlePath = normalizePathSep(
-          relativeRequest.replace(/\.[^.\\/]+$/, '').replace(/^src[\\/]/, '')
+          appDirRelativeRequest.replace(/\.[^.\\/]+$/, '')
         )
 
         // For metadata routes, the entry name can be used as the bundle path,
         // as it has been normalized already.
         // e.g.
-        // relativeRequest -> 'app/sitemap.js'
-        if (
-          isMetadataRouteFile(
-            relativeRequest,
-            DEFAULT_METADATA_ROUTE_EXTENSIONS,
-            true
-          )
-        ) {
+        // appDirRelativeRequest -> '/sitemap.js'
+        const isMetadataEntryFile = isMetadataRouteFile(
+          appDirRelativeRequest,
+          DEFAULT_METADATA_ROUTE_EXTENSIONS,
+          true
+        )
+        if (isMetadataEntryFile) {
           bundlePath = name
         }
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -43,7 +43,10 @@ import { PAGE_TYPES } from '../../../lib/page-types'
 import { getModuleBuildInfo } from '../loaders/get-module-build-info'
 import { getAssumedSourceType } from '../loaders/next-flight-loader'
 import { isAppRouteRoute } from '../../../lib/is-app-route-route'
-import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
+import {
+  DEFAULT_METADATA_ROUTE_EXTENSIONS,
+  isMetadataRouteFile,
+} from '../../../lib/metadata/is-metadata-route'
 import type { MetadataRouteLoaderOptions } from '../loaders/next-metadata-route-loader'
 import type { FlightActionEntryLoaderActions } from '../loaders/next-flight-action-entry-loader'
 
@@ -352,7 +355,15 @@ export class FlightClientEntryPlugin {
 
         // For metadata routes, the entry name can be used as the bundle path,
         // as it has been normalized already.
-        if (isMetadataRoute(bundlePath)) {
+        // e.g.
+        // relativeRequest -> 'app/sitemap.js'
+        if (
+          isMetadataRouteFile(
+            relativeRequest,
+            DEFAULT_METADATA_ROUTE_EXTENSIONS,
+            true
+          )
+        ) {
           bundlePath = name
         }
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -347,19 +347,23 @@ export class FlightClientEntryPlugin {
         const relativeRequest = isAbsoluteRequest
           ? path.relative(compilation.options.context!, entryRequest)
           : entryRequest
-        const appDirRelativeRequest = relativeRequest
-          .replace(/^src[\\/]/, '')
-          .replace(/^app[\\/]/, '/')
 
         // Replace file suffix as `.js` will be added.
+        // bundlePath will have app/ prefix but not src/.
+        // e.g. src/app/foo/page.js -> app/foo/page
         let bundlePath = normalizePathSep(
-          appDirRelativeRequest.replace(/\.[^.\\/]+$/, '')
+          relativeRequest.replace(/\.[^.\\/]+$/, '').replace(/^src[\\/]/, '')
         )
 
         // For metadata routes, the entry name can be used as the bundle path,
         // as it has been normalized already.
         // e.g.
-        // appDirRelativeRequest -> '/sitemap.js'
+        // When `relativeRequest` is 'src/app/sitemap.js',
+        // `appDirRelativeRequest` will be '/sitemap.js'
+        // then `isMetadataEntryFile` will be `true`
+        const appDirRelativeRequest = relativeRequest
+          .replace(/^src[\\/]/, '')
+          .replace(/^app[\\/]/, '/')
         const isMetadataEntryFile = isMetadataRouteFile(
           appDirRelativeRequest,
           DEFAULT_METADATA_ROUTE_EXTENSIONS,

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -18,7 +18,7 @@ import picomatch from 'next/dist/compiled/picomatch'
 import { getModuleBuildInfo } from '../loaders/get-module-build-info'
 import { getPageFilePath } from '../../entries'
 import { resolveExternal } from '../../handle-externals'
-import { isStaticMetadataRoutePage } from '../../../lib/metadata/is-metadata-route'
+import { isMetadataRouteFile } from '../../../lib/metadata/is-metadata-route'
 import { getCompilationSpan } from '../utils'
 
 const PLUGIN_NAME = 'TraceEntryPointsPlugin'
@@ -243,7 +243,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
 
           const entryIsStaticMetadataRoute =
             appDirRelativeEntryPath &&
-            isStaticMetadataRoutePage(appDirRelativeEntryPath)
+            isMetadataRouteFile(appDirRelativeEntryPath, [], true)
 
           // Include the client reference manifest in the trace, but not for
           // static metadata routes, for which we don't generate those.

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -103,7 +103,7 @@ export async function exportAppRoute(
     // we don't bail from the static optimization for
     // metadata routes
     const normalizedPage = normalizeAppPath(page)
-    const isMetadataRoute = isMetadataRouteFile(normalizedPage, [], true)
+    const isMetadataRoute = isMetadataRouteFile(normalizedPage, [], false)
 
     if (
       !isStaticGenEnabled(userland) &&

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -103,7 +103,7 @@ export async function exportAppRoute(
     // we don't bail from the static optimization for
     // metadata routes
     const normalizedPage = normalizeAppPath(page)
-    const isMetadataRoute = isMetadataRouteFile(normalizedPage, [], false)
+    const isMetadataRoute = isMetadataRouteFile(normalizedPage, [], true)
 
     if (
       !isStaticGenEnabled(userland) &&

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -23,7 +23,7 @@ import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
 import { hasNextSupport } from '../../server/ci-info'
 import { isStaticGenEnabled } from '../../server/route-modules/app-route/helpers/is-static-gen-enabled'
 import type { ExperimentalConfig } from '../../server/config-shared'
-import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
+import { isMetadataRoute } from '../../lib/metadata/is-metadata-route'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import type { Params } from '../../server/request/params'
 import { AfterRunner } from '../../server/after/run-with-after'
@@ -101,13 +101,13 @@ export async function exportAppRoute(
   try {
     const userland = module.userland
     // we don't bail from the static optimization for
-    // metadata routes
-    const normalizedPage = normalizeAppPath(page)
-    const isMetadataRoute = isMetadataRouteFile(normalizedPage, [], false)
+    // metadata routes, since it's app-route we can always append /route suffix.
+    const routePath = normalizeAppPath(page) + '/route'
+    const isPageMetadataRoute = isMetadataRoute(routePath)
 
     if (
       !isStaticGenEnabled(userland) &&
-      !isMetadataRoute &&
+      !isPageMetadataRoute &&
       // We don't disable static gen when dynamicIO is enabled because we
       // expect that anything dynamic in the GET handler will make it dynamic
       // and thus avoid the cache surprises that led to us removing static gen

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -1,4 +1,4 @@
-import { isMetadataRoute } from './is-metadata-route'
+import { isMetadataPage } from './is-metadata-route'
 import path from '../../shared/lib/isomorphic/path'
 import { interpolateDynamicPath } from '../../server/server-utils'
 import { getNamedRouteRegex } from '../../shared/lib/router/utils/route-regex'
@@ -83,7 +83,7 @@ export function fillMetadataSegment(
  * @returns
  */
 export function normalizeMetadataRoute(page: string) {
-  if (!isMetadataRoute(page)) {
+  if (!isMetadataPage(page)) {
     return page
   }
   let route = page

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -1,4 +1,7 @@
-import { getExtensionRegexString } from './is-metadata-route'
+import {
+  getExtensionRegexString,
+  isMetadataRouteFile,
+} from './is-metadata-route'
 
 describe('getExtensionRegexString', () => {
   function createExtensionMatchRegex(
@@ -51,6 +54,24 @@ describe('getExtensionRegexString', () => {
 
       expect(regex.test('.tsx')).toBe(false)
       expect(regex.test('.js')).toBe(false)
+    })
+  })
+})
+
+describe('isMetadataRouteFile', () => {
+  describe('without extension', () => {
+    it('should match metadata routes', () => {
+      expect(isMetadataRouteFile('/icons/descriptor/page', [], false)).toBe(
+        false
+      )
+    })
+  })
+
+  describe('with extension', () => {
+    it('should match metadata routes', () => {
+      expect(isMetadataRouteFile('/icons/descriptor/page', [], true)).toBe(
+        false
+      )
     })
   })
 })

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -2,6 +2,7 @@ import {
   getExtensionRegexString,
   isMetadataRouteFile,
   isMetadataRoute,
+  isMetadataPage,
 } from './is-metadata-route'
 
 describe('getExtensionRegexString', () => {
@@ -92,5 +93,21 @@ describe('isMetadataRoute', () => {
   it('should support metadata variant numeric suffix', () => {
     expect(isMetadataRoute('/icon0/route')).toBe(true)
     expect(isMetadataRoute('/opengraph-image1/route')).toBe(true)
+  })
+})
+
+describe('isMetadataPage', () => {
+  it('should match metadata page path', () => {
+    expect(isMetadataPage('/sitemap.xml')).toBe(true)
+    expect(isMetadataPage('/favicon.ico')).toBe(true)
+    expect(isMetadataPage('/manifest.json')).toBe(true)
+    expect(isMetadataPage('/robots.txt')).toBe(true)
+  })
+
+  it('should not match app router page or boundary path', () => {
+    expect(isMetadataPage('/icon/error')).toBe(false)
+    expect(isMetadataPage('/icon/route')).toBe(false)
+    expect(isMetadataPage('/icon/page')).toBe(false)
+    expect(isMetadataPage('/icon/route')).toBe(false)
   })
 })

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -1,6 +1,7 @@
 import {
   getExtensionRegexString,
   isMetadataRouteFile,
+  isMetadataRoute,
 } from './is-metadata-route'
 
 describe('getExtensionRegexString', () => {
@@ -73,5 +74,23 @@ describe('isMetadataRouteFile', () => {
         false
       )
     })
+  })
+})
+
+describe('isMetadataRoute', () => {
+  it('should require suffix for metadata routes', () => {
+    expect(isMetadataRoute('/icon')).toBe(false)
+    expect(isMetadataRoute('/icon/route')).toBe(true)
+    expect(isMetadataRoute('/opengraph-image')).toBe(false)
+    expect(isMetadataRoute('/opengraph-image/route')).toBe(true)
+  })
+
+  it('should match grouped metadata routes', () => {
+    expect(isMetadataRoute('/opengraph-image-1ow20b/route')).toBe(true)
+  })
+
+  it('should support metadata variant numeric suffix', () => {
+    expect(isMetadataRoute('/icon0/route')).toBe(true)
+    expect(isMetadataRoute('/opengraph-image1/route')).toBe(true)
   })
 })

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -61,19 +61,52 @@ describe('getExtensionRegexString', () => {
 })
 
 describe('isMetadataRouteFile', () => {
-  describe('without extension', () => {
-    it('should match metadata routes', () => {
+  describe('match route - without extension', () => {
+    it('should match metadata route page paths', () => {
       expect(isMetadataRouteFile('/icons/descriptor/page', [], false)).toBe(
         false
       )
+      expect(isMetadataRouteFile('/foo/icon', [], false)).toBe(true)
+      expect(isMetadataRouteFile('/foo/opengraph-image', [], false)).toBe(true)
+      expect(isMetadataRouteFile('/foo/sitemap.xml', [], false)).toBe(true)
+      // group routes
+      expect(
+        isMetadataRouteFile('/foo/opengraph-image-abc123', [], false)
+      ).toBe(true)
+      // These pages are not normalized from actual entry files
+      expect(isMetadataRouteFile('/foo/sitemap/0.xml', [], false)).toBe(false)
+      expect(
+        isMetadataRouteFile('/foo/opengraph-image-abc12313333', [], false)
+      ).toBe(false)
     })
   })
 
-  describe('with extension', () => {
-    it('should match metadata routes', () => {
+  describe('match file - with extension', () => {
+    it('should match static metadata route files', () => {
       expect(isMetadataRouteFile('/icons/descriptor/page', [], true)).toBe(
         false
       )
+      expect(isMetadataRouteFile('/foo/icon.png', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/bar/opengraph-image.jpg', [], true)).toBe(
+        true
+      )
+      expect(isMetadataRouteFile('/favicon.ico', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/robots.txt', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/manifest.json', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/sitemap.xml', [], true)).toBe(true)
+    })
+
+    it('should match dynamic metadata routes', () => {
+      // with dynamic extensions, passing the 2nd arg: such as ['tsx', 'ts']
+      expect(isMetadataRouteFile('/foo/icon.js', ['tsx', 'ts'], true)).toBe(
+        false
+      )
+      expect(isMetadataRouteFile('/foo/icon.ts', ['tsx', 'ts'], true)).toBe(
+        true
+      )
+      expect(
+        isMetadataRouteFile('/foo/icon.tsx', ['js', 'jsx', 'tsx', 'ts'], true)
+      ).toBe(true)
     })
   })
 })
@@ -86,13 +119,24 @@ describe('isMetadataRoute', () => {
     expect(isMetadataRoute('/opengraph-image/route')).toBe(true)
   })
 
+  it('should match metadata routes', () => {
+    expect(isMetadataRoute('/app/robots/route')).toBe(true)
+    expect(isMetadataRoute('/robots/route')).toBe(true)
+    expect(isMetadataRoute('/sitemap/[__metadata_id__]/route')).toBe(true)
+    expect(isMetadataRoute('/app/sitemap/page')).toBe(false)
+    expect(isMetadataRoute('/icon-a102f4/route')).toBe(true)
+  })
+
   it('should match grouped metadata routes', () => {
     expect(isMetadataRoute('/opengraph-image-1ow20b/route')).toBe(true)
+    expect(isMetadataRoute('/foo/icon2-1ow20b/route')).toBe(true)
   })
 
   it('should support metadata variant numeric suffix', () => {
     expect(isMetadataRoute('/icon0/route')).toBe(true)
     expect(isMetadataRoute('/opengraph-image1/route')).toBe(true)
+    expect(isMetadataRoute('/foo/icon0-a120ff/route')).toBe(true)
+    expect(isMetadataRoute('/foo/icon0-a120ff3/route')).toBe(false)
   })
 })
 
@@ -104,10 +148,10 @@ describe('isMetadataPage', () => {
     expect(isMetadataPage('/robots.txt')).toBe(true)
   })
 
-  it('should not match app router page or boundary path', () => {
-    expect(isMetadataPage('/icon/error')).toBe(false)
-    expect(isMetadataPage('/icon/route')).toBe(false)
+  it('should not match app router page path or error boundary path', () => {
     expect(isMetadataPage('/icon/page')).toBe(false)
     expect(isMetadataPage('/icon/route')).toBe(false)
+    expect(isMetadataPage('/icon/error')).toBe(false)
+    expect(isMetadataPage('/icon/not-found')).toBe(false)
   })
 })

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -101,9 +101,12 @@ export function isMetadataRouteFile(
   ]
 
   const normalizedAppDirRelativePath = normalizePathSep(appDirRelativePath)
-  return metadataRouteFilesRegex.some((r) =>
+  const matched = metadataRouteFilesRegex.some((r) =>
     r.test(normalizedAppDirRelativePath)
   )
+
+  console.log('isMetadataRouteFile', appDirRelativePath, matched)
+  return matched
 }
 
 export function isStaticMetadataRoutePage(appDirRelativePath: string) {

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -54,48 +54,48 @@ export function isMetadataRouteFile(
   pageExtensions: PageExtensions,
   strictlyMatchExtensions: boolean
 ) {
+  // End with the extension or optional to have the extension
+  const trailingMatcher = strictlyMatchExtensions ? '$' : '?'
   const metadataRouteFilesRegex = [
     new RegExp(
       `^[\\\\/]robots${getExtensionRegexString(
         pageExtensions.concat('txt'),
         null
-      )}${strictlyMatchExtensions ? '' : '$'}`
+      )}${trailingMatcher}`
     ),
     new RegExp(
       `^[\\\\/]manifest${getExtensionRegexString(
         pageExtensions.concat('webmanifest', 'json'),
         null
-      )}${strictlyMatchExtensions ? '' : '$'}`
+      )}${trailingMatcher}`
     ),
     new RegExp(`^[\\\\/]favicon\\.ico$`),
     new RegExp(
-      `[\\\\/]sitemap${getExtensionRegexString(['xml'], pageExtensions)}${
-        strictlyMatchExtensions ? '' : '$'
-      }`
+      `[\\\\/]sitemap${getExtensionRegexString(['xml'], pageExtensions)}${trailingMatcher}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.icon.extensions,
         pageExtensions
-      )}${strictlyMatchExtensions ? '' : '$'}`
+      )}${trailingMatcher}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.apple.extensions,
         pageExtensions
-      )}${strictlyMatchExtensions ? '' : '$'}`
+      )}${trailingMatcher}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.openGraph.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.openGraph.extensions,
         pageExtensions
-      )}${strictlyMatchExtensions ? '' : '$'}`
+      )}${trailingMatcher}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.twitter.extensions,
         pageExtensions
-      )}${strictlyMatchExtensions ? '' : '$'}`
+      )}${trailingMatcher}`
     ),
   ]
 
@@ -131,14 +131,7 @@ export function isStaticMetadataRoute(route: string) {
 export function isMetadataPage(pathname: string) {
   const res =
     !isAppRouteRoute(pathname) && isMetadataRouteFile(pathname, [], false)
-  if (pathname.endsWith('.png')) {
-    console.trace(
-      'res',
-      res,
-      pathname,
-      isMetadataRouteFile(pathname, [], false)
-    )
-  }
+
   return res
 }
 
@@ -154,5 +147,5 @@ export function isMetadataRoute(route: string): boolean {
 
   if (page[0] !== '/') page = '/' + page
 
-  return isAppRouteRoute(route) && isMetadataRouteFile(page, [], true)
+  return isAppRouteRoute(route) && isMetadataRouteFile(page, [], false)
 }

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -58,9 +58,9 @@ export function isMetadataRouteFile(
     new RegExp(
       `^[\\\\/]robots${
         withExtension
-          ? `${getExtensionRegexString(pageExtensions.concat('txt'), null)}$`
+          ? `${getExtensionRegexString(pageExtensions.concat('txt'), null)}`
           : ''
-      }`
+      }$`
     ),
     new RegExp(
       `^[\\\\/]manifest${
@@ -68,17 +68,17 @@ export function isMetadataRouteFile(
           ? `${getExtensionRegexString(
               pageExtensions.concat('webmanifest', 'json'),
               null
-            )}$`
+            )}`
           : ''
-      }`
+      }$`
     ),
     new RegExp(`^[\\\\/]favicon\\.ico$`),
     new RegExp(
       `[\\\\/]sitemap${
         withExtension
-          ? `${getExtensionRegexString(['xml'], pageExtensions)}$`
+          ? `${getExtensionRegexString(['xml'], pageExtensions)}`
           : ''
-      }`
+      }$`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}\\d?${
@@ -86,9 +86,9 @@ export function isMetadataRouteFile(
           ? `${getExtensionRegexString(
               STATIC_METADATA_IMAGES.icon.extensions,
               pageExtensions
-            )}$`
+            )}`
           : ''
-      }`
+      }$`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}\\d?${
@@ -96,9 +96,9 @@ export function isMetadataRouteFile(
           ? `${getExtensionRegexString(
               STATIC_METADATA_IMAGES.apple.extensions,
               pageExtensions
-            )}$`
+            )}`
           : ''
-      }`
+      }$`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.openGraph.filename}\\d?${
@@ -106,9 +106,9 @@ export function isMetadataRouteFile(
           ? `${getExtensionRegexString(
               STATIC_METADATA_IMAGES.openGraph.extensions,
               pageExtensions
-            )}$`
+            )}`
           : ''
-      }`
+      }$`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}\\d?${
@@ -116,9 +116,9 @@ export function isMetadataRouteFile(
           ? `${getExtensionRegexString(
               STATIC_METADATA_IMAGES.twitter.extensions,
               pageExtensions
-            )}$`
+            )}`
           : ''
-      }`
+      }$`
     ),
   ]
 
@@ -152,7 +152,9 @@ export function isStaticMetadataRoute(route: string) {
 // The input is a page, which can be with or without page suffix /foo/page or /foo.
 // But it will not contain the /route suffix.
 export function isMetadataPage(pathname: string) {
-  return !isAppRouteRoute(pathname) && isMetadataRouteFile(pathname, [], true)
+  const res =
+    !isAppRouteRoute(pathname) && isMetadataRouteFile(pathname, [], false)
+  return res
 }
 
 /*

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -116,7 +116,7 @@ export function isStaticMetadataRoutePage(appDirRelativePath: string) {
 // Checking route path is not enough to determine if text routes is dynamic.
 export function isStaticMetadataRoute(route: string) {
   const pathname = route.slice(0, -'/route'.length)
-  return (
+  const matched =
     isAppRouteRoute(route) &&
     isStaticMetadataRoutePage(pathname) &&
     // These routes can either be built by static or dynamic entrypoints,
@@ -124,7 +124,8 @@ export function isStaticMetadataRoute(route: string) {
     pathname !== '/robots.txt' &&
     pathname !== '/manifest.webmanifest' &&
     !pathname.endsWith('/sitemap.xml')
-  )
+
+  return matched
 }
 
 // The input is a page, which can be with or without page suffix /foo/page or /foo.
@@ -138,12 +139,18 @@ export function isMetadataPage(page: string) {
 /*
  * Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
  * e.g.
- * /app/robots/route -> /robots
- * app/robots/route -> /robots
- * /robots/route -> /robots
+ * /app/robots/route -> /robots -> true
+ * app/robots/route -> /robots -> true
+ * /robots/route -> /robots -> true
+ * /sitemap/[__metadata_id__]/route -> /sitemap/route -> true
+ * /app/sitemap/page -> /sitemap/page -> false
+ *
  */
 export function isMetadataRoute(route: string): boolean {
-  let page = route.replace(/^\/?app\//, '').slice(0, -'/route'.length)
+  let page = route
+    .replace(/^\/?app\//, '')
+    .slice(0, -'/route'.length)
+    .replace('/[__metadata_id__]', '')
 
   if (page[0] !== '/') page = '/' + page
 

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -52,73 +52,55 @@ export const getExtensionRegexString = (
 export function isMetadataRouteFile(
   appDirRelativePath: string,
   pageExtensions: PageExtensions,
-  withExtension: boolean
+  strictlyMatchExtensions: boolean
 ) {
   const metadataRouteFilesRegex = [
     new RegExp(
-      `^[\\\\/]robots${
-        withExtension
-          ? `${getExtensionRegexString(pageExtensions.concat('txt'), null)}`
-          : ''
-      }$`
+      `^[\\\\/]robots${getExtensionRegexString(
+        pageExtensions.concat('txt'),
+        null
+      )}
+        ${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
-      `^[\\\\/]manifest${
-        withExtension
-          ? `${getExtensionRegexString(
-              pageExtensions.concat('webmanifest', 'json'),
-              null
-            )}`
-          : ''
-      }$`
+      `^[\\\\/]manifest${getExtensionRegexString(
+        pageExtensions.concat('webmanifest', 'json'),
+        null
+      )}
+        ${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(`^[\\\\/]favicon\\.ico$`),
     new RegExp(
-      `[\\\\/]sitemap${
-        withExtension
-          ? `${getExtensionRegexString(['xml'], pageExtensions)}`
-          : ''
-      }$`
+      `[\\\\/]sitemap${getExtensionRegexString(['xml'], pageExtensions)}
+        ${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}\\d?${
-        withExtension
-          ? `${getExtensionRegexString(
-              STATIC_METADATA_IMAGES.icon.extensions,
-              pageExtensions
-            )}`
-          : ''
-      }$`
+      `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}\\d?${getExtensionRegexString(
+        STATIC_METADATA_IMAGES.icon.extensions,
+        pageExtensions
+      )}
+        ${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}\\d?${
-        withExtension
-          ? `${getExtensionRegexString(
-              STATIC_METADATA_IMAGES.apple.extensions,
-              pageExtensions
-            )}`
-          : ''
-      }$`
+      `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}\\d?${getExtensionRegexString(
+        STATIC_METADATA_IMAGES.apple.extensions,
+        pageExtensions
+      )}
+        ${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.openGraph.filename}\\d?${
-        withExtension
-          ? `${getExtensionRegexString(
-              STATIC_METADATA_IMAGES.openGraph.extensions,
-              pageExtensions
-            )}`
-          : ''
-      }$`
+      `[\\\\/]${STATIC_METADATA_IMAGES.openGraph.filename}\\d?${getExtensionRegexString(
+        STATIC_METADATA_IMAGES.openGraph.extensions,
+        pageExtensions
+      )}
+        ${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}\\d?${
-        withExtension
-          ? `${getExtensionRegexString(
-              STATIC_METADATA_IMAGES.twitter.extensions,
-              pageExtensions
-            )}`
-          : ''
-      }$`
+      `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}\\d?${getExtensionRegexString(
+        STATIC_METADATA_IMAGES.twitter.extensions,
+        pageExtensions
+      )}
+        ${strictlyMatchExtensions ? '' : '$'}`
     ),
   ]
 
@@ -154,6 +136,14 @@ export function isStaticMetadataRoute(route: string) {
 export function isMetadataPage(pathname: string) {
   const res =
     !isAppRouteRoute(pathname) && isMetadataRouteFile(pathname, [], false)
+  if (pathname.endsWith('.png')) {
+    console.trace(
+      'res',
+      res,
+      pathname,
+      isMetadataRouteFile(pathname, [], false)
+    )
+  }
   return res
 }
 

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -59,48 +59,43 @@ export function isMetadataRouteFile(
       `^[\\\\/]robots${getExtensionRegexString(
         pageExtensions.concat('txt'),
         null
-      )}
-        ${strictlyMatchExtensions ? '' : '$'}`
+      )}${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
       `^[\\\\/]manifest${getExtensionRegexString(
         pageExtensions.concat('webmanifest', 'json'),
         null
-      )}
-        ${strictlyMatchExtensions ? '' : '$'}`
+      )}${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(`^[\\\\/]favicon\\.ico$`),
     new RegExp(
-      `[\\\\/]sitemap${getExtensionRegexString(['xml'], pageExtensions)}
-        ${strictlyMatchExtensions ? '' : '$'}`
+      `[\\\\/]sitemap${getExtensionRegexString(['xml'], pageExtensions)}${
+        strictlyMatchExtensions ? '' : '$'
+      }`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.icon.extensions,
         pageExtensions
-      )}
-        ${strictlyMatchExtensions ? '' : '$'}`
+      )}${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.apple.extensions,
         pageExtensions
-      )}
-        ${strictlyMatchExtensions ? '' : '$'}`
+      )}${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.openGraph.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.openGraph.extensions,
         pageExtensions
-      )}
-        ${strictlyMatchExtensions ? '' : '$'}`
+      )}${strictlyMatchExtensions ? '' : '$'}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}\\d?${getExtensionRegexString(
         STATIC_METADATA_IMAGES.twitter.extensions,
         pageExtensions
-      )}
-        ${strictlyMatchExtensions ? '' : '$'}`
+      )}${strictlyMatchExtensions ? '' : '$'}`
     ),
   ]
 

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -55,7 +55,7 @@ export function isMetadataRouteFile(
   strictlyMatchExtensions: boolean
 ) {
   // End with the extension or optional to have the extension
-  const trailingMatcher = strictlyMatchExtensions ? '$' : '?'
+  const trailingMatcher = (strictlyMatchExtensions ? '' : '?') + '$'
   const metadataRouteFilesRegex = [
     new RegExp(
       `^[\\\\/]robots${getExtensionRegexString(
@@ -129,10 +129,10 @@ export function isStaticMetadataRoute(route: string) {
 // The input is a page, which can be with or without page suffix /foo/page or /foo.
 // But it will not contain the /route suffix.
 export function isMetadataPage(pathname: string) {
-  const res =
+  const matched =
     !isAppRouteRoute(pathname) && isMetadataRouteFile(pathname, [], false)
 
-  return res
+  return matched
 }
 
 /*
@@ -147,5 +147,6 @@ export function isMetadataRoute(route: string): boolean {
 
   if (page[0] !== '/') page = '/' + page
 
-  return isAppRouteRoute(route) && isMetadataRouteFile(page, [], false)
+  const matched = isAppRouteRoute(route) && isMetadataRouteFile(page, [], false)
+  return matched
 }

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -27,7 +27,7 @@ export const STATIC_METADATA_IMAGES = {
 
 // Match routes that are metadata routes, e.g. /sitemap.xml, /favicon.<ext>, /<icon>.<ext>, etc.
 // TODO-METADATA: support more metadata routes with more extensions
-// const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
+export const DEFAULT_METADATA_ROUTE_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
 
 // Match the file extension with the dynamic multi-routes extensions
 // e.g. ([xml, js], null) -> can match `/sitemap.xml/route`, `sitemap.js/route`
@@ -56,6 +56,7 @@ export function isMetadataRouteFile(
 ) {
   // End with the extension or optional to have the extension
   const trailingMatcher = (strictlyMatchExtensions ? '' : '?') + '$'
+  const variantsOSubRoutesMatcher = '((\\/)?\\d)?'
   const metadataRouteFilesRegex = [
     new RegExp(
       `^[\\\\/]robots${getExtensionRegexString(
@@ -71,28 +72,28 @@ export function isMetadataRouteFile(
     ),
     new RegExp(`^[\\\\/]favicon\\.ico$`),
     new RegExp(
-      `[\\\\/]sitemap${getExtensionRegexString(['xml'], pageExtensions)}${trailingMatcher}`
+      `[\\\\/]sitemap(\\/\\d)?${getExtensionRegexString(['xml'], pageExtensions)}${trailingMatcher}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}\\d?${getExtensionRegexString(
+      `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}${variantsOSubRoutesMatcher}${getExtensionRegexString(
         STATIC_METADATA_IMAGES.icon.extensions,
         pageExtensions
       )}${trailingMatcher}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}\\d?${getExtensionRegexString(
+      `[\\\\/]${STATIC_METADATA_IMAGES.apple.filename}${variantsOSubRoutesMatcher}${getExtensionRegexString(
         STATIC_METADATA_IMAGES.apple.extensions,
         pageExtensions
       )}${trailingMatcher}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.openGraph.filename}\\d?${getExtensionRegexString(
+      `[\\\\/]${STATIC_METADATA_IMAGES.openGraph.filename}${variantsOSubRoutesMatcher}${getExtensionRegexString(
         STATIC_METADATA_IMAGES.openGraph.extensions,
         pageExtensions
       )}${trailingMatcher}`
     ),
     new RegExp(
-      `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}\\d?${getExtensionRegexString(
+      `[\\\\/]${STATIC_METADATA_IMAGES.twitter.filename}${variantsOSubRoutesMatcher}${getExtensionRegexString(
         STATIC_METADATA_IMAGES.twitter.extensions,
         pageExtensions
       )}${trailingMatcher}`
@@ -128,9 +129,8 @@ export function isStaticMetadataRoute(route: string) {
 
 // The input is a page, which can be with or without page suffix /foo/page or /foo.
 // But it will not contain the /route suffix.
-export function isMetadataPage(pathname: string) {
-  const matched =
-    !isAppRouteRoute(pathname) && isMetadataRouteFile(pathname, [], false)
+export function isMetadataPage(page: string) {
+  const matched = !isAppRouteRoute(page) && isMetadataRouteFile(page, [], false)
 
   return matched
 }
@@ -147,6 +147,9 @@ export function isMetadataRoute(route: string): boolean {
 
   if (page[0] !== '/') page = '/' + page
 
-  const matched = isAppRouteRoute(route) && isMetadataRouteFile(page, [], false)
+  const matched =
+    isAppRouteRoute(route) &&
+    isMetadataRouteFile(page, DEFAULT_METADATA_ROUTE_EXTENSIONS, false)
+
   return matched
 }

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -27,7 +27,7 @@ export const STATIC_METADATA_IMAGES = {
 
 // Match routes that are metadata routes, e.g. /sitemap.xml, /favicon.<ext>, /<icon>.<ext>, etc.
 // TODO-METADATA: support more metadata routes with more extensions
-const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
+// const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
 
 // Match the file extension with the dynamic multi-routes extensions
 // e.g. ([xml, js], null) -> can match `/sitemap.xml/route`, `sitemap.js/route`
@@ -149,19 +149,23 @@ export function isStaticMetadataRoute(route: string) {
   )
 }
 
+// The input is a page, which can be with or without page suffix /foo/page or /foo.
+// But it will not contain the /route suffix.
+export function isMetadataPage(pathname: string) {
+  return !isAppRouteRoute(pathname) && isMetadataRouteFile(pathname, [], true)
+}
+
 /*
  * Remove the 'app' prefix or '/route' suffix, only check the route name since they're only allowed in root app directory
  * e.g.
- * /app/robots -> /robots
- * app/robots -> /robots
- * /robots -> /robots
+ * /app/robots/route -> /robots
+ * app/robots/route -> /robots
+ * /robots/route -> /robots
  */
 export function isMetadataRoute(route: string): boolean {
-  let page = route.replace(/^\/?app\//, '').replace(/\/route$/, '')
+  let page = route.replace(/^\/?app\//, '').slice(0, -'/route'.length)
+
   if (page[0] !== '/') page = '/' + page
 
-  return (
-    !page.endsWith('/page') &&
-    isMetadataRouteFile(page, defaultExtensions, false)
-  )
+  return isAppRouteRoute(route) && isMetadataRouteFile(page, [], true)
 }

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -60,11 +60,11 @@ export function isMetadataRouteFile(
   // Match the optional variants like /opengraph-image2, /icon-a102f4.png, etc.
   const variantsMatcher = '\\d?'
   // Match the optional sub-routes like /sitemap/1.xml, /icon/1, etc.
-  const subRoutesMatcher = '(\\/\\w+)?'
+  // const subRoutesMatcher = '' // '(\\/\\w+)?'
   // The -\w{6} is the suffix that normalized from group routes;
   const groupSuffix = strictlyMatchExtensions ? '' : '(-\\w{6})?'
 
-  const suffixMatcher = `${variantsMatcher}${groupSuffix}${subRoutesMatcher}`
+  const suffixMatcher = `${variantsMatcher}${groupSuffix}`
 
   const metadataRouteFilesRegex = [
     new RegExp(
@@ -81,7 +81,7 @@ export function isMetadataRouteFile(
     ),
     new RegExp(`^[\\\\/]favicon\\.ico$`),
     new RegExp(
-      `[\\\\/]sitemap${subRoutesMatcher}${getExtensionRegexString(['xml'], pageExtensions)}${trailingMatcher}`
+      `[\\\\/]sitemap${getExtensionRegexString(['xml'], pageExtensions)}${trailingMatcher}`
     ),
     new RegExp(
       `[\\\\/]${STATIC_METADATA_IMAGES.icon.filename}${suffixMatcher}${getExtensionRegexString(

--- a/test/e2e/app-dir/metadata-route-like-pages/app/icon/error.tsx
+++ b/test/e2e/app-dir/metadata-route-like-pages/app/icon/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <p>Error</p>
+}

--- a/test/e2e/app-dir/metadata-route-like-pages/app/icon/page.tsx
+++ b/test/e2e/app-dir/metadata-route-like-pages/app/icon/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Icon</h1>
+}

--- a/test/e2e/app-dir/metadata-route-like-pages/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-route-like-pages/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/metadata-route-like-pages/app/sitemap/error.tsx
+++ b/test/e2e/app-dir/metadata-route-like-pages/app/sitemap/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <p>Error</p>
+}

--- a/test/e2e/app-dir/metadata-route-like-pages/app/sitemap/page.tsx
+++ b/test/e2e/app-dir/metadata-route-like-pages/app/sitemap/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Sitemap</h1>
+}

--- a/test/e2e/app-dir/metadata-route-like-pages/metadata-route-like-pages.test.ts
+++ b/test/e2e/app-dir/metadata-route-like-pages/metadata-route-like-pages.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox } from 'next-test-utils'
+
+describe('metadata-route-like-pages', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should able to visit sitemap page', async () => {
+    const browser = await next.browser('/sitemap')
+    await assertNoRedbox(browser)
+    expect(await browser.elementByCss('h1')).toBe('Sitemap')
+  })
+
+  it('should able to visit icon page', async () => {
+    const browser = await next.browser('/icon')
+    await assertNoRedbox(browser)
+    expect(await browser.elementByCss('h1')).toBe('Icon')
+  })
+})

--- a/test/e2e/app-dir/metadata-route-like-pages/metadata-route-like-pages.test.ts
+++ b/test/e2e/app-dir/metadata-route-like-pages/metadata-route-like-pages.test.ts
@@ -9,12 +9,12 @@ describe('metadata-route-like-pages', () => {
   it('should able to visit sitemap page', async () => {
     const browser = await next.browser('/sitemap')
     await assertNoRedbox(browser)
-    expect(await browser.elementByCss('h1')).toBe('Sitemap')
+    expect(await browser.elementByCss('h1').text()).toBe('Sitemap')
   })
 
   it('should able to visit icon page', async () => {
     const browser = await next.browser('/icon')
     await assertNoRedbox(browser)
-    expect(await browser.elementByCss('h1')).toBe('Icon')
+    expect(await browser.elementByCss('h1').text()).toBe('Icon')
   })
 })

--- a/test/e2e/app-dir/metadata-route-like-pages/next.config.js
+++ b/test/e2e/app-dir/metadata-route-like-pages/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What

- Fix the metadata route like pages rendering, e.g. `/sitemap/page.js` should still work properly rather than being treated as route
- Refactor metadata utils, should prefer using the file matcher rather than just checking the route or page path if possible to determine if it's metadata route

Previously the metadata regex didn't handle the route well. For example:

When it's not checking the end, `/opengraph-image-abc` can still be matched, but actually it's not a valid metadata route. This PR refines the route/file path regex matching for metadata entries and add more tests.

The underlayer helper - `isMetadataRouteFile`, you can use it to check if a file path is an metadata entry.
The helpers built on top of it:
- `isMetadataPage`: determine if a page path is metadata route, the input is more like a pathname.
- `isMetadataRoute`: determine if a route is metadata route, the input contains nextjs route suffix like `/route`.

We change the most of places to use `isMetadataRouteFile` if possible, since it's more accurate, especially when we check the static metadata routes, e.g. `/opengraph-image.png`, `/opengraph-image.js` will require the extension check and strict matching on file name convention.

Closes #77250 
Fixes #76747



