### PR TITLE
pack-next: use default `--js-build` as option instead of `--no-js-build`

### DIFF
--- a/scripts/pack-next.ts
+++ b/scripts/pack-next.ts
@@ -33,9 +33,11 @@ interface CliOptions {
 
 const cliOptions = yargs(process.argv.slice(2))
   .command('$0')
-  .option('no-js-build', {
+  .option('js-build', {
     type: 'boolean',
-    describe: 'Skip building JavaScript code',
+    default: true,
+    describe:
+      'Build JavaScript code (default). Use `--no-js-build` to skip building JavaScript',
   })
   .option('project', {
     alias: 'p',


### PR DESCRIPTION
Yargs automatically creates `--no-` variations of options. Using `--no-js-build` as an option directly confuses it.

`--no-js-build` remains a valid cli argument.

Test Plan: Verify `pnpm pack-next` builds JS by default and `pnpm pack-next --no-js-build` doesn’t.

Help now looks like this:

```
pack-next.ts

Options:
      --help      Show help                                            [boolean]
      --version   Show version number                                  [boolean]
      --js-build  Build JavaScript code (default). Use `--no-js-build` to skip
                  building JavaScript                  [boolean] [default: true]
  -p, --project                                                         [string]
      --tar       Create tarballs instead of direct reflinks           [boolean]
      --compress  How compress the binary, useful on platforms where tarballs
                  can exceed 2 GiB, which causes ERR_FS_FILE_TOO_LARGE with
                  pnpm. Defaults to "strip" on Linux, otherwise defaults to
                  "none". Requires `--tar` to be set.
                                             [string] [choices: "none", "strip"]
```


Closes PACK-4242