### PR TITLE
Do not call `expireTags`/`getExpiration` unnecessarily

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -260,6 +260,12 @@ export class IncrementalCache implements IncrementalCacheType {
   }
 
   async revalidateTag(tags: string | string[]): Promise<void> {
+    tags = Array.isArray(tags) ? tags : [tags]
+
+    if (tags.length === 0) {
+      return
+    }
+
     const promises: Promise<void>[] = []
 
     if (this.cacheHandler?.revalidateTag) {
@@ -268,7 +274,6 @@ export class IncrementalCache implements IncrementalCacheType {
 
     const handlers = getCacheHandlers()
     if (handlers) {
-      tags = Array.isArray(tags) ? tags : [tags]
       for (const handler of handlers) {
         promises.push(handler.expireTags(...tags))
       }
@@ -279,7 +284,11 @@ export class IncrementalCache implements IncrementalCacheType {
     const workUnitStore = workUnitAsyncStorage.getStore()
 
     if (workUnitStore?.implicitTags) {
-      await updateImplicitTagsExpiration(workUnitStore.implicitTags)
+      const tagsSet = new Set(tags)
+
+      if (workUnitStore.implicitTags.tags.some((tag) => tagsSet.has(tag))) {
+        await updateImplicitTagsExpiration(workUnitStore.implicitTags)
+      }
     }
   }
 

--- a/test/e2e/app-dir/use-cache-custom-handler/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-custom-handler/app/layout.tsx
@@ -1,8 +1,12 @@
+import { Suspense } from 'react'
+
 export default function RootLayout({ children }) {
   return (
     <html>
       <head />
-      <body>{children}</body>
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/use-cache-custom-handler/app/legacy/page.tsx
+++ b/test/e2e/app-dir/use-cache-custom-handler/app/legacy/page.tsx
@@ -5,6 +5,8 @@ import {
   revalidateTag,
 } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { connection } from 'next/server'
+import React from 'react'
 
 async function getData() {
   'use cache: legacy'
@@ -21,7 +23,9 @@ async function AsyncComp() {
   return <p id="data">{data}</p>
 }
 
-export default function Legacy() {
+export default async function Legacy() {
+  await connection()
+
   return (
     <main>
       <Suspense fallback={<p>Loading...</p>}>

--- a/test/e2e/app-dir/use-cache-custom-handler/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-custom-handler/app/page.tsx
@@ -2,9 +2,12 @@ import { Suspense } from 'react'
 import {
   unstable_cacheLife as cacheLife,
   unstable_cacheTag as cacheTag,
+  revalidatePath,
   revalidateTag,
 } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { connection } from 'next/server'
+import React from 'react'
 
 async function getData() {
   'use cache'
@@ -21,21 +24,46 @@ async function AsyncComp() {
   return <p id="data">{data}</p>
 }
 
-export default function Home() {
+export default async function Home() {
+  await connection()
+
   return (
     <main>
       <Suspense fallback={<p>Loading...</p>}>
         <AsyncComp />
       </Suspense>
-      <form
-        action={async () => {
-          'use server'
+      <form>
+        <button
+          id="revalidate-tag"
+          formAction={async () => {
+            'use server'
 
-          revalidateTag('modern')
-          redirect('/')
-        }}
-      >
-        <button id="revalidate">Revalidate Tag</button>
+            revalidateTag('modern')
+          }}
+        >
+          Revalidate Tag
+        </button>{' '}
+        <button
+          id="revalidate-path"
+          formAction={async () => {
+            'use server'
+
+            revalidatePath('/')
+          }}
+        >
+          Revalidate Path
+        </button>{' '}
+        <button
+          id="revalidate-redirect"
+          formAction={async () => {
+            'use server'
+
+            revalidateTag('modern')
+            redirect('/')
+          }}
+        >
+          Revalidate Tag & Redirect
+        </button>
       </form>
     </main>
   )

--- a/test/e2e/app-dir/use-cache-custom-handler/handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/handler.js
@@ -8,27 +8,27 @@ const defaultCacheHandler =
  */
 const cacheHandler = {
   async get(cacheKey) {
-    console.log('CustomCacheHandler::get', cacheKey)
+    console.log('ModernCustomCacheHandler::get', cacheKey)
     return defaultCacheHandler.get(cacheKey)
   },
 
   async set(cacheKey, pendingEntry) {
-    console.log('CustomCacheHandler::set', cacheKey)
+    console.log('ModernCustomCacheHandler::set', cacheKey)
     return defaultCacheHandler.set(cacheKey, pendingEntry)
   },
 
   async refreshTags() {
-    console.log('CustomCacheHandler::refreshTags')
+    console.log('ModernCustomCacheHandler::refreshTags')
     return defaultCacheHandler.refreshTags()
   },
 
   async getExpiration(...tags) {
-    console.log('CustomCacheHandler::getExpiration', JSON.stringify(tags))
+    console.log('ModernCustomCacheHandler::getExpiration', JSON.stringify(tags))
     return defaultCacheHandler.getExpiration(...tags)
   },
 
   async expireTags(...tags) {
-    console.log('CustomCacheHandler::expireTags', JSON.stringify(tags))
+    console.log('ModernCustomCacheHandler::expireTags', JSON.stringify(tags))
     return defaultCacheHandler.expireTags(...tags)
   },
 }

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -1,4 +1,4 @@
-import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
@@ -12,32 +12,31 @@ describe('use-cache-custom-handler', () => {
 
   if (skipped) return
 
+  let outputIndex: number
+
+  beforeEach(() => {
+    outputIndex = next.cliOutput.length
+  })
+
   it('should use a modern custom cache handler if provided', async () => {
-    const outputIndex = next.cliOutput.length
     const browser = await next.browser(`/`)
-
-    if (isNextStart) {
-      // Refresh once to let it revalidate the prerendered page.
-      await browser.refresh()
-    }
-
     const initialData = await browser.elementById('data').text()
     expect(initialData).toMatch(isoDateRegExp)
 
     expect(next.cliOutput.slice(outputIndex)).toContain(
-      'CustomCacheHandler::refreshTags'
+      'ModernCustomCacheHandler::refreshTags'
     )
 
     expect(next.cliOutput.slice(outputIndex)).toContain(
-      `CustomCacheHandler::getExpiration ["_N_T_/layout","_N_T_/page","_N_T_/"]`
+      `ModernCustomCacheHandler::getExpiration ["_N_T_/layout","_N_T_/page","_N_T_/"]`
     )
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /CustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\]/
     )
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /CustomCacheHandler::set \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::set \["(development|[A-Za-z0-9_-]{21})","\$undefined","([0-9a-f]{2})+",\[\]\]/
     )
 
     // The data should be cached initially.
@@ -59,14 +58,7 @@ describe('use-cache-custom-handler', () => {
   })
 
   it('should use a legacy custom cache handler if provided', async () => {
-    const outputIndex = next.cliOutput.length
     const browser = await next.browser(`/legacy`)
-
-    if (isNextStart) {
-      // Refresh once to let it revalidate the prerendered page.
-      await browser.refresh()
-    }
-
     const initialData = await browser.elementById('data').text()
     expect(initialData).toMatch(isoDateRegExp)
 
@@ -100,17 +92,16 @@ describe('use-cache-custom-handler', () => {
     }, 5000)
   })
 
-  it('should revalidate using a modern custom cache handler', async () => {
-    const outputIndex = next.cliOutput.length
+  it('should revalidate after redirect using a modern custom cache handler', async () => {
     const browser = await next.browser(`/`)
     const initialData = await browser.elementById('data').text()
     expect(initialData).toMatch(isoDateRegExp)
 
-    await browser.elementById('revalidate').click()
+    await browser.elementById('revalidate-redirect').click()
 
     await retry(async () => {
       expect(next.cliOutput.slice(outputIndex)).toContain(
-        'CustomCacheHandler::expireTags ["modern"]'
+        'ModernCustomCacheHandler::expireTags ["modern"]'
       )
 
       const data = await browser.elementById('data').text()
@@ -119,8 +110,7 @@ describe('use-cache-custom-handler', () => {
     }, 5000)
   })
 
-  it('should revalidate using a legacy custom cache handler', async () => {
-    const outputIndex = next.cliOutput.length
+  it('should revalidate after redirect using a legacy custom cache handler', async () => {
     const browser = await next.browser(`/legacy`)
     const initialData = await browser.elementById('data').text()
     expect(initialData).toMatch(isoDateRegExp)
@@ -144,5 +134,66 @@ describe('use-cache-custom-handler', () => {
       expect(data).toMatch(isoDateRegExp)
       expect(data).not.toEqual(initialData)
     }, 5000)
+  })
+
+  it('should not call expireTags for a normal invocation', async () => {
+    await next.fetch(`/`)
+
+    await retry(async () => {
+      const cliOutput = next.cliOutput.slice(outputIndex)
+      expect(cliOutput).toInclude('ModernCustomCacheHandler::refreshTags')
+      expect(cliOutput).toInclude('ModernCustomCacheHandler::getExpiration')
+      expect(cliOutput).not.toInclude('ModernCustomCacheHandler::expireTags')
+    })
+  })
+
+  it('should not call getExpiration again after an action if only explicit tags were revalidated', async () => {
+    const browser = await next.browser(`/`)
+
+    await retry(async () => {
+      const cliOutput = next.cliOutput.slice(outputIndex)
+      expect(cliOutput).toInclude('ModernCustomCacheHandler::getExpiration')
+    })
+
+    outputIndex = next.cliOutput.length
+
+    await browser.elementById('revalidate-tag').click()
+
+    await retry(async () => {
+      const cliOutput = next.cliOutput.slice(outputIndex)
+      expect(cliOutput).toIncludeRepeated(
+        'ModernCustomCacheHandler::getExpiration',
+        1
+      )
+      expect(cliOutput).toIncludeRepeated(
+        `ModernCustomCacheHandler::expireTags`,
+        1
+      )
+    })
+  })
+
+  it('should call getExpiration again after an action if implicit tags were revalidated', async () => {
+    const browser = await next.browser(`/`)
+
+    await retry(async () => {
+      const cliOutput = next.cliOutput.slice(outputIndex)
+      expect(cliOutput).toInclude('ModernCustomCacheHandler::getExpiration')
+    })
+
+    outputIndex = next.cliOutput.length
+
+    await browser.elementById('revalidate-path').click()
+
+    await retry(async () => {
+      const cliOutput = next.cliOutput.slice(outputIndex)
+      expect(cliOutput).toIncludeRepeated(
+        'ModernCustomCacheHandler::expireTags',
+        1
+      )
+      expect(cliOutput).toIncludeRepeated(
+        'ModernCustomCacheHandler::getExpiration',
+        2
+      )
+    })
   })
 })


### PR DESCRIPTION
- At the end of a request, or after a server action, when no tags were revalidated, we should not call the `expireTags` method of the configured cache handlers.
- After a server action, when no implicit tags were revalidated, we should not call the `getExpiration` method of the configured cache handlers.