### PR TITLE
Turbopack build: Fix basepath test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -568,7 +568,7 @@ jobs:
     with:
       afterBuild: pnpm playwright install &&
         BROWSER_NAME=firefox node run-tests.js test/production/pages-dir/production/test/index.test.ts &&
-        NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/e2e/basepath.test.ts &&
+        NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/e2e/basepath/basepath.test.ts &&
         BROWSER_NAME=safari DEVICE_NAME='iPhone XR' node run-tests.js -c 1 test/production/prerender-prefetch/index.test.ts
 
       stepName: 'test-firefox-safari'

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -51,7 +51,7 @@
       "test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.js",
       "test/e2e/app-dir/metadata/metadata.test.ts",
       "test/e2e/app-dir/rsc-basic/rsc-basic.test.ts",
-      "test/e2e/basepath.test.ts",
+      "test/e2e/basepath/basepath.test.ts",
       "test/e2e/postcss-config-cjs/index.test.ts",
       "test/e2e/socket-io/index.test.js",
       "test/e2e/middleware-matcher/index.test.ts",

--- a/test/e2e/basepath/basepath-trailing-slash.test.ts
+++ b/test/e2e/basepath/basepath-trailing-slash.test.ts
@@ -1,6 +1,5 @@
-import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import { assertNoRedbox } from 'next-test-utils'
 
@@ -10,11 +9,7 @@ describe('basePath + trailingSlash', () => {
 
   beforeAll(async () => {
     next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'basepath/pages')),
-        public: new FileRef(join(__dirname, 'basepath/public')),
-        external: new FileRef(join(__dirname, 'basepath/external')),
-      },
+      files: __dirname,
       nextConfig: {
         trailingSlash: true,
         basePath,

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -1,9 +1,8 @@
 import url from 'url'
-import { join } from 'path'
 import assert from 'assert'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {
   assertNoRedbox,
@@ -19,11 +18,7 @@ describe('basePath', () => {
 
   beforeAll(async () => {
     next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, 'basepath/pages')),
-        public: new FileRef(join(__dirname, 'basepath/public')),
-        external: new FileRef(join(__dirname, 'basepath/external')),
-      },
+      files: __dirname,
       nextConfig: {
         basePath,
         onDemandEntries: {
@@ -290,13 +285,13 @@ describe('basePath', () => {
             `[].slice.call(document.querySelectorAll("link[rel=prefetch]")).map((e) => new URL(e.href).pathname)`
           )
           expect(prefetches).toContainEqual(
-            expect.stringMatching(/\/gsp-[^./]+\.js/)
+            expect.stringMatching(/\/gsp-?([^./]+)?\.js/)
           )
           expect(prefetches).toContainEqual(
-            expect.stringMatching(/\/gssp-[^./]+\.js/)
+            expect.stringMatching(/\/gssp-?([^./]+)?\.js/)
           )
           expect(prefetches).toContainEqual(
-            expect.stringMatching(/\/other-page-[^./]+\.js/)
+            expect.stringMatching(/\/other-page-?([^./]+)?\.js/)
           )
           return 'yes'
         }, 'yes')

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -5887,7 +5887,7 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/e2e/basepath.test.ts": {
+  "test/e2e/basepath/basepath.test.ts": {
     "passed": [
       "basePath should 404 for public file without basePath",
       "basePath should 404 when manually adding basePath with <Link>",

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -9158,7 +9158,7 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/e2e/basepath.test.ts": {
+  "test/e2e/basepath/basepath.test.ts": {
     "passed": [
       "basePath should 404 for public file without basePath",
       "basePath should 404 when manually adding basePath with <Link>",

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5770,7 +5770,7 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/e2e/basepath-trailing-slash.test.ts": {
+  "test/e2e/basepath/basepath-trailing-slash.test.ts": {
     "passed": [
       "basePath + trailingSlash should allow URL query strings on index without refresh",
       "basePath + trailingSlash should allow URL query strings without refresh",
@@ -5781,7 +5781,7 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/e2e/basepath.test.ts": {
+  "test/e2e/basepath/basepath.test.ts": {
     "passed": [
       "basePath should 404 for public file without basePath",
       "basePath should 404 when manually adding basePath with <Link>",
@@ -5847,11 +5847,10 @@
       "basePath should work with catch-all page",
       "basePath should work with hash links",
       "basePath should work with nested folder with same name as basePath",
-      "basePath should work with normal dynamic page"
-    ],
-    "failed": [
+      "basePath should work with normal dynamic page",
       "basePath should prefetch pages correctly in viewport with <Link>"
     ],
+    "failed": [],
     "pending": [
       "basePath should navigate back to a non-basepath 404 that starts with basepath",
       "basePath should navigate to nested index page with getStaticProps"

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -8999,7 +8999,7 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/e2e/basepath-trailing-slash.test.ts": {
+  "test/e2e/basepath/basepath-trailing-slash.test.ts": {
     "passed": [
       "basePath + trailingSlash should allow URL query strings on index without refresh",
       "basePath + trailingSlash should allow URL query strings without refresh",
@@ -9010,7 +9010,7 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/e2e/basepath.test.ts": {
+  "test/e2e/basepath/basepath.test.ts": {
     "passed": [
       "basePath should 404 for public file without basePath",
       "basePath should 404 when manually adding basePath with <Link>",


### PR DESCRIPTION
## What?

Moved the basepath e2e tests into a dedicated directory structure and simplified the test setup:

1. Relocated `basepath-trailing-slash.test.ts` and `basepath.test.ts` into a dedicated `basepath` directory
2. Simplified the test file setup by using `files: __dirname` instead of explicitly referencing individual directories
3. Updated the regex patterns in the prefetch test to be more flexible with optional characters, matching the Turbopack pattern.
4. Updated the test manifest files to reflect the new file paths
5. Fixed a previously failing test: "basePath should prefetch pages correctly in viewport with <Link>"


Closes PACK-4223