### PR TITLE
[dev-overlay] Remove "Unhandled Runtime Error" label

### DIFF
--- a/packages/next/src/client/components/errors/console-error.ts
+++ b/packages/next/src/client/components/errors/console-error.ts
@@ -4,20 +4,20 @@ const consoleTypeSym = Symbol.for('next.console.error.type')
 
 // Represent non Error shape unhandled promise rejections or console.error errors.
 // Those errors will be captured and displayed in Error Overlay.
-type UnhandledError = Error & {
-  [digestSym]: 'NEXT_UNHANDLED_ERROR'
+export type ConsoleError = Error & {
+  [digestSym]: 'NEXT_CONSOLE_ERROR'
   [consoleTypeSym]: 'string' | 'error'
   environmentName: string
 }
 
-export function createUnhandledError(
+export function createConsoleError(
   message: string | Error,
   environmentName?: string | null
-): UnhandledError {
+): ConsoleError {
   const error = (
     typeof message === 'string' ? new Error(message) : message
-  ) as UnhandledError
-  error[digestSym] = 'NEXT_UNHANDLED_ERROR'
+  ) as ConsoleError
+  error[digestSym] = 'NEXT_CONSOLE_ERROR'
   error[consoleTypeSym] = typeof message === 'string' ? 'string' : 'error'
 
   if (environmentName && !error.environmentName) {
@@ -27,12 +27,10 @@ export function createUnhandledError(
   return error
 }
 
-export const isUnhandledConsoleOrRejection = (
-  error: any
-): error is UnhandledError => {
-  return error && error[digestSym] === 'NEXT_UNHANDLED_ERROR'
+export const isConsoleError = (error: any): error is ConsoleError => {
+  return error && error[digestSym] === 'NEXT_CONSOLE_ERROR'
 }
 
-export const getUnhandledErrorType = (error: UnhandledError) => {
+export const getConsoleErrorType = (error: ConsoleError) => {
   return error[consoleTypeSym]
 }

--- a/packages/next/src/client/components/errors/use-error-handler.ts
+++ b/packages/next/src/client/components/errors/use-error-handler.ts
@@ -4,7 +4,7 @@ import { isNextRouterError } from '../is-next-router-error'
 import { storeHydrationErrorStateFromConsoleArgs } from './hydration-error-info'
 import { formatConsoleArgs, parseConsoleArgs } from '../../lib/console'
 import isError from '../../../lib/is-error'
-import { createUnhandledError } from './console-error'
+import { createConsoleError } from './console-error'
 import { enqueueConsecutiveDedupedError } from './enqueue-client-error'
 import { getReactStitchedError } from '../errors/stitched-error'
 
@@ -18,25 +18,46 @@ const errorHandlers: Array<ErrorHandler> = []
 const rejectionQueue: Array<Error> = []
 const rejectionHandlers: Array<ErrorHandler> = []
 
-export function handleClientError(
+export function handleConsoleError(
   originError: unknown,
-  consoleErrorArgs: any[],
-  capturedFromConsole: boolean = false
+  consoleErrorArgs: any[]
 ) {
   let error: Error
-  if (!originError || !isError(originError)) {
-    // If it's not an error, format the args into an error
-    const formattedErrorMessage = formatConsoleArgs(consoleErrorArgs)
-    const { environmentName } = parseConsoleArgs(consoleErrorArgs)
-    error = createUnhandledError(formattedErrorMessage, environmentName)
+  const { environmentName } = parseConsoleArgs(consoleErrorArgs)
+  if (isError(originError)) {
+    error = createConsoleError(originError, environmentName)
   } else {
-    error = capturedFromConsole
-      ? createUnhandledError(originError)
-      : originError
+    error = createConsoleError(
+      formatConsoleArgs(consoleErrorArgs),
+      environmentName
+    )
   }
   error = getReactStitchedError(error)
 
   storeHydrationErrorStateFromConsoleArgs(...consoleErrorArgs)
+  attachHydrationErrorState(error)
+
+  enqueueConsecutiveDedupedError(errorQueue, error)
+  for (const handler of errorHandlers) {
+    // Delayed the error being passed to React Dev Overlay,
+    // avoid the state being synchronously updated in the component.
+    queueMicroTask(() => {
+      handler(error)
+    })
+  }
+}
+
+export function handleClientError(originError: unknown) {
+  let error: Error
+  if (isError(originError)) {
+    error = originError
+  } else {
+    // If it's not an error, format the args into an error
+    const formattedErrorMessage = originError + ''
+    error = new Error(formattedErrorMessage)
+  }
+  error = getReactStitchedError(error)
+
   attachHydrationErrorState(error)
 
   enqueueConsecutiveDedupedError(errorQueue, error)
@@ -85,7 +106,7 @@ function onUnhandledError(event: WindowEventMap['error']): void | boolean {
   // When there's an error property present, we log the error to error overlay.
   // Otherwise we don't do anything as it's not logging in the console either.
   if (event.error) {
-    handleClientError(event.error, [])
+    handleClientError(event.error)
   }
 }
 
@@ -98,7 +119,7 @@ function onUnhandledRejection(ev: WindowEventMap['unhandledrejection']): void {
 
   let error = reason
   if (error && !isError(error)) {
-    error = createUnhandledError(error + '')
+    error = new Error(error + '')
   }
 
   rejectionQueue.push(error)

--- a/packages/next/src/client/components/globals/intercept-console-error.ts
+++ b/packages/next/src/client/components/globals/intercept-console-error.ts
@@ -1,6 +1,6 @@
 import isError from '../../../lib/is-error'
 import { isNextRouterError } from '../is-next-router-error'
-import { handleClientError } from '../errors/use-error-handler'
+import { handleConsoleError } from '../errors/use-error-handler'
 import { parseConsoleArgs } from '../../lib/console'
 
 export const originConsoleError = globalThis.console.error
@@ -29,12 +29,11 @@ export function patchConsoleError() {
 
     if (!isNextRouterError(maybeError)) {
       if (process.env.NODE_ENV !== 'production') {
-        handleClientError(
+        handleConsoleError(
           // replayed errors have their own complex format string that should be used,
           // but if we pass the error directly, `handleClientError` will ignore it
           maybeError,
-          args,
-          true
+          args
         )
       }
 

--- a/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
@@ -55,7 +55,7 @@ function ReplaySsrOnlyErrors({
         // TODO(veil): Produces wrong Owner Stack
         // TODO(veil): Mark as recoverable error
         // TODO(veil): console.error
-        handleClientError(ssrError, [])
+        handleClientError(ssrError)
 
         // If it's missing root tags, we can't recover, make it blocking.
         if (ssrError.digest === MISSING_ROOT_TAGS_ERROR) {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -37,7 +37,7 @@ import { EnvironmentNameLabel } from '../environment-name-label/environment-name
 import { useFocusTrap } from '../dev-tools-indicator/utils'
 import { Fader } from '../../fader'
 
-interface ErrorOverlayLayoutProps extends ErrorBaseProps {
+export interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   errorMessage: ErrorMessageType
   errorType: ErrorType
   children?: React.ReactNode

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.stories.tsx
@@ -31,12 +31,6 @@ export const ConsoleError: Story = {
   },
 }
 
-export const UnhandledRuntimeError: Story = {
-  args: {
-    errorType: 'Unhandled Runtime Error',
-  },
-}
-
 export const MissingRequiredHTMLTag: Story = {
   args: {
     errorType: 'Missing Required HTML Tag',

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -2,7 +2,6 @@ export type ErrorType =
   | 'Build Error'
   | 'Runtime Error'
   | 'Console Error'
-  | 'Unhandled Runtime Error'
   | 'Missing Required HTML Tag'
 
 type ErrorTypeLabelProps = {

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -10,11 +10,14 @@ import {
   getHydrationWarningType,
 } from '../../../errors/hydration-error-info'
 import {
-  getUnhandledErrorType,
-  isUnhandledConsoleOrRejection,
+  isConsoleError,
+  getConsoleErrorType,
 } from '../../../errors/console-error'
 import { extractNextErrorCode } from '../../../../../lib/error-telemetry-utils'
-import { ErrorOverlayLayout } from '../components/errors/error-overlay-layout/error-overlay-layout'
+import {
+  ErrorOverlayLayout,
+  type ErrorOverlayLayoutProps,
+} from '../components/errors/error-overlay-layout/error-overlay-layout'
 import { NEXTJS_HYDRATION_ERROR_LINK } from '../../../is-hydration-error'
 import type { ReadyRuntimeError } from '../../utils/get-error-by-type'
 import type { ErrorBaseProps } from '../components/errors/error-overlay/error-overlay'
@@ -38,9 +41,8 @@ function ErrorDescription({
   error: Error
   hydrationWarning: string | null
 }) {
-  const isUnhandledOrReplayError = isUnhandledConsoleOrRejection(error)
-  const unhandledErrorType = isUnhandledOrReplayError
-    ? getUnhandledErrorType(error)
+  const unhandledErrorType = isConsoleError(error)
+    ? getConsoleErrorType(error)
     : null
   const isConsoleErrorStringMessage = unhandledErrorType === 'string'
   // If the error is:
@@ -48,10 +50,7 @@ function ErrorDescription({
   // - captured console error or unhandled rejection
   // skip displaying the error name
   const title =
-    (isUnhandledOrReplayError && isConsoleErrorStringMessage) ||
-    hydrationWarning
-      ? ''
-      : error.name + ': '
+    isConsoleErrorStringMessage || hydrationWarning ? '' : error.name + ': '
 
   const environmentName =
     'environmentName' in error ? error.environmentName : ''
@@ -73,6 +72,13 @@ function ErrorDescription({
       />
     </>
   )
+}
+
+function getErrorType(error: Error): ErrorOverlayLayoutProps['errorType'] {
+  if (isConsoleError(error)) {
+    return 'Console Error'
+  }
+  return 'Runtime Error'
 }
 
 export function Errors({
@@ -119,7 +125,7 @@ export function Errors({
   const isServerError = ['server', 'edge-server'].includes(
     getErrorSource(error) || ''
   )
-  const isUnhandledError = isUnhandledConsoleOrRejection(error)
+  const errorType = getErrorType(error)
   const errorDetails: HydrationErrorState = (error as any).details || {}
   const notes = errorDetails.notes || ''
   const [warningTemplate, serverContent, clientContent] =
@@ -145,13 +151,7 @@ export function Errors({
   return (
     <ErrorOverlayLayout
       errorCode={errorCode}
-      errorType={
-        isServerError
-          ? 'Runtime Error'
-          : isUnhandledError
-            ? 'Console Error'
-            : 'Unhandled Runtime Error'
-      }
+      errorType={errorType}
       errorMessage={
         <ErrorDescription error={error} hydrationWarning={hydrationWarning} />
       }

--- a/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
+++ b/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
@@ -79,7 +79,7 @@ export function onCaughtError(
     // Log and report the error with location but without modifying the error stack
     originConsoleError('%o\n\n%s', err, errorLocation)
 
-    handleClientError(stitchedError, [])
+    handleClientError(stitchedError)
   } else {
     originConsoleError(err)
   }

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -93,7 +93,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: no",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (3:7) @ [project]/index.js [app-client] (ecmascript)
        > 3 | throw new Error('no')
            |       ^",
@@ -109,7 +109,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 2,
          "description": "Error: no",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (3:7) @ eval
        > 3 | throw new Error('no')
            |       ^",
@@ -353,7 +353,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: ",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "Child.js (4:11) @ ClickCount.render
        > 4 |     throw new Error()
            |           ^",
@@ -502,7 +502,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('end https://nextjs.org')
            |           ^",
@@ -522,7 +522,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('end https://nextjs.org')
            |           ^",
@@ -587,7 +587,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('https://nextjs.org start')
            |           ^",
@@ -607,7 +607,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('https://nextjs.org start')
            |           ^",
@@ -671,7 +671,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('middle https://nextjs.org end')
            |           ^",
@@ -691,7 +691,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('middle https://nextjs.org end')
            |           ^",
@@ -755,7 +755,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('multiple https://nextjs.org links http://example.com')
            |           ^",
@@ -775,7 +775,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('multiple https://nextjs.org links http://example.com')
            |           ^",
@@ -949,7 +949,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: test",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (3:11) @
        {default export}
        > 3 |     throw new Error('test')
@@ -966,7 +966,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: test",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (3:11) @ default
        > 3 |     throw new Error('test')
            |           ^",
@@ -1052,7 +1052,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: Component error",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (2:44) @ Index
        > 2 |   if (typeof window !== 'undefined') throw new Error('Component error')
            |                                            ^",
@@ -1068,7 +1068,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: Component error",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (2:44) @ Index
        > 2 |   if (typeof window !== 'undefined') throw new Error('Component error')
            |                                            ^",
@@ -1106,7 +1106,7 @@ describe('ReactRefreshLogBox app', () => {
        "count": 1,
        "description": "Error: Client error",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/page.js (4:11) @ Page
      > 4 |     throw new Error('Client error')
          |           ^",
@@ -1138,7 +1138,7 @@ describe('ReactRefreshLogBox app', () => {
        "count": 1,
        "description": "Error: Server error",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/page.js (2:9) @ Page
      > 2 |   throw new Error('Server error')
          |         ^",
@@ -1178,7 +1178,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: This is an error from an anonymous function",
          "environmentLabel": "Server",
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/page.js (4:13) @ <anonymous>
        > 4 |       throw new Error("This is an error from an anonymous function");
            |             ^",
@@ -1194,7 +1194,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "Error: This is an error from an anonymous function",
          "environmentLabel": "Server",
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/page.js (4:13) @ eval
        > 4 |       throw new Error("This is an error from an anonymous function");
            |             ^",
@@ -1229,7 +1229,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "TypeError: Invalid URL",
          "environmentLabel": "Server",
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/page.js (2:3) @ Page
        > 2 |   new URL("/", "invalid");
            |   ^",
@@ -1244,7 +1244,7 @@ describe('ReactRefreshLogBox app', () => {
          "count": 1,
          "description": "TypeError: Invalid URL",
          "environmentLabel": "Server",
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/page.js (2:3) @ Page
        > 2 |   new URL("/", "invalid");
            |   ^",
@@ -1279,7 +1279,7 @@ describe('ReactRefreshLogBox app', () => {
        "count": 1,
        "description": "Error: Server component error",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/page.js (2:9) @ Page
      > 2 |   throw new Error('Server component error')
          |         ^",
@@ -1319,7 +1319,7 @@ describe('ReactRefreshLogBox app', () => {
        "count": 1,
        "description": "Error: Server component error!",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/page.js (2:9) @ Page
      > 2 |   throw new Error('Server component error!')
          |         ^",
@@ -1522,7 +1522,7 @@ export default function Home() {
        "count": 1,
        "description": "Error: server action was here",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/actions.ts (4:9) @ serverAction
      > 4 |   throw new Error("server action was here");
          |         ^",
@@ -1571,7 +1571,7 @@ export default function Home() {
        "count": 1,
        "description": "Error: server action was here",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/actions.ts (4:9) @ serverAction
      > 4 |   throw new Error("server action was here");
          |         ^",
@@ -1616,7 +1616,7 @@ export default function Home() {
          "count": 1,
          "description": "Error: utils error",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/utils.ts (1:7) @ [project]/app/utils.ts [app-client] (ecmascript)
        > 1 | throw new Error('utils error')
            |       ^",
@@ -1633,7 +1633,7 @@ export default function Home() {
          "count": 2,
          "description": "Error: utils error",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/utils.ts (1:7) @ eval
        > 1 | throw new Error('utils error')
            |       ^",

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -272,7 +272,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (7:11) @ Index.useCallback[increment]
        >  7 |     throw new Error('oops')
             |           ^",
@@ -293,7 +293,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (7:11) @ Index.useCallback[increment]
        >  7 |     throw new Error('oops')
             |           ^",
@@ -388,7 +388,7 @@ describe('Error recovery app', () => {
        "count": 1,
        "description": "Error: oops",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "child.js (3:9) @ Child
      > 3 |   throw new Error('oops')
          |         ^",
@@ -464,7 +464,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "child.js (3:9) @ Child
        > 3 |   throw new Error('oops')
            |         ^",
@@ -481,7 +481,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "child.js (3:9) @ Child
        > 3 |   throw new Error('oops')
            |         ^",
@@ -553,7 +553,7 @@ describe('Error recovery app', () => {
        "count": 1,
        "description": "Error: no 1",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "index.js (7:11) @ eval
      >  7 |     throw Error('no ' + i)
           |           ^",
@@ -708,7 +708,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: React is not defined",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -725,7 +725,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: React is not defined",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -915,7 +915,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: nooo",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ ClassDefault.render
        > 5 |     throw new Error('nooo');
            |           ^",
@@ -931,7 +931,7 @@ describe('Error recovery app', () => {
          "count": 1,
          "description": "Error: nooo",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ ClassDefault.render
        > 5 |     throw new Error('nooo');
            |           ^",

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -26,7 +26,7 @@ describe('Error overlay - RSC runtime errors', () => {
        "count": 1,
        "description": "TypeError: useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/server/page.js (3:16) @ Page
      > 3 |   callClientApi()
          |                ^",
@@ -59,7 +59,7 @@ describe('Error overlay - RSC runtime errors', () => {
          "count": 1,
          "description": "Error: \`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/client/page.js (4:15) @ Page
        > 4 |   callServerApi()
            |               ^",
@@ -74,7 +74,7 @@ describe('Error overlay - RSC runtime errors', () => {
          "count": 1,
          "description": "Error: \`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/client/page.js (4:16) @ Page
        > 4 |   callServerApi()
            |                ^",
@@ -103,7 +103,7 @@ describe('Error overlay - RSC runtime errors', () => {
        "count": 1,
        "description": "ReferenceError: alert is not defined",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/server/page.js (2:16) @ Page
      > 2 |   return <div>{alert('warn')}</div>
          |                ^",

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -49,7 +49,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: idk",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (8:27) @ onClick
        >  8 |                     throw new Error('idk')
             |                           ^",
@@ -66,7 +66,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: idk",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (8:27) @ onClick
        >  8 |                     throw new Error('idk')
             |                           ^",
@@ -279,7 +279,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 2,
          "description": "Error: no",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "FunctionDefault.js (1:51) @ FunctionDefault
        > 1 | export default function FunctionDefault() { throw new Error('no'); }
            |                                                   ^",
@@ -297,7 +297,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: no",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "FunctionDefault.js (1:51) @ FunctionDefault
        > 1 | export default function FunctionDefault() { throw new Error('no'); }
            |                                                   ^",
@@ -468,7 +468,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 2,
          "description": "Error: ",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "Child.js (4:11) @ ClickCount.render
        > 4 |     throw new Error()
            |           ^",
@@ -486,7 +486,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: ",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "Child.js (4:11) @ ClickCount.render
        > 4 |     throw new Error()
            |           ^",
@@ -637,7 +637,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('end https://nextjs.org')
            |           ^",
@@ -654,7 +654,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('end https://nextjs.org')
            |           ^",
@@ -694,7 +694,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('https://nextjs.org start')
            |           ^",
@@ -711,7 +711,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('https://nextjs.org start')
            |           ^",
@@ -751,7 +751,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('middle https://nextjs.org end')
            |           ^",
@@ -768,7 +768,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('middle https://nextjs.org end')
            |           ^",
@@ -808,7 +808,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('multiple https://nextjs.org links http://example.com')
            |           ^",
@@ -825,7 +825,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('multiple https://nextjs.org links http://example.com')
            |           ^",
@@ -865,7 +865,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: multiple https://nextjs.org links (http://example.com)",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('multiple https://nextjs.org links (http://example.com)')
            |           ^",
@@ -882,7 +882,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: multiple https://nextjs.org links (http://example.com)",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
        > 5 |     throw new Error('multiple https://nextjs.org links (http://example.com)')
            |           ^",
@@ -1115,7 +1115,7 @@ describe('ReactRefreshLogBox', () => {
            "count": 3,
            "description": "Error: Client error",
            "environmentLabel": null,
-           "label": "Unhandled Runtime Error",
+           "label": "Runtime Error",
            "source": "pages/index.js (3:11) @ Page
          > 3 |     throw new Error('Client error')
              |           ^",
@@ -1134,7 +1134,7 @@ describe('ReactRefreshLogBox', () => {
            "count": 3,
            "description": "Error: Client error",
            "environmentLabel": null,
-           "label": "Unhandled Runtime Error",
+           "label": "Runtime Error",
            "source": "pages/index.js (3:11) @ Page
          > 3 |     throw new Error('Client error')
              |           ^",
@@ -1150,7 +1150,7 @@ describe('ReactRefreshLogBox', () => {
          "count": 1,
          "description": "Error: Client error",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "pages/index.js (3:11) @ Page
        > 3 |     throw new Error('Client error')
            |           ^",

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -165,7 +165,7 @@ describe('pages/ error recovery', () => {
        "count": 1,
        "description": "Error: oops",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "index.js (7:11) @ Index.useCallback[increment]
      >  7 |     throw new Error('oops')
           |           ^",
@@ -258,7 +258,7 @@ describe('pages/ error recovery', () => {
          "count": 2,
          "description": "Error: oops",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "child.js (3:9) @ Child
        > 3 |   throw new Error('oops')
            |         ^",
@@ -276,7 +276,7 @@ describe('pages/ error recovery', () => {
          "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "child.js (3:9) @ Child
        > 3 |   throw new Error('oops')
            |         ^",
@@ -538,7 +538,7 @@ describe('pages/ error recovery', () => {
          "count": 2,
          "description": "Error: nooo",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:11) @ ClassDefault.render
        > 5 |     throw new Error('nooo');
            |           ^",
@@ -572,7 +572,7 @@ describe('pages/ error recovery', () => {
            "count": 1,
            "description": "Error: nooo",
            "environmentLabel": null,
-           "label": "Unhandled Runtime Error",
+           "label": "Runtime Error",
            "source": "index.js (5:11) @ ClassDefault.render
          > 5 |     throw new Error('nooo');
              |           ^",
@@ -641,7 +641,7 @@ describe('pages/ error recovery', () => {
          "count": 2,
          "description": "ReferenceError: React is not defined",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -659,7 +659,7 @@ describe('pages/ error recovery', () => {
          "count": 1,
          "description": "ReferenceError: React is not defined",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -727,7 +727,7 @@ describe('pages/ error recovery', () => {
               "count": 1,
               "description": "Error: no 1",
               "environmentLabel": null,
-              "label": "Unhandled Runtime Error",
+              "label": "Runtime Error",
               "source": "index.js (5:9) @ <unknown>
             > 5 |   throw Error('no ' + i)
                 |         ^",
@@ -742,7 +742,7 @@ describe('pages/ error recovery', () => {
          "count": 1,
          "description": "Error: no 1",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "index.js (5:9) @ eval
        > 5 |   throw Error('no ' + i)
            |         ^",

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -85,7 +85,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 2,
          "description": "Text content did not match. Server: "server" Client: "client"",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -110,7 +110,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -169,7 +169,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <main> in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -192,7 +192,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -237,7 +237,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching text node for "second" in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -263,7 +263,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -300,7 +300,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 2,
          "description": "Did not expect server HTML to contain a <main> in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -324,7 +324,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -359,7 +359,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 2,
          "description": "Did not expect server HTML to contain the text node "only" in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -383,7 +383,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -430,7 +430,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <table> in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -454,7 +454,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -495,7 +495,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <table> in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -519,7 +519,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -567,7 +567,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <main> in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -592,7 +592,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -666,7 +666,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <p> in <p>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -691,7 +691,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "description": "In HTML, <p> cannot be a descendant of <p>.
        This will cause a hydration error.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -738,7 +738,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <div> in <p>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -763,7 +763,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "description": "In HTML, <div> cannot be a descendant of <p>.
        This will cause a hydration error.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -800,7 +800,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <tr> in <div>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -825,7 +825,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "description": "In HTML, <tr> cannot be a child of <div>.
        This will cause a hydration error.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -868,7 +868,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "count": 3,
          "description": "Expected server HTML to contain a matching <p> in <span>.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }
@@ -897,7 +897,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
          "description": "In HTML, <p> cannot be a descendant of <p>.
        This will cause a hydration error.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -16,7 +16,7 @@ describe('app dir - dynamic error trace', () => {
        "count": 1,
        "description": "Error: Route / with \`dynamic = "error"\` couldn't be rendered statically because it used \`headers\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
        "environmentLabel": "Server",
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/lib.js (4:13) @ Foo
      > 4 |   useHeaders()
          |             ^",

--- a/test/development/app-dir/hook-function-names/hook-function-names.test.ts
+++ b/test/development/app-dir/hook-function-names/hook-function-names.test.ts
@@ -15,7 +15,7 @@ describe('hook-function-names', () => {
        "count": 1,
        "description": "Error: Kaputt!",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/button/page.tsx (7:11) @ Button.useCallback[handleClick]
      >  7 |     throw new Error(message)
           |           ^",
@@ -37,7 +37,7 @@ describe('hook-function-names', () => {
        "count": 1,
        "description": "Error: error in useEffect",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/page.tsx (7:11) @ Page.useEffect
      >  7 |     throw new Error('error in useEffect')
           |           ^",

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -162,7 +162,7 @@ describe('hydration-error-count', () => {
        "description": "In HTML, <p> cannot be a descendant of <p>.
      This will cause a hydration error.",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
      > 12 |       sneaky <p>very sneaky</p>
           |              ^",
@@ -179,7 +179,7 @@ describe('hydration-error-count', () => {
        "count": 3,
        "description": "Error: runtime error",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/hydration-with-runtime-errors/page.tsx (7:11) @ Page.useEffect
      >  7 |     throw new Error('runtime error')
           |           ^",

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -29,7 +29,7 @@ describe('app-dir - missing required html tags', () => {
        "description": "Error: Missing <html> and <body> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": null,
        "stack": [],
      }
@@ -51,7 +51,7 @@ describe('app-dir - missing required html tags', () => {
        "description": "Error: Missing <html> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": null,
        "stack": [],
      }
@@ -83,7 +83,7 @@ describe('app-dir - missing required html tags', () => {
          "description": "Error: Missing <html> and <body> tags in the root layout.
        Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": null,
          "stack": [],
        }

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -15,7 +15,7 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
      Check the render method of \`BrowserOnly\`.",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/browser/browser-only.js (8:7) @ BrowserOnly
      >  8 |       <Foo />
           |       ^",
@@ -38,7 +38,7 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
      Check the render method of \`Inner\`.",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/rsc/page.js (5:10) @ Inner
      > 5 |   return <Foo />
          |          ^",
@@ -60,7 +60,7 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
      Check the render method of \`Inner\`.",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/ssr/page.js (7:10) @ Inner
      >  7 |   return <Foo />
           |          ^",

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -58,7 +58,7 @@ describe('app-dir - owner-stack', () => {
        "count": 1,
        "description": "Error: browser error",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/browser/uncaught/page.js (5:11) @ useThrowError
      > 5 |     throw new Error('browser error')
          |           ^",
@@ -95,7 +95,7 @@ describe('app-dir - owner-stack', () => {
        "count": 1,
        "description": "Error: browser error",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/browser/caught/page.js (34:11) @ useThrowError
      > 34 |     throw new Error('browser error')
           |           ^",
@@ -144,7 +144,7 @@ describe('app-dir - owner-stack', () => {
        "count": 1,
        "description": "Error: ssr error",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/ssr/page.js (4:9) @ useThrowError
      > 4 |   throw new Error('ssr error')
          |         ^",
@@ -172,9 +172,9 @@ describe('app-dir - owner-stack', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "count": 1,
-       "description": "string in rejected promise",
+       "description": "Error: string in rejected promise",
        "environmentLabel": null,
-       "label": "Console Error",
+       "label": "Runtime Error",
        "source": null,
        "stack": [],
      }

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -15,7 +15,7 @@ describe('ssr-only-error', () => {
        "count": 1,
        "description": "Error: SSR only error",
        "environmentLabel": null,
-       "label": "Unhandled Runtime Error",
+       "label": "Runtime Error",
        "source": "app/page.tsx (5:11) @ Component
      > 5 |     throw new Error('SSR only error')
          |           ^",

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -270,7 +270,7 @@ describe('Client Navigation', () => {
            "count": 1,
            "description": "Error: "EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
            "environmentLabel": null,
-           "label": "Unhandled Runtime Error",
+           "label": "Runtime Error",
            "source": null,
            "stack": [],
          }
@@ -1257,7 +1257,7 @@ describe('Client Navigation', () => {
            "count": ${isReact18 ? 3 : 1},
            "description": "Error: An Expected error occurred",
            "environmentLabel": null,
-           "label": "Unhandled Runtime Error",
+           "label": "Runtime Error",
            "source": "pages/error-inside-browser-page.js (5:13) @ ErrorInRenderPage.render
          > 5 |       throw new Error('An Expected error occurred')
              |             ^",
@@ -1301,7 +1301,7 @@ describe('Client Navigation', () => {
              "count": 1,
              "description": "Error: An Expected error occurred",
              "environmentLabel": null,
-             "label": "Unhandled Runtime Error",
+             "label": "Runtime Error",
              "source": "pages/error-in-the-browser-global-scope.js (2:9) @ [project]/pages/error-in-the-browser-global-scope.js [client] (ecmascript)
            > 2 |   throw new Error('An Expected error occurred')
                |         ^",
@@ -1316,7 +1316,7 @@ describe('Client Navigation', () => {
              "count": 1,
              "description": "Error: An Expected error occurred",
              "environmentLabel": null,
-             "label": "Unhandled Runtime Error",
+             "label": "Runtime Error",
              "source": "pages/error-in-the-browser-global-scope.js (2:9) @ eval
            > 2 |   throw new Error('An Expected error occurred')
                |         ^",

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -179,7 +179,7 @@ describe('app-dir - errors', () => {
            "count": 1,
            "description": "Error: this is a test",
            "environmentLabel": null,
-           "label": "Unhandled Runtime Error",
+           "label": "Runtime Error",
            "source": "app/global-error-boundary/client/page.js (8:11) @ Page
          >  8 |     throw new Error('this is a test')
               |           ^",
@@ -219,7 +219,7 @@ describe('app-dir - errors', () => {
             "count": 1,
             "description": "Error: custom server error",
             "environmentLabel": "Server",
-            "label": "Unhandled Runtime Error",
+            "label": "Runtime Error",
             "source": "app/global-error-boundary/server/page.js (2:9) @ Page
           > 2 |   throw Error('custom server error')
               |         ^",

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -18,7 +18,7 @@ describe('app dir - global-error - error-in-global-error', () => {
          "count": 1,
          "description": "Error: error in page",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/page.js (7:11) @ Page.useEffect
        >  7 |     throw new Error('error in page')
             |           ^",
@@ -44,7 +44,7 @@ describe('app dir - global-error - error-in-global-error', () => {
          "count": 2,
          "description": "Error: error in global error",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/global-error.js (10:11) @ InnerGlobalError
        > 10 |     throw new Error('error in global error')
             |           ^",

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -221,7 +221,7 @@ describe('app-dir - server source maps', () => {
          "count": 1,
          "description": "Error: Boom",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/ssr-throw/Thrower.js (4:9) @ throwError
        > 4 |   throw new Error('Boom')
            |         ^",

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -253,7 +253,7 @@ describe('use-cache-hanging-inputs', () => {
 
         expect({ count, title, description }).toEqual({
           count: 1,
-          title: 'Unhandled Runtime Error\nCache',
+          title: 'Runtime Error\nCache',
           description: 'Error: kaputt!',
         })
       })

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -20,7 +20,7 @@ describe('next-link', () => {
          "description": "Error: Failed prop type: The prop \`href\` expects a \`string\` or \`object\` in \`<Link>\`, but got \`undefined\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/invalid-href/page.js (6:10) @ Hello
        > 6 |   return <Link>Hello, Dave!</Link>
            |          ^",
@@ -46,7 +46,7 @@ describe('next-link', () => {
          "count": 1,
          "description": "Error: No children were passed to <Link> with \`href\` of \`/about\` but one child is required https://nextjs.org/docs/messages/link-no-children",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/no-children/page.js (7:10) @ Page
        > 7 |   return <Link href="/about" legacyBehavior></Link>
            |          ^",
@@ -72,7 +72,7 @@ describe('next-link', () => {
          "description": "Error: Multiple children were passed to <Link> with \`href\` of \`/\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children 
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
-         "label": "Unhandled Runtime Error",
+         "label": "Runtime Error",
          "source": "app/multiple-children/page.js (7:5) @ Index
        >  7 |     <Link href="/" legacyBehavior>
             |     ^",


### PR DESCRIPTION
We already have "Runtime Error" and the distinction between the two is currently pretty obscure.
This enables us to cleanup some of the confusing "isUnhandledError" logic that returned true for console errors.