### PR TITLE
Refer to X-Forwarded-Port header in CSRF prevension for server actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.test.ts
+++ b/packages/next/src/server/app-render/action-handler.test.ts
@@ -32,6 +32,39 @@ describe('parseHostHeader', () => {
         'x-forwarded-host': 'www.bar.com',
       })
     ).toEqual({ type: 'x-forwarded-host', value: 'www.bar.com' })
+
+    expect(
+      parseHostHeader({
+        host: 'www.foo.com',
+        'x-forwarded-host': 'www.bar.com:3000',
+      })
+    ).toEqual({ type: 'x-forwarded-host', value: 'www.bar.com:3000' })
+
+    expect(
+      parseHostHeader({
+        host: 'www.foo.com',
+        'x-forwarded-host': 'www.bar.com',
+        'x-forwarded-port': '3000',
+      })
+    ).toEqual({ type: 'x-forwarded-host', value: 'www.bar.com:3000' })
+
+    expect(
+      parseHostHeader({
+        host: 'www.foo.com',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'www.bar.com',
+        'x-forwarded-port': '443',
+      })
+    ).toEqual({ type: 'x-forwarded-host', value: 'www.bar.com' })
+
+    expect(
+      parseHostHeader({
+        host: 'www.foo.com',
+        'x-forwarded-proto': 'http',
+        'x-forwarded-host': 'www.bar.com',
+        'x-forwarded-port': '80',
+      })
+    ).toEqual({ type: 'x-forwarded-host', value: 'www.bar.com' })
   })
 
   it('should return correct x-forwarded-host when provided in array', () => {

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -391,22 +391,35 @@ function limitUntrustedHeaderValueForLogs(value: string) {
   return value.length > 100 ? value.slice(0, 100) + '...' : value
 }
 
+function extractFirstHeaderValue(header: string | string[] | undefined) {
+  return header && Array.isArray(header)
+    ? header[0]
+    : header?.split(',')?.[0]?.trim()
+}
+
 export function parseHostHeader(
   headers: IncomingHttpHeaders,
   originDomain?: string
 ) {
-  const forwardedHostHeader = headers['x-forwarded-host']
-  const forwardedHostHeaderValue =
-    forwardedHostHeader && Array.isArray(forwardedHostHeader)
-      ? forwardedHostHeader[0]
-      : forwardedHostHeader?.split(',')?.[0]?.trim()
+  let forwardedValue: string | undefined
+  const forwardedHost = extractFirstHeaderValue(headers['x-forwarded-host'])
+  if (forwardedHost) {
+    const forwardedProto = extractFirstHeaderValue(headers['x-forwarded-proto'])
+    const proto = forwardedProto === 'http' ? 'http' : 'https'
+    const forwardedUrl = new URL(`${proto}://${forwardedHost}`)
+    const forwardedPort = extractFirstHeaderValue(headers['x-forwarded-port'])
+    if (forwardedPort) {
+      forwardedUrl.port = forwardedPort
+    }
+    forwardedValue = forwardedUrl.host
+  }
   const hostHeader = headers['host']
 
   if (originDomain) {
-    return forwardedHostHeaderValue === originDomain
+    return forwardedValue === originDomain
       ? {
           type: HostType.XForwardedHost,
-          value: forwardedHostHeaderValue,
+          value: forwardedValue,
         }
       : hostHeader === originDomain
         ? {
@@ -416,10 +429,10 @@ export function parseHostHeader(
         : undefined
   }
 
-  return forwardedHostHeaderValue
+  return forwardedValue
     ? {
         type: HostType.XForwardedHost,
-        value: forwardedHostHeaderValue,
+        value: forwardedValue,
       }
     : hostHeader
       ? {


### PR DESCRIPTION
### What?

This pull request modifies CSRF prevention logic for server actions. In the current logic, the host and port a user tried to access are constructed from `X-Forwarded-Host` header. In this pull request, the host and port are constructed not only from `X-Forwarded-Host` header but also from `X-Forwareded-Port` header and `X-Forwarded-Proto` header.

### Why?

Some reverse proxies don't include the original port in `X-Forwarded-Host` header but include it in `X-Forwarded-Port` header. Current CSRF prevention logic can't handle that case.

### How?

If `X-Forwarded-Port` header and `X-Forwarded-Proto` header are present in addtion to `X-Forwarded-Host` header, use port in `X-Forwarded-Port` header to construct the host and port a user tried to access.

Fixes #77556 
