### PR TITLE
fix: make sure body can be read using `nodejs` runtime in middleware

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1605,7 +1605,7 @@ export default class NextNodeServer extends BaseServer<
 
       result = await adapterFn({
         handler: middlewareModule.middleware || middlewareModule,
-        request: requestData,
+        request: { ...requestData, body: requestData.body?.cloneBodyStream() },
         page: 'middleware',
       })
     } else {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1605,7 +1605,12 @@ export default class NextNodeServer extends BaseServer<
 
       result = await adapterFn({
         handler: middlewareModule.middleware || middlewareModule,
-        request: { ...requestData, body: requestData.body?.cloneBodyStream() },
+        request: {
+          ...requestData,
+          body: !['HEAD', 'GET'].includes(params.request.method)
+            ? requestData.body?.cloneBodyStream()
+            : undefined,
+        },
         page: 'middleware',
       })
     } else {

--- a/test/e2e/middleware-general/app/middleware-node.js
+++ b/test/e2e/middleware-general/app/middleware-node.js
@@ -253,6 +253,10 @@ export async function middleware(request) {
     throw new Error('test error')
   }
 
+  if (url.pathname === '/request-body' && request.method === 'POST') {
+    return NextResponse.json(await request.json())
+  }
+
   const original = new URL(request.url)
   return NextResponse.next({
     headers: {

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -252,6 +252,10 @@ export async function middleware(request) {
     throw new Error('test error')
   }
 
+  if (url.pathname === '/request-body' && request.method === 'POST') {
+    return NextResponse.json(await request.json())
+  }
+
   const original = new URL(request.url)
   return NextResponse.next({
     headers: {

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -824,6 +824,17 @@ describe('Middleware Runtime', () => {
         }/sha.json?hello=goodbye`,
       ])
     })
+
+    it(`should read request body`, async () => {
+      const body = { hello: 'world' }
+      const res = await fetchViaHTTP(next.url, '/request-body', undefined, {
+        body: JSON.stringify(body),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      })
+
+      expect(await res.json()).toEqual(body)
+    })
   }
   describe('with i18n', () => {
     setup({ i18n: true })


### PR DESCRIPTION
This fixes an issue where the body couldn't be read when running the middleware with the `nodejs` runtime. When running it in the `edge` runtime, `cloneBodyStream()` is ran [here](https://github.com/vercel/next.js/blob/ca4a18789d37dbd01ca3c88091d1f86134072dee/packages/next/src/server/web/sandbox/sandbox.ts#L104) so we need to do the same for the `nodejs`. 

Fixes #77551