### PR TITLE
[metadata] always serve streaming metadata in build

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -253,11 +253,6 @@ async function exportPageImpl(
     )
   }
 
-  // During the export phase in next build, we always enable the streaming metadata since if there's
-  // any dynamic access in metadata we can determine it in the build phase.
-  // If it's static, then it won't affect anything.
-  // If it's dynamic, then it can be handled when request hits the route.
-  const serveStreamingMetadata = true
   const renderOpts: WorkerRenderOpts = {
     ...components,
     ...input.renderOpts,
@@ -267,7 +262,11 @@ async function exportPageImpl(
     disableOptimizedLoading,
     locale,
     supportsDynamicResponse: false,
-    serveStreamingMetadata,
+    // During the export phase in next build, we always enable the streaming metadata since if there's
+    // any dynamic access in metadata we can determine it in the build phase.
+    // If it's static, then it won't affect anything.
+    // If it's dynamic, then it can be handled when request hits the route.
+    serveStreamingMetadata: true,
     experimental: {
       ...input.renderOpts.experimental,
       isRoutePPREnabled,

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -253,11 +253,11 @@ async function exportPageImpl(
     )
   }
 
-  // During the export phase in next build, if it's using PPR we can serve streaming metadata
-  // when it's available. When we're building the PPR rendering result, we don't need to rely
-  // on the user agent. The result can be determined to serve streaming on infrastructure level.
-  const serveStreamingMetadata = !!isRoutePPREnabled
-
+  // During the export phase in next build, we always enable the streaming metadata since if there's
+  // any dynamic access in metadata we can determine it in the build phase.
+  // If it's static, then it won't affect anything.
+  // If it's dynamic, then it can be handled when request hits the route.
+  const serveStreamingMetadata = true
   const renderOpts: WorkerRenderOpts = {
     ...components,
     ...input.renderOpts,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -978,6 +978,7 @@ async function getErrorRSCPayload(
       {process.env.NODE_ENV === 'development' && (
         <meta name="next-error" content="not-found" />
       )}
+      {StreamingMetadata ? <StreamingMetadata /> : null}
       <StaticMetadata />
     </React.Fragment>
   )
@@ -998,7 +999,10 @@ async function getErrorRSCPayload(
   const seedData: CacheNodeSeedData = [
     initialTree[0],
     <html id="__next_error__">
-      <head>{StreamingMetadata ? <StreamingMetadata /> : null}</head>
+      <head>
+        {StreamingMetadata ? <StreamingMetadata /> : null}
+        <StaticMetadata />
+      </head>
       <body>
         {process.env.NODE_ENV !== 'production' && err ? (
           <template
@@ -2112,12 +2116,14 @@ async function renderToStream(
         {
           ReactDOMServer: require('react-dom/server.edge'),
           element: (
-            <AppWithoutContext
-              reactServerStream={errorServerStream}
-              preinitScripts={errorPreinitScripts}
-              clientReferenceManifest={clientReferenceManifest}
-              nonce={ctx.nonce}
-            />
+            <ServerInsertedHTMLProvider>
+              <AppWithoutContext
+                reactServerStream={errorServerStream}
+                preinitScripts={errorPreinitScripts}
+                clientReferenceManifest={clientReferenceManifest}
+                nonce={ctx.nonce}
+              />
+            </ServerInsertedHTMLProvider>
           ),
           streamOptions: {
             nonce: ctx.nonce,
@@ -4025,12 +4031,14 @@ async function prerenderToStream(
       const fizzStream = await renderToInitialFizzStream({
         ReactDOMServer: require('react-dom/server.edge'),
         element: (
-          <AppWithoutContext
-            reactServerStream={errorServerStream}
-            preinitScripts={errorPreinitScripts}
-            clientReferenceManifest={clientReferenceManifest}
-            nonce={ctx.nonce}
-          />
+          <ServerInsertedMetadataProvider>
+            <AppWithoutContext
+              reactServerStream={errorServerStream}
+              preinitScripts={errorPreinitScripts}
+              clientReferenceManifest={clientReferenceManifest}
+              nonce={ctx.nonce}
+            />
+          </ServerInsertedMetadataProvider>
         ),
         streamOptions: {
           nonce: ctx.nonce,

--- a/test/e2e/app-dir/metadata-streaming/app/static/full/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/static/full/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return <div>static page</div>
+}
+
+export async function generateMetadata() {
+  return {
+    title: 'static page',
+    description: 'static page description',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming/app/static/partial/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/static/partial/layout.tsx
@@ -1,0 +1,18 @@
+import React, { Suspense } from 'react'
+
+async function Inner({ children }) {
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  return (
+    <div className="inner">
+      <Suspense>{children}</Suspense>
+    </div>
+  )
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense>
+      <Inner>{children}</Inner>
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming/app/static/partial/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/static/partial/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export default function Page() {
+  return (
+    <div>
+      inner static page
+      <Suspense>
+        <Inner />
+      </Suspense>
+    </div>
+  )
+}
+
+async function Inner() {
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return <div>inner</div>
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 1 * 1000))
+  await connection()
+  return {
+    title: 'partial static page',
+    description: 'partial static page description',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -205,4 +205,32 @@ describe('app-dir - metadata-streaming', () => {
       expect(status).toBe(307)
     })
   })
+
+  describe('static', () => {
+    it('should render static metadata in the head', async () => {
+      const $ = await next.render$('/static/full')
+      expect($('title').length).toBe(1)
+      expect($('head title').text()).toBe('static page')
+    })
+
+    it('should determine dynamic metadata in build and render in the body', async () => {
+      const $ = await next.render$('/static/partial')
+      expect($('title').length).toBe(1)
+      expect($('body title').text()).toBe('partial static page')
+    })
+
+    it('should still render dynamic metadata in the head for html bots', async () => {
+      const $ = await next.render$(
+        '/static/partial',
+        {},
+        {
+          headers: {
+            'user-agent': 'Twitterbot',
+          },
+        }
+      )
+      expect($('title').length).toBe(1)
+      expect($('head title').text()).toBe('partial static page')
+    })
+  })
 })

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -1,9 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-const isPPR = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-
 describe('parallel-routes-and-interception', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     // TODO: remove after deployment handling is updated
     skipDeployment: true,
@@ -23,21 +21,9 @@ describe('parallel-routes-and-interception', () => {
 
     // we also check that the #children-slot id is not present
     expect(await browser.hasElementByCssSelector('#children-slot')).toBe(false)
-
-    if (isPPR && !isNextDev) {
-      let $ = await next.render$('/')
-      expect($('title').text()).toBe('')
-
-      $ = await next.render$('/', null, {
-        headers: {
-          'User-Agent': 'Discordbot',
-        },
-      })
-      expect($('title').text()).toBe('layout title')
-    } else {
-      const $ = await next.render$('/')
-      expect($('title').text()).toBe('layout title')
-    }
+    const $ = await next.render$('/')
+    expect($('title').length).toBe(1)
+    expect($('title').text()).toBe('layout title')
   })
 
   it('should render the title once for the non-existed route', async () => {


### PR DESCRIPTION
### What

During the export phase in next build, we always enable the streaming metadata since if there's any dynamic access in metadata we can determine it in the build phase. If it's static, then it won't affect anything. If it's dynamic, then it can be handled when request hits the route.

### Why

We want it enabled even during build b/c this is how we will enforce DIO rules without making any dynamic metadata automatically a build failure