### PR TITLE
fix: Update `swc_core` and use `rayon` instead of `chili`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,12 +1104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
-name = "chili"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72f874459a658df39dd1d99f7f62a9c421792efc26eaae8d497ae5d2e816a62"
-
-[[package]]
 name = "chromiumoxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7205,9 +7199,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "16.6.2"
+version = "16.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176ed65e403fb5fa1be022686e7fff1e85d0d2a23e03a3bb744376d186fca90c"
+checksum = "53aab44edf803a2aa9524d621c55ec763ff634b45ed24b9bd3fc0a69348b17fc"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7688,9 +7682,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "12.1.2"
+version = "12.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7e71138f0a48813a57cce10fb28ac55fecb7bb70c492f56e3517a1bb039f35"
+checksum = "ecb9f5964120e890a88ec048f049fe1f5e525d54aa394b50de2fcf2fd9bbb228"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -8227,11 +8221,10 @@ dependencies = [
 
 [[package]]
 name = "swc_parallel"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f75f1094d69174ef628e3665fff0f81d58e9f568802e3c90d332c72b0b6026"
+checksum = "8f16052d5123ec45c1c49100781363f3f4e4a6be2da6d82f473b79db1e3abeb8"
 dependencies = [
- "chili",
  "once_cell",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7200,9 +7200,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "16.8.0"
+version = "16.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53aab44edf803a2aa9524d621c55ec763ff634b45ed24b9bd3fc0a69348b17fc"
+checksum = "713c3ffe5b2378ee62315875422840943e15fb956f5a7c24e04fd0bc1d4fe141"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7683,9 +7683,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "12.2.0"
+version = "12.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb9f5964120e890a88ec048f049fe1f5e525d54aa394b50de2fcf2fd9bbb228"
+checksum = "a7866d3eea5cfafe9fc730f5d3bf1eba60d5d63e4823ec83dd15acfcce21cc8d"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -8053,9 +8053,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "12.0.1"
+version = "12.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384c49a5891a06857543370518bd37e1e27727e3174e439dc662b79333d6a652"
+checksum = "8af89be14ef84b16529f89a70972c7f85b0e9e2599ea09d9f7c3e5b186b8f225"
 dependencies = [
  "indexmap 2.7.1",
  "rustc-hash 2.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,6 +4586,7 @@ dependencies = [
  "serde_json",
  "supports-hyperlinks",
  "swc_core",
+ "swc_parallel",
  "terminal_hyperlink",
  "tokio",
  "tracing",
@@ -8226,6 +8227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f16052d5123ec45c1c49100781363f3f4e4a6be2da6d82f473b79db1e3abeb8"
 dependencies = [
  "once_cell",
+ "rayon",
 ]
 
 [[package]]
@@ -9744,6 +9746,7 @@ dependencies = [
  "sourcemap",
  "strsim 0.11.1",
  "swc_core",
+ "swc_parallel",
  "tokio",
  "tracing",
  "turbo-rcstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "16.8.0", features = [
+swc_core = { version = "16.9.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,6 +300,7 @@ swc_core = { version = "16.8.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
+swc_parallel = { version = "1.3.0", default-features = false, features = ["rayon"] }
 testing = { version = "8.0.0" }
 
 # Keep consistent with preset_env_base through swc_core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "16.6.2", features = [
+swc_core = { version = "16.8.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -97,6 +97,7 @@ swc_core = { workspace = true, features = [
     "ecma_utils",
     "ecma_visit",
 ] }
+swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }
 
 # Dependencies for the native, non-wasm32 build.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -71,6 +71,7 @@ swc_core = { workspace = true, features = [
   "testing",
   "base",
 ] }
+swc_parallel = { workspace = true, default-features = false, features = ["rayon"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }


### PR DESCRIPTION
### What?

Use `rayon` for parallelism

### Why?

`chili` seems to have some bugs regarding the CPU usage of heartbeat thread in idle mode.

### How?

 - Closes https://github.com/vercel/next.js/issues/77192
 - Closes SWC-630
 


Closes PACK-4197