### PR TITLE
refactor(turbo-tasks): Make TraceRawVcs a supertrait of TaskInput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9711,6 +9711,7 @@ dependencies = [
  "tracing",
  "turbo-rcstr",
  "turbo-tasks",
+ "turbo-tasks-backend",
  "turbo-tasks-build",
  "turbo-tasks-bytes",
  "turbo-tasks-fs",

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt, ValueToString,
-    Vc,
+    trace::TraceRawVcs, FxIndexSet, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt,
+    TryJoinIterExt, ValueToString, Vc,
 };
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
@@ -30,7 +30,7 @@ use crate::{
     util::NextRuntime,
 };
 
-#[derive(TaskInput, Clone, Hash, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(TaskInput, Clone, Hash, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 pub struct ClientReferenceManifestOptions {
     pub node_root: Vc<FileSystemPath>,
     pub client_relative_path: Vc<FileSystemPath>,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -40,7 +40,9 @@ use crate::{
 
 const NEXT_TEMPLATE_PATH: &str = "dist/esm/build/templates";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TaskInput, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, TaskInput, Serialize, Deserialize, TraceRawVcs,
+)]
 pub enum PathType {
     PagesPage,
     PagesApi,

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
@@ -4,12 +4,12 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{Completion, ReadRef, TaskInput, Vc};
+use turbo_tasks::{trace::TraceRawVcs, Completion, ReadRef, TaskInput, Vc};
 use turbo_tasks_testing::{register, run, Registration};
 
 static REGISTRATION: Registration = register!();
 
-#[derive(Clone, TaskInput, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, TaskInput, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TraceRawVcs)]
 struct OneUnnamedField(u32);
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-testing/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/detached.rs
@@ -6,7 +6,11 @@ use tokio::{
     sync::{watch, Notify},
     time::{sleep, timeout, Duration},
 };
-use turbo_tasks::{turbo_tasks, State, TransientInstance, Vc};
+use turbo_tasks::{
+    prevent_gc,
+    trace::{TraceRawVcs, TraceRawVcsContext},
+    turbo_tasks, State, TransientInstance, Vc,
+};
 use turbo_tasks_testing::{register, run, Registration};
 
 static REGISTRATION: Registration = register!();
@@ -14,11 +18,14 @@ static REGISTRATION: Registration = register!();
 #[tokio::test]
 async fn test_spawns_detached() -> anyhow::Result<()> {
     run(&REGISTRATION, || async {
+        // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`, just
+        // disable GC for the test so this can't cause any problems.
+        prevent_gc();
         // timeout: prevent the test from hanging, and fail instead if this is broken
         timeout(Duration::from_secs(5), async {
-            let notify = TransientInstance::new(Notify::new());
+            let notify = TransientInstance::new(NotifyTaskInput(Notify::new()));
             let (tx, mut rx) = watch::channel(None);
-            let tx = TransientInstance::new(tx);
+            let tx = TransientInstance::new(WatchSenderTaskInput(tx));
 
             // create the task
             let out_vc = spawns_detached(notify.clone(), tx.clone());
@@ -29,7 +36,7 @@ async fn test_spawns_detached() -> anyhow::Result<()> {
                 .expect_err("should wait on the detached task");
 
             // let the detached future exit
-            notify.notify_waiters();
+            notify.0.notify_waiters();
 
             // it should send us back a cell
             let detached_vc: Vc<u32> = rx.wait_for(|opt| opt.is_some()).await?.unwrap();
@@ -45,16 +52,31 @@ async fn test_spawns_detached() -> anyhow::Result<()> {
     .await
 }
 
+#[derive(TraceRawVcs)]
+struct NotifyTaskInput(
+    // trace_ignore: `notify` doesn't store any data
+    #[turbo_tasks(trace_ignore)] Notify,
+);
+
+struct WatchSenderTaskInput<T>(watch::Sender<T>);
+
+impl<T: TraceRawVcs> TraceRawVcs for WatchSenderTaskInput<T> {
+    fn trace_raw_vcs(&self, _trace_context: &mut TraceRawVcsContext) {
+        // HACK: This implementation is wrong (the channel contains a `Vc`), but we can't access it.
+        // Instead we just `prevent_gc` in the tests.
+    }
+}
+
 #[turbo_tasks::function]
 async fn spawns_detached(
-    notify: TransientInstance<Notify>,
-    sender: TransientInstance<watch::Sender<Option<Vc<u32>>>>,
+    notify: TransientInstance<NotifyTaskInput>,
+    sender: TransientInstance<WatchSenderTaskInput<Option<Vc<u32>>>>,
 ) -> Vc<()> {
     tokio::spawn(turbo_tasks().detached_for_testing(Box::pin(async move {
-        notify.notified().await;
+        notify.0.notified().await;
         // creating cells after the normal lifetime of the task should be okay, as the parent task
         // is waiting on us before exiting!
-        sender.send(Some(Vc::cell(42))).unwrap();
+        sender.0.send(Some(Vc::cell(42))).unwrap();
         Ok(())
     })));
     Vc::cell(())
@@ -63,10 +85,12 @@ async fn spawns_detached(
 #[tokio::test]
 async fn test_spawns_detached_changing() -> anyhow::Result<()> {
     run(&REGISTRATION, || async {
+        // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`
+        prevent_gc();
         // timeout: prevent the test from hanging, and fail instead if this is broken
         timeout(Duration::from_secs(5), async {
             let (tx, mut rx) = watch::channel(None);
-            let tx = TransientInstance::new(tx);
+            let tx = TransientInstance::new(WatchSenderTaskInput(tx));
 
             // state that's read by the detached future
             let changing_input_detached = ChangingInput {
@@ -113,7 +137,7 @@ struct ChangingInput {
 
 #[turbo_tasks::function]
 async fn spawns_detached_changing(
-    sender: TransientInstance<watch::Sender<Option<Vc<u32>>>>,
+    sender: TransientInstance<WatchSenderTaskInput<Option<Vc<u32>>>>,
     changing_input_detached: Vc<ChangingInput>,
     changing_input_outer: Vc<ChangingInput>,
 ) -> Vc<u32> {
@@ -126,6 +150,7 @@ async fn spawns_detached_changing(
             // creating cells after the normal lifetime of the task should be okay, as the parent
             // task is waiting on us before exiting!
             sender
+                .0
                 .send(Some(Vc::cell(
                     *read_changing_input(changing_input_detached).await.unwrap(),
                 )))

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -7,7 +7,11 @@ use std::{
 
 use serde::{de::Visitor, Deserialize, Serialize};
 
-use crate::{registry, TaskPersistence};
+use crate::{
+    registry,
+    trace::{TraceRawVcs, TraceRawVcsContext},
+    TaskPersistence,
+};
 
 macro_rules! define_id {
     (
@@ -68,6 +72,10 @@ macro_rules! define_id {
             fn try_from(id: NonZeroU64) -> Result<Self, Self::Error> {
                 Ok(Self { id: NonZero::try_from(id)? })
             }
+        }
+
+        impl TraceRawVcs for $name {
+            fn trace_raw_vcs(&self, _trace_context: &mut TraceRawVcsContext) {}
         }
     };
 }

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -43,6 +43,7 @@ macro_rules! impl_auto_marker_trait {
             ::serde_json::Value, ::serde_json::Map<String, ::serde_json::Value>
         );
 
+        $crate::marker_trait::impl_marker_trait_fn_ptr!($trait: E D C B A Z Y X W V U T);
         $crate::marker_trait::impl_marker_trait_tuple!($trait: E D C B A Z Y X W V U T);
 
         unsafe impl<T: $trait> $trait for ::std::option::Option<T> {}
@@ -101,6 +102,24 @@ macro_rules! impl_marker_trait {
     }
 }
 
+/// Create an implementation for every possible `fn` pointer type, regardless of the type of the
+/// arguments and return type.
+///
+/// This is typically valid for marker traits as `fn` pointer types (not the `Fn` trait) do not
+/// contain any data, they are compile-time pointers to static code.
+macro_rules! impl_marker_trait_fn_ptr {
+    ($trait:ident: $T:ident) => {
+        $crate::marker_trait::impl_marker_trait_fn_ptr!(@impl $trait: $T);
+    };
+    ($trait:ident: $T:ident $( $U:ident )+) => {
+        $crate::marker_trait::impl_marker_trait_fn_ptr!($trait: $( $U )+);
+        $crate::marker_trait::impl_marker_trait_fn_ptr!(@impl $trait: $T $( $U )+);
+    };
+    (@impl $trait:ident: $( $T:ident )+) => {
+        unsafe impl<$($T,)+ Return> $trait for fn($($T),+) -> Return {}
+    };
+}
+
 /// Create an implementation for every possible tuple where every element implements `$trait`.
 ///
 /// Must be passed a sequence of identifier fo the tuple's generic parameters. This will only
@@ -122,4 +141,5 @@ macro_rules! impl_marker_trait_tuple {
 
 pub(crate) use impl_auto_marker_trait;
 pub(crate) use impl_marker_trait;
+pub(crate) use impl_marker_trait_fn_ptr;
 pub(crate) use impl_marker_trait_tuple;

--- a/turbopack/crates/turbo-tasks/src/trace.rs
+++ b/turbopack/crates/turbo-tasks/src/trace.rs
@@ -107,6 +107,25 @@ macro_rules! impl_trace_tuple {
 
 impl_trace_tuple!(E D C B A Z Y X W V U T);
 
+/// Function pointers (the lowercase `fn` type, not `Fn`) don't contain any data, so it's not
+/// possible for them to contain a `Vc`.
+macro_rules! impl_trace_fn_ptr {
+    ($T:ident) => {
+        impl_trace_fn_ptr!(@impl $T);
+    };
+    ($T:ident $( $U:ident )+) => {
+        impl_trace_fn_ptr!($( $U )+);
+        impl_trace_fn_ptr!(@impl $T $( $U )+);
+    };
+    (@impl $( $T:ident )+) => {
+        impl<$($T,)+ Return> TraceRawVcs for fn($($T),+) -> Return {
+            fn trace_raw_vcs(&self, _trace_context: &mut TraceRawVcsContext) {}
+        }
+    };
+}
+
+impl_trace_fn_ptr!(E D C B A Z Y X W V U T);
+
 impl<T: TraceRawVcs> TraceRawVcs for Option<T> {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         if let Some(item) = self {

--- a/turbopack/crates/turbo-tasks/src/value.rs
+++ b/turbopack/crates/turbo-tasks/src/value.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     debug::{ValueDebugFormat, ValueDebugString},
+    trace::{TraceRawVcs, TraceRawVcsContext},
     ReadRef, SharedReference,
 };
 
@@ -56,6 +57,12 @@ impl<T: ValueDebugFormat> Value<T> {
     }
 }
 
+impl<T: TraceRawVcs> TraceRawVcs for Value<T> {
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        self.inner.trace_raw_vcs(trace_context)
+    }
+}
+
 /// Pass a value by value (`Value<Xxx>`) instead of by reference (`Vc<Xxx>`).
 ///
 /// Doesn't require serialization, and won't be stored in the persistent cache
@@ -80,6 +87,12 @@ impl<T> Deref for TransientValue<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl<T: TraceRawVcs> TraceRawVcs for TransientValue<T> {
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        self.inner.trace_raw_vcs(trace_context)
     }
 }
 
@@ -175,5 +188,11 @@ impl<T: 'static> Deref for TransientInstance<T> {
 
     fn deref(&self) -> &Self::Target {
         self.inner.0.downcast_ref().unwrap()
+    }
+}
+
+impl<T: TraceRawVcs + 'static> TraceRawVcs for TransientInstance<T> {
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        self.inner.downcast_ref::<T>().trace_raw_vcs(trace_context)
     }
 }

--- a/turbopack/crates/turbopack-cli/src/arguments.rs
+++ b/turbopack/crates/turbopack-cli/src/arguments.rs
@@ -5,7 +5,7 @@ use std::{
 
 use clap::{Args, Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{NonLocalValue, TaskInput};
+use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, TaskInput};
 use turbopack_cli_utils::issue::IssueSeverityCliOption;
 
 #[derive(Debug, Parser)]
@@ -37,6 +37,7 @@ impl Arguments {
     Hash,
     TaskInput,
     NonLocalValue,
+    TraceRawVcs,
 )]
 pub enum Target {
     Browser,

--- a/turbopack/crates/turbopack-cli/src/util.rs
+++ b/turbopack/crates/turbopack-cli/src/util.rs
@@ -4,10 +4,12 @@ use anyhow::{Context, Result};
 use dunce::canonicalize;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{NonLocalValue, TaskInput, Vc};
+use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, TaskInput, Vc};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 
-#[derive(Clone, Debug, TaskInput, Hash, PartialEq, Eq, NonLocalValue, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, TaskInput, Hash, PartialEq, Eq, NonLocalValue, Serialize, Deserialize, TraceRawVcs,
+)]
 pub enum EntryRequest {
     Relative(RcStr),
     Module(RcStr, RcStr),

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -151,7 +151,7 @@ impl ChunkGroupEntry {
     }
 }
 
-#[derive(Debug, Clone, Hash, TaskInput, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, TaskInput, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 pub enum ChunkGroup {
     /// e.g. a page
     Entry(Vec<ResolvedVc<Box<dyn Module>>>),

--- a/turbopack/crates/turbopack-dev-server/Cargo.toml
+++ b/turbopack/crates/turbopack-dev-server/Cargo.toml
@@ -48,5 +48,8 @@ turbopack-ecmascript = { workspace = true }
 turbopack-ecmascript-hmr-protocol = { workspace = true }
 urlencoding = "2.1.2"
 
+[dev-dependencies]
+turbo-tasks-backend = { workspace = true }
+
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbopack-dev-server/src/source/request.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/request.rs
@@ -1,10 +1,10 @@
 use hyper::{HeaderMap, Uri};
-use turbo_tasks::NonLocalValue;
+use turbo_tasks::{trace::TraceRawVcs, NonLocalValue};
 
 use super::Body;
 
 /// A request to a content source.
-#[derive(Debug, Clone, NonLocalValue)]
+#[derive(Debug, Clone, NonLocalValue, TraceRawVcs)]
 pub struct SourceRequest {
     /// The HTTP method to use.
     pub method: String,

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -24,7 +24,7 @@ use super::{
 /// The result of [`resolve_source_request`]. Similar to a
 /// `ContentSourceContent`, but without the `Rewrite` variant as this is taken
 /// care in the function.
-#[turbo_tasks::value(serialization = "none")]
+#[turbo_tasks::value(serialization = "none", shared)]
 pub enum ResolveSourceRequestResult {
     NotFound,
     Static(ResolvedVc<StaticContent>, ResolvedVc<HeaderList>),

--- a/turbopack/crates/turbopack-dev-server/src/update/server.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/server.rs
@@ -1,4 +1,5 @@
 use std::{
+    ops::ControlFlow,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -11,7 +12,9 @@ use pin_project_lite::pin_project;
 use tokio::select;
 use tokio_stream::StreamMap;
 use tracing::{instrument, Level};
-use turbo_tasks::{NonLocalValue, TransientInstance, TurboTasksApi, Vc};
+use turbo_tasks::{
+    trace::TraceRawVcs, NonLocalValue, OperationVc, ReadRef, TransientInstance, TurboTasksApi, Vc,
+};
 use turbo_tasks_fs::json::parse_json_with_source_context;
 use turbopack_core::{error::PrettyPrintError, issue::IssueReporter, version::Update};
 use turbopack_ecmascript_hmr_protocol::{
@@ -19,7 +22,11 @@ use turbopack_ecmascript_hmr_protocol::{
 };
 
 use crate::{
-    source::{request::SourceRequest, resolve::resolve_source_request, Body},
+    source::{
+        request::SourceRequest,
+        resolve::{resolve_source_request, ResolveSourceRequestResult},
+        Body,
+    },
     update::stream::{GetContentFn, UpdateStream, UpdateStreamItem},
     SourceProvider,
 };
@@ -33,7 +40,7 @@ pub(crate) struct UpdateServer<P: SourceProvider> {
 
 impl<P> UpdateServer<P>
 where
-    P: SourceProvider + NonLocalValue + Clone + Send + Sync,
+    P: SourceProvider + NonLocalValue + TraceRawVcs + Clone + Send + Sync,
 {
     /// Create a new update server with the given websocket and content source.
     pub fn new(source_provider: P, issue_reporter: Vc<Box<dyn IssueReporter>>) -> Self {
@@ -60,60 +67,25 @@ where
         let mut streams = StreamMap::new();
 
         loop {
+            // most logic is in helper functions as rustfmt cannot format code inside the macro
             select! {
                 message = client.try_next() => {
-                    match message? {
-                        Some(ClientMessage::Subscribe { resource }) => {
-                            let get_content = {
-                                let source_provider = self.source_provider.clone();
-                                let request = resource_to_request(&resource)?;
-                                move || {
-                                    let request = request.clone();
-                                    let source = source_provider.get_source();
-                                    resolve_source_request(
-                                        source,
-                                        TransientInstance::new(request)
-                                    )
-                                }
-                            };
-                            match UpdateStream::new(
-                                resource.to_string().into(),
-                                // safety: Everything that `get_content` captures in it's closure is
-                                // a `NonLocalValue`.
-                                TransientInstance::new(unsafe { GetContentFn::new(get_content) })
-                            ).await {
-                                Ok(stream) => {
-                                    streams.insert(resource, stream);
-                                }
-                                Err(err) => {
-                                    eprintln!(
-                                        "Failed to create update stream for {resource}: {}",
-                                        PrettyPrintError(&err),
-                                    );
-                                    client
-                                        .send(ClientUpdateInstruction::not_found(&resource))
-                                        .await?;
-                                }
-                            }
-                        }
-                        Some(ClientMessage::Unsubscribe { resource }) => {
-                            streams.remove(&resource);
-                        }
-                        None => {
-                            // WebSocket was closed, stop sending updates
-                            break;
-                        }
+                    if Self::on_message(
+                        &mut client,
+                        &mut streams,
+                        &self.source_provider,
+                        message?,
+                    ).await?.is_break() {
+                        break;
                     }
                 }
-                Some((resource, update)) = streams.next() => {
-                    match update {
-                        Ok(update) => {
-                            Self::send_update(&mut client, &mut streams, resource, &update).await?;
-                        }
-                        Err(err) => {
-                            eprintln!("Failed to get update for {resource}: {}", PrettyPrintError(&err));
-                        }
-                    }
+                Some((resource, update_result)) = streams.next() => {
+                    Self::on_stream(
+                        &mut client,
+                        &mut streams,
+                        resource,
+                        update_result,
+                    ).await?
                 }
                 else => break
             }
@@ -122,13 +94,86 @@ where
         Ok(())
     }
 
+    /// Helper for `on_message` used to construct a `GetContentFn`. Argument must match
+    /// `get_content_capture`.
+    fn get_content(
+        (source_provider, request): &(P, SourceRequest),
+    ) -> OperationVc<ResolveSourceRequestResult> {
+        let request = request.clone();
+        let source = source_provider.get_source();
+        resolve_source_request(source, TransientInstance::new(request))
+    }
+
+    /// receives ClientMessages and passes subscriptions to `on_stream` via the `streams` map.
+    async fn on_message(
+        client: &mut UpdateClient,
+        streams: &mut StreamMap<ResourceIdentifier, UpdateStream>,
+        source_provider: &P,
+        message: Option<ClientMessage>,
+    ) -> Result<ControlFlow<()>> {
+        match message {
+            Some(ClientMessage::Subscribe { resource }) => {
+                let get_content_capture =
+                    (source_provider.clone(), resource_to_request(&resource)?);
+                match UpdateStream::new(
+                    resource.to_string().into(),
+                    TransientInstance::new(GetContentFn::new(
+                        get_content_capture,
+                        Self::get_content,
+                    )),
+                )
+                .await
+                {
+                    Ok(stream) => {
+                        streams.insert(resource, stream);
+                    }
+                    Err(err) => {
+                        eprintln!(
+                            "Failed to create update stream for {resource}: {}",
+                            PrettyPrintError(&err),
+                        );
+                        client
+                            .send(ClientUpdateInstruction::not_found(&resource))
+                            .await?;
+                    }
+                }
+            }
+            Some(ClientMessage::Unsubscribe { resource }) => {
+                streams.remove(&resource);
+            }
+            None => {
+                // WebSocket was closed, stop sending updates
+                return Ok(ControlFlow::Break(()));
+            }
+        }
+        Ok(ControlFlow::Continue(()))
+    }
+
+    async fn on_stream(
+        client: &mut UpdateClient,
+        streams: &mut StreamMap<ResourceIdentifier, UpdateStream>,
+        resource: ResourceIdentifier,
+        update_result: Result<ReadRef<UpdateStreamItem>>,
+    ) -> Result<()> {
+        match update_result {
+            Ok(update_item) => Self::send_update(client, streams, resource, &update_item).await,
+            Err(err) => {
+                eprintln!(
+                    "Failed to get update for {resource}: {}",
+                    PrettyPrintError(&err)
+                );
+                Ok(())
+            }
+        }
+    }
+
     async fn send_update(
         client: &mut UpdateClient,
         streams: &mut StreamMap<ResourceIdentifier, UpdateStream>,
         resource: ResourceIdentifier,
-        item: &UpdateStreamItem,
+        update_item: &UpdateStreamItem,
     ) -> Result<()> {
-        match item {
+        match update_item {
             UpdateStreamItem::NotFound => {
                 // If the resource was not found, we remove the stream and indicate that to the
                 // client.

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -772,7 +772,7 @@ pub struct EcmascriptModuleContent {
     // pub refresh: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TaskInput)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TaskInput, TraceRawVcs)]
 pub struct EcmascriptModuleContentOptions {
     parsed: ResolvedVc<ParseResult>,
     ident: Vc<AssetIdent>,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -12,9 +12,9 @@ use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_tasks::{
-    apply_effects, duration_span, fxindexmap, mark_finished, prevent_gc, util::SharedError,
-    Completion, FxIndexMap, NonLocalValue, OperationVc, RawVc, ResolvedVc, TaskInput,
-    TryJoinIterExt, Value, Vc,
+    apply_effects, duration_span, fxindexmap, mark_finished, prevent_gc, trace::TraceRawVcs,
+    util::SharedError, Completion, FxIndexMap, NonLocalValue, OperationVc, RawVc, ResolvedVc,
+    TaskInput, TryJoinIterExt, Value, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
@@ -201,7 +201,17 @@ async fn emit_evaluate_pool_assets_with_effects_operation(
 }
 
 #[derive(
-    Clone, Copy, Hash, Debug, PartialEq, Eq, Serialize, Deserialize, TaskInput, NonLocalValue,
+    Clone,
+    Copy,
+    Hash,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TaskInput,
+    NonLocalValue,
+    TraceRawVcs,
 )]
 pub enum EnvVarTracking {
     WholeEnvTracked,
@@ -567,7 +577,7 @@ async fn basic_compute(
     compute(evaluate_context, sender).await
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, TaskInput, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, TaskInput, Debug, Serialize, Deserialize, TraceRawVcs)]
 struct BasicEvaluateContext {
     module_asset: ResolvedVc<Box<dyn Module>>,
     cwd: ResolvedVc<FileSystemPath>,

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -8,8 +8,8 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    duration_span, mark_finished, prevent_gc, util::SharedError, RawVc, ResolvedVc, TaskInput,
-    ValueToString, Vc,
+    duration_span, mark_finished, prevent_gc, trace::TraceRawVcs, util::SharedError, RawVc,
+    ResolvedVc, TaskInput, ValueToString, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
@@ -149,7 +149,7 @@ struct RenderStreamSender {
 #[turbo_tasks::value(transparent)]
 struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
 
-#[derive(Clone, Debug, TaskInput, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, TaskInput, PartialEq, Eq, Hash, Serialize, Deserialize, TraceRawVcs)]
 struct RenderStreamOptions {
     cwd: ResolvedVc<FileSystemPath>,
     env: ResolvedVc<Box<dyn ProcessEnv>>,

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -7,8 +7,8 @@ use futures::{
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    duration_span, mark_finished, prevent_gc, util::SharedError, RawVc, ResolvedVc, TaskInput,
-    ValueToString, Vc,
+    duration_span, mark_finished, prevent_gc, trace::TraceRawVcs, util::SharedError, RawVc,
+    ResolvedVc, TaskInput, ValueToString, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
@@ -199,7 +199,7 @@ struct RenderStreamSender {
 #[turbo_tasks::value(transparent)]
 struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
 
-#[derive(Clone, Debug, TaskInput, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, TaskInput, PartialEq, Eq, Hash, Deserialize, Serialize, TraceRawVcs)]
 struct RenderStreamOptions {
     cwd: ResolvedVc<FileSystemPath>,
     env: ResolvedVc<Box<dyn ProcessEnv>>,

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -368,7 +368,7 @@ pub enum InfoMessage {
     Log(LogInfo),
 }
 
-#[derive(Debug, Clone, TaskInput, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, TaskInput, Hash, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(rename_all = "camelCase")]
 pub struct WebpackResolveOptions {
     alias_fields: Option<Vec<RcStr>>,
@@ -399,7 +399,7 @@ pub enum ResponseMessage {
     Resolve { path: RcStr },
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, TaskInput, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, TaskInput, Serialize, Deserialize, Debug, TraceRawVcs)]
 pub struct WebpackLoaderContext {
     pub module_asset: ResolvedVc<Box<dyn Module>>,
     pub cwd: ResolvedVc<FileSystemPath>,


### PR DESCRIPTION
For a tracing GC to work (different for cache eviction), we need `TraceRawVcs` to be able to inspect function arguments.

While a tracing GC is still far off, the immediate motivation here is using tracing to improve logging for "transient task called from persistent task" error messages.

There's one non-test mpsc queue (`ComputeUpdateStreamSender`) with a sketchy `TraceRawVcs` impl. We should have a way of excluding certain objects from GC (marking them as roots) to fix this in the GC case. IMO this doesn't really matter for non-GC debug use-cases of `TraceRawVcs`.

Closes PACK-4227