### PR TITLE
fix(CI): Re-enable retries for bundler integration tests

### DIFF
--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -22,7 +22,4 @@ jobs:
       integration_groups: 12
       e2e_timeout_minutes: 90
       integration_timeout_minutes: 90
-      # Don't retry, instead of the default of twice, many of these tests are
-      # currently failing, and it's wasteful to keep retrying them.
-      num_retries: 0
     secrets: inherit

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -22,7 +22,4 @@ jobs:
       integration_groups: 16
       e2e_timeout_minutes: 90
       integration_timeout_minutes: 90
-      # Don't retry, instead of the default of twice, many of these tests are
-      # currently failing, and it's wasteful to keep retrying them.
-      num_retries: 0
     secrets: inherit


### PR DESCRIPTION
These retries were breaking CI (too slow, causing timeouts) when most of these tests were failing, but now that most of the tests are passing, re-enable retries because many tests have some amount of flakiness.

- Development tests: https://github.com/vercel/next.js/actions/runs/13936223704
- Production build tests: https://github.com/vercel/next.js/actions/runs/13936225174

Closes PACK-4186