### PR TITLE
Turbopack build: Implement error when using next start without --turbopack

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -666,5 +666,7 @@
   "665": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "666": "Turbopack builds are only available in canary builds of Next.js.",
   "667": "receiveExpiredTags is deprecated, and not expected to be called.",
-  "668": "Internal Next.js error: Router action dispatched before initialization."
+  "668": "Internal Next.js error: Router action dispatched before initialization.",
+  "669": "Invariant: --turbopack is set but the build used Webpack",
+  "670": "Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to \"next start\"."
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2334,6 +2334,7 @@ export default async function build(
                   ]
                 : []),
               BUILD_ID_FILE,
+              IS_TURBOPACK_BUILD_FILE,
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.js'),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.json'),
               ...instrumentationHookEntryFiles,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -81,6 +81,7 @@ import {
   UNDERSCORE_NOT_FOUND_ROUTE,
   DYNAMIC_CSS_MANIFEST,
   TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST,
+  IS_TURBOPACK_BUILD_FILE,
 } from '../shared/lib/constants'
 import {
   getSortedRoutes,
@@ -1452,7 +1453,7 @@ export default async function build(
       let shutdownPromise = Promise.resolve()
       if (!isGenerateMode) {
         if (turboNextBuild) {
-          await writeFileUtf8(path.join(distDir, 'IS_TURBOPACK_BUILD'), '')
+          await writeFileUtf8(path.join(distDir, IS_TURBOPACK_BUILD_FILE), '')
           const {
             duration: compilerDuration,
             shutdownPromise: p,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2334,7 +2334,7 @@ export default async function build(
                   ]
                 : []),
               BUILD_ID_FILE,
-              IS_TURBOPACK_BUILD_FILE,
+              turboNextBuild ? IS_TURBOPACK_BUILD_FILE : null,
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.js'),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.json'),
               ...instrumentationHookEntryFiles,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -193,11 +193,11 @@ export default class NextNodeServer extends BaseServer<
 
     if (process.env.TURBOPACK && !isTurbopackBuild) {
       throw new Error(
-        `Invariant: --turbopack is set but the build is not a Turbopack build`
+        `Invariant: --turbopack is set but the build used Webpack`
       )
     } else if (!process.env.TURBOPACK && isTurbopackBuild) {
       throw new Error(
-        `Invariant: --turbopack is not set but the build is a Turbopack build`
+        `Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to "next start".`
       )
     }
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -189,20 +189,23 @@ export default class NextNodeServer extends BaseServer<
     // Initialize super class
     super(options)
 
+    const isDev = options.dev ?? false
+    this.isDev = isDev
+    this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
+
     const isTurbopackBuild = this.isTurbopackBuild()
 
-    if (process.env.TURBOPACK && !isTurbopackBuild) {
-      throw new Error(
-        `Invariant: --turbopack is set but the build used Webpack`
-      )
-    } else if (!process.env.TURBOPACK && isTurbopackBuild) {
-      throw new Error(
-        `Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to "next start".`
-      )
+    if (!isDev) {
+      if (process.env.TURBOPACK && !isTurbopackBuild) {
+        throw new Error(
+          `Invariant: --turbopack is set but the build used Webpack`
+        )
+      } else if (!process.env.TURBOPACK && isTurbopackBuild) {
+        throw new Error(
+          `Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to "next start".`
+        )
+      }
     }
-
-    this.isDev = options.dev ?? false
-    this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
 
     /**
      * This sets environment variable to be used at the time of SSR by head.tsx.

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -56,6 +56,7 @@ export const CONFIG_FILES = [
   'next.config.ts',
 ]
 export const BUILD_ID_FILE = 'BUILD_ID'
+export const IS_TURBOPACK_BUILD_FILE = 'IS_TURBOPACK_BUILD'
 export const BLOCKED_PAGES = ['/_document', '/_app', '/_error']
 export const CLIENT_PUBLIC_FILES_PATH = 'public'
 export const CLIENT_STATIC_FILES_PATH = 'static'


### PR DESCRIPTION
### What?

This PR adds validation to ensure that the build tool used during `next build` matches the one used during `next start`. It prevents mismatches between Turbopack and Webpack builds.

### Why?
When a project is built with Turbopack but started without the `--turbopack` flag (or vice versa), it can lead to unexpected behavior and errors. This change ensures consistency between build and runtime environments.

### How?
- Added a constant `IS_TURBOPACK_BUILD_FILE` to track which build tool was used
- Added validation in the server startup to check if the `--turbopack` flag matches the build tool that was used
- Added appropriate error messages (669 and 670) to provide clear guidance when mismatches occur


Closes PACK-4239