### PR TITLE
 [dev-overlay] Re-enable some Turbopack HMR Redbox tests

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -411,6 +411,16 @@ export function getOverlayMiddleware(project: Project, projectPath: string) {
             }
             return { status: 'fulfilled', value: stackFrame }
           } catch (error) {
+            if (process.env.__NEXT_TEST_MODE) {
+              console.error(
+                new Error(
+                  `Failed to create original stack frame for \n${JSON.stringify(frame, null, 2)}`,
+                  {
+                    cause: error,
+                  }
+                )
+              )
+            }
             return {
               status: 'rejected',
               reason: inspect(error, { colors: false }),


### PR DESCRIPTION
Checking if these got fixed by https://github.com/vercel/next.js/pull/77511