### PR TITLE
Fix message not showing

### DIFF
--- a/examples/with-supabase/components/form-message.tsx
+++ b/examples/with-supabase/components/form-message.tsx
@@ -12,7 +12,7 @@ export function FormMessage({ message }: { message: Message }) {
         </div>
       )}
       {"error" in message && (
-        <div className="text-destructive-foreground border-l-2 border-destructive-foreground px-4">
+        <div className="text-destructive border-l-2 border-destructive-foreground px-4">
           {message.error}
         </div>
       )}


### PR DESCRIPTION
### What?
The message uses an undefined color
<img width="190" alt="Screenshot 2025-03-21 at 21 23 17" src="https://github.com/user-attachments/assets/1dbaa291-3b6a-45b5-b956-dd00d9e947e6" />

### Fix
Using a defined red alert color
