### PR TITLE
Suggest using import (instead of require) in bundle-analyzer config

### DIFF
--- a/docs/01-app/03-building-your-application/06-optimizing/06-package-bundling.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/06-package-bundling.mdx
@@ -32,8 +32,8 @@ Then, add the bundle analyzer's settings to your `next.config.js`.
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
 
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: process.env.ANALYZE === 'true',
+const withBundleAnalyzer = (await import("@next/bundle-analyzer")).default({
+  enabled: process.env.ANALYZE === "true",
 })
 
 module.exports = withBundleAnalyzer(nextConfig)


### PR DESCRIPTION
### What?
Suggest using import (instead of require) in bundle-analyzer config

### Why?
Using import is generally considered better than require in modern JavaScript 

### How?
Small doc change!