### PR TITLE
[metadata] render streaming metadata on the top level

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -20,7 +20,19 @@ function findHeadInCacheImpl(
     return [cache, keyPrefix]
   }
 
-  for (const key in parallelRoutes) {
+  // First try the 'children' parallel route if it exists
+  // when starting from the "root", this corresponds with the main page component
+  const parallelRoutesKeys = Object.keys(parallelRoutes).filter(
+    (key) => key !== 'children'
+  )
+
+  // if we are at the root, we need to check the children slot first
+  if ('children' in parallelRoutes) {
+    parallelRoutesKeys.unshift('children')
+  }
+
+  // if we didn't find metadata in the page slot, check the other parallel routes
+  for (const key of parallelRoutesKeys) {
     const [segment, childParallelRoutes] = parallelRoutes[key]
     const childSegmentMap = cache.parallelRoutes.get(key)
     if (!childSegmentMap) {

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -20,29 +20,7 @@ function findHeadInCacheImpl(
     return [cache, keyPrefix]
   }
 
-  // First try the 'children' parallel route if it exists
-  // when starting from the "root", this corresponds with the main page component
-  if (parallelRoutes.children) {
-    const [segment, childParallelRoutes] = parallelRoutes.children
-    const childSegmentMap = cache.parallelRoutes.get('children')
-    if (childSegmentMap) {
-      const cacheKey = createRouterCacheKey(segment)
-      const cacheNode = childSegmentMap.get(cacheKey)
-      if (cacheNode) {
-        const item = findHeadInCacheImpl(
-          cacheNode,
-          childParallelRoutes,
-          keyPrefix + '/' + cacheKey
-        )
-        if (item) return item
-      }
-    }
-  }
-
-  // if we didn't find metadata in the page slot, check the other parallel routes
   for (const key in parallelRoutes) {
-    if (key === 'children') continue // already checked above
-
     const [segment, childParallelRoutes] = parallelRoutes[key]
     const childSegmentMap = cache.parallelRoutes.get(key)
     if (!childSegmentMap) {

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -31,7 +31,6 @@ function findHeadInCacheImpl(
     parallelRoutesKeys.unshift('children')
   }
 
-  // if we didn't find metadata in the page slot, check the other parallel routes
   for (const key of parallelRoutesKeys) {
     const [segment, childParallelRoutes] = parallelRoutes[key]
     const childSegmentMap = cache.parallelRoutes.get(key)

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -206,9 +206,11 @@ export function createMetadataComponents({
     const promise = resolveFinalMetadata()
     if (serveStreamingMetadata) {
       return (
-        <Suspense fallback={null}>
-          <AsyncMetadata promise={promise} />
-        </Suspense>
+        <div hidden>
+          <Suspense fallback={null}>
+            <AsyncMetadata promise={promise} />
+          </Suspense>
+        </div>
       )
     }
     const metadataState = await promise

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -503,13 +503,6 @@ async function generateDynamicRSCPayload(
       serveStreamingMetadata,
     })
 
-    // const { StreamingMetadata, StaticMetadata } =
-    //   createRootMetadata(() => {
-    //     return (
-
-    //     )
-    //   }, serveStreamingMetadata)
-
     flightData = (
       await walkTreeWithFlightRouterState({
         ctx,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -245,6 +245,8 @@ interface ParseRequestHeadersOptions {
 }
 
 const flightDataPathHeadKey = 'h'
+const getFlightViewportKey = (requestId: string) => requestId + 'v'
+const getFlightMetadataKey = (requestId: string) => requestId + 'm'
 
 interface ParsedRequestHeaders {
   /**
@@ -519,9 +521,9 @@ async function generateDynamicRSCPayload(
               isPossibleServerAction={ctx.isPossibleServerAction}
             />
             {/* Adding requestId as react key to make metadata remount for each render */}
-            <ViewportTree key={requestId} />
+            <ViewportTree key={getFlightViewportKey(requestId)} />
             {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
-            <MetadataTree />
+            <MetadataTree key={getFlightMetadataKey(requestId)} />
           </React.Fragment>
         ),
         injectedCSS: new Set(),
@@ -855,7 +857,7 @@ async function getRSCPayload(
         statusCode={ctx.res.statusCode}
         isPossibleServerAction={ctx.isPossibleServerAction}
       />
-      <ViewportTree key={ctx.requestId} />
+      <ViewportTree key={getFlightViewportKey(ctx.requestId)} />
       {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
       <MetadataTree />
     </React.Fragment>
@@ -944,12 +946,8 @@ async function getErrorRSCPayload(
     serveStreamingMetadata: serveStreamingMetadata,
   })
 
-  const metadata = (
-    <React.Fragment key={flightDataPathHeadKey}>
-      {/* Adding requestId as react key to make metadata remount for each render */}
-      <MetadataTree key={requestId} />
-    </React.Fragment>
-  )
+  // {/* Adding requestId as react key to make metadata remount for each render */}
+  const metadata = <MetadataTree key={getFlightMetadataKey(requestId)} />
 
   const initialHead = (
     <React.Fragment key={flightDataPathHeadKey}>
@@ -959,7 +957,7 @@ async function getErrorRSCPayload(
         isPossibleServerAction={ctx.isPossibleServerAction}
       />
       {/* Adding requestId as react key to make metadata remount for each render */}
-      <ViewportTree key={requestId} />
+      <ViewportTree key={getFlightViewportKey(requestId)} />
       {process.env.NODE_ENV === 'development' && (
         <meta name="next-error" content="not-found" />
       )}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -39,7 +39,6 @@ export function createComponentTree(props: {
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  StreamingMetadata: React.ComponentType | null
   StreamingMetadataOutlet: React.ComponentType
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
@@ -76,7 +75,6 @@ async function createComponentTreeInternal({
   missingSlots,
   preloadCallbacks,
   authInterrupts,
-  StreamingMetadata,
   StreamingMetadataOutlet,
 }: {
   loaderTree: LoaderTree
@@ -91,7 +89,6 @@ async function createComponentTreeInternal({
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  StreamingMetadata: React.ComponentType | null
   StreamingMetadataOutlet: React.ComponentType | null
 }): Promise<CacheNodeSeedData> {
   const {
@@ -390,7 +387,6 @@ async function createComponentTreeInternal({
 
   // Resolve the segment param
   const actualSegment = segmentParam ? segmentParam.treeSegment : segment
-  const metadata = StreamingMetadata ? <StreamingMetadata /> : undefined
 
   // Use the same condition to render metadataOutlet as metadata
   const metadataOutlet = StreamingMetadataOutlet ? (
@@ -513,7 +509,6 @@ async function createComponentTreeInternal({
             missingSlots,
             preloadCallbacks,
             authInterrupts,
-            StreamingMetadata: isChildrenRouteKey ? StreamingMetadata : null,
             // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
             // but we only want to throw on the first one.
             StreamingMetadataOutlet: isChildrenRouteKey
@@ -699,12 +694,6 @@ async function createComponentTreeInternal({
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
         {pageElement}
-        {/*
-         * The order here matters since a parent might call findDOMNode().
-         * findDOMNode() will return the first child if multiple children are rendered.
-         * But React will hoist metadata into <head> which breaks scroll handling.
-         */}
-        {metadata}
         {layerAssets}
         <OutletBoundary>
           <MetadataOutlet ready={getViewportReady} />

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -202,7 +202,6 @@ export async function walkTreeWithFlightRouterState({
         getMetadataReady,
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
-        StreamingMetadata: null,
         StreamingMetadataOutlet,
       }
     )

--- a/test/e2e/esm-externals/app/client/page.js
+++ b/test/e2e/esm-externals/app/client/page.js
@@ -6,8 +6,8 @@ import World3 from 'app-cjs-esm-package/entry'
 
 export default function Index() {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/app/server/page.js
+++ b/test/e2e/esm-externals/app/server/page.js
@@ -4,8 +4,8 @@ import World3 from 'app-cjs-esm-package/entry'
 
 export default function Page() {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/esm-externals.test.ts
+++ b/test/e2e/esm-externals/esm-externals.test.ts
@@ -28,15 +28,13 @@ describe('esm-externals', () => {
 
     it('should return the correct SSR HTML', async () => {
       const $ = await next.render$(url)
-      const body = $('body > div > div').html()
+      const body = $('body p').html()
       expect(normalize(body)).toEqual(expectedHtml)
     })
 
     it('should render the correct page', async () => {
       const browser = await next.browser(url)
-      expect(await browser.elementByCss('body > div').text()).toEqual(
-        expectedText
-      )
+      expect(await browser.elementByCss('body p').text()).toEqual(expectedText)
     })
   })
 
@@ -54,13 +52,13 @@ describe('esm-externals', () => {
 
     it('should return the correct SSR HTML', async () => {
       const $ = await next.render$(url)
-      const body = $('body > div').html()
+      const body = $('body > p').html()
       expect(normalize(body)).toEqual(expectedHtml)
     })
 
     it('should render the correct page', async () => {
       const browser = await next.browser(url)
-      expect(await browser.elementByCss('body > div').text()).toEqual(
+      expect(await browser.elementByCss('body > p').text()).toEqual(
         expectedText
       )
     })

--- a/test/e2e/esm-externals/pages/ssg.js
+++ b/test/e2e/esm-externals/pages/ssg.js
@@ -13,8 +13,8 @@ export async function getStaticProps() {
 
 export default function Index({ worlds }) {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}+{worlds}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/pages/ssr.js
+++ b/test/e2e/esm-externals/pages/ssr.js
@@ -13,8 +13,8 @@ export function getServerSideProps() {
 
 export default function Index({ worlds }) {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}+{worlds}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/pages/static.js
+++ b/test/e2e/esm-externals/pages/static.js
@@ -7,8 +7,8 @@ const worlds = 'World+World+World'
 
 export default function Index() {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}+{worlds}
-    </div>
+    </p>
   )
 }


### PR DESCRIPTION
### Why

When we start doing the streaming metadata, React were not able to render the Suspense boundary on the top level. We came up with the plan that render the metadata inside the layout so that React can still handle the Suspended metadata under some DOM nodes. Then React shipped the support of rendering top-level Suspense boundary which let us be able. to simplify the implementation.

Note that the top level suspenseful metadata still requires to stay under a hidden div. It's the requirement of React


### Changes

* Wrap the Suspended meadata under a hidden div, and always render on the top of the component tree
* Remove the diverage of static/streaming metadata, as now the only difference is just the Suspenseful wrapper. The code looks more clean now.

Closes NDX-1017
