### PR TITLE
Add deprecation warning for legacyBehavior prop

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -176,6 +176,7 @@ type InternalLinkProps = {
    * Enable legacy link behavior, requiring an `<a>` tag to wrap the child content
    * if the child is a string or number.
    *
+   * @deprecated This will be removed in v16
    * @defaultValue `false`
    * @see https://github.com/vercel/next.js/commit/489e65ed98544e69b0afd7e0cfc3f9f6c2b803b7
    */
@@ -670,9 +671,19 @@ export default function LinkComponent(
     childProps.href = addBasePath(as)
   }
 
-  return legacyBehavior ? (
-    React.cloneElement(child, childProps)
-  ) : (
+  if (legacyBehavior) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        '`legacyBehavior` is deprecated and will be removed in a future ' +
+          'release. A codemod is available to upgrade your components:\n\n' +
+          'npx @next/codemod@latest new-link .\n\n' +
+          'Learn more: https://nextjs.org/docs/app/building-your-application/upgrading/codemods#remove-a-tags-from-link-components'
+      )
+    }
+    return React.cloneElement(child, childProps)
+  }
+
+  return (
     <a {...restProps} {...childProps}>
       {children}
     </a>

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -90,6 +90,7 @@ type InternalLinkProps = {
   locale?: string | false
   /**
    * Enable legacy link behavior.
+   * @deprecated This will be removed in v16
    * @defaultValue `false`
    * @see https://github.com/vercel/next.js/commit/489e65ed98544e69b0afd7e0cfc3f9f6c2b803b7
    */
@@ -665,9 +666,19 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
         addBasePath(addLocale(as, curLocale, router?.defaultLocale))
     }
 
-    return legacyBehavior ? (
-      React.cloneElement(child, childProps)
-    ) : (
+    if (legacyBehavior) {
+      if (process.env.NODE_ENV === 'development') {
+        console.error(
+          '`legacyBehavior` is deprecated and will be removed in a future ' +
+            'release. A codemod is available to upgrade your components:\n\n' +
+            'npx @next/codemod@latest new-link .\n\n' +
+            'Learn more: https://nextjs.org/docs/app/building-your-application/upgrading/codemods#remove-a-tags-from-link-components'
+        )
+      }
+      return React.cloneElement(child, childProps)
+    }
+
+    return (
       <a {...restProps} {...childProps}>
         {children}
       </a>

--- a/test/e2e/app-dir/link-component-deprecations/app/layout.tsx
+++ b/test/e2e/app-dir/link-component-deprecations/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/link-component-deprecations/app/page.tsx
+++ b/test/e2e/app-dir/link-component-deprecations/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <Link legacyBehavior href="/target-page">
+      <a>Target page</a>
+    </Link>
+  )
+}

--- a/test/e2e/app-dir/link-component-deprecations/app/target-page/page.tsx
+++ b/test/e2e/app-dir/link-component-deprecations/app/target-page/page.tsx
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function TargetPage() {
+  return <Link href="/">Home</Link>
+}

--- a/test/e2e/app-dir/link-component-deprecations/link-component-deprecations.test.ts
+++ b/test/e2e/app-dir/link-component-deprecations/link-component-deprecations.test.ts
@@ -1,0 +1,22 @@
+import { nextTestSetup, isNextDev } from 'e2e-utils'
+
+describe('Link component deprecations', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('logs deprecation warning for legacyBehavior prop', async () => {
+    const browser = await next.browser('/')
+    const logs = await browser.log()
+
+    const didWarn = logs.some(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          '`legacyBehavior` is deprecated and will be removed in a future release.'
+        )
+    )
+
+    expect(didWarn).toBe(isNextDev)
+  })
+})

--- a/test/integration/link-ref-pages/test/index.test.js
+++ b/test/integration/link-ref-pages/test/index.test.js
@@ -16,7 +16,7 @@ let app
 let appPort
 const appDir = join(__dirname, '..')
 
-const noError = async (pathname) => {
+const collectErrors = async (pathname) => {
   const browser = await webdriver(appPort, '/')
   await browser.eval(`(function() {
     window.caughtErrors = []
@@ -29,8 +29,14 @@ const noError = async (pathname) => {
   })()`)
   await waitFor(1000)
   const errors = await browser.eval(`window.caughtErrors`)
-  expect(errors).toEqual([])
   await browser.close()
+  return errors
+}
+
+const noError = async (pathname) => {
+  const errors = await collectErrors(pathname)
+  expect(errors).toEqual([])
+  return errors
 }
 
 const didPrefetch = async (pathname) => {
@@ -74,11 +80,21 @@ describe('Invalid hrefs', () => {
       runCommonTests()
 
       it('should not show error for function component with forwardRef', async () => {
-        await noError('/function')
+        const errors = await collectErrors('/function')
+        const legacyBehaviorDeprecation =
+          '`legacyBehavior` is deprecated and will be removed in a future release.'
+        errors.forEach((error) => {
+          expect(error).toContain(legacyBehaviorDeprecation)
+        })
       })
 
       it('should not show error for class component as child of next/link', async () => {
-        await noError('/class')
+        const errors = await collectErrors('/class')
+        const legacyBehaviorDeprecation =
+          '`legacyBehavior` is deprecated and will be removed in a future release.'
+        errors.forEach((error) => {
+          expect(error).toContain(legacyBehaviorDeprecation)
+        })
       })
 
       it('should handle child ref with React.createRef', async () => {


### PR DESCRIPTION
We plan to remove this feature in v16. The deprecation warning includes a link to the docs and an example of how to run a codemod.

<img width="976" alt="Screenshot 2025-03-24 at 12 51 05 PM" src="https://github.com/user-attachments/assets/e044e143-f88a-4f24-bb94-4dd8b46f6288" />

