### PR TITLE
Fix type definitions for MDX plugins

### DIFF
--- a/packages/next-mdx/index.d.ts
+++ b/packages/next-mdx/index.d.ts
@@ -1,10 +1,27 @@
+import type { Program } from 'estree'
+import type * as hast from 'hast'
+import type * as mdast from 'mdast'
 import type { NextConfig } from 'next'
 import type { Options } from '@mdx-js/loader'
+import type { Plugin } from 'unified'
+import type * as unist from 'unist'
 import type { RuleSetConditionAbsolute } from 'webpack'
 
 type WithMDX = (config: NextConfig) => NextConfig
 
 declare namespace nextMDX {
+  type Pluggable<Node extends unist.Node> =
+    | Plugin<any[], Node>
+    | [Plugin<any[], Node>, ...any[]]
+    | [string, ...any[]]
+
+  interface MDXOptions
+    extends Omit<Options, 'recmaPlugins' | 'rehypePlugins' | 'remarkPlugins'> {
+    recmaPlugins: Pluggable<Program>[]
+    rehypePlugins: Pluggable<hast.Root>[]
+    remarkPlugins: Pluggable<mdast.Root>[]
+  }
+
   interface NextMDXOptions {
     /**
      * A webpack rule test to match files to treat as MDX.
@@ -21,7 +38,7 @@ declare namespace nextMDX {
      *
      * @see https://mdxjs.com/packages/mdx/#api
      */
-    options?: Options
+    options?: MDXOptions
   }
 }
 


### PR DESCRIPTION
### What?

This changes that by allowing a string whose first member is a string. It’s also more strict about the plugin types that may be passed in. This prevents users from accidentally passing a remark plugin into `rehypePlugins`, etc.

Ideally `@next/mdx` should define types dependencies in `package.json`, but for now I refrained from doing so as some more types dependencies are missing.

### Why?

`@next/mdx` allows users to pass an array as a plugin where the first member is a string referencing the plugin. This is not allowed by the MDX options.

### How?

I tested this against a small Next.js project.