### PR TITLE
[dynamicIO] Model invalid dynamic on empty shells

### DIFF
--- a/errors/next-prerender-dynamic-viewport.mdx
+++ b/errors/next-prerender-dynamic-viewport.mdx
@@ -1,0 +1,109 @@
+---
+title: Cannot access Request information or uncached data in `generateViewport()`
+---
+
+## Why This Error Occurred
+
+When `dynamicIO` is enabled, Next.js requires that `generateViewport()` not depend on uncached data or Request data unless you explicitly opt into having a fully dynamic page. If you encountered this error, it means that `generateViewport` depends on one of these types of data and you have not specifically indicated that the affected route should be entirely dynamic.
+
+## Possible Ways to Fix It
+
+To fix this issue, you must first determine your goal for the affected route.
+
+Normally, the way you indicate to Next.js that you want to allow reading Request data or uncached external data is by performing this data access inside a component with an ancestor Suspense boundary. With Viewport, however, you aren't directly in control of wrapping the location where this metadata will be rendered, and even if you could wrap it in a Suspense boundary, it would not be correct to render it with a fallback. This is because this metadata is critical to properly loading resources such as images and must be part of the initial App Shell (the initial HTML containing the document head as well as the first paintable UI).
+
+### If you must access Request Data or your external data is uncacheable
+
+The only way to use Request data or uncacheable external data within `generateViewport` is to make this route entirely dynamic. While Next.js can operate in this mode, it does preclude future use of the prerendering capabilities of Next.js, so you should be certain this is necessary for your use case. To indicate the route should be entirely dynamic, you must add a Suspense boundary above where you render the document body.
+
+Before:
+
+```jsx filename="app/layout.tsx"
+import { cookies } from 'next/headers'
+
+export async function generateViewport() {
+  const cookieJar = await cookies()
+  return {
+    themeColor: cookieJar.get('theme-color'),
+  }
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+After:
+
+```jsx filename="app/layout.tsx"
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export async function generateViewport() {
+  const cookieJar = await cookies()
+  return {
+    themeColor: cookieJar.get('theme-color'),
+  }
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <Suspense>
+      <html>
+        <body>{children}</body>
+      </html>
+    </Suspense>
+  )
+}
+```
+
+### Caching External Data
+
+When external data is cached, Next.js can prerender with it, which ensures that the App Shell always has the complete viewport metadata available. Consider using `"use cache"` to mark the function producing the external data as cacheable.
+
+Before:
+
+```jsx filename="app/.../layout.tsx"
+import { db } from './db'
+
+export async function generateViewport() {
+  const { width, initialScale } = await db.query('viewport-size')
+  return {
+    width,
+    initialScale,
+  }
+}
+
+export default async function Layout({ children }) {
+  return ...
+}
+```
+
+After:
+
+```jsx filename="app/.../layout.tsx"
+import { db } from './db'
+
+export async function generateViewport() {
+  "use cache"
+  const { width, initialScale } = await db.query('viewport-size')
+  return {
+    width,
+    initialScale,
+  }
+}
+
+export default async function Layout({ children }) {
+  return ...
+}
+```
+
+## Useful Links
+
+- [`generateViewport()`](docs/app/api-reference/functions/generate-viewport)
+- [`cookies()`](docs/app/api-reference/functions/cookies)
+- [`"use cache"`](/docs/app/api-reference/directives/use-cache)

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -671,5 +671,7 @@
   "670": "Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to \"next start\".",
   "671": "Specified images.remotePatterns must have protocol \"http\" or \"https\" received \"%s\".",
   "672": "Expected `telemetry` to be set in globals",
-  "673": "Thrown value was ignored. This is a bug in Next.js."
+  "673": "Thrown value was ignored. This is a bug in Next.js.",
+  "674": "Route \"%s\" has a \\`generateViewport\\` that depends on Request data (\\`cookies()\\`, etc...) or uncached external data (\\`fetch(...)\\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
+  "675": "Expected `generateMetadata` not to block the application shell but it did."
 }

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -494,3 +494,17 @@ function createClosingStream(
     },
   })
 }
+
+export async function processPrelude(
+  unprocessedPrelude: ReadableStream<Uint8Array>
+) {
+  const [prelude, peek] = unprocessedPrelude.tee()
+
+  const reader = peek.getReader()
+  const firstResult = await reader.read()
+  reader.cancel()
+
+  const preludeIsEmpty = firstResult.done === true
+
+  return { prelude, preludeIsEmpty }
+}

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -42,6 +42,7 @@ import {
   OUTLET_BOUNDARY_NAME,
 } from '../../lib/metadata/metadata-constants'
 import { scheduleOnNextTick } from '../../lib/scheduler'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 const hasPostpone = typeof React.unstable_postpone === 'function'
 
@@ -73,16 +74,13 @@ export type DynamicTrackingState = {
 
   syncDynamicExpression: undefined | string
   syncDynamicErrorWithStack: null | Error
-  // Dev only
-  syncDynamicLogged?: boolean
 }
 
 // Stores dynamic reasons used during an SSR render.
 export type DynamicValidationState = {
-  hasSuspendedDynamic: boolean
+  hasSuspenseAboveBody: boolean
   hasDynamicMetadata: boolean
   hasDynamicViewport: boolean
-  hasSyncDynamicErrors: boolean
   dynamicErrors: Array<Error>
 }
 
@@ -99,10 +97,9 @@ export function createDynamicTrackingState(
 
 export function createDynamicValidationState(): DynamicValidationState {
   return {
-    hasSuspendedDynamic: false,
+    hasSuspenseAboveBody: false,
     hasDynamicMetadata: false,
     hasDynamicViewport: false,
-    hasSyncDynamicErrors: false,
     dynamicErrors: [],
   }
 }
@@ -333,11 +330,6 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
       if (dynamicTracking.syncDynamicErrorWithStack === null) {
         dynamicTracking.syncDynamicExpression = expression
         dynamicTracking.syncDynamicErrorWithStack = errorWithStack
-        if (prerenderStore.validating === true) {
-          // We always log Request Access in dev at the point of calling the function
-          // So we mark the dynamic validation as not requiring it to be printed
-          dynamicTracking.syncDynamicLogged = true
-        }
       }
     }
     abortOnSynchronousDynamicDataAccess(route, expression, prerenderStore)
@@ -605,6 +597,8 @@ export function useDynamicRouteParams(expression: string) {
 }
 
 const hasSuspenseRegex = /\n\s+at Suspense \(<anonymous>\)/
+const hasSuspenseAfterBodyOrHtmlRegex =
+  /\n\s+at (?:body|html) \(<anonymous>\)[\s\S]*?\n\s+at Suspense \(<anonymous>\)/
 const hasMetadataRegex = new RegExp(
   `\\n\\s+at ${METADATA_BOUNDARY_NAME}[\\n\\s]`
 )
@@ -616,9 +610,7 @@ const hasOutletRegex = new RegExp(`\\n\\s+at ${OUTLET_BOUNDARY_NAME}[\\n\\s]`)
 export function trackAllowedDynamicAccess(
   route: string,
   componentStack: string,
-  dynamicValidation: DynamicValidationState,
-  serverDynamic: DynamicTrackingState,
-  clientDynamic: DynamicTrackingState
+  dynamicValidation: DynamicValidationState
 ) {
   if (hasOutletRegex.test(componentStack)) {
     // We don't need to track that this is dynamic. It is only so when something else is also dynamic.
@@ -629,14 +621,14 @@ export function trackAllowedDynamicAccess(
   } else if (hasViewportRegex.test(componentStack)) {
     dynamicValidation.hasDynamicViewport = true
     return
-  } else if (hasSuspenseRegex.test(componentStack)) {
-    dynamicValidation.hasSuspendedDynamic = true
+  } else if (hasSuspenseAfterBodyOrHtmlRegex.test(componentStack)) {
+    // This prerender has a Suspense boundary above the body which
+    // effectively opts the page into allowing 100% dynamic rendering
+    dynamicValidation.hasSuspenseAboveBody = true
     return
-  } else if (
-    serverDynamic.syncDynamicErrorWithStack ||
-    clientDynamic.syncDynamicErrorWithStack
-  ) {
-    dynamicValidation.hasSyncDynamicErrors = true
+  } else if (hasSuspenseRegex.test(componentStack)) {
+    // this error had a Suspense boundary above it so we don't need to report it as a source
+    // of disallowed
     return
   } else {
     const message = `Route "${route}": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
@@ -655,39 +647,46 @@ function createErrorWithComponentStack(
   return error
 }
 
-export function throwIfDisallowedDynamic(
+export function throwIfDisallowedEmptyShell(
   route: string,
   dynamicValidation: DynamicValidationState,
   serverDynamic: DynamicTrackingState,
   clientDynamic: DynamicTrackingState
 ): void {
-  let syncError: null | Error
-  let syncExpression: undefined | string
-  let syncLogged: boolean
-  if (serverDynamic.syncDynamicErrorWithStack) {
-    syncError = serverDynamic.syncDynamicErrorWithStack
-    syncExpression = serverDynamic.syncDynamicExpression!
-    syncLogged = serverDynamic.syncDynamicLogged === true
-  } else if (clientDynamic.syncDynamicErrorWithStack) {
-    syncError = clientDynamic.syncDynamicErrorWithStack
-    syncExpression = clientDynamic.syncDynamicExpression!
-    syncLogged = clientDynamic.syncDynamicLogged === true
-  } else {
-    syncError = null
-    syncExpression = undefined
-    syncLogged = false
+  // TODO: Now that metadata is streaming we don't really need to check if it is blocking
+  // the root. We leave this here for now to ensure we've actually covered all our bases here
+  // but we can actually remove this in a future update
+  if (dynamicValidation.hasDynamicMetadata) {
+    throw new InvariantError(
+      'Expected `generateMetadata` not to block the application shell but it did.'
+    )
   }
 
-  if (dynamicValidation.hasSyncDynamicErrors && syncError) {
-    if (!syncLogged) {
-      // In dev we already log errors about sync dynamic access. But during builds we need to ensure
-      // the offending sync error is logged before we exit the build
-      console.error(syncError)
-    }
-    // The actual error should have been logged when the sync access ocurred
+  if (dynamicValidation.hasSuspenseAboveBody) {
+    // This route has opted into allowing fully dynamic rendering
+    // by including a Suspense boundary above the body. In this case
+    // a lack of a shell is not considered disallowed so we simply return
+    return
+  }
+
+  if (serverDynamic.syncDynamicErrorWithStack) {
+    // There is no shell and the server did something sync dynamic likely
+    // leading to an early termination of the prerender before the shell
+    // could be completed.
+    console.error(serverDynamic.syncDynamicErrorWithStack)
+    // We terminate the build/validating render
     throw new StaticGenBailoutError()
   }
 
+  if (clientDynamic.syncDynamicErrorWithStack) {
+    // Just like above but within the client render...
+    console.error(clientDynamic.syncDynamicErrorWithStack)
+    throw new StaticGenBailoutError()
+  }
+
+  // We didn't have any sync bailouts but there may be user code which
+  // blocked the root. We would have captured these during the prerender
+  // and can log them here and then terminate the build/validating render
   const dynamicErrors = dynamicValidation.dynamicErrors
   if (dynamicErrors.length) {
     for (let i = 0; i < dynamicErrors.length; i++) {
@@ -697,27 +696,13 @@ export function throwIfDisallowedDynamic(
     throw new StaticGenBailoutError()
   }
 
-  if (!dynamicValidation.hasSuspendedDynamic) {
-    if (dynamicValidation.hasDynamicMetadata) {
-      if (syncError) {
-        console.error(syncError)
-        throw new StaticGenBailoutError(
-          `Route "${route}" has a \`generateMetadata\` that could not finish rendering before ${syncExpression} was used. Follow the instructions in the error for this expression to resolve.`
-        )
-      }
-      throw new StaticGenBailoutError(
-        `Route "${route}" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or external data (\`fetch(...)\`, etc...) but the rest of the route was static or only used cached data (\`"use cache"\`). If you expected this route to be prerenderable update your \`generateMetadata\` to not use Request data and only use cached external data. Otherwise, add \`await connection()\` somewhere within this route to indicate explicitly it should not be prerendered.`
-      )
-    } else if (dynamicValidation.hasDynamicViewport) {
-      if (syncError) {
-        console.error(syncError)
-        throw new StaticGenBailoutError(
-          `Route "${route}" has a \`generateViewport\` that could not finish rendering before ${syncExpression} was used. Follow the instructions in the error for this expression to resolve.`
-        )
-      }
-      throw new StaticGenBailoutError(
-        `Route "${route}" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or external data (\`fetch(...)\`, etc...) but the rest of the route was static or only used cached data (\`"use cache"\`). If you expected this route to be prerenderable update your \`generateViewport\` to not use Request data and only use cached external data. Otherwise, add \`await connection()\` somewhere within this route to indicate explicitly it should not be prerendered.`
-      )
-    }
+  // If we got this far then the only other thing that could be blocking
+  // the root is dynamic Viewport. If this is dynamic then
+  // you need to opt into that by adding a Suspense boundary above the body
+  // to indicate your are ok with fully dynamic rendering.
+  if (dynamicValidation.hasDynamicViewport) {
+    throw new StaticGenBailoutError(
+      `Route "${route}" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport`
+    )
   }
 }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -117,12 +117,6 @@ export interface PrerenderStoreModern extends CommonWorkUnitStore {
    */
   prerenderResumeDataCache: PrerenderResumeDataCache | null
 
-  // DEV ONLY
-  // When used this flag informs certain APIs to skip logging because we're
-  // not part of the primary render path and are just prerendering to produce
-  // validation results
-  validating?: boolean
-
   /**
    * The HMR refresh hash is only provided in dev mode. It is needed for the dev
    * warmup render to ensure that the cache keys will be identical for the

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -69,18 +69,22 @@ function runTests(options: { withMinification: boolean }) {
         }
       })
 
-      it('should error the build if generateMetadata is dynamic', async () => {
+      // This test used to assert the opposite but now that metadata is streaming during prerenders
+      // we don't have to error the build when it is dynamic
+      it('should not error the build if generateMetadata is dynamic', async () => {
         try {
           await next.start()
         } catch {
-          // we expect the build to fail
+          throw new Error('expected build not to fail')
         }
-        const expectError = createExpectError(next.cliOutput)
 
-        expectError('Error occurred prerendering page "/"')
-        expectError(
-          'Error: Route "/" has a `generateMetadata` that depends on Request data (`cookies()`, etc...) or external data (`fetch(...)`, etc...) but the rest of the route was static or only used cached data (`"use cache"`). If you expected this route to be prerenderable update your `generateMetadata` to not use Request data and only use cached external data. Otherwise, add `await connection()` somewhere within this route to indicate explicitly it should not be prerendered.'
-        )
+        if (WITH_PPR) {
+          expect(next.cliOutput).toContain('◐ / ')
+        } else {
+          expect(next.cliOutput).toContain('ƒ / ')
+        }
+        const $ = await next.render$('/')
+        expect($('#sentinel').text()).toBe('sentinel')
       })
     })
     describe('Dynamic Metadata - Static Route With Suspense', () => {
@@ -110,18 +114,22 @@ function runTests(options: { withMinification: boolean }) {
         }
       })
 
-      it('should error the build if generateMetadata is dynamic', async () => {
+      // This test used to assert the opposite but now that metadata is streaming during prerenders
+      // we don't have to error the build when it is dynamic
+      it('should not error the build if generateMetadata is dynamic', async () => {
         try {
           await next.start()
         } catch {
-          // we expect the build to fail
+          throw new Error('expected build not to fail')
         }
-        const expectError = createExpectError(next.cliOutput)
 
-        expectError('Error occurred prerendering page "/"')
-        expectError(
-          'Error: Route "/" has a `generateMetadata` that depends on Request data (`cookies()`, etc...) or external data (`fetch(...)`, etc...) but the rest of the route was static or only used cached data (`"use cache"`). If you expected this route to be prerenderable update your `generateMetadata` to not use Request data and only use cached external data. Otherwise, add `await connection()` somewhere within this route to indicate explicitly it should not be prerendered.'
-        )
+        if (WITH_PPR) {
+          expect(next.cliOutput).toContain('◐ / ')
+        } else {
+          expect(next.cliOutput).toContain('ƒ / ')
+        }
+        const $ = await next.render$('/')
+        expect($('#sentinel').text()).toBe('sentinel')
       })
     })
 
@@ -209,7 +217,7 @@ function runTests(options: { withMinification: boolean }) {
 
         expectError('Error occurred prerendering page "/"')
         expectError(
-          'Error: Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or external data (`fetch(...)`, etc...) but the rest of the route was static or only used cached data (`"use cache"`). If you expected this route to be prerenderable update your `generateViewport` to not use Request data and only use cached external data. Otherwise, add `await connection()` somewhere within this route to indicate explicitly it should not be prerendered.'
+          'Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or uncached external data (`fetch(...)`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport'
         )
       })
     })
@@ -241,17 +249,18 @@ function runTests(options: { withMinification: boolean }) {
         }
       })
 
-      it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
+      it('should error the build if generateViewport is dynamic even if there are other uses of dynamic on the page', async () => {
         try {
           await next.start()
         } catch {
-          throw new Error('expected build not to fail for fully static project')
+          // we expect the build to fail
         }
+        const expectError = createExpectError(next.cliOutput)
 
-        expect(next.cliOutput).toContain('ƒ / ')
-        const $ = await next.render$('/')
-        expect($('#dynamic').text()).toBe('Dynamic')
-        expect($('[data-fallback]').length).toBe(0)
+        expectError('Error occurred prerendering page "/"')
+        expectError(
+          'Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or uncached external data (`fetch(...)`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport'
+        )
       })
     })
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-route/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-route/app/page.tsx
@@ -7,11 +7,13 @@ export default async function Page() {
   return (
     <>
       <p>
-        This page is static except for generateMetadata which does some IO. This
-        is a build error because metadata is not wrapped in a Suspense boundary.
-        We expect that if you intended for your metadata to be dynamic you will
-        ensure your page is dynamic too
+        This page is static except for metadata. Metadata can now be streamed in
+        so if PPR is enabled we expect that the visual content of this page will
+        be statically served and the metadata will be resumed dynamically. If
+        this project is not PPR then we expect this page to just render
+        dynamically.
       </p>
+      <span id="sentinel">sentinel</span>
     </>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/app/page.tsx
@@ -12,6 +12,7 @@ export default async function Page() {
         We expect that if you intended for your metadata to be dynamic you will
         ensure your page is dynamic too
       </p>
+      <span id="sentinel">sentinel</span>
     </>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-dynamic-route/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-dynamic-route/app/page.tsx
@@ -9,10 +9,12 @@ export default async function Page() {
   return (
     <>
       <p>
-        This page is static except for generateViewport which does some IO. This
-        is a build error because metadata is not wrapped in a Suspense boundary.
-        We expect that if you intended for your metadata to be dynamic you will
-        ensure your page is dynamic too
+        This page is dynamic and also has dynamic `generateViewport`. This is a
+        build error because anything dynamic must be wrapped in a Suspense
+        boundary. While you aren't directly in control of where viewport renders
+        it semantically renders as part of the page preamble and so you must put
+        a Suspense boundary around the root layout to opt into allowing dynamic
+        in generateViewport.
       </p>
       <Suspense fallback={<Fallback />}>
         <Dynamic />

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-static-route/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-static-route/app/page.tsx
@@ -7,10 +7,12 @@ export default async function Page() {
   return (
     <>
       <p>
-        This page is static except for generateViewport which does some IO. This
-        is a build error because metadata is not wrapped in a Suspense boundary.
-        We expect that if you intended for your metadata to be dynamic you will
-        ensure your page is dynamic too
+        This page is static except for `generateViewport`. This is a build error
+        because anything dynamic must be wrapped in a Suspense boundary. While
+        you aren't directly in control of where viewport renders it semantically
+        renders as part of the page preamble and so you must put a Suspense
+        boundary around the root layout to opt into allowing dynamic in
+        generateViewport.
       </p>
     </>
   )

--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/layout.tsx
@@ -1,11 +1,15 @@
+import { Suspense } from 'react'
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
+    <Suspense>
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </Suspense>
   )
 }


### PR DESCRIPTION
Dynamic is disallowed unless a Suspense boundary is above it. This now applies to metadaata (though this shouldn't matter because it now streams) and viewport. To allow for fully dynamic routes including viewport you must put a Suspense boundary around your root layout.