### PR TITLE
Turbopack build: Fix symbolic-file-links test

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -122,6 +122,12 @@ export class NextInstance {
 
       await fs.cp(files.fsPath, testDir, {
         recursive: true,
+        // By default Node.js turns relative symlinks into absolute symlinks.
+        // We don't want absolute symlinks because the test directory is isolated
+        // and the symlink would turn into a path to the Next.js repo original file.
+        // Setting this option to `true` will keep the symlink relative. Ensuring it's isolated.
+        // See https://nodejs.org/api/fs.html#fscpsrc-dest-options-callback
+        verbatimSymlinks: true,
         filter(source) {
           // we don't copy a package.json as it's manually written
           // via the createNextInstall process

--- a/test/production/app-dir/symbolic-file-links/symbolic-file-links.test.ts
+++ b/test/production/app-dir/symbolic-file-links/symbolic-file-links.test.ts
@@ -5,12 +5,6 @@ describe('symbolic-file-links', () => {
     files: __dirname,
   })
 
-  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
-  it('should work using cheerio', async () => {
-    const $ = await next.render$('/')
-    expect($('p').text()).toBe('hello world')
-  })
-
   // Recommended for tests that need a full browser
   it('should work using browser', async () => {
     const browser = await next.browser('/')
@@ -20,13 +14,6 @@ describe('symbolic-file-links', () => {
   // In case you need the full HTML. Can also use $.html() with cheerio.
   it('should work with html', async () => {
     const html = await next.render('/')
-    expect(html).toContain('hello world')
-  })
-
-  // In case you need to test the response object
-  it('should work with fetch', async () => {
-    const res = await next.fetch('/')
-    const html = await res.text()
     expect(html).toContain('hello world')
   })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -17853,13 +17853,11 @@
     "runtimeError": false
   },
   "test/production/app-dir/symbolic-file-links/symbolic-file-links.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "symbolic-file-links should work using browser",
-      "symbolic-file-links should work using cheerio",
-      "symbolic-file-links should work with fetch",
       "symbolic-file-links should work with html"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Fixes the tests in `test/production/app-dir/symbolic-file-links/symbolic-file-links.test.ts`.

Found that the test was failing because symlinks were incorrectly copied, they got turned into absolute paths linking to the original repository. Fixed that.

Also removed two tests that are the same as checking the html version of the page. As they are effectively duplicated.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-4220