### PR TITLE
Validate subrequest header further

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -665,5 +665,6 @@
   "664": "Missing 'next-action' header.",
   "665": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "666": "Turbopack builds are only available in canary builds of Next.js.",
-  "667": "receiveExpiredTags is deprecated, and not expected to be called."
+  "667": "receiveExpiredTags is deprecated, and not expected to be called.",
+  "668": "Invariant: middleware subrequest id not initialized"
 }

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1106,6 +1106,9 @@ export async function isPageStatic({
           name: edgeInfo.name,
           useCache: true,
           distDir,
+          // This is only used during build time so does not need
+          // to handle incoming requests
+          middlewareSubrequestId: 'fallback',
         })
         const mod = (
           await runtime.context._ENTRIES[`middleware_${edgeInfo.name}`]

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -48,8 +48,8 @@ import {
 import { normalizedAssetPrefix } from '../../shared/lib/normalized-asset-prefix'
 import { NEXT_PATCH_SYMBOL } from './patch-fetch'
 import type { ServerInitResult } from './render-server'
-import { filterInternalHeaders } from './server-ipc/utils'
 import { blockCrossSite } from './router-utils/block-cross-site'
+import { filterInternalHeaders } from './server-ipc/filter-internal-headers'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -166,7 +166,7 @@ export async function initialize(opts: {
   renderServer.instance =
     require('./render-server') as typeof import('./render-server')
 
-  const randomBytes = new Uint8Array(8)
+  const randomBytes = new Uint8Array(16)
   crypto.getRandomValues(randomBytes)
   const middlewareSubrequestId = Buffer.from(randomBytes).toString('hex')
   ;(globalThis as any)[Symbol.for('@next/middleware-subrequest-id')] =

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -168,14 +168,12 @@ export async function initialize(opts: {
 
   const randomBytes = new Uint8Array(16)
   crypto.getRandomValues(randomBytes)
-  const middlewareSubrequestId = Buffer.from(randomBytes).toString('hex')
-  ;(globalThis as any)[Symbol.for('@next/middleware-subrequest-id')] =
-    middlewareSubrequestId
+  const middlewareSubrequestId = Buffer.from(randomBytes)
 
   const requestHandlerImpl: WorkerRequestHandler = async (req, res) => {
     // internal headers should not be honored by the request handler
     if (!process.env.NEXT_PRIVATE_TEST_HEADERS) {
-      filterInternalHeaders(req.headers)
+      filterInternalHeaders(req.headers, middlewareSubrequestId)
     }
 
     if (
@@ -636,6 +634,7 @@ export async function initialize(opts: {
     serverFields: {
       ...(developmentBundler?.serverFields || {}),
       setIsrStatus: devBundlerService?.setIsrStatus.bind(devBundlerService),
+      middlewareSubrequestId: middlewareSubrequestId.toString('hex'),
     } satisfies ServerFields,
     experimentalTestProxy: !!config.experimental.testProxy,
     experimentalHttpsServer: !!opts.experimentalHttpsServer,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -99,6 +99,7 @@ export type SetupOpts = {
 }
 
 export type ServerFields = {
+  middlewareSubrequestId?: string
   actualMiddlewareFile?: string | undefined
   actualInstrumentationHookFile?: string | undefined
   appPathRoutes?: Record<string, string | string[]>

--- a/packages/next/src/server/lib/server-ipc/filter-internal-headers.ts
+++ b/packages/next/src/server/lib/server-ipc/filter-internal-headers.ts
@@ -19,7 +19,8 @@ export const filterInternalHeaders = (
 ) => {
   const subrequestIdHeader = headers['x-middleware-subrequest-id']
   const subrequestIdBuffer = Buffer.from(
-    typeof subrequestIdHeader === 'string' ? subrequestIdHeader : 'user'
+    typeof subrequestIdHeader === 'string' ? subrequestIdHeader : '',
+    'hex'
   )
 
   for (const header in headers) {

--- a/packages/next/src/server/lib/server-ipc/filter-internal-headers.ts
+++ b/packages/next/src/server/lib/server-ipc/filter-internal-headers.ts
@@ -1,0 +1,44 @@
+import crypto from 'crypto'
+
+// These are headers that are only used internally and should
+// not be honored from the external request
+const INTERNAL_HEADERS = [
+  'x-middleware-rewrite',
+  'x-middleware-redirect',
+  'x-middleware-set-cookie',
+  'x-middleware-skip',
+  'x-middleware-override-headers',
+  'x-middleware-next',
+  'x-now-route-matches',
+  'x-matched-path',
+]
+
+export const filterInternalHeaders = (
+  headers: Record<string, undefined | string | string[]>
+) => {
+  const subrequestIdHeader = headers['x-middleware-subrequest-id']
+
+  for (const header in headers) {
+    if (INTERNAL_HEADERS.includes(header)) {
+      delete headers[header]
+    }
+
+    // If this request didn't origin from this session we filter
+    // out the "x-middleware-subrequest" header so we don't skip
+    // middleware incorrectly
+    if (
+      header === 'x-middleware-subrequest' &&
+      !crypto.timingSafeEqual(
+        Buffer.from(
+          typeof subrequestIdHeader === 'string' ? subrequestIdHeader : ''
+        ),
+        Buffer.from(
+          (globalThis as any)[Symbol.for('@next/middleware-subrequest-id')] ||
+            ''
+        )
+      )
+    ) {
+      delete headers['x-middleware-subrequest']
+    }
+  }
+}

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -36,37 +36,3 @@ export const filterReqHeaders = (
   }
   return headers as Record<string, undefined | string | string[]>
 }
-
-// These are headers that are only used internally and should
-// not be honored from the external request
-const INTERNAL_HEADERS = [
-  'x-middleware-rewrite',
-  'x-middleware-redirect',
-  'x-middleware-set-cookie',
-  'x-middleware-skip',
-  'x-middleware-override-headers',
-  'x-middleware-next',
-  'x-now-route-matches',
-  'x-matched-path',
-]
-
-export const filterInternalHeaders = (
-  headers: Record<string, undefined | string | string[]>
-) => {
-  for (const header in headers) {
-    if (INTERNAL_HEADERS.includes(header)) {
-      delete headers[header]
-    }
-
-    // If this request didn't origin from this session we filter
-    // out the "x-middleware-subrequest" header so we don't skip
-    // middleware incorrectly
-    if (
-      header === 'x-middleware-subrequest' &&
-      headers['x-middleware-subrequest-id'] !==
-        (globalThis as any)[Symbol.for('@next/middleware-subrequest-id')]
-    ) {
-      delete headers['x-middleware-subrequest']
-    }
-  }
-}

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -375,7 +375,7 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
         }
         init.headers.set(
           'x-middleware-subrequest-id',
-          (globalThis as any)[Symbol.for('@next/middleware-subrequest-id')]
+          options.middlewareSubrequestId
         )
 
         const prevs =
@@ -505,6 +505,7 @@ interface ModuleContextOptions {
   useCache: boolean
   distDir: string
   edgeFunctionEntry: Pick<EdgeFunctionDefinition, 'assets' | 'wasm' | 'env'>
+  middlewareSubrequestId: string
 }
 
 function getModuleContextShared(options: ModuleContextOptions) {

--- a/packages/next/src/server/web/sandbox/sandbox.ts
+++ b/packages/next/src/server/web/sandbox/sandbox.ts
@@ -32,6 +32,7 @@ interface RunnerFnParams {
   edgeFunctionEntry: Pick<EdgeFunctionDefinition, 'assets' | 'wasm' | 'env'>
   distDir: string
   incrementalCache?: any
+  middlewareSubrequestId: string
   serverComponentsHmrCache?: ServerComponentsHmrCache
 }
 
@@ -74,6 +75,7 @@ export async function getRuntimeContext(
     useCache: params.useCache !== false,
     edgeFunctionEntry: params.edgeFunctionEntry,
     distDir: params.distDir,
+    middlewareSubrequestId: params.middlewareSubrequestId,
   })
 
   if (params.incrementalCache) {


### PR DESCRIPTION
Currently we have an existing mitigation although we can make this check even stronger by increasing the length of the generated id and use `crypto.timeSafeEqual` for the comparison. 
