### PR TITLE
feat(turbo-tasks): Generate a trace of transient tasks when panicking

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
@@ -1,0 +1,74 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput, Vc};
+use turbo_tasks_testing::{register, run_without_cache_check, Registration};
+
+static REGISTRATION: Registration = register!();
+
+const EXPECTED_TRACE: &str = "\
+Adder::add_method (read cell of type turbo-tasks@TODO::::primitives::u64)
+  self:
+    Adder::new (read cell of type turbo-tasks-backend@TODO::::Adder)
+      args:
+        unknown transient task (read cell of type turbo-tasks@TODO::::primitives::unit)
+  args:
+    unknown transient task (read cell of type turbo-tasks@TODO::::primitives::u16)
+    unknown transient task (read cell of type turbo-tasks@TODO::::primitives::u32)";
+
+#[tokio::test]
+async fn test_trace_transient() {
+    let result = run_without_cache_check(&REGISTRATION, async {
+        read_incorrect_task_input_operation(IncorrectTaskInput(
+            Adder::new(Vc::cell(()))
+                .add_method(Vc::cell(2), Vc::cell(3))
+                .to_resolved()
+                .await?,
+        ))
+        .read_strongly_consistent()
+        .await?;
+        anyhow::Ok(())
+    })
+    .await;
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains(&EXPECTED_TRACE.escape_debug().to_string()));
+}
+
+#[turbo_tasks::value]
+struct Adder;
+
+#[turbo_tasks::value_impl]
+impl Adder {
+    #[turbo_tasks::function]
+    fn new(arg: ResolvedVc<()>) -> Vc<Adder> {
+        let _ = arg; // Make sure unused argument filtering doesn't remove the arg
+        Adder.cell()
+    }
+
+    #[turbo_tasks::function]
+    async fn add_method(&self, arg1: ResolvedVc<u16>, arg2: ResolvedVc<u32>) -> Result<Vc<u64>> {
+        Ok(Vc::cell(u64::from(*arg1.await?) + u64::from(*arg2.await?)))
+    }
+}
+
+#[turbo_tasks::function(operation)]
+async fn read_incorrect_task_input_operation(value: IncorrectTaskInput) -> Result<Vc<u64>> {
+    Ok(Vc::cell(*value.0.await?))
+}
+
+/// Has an intentionally incorrect `TaskInput` implementation, representing some code that the debug
+/// tracing might be particularly useful with.
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+)]
+struct IncorrectTaskInput(ResolvedVc<u64>);
+
+impl TaskInput for IncorrectTaskInput {
+    fn is_transient(&self) -> bool {
+        false
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -68,6 +68,8 @@ pub struct CachedTaskType {
 }
 
 impl CachedTaskType {
+    /// Get the name of the function from the registry. Equivalent to the
+    /// [`fmt::Display::to_string`] implementation, but does not allocate a `String`.
     pub fn get_name(&self) -> &'static str {
         &registry::get_function(self.fn_type).name
     }

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -216,6 +216,13 @@ impl RawVc {
         }
     }
 
+    pub fn try_get_type_id(&self) -> Option<ValueTypeId> {
+        match self {
+            RawVc::TaskCell(_, CellId { type_id, .. }) => Some(*type_id),
+            RawVc::TaskOutput(_) | RawVc::LocalOutput(_, _) => None,
+        }
+    }
+
     /// For a cell that's already resolved, synchronously check if it implements a trait using the
     /// type information in `RawVc::TaskCell` (we don't actualy need to read the cell!).
     pub(crate) fn resolved_has_trait(&self, trait_id: TraitTypeId) -> bool {


### PR DESCRIPTION
When panicking due to a transient task called from a persistent task, it's often hard to figure out why the read task was transient in the first place, as turbo-tasks doesn't have normal stack traces.

To make it worse, these issues are often hard to reproduce (can happen due to file invalidations, turbopack restarts, etc), so we want to gather as much information from users reporting bugs as possible in the panic message.

This uses `TraceRawVcs` to log debug information about transient dependencies:

```
Adder::add_method (read cell of type turbo-tasks@TODO::::primitives::u64)
  self:
    Adder::new (read cell of type turbo-tasks-backend@TODO::::Adder)
      args:
        unknown transient task (read cell of type turbo-tasks@TODO::::primitives::unit)
  args:
    unknown transient task (read cell of type turbo-tasks@TODO::::primitives::u16)
    unknown transient task (read cell of type turbo-tasks@TODO::::primitives::u32)
```

In this example, `unknown transient task` refers to a `TurboTasks::run_once` call, which has no name.

For a real-world example of this in use, see #77798.

This uses information already stored on cached tasks, so there's no additional tracking overhead, outside of the work that must happen on a panic (a cold codepath).

Closes PACK-4368