### PR TITLE
chore(turbopack): Make TaskInputs use ResolvedVc

### DIFF
--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -32,18 +32,18 @@ use crate::{
 
 #[derive(TaskInput, Clone, Hash, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 pub struct ClientReferenceManifestOptions {
-    pub node_root: Vc<FileSystemPath>,
-    pub client_relative_path: Vc<FileSystemPath>,
+    pub node_root: ResolvedVc<FileSystemPath>,
+    pub client_relative_path: ResolvedVc<FileSystemPath>,
     pub entry_name: RcStr,
-    pub client_references: Vc<ClientReferenceGraphResult>,
-    pub client_references_chunks: Vc<ClientReferencesChunks>,
-    pub rsc_app_entry_chunks: Vc<OutputAssets>,
-    pub client_chunking_context: Vc<Box<dyn ChunkingContext>>,
-    pub ssr_chunking_context: Option<Vc<Box<dyn ChunkingContext>>>,
-    pub async_module_info: Vc<AsyncModulesInfo>,
-    pub next_config: Vc<NextConfig>,
+    pub client_references: ResolvedVc<ClientReferenceGraphResult>,
+    pub client_references_chunks: ResolvedVc<ClientReferencesChunks>,
+    pub rsc_app_entry_chunks: ResolvedVc<OutputAssets>,
+    pub client_chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    pub ssr_chunking_context: Option<ResolvedVc<Box<dyn ChunkingContext>>>,
+    pub async_module_info: ResolvedVc<AsyncModulesInfo>,
+    pub next_config: ResolvedVc<NextConfig>,
     pub runtime: NextRuntime,
-    pub mode: Vc<NextMode>,
+    pub mode: NextMode,
 }
 
 #[turbo_tasks::value_impl]
@@ -181,7 +181,7 @@ impl ClientReferenceManifest {
                 let server_path = client_reference_module_ref.server_ident.to_string().await?;
                 let client_module = client_reference_module_ref.client_module;
                 let client_chunk_item_id = client_module
-                    .chunk_item_id(Vc::upcast(client_chunking_context))
+                    .chunk_item_id(*ResolvedVc::upcast(client_chunking_context))
                     .await?;
 
                 let (client_chunks_paths, client_is_async) =
@@ -226,11 +226,11 @@ impl ClientReferenceManifest {
                 if let Some(ssr_chunking_context) = ssr_chunking_context {
                     let ssr_module = client_reference_module_ref.ssr_module;
                     let ssr_chunk_item_id = ssr_module
-                        .chunk_item_id(Vc::upcast(ssr_chunking_context))
+                        .chunk_item_id(*ResolvedVc::upcast(ssr_chunking_context))
                         .await?;
 
                     let rsc_chunk_item_id = client_reference_module
-                        .chunk_item_id(Vc::upcast(ssr_chunking_context))
+                        .chunk_item_id(*ResolvedVc::upcast(ssr_chunking_context))
                         .await?;
 
                     let (ssr_chunks_paths, ssr_is_async) = if runtime == NextRuntime::Edge {
@@ -385,7 +385,7 @@ impl ClientReferenceManifest {
                 }
 
                 let inlined = next_config.await?.experimental.inline_css.unwrap_or(false)
-                    && mode.await?.is_production();
+                    && mode.is_production();
                 let entry_css_files_vec = entry_css_files_with_chunk
                     .into_iter()
                     .map(async |(path, chunk)| {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -413,9 +413,9 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     async fn module_content(
         self: Vc<Self>,
-        module_graph: Vc<ModuleGraph>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        async_module_info: Option<Vc<AsyncModuleInfo>>,
+        module_graph: ResolvedVc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+        async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptModuleContent>> {
         let parsed = self.parse().to_resolved().await?;
 
@@ -430,17 +430,17 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
         Ok(EcmascriptModuleContent::new(
             EcmascriptModuleContentOptions {
                 parsed,
-                ident: self.ident(),
+                ident: self.ident().to_resolved().await?,
                 specified_module_type: module_type_result.module_type,
                 module_graph,
                 chunking_context,
-                references: analyze.references(),
-                esm_references: *analyze_ref.esm_references,
-                code_generation: *analyze_ref.code_generation,
-                async_module: *analyze_ref.async_module,
+                references: analyze.references().to_resolved().await?,
+                esm_references: analyze_ref.esm_references,
+                code_generation: analyze_ref.code_generation,
+                async_module: analyze_ref.async_module,
                 generate_source_map,
                 original_source_map: analyze_ref.source_map,
-                exports: *analyze_ref.exports,
+                exports: analyze_ref.exports,
                 async_module_info,
             },
         ))
@@ -775,18 +775,18 @@ pub struct EcmascriptModuleContent {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TaskInput, TraceRawVcs)]
 pub struct EcmascriptModuleContentOptions {
     parsed: ResolvedVc<ParseResult>,
-    ident: Vc<AssetIdent>,
+    ident: ResolvedVc<AssetIdent>,
     specified_module_type: SpecifiedModuleType,
-    module_graph: Vc<ModuleGraph>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    references: Vc<ModuleReferences>,
-    esm_references: Vc<EsmAssetReferences>,
-    code_generation: Vc<CodeGens>,
-    async_module: Vc<OptionAsyncModule>,
+    module_graph: ResolvedVc<ModuleGraph>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    references: ResolvedVc<ModuleReferences>,
+    esm_references: ResolvedVc<EsmAssetReferences>,
+    code_generation: ResolvedVc<CodeGens>,
+    async_module: ResolvedVc<OptionAsyncModule>,
     generate_source_map: bool,
     original_source_map: ResolvedVc<OptionStringifiedSourceMap>,
-    exports: Vc<EcmascriptExports>,
-    async_module_info: Option<Vc<AsyncModuleInfo>>,
+    exports: ResolvedVc<EcmascriptExports>,
+    async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -815,7 +815,11 @@ impl EcmascriptModuleContent {
                 if let Some(async_module) = &*async_module.await? {
                     Some(
                         async_module
-                            .code_generation(async_module_info, references, chunking_context)
+                            .code_generation(
+                                async_module_info.map(|info| *info),
+                                *references,
+                                *chunking_context,
+                            )
                             .await?,
                     )
                 } else {
@@ -824,7 +828,7 @@ impl EcmascriptModuleContent {
                 if let EcmascriptExports::EsmExports(exports) = *exports.await? {
                     Some(
                         exports
-                            .code_generation(module_graph, chunking_context, *parsed)
+                            .code_generation(*module_graph, *chunking_context, *parsed)
                             .await?,
                     )
                 } else {
@@ -835,13 +839,13 @@ impl EcmascriptModuleContent {
             let esm_code_gens = esm_references
                 .await?
                 .iter()
-                .map(|r| r.code_generation(chunking_context))
+                .map(|r| r.code_generation(*chunking_context))
                 .try_join()
                 .await?;
             let code_gens = code_generation
                 .await?
                 .iter()
-                .map(|c| c.code_generation(module_graph, chunking_context))
+                .map(|c| c.code_generation(*module_graph, *chunking_context))
                 .try_join()
                 .await?;
 
@@ -857,7 +861,7 @@ impl EcmascriptModuleContent {
 
         gen_content_with_code_gens(
             parsed,
-            ident,
+            *ident,
             specified_module_type,
             code_gens,
             generate_source_map,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -34,12 +34,12 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
     #[turbo_tasks::function]
     async fn content_with_async_module_info(
         &self,
-        async_module_info: Option<Vc<AsyncModuleInfo>>,
+        async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let module = self.module.await?;
         let chunking_context = self.chunking_context;
         let module_graph = self.module_graph;
-        let exports = self.module.get_exports();
+        let exports = self.module.get_exports().to_resolved().await?;
         let original_module = module.module;
         let parsed = original_module.parse().to_resolved().await?;
 
@@ -47,7 +47,7 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
         let analyze_result = analyze.await?;
         let async_module_options = analyze_result
             .async_module
-            .module_options(async_module_info);
+            .module_options(async_module_info.map(|info| *info));
 
         let module_type_result = *original_module.determine_module_type().await?;
         let generate_source_map = *chunking_context
@@ -56,14 +56,14 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
 
         let content = EcmascriptModuleContent::new(EcmascriptModuleContentOptions {
             parsed,
-            ident: self.module.ident(),
+            ident: self.module.ident().to_resolved().await?,
             specified_module_type: module_type_result.module_type,
-            module_graph: *module_graph,
-            chunking_context: *chunking_context,
-            references: analyze.local_references(),
-            esm_references: *analyze_result.esm_local_references,
-            code_generation: *analyze_result.code_generation,
-            async_module: *analyze_result.async_module,
+            module_graph,
+            chunking_context,
+            references: analyze.local_references().to_resolved().await?,
+            esm_references: analyze_result.esm_local_references,
+            code_generation: analyze_result.code_generation,
+            async_module: analyze_result.async_module,
             generate_source_map,
             original_source_map: analyze_result.source_map,
             exports,


### PR DESCRIPTION
It's totally valid for `TaskInput`s to use `Vc`, but `ResolvedVc` is marginally more preferable for a number of performance and functionality reasons (a sane `Eq`+`Hash` impl, doing work more eagerly, synchronous downcasting support).

Closes PACK-4246