### PR TITLE
directly import param resolver in metadata

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -2,7 +2,6 @@ import React, { Suspense, cache, cloneElement } from 'react'
 import type { ParsedUrlQuery } from 'querystring'
 import type { GetDynamicParamFromSegment } from '../../server/app-render/app-render'
 import type { LoaderTree } from '../../server/lib/app-dir-module'
-import type { CreateServerParamsForMetadata } from '../../server/request/params'
 import type { StreamingMetadataResolvedState } from '../../client/components/metadata/types'
 import {
   AppleWebAppMeta,
@@ -57,7 +56,6 @@ export function createMetadataComponents({
   getDynamicParamFromSegment,
   appUsingSizeAdjustment,
   errorType,
-  createServerParamsForMetadata,
   workStore,
   MetadataBoundary,
   ViewportBoundary,
@@ -69,7 +67,6 @@ export function createMetadataComponents({
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   appUsingSizeAdjustment: boolean
   errorType?: MetadataErrorType | 'redirect'
-  createServerParamsForMetadata: CreateServerParamsForMetadata
   workStore: WorkStore
   MetadataBoundary: (props: { children: React.ReactNode }) => React.ReactNode
   ViewportBoundary: (props: { children: React.ReactNode }) => React.ReactNode
@@ -108,7 +105,6 @@ export function createMetadataComponents({
       tree,
       searchParams,
       getDynamicParamFromSegment,
-      createServerParamsForMetadata,
       workStore,
       errorType
     )
@@ -124,7 +120,6 @@ export function createMetadataComponents({
             tree,
             searchParams,
             getDynamicParamFromSegment,
-            createServerParamsForMetadata,
             workStore
           )
         } catch {}
@@ -144,7 +139,6 @@ export function createMetadataComponents({
       searchParams,
       getDynamicParamFromSegment,
       metadataContext,
-      createServerParamsForMetadata,
       workStore,
       errorType
     )
@@ -169,7 +163,6 @@ export function createMetadataComponents({
             searchParams,
             getDynamicParamFromSegment,
             metadataContext,
-            createServerParamsForMetadata,
             workStore
           )
           return {
@@ -253,7 +246,6 @@ async function getResolvedMetadataImpl(
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore,
   errorType?: MetadataErrorType | 'redirect'
 ): Promise<React.ReactNode> {
@@ -263,7 +255,6 @@ async function getResolvedMetadataImpl(
     searchParams,
     getDynamicParamFromSegment,
     metadataContext,
-    createServerParamsForMetadata,
     workStore,
     errorConvention
   )
@@ -275,7 +266,6 @@ async function getNotFoundMetadataImpl(
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
@@ -284,7 +274,6 @@ async function getNotFoundMetadataImpl(
     searchParams,
     getDynamicParamFromSegment,
     metadataContext,
-    createServerParamsForMetadata,
     workStore,
     notFoundErrorConvention
   )
@@ -295,7 +284,6 @@ async function getResolvedViewportImpl(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore,
   errorType?: MetadataErrorType | 'redirect'
 ): Promise<React.ReactNode> {
@@ -304,7 +292,6 @@ async function getResolvedViewportImpl(
     tree,
     searchParams,
     getDynamicParamFromSegment,
-    createServerParamsForMetadata,
     workStore,
     errorConvention
   )
@@ -315,7 +302,6 @@ async function getNotFoundViewportImpl(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
@@ -323,7 +309,6 @@ async function getNotFoundViewportImpl(
     tree,
     searchParams,
     getDynamicParamFromSegment,
-    createServerParamsForMetadata,
     workStore,
     notFoundErrorConvention
   )
@@ -334,7 +319,6 @@ async function renderMetadata(
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore,
   errorConvention?: MetadataErrorType
 ) {
@@ -343,7 +327,6 @@ async function renderMetadata(
     searchParams,
     errorConvention,
     getDynamicParamFromSegment,
-    createServerParamsForMetadata,
     workStore,
     metadataContext
   )
@@ -362,7 +345,6 @@ async function renderViewport(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore,
   errorConvention?: MetadataErrorType
 ) {
@@ -371,7 +353,6 @@ async function renderViewport(
     searchParams,
     errorConvention,
     getDynamicParamFromSegment,
-    createServerParamsForMetadata,
     workStore
   )
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -20,6 +20,8 @@ import type {
 } from './types/metadata-types'
 import type { ParsedUrlQuery } from 'querystring'
 import type { StaticMetadata } from './types/icons'
+import type { WorkStore } from '../../server/app-render/work-async-storage.external'
+import type { Params } from '../../server/request/params'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'server-only'
@@ -53,11 +55,7 @@ import { getTracer } from '../../server/lib/trace/tracer'
 import { ResolveMetadataSpan } from '../../server/lib/trace/constants'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import * as Log from '../../build/output/log'
-import type { WorkStore } from '../../server/app-render/work-async-storage.external'
-import type {
-  Params,
-  CreateServerParamsForMetadata,
-} from '../../server/request/params'
+import { createServerParamsForMetadata } from '../../server/request/params'
 
 type StaticIcons = Pick<ResolvedIcons, 'icon' | 'apple'>
 
@@ -483,7 +481,6 @@ const resolveMetadataItems = cache(async function (
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore
 ) {
   const parentParams = {}
@@ -499,7 +496,6 @@ const resolveMetadataItems = cache(async function (
     errorConvention,
     errorMetadataItem,
     getDynamicParamFromSegment,
-    createServerParamsForMetadata,
     workStore
   )
 })
@@ -514,7 +510,6 @@ async function resolveMetadataItemsImpl(
   errorConvention: MetadataErrorType | undefined,
   errorMetadataItem: MetadataItems[number],
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore
 ): Promise<MetadataItems> {
   const [segment, parallelRoutes, { page }] = tree
@@ -572,7 +567,6 @@ async function resolveMetadataItemsImpl(
       errorConvention,
       errorMetadataItem,
       getDynamicParamFromSegment,
-      createServerParamsForMetadata,
       workStore
     )
   }
@@ -914,7 +908,6 @@ export async function resolveMetadata(
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore,
   metadataContext: MetadataContext
 ): Promise<ResolvedMetadata> {
@@ -923,7 +916,6 @@ export async function resolveMetadata(
     searchParams,
     errorConvention,
     getDynamicParamFromSegment,
-    createServerParamsForMetadata,
     workStore
   )
   return accumulateMetadata(metadataItems, metadataContext)
@@ -935,7 +927,6 @@ export async function resolveViewport(
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
-  createServerParamsForMetadata: CreateServerParamsForMetadata,
   workStore: WorkStore
 ): Promise<ResolvedViewport> {
   const metadataItems = await resolveMetadataItems(
@@ -943,7 +934,6 @@ export async function resolveViewport(
     searchParams,
     errorConvention,
     getDynamicParamFromSegment,
-    createServerParamsForMetadata,
     workStore
   )
   return accumulateViewport(metadataItems)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -469,7 +469,6 @@ async function generateDynamicRSCPayload(
     componentMod: {
       tree: loaderTree,
       createServerSearchParamsForMetadata,
-      createServerParamsForMetadata,
       createMetadataComponents,
       MetadataBoundary,
       ViewportBoundary,
@@ -505,7 +504,6 @@ async function generateDynamicRSCPayload(
       ),
       getDynamicParamFromSegment,
       appUsingSizeAdjustment,
-      createServerParamsForMetadata,
       workStore,
       MetadataBoundary,
       ViewportBoundary,
@@ -789,7 +787,6 @@ async function getRSCPayload(
     componentMod: {
       GlobalError,
       createServerSearchParamsForMetadata,
-      createServerParamsForMetadata,
       createMetadataComponents,
       MetadataBoundary,
       ViewportBoundary,
@@ -823,7 +820,6 @@ async function getRSCPayload(
     ),
     getDynamicParamFromSegment,
     appUsingSizeAdjustment,
-    createServerParamsForMetadata,
     workStore,
     MetadataBoundary,
     ViewportBoundary,
@@ -931,7 +927,6 @@ async function getErrorRSCPayload(
     componentMod: {
       GlobalError,
       createServerSearchParamsForMetadata,
-      createServerParamsForMetadata,
       createMetadataComponents,
       MetadataBoundary,
       ViewportBoundary,
@@ -952,7 +947,6 @@ async function getErrorRSCPayload(
     errorType,
     getDynamicParamFromSegment,
     appUsingSizeAdjustment,
-    createServerParamsForMetadata,
     workStore,
     MetadataBoundary,
     ViewportBoundary,

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -24,7 +24,6 @@ import {
 } from '../request/search-params'
 import {
   createServerParamsForServerSegment,
-  createServerParamsForMetadata,
   createPrerenderParamsForClientSegment,
 } from '../request/params'
 import * as serverHooks from '../../client/components/hooks-server-context'
@@ -63,7 +62,6 @@ export {
   createServerSearchParamsForMetadata,
   createPrerenderSearchParamsForClientPage,
   createServerParamsForServerSegment,
-  createServerParamsForMetadata,
   createPrerenderParamsForClientSegment,
   serverHooks,
   preloadStyle,


### PR DESCRIPTION
This function is indirectly routed through componentMod when it doesn't need to be. Both it and it's consumer are part of the RSC layer.