### PR TITLE
Turbopack: Allow overriding tsconfig path via next-config

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
@@ -169,7 +169,7 @@ pub async fn get_client_resolve_options_context(
             .to_resolved()
             .await?;
     let custom_conditions = vec![mode.await?.condition().into()];
-    let module_options_context = ResolveOptionsContext {
+    let resolve_options_context = ResolveOptionsContext {
         enable_node_modules: Some(project_path.root().to_resolved().await?),
         custom_conditions,
         import_map: Some(next_client_import_map),
@@ -201,16 +201,24 @@ pub async fn get_client_resolve_options_context(
         )],
         ..Default::default()
     };
+
     Ok(ResolveOptionsContext {
         enable_typescript: true,
         enable_react: true,
         enable_mjs_extension: true,
         custom_extensions: next_config.resolve_extension().owned().await?,
+        tsconfig_path: next_config
+            .typescript_tsconfig_path()
+            .await?
+            .as_ref()
+            .map(|p| project_path.join(p.to_owned()))
+            .to_resolved()
+            .await?,
         rules: vec![(
             foreign_code_context_condition(next_config, project_path).await?,
-            module_options_context.clone().resolved_cell(),
+            resolve_options_context.clone().resolved_cell(),
         )],
-        ..module_options_context
+        ..resolve_options_context
     }
     .cell())
 }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -417,7 +417,7 @@ pub struct Rewrites {
 #[serde(rename_all = "camelCase")]
 pub struct TypeScriptConfig {
     pub ignore_build_errors: Option<bool>,
-    pub ts_config_path: Option<String>,
+    pub tsconfig_path: Option<String>,
 }
 
 #[turbo_tasks::value(eq = "manual", operation)]
@@ -1533,6 +1533,16 @@ impl NextConfig {
         let source_maps = self.experimental.turbo.as_ref().and_then(|t| t.source_maps);
 
         Ok(Vc::cell(source_maps.unwrap_or(true)))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn typescript_tsconfig_path(&self) -> Result<Vc<Option<RcStr>>> {
+        Ok(Vc::cell(
+            self.typescript
+                .tsconfig_path
+                .as_ref()
+                .map(|path| path.to_owned().into()),
+        ))
     }
 }
 

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{css::chunk::CssChunkType, resolve_options_context::ResolveOptionsContext};
@@ -183,6 +183,7 @@ pub async fn get_edge_resolve_options_context(
         browser: true,
         after_resolve_plugins,
         before_resolve_plugins,
+
         ..Default::default()
     };
 
@@ -192,6 +193,13 @@ pub async fn get_edge_resolve_options_context(
         enable_mjs_extension: true,
         enable_edge_node_externals: true,
         custom_extensions: next_config.resolve_extension().owned().await?,
+        tsconfig_path: next_config
+            .typescript_tsconfig_path()
+            .await?
+            .as_ref()
+            .map(|p| project_path.join(p.to_owned()))
+            .to_resolved()
+            .await?,
         rules: vec![(
             foreign_code_context_condition(next_config, project_path).await?,
             resolve_options_context.clone().resolved_cell(),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
@@ -324,6 +324,13 @@ pub async fn get_server_resolve_options_context(
         enable_react: true,
         enable_mjs_extension: true,
         custom_extensions: next_config.resolve_extension().owned().await?,
+        tsconfig_path: next_config
+            .typescript_tsconfig_path()
+            .await?
+            .as_ref()
+            .map(|p| project_path.join(p.to_owned()))
+            .to_resolved()
+            .await?,
         rules: vec![(
             foreign_code_context_condition,
             resolve_options_context.clone().resolved_cell(),

--- a/test/e2e/tsconfig-path/app/layout.tsx
+++ b/test/e2e/tsconfig-path/app/layout.tsx
@@ -1,0 +1,15 @@
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export async function generateMetadata() {
+  return {}
+}

--- a/test/e2e/tsconfig-path/app/page.tsx
+++ b/test/e2e/tsconfig-path/app/page.tsx
@@ -1,0 +1,5 @@
+import foo from 'foo'
+
+export default function Page() {
+  return <p>{foo}</p>
+}

--- a/test/e2e/tsconfig-path/bar.ts
+++ b/test/e2e/tsconfig-path/bar.ts
@@ -1,0 +1,1 @@
+export default 'bar123'

--- a/test/e2e/tsconfig-path/index.test.ts
+++ b/test/e2e/tsconfig-path/index.test.ts
@@ -1,0 +1,29 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+
+describe('specified tsconfig', () => {
+  const { next, skipped } = nextTestSetup({
+    files: new FileRef(__dirname),
+    dependencies: {
+      typescript: '5.4.4',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('app router: allows a user-specific tsconfig via the next config', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('bar123')
+  })
+
+  it('pages router: allows a user-specific tsconfig via the next config', async () => {
+    const html = await next.render('/page')
+    expect(html).toContain('bar123')
+  })
+
+  it('middleware: allows a user-specific tsconfig via the next config', async () => {
+    const html = await next.render('/middleware')
+    expect(html).toContain('bar123')
+  })
+})

--- a/test/e2e/tsconfig-path/middleware.ts
+++ b/test/e2e/tsconfig-path/middleware.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import foo from 'foo'
+
+// This function can be marked `async` if using `await` inside
+export function middleware(request: NextRequest) {
+  return NextResponse.json({ foo })
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: '/middleware',
+}

--- a/test/e2e/tsconfig-path/myconfig.json
+++ b/test/e2e/tsconfig-path/myconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "foo": ["./bar.ts"]
+    },
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/test/e2e/tsconfig-path/next.config.ts
+++ b/test/e2e/tsconfig-path/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  typescript: {
+    tsconfigPath: 'myconfig.json',
+  },
+}
+
+export default nextConfig

--- a/test/e2e/tsconfig-path/pages/page.tsx
+++ b/test/e2e/tsconfig-path/pages/page.tsx
@@ -1,0 +1,5 @@
+import foo from 'foo'
+
+export default function Page() {
+  return <p>{foo}</p>
+}

--- a/test/e2e/typescript-custom-tsconfig/app/layout.tsx
+++ b/test/e2e/typescript-custom-tsconfig/app/layout.tsx
@@ -1,0 +1,15 @@
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export async function generateMetadata() {
+  return {}
+}

--- a/test/e2e/typescript-custom-tsconfig/app/page.tsx
+++ b/test/e2e/typescript-custom-tsconfig/app/page.tsx
@@ -1,0 +1,5 @@
+import foo from 'foo'
+
+export default function Page() {
+  return <p>{foo}</p>
+}

--- a/test/e2e/typescript-custom-tsconfig/bar.ts
+++ b/test/e2e/typescript-custom-tsconfig/bar.ts
@@ -1,0 +1,1 @@
+export default 'bar123'

--- a/test/e2e/typescript-custom-tsconfig/middleware.ts
+++ b/test/e2e/typescript-custom-tsconfig/middleware.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import foo from 'foo'
+
+// This function can be marked `async` if using `await` inside
+export function middleware(request: NextRequest) {
+  return NextResponse.json({ foo })
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: '/middleware',
+}

--- a/test/e2e/typescript-custom-tsconfig/next.config.ts
+++ b/test/e2e/typescript-custom-tsconfig/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  typescript: {
+    tsconfigPath: 'web.tsconfig.json',
+  },
+}
+
+export default nextConfig

--- a/test/e2e/typescript-custom-tsconfig/pages/page.tsx
+++ b/test/e2e/typescript-custom-tsconfig/pages/page.tsx
@@ -1,0 +1,5 @@
+import foo from 'foo'
+
+export default function Page() {
+  return <p>{foo}</p>
+}

--- a/test/e2e/typescript-custom-tsconfig/test/index.test.js
+++ b/test/e2e/typescript-custom-tsconfig/test/index.test.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import { nextTestSetup, FileRef } from 'e2e-utils'
+
+describe('Custom TypeScript Config', () => {
+  const { next, skipped } = nextTestSetup({
+    files: new FileRef(join(__dirname, '..')),
+    dependencies: {
+      typescript: '5.4.4',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('app router: allows a user-specific tsconfig via the next config', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('bar123')
+  })
+
+  it('pages router: allows a user-specific tsconfig via the next config', async () => {
+    const html = await next.render('/page')
+    expect(html).toContain('bar123')
+  })
+
+  it('middleware: allows a user-specific tsconfig via the next config', async () => {
+    const html = await next.render('/middleware')
+    expect(html).toContain('bar123')
+  })
+})

--- a/test/e2e/typescript-custom-tsconfig/web.tsconfig.json
+++ b/test/e2e/typescript-custom-tsconfig/web.tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "foo": ["./bar.ts"]
+    },
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -32,6 +32,10 @@ pub struct ResolveOptionsContext {
     /// directory
     pub enable_node_modules: Option<ResolvedVc<FileSystemPath>>,
     #[serde(default)]
+    /// A specific path to a tsconfig.json file to use for resolving modules. If `None`, one will
+    /// be looked up through the filesystem
+    pub tsconfig_path: Option<ResolvedVc<FileSystemPath>>,
+    #[serde(default)]
     /// Mark well-known Node.js modules as external imports and load them using
     /// native `require`. e.g. url, querystring, os
     pub enable_node_externals: bool,


### PR DESCRIPTION
This:
- Adds a test asserting the user can override the tsconfig path via the next-config. This is already supported with Next.js and Webpack.
- Implements the necessary code to pass the test and implement support with Turbopack.

Test Plan: `pnpm test-dev test/e2e/tsconfig-path/index.test.ts && pnpm test-dev-turbo test/e2e/tsconfig-path/index.test.ts`

Closes PACK-4215