### PR TITLE
legacyBehavior deprecation error should only trigger once

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -20,6 +20,7 @@ import {
 } from '../components/links'
 import { isLocalURL } from '../../shared/lib/router/utils/is-local-url'
 import { dispatchNavigateAction } from '../components/app-router-instance'
+import { errorOnce } from '../../shared/lib/utils/error-once'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -684,7 +685,7 @@ export default function LinkComponent(
 
   if (legacyBehavior) {
     if (process.env.NODE_ENV === 'development') {
-      console.error(
+      errorOnce(
         '`legacyBehavior` is deprecated and will be removed in a future ' +
           'release. A codemod is available to upgrade your components:\n\n' +
           'npx @next/codemod@latest new-link .\n\n' +

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -18,6 +18,7 @@ import { useIntersection } from './use-intersection'
 import { getDomainLocale } from './get-domain-locale'
 import { addBasePath } from './add-base-path'
 import { useMergedRef } from './use-merged-ref'
+import { errorOnce } from '../shared/lib/utils/error-once'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -668,7 +669,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
     if (legacyBehavior) {
       if (process.env.NODE_ENV === 'development') {
-        console.error(
+        errorOnce(
           '`legacyBehavior` is deprecated and will be removed in a future ' +
             'release. A codemod is available to upgrade your components:\n\n' +
             'npx @next/codemod@latest new-link .\n\n' +

--- a/packages/next/src/shared/lib/utils/error-once.ts
+++ b/packages/next/src/shared/lib/utils/error-once.ts
@@ -1,0 +1,12 @@
+let errorOnce = (_: string) => {}
+if (process.env.NODE_ENV !== 'production') {
+  const errors = new Set<string>()
+  errorOnce = (msg: string) => {
+    if (!errors.has(msg)) {
+      console.error(msg)
+    }
+    errors.add(msg)
+  }
+}
+
+export { errorOnce }

--- a/test/e2e/app-dir/link-component-deprecations/app/page.tsx
+++ b/test/e2e/app-dir/link-component-deprecations/app/page.tsx
@@ -2,8 +2,13 @@ import Link from 'next/link'
 
 export default function HomePage() {
   return (
-    <Link legacyBehavior href="/target-page">
-      <a>Target page</a>
-    </Link>
+    <>
+      <Link legacyBehavior href="/target-page">
+        <a>Target page</a>
+      </Link>
+      <Link legacyBehavior href="/target-page?foo=bar">
+        <a>Another Target page</a>
+      </Link>
+    </>
   )
 }

--- a/test/e2e/app-dir/link-component-deprecations/link-component-deprecations.test.ts
+++ b/test/e2e/app-dir/link-component-deprecations/link-component-deprecations.test.ts
@@ -9,7 +9,7 @@ describe('Link component deprecations', () => {
     const browser = await next.browser('/')
     const logs = await browser.log()
 
-    const didWarn = logs.some(
+    const errors = logs.filter(
       (log) =>
         log.source === 'error' &&
         log.message.includes(
@@ -17,6 +17,6 @@ describe('Link component deprecations', () => {
         )
     )
 
-    expect(didWarn).toBe(isNextDev)
+    expect(errors.length).toBe(isNextDev ? 1 : 0)
   })
 })


### PR DESCRIPTION
We added a deprecation warning for `legacyBehavior` on the `Link` component but since we show errors in the error overlay, this could lead to a lot of noise if many links are using the `legacyBehavior` prop.

This copies over the `warn-once` utility to `error-once` and uses that utility to dedupe. 