### PR TITLE
Turbopack: fix bug in handling of module batches

### DIFF
--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]
 #![feature(map_try_insert)]
+#![feature(hash_set_entry)]
 
 pub mod asset;
 pub mod changed;

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -241,6 +241,7 @@ struct TraversalState<'l> {
 }
 
 struct PreBatches {
+    boundary_modules: FxHashSet<ResolvedVc<Box<dyn Module>>>,
     batches: Vec<PreBatch>,
     entries: FxHashMap<ResolvedVc<Box<dyn Module>>, PreBatchIndex>,
     single_module_entries: FxIndexSet<ResolvedVc<Box<dyn Module>>>,
@@ -249,6 +250,7 @@ struct PreBatches {
 impl PreBatches {
     fn new() -> Self {
         Self {
+            boundary_modules: FxHashSet::default(),
             batches: Vec::new(),
             entries: FxHashMap::default(),
             single_module_entries: FxIndexSet::default(),
@@ -258,20 +260,24 @@ impl PreBatches {
     fn ensure_pre_batch_for_module(
         &mut self,
         module: ResolvedVc<Box<dyn Module>>,
-        chunk_groups: &RoaringBitmapWrapper,
+        chunk_group_info: &ChunkGroupInfo,
         queue: &mut VecDeque<(ResolvedVc<Box<dyn Module>>, PreBatchIndex)>,
-    ) -> PreBatchIndex {
-        match self.entries.entry(module) {
+    ) -> Result<PreBatchIndex> {
+        Ok(match self.entries.entry(module) {
             Entry::Vacant(e) => {
                 let index = self.batches.len();
                 queue.push_back((module, index));
+                let chunk_groups = chunk_group_info
+                    .module_chunk_groups
+                    .get(&module)
+                    .context("all modules need to have chunk group info")?;
                 let batch = PreBatch::new(chunk_groups.clone());
                 self.batches.push(batch);
                 e.insert(index);
                 index
             }
             Entry::Occupied(e) => *e.get(),
-        }
+        })
     }
 
     async fn get_pre_batch_items(
@@ -281,10 +287,6 @@ impl PreBatches {
         module_graph: &ModuleGraph,
         queue: &mut VecDeque<(ResolvedVc<Box<dyn Module>>, PreBatchIndex)>,
     ) -> Result<Vec<PreBatchItem>> {
-        let entry_chunk_groups = chunk_group_info
-            .module_chunk_groups
-            .get(&ResolvedVc::upcast(entry))
-            .context("all modules need to have chunk group info")?;
         let mut state = TraversalState {
             items: Vec::new(),
             this: self,
@@ -305,15 +307,12 @@ impl PreBatches {
                         return Ok(GraphTraversalAction::Exclude);
                     }
                     if visited.insert(module) {
-                        let chunk_groups = chunk_group_info
-                            .module_chunk_groups
-                            .get(&module)
-                            .context("all modules need to have chunk group info")?;
-                        if chunk_groups != entry_chunk_groups {
-                            let idx =
-                                state
-                                    .this
-                                    .ensure_pre_batch_for_module(module, chunk_groups, queue);
+                        if parent_info.is_some() && state.this.boundary_modules.contains(&module) {
+                            let idx = state.this.ensure_pre_batch_for_module(
+                                module,
+                                chunk_group_info,
+                                queue,
+                            )?;
                             state.items.push(PreBatchItem::ParallelReference(idx));
                             return Ok(GraphTraversalAction::Exclude);
                         }
@@ -351,6 +350,44 @@ pub async fn compute_module_batches(
         let module_graph = module_graph.await?;
 
         let mut pre_batches = PreBatches::new();
+
+        // Walk the module graph and mark all modules that are boundary modules (referenced from a
+        // different chunk group bitmap)
+        module_graph
+            .traverse_all_edges_unordered(|(parent, ty), node| {
+                let std::collections::hash_set::Entry::Vacant(entry) =
+                    pre_batches.boundary_modules.entry(node.module)
+                else {
+                    // Already a boundary module, can skip check
+                    return Ok(());
+                };
+                if ty.is_parallel() {
+                    let parent_chunk_groups = chunk_group_info
+                        .module_chunk_groups
+                        .get(&parent.module)
+                        .context("all modules need to have chunk group info")?;
+                    let chunk_groups = chunk_group_info
+                        .module_chunk_groups
+                        .get(&node.module)
+                        .context("all modules need to have chunk group info")?;
+                    if parent_chunk_groups != chunk_groups {
+                        // This is a boundary module
+                        entry.insert();
+                    }
+                } else {
+                    entry.insert();
+                }
+                Ok(())
+            })
+            .await?;
+
+        // All entries are boundary modules too
+        for chunk_group in &chunk_group_info.chunk_groups {
+            for entry in chunk_group.entries() {
+                pre_batches.boundary_modules.insert(entry);
+            }
+        }
+
         let mut queue: VecDeque<(ResolvedVc<Box<dyn Module>>, PreBatchIndex)> = VecDeque::new();
 
         let mut chunk_group_indicies_with_merged_children = FxHashSet::default();
@@ -359,15 +396,11 @@ pub async fn compute_module_batches(
         for chunk_group in &chunk_group_info.chunk_groups {
             for entry in chunk_group.entries() {
                 if let Some(chunkable_module) = ResolvedVc::try_downcast(entry) {
-                    let chunk_groups = chunk_group_info
-                        .module_chunk_groups
-                        .get(&entry)
-                        .context("all modules need to have chunk group info")?;
                     pre_batches.ensure_pre_batch_for_module(
                         chunkable_module,
-                        chunk_groups,
+                        &chunk_group_info,
                         &mut queue,
-                    );
+                    )?;
                 } else {
                     pre_batches.single_module_entries.insert(entry);
                 }

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -1,6 +1,6 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, path::PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -8,8 +8,7 @@ use similar::TextDiff;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ReadRef, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{
-    DirectoryContent, DirectoryEntry, DiskFileSystem, File, FileContent, FileSystemEntryType,
-    FileSystemPath,
+    DirectoryContent, DirectoryEntry, File, FileContent, FileSystemEntryType, FileSystemPath,
 };
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use turbopack_cli_utils::issue::{format_issue, LogOptions};
@@ -187,12 +186,7 @@ async fn get_contents(file: Vc<AssetContent>, path: Vc<FileSystemPath>) -> Resul
 }
 
 async fn remove_file(path: Vc<FileSystemPath>) -> Result<()> {
-    let fs = Vc::try_resolve_downcast_type::<DiskFileSystem>(path.fs())
-        .await?
-        .context(anyhow!("unexpected fs type"))?
-        .await?;
-    let sys_path = fs.to_sys_path(path).await?;
-    fs::remove_file(&sys_path).context(format!("remove file {} error", sys_path.display()))?;
+    path.write(FileContent::NotFound.cell()).await?;
     Ok(())
 }
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css
@@ -1,0 +1,3 @@
+@import "a.css";
+@import "x.css";
+@import "y.css";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css
@@ -1,0 +1,2 @@
+@import "y.css";
+@import "x.css";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css
@@ -1,0 +1,5 @@
+@import "b.css";
+
+.a {
+  content: "5 2";
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css
@@ -1,0 +1,5 @@
+@import "c.css";
+
+.b {
+  content: "4 1";
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css
@@ -1,0 +1,5 @@
+@import "d.css";
+
+.c {
+  content: "3 5";
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css
@@ -1,0 +1,5 @@
+@import "e.css";
+
+.d {
+  content: "2 4";
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css
@@ -1,0 +1,5 @@
+@import "a.css";
+
+.e {
+  content: "1 3";
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/index.js
@@ -1,0 +1,2 @@
+import("./1.css");
+import("./2.css");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css
@@ -1,0 +1,5 @@
+@import "a.css";
+
+.x {
+  content: "6 7";
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css
@@ -1,0 +1,5 @@
+@import "c.css";
+
+.y {
+  content: "7 6";
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css [test] (css) */
+
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_b7298ed4._.single.css.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css"],"sourcesContent":["@import \"a.css\";\n@import \"x.css\";\n@import \"y.css\";\n"],"names":[],"mappings":""}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_23ea52ac._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_23ea52ac._.js
@@ -1,0 +1,86 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_23ea52ac._.js", {
+
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css [test] (css, async loader)": ((__turbopack_context__) => {
+
+var { g: global, __dirname } = __turbopack_context__;
+{
+__turbopack_context__.v((parentImport) => {
+    return Promise.all([
+  {
+    "path": "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css",
+    "included": [
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css [test] (css)"
+    ],
+    "moduleChunks": [
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css"
+    ]
+  }
+].map((chunk) => __turbopack_context__.l(chunk))).then(() => {});
+});
+}}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css [test] (css, async loader)": ((__turbopack_context__) => {
+
+var { g: global, __dirname } = __turbopack_context__;
+{
+__turbopack_context__.v((parentImport) => {
+    return Promise.all([
+  {
+    "path": "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css",
+    "included": [
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css [test] (css)",
+      "[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css [test] (css)"
+    ],
+    "moduleChunks": [
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css",
+      "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css"
+    ]
+  }
+].map((chunk) => __turbopack_context__.l(chunk))).then(() => {});
+});
+}}),
+}]);

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_23ea52ac._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_23ea52ac._.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css [test] (css) */
+
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_b7298ed4._.single.css.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css"],"sourcesContent":["@import \"y.css\";\n@import \"x.css\";\n"],"names":[],"mappings":""}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css
@@ -1,0 +1,25 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css [test] (css) */
+.b{content:"4 1"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css [test] (css) */
+.a{content:"5 2"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css [test] (css) */
+.e{content:"1 3"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css [test] (css) */
+.d{content:"2 4"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css [test] (css) */
+.c{content:"3 5"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css [test] (css) */
+.y{content:"7 6"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css [test] (css) */
+.x{content:"6 7"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css [test] (css) */
+
+
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css.map
@@ -1,0 +1,20 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css"],"sourcesContent":["@import \"c.css\";\n\n.b {\n  content: \"4 1\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css"],"sourcesContent":["@import \"b.css\";\n\n.a {\n  content: \"5 2\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 4, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 7, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css"],"sourcesContent":["@import \"a.css\";\n\n.e {\n  content: \"1 3\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 7, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 10, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css"],"sourcesContent":["@import \"e.css\";\n\n.d {\n  content: \"2 4\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 10, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 13, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css"],"sourcesContent":["@import \"d.css\";\n\n.c {\n  content: \"3 5\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 13, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 16, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css"],"sourcesContent":["@import \"c.css\";\n\n.y {\n  content: \"7 6\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 16, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 19, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css"],"sourcesContent":["@import \"a.css\";\n\n.x {\n  content: \"6 7\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 19, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css"],"sourcesContent":["@import \"y.css\";\n@import \"x.css\";\n"],"names":[],"mappings":""}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css [test] (css) */
+.a{content:"5 2"}
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_b7298ed4._.single.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css"],"sourcesContent":["@import \"b.css\";\n\n.a {\n  content: \"5 2\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css [test] (css) */
+.b{content:"4 1"}
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_b7298ed4._.single.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css"],"sourcesContent":["@import \"c.css\";\n\n.b {\n  content: \"4 1\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css [test] (css) */
+.c{content:"3 5"}
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_b7298ed4._.single.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css"],"sourcesContent":["@import \"d.css\";\n\n.c {\n  content: \"3 5\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css [test] (css) */
+.d{content:"2 4"}
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_b7298ed4._.single.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css"],"sourcesContent":["@import \"e.css\";\n\n.d {\n  content: \"2 4\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css [test] (css) */
+.e{content:"1 3"}
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_b7298ed4._.single.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css"],"sourcesContent":["@import \"a.css\";\n\n.e {\n  content: \"1 3\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css
@@ -1,0 +1,25 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css [test] (css) */
+.e{content:"1 3"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css [test] (css) */
+.d{content:"2 4"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css [test] (css) */
+.c{content:"3 5"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css [test] (css) */
+.b{content:"4 1"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css [test] (css) */
+.a{content:"5 2"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css [test] (css) */
+.x{content:"6 7"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css [test] (css) */
+.y{content:"7 6"}
+
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css [test] (css) */
+
+
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css.map
@@ -1,0 +1,20 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css"],"sourcesContent":["@import \"a.css\";\n\n.e {\n  content: \"1 3\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css"],"sourcesContent":["@import \"e.css\";\n\n.d {\n  content: \"2 4\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 4, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 7, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css"],"sourcesContent":["@import \"d.css\";\n\n.c {\n  content: \"3 5\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 7, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 10, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css"],"sourcesContent":["@import \"c.css\";\n\n.b {\n  content: \"4 1\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 10, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 13, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css"],"sourcesContent":["@import \"b.css\";\n\n.a {\n  content: \"5 2\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 13, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 16, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css"],"sourcesContent":["@import \"a.css\";\n\n.x {\n  content: \"6 7\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 16, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 19, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css"],"sourcesContent":["@import \"c.css\";\n\n.y {\n  content: \"7 6\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 19, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css"],"sourcesContent":["@import \"a.css\";\n@import \"x.css\";\n@import \"y.css\";\n"],"names":[],"mappings":""}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_314a3e75.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_314a3e75.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_314a3e75.js",
+    {},
+    {"otherChunks":["output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_23ea52ac._.js","output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_314a3e75.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_314a3e75.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js
@@ -1,0 +1,12 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js", {
+
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/index.js [test] (ecmascript)": (function(__turbopack_context__) {
+
+var { g: global, __dirname, m: module, e: exports } = __turbopack_context__;
+{
+__turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css [test] (css, async loader)")(__turbopack_context__.i);
+__turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css [test] (css, async loader)")(__turbopack_context__.i);
+}}),
+}]);
+
+//# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 6, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css [test] (css) */
+.x{content:"6 7"}
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_b7298ed4._.single.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css"],"sourcesContent":["@import \"a.css\";\n\n.x {\n  content: \"6 7\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css
@@ -1,0 +1,3 @@
+/* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css [test] (css) */
+.y{content:"7 6"}
+/*# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_b7298ed4._.single.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css"],"sourcesContent":["@import \"c.css\";\n\n.y {\n  content: \"7 6\";\n}\n"],"names":[],"mappings":"AAEA"}},
+    {"offset": {"line": 1, "column": 17}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-f9a205.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-f9a205.txt
@@ -1,3 +1,4 @@
 warning - [analysis] [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js  unexpected export *
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
+  


### PR DESCRIPTION
### What?

Before that change pre batch boundaries where discovered while collecting the pre batch items. But in some edge cases this is too late. A module should be a boundary when any edge fulfills the boundary condition. So we need to check all incoming edges before traversing the module for pre batch items.

This adds a step before pre batches, that checks all edges and discovers all module boundaries.


Closes PACK-4238