### PR TITLE
ensure /__next middleware URLs are included in the origin check

### DIFF
--- a/packages/next/src/server/lib/router-utils/block-cross-site.ts
+++ b/packages/next/src/server/lib/router-utils/block-cross-site.ts
@@ -50,8 +50,9 @@ export const blockCrossSite = (
     allowedOrigins.push(hostname)
   }
 
-  // only process _next URLs
-  if (!req.url?.includes('/_next')) {
+  // only process internal URLs/middleware
+  // TODO: We should standardize on a single prefix for this
+  if (!req.url?.includes('/_next') && !req.url?.includes('/__nextjs')) {
     return false
   }
   // block non-cors request from cross-site e.g. script tag on


### PR DESCRIPTION
We have special development endpoints that are also prefixed under `/__nextjs`. This updates the origin checking logic to account for those in addition to `/_next`, and adds a test.