### PR TITLE
perf(turbopack): Use `chili` instead of `rayon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4833,9 +4833,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "oorandom"
@@ -4947,6 +4947,25 @@ dependencies = [
  "bytecount",
  "fnv",
  "unicode-width",
+]
+
+[[package]]
+name = "par-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ad734db961818c8d817a239053f9e6b9ad4487f6f236181c75d91573d8515"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "par-iter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475a015a1cd1720f1a371c089c06dd50bbfbedf2e721ca23d180c18794180360"
+dependencies = [
+ "either",
+ "par-core",
 ]
 
 [[package]]
@@ -9124,6 +9143,7 @@ dependencies = [
  "byteorder",
  "lzzzz",
  "memmap2 0.9.5",
+ "par-iter",
  "parking_lot",
  "pot",
  "qfilter",
@@ -9231,6 +9251,7 @@ dependencies = [
  "indexmap 2.7.1",
  "lmdb-rkv",
  "once_cell",
+ "par-iter",
  "parking_lot",
  "pot",
  "rand",
@@ -9333,6 +9354,7 @@ dependencies = [
  "jsonc-parser 0.21.0",
  "mime",
  "notify",
+ "par-iter",
  "parking_lot",
  "rayon",
  "rstest",
@@ -10054,6 +10076,7 @@ dependencies = [
  "flate2",
  "indexmap 2.7.1",
  "itertools 0.10.5",
+ "par-iter",
  "postcard",
  "rayon",
  "rustc-demangle",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true }
 thread_local = { workspace = true }
 twox-hash = { version = "2.0.1", features = ["xxhash64"] }
 zstd = { version = "0.13.2", features = ["zdict_builder"] }
+par-iter = "1.0.0"
 
 [dev-dependencies]
 rand = { workspace = true, features = ["small_rng"] }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -15,8 +15,8 @@ use anyhow::{bail, Context, Result};
 use byteorder::{ReadBytesExt, WriteBytesExt, BE};
 use lzzzz::lz4::decompress;
 use memmap2::Mmap;
+use par_iter::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use parking_lot::{Mutex, RwLock};
-use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 use crate::{
     arc_slice::ArcSlice,

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use anyhow::Result;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use par_iter::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{db::TurboPersistence, write_batch::WriteBatch};
 

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -11,11 +11,9 @@ use std::{
 use anyhow::{Context, Result};
 use byteorder::{WriteBytesExt, BE};
 use lzzzz::lz4::{self, ACC_LEVEL_DEFAULT};
+use par_iter::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use parking_lot::Mutex;
-use rayon::{
-    iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator},
-    scope, Scope,
-};
+use rayon::{scope, Scope};
 use thread_local::ThreadLocal;
 
 use crate::{

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -52,6 +52,7 @@ turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 turbo-tasks-malloc = { workspace = true, default-features = false }
 turbo-tasks-testing = { workspace = true }
+par-iter = "1.0.0"
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use par_iter::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
 use serde::{ser::SerializeSeq, Serialize};
 use tracing::Span;

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -55,6 +55,7 @@ turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 unicode-segmentation = { workspace = true }
 urlencoding = { workspace = true }
+par-iter = "1.0.0"
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -46,7 +46,7 @@ use invalidation::InvalidateFilesystem;
 use invalidator_map::InvalidatorMap;
 use jsonc_parser::{parse_to_serde_value, ParseOptions};
 use mime::Mime;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use par_iter::iter::{IntoParallelIterator, ParallelIterator};
 use read_glob::read_glob;
 pub use read_glob::ReadGlobResult;
 use serde::{Deserialize, Serialize};

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -13,7 +13,7 @@ use notify::{
     event::{MetadataKind, ModifyKind, RenameMode},
     Config, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher,
 };
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use par_iter::iter::{IntoParallelIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;

--- a/turbopack/crates/turbopack-trace-server/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-server/Cargo.toml
@@ -17,6 +17,7 @@ either = { workspace = true }
 flate2 = { version = "1.0.28" }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
+par-iter = "1.0.0"
 postcard = { workspace = true }
 rayon = { workspace = true }
 rustc-demangle = "0.1"

--- a/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use par_iter::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     bottom_up::build_bottom_up_graph,

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -5,7 +5,7 @@ use std::{
     vec,
 };
 
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use par_iter::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{

--- a/turbopack/crates/turbopack-trace-server/src/viewer.rs
+++ b/turbopack/crates/turbopack-trace-server/src/viewer.rs
@@ -2,7 +2,7 @@ use std::cmp::{max, Reverse};
 
 use either::Either;
 use itertools::Itertools;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use par_iter::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
### What?

Switch to `chili` from `rayon`. 

**Notes**: 
 - `par-core` allow switching parallelization library with a cargo feature.
 - `par-iter` and `par-core` are renamed from `swc_par_iter` and `swc_parallel` respectively. (Extracted to reduce CI waste)
 - We need to wait for https://github.com/dragostis/chili/pull/22


### Why?

`chili` is more CPU-efficient, especially when there's lots of CPU cores.

x-ref: I posted the numbers for internal apps at https://vercel.slack.com/archives/C03EWR7LGEN/p1742936353663429

### How?


Closes PACK-4610