### PR TITLE
docs: Update template.js documentation to clarify parallel route rendering

### DIFF
--- a/docs/01-app/04-api-reference/03-file-conventions/template.mdx
+++ b/docs/01-app/04-api-reference/03-file-conventions/template.mdx
@@ -3,7 +3,7 @@ title: template.js
 description: API Reference for the template.js file.
 ---
 
-A **template** file is similar to a [layout](/docs/app/building-your-application/routing/layouts-and-templates#layouts) in that it wraps a layout or page. Unlike layouts that persist across routes and maintain state, templates are given a unique key, meaning children Client Components reset their state on navigation.
+A **template** file is similar to a [layout](/docs/app/building-your-application/routing/layouts-and-templates#layouts) in that it wraps a layout or page. Unlike layouts that persist across routes and maintain state, templates are given a unique key, meaning children Client Components reset their state on navigation. Additionally, the template is rendered for each parallel route
 
 ```tsx filename="app/template.tsx" switcher
 export default function Template({ children }: { children: React.ReactNode }) {
@@ -39,7 +39,9 @@ Template accepts a `children` prop. For example:
 ```jsx filename="Output"
 <Layout>
   {/* Note that the template is automatically given a unique key. */}
-  <Template key={routeParam}>{children}</Template>
+  {parallelRoutes.map(parallelRoute => (
+    <Template key={parallelRoute.key}>{parallelRoute.children}</Template>
+  ))}
 </Layout>
 ```
 
@@ -47,6 +49,7 @@ Template accepts a `children` prop. For example:
 >
 > - By default, `template` is a [Server Component](/docs/app/building-your-application/rendering/server-components), but can also be used as a [Client Component](/docs/app/building-your-application/rendering/client-components) through the `"use client"` directive.
 > - When a user navigates between routes that share a `template`, a new instance of the component is mounted, DOM elements are recreated, state is **not** preserved in Client Components, and effects are re-synchronized.
+> - The template is rendered for each parallel route.
 
 ## Version History
 


### PR DESCRIPTION
### What?

This PR updates the documentation for the template.js file to clarify how templates are rendered for parallel routes. The changes include updating the description, modifying the example code, and adding details to the "Good to know" section to better reflect the behavior of templates in Next.js.

### Why?

The documentation is unclear about the rendering behavior of templates for parallel routes, which could lead to confusion for developers using this feature. By clarifying that templates are rendered for each parallel route, we ensure that developers have a better understanding of how to use templates effectively in their applications.

### How?

- Clarified that the template is rendered for each parallel route.
- Updated example code to reflect parallel route rendering.
- Added additional details to the "Good to know" section.

explain [#67139](https://github.com/vercel/next.js/issues/67139)

