### PR TITLE
only log when instrumentation client takes too long

### DIFF
--- a/packages/next/src/lib/require-instrumentation-client.ts
+++ b/packages/next/src/lib/require-instrumentation-client.ts
@@ -6,12 +6,27 @@
  */
 if (process.env.__NEXT_EXPERIMENTAL_CLIENT_INSTRUMENTATION_HOOK) {
   if (process.env.NODE_ENV === 'development') {
+    const measureName = 'Client Instrumentation Hook'
     const startTime = performance.now()
     require('private-next-instrumentation-client')
     const endTime = performance.now()
-    console.log(
-      `[Client Instrumentation Hook] executed in ${(endTime - startTime).toFixed(0)}ms (Note: Code download overhead is not included in this measurement)`
-    )
+
+    const duration = endTime - startTime
+    performance.measure(measureName, {
+      start: startTime,
+      end: endTime,
+      detail: 'Client instrumentation initialization',
+    })
+
+    // Using 16ms threshold as it represents one frame (1000ms/60fps)
+    // This helps identify if the instrumentation hook initialization
+    // could potentially cause frame drops during development.
+    const THRESHOLD = 16
+    if (duration > THRESHOLD) {
+      console.log(
+        `[${measureName}] Slow execution detected: ${duration.toFixed(0)}ms (Note: Code download overhead is not included in this measurement)`
+      )
+    }
   } else {
     require('private-next-instrumentation-client')
   }

--- a/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
+++ b/test/e2e/instrumentation-client-hook/app-router/instrumentation-client.ts
@@ -1,1 +1,6 @@
 ;(window as any).__INSTRUMENTATION_CLIENT_EXECUTED_AT = performance.now()
+
+const start = performance.now()
+while (performance.now() - start < 20) {
+  // Intentionally block for 20ms to test instrumentation timing
+}

--- a/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+++ b/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
@@ -7,18 +7,21 @@ describe('Instrumentation Client Hook', () => {
     {
       name: 'With src folder',
       appDir: 'app-with-src',
+      shouldLog: false,
     },
     {
       name: 'App Router',
       appDir: 'app-router',
+      shouldLog: true,
     },
     {
       name: 'Pages Router',
       appDir: 'pages-router',
+      shouldLog: false,
     },
   ]
 
-  testCases.forEach(({ name, appDir }) => {
+  testCases.forEach(({ name, appDir, shouldLog }) => {
     describe(name, () => {
       const { next, isNextDev } = nextTestSetup({
         files: path.join(__dirname, appDir),
@@ -37,9 +40,11 @@ describe('Instrumentation Client Hook', () => {
         expect(instrumentationTime).toBeLessThan(hydrationTime)
         expect(
           (await browser.log()).some((log) =>
-            log.message.startsWith('[Client Instrumentation Hook]')
+            log.message.startsWith(
+              '[Client Instrumentation Hook] Slow execution detected'
+            )
           )
-        ).toBe(isNextDev)
+        ).toBe(isNextDev && shouldLog)
       })
     })
   })


### PR DESCRIPTION
Only log when the sync code inside instrumentation client takes more than 16ms, instead of logging every single time.