### PR TITLE
[dev-overlay] Remove unused fields from hydration error state

### DIFF
--- a/packages/next/src/client/components/errors/hydration-error-info.ts
+++ b/packages/next/src/client/components/errors/hydration-error-info.ts
@@ -6,7 +6,6 @@ import {
 export type HydrationErrorState = {
   // Hydration warning template format: <message> <serverContent> <clientContent>
   warning?: [string, string, string]
-  componentStack?: string
   serverContent?: string
   clientContent?: string
   // React 19 hydration diff format: <notes> <link> <component diff?>

--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -515,8 +515,7 @@ export default function HotReload({
         | HydrationErrorState
         | undefined
       // Component stack is added to the error in use-error-handler in case there was a hydration error
-      const componentStackTrace =
-        (error as any)._componentStack || errorDetails?.componentStack
+      const componentStackTrace = (error as any)._componentStack
       const warning = errorDetails?.warning
 
       dispatch({

--- a/packages/next/src/client/components/react-dev-overlay/pages/client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/client.ts
@@ -1,10 +1,7 @@
 import * as Bus from './bus'
 import { parseStack } from '../utils/parse-stack'
 import { parseComponentStack } from '../utils/parse-component-stack'
-import {
-  hydrationErrorState,
-  storeHydrationErrorStateFromConsoleArgs,
-} from '../../errors/hydration-error-info'
+import { storeHydrationErrorStateFromConsoleArgs } from '../../errors/hydration-error-info'
 import {
   ACTION_BEFORE_REFRESH,
   ACTION_BUILD_ERROR,
@@ -30,8 +27,7 @@ function handleError(error: unknown) {
 
   attachHydrationErrorState(error)
 
-  const componentStackTrace =
-    (error as any)._componentStack || hydrationErrorState.componentStack
+  const componentStackTrace = (error as any)._componentStack
   const componentStackFrames =
     typeof componentStackTrace === 'string'
       ? parseComponentStack(componentStackTrace)


### PR DESCRIPTION
Can't see what's supposed to write to this field.