### PR TITLE
fix(CI build_and_deploy): Use a larger fetch-depth for build-native job

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -297,6 +297,10 @@ jobs:
       # we use checkout here instead of the build cache since
       # it can fail to restore in different OS'
       - uses: actions/checkout@v4
+        with:
+          # crates/napi/build.rs uses git-describe to find the most recent git tag. It's okay if
+          # this fails, but fetch with enough depth that we're likely to find a recent tag.
+          fetch-depth: 100
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -351,7 +351,17 @@ jobs:
 
       - name: Build in docker
         if: ${{ matrix.settings.docker && steps.build-exists.outputs.BUILD_EXISTS == 'no' }}
-        run: docker run -v "/var/run/docker.sock":"/var/run/docker.sock" -e RUST_BACKTRACE -e NAPI_CLI_VERSION -e CARGO_TERM_COLOR -e CARGO_INCREMENTAL -e CARGO_PROFILE_RELEASE_LTO -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL -e TURBO_API -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE="remote:rw" -v ${{ env.HOME }}/.cargo/git:/root/.cargo/git -v ${{ env.HOME }}/.cargo/registry:/root/.cargo/registry -v ${{ github.workspace }}:/build -w /build --entrypoint=bash ${{ matrix.settings.docker }} -c "${{ matrix.settings.build }}"
+        run: |
+          docker run -v "/var/run/docker.sock":"/var/run/docker.sock" \
+            -e CI -e RUST_BACKTRACE -e NAPI_CLI_VERSION -e CARGO_TERM_COLOR -e CARGO_INCREMENTAL \
+            -e CARGO_PROFILE_RELEASE_LTO -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL -e TURBO_API \
+            -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE="remote:rw" \
+            -v ${{ env.HOME }}/.cargo/git:/root/.cargo/git \
+            -v ${{ env.HOME }}/.cargo/registry:/root/.cargo/registry \
+            -v ${{ github.workspace }}:/build \
+            -w /build \
+            --entrypoint=bash ${{ matrix.settings.docker }} \
+            -c "${{ matrix.settings.build }}"
 
       - name: cache build
         if: ${{ matrix.settings.docker && steps.build-exists.outputs.BUILD_EXISTS == 'no' }}


### PR DESCRIPTION
If not supplied, this defaults to a fetch-depth of 1, which likely explains some of the tagless version strings I've seen...

Use a fetch-depth of 100 so that we're always likely to find a previous tag.

Closes PACK-4193