### PR TITLE
Update 01-vitest.mdx

### DIFF
--- a/docs/01-app/03-building-your-application/08-testing/01-vitest.mdx
+++ b/docs/01-app/03-building-your-application/08-testing/01-vitest.mdx
@@ -38,6 +38,7 @@ export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
     environment: 'jsdom',
+    globals: true,
   },
 })
 ```


### PR DESCRIPTION
Without `globals: true` in the config, `test` is not globally available.
<img width="797" alt="Screenshot 2025-03-23 at 10 44 17 PM" src="https://github.com/user-attachments/assets/eb5f4dbb-6c7f-4534-92e8-5b3e3af7d574" />
