### PR TITLE
Implement render indicator with useOptimistic

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator.tsx
@@ -1,16 +1,22 @@
-import { useEffect, useTransition } from 'react'
+import { startTransition, useCallback, useEffect, useOptimistic } from 'react'
 import { devRenderIndicator } from './dev-render-indicator'
 
 export const useSyncDevRenderIndicator = () => {
-  const [isPending, startTransition] = useTransition()
+  const [isRendering, setIsRendering] = useOptimistic(false)
 
   useEffect(() => {
-    if (isPending) {
+    if (isRendering) {
       devRenderIndicator.show()
     } else {
       devRenderIndicator.hide()
     }
-  }, [isPending])
+  }, [isRendering])
 
-  return startTransition
+  return useCallback(
+    (fn: () => void) => {
+      startTransition(() => setIsRendering(true))
+      fn()
+    },
+    [setIsRendering]
+  )
 }


### PR DESCRIPTION
`useOptimistic` automatically reverts the optimistic state back to `false` when the transition is done, which simplifies the previous code.