### PR TITLE
Do no suspend when resolving metadata during SSR

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -666,5 +666,6 @@
   "665": "Failed to find Server Action \"%s\". This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "666": "Turbopack builds are only available in canary builds of Next.js.",
   "667": "receiveExpiredTags is deprecated, and not expected to be called.",
-  "668": "Internal Next.js error: Router action dispatched before initialization."
+  "668": "Internal Next.js error: Router action dispatched before initialization.",
+  "669": "ServerInsertMetadata must be used within a ServerInsertedMetadataProvider but no context value was found."
 }

--- a/packages/next/src/client/components/metadata/server-inserted-metadata.tsx
+++ b/packages/next/src/client/components/metadata/server-inserted-metadata.tsx
@@ -1,29 +1,35 @@
-import { use, useContext } from 'react'
-import {
-  type MetadataResolver,
-  ServerInsertedMetadataContext,
-} from '../../../shared/lib/server-inserted-metadata.shared-runtime'
+import { useContext } from 'react'
+import { ServerInsertedMetadataContext } from '../../../shared/lib/server-inserted-metadata.shared-runtime'
 import type { StreamingMetadataResolvedState } from './types'
-
-// Receives a metadata resolver setter from the context, and will pass the metadata resolving promise to
-// the context where we gonna use it to resolve the metadata, and render as string to append in <body>.
-const useServerInsertedMetadata = (metadataResolver: MetadataResolver) => {
-  const setMetadataResolver = useContext(ServerInsertedMetadataContext)
-
-  if (setMetadataResolver) {
-    setMetadataResolver(metadataResolver)
-  }
-}
+import { InvariantError } from '../../../shared/lib/invariant-error'
 
 export function ServerInsertMetadata({
   promise,
 }: {
   promise: Promise<StreamingMetadataResolvedState>
 }) {
-  // Apply use() to the metadata promise to suspend the rendering in SSR.
-  const { metadata } = use(promise)
-  // Insert metadata into the HTML stream through the `useServerInsertedMetadata`
-  useServerInsertedMetadata(() => metadata)
+  const setPendingMetadata = useContext(ServerInsertedMetadataContext)
+
+  if (typeof setPendingMetadata !== 'function') {
+    throw new InvariantError(
+      'ServerInsertMetadata must be used within a ServerInsertedMetadataProvider but no context value was found.'
+    )
+  }
+
+  // We create a wrapper promise because React promises through flight don't actually
+  // implement the promise API where new promises are returned from then calls
+  const metadataPromise = new Promise<React.ReactNode>((resolve, reject) => {
+    promise.then(
+      (result) => {
+        resolve(result.metadata)
+      },
+      (error) => {
+        reject(error)
+      }
+    )
+  })
+
+  setPendingMetadata(metadataPromise)
 
   return null
 }

--- a/packages/next/src/shared/lib/server-inserted-metadata.shared-runtime.ts
+++ b/packages/next/src/shared/lib/server-inserted-metadata.shared-runtime.ts
@@ -3,8 +3,8 @@
 import type React from 'react'
 import { createContext } from 'react'
 
-export type MetadataResolver = () => React.ReactNode
-type MetadataResolverSetter = (m: MetadataResolver) => void
+export type PendingMetadataNodes = Promise<React.ReactNode>
+type PendingMetadataSetter = (m: PendingMetadataNodes) => void
 
 export const ServerInsertedMetadataContext =
-  createContext<MetadataResolverSetter | null>(null)
+  createContext<PendingMetadataSetter | null>(null)


### PR DESCRIPTION
When streaming metadata during SSR we currently suspend unecessarily. Instead we can make the resolver async. This allows the metadata resolution to complete synchronously and thus not appear as dynamic from the perspective of dynamicIO.
