### PR TITLE
Use `NEXT_PRIVATE_DEBUG_CACHE` env variable for cache handler debug logs

### DIFF
--- a/packages/next/src/server/use-cache/handlers.ts
+++ b/packages/next/src/server/use-cache/handlers.ts
@@ -1,9 +1,9 @@
 import DefaultCacheHandler from '../lib/cache-handlers/default'
 import type { CacheHandlerCompat } from '../lib/cache-handlers/types'
 
-const debug = process.env.NEXT_PRIVATE_DEBUG_USE_CACHE
+const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? (message: string, ...args: any[]) => {
-      console.log(`use-cache[${process.pid}]: ${message}`, ...args)
+      console.log(`use-cache: ${message}`, ...args)
     }
   : () => {}
 


### PR DESCRIPTION
Instead of `NEXT_PRIVATE_DEBUG_USE_CACHE`, we're now using the env variable `NEXT_PRIVATE_DEBUG_CACHE`, which is already used in other places for cache debugging.

In addition, `process.pid` is not logged anymore. This prevents Node.js API usage errors in #77577 when bundling with Turbopack.