### PR TITLE
remove direct ip/port bypass in dev origin check

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -323,15 +323,7 @@ export async function initialize(opts: {
 
       // handle hot-reloader first
       if (developmentBundler) {
-        if (
-          blockCrossSite(
-            req,
-            res,
-            config.allowedDevOrigins,
-            opts.hostname,
-            `${opts.port}`
-          )
-        ) {
+        if (blockCrossSite(req, res, config.allowedDevOrigins, opts.hostname)) {
           return
         }
         const origUrl = req.url || '/'
@@ -698,13 +690,7 @@ export async function initialize(opts: {
 
       if (opts.dev && developmentBundler && req.url) {
         if (
-          blockCrossSite(
-            req,
-            socket,
-            config.allowedDevOrigins,
-            opts.hostname,
-            `${opts.port}`
-          )
+          blockCrossSite(req, socket, config.allowedDevOrigins, opts.hostname)
         ) {
           return
         }

--- a/packages/next/src/server/lib/router-utils/block-cross-site.ts
+++ b/packages/next/src/server/lib/router-utils/block-cross-site.ts
@@ -1,7 +1,6 @@
 import type { Duplex } from 'stream'
 import type { IncomingMessage, ServerResponse } from 'webpack-dev-server'
 import { parseUrl } from '../../../lib/url'
-import net from 'net'
 import { warnOnce } from '../../../build/output/log'
 import { isCsrfOriginAllowed } from '../../app-render/csrf-protection'
 
@@ -36,8 +35,7 @@ export const blockCrossSite = (
   req: IncomingMessage,
   res: ServerResponse | Duplex,
   allowedDevOrigins: string[] | undefined,
-  hostname: string | undefined,
-  activePort: string
+  hostname: string | undefined
 ): boolean => {
   // in the future, these will be blocked by default when allowed origins aren't configured.
   // for now, we warn when allowed origins aren't configured
@@ -52,7 +50,7 @@ export const blockCrossSite = (
     allowedOrigins.push(hostname)
   }
 
-  // only process _next URLs when
+  // only process _next URLs
   if (!req.url?.includes('/_next')) {
     return false
   }
@@ -73,16 +71,8 @@ export const blockCrossSite = (
 
     if (parsedOrigin) {
       const originLowerCase = parsedOrigin.hostname.toLowerCase()
-      const isMatchingPort = parsedOrigin.port === activePort
-      const isIpRequest =
-        net.isIPv4(originLowerCase) || net.isIPv6(originLowerCase)
 
-      if (
-        // allow requests if direct IP and matching port and
-        // allow if any of the allowed origins match
-        !(isIpRequest && isMatchingPort) &&
-        !isCsrfOriginAllowed(originLowerCase, allowedOrigins)
-      ) {
+      if (!isCsrfOriginAllowed(originLowerCase, allowedOrigins)) {
         return warnOrBlockRequest(res, originLowerCase, mode)
       }
     }


### PR DESCRIPTION
It's potentially unsafe to allow any sort of origin bypass if `allowedDevOrigins` is configured as it's trivial to stand up a remote server on the same port. This removes the case that would bypass the origin check. 