### PR TITLE
Fix: RESTORE_ACTION should not be thenable

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -199,7 +199,7 @@ export function createMutableActionQueue(
     state: initialState,
     dispatch: (payload: ReducerActions, setState: DispatchStatePromise) =>
       dispatchAction(actionQueue, payload, setState),
-    action: async (state: AppRouterState, action: ReducerActions) => {
+    action: (state: AppRouterState, action: ReducerActions) => {
       const result = reducer(state, action)
       return result
     },


### PR DESCRIPTION
Respect sync/async actions by reducer. RESTORE_ACTION is sync action so should not return a `thenable`.