### PR TITLE
fix(docs): update playwright discord invite

### DIFF
--- a/docs/01-app/03-building-your-application/08-testing/03-playwright.mdx
+++ b/docs/01-app/03-building-your-application/08-testing/03-playwright.mdx
@@ -127,4 +127,4 @@ You can learn more about Playwright and Continuous Integration from these resour
 
 - [Next.js with Playwright example](https://github.com/vercel/next.js/tree/canary/examples/with-playwright)
 - [Playwright on your CI provider](https://playwright.dev/docs/ci)
-- [Playwright Discord](https://discord.com/invite/playwright-807756831384403968)
+- [Playwright Discord](https://discord.gg/invite/playwright)


### PR DESCRIPTION
### What?

Replace expired playwright discord invite link with invite permalink

### Why?

To never worry about it again