### PR TITLE
Scripts: migrate unpack-next to TypeScript

### DIFF
--- a/scripts/unpack-next.ts
+++ b/scripts/unpack-next.ts
@@ -1,14 +1,14 @@
 // This script must be run with tsx
 
-const { NEXT_DIR, exec } = require('./pack-util')
-const fs = require('fs')
-const path = require('path')
+import { NEXT_DIR, exec } from './pack-util'
+import fs from 'fs'
+import path from 'path'
 
 const TARBALLS = `${NEXT_DIR}/tarballs`
 
 const PROJECT_DIR = path.resolve(process.argv[2])
 
-function realPathIfAny(path) {
+function realPathIfAny(path: fs.PathLike) {
   try {
     return fs.realpathSync(path)
   } catch {


### PR DESCRIPTION
## Convert unpack-next.cjs to TypeScript

### What?
Converted `scripts/unpack-next.cjs` to TypeScript, renaming it to `scripts/unpack-next.ts` and updating the imports and type definitions.

### Why?
This change continues the ongoing TypeScript migration efforts in the codebase, providing better type safety and developer experience.

### How?
- Renamed file from `.cjs` to `.ts`
- Converted CommonJS `require()` statements to ES module `import` statements
- Added type annotation for the `path` parameter in the `realPathIfAny` function

Fixes #

Closes PACK-4244