### PR TITLE
fix: comment spelling error

### DIFF
--- a/packages/next/src/lib/has-necessary-dependencies.ts
+++ b/packages/next/src/lib/has-necessary-dependencies.ts
@@ -18,7 +18,7 @@ export interface MissingDependency {
    * resolves to `path.join(dirname(resolvedPackageJsonPath), 'index.d.ts')`.
    *
    * If false, will resolve `file` relative to the baseDir.
-   * ForFor example, `{ file: '@types/react/index.d.ts', pkg: '@types/react', exportsRestrict: true }`
+   * For example, `{ file: '@types/react/index.d.ts', pkg: '@types/react', exportsRestrict: true }`
    * will try to resolve `@types/react/index.d.ts` directly.
    */
   exportsRestrict: boolean

--- a/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
@@ -21,7 +21,7 @@ function resolveAlternateUrl(
   metadataBase: URL | null,
   metadataContext: MetadataContext
 ) {
-  // If alter native url is an URL instance,
+  // If alternative url is an URL instance,
   // we treat it as a URL base and resolve with current pathname
   if (url instanceof URL) {
     const newUrl = new URL(metadataContext.pathname, url)


### PR DESCRIPTION
1. forfor：That's one more 'for'
2. alter native：alter native is not a word