### PR TITLE
Refactor: move `"use cache"` revalidation logic out of incremental cache

### DIFF
--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -4,7 +4,7 @@ import type { AfterCallback, AfterTask } from './after'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { isThenable } from '../../shared/lib/is-thenable'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
-import { withExecuteRevalidates } from './revalidation-utils'
+import { withExecuteRevalidates } from '../revalidation-utils'
 import { bindSnapshot } from '../app-render/async-local-storage'
 import {
   workUnitAsyncStorage,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -187,6 +187,7 @@ import isError from '../../lib/is-error'
 import { isUseCacheTimeoutError } from '../use-cache/use-cache-errors'
 import { createServerInsertedMetadata } from './metadata-insertion/create-server-inserted-metadata'
 import { getPreviouslyRevalidatedTags } from '../server-utils'
+import { executeRevalidates } from '../revalidation-utils'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -1407,13 +1408,7 @@ async function renderToHTMLOrFlightImpl(
       workStore.pendingRevalidateWrites ||
       workStore.pendingRevalidatedTags
     ) {
-      const pendingPromise = Promise.all([
-        workStore.incrementalCache?.revalidateTag(
-          workStore.pendingRevalidatedTags || []
-        ),
-        ...Object.values(workStore.pendingRevalidates || {}),
-        ...(workStore.pendingRevalidateWrites || []),
-      ]).finally(() => {
+      const pendingPromise = executeRevalidates(workStore).finally(() => {
         if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
           console.log('pending revalidates promise finished for:', url)
         }
@@ -1582,13 +1577,7 @@ async function renderToHTMLOrFlightImpl(
       workStore.pendingRevalidateWrites ||
       workStore.pendingRevalidatedTags
     ) {
-      const pendingPromise = Promise.all([
-        workStore.incrementalCache?.revalidateTag(
-          workStore.pendingRevalidatedTags || []
-        ),
-        ...Object.values(workStore.pendingRevalidates || {}),
-        ...(workStore.pendingRevalidateWrites || []),
-      ]).finally(() => {
+      const pendingPromise = executeRevalidates(workStore).finally(() => {
         if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
           console.log('pending revalidates promise finished for:', url)
         }

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -30,10 +30,8 @@ import {
   getRenderResumeDataCache,
   workUnitAsyncStorage,
 } from '../../app-render/work-unit-async-storage.external'
-import { getCacheHandlers } from '../../use-cache/handlers'
 import { InvariantError } from '../../../shared/lib/invariant-error'
 import type { Revalidate } from '../cache-control'
-import { updateImplicitTagsExpiration } from '../implicit-tags'
 import { getPreviouslyRevalidatedTags } from '../../server-utils'
 import { workAsyncStorage } from '../../app-render/work-async-storage.external'
 
@@ -260,36 +258,7 @@ export class IncrementalCache implements IncrementalCacheType {
   }
 
   async revalidateTag(tags: string | string[]): Promise<void> {
-    tags = Array.isArray(tags) ? tags : [tags]
-
-    if (tags.length === 0) {
-      return
-    }
-
-    const promises: Promise<void>[] = []
-
-    if (this.cacheHandler?.revalidateTag) {
-      promises.push(this.cacheHandler.revalidateTag(tags))
-    }
-
-    const handlers = getCacheHandlers()
-    if (handlers) {
-      for (const handler of handlers) {
-        promises.push(handler.expireTags(...tags))
-      }
-    }
-
-    await Promise.all(promises)
-
-    const workUnitStore = workUnitAsyncStorage.getStore()
-
-    if (workUnitStore?.implicitTags) {
-      const tagsSet = new Set(tags)
-
-      if (workUnitStore.implicitTags.tags.some((tag) => tagsSet.has(tag))) {
-        await updateImplicitTagsExpiration(workUnitStore.implicitTags)
-      }
-    }
+    return this.cacheHandler?.revalidateTag(tags)
   }
 
   // x-ref: https://github.com/facebook/react/blob/2655c9354d8e1c54ba888444220f63e836925caa/packages/react/src/ReactFetch.js#L23

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -82,6 +82,7 @@ import {
 } from '../../../client/components/http-access-fallback/http-access-fallback'
 import { RedirectStatusCode } from '../../../client/components/redirect-status-code'
 import { INFINITE_CACHE } from '../../../lib/constants'
+import { executeRevalidates } from '../../revalidation-utils'
 
 export class WrappedNextRouterError {
   constructor(
@@ -323,13 +324,9 @@ export class AppRouteRouteModule extends RouteModule<
     }
 
     const resolvePendingRevalidations = () => {
-      context.renderOpts.pendingWaitUntil = Promise.all([
-        workStore.incrementalCache?.revalidateTag(
-          workStore.pendingRevalidatedTags || []
-        ),
-        ...Object.values(workStore.pendingRevalidates || {}),
-        ...(workStore.pendingRevalidateWrites || []),
-      ]).finally(() => {
+      context.renderOpts.pendingWaitUntil = executeRevalidates(
+        workStore
+      ).finally(() => {
         if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
           console.log(
             'pending revalidates promise finished for:',


### PR DESCRIPTION
The `revalidateTag` method of the incremental cache should not also handle the revalidation for the `"use cache"` cache handlers.

This PR relocates those bits to the revalidation utils module, which was previously used for `after`, and has now been lifted one level up.

There should be no behavioral change in this refactoring.