### PR TITLE
Remove typeofs optimization in swc options

### DIFF
--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -58,7 +58,6 @@ function getBaseSWCOptions({
   jest,
   development,
   hasReactRefresh,
-  globalWindow,
   esm,
   modularizeImports,
   swcPlugins,
@@ -78,7 +77,6 @@ function getBaseSWCOptions({
   jest?: boolean
   development: boolean
   hasReactRefresh: boolean
-  globalWindow: boolean
   esm: boolean
   modularizeImports?: NextConfig['modularizeImports']
   compilerOptions: NextConfig['compiler']
@@ -157,9 +155,6 @@ function getBaseSWCOptions({
           globals: jest
             ? null
             : {
-                typeofs: {
-                  window: globalWindow ? 'object' : 'undefined',
-                },
                 envs: {
                   NODE_ENV: development ? '"development"' : '"production"',
                 },
@@ -297,7 +292,6 @@ function getEmotionOptions(
 }
 
 export function getJestSWCOptions({
-  isServer,
   filename,
   esm,
   modularizeImports,
@@ -325,7 +319,6 @@ export function getJestSWCOptions({
     jest: true,
     development: false,
     hasReactRefresh: false,
-    globalWindow: !isServer,
     modularizeImports,
     swcPlugins,
     compilerOptions,
@@ -414,7 +407,6 @@ export function getLoaderSWCOptions({
   let baseOptions: any = getBaseSWCOptions({
     filename,
     development,
-    globalWindow: !isServer,
     hasReactRefresh,
     modularizeImports,
     swcPlugins,
@@ -525,14 +517,6 @@ export function getLoaderSWCOptions({
     options.isPageFile = false
     options.optimizeServerReact = undefined
     options.cjsRequireOptimizer = undefined
-    // Disable optimizer for node_modules in app browser layer, to avoid unnecessary replacement.
-    // e.g. typeof window could result differently in js worker or browser.
-    if (
-      options.jsc.transform.optimizer.globals?.typeofs &&
-      !filename.includes(nextDirname)
-    ) {
-      delete options.jsc.transform.optimizer.globals.typeofs.window
-    }
   }
 
   return options


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Fixes #39605
Fixes #36514
(possibly more issues I've overlooked)

I'm not sure if this has any further side-effects, but since it's generally not true, that `typeof window === "object"` in a browser context (web workers...) I think, it's safer to just remove that optimization.

Alternatively we could extend the removed section that disables the optimization to check for more cases where it could possibly be an issue, but I'm not sure how much benefit that optimization really gives anyhow (more tree-shaking potential?).

How I triggered this problem (with web-workers, described e.g. in #39605): a file dependency to a local three.js fork, which is used within a web-worker. With this PR applied it works as expected.