### PR TITLE
Turbopack build: Fix node-file-trace test

### DIFF
--- a/test/production/pages-dir/production/fixture/pages/index.js
+++ b/test/production/pages-dir/production/fixture/pages/index.js
@@ -1,15 +1,11 @@
 import Link from 'next/link?loaderQuery'
 
-if (typeof window === 'undefined') {
-  try {
-    let file = 'clear.js'
-    require('es5-ext/array/#/' + file)
-  } catch (_) {}
-  import('nanoid').then((mod) => console.log(mod.nanoid()))
-}
-
 // prevent static generation for build trace test
 export function getServerSideProps() {
+  try {
+    require('es5-ext/array/from/index.js')
+  } catch (_) {}
+  import('nanoid').then((mod) => console.log(mod.nanoid()))
   return {
     props: {},
   }

--- a/test/production/pages-dir/production/fixture/pages/index.js
+++ b/test/production/pages-dir/production/fixture/pages/index.js
@@ -2,8 +2,8 @@ import Link from 'next/link?loaderQuery'
 
 if (typeof window === 'undefined') {
   try {
-    let file = 'clear.js'
-    require('es5-ext/array/#/' + file)
+    let file = 'index.js'
+    require('es5-ext/array/of/' + file)
   } catch (_) {}
   import('nanoid').then((mod) => console.log(mod.nanoid()))
 }

--- a/test/production/pages-dir/production/fixture/pages/index.js
+++ b/test/production/pages-dir/production/fixture/pages/index.js
@@ -2,8 +2,8 @@ import Link from 'next/link?loaderQuery'
 
 if (typeof window === 'undefined') {
   try {
-    let file = 'index.js'
-    require('es5-ext/array/of/' + file)
+    let file = 'clear.js'
+    require('es5-ext/array/#/' + file)
   } catch (_) {}
   import('nanoid').then((mod) => console.log(mod.nanoid()))
 }

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -297,7 +297,7 @@ describe('Production Usage', () => {
           if (files.some((file) => item.test(file))) {
             return true
           }
-          console.error(
+          require('console').error(
             `Failed to find ${item} for page ${check.page} in`,
             files
           )

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -297,7 +297,7 @@ describe('Production Usage', () => {
           if (files.some((file) => item.test(file))) {
             return true
           }
-          require('console').error(
+          console.error(
             `Failed to find ${item} for page ${check.page} in`,
             files
           )

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -257,7 +257,7 @@ describe('Production Usage', () => {
       {
         page: '/api/readfile-dirname',
         tests: [
-          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
+          /(webpack-api-runtime\.js|\[turbopack\]_runtime\.js)/,
           /static\/data\/item\.txt/,
         ],
         notTests: [
@@ -271,7 +271,7 @@ describe('Production Usage', () => {
       {
         page: '/api/readfile-processcwd',
         tests: [
-          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
+          /(webpack-api-runtime\.js|\[turbopack\]_runtime\.js)/,
           /static\/data\/item\.txt/,
         ],
         notTests: [

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -216,7 +216,7 @@ describe('Production Usage', () => {
           /node_modules\/next/,
           /node_modules\/nanoid\/index\.js/,
           /node_modules\/nanoid\/url-alphabet\/index\.js/,
-          /node_modules\/es5-ext\/array\/#\/clear\.js/,
+          /node_modules\/es5-ext\/array\/of\/index\.js/,
         ],
         notTests: [/next\/dist\/pages\/_error\.js/, /\0/, /\?/, /!/],
       },
@@ -256,7 +256,10 @@ describe('Production Usage', () => {
       },
       {
         page: '/api/readfile-dirname',
-        tests: [/webpack-api-runtime\.js/, /static\/data\/item\.txt/],
+        tests: [
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
+          /static\/data\/item\.txt/,
+        ],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,
@@ -267,7 +270,10 @@ describe('Production Usage', () => {
       },
       {
         page: '/api/readfile-processcwd',
-        tests: [/webpack-api-runtime\.js/, /static\/data\/item\.txt/],
+        tests: [
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
+          /static\/data\/item\.txt/,
+        ],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,
@@ -291,7 +297,7 @@ describe('Production Usage', () => {
           if (files.some((file) => item.test(file))) {
             return true
           }
-          console.error(
+          require('console').error(
             `Failed to find ${item} for page ${check.page} in`,
             files
           )

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -216,7 +216,7 @@ describe('Production Usage', () => {
           /node_modules\/next/,
           /node_modules\/nanoid\/index\.js/,
           /node_modules\/nanoid\/url-alphabet\/index\.js/,
-          /node_modules\/es5-ext\/array\/of\/index\.js/,
+          /node_modules\/es5-ext\/array\/#\/clear\.js/,
         ],
         notTests: [/next\/dist\/pages\/_error\.js/, /\0/, /\?/, /!/],
       },
@@ -256,10 +256,7 @@ describe('Production Usage', () => {
       },
       {
         page: '/api/readfile-dirname',
-        tests: [
-          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
-          /static\/data\/item\.txt/,
-        ],
+        tests: [/webpack-api-runtime\.js/, /static\/data\/item\.txt/],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,
@@ -270,10 +267,7 @@ describe('Production Usage', () => {
       },
       {
         page: '/api/readfile-processcwd',
-        tests: [
-          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
-          /static\/data\/item\.txt/,
-        ],
+        tests: [/webpack-api-runtime\.js/, /static\/data\/item\.txt/],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,
@@ -297,7 +291,7 @@ describe('Production Usage', () => {
           if (files.some((file) => item.test(file))) {
             return true
           }
-          require('console').error(
+          console.error(
             `Failed to find ${item} for page ${check.page} in`,
             files
           )

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -216,7 +216,7 @@ describe('Production Usage', () => {
           /node_modules\/next/,
           /node_modules\/nanoid\/index\.js/,
           /node_modules\/nanoid\/url-alphabet\/index\.js/,
-          /node_modules\/es5-ext\/array\/#\/clear\.js/,
+          /node_modules\/es5-ext\/array\/from\/index\.js/,
         ],
         notTests: [/next\/dist\/pages\/_error\.js/, /\0/, /\?/, /!/],
       },
@@ -256,7 +256,10 @@ describe('Production Usage', () => {
       },
       {
         page: '/api/readfile-dirname',
-        tests: [/webpack-api-runtime\.js/, /static\/data\/item\.txt/],
+        tests: [
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
+          /static\/data\/item\.txt/,
+        ],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,
@@ -267,7 +270,10 @@ describe('Production Usage', () => {
       },
       {
         page: '/api/readfile-processcwd',
-        tests: [/webpack-api-runtime\.js/, /static\/data\/item\.txt/],
+        tests: [
+          /(webpack-runtime\.js|\[turbopack\]_runtime\.js)/,
+          /static\/data\/item\.txt/,
+        ],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -18486,9 +18486,10 @@
       "Production Usage should remove placeholder for next/image correctly",
       "Production Usage should replace static pages with HTML files",
       "Production Usage should respond with 405 for POST to static page",
-      "Production Usage should warn when prefetch is true"
+      "Production Usage should warn when prefetch is true",
+      "Production Usage should output traces"
     ],
-    "failed": ["Production Usage should output traces"],
+    "failed": [],
     "pending": [
       "Production Usage With Security Related Issues should handle invalid URL properly",
       "Production Usage With basic usage should allow etag header support with getServerSideProps",

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -18486,10 +18486,9 @@
       "Production Usage should remove placeholder for next/image correctly",
       "Production Usage should replace static pages with HTML files",
       "Production Usage should respond with 405 for POST to static page",
-      "Production Usage should warn when prefetch is true",
-      "Production Usage should output traces"
+      "Production Usage should warn when prefetch is true"
     ],
-    "failed": [],
+    "failed": ["Production Usage should output traces"],
     "pending": [
       "Production Usage With Security Related Issues should handle invalid URL properly",
       "Production Usage With basic usage should allow etag header support with getServerSideProps",


### PR DESCRIPTION
### What?
- Changed the ES5-Ext module path from `es5-ext/array/#/clear.js` to `es5-ext/array/of/index.js` in the test fixture
- Updated corresponding test assertions to match the new module path
- Modified runtime detection in API tests to support both webpack and Turbopack runtime patterns
- Fixed console error usage in test to use require('console').error
- Updated Turbopack build tests manifest to mark "should output traces" test as passing

Turbopack failed to detect `#` folders, likely because it treats it like a hash regardless of `/#/`. I've created a new issue for this to track it. It's not a blocker for what this test is checking for.

### Why?
This PR fixes the "should output traces" test that was previously failing in the Turbopack build tests. The changes ensure proper module path resolution and test assertions that work with both webpack and Turbopack runtimes.

### How?
- Updated the module import path in the test fixture
- Adjusted test assertions to match the new module path
- Added regex patterns to support both webpack and Turbopack runtime files
- Fixed console error usage to ensure proper error reporting
- Updated the test manifest to reflect the now passing test

Closes PACK-4237