### PR TITLE
Include endpoint when we can't find a Server Action

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -666,5 +666,6 @@
   "665": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "666": "Turbopack builds are only available in canary builds of Next.js.",
   "667": "receiveExpiredTags is deprecated, and not expected to be called.",
-  "668": "Internal Next.js error: Router action dispatched before initialization."
+  "668": "Internal Next.js error: Router action dispatched before initialization.",
+  "669": "%s: Failed to find Server Action \"%s\". This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action"
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -693,7 +693,7 @@ export async function handleAction({
           }
         } else {
           try {
-            actionModId = getActionModIdOrError(actionId, serverModuleMap)
+            actionModId = getActionModIdOrError(req, actionId, serverModuleMap)
           } catch (err) {
             if (actionId !== null) {
               console.error(err)
@@ -848,7 +848,7 @@ export async function handleAction({
           }
         } else {
           try {
-            actionModId = getActionModIdOrError(actionId, serverModuleMap)
+            actionModId = getActionModIdOrError(req, actionId, serverModuleMap)
           } catch (err) {
             if (actionId !== null) {
               console.error(err)
@@ -898,7 +898,7 @@ export async function handleAction({
 
       try {
         actionModId =
-          actionModId ?? getActionModIdOrError(actionId, serverModuleMap)
+          actionModId ?? getActionModIdOrError(req, actionId, serverModuleMap)
       } catch (err) {
         if (actionId !== null) {
           console.error(err)
@@ -1039,6 +1039,7 @@ export async function handleAction({
  * In either case, we'll throw an error to be handled by the caller.
  */
 function getActionModIdOrError(
+  req: BaseNextRequest,
   actionId: string | null,
   serverModuleMap: ServerModuleMap
 ): string {
@@ -1051,7 +1052,7 @@ function getActionModIdOrError(
 
   if (!actionModId) {
     throw new Error(
-      `Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
+      `${req.url}: Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
     )
   }
 


### PR DESCRIPTION
Actually, maybe silly? You should have the request in logs. Checking with customer if that's not the case.

## Test plan

1. Change code to always throw
1. `pnpm next build test/e2e/app-dir/actions/`
1. `pnpm next start test/e2e/app-dir/actions/`
1. Goto http://localhost:3000/server
1. Press "+1"

```console
Error: /server: Failed to find Server Action "40fe7aab39b7c6e39845fef8af59ec4747c0ea5a90". This request might be from an older or newer deployment.
Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
    at async doRender (packages/next/src/server/base-server.ts:2787:21)
```