### PR TITLE
Turbopack: log telemetry events when `TurbopackInternalError`s occur

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -669,5 +669,6 @@
   "668": "Internal Next.js error: Router action dispatched before initialization.",
   "669": "Invariant: --turbopack is set but the build used Webpack",
   "670": "Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to \"next start\".",
-  "671": "Specified images.remotePatterns must have protocol \"http\" or \"https\" received \"%s\"."
+  "671": "Specified images.remotePatterns must have protocol \"http\" or \"https\" received \"%s\".",
+  "672": "Expected `telemetry` to be set in globals"
 }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -509,7 +509,7 @@ function bindingToApi(
     try {
       return await fn()
     } catch (nativeError: any) {
-      throw new TurbopackInternalError(nativeError)
+      throw TurbopackInternalError.createAndRecordTelemetry(nativeError)
     }
   }
 
@@ -577,7 +577,7 @@ function bindingToApi(
       } catch (e) {
         if (e === cancel) return
         if (e instanceof Error) {
-          throw new TurbopackInternalError(e)
+          throw TurbopackInternalError.createAndRecordTelemetry(e)
         }
         throw e
       } finally {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -50,6 +50,7 @@ import { NEXT_PATCH_SYMBOL } from './patch-fetch'
 import type { ServerInitResult } from './render-server'
 import { filterInternalHeaders } from './server-ipc/utils'
 import { blockCrossSite } from './router-utils/block-cross-site'
+import { traceGlobals } from '../../trace/shared'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -122,6 +123,8 @@ export async function initialize(opts: {
     const telemetry = new Telemetry({
       distDir: path.join(opts.dir, config.distDir),
     })
+    traceGlobals.set('telemetry', telemetry)
+
     const { pagesDir, appDir } = findPagesDir(opts.dir)
 
     const { setupDevBundler } =

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -3,6 +3,7 @@ import type {
   StyledString,
   TurbopackResult,
 } from '../../../build/swc/types'
+
 import { bold, green, magenta, red } from '../../../lib/picocolors'
 import isInternal from '../is-internal'
 import {
@@ -13,6 +14,8 @@ import type { EntryKey } from './entry-key'
 import * as Log from '../../../build/output/log'
 import type { NextConfigComplete } from '../../../server/config-shared'
 import loadJsConfig from '../../../build/load-jsconfig'
+import { eventErrorThrown } from '../../../telemetry/events'
+import { traceGlobals } from '../../../trace/shared'
 
 type IssueKey = `${Issue['severity']}-${Issue['filePath']}-${string}-${string}`
 export type IssuesMap = Map<IssueKey, Issue>
@@ -29,6 +32,22 @@ export class ModuleBuildError extends Error {
 // to a log file and details should not be shown to the user.
 export class TurbopackInternalError extends Error {
   name = 'TurbopackInternalError'
+
+  // Manually set this as this isn't statically determinable
+  __NEXT_ERROR_CODE = 'TurbopackInternalError'
+
+  static createAndRecordTelemetry(cause: Error) {
+    const error = new TurbopackInternalError(cause)
+
+    const telemetry = traceGlobals.get('telemetry')
+    if (telemetry) {
+      telemetry.record(eventErrorThrown(error))
+    } else {
+      console.error('Expected `telemetry` to be set in globals')
+    }
+
+    return error
+  }
 
   constructor(cause: Error) {
     super(cause.message)

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -1,6 +1,7 @@
 import type { TelemetryPlugin } from '../../build/webpack/plugins/telemetry-plugin/telemetry-plugin'
 import type { SWC_TARGET_TRIPLE } from '../../build/webpack/plugins/telemetry-plugin/telemetry-plugin'
 import type { UseCacheTrackerKey } from '../../build/webpack/plugins/telemetry-plugin/use-cache-tracker-utils'
+import { extractNextErrorCode } from '../../lib/error-telemetry-utils'
 
 const REGEXP_DIRECTORY_DUNDER =
   /[\\/]__[^\\/]+(?<![\\/]__(?:tests|mocks))__[\\/]/i
@@ -211,4 +212,22 @@ export function eventPackageUsedInGetServerSideProps(
       package: packageName,
     },
   }))
+}
+
+export const ERROR_THROWN_EVENT = 'NEXT_ERROR_THROWN'
+type ErrorThrownEvent = {
+  eventName: typeof ERROR_THROWN_EVENT
+  payload: {
+    errorCode: string | undefined
+  }
+}
+
+// Creates a Telemetry event for errors. For privacy, only includes the error code.
+export function eventErrorThrown(error: Error): ErrorThrownEvent {
+  return {
+    eventName: ERROR_THROWN_EVENT,
+    payload: {
+      errorCode: extractNextErrorCode(error) || 'Unknown',
+    },
+  }
 }

--- a/test/unit/TurbopackInternalError.test.ts
+++ b/test/unit/TurbopackInternalError.test.ts
@@ -1,0 +1,33 @@
+import path from 'path'
+import os from 'os'
+import { TurbopackInternalError } from 'next/dist/shared/lib/turbopack/utils'
+import { Telemetry } from 'next/dist/telemetry/storage'
+import { setGlobal } from 'next/dist/trace'
+import { traceGlobals } from 'next/dist/trace/shared'
+
+describe('TurbopackInternalError', () => {
+  it('sends a telemetry event when TurbopackInternalError.createAndRecordTelemetry() is called', async () => {
+    const oldTelemetry = traceGlobals.get('telemetry')
+
+    try {
+      const distDir = path.join(os.tmpdir(), 'next-telemetry')
+      const telemetry = new Telemetry({ distDir })
+      setGlobal('telemetry', telemetry)
+      const submitRecord = jest
+        // @ts-ignore
+        .spyOn(telemetry, 'submitRecord')
+        // @ts-ignore
+        .mockImplementation(() => Promise.resolve())
+      TurbopackInternalError.createAndRecordTelemetry(new Error('test error'))
+
+      expect(submitRecord).toHaveBeenCalledWith({
+        eventName: 'NEXT_ERROR_THROWN',
+        payload: {
+          errorCode: 'TurbopackInternalError',
+        },
+      })
+    } finally {
+      setGlobal('telemetry', oldTelemetry)
+    }
+  })
+})


### PR DESCRIPTION
Note: **This does not include any error content aside from that the error is a `TurbopackInternalError`.**

This adds a function, `TurbopackInternalError.createAndRecordTelemetry` that both creates the `TurbopackInternalError` instance and logs that it occurred to telemetry. This telemetry event only includes 1) that an error occurred once and 2) the error code or error name of the error, in this case `TurbopackInternalError`.

Test Plan: Added a unit test, `TurbopackInternalError.test.ts`

Manual test plan:
- Insert a panic into Turbopack source in `analyse_ecmascript_module`.
- Run `NEXT_TELEMETRY_DEBUG=1 NODE_OPTIONS="--trace-deprecation --enable-source-maps" pnpm next "build" "--turbo" "test/e2e/app-dir/app/“`.
- Verify telemetry debugging shows an event called `NEXT_ERROR_THROWN` with `errorCode` of `TurbopackInternalError`.
- Do the same with `NEXT_TELEMETRY_DEBUG=1 NODE_OPTIONS="--trace-deprecation --enable-source-maps" pnpm next "dev" "--turbo" "test/e2e/app-dir/app/“`


Closes PACK-4271