### PR TITLE
[metadata] remove dead code of metadata routes handling

### DIFF
--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -18,6 +18,17 @@ describe('getExtensionRegexString', () => {
       expect(regex.test('.ts')).toBe(true)
       expect(regex.test('.js')).toBe(false)
     })
+
+    it('should not handle js extensions with empty dynamic extensions', () => {
+      const regex = createExtensionMatchRegex(['png', 'jpg'], [])
+      expect(regex.test('.png')).toBe(true)
+      expect(regex.test('.jpg')).toBe(true)
+      expect(regex.test('.webp')).toBe(false)
+
+      expect(regex.test('.ts')).toBe(false)
+      expect(regex.test('.tsx')).toBe(false)
+      expect(regex.test('.js')).toBe(false)
+    })
   })
 
   describe('without dynamic extensions', () => {

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -18,17 +18,6 @@ describe('getExtensionRegexString', () => {
       expect(regex.test('.ts')).toBe(true)
       expect(regex.test('.js')).toBe(false)
     })
-
-    it('should match dynamic multi-routes with dynamic extensions', () => {
-      const regex = createExtensionMatchRegex(['png'], ['ts'])
-      expect(regex.test('.png')).toBe(true)
-      expect(regex.test('[].png')).toBe(false)
-
-      expect(regex.test('.ts')).toBe(true)
-      expect(regex.test('[].ts')).toBe(true)
-      expect(regex.test('.tsx')).toBe(false)
-      expect(regex.test('[].tsx')).toBe(false)
-    })
   })
 
   describe('without dynamic extensions', () => {

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -29,6 +29,17 @@ describe('getExtensionRegexString', () => {
       expect(regex.test('.tsx')).toBe(false)
       expect(regex.test('.js')).toBe(false)
     })
+
+    it('should not handle js extensions with passing null for dynamic extensions', () => {
+      const regex = createExtensionMatchRegex(['png', 'jpg'], null)
+      expect(regex.test('.png')).toBe(true)
+      expect(regex.test('.jpg')).toBe(true)
+      expect(regex.test('.webp')).toBe(false)
+
+      expect(regex.test('.ts')).toBe(false)
+      expect(regex.test('.tsx')).toBe(false)
+      expect(regex.test('.js')).toBe(false)
+    })
   })
 
   describe('without dynamic extensions', () => {

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -31,13 +31,13 @@ const defaultExtensions = ['js', 'jsx', 'ts', 'tsx']
 
 // Match the file extension with the dynamic multi-routes extensions
 // e.g. ([xml, js], null) -> can match `/sitemap.xml/route`, `sitemap.js/route`
-// e.g. ([png], [ts]) -> can match `/opengrapg-image.png/route`, `/opengraph-image.ts[]/route`
+// e.g. ([png], [ts]) -> can match `/opengrapg-image.png`, `/opengraph-image.ts`
 export const getExtensionRegexString = (
   staticExtensions: readonly string[],
   dynamicExtensions: readonly string[] | null
 ) => {
   // If there's no possible multi dynamic routes, will not match any <name>[].<ext> files
-  if (!dynamicExtensions) {
+  if (!dynamicExtensions || dynamicExtensions.length === 0) {
     return `\\.(?:${staticExtensions.join('|')})`
   }
   return `(?:\\.(${staticExtensions.join('|')})|((\\[\\])?\\.(${dynamicExtensions.join('|')})))`


### PR DESCRIPTION
### What

- `[].[ext]` was temporary convention invented in a PR but we never decided to go that way. Remove the tests for it
- `dynamicExtensions` can be either empty array or null, for both case it can skip adding the regex for it. This just saves some bytes for generated regex. Also added some test