### PR TITLE
Refactor metadata and viewport preloading

### DIFF
--- a/packages/next/src/lib/metadata/clone-metadata.ts
+++ b/packages/next/src/lib/metadata/clone-metadata.ts
@@ -1,4 +1,7 @@
-import type { ResolvedMetadata } from './types/metadata-interface'
+import type {
+  ResolvedMetadata,
+  ResolvedViewport,
+} from './types/metadata-interface'
 
 const TYPE_URL = '__METADATA_URL'
 
@@ -17,7 +20,9 @@ function reviver(_key: string, val: any) {
   return val
 }
 
-export function cloneMetadata(metadata: ResolvedMetadata): ResolvedMetadata {
+export function cloneMetadata<T extends ResolvedMetadata | ResolvedViewport>(
+  metadata: T
+): T {
   const jsonString = JSON.stringify(metadata, replacer)
   return JSON.parse(jsonString, reviver)
 }

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -682,98 +682,80 @@ function postProcessMetadata(
   return metadata
 }
 
-type DataResolver<Data, ResolvedData> = (
-  parent: Promise<ResolvedData>
-) => Data | Promise<Data>
+type Result<T> = null | T | Promise<null | T> | PromiseLike<null | T>
 
-function collectMetadataExportPreloading<Data, ResolvedData>(
-  results: (Data | Promise<Data>)[],
-  dynamicMetadataExportFn: DataResolver<Data, ResolvedData>,
-  resolvers: ((value: ResolvedData) => void)[]
-) {
-  const result = dynamicMetadataExportFn(
-    new Promise<any>((resolve) => {
-      resolvers.push(resolve)
-    })
-  )
-
-  if (result instanceof Promise) {
-    // since we eager execute generateMetadata and
-    // they can reject at anytime we need to ensure
-    // we attach the catch handler right away to
-    // prevent unhandled rejections crashing the process
-    result.catch((err) => {
-      return {
-        __nextError: err,
-      }
-    })
+function prerenderMetadata(metadataItems: MetadataItems) {
+  // If the index is a function then it is a resolver and the next slot
+  // is the corresponding result. If the index is not a function it is the result
+  // itself.
+  const resolversAndResults: Array<
+    ((value: ResolvedMetadata) => void) | Result<Metadata>
+  > = []
+  for (let i = 0; i < metadataItems.length; i++) {
+    const metadataExport = metadataItems[i][0]
+    getResult(resolversAndResults, metadataExport)
   }
-  results.push(result)
+  return resolversAndResults
 }
 
-async function getMetadataFromExport<Data, ResolvedData>(
-  getPreloadMetadataExport: (
-    metadataItem: NonNullable<MetadataItems[number]>
-  ) => Data | DataResolver<Data, ResolvedData> | null,
-  dynamicMetadataResolveState: {
-    resolvers: ((value: ResolvedData) => void)[]
-    resolvingIndex: number
-  },
-  metadataItems: MetadataItems,
-  currentIndex: number,
-  resolvedMetadata: ResolvedData,
-  metadataResults: (Data | Promise<Data>)[]
+function prerenderViewport(metadataItems: MetadataItems) {
+  // If the index is a function then it is a resolver and the next slot
+  // is the corresponding result. If the index is not a function it is the result
+  // itself.
+  const resolversAndResults: Array<
+    ((value: ResolvedViewport) => void) | Result<Viewport>
+  > = []
+  for (let i = 0; i < metadataItems.length; i++) {
+    const viewportExport = metadataItems[i][2]
+    getResult(resolversAndResults, viewportExport)
+  }
+  return resolversAndResults
+}
+
+type Resolved<T> = T extends Metadata ? ResolvedMetadata : ResolvedViewport
+
+function getResult<T extends Metadata | Viewport>(
+  resolversAndResults: Array<((value: Resolved<T>) => void) | Result<T>>,
+  exportForResult: null | T | ((parent: Promise<Resolved<T>>) => Result<T>)
 ) {
-  const metadataExport = getPreloadMetadataExport(metadataItems[currentIndex])
-  const dynamicMetadataResolvers = dynamicMetadataResolveState.resolvers
-  let metadata: Data | null = null
-  if (typeof metadataExport === 'function') {
-    // Only preload at the beginning when resolves are empty
-    if (!dynamicMetadataResolvers.length) {
-      for (let j = currentIndex; j < metadataItems.length; j++) {
-        const preloadMetadataExport = getPreloadMetadataExport(metadataItems[j])
-        // call each `generateMetadata function concurrently and stash their resolver
-        if (typeof preloadMetadataExport === 'function') {
-          collectMetadataExportPreloading<Data, ResolvedData>(
-            metadataResults,
-            preloadMetadataExport as DataResolver<Data, ResolvedData>,
-            dynamicMetadataResolvers
-          )
+  if (typeof exportForResult === 'function') {
+    const result = exportForResult(
+      new Promise<Resolved<T>>((resolve) => resolversAndResults.push(resolve))
+    )
+    resolversAndResults.push(result)
+    if (result instanceof Promise) {
+      // since we eager execute generateMetadata and
+      // they can reject at anytime we need to ensure
+      // we attach the catch handler right away to
+      // prevent unhandled rejections crashing the process
+      result.catch((err) => {
+        return {
+          __nextError: err,
         }
-      }
+      })
     }
+  } else if (typeof exportForResult === 'object') {
+    resolversAndResults.push(exportForResult)
+  } else {
+    resolversAndResults.push(null)
+  }
+}
 
-    const resolveParent =
-      dynamicMetadataResolvers[dynamicMetadataResolveState.resolvingIndex]
-    const metadataResult =
-      metadataResults[dynamicMetadataResolveState.resolvingIndex++]
-
-    // In dev we clone and freeze to prevent relying on mutating resolvedMetadata directly.
-    // In prod we just pass resolvedMetadata through without any copying.
-    const currentResolvedMetadata =
-      process.env.NODE_ENV === 'development'
-        ? Object.freeze(
-            require('./clone-metadata').cloneMetadata(resolvedMetadata)
-          )
-        : resolvedMetadata
-
-    // This resolve should unblock the generateMetadata function if it awaited the parent
-    // argument. If it didn't await the parent argument it might already have a value since it was
-    // called concurrently. Regardless we await the return value before continuing on to the next layer
-    resolveParent(currentResolvedMetadata)
-    metadata =
-      metadataResult instanceof Promise ? await metadataResult : metadataResult
-
-    if (metadata && typeof metadata === 'object' && '__nextError' in metadata) {
-      // re-throw caught metadata error from preloading
-      throw metadata['__nextError']
-    }
-  } else if (metadataExport !== null && typeof metadataExport === 'object') {
-    // This metadataExport is the object form
-    metadata = metadataExport
+function resolvePendingResult<
+  ResolvedType extends ResolvedMetadata | ResolvedViewport,
+>(
+  parentResult: ResolvedType,
+  resolveParentResult: (value: ResolvedType) => void
+): void {
+  // In dev we clone and freeze to prevent relying on mutating resolvedMetadata directly.
+  // In prod we just pass resolvedMetadata through without any copying.
+  if (process.env.NODE_ENV === 'development') {
+    parentResult = require('../../shared/lib/deep-freeze').deepFreeze(
+      require('./clone-metadata').cloneMetadata(parentResult)
+    )
   }
 
-  return metadata
+  resolveParentResult(parentResult)
 }
 
 export async function accumulateMetadata(
@@ -781,7 +763,6 @@ export async function accumulateMetadata(
   metadataContext: MetadataContext
 ): Promise<ResolvedMetadata> {
   const resolvedMetadata = createDefaultMetadata()
-  const metadataResults: (Metadata | Promise<Metadata>)[] = []
 
   let titleTemplates: TitleTemplates = {
     title: null,
@@ -789,12 +770,6 @@ export async function accumulateMetadata(
     openGraph: null,
   }
 
-  // Loop over all metadata items again, merging synchronously any static object exports,
-  // awaiting any static promise exports, and resolving parent metadata and awaiting any generated metadata
-  const dynamicMetadataResolvers = {
-    resolvers: [],
-    resolvingIndex: 0,
-  }
   const buildState = {
     warnings: new Set<string>(),
   }
@@ -807,9 +782,12 @@ export async function accumulateMetadata(
     icon: [],
     apple: [],
   }
+
+  const resolversAndResults = prerenderMetadata(metadataItems)
+  let resultIndex = 0
+
   for (let i = 0; i < metadataItems.length; i++) {
     const staticFilesMetadata = metadataItems[i][1]
-
     // Treat favicon as special case, it should be the first icon in the list
     // i <= 1 represents root layout, and if current page is also at root
     if (i <= 1 && isFavicon(staticFilesMetadata?.icon?.[0])) {
@@ -817,14 +795,26 @@ export async function accumulateMetadata(
       if (i === 0) favicon = iconMod
     }
 
-    const metadata = await getMetadataFromExport<Metadata, ResolvedMetadata>(
-      (metadataItem) => metadataItem[0],
-      dynamicMetadataResolvers,
-      metadataItems,
-      i,
-      resolvedMetadata,
-      metadataResults
-    )
+    let pendingMetadata = resolversAndResults[resultIndex++]
+    if (typeof pendingMetadata === 'function') {
+      // This metadata item had a `generateMetadata` and
+      // we need to provide the currently resolved metadata
+      // to it before we continue;
+      const resolveParentMetadata = pendingMetadata
+      // we know that the next item is a result if this item
+      // was a resolver
+      pendingMetadata = resolversAndResults[resultIndex++] as Result<Metadata>
+
+      resolvePendingResult(resolvedMetadata, resolveParentMetadata)
+    }
+    // Otherwise the item was either null or a static export
+
+    let metadata: Metadata | null
+    if (isPromiseLike(pendingMetadata)) {
+      metadata = await pendingMetadata
+    } else {
+      metadata = pendingMetadata
+    }
 
     mergeMetadata({
       target: resolvedMetadata,
@@ -885,20 +875,30 @@ export async function accumulateViewport(
 ): Promise<ResolvedViewport> {
   const resolvedViewport: ResolvedViewport = createDefaultViewport()
 
-  const viewportResults: (Viewport | Promise<Viewport>)[] = []
-  const dynamicMetadataResolvers = {
-    resolvers: [],
-    resolvingIndex: 0,
-  }
-  for (let i = 0; i < metadataItems.length; i++) {
-    const viewport = await getMetadataFromExport<Viewport, ResolvedViewport>(
-      (metadataItem) => metadataItem[2],
-      dynamicMetadataResolvers,
-      metadataItems,
-      i,
-      resolvedViewport,
-      viewportResults
-    )
+  const resolversAndResults = prerenderViewport(metadataItems)
+  let i = 0
+
+  while (i < resolversAndResults.length) {
+    let pendingViewport = resolversAndResults[i++]
+    if (typeof pendingViewport === 'function') {
+      // this viewport item had a `generateViewport` and
+      // we need to provide the currently resolved viewport
+      // to it before we continue;
+      const resolveParentViewport = pendingViewport
+      // we know that the next item is a result if this item
+      // was a resolver
+      pendingViewport = resolversAndResults[i++] as Result<Viewport>
+
+      resolvePendingResult(resolvedViewport, resolveParentViewport)
+    }
+    // Otherwise the item was either null or a static export
+
+    let viewport: Viewport | null
+    if (isPromiseLike(pendingViewport)) {
+      viewport = await pendingViewport
+    } else {
+      viewport = pendingViewport
+    }
 
     mergeViewport({
       target: resolvedViewport,
@@ -947,4 +947,14 @@ export async function resolveViewport(
     workStore
   )
   return accumulateViewport(metadataItems)
+}
+
+function isPromiseLike<T>(
+  value: unknown | PromiseLike<T>
+): value is PromiseLike<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PromiseLike<unknown>).then === 'function'
+  )
 }


### PR DESCRIPTION
metadata and viewport are attempted to be resolved concurrently even when async functions are used via `generateMetadata` and `generateViewport`. We call this preloading because we initiate the generation ahead of time but if it turns out that any particular generator requires the parent resolved values we can progressively reveal these to each pending generator. This PR refactors the code a bit to simplify and clarify this process. This is setting the stage to later separate out the resolution of viewport from metadata since only viewport is now blocking the root.