### PR TITLE
Fix typo in docs/index.mdx

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -50,7 +50,7 @@ To get the most out of our docs, it's recommended that you have a basic understa
 
 ## Accessibility
 
-For optimal accessibility when using a screen reader while reading the docs, we recommend using Firefox and NVDA, or Safari and VoiceOver.
+For optimal accessibility when using a screen reader while reading the docs, we recommend using Firefox and NVIDIA, or Safari and VoiceOver.
 
 ## Join our Community
 


### PR DESCRIPTION
This fixes the typo of the ```NVIDIA``` which was previously written as ```NVDA```