### PR TITLE
Turbopack: fix `sideEffects` matching for non-relative globs

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
 use turbo_tasks_fs::{glob::Glob, FileJsonContent, FileSystemPath};
 use turbopack_core::{
     asset::Asset,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -188,10 +188,6 @@ pub async fn is_marked_as_side_effect_free(
         }
     }
 
-    println!(
-        "is_marked_as_side_effect_free flase {:?}",
-        path.to_string().await?
-    );
     Ok(Vc::cell(false))
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{glob::Glob, FileJsonContent, FileSystemPath};
 use turbopack_core::{
     asset::Asset,
@@ -50,7 +50,9 @@ async fn side_effects_from_package_json(
                     .filter_map(|side_effect| {
                         if let Some(side_effect) = side_effect.as_str() {
                             if side_effect.contains('/') {
-                                Some(Glob::new(side_effect.into()))
+                                Some(Glob::new(
+                                    side_effect.strip_prefix("./").unwrap_or(side_effect).into(),
+                                ))
                             } else {
                                 Some(Glob::new(format!("**/{side_effect}").into()))
                             }
@@ -179,12 +181,17 @@ pub async fn is_marked_as_side_effect_free(
                     .await?
                     .get_relative_path_to(&*path.await?)
                 {
-                    return Ok(Vc::cell(!glob.await?.execute(&rel_path)));
+                    let rel_path = rel_path.strip_prefix("./").unwrap_or(&rel_path);
+                    return Ok(Vc::cell(!glob.await?.execute(rel_path)));
                 }
             }
         }
     }
 
+    println!(
+        "is_marked_as_side_effect_free flase {:?}",
+        path.to_string().await?
+    );
     Ok(Vc::cell(false))
 }
 

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/index.js
@@ -102,7 +102,12 @@ import { effects } from "package-partial/effect";
 it("should handle globs in sideEffects field", () => {
   expect(a9).toBe("a");
   expect(b9).toBe("b");
-  expect(effects).toEqual(["file.side.js", "dir/file.js"]);
+  expect(effects).toEqual([
+    "file.side.js",
+    "sub/file.side.js",
+    "sub/bare.js",
+    "dir/file.js"
+  ]);
 });
 
 it("should generate a correct facade from async modules", async () => {

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/index.js
@@ -5,6 +5,9 @@ export * from "./not-compiled.js";
 // export * from "./not-existing.js";
 export * from "./not-executed.js";
 export * from "./file.side.js";
+export * from "./sub/file.side.js";
+export * from "./sub/bare.js";
 export { named } from "./dir/file.js";
+
 export { a } from "./a.js";
 export { b } from "./b.js";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/package.json
@@ -2,6 +2,7 @@
   "sideEffects": [
     "./index.js",
     "*.side.js",
+    "sub/bare.js",
     "./dir/*.js"
   ]
 }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/sub/bare.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/sub/bare.js
@@ -1,0 +1,5 @@
+import { effects } from "../effect.js";
+
+export const bare = "bare";
+
+effects.push("sub/bare.js");

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/sub/file.side.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/sub/file.side.js
@@ -1,0 +1,5 @@
+import { effects } from "../effect.js";
+
+export const namedDir = "named-dir";
+
+effects.push("sub/file.side.js");


### PR DESCRIPTION
Previously, `"sideEffects": ["lib/common.js"]` never matched.

Closes #66348
Closes PACK-4241