### PR TITLE
Turbopack build: Add marker for when a build used Turbopack

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1452,6 +1452,7 @@ export default async function build(
       let shutdownPromise = Promise.resolve()
       if (!isGenerateMode) {
         if (turboNextBuild) {
+          await writeFileUtf8(path.join(distDir, 'IS_TURBOPACK_BUILD'), '')
           const {
             duration: compilerDuration,
             shutdownPromise: p,

--- a/test/production/app-dir/turbopack-build-marker/app/layout.tsx
+++ b/test/production/app-dir/turbopack-build-marker/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/turbopack-build-marker/app/page.tsx
+++ b/test/production/app-dir/turbopack-build-marker/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/turbopack-build-marker/next.config.js
+++ b/test/production/app-dir/turbopack-build-marker/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
+++ b/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
@@ -1,0 +1,13 @@
+import { nextTestSetup } from 'e2e-utils'
+;(process.env.TURBOPACK ? describe : describe.skip)(
+  'turbopack-build-marker',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+    })
+
+    it('should have Turbopack build marker', async () => {
+      expect(await next.hasFile('.next/IS_TURBOPACK_BUILD')).toBe(true)
+    })
+  }
+)

--- a/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
+++ b/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
@@ -1,13 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
-;(process.env.TURBOPACK ? describe : describe.skip)(
-  'turbopack-build-marker',
-  () => {
-    const { next } = nextTestSetup({
-      files: __dirname,
-    })
+describe('turbopack-build-marker', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
 
-    it('should have Turbopack build marker', async () => {
-      expect(await next.hasFile('.next/IS_TURBOPACK_BUILD')).toBe(true)
-    })
-  }
-)
+  it('should have Turbopack build marker', async () => {
+    expect(await next.hasFile('.next/IS_TURBOPACK_BUILD')).toBe(
+      !!process.env.TURBOPACK
+    )
+  })
+})


### PR DESCRIPTION
## What?

When using Turbopack build it currently requires `TURBOPACK=1` when running in production. This is handled automatically in `next dev` / `next build` / `next start`. However there's cases where `next start` is not used, e.g. on deployment platforms. For those cases I've added a new marker file `IS_TURBOPACK_BUILD` part of the build output (`.next/IS_TURBOPACK_BUILD`) so that it can detect Turbopack build and apply `TURBOPACK=1` env var for the relevant places.

This marker is also needed in order to improve the error when someone accidentally forgets `--turbopack` on `next start` after doing a Turbopack build. Going to add that error in a separate PR.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-4234