### PR TITLE
fix(CI build_and_deploy): Pass `CI` environment variable through for docker builds

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -351,7 +351,17 @@ jobs:
 
       - name: Build in docker
         if: ${{ matrix.settings.docker && steps.build-exists.outputs.BUILD_EXISTS == 'no' }}
-        run: docker run -v "/var/run/docker.sock":"/var/run/docker.sock" -e RUST_BACKTRACE -e NAPI_CLI_VERSION -e CARGO_TERM_COLOR -e CARGO_INCREMENTAL -e CARGO_PROFILE_RELEASE_LTO -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL -e TURBO_API -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE="remote:rw" -v ${{ env.HOME }}/.cargo/git:/root/.cargo/git -v ${{ env.HOME }}/.cargo/registry:/root/.cargo/registry -v ${{ github.workspace }}:/build -w /build --entrypoint=bash ${{ matrix.settings.docker }} -c "${{ matrix.settings.build }}"
+        run: |
+          docker run -v "/var/run/docker.sock":"/var/run/docker.sock" \
+            -e CI -e RUST_BACKTRACE -e NAPI_CLI_VERSION -e CARGO_TERM_COLOR -e CARGO_INCREMENTAL \
+            -e CARGO_PROFILE_RELEASE_LTO -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL -e TURBO_API \
+            -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE="remote:rw" \
+            -v ${{ env.HOME }}/.cargo/git:/root/.cargo/git \
+            -v ${{ env.HOME }}/.cargo/registry:/root/.cargo/registry \
+            -v ${{ github.workspace }}:/build \
+            -w /build \
+            --entrypoint=bash ${{ matrix.settings.docker }} \
+            -c "${{ matrix.settings.build }}"
 
       - name: cache build
         if: ${{ matrix.settings.docker && steps.build-exists.outputs.BUILD_EXISTS == 'no' }}


### PR DESCRIPTION
We use the `CI` environment variable to override turbopack's "dirty" state: https://github.com/vercel/next.js/blob/ed10f7ed0246fcc763194197eb9beebcbd063162/crates/napi/src/next_api/utils.rs#L138-L139

More discussion here: 🧵 https://vercel.slack.com/archives/C03EWR7LGEN/p1742223536560419?thread_ts=1742223415.894359&cid=C03EWR7LGEN

Here's a `build_and_deploy` CI job running on this branch: https://github.com/vercel/next.js/actions/runs/13961735504/job/39084197470

Closes PACK-4191