### PR TITLE
fix PPR cache miss when navigating to page with searchParams

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -242,7 +242,8 @@ export function navigateReducer(
           state,
           flightData,
           url,
-          mutable
+          mutable,
+          postponed
         )
 
         // We didn't return new router state because we didn't apply the aliased entry for some reason.

--- a/test/e2e/app-dir/ppr-navigations/prefetch-navigation/app/loading.tsx
+++ b/test/e2e/app-dir/ppr-navigations/prefetch-navigation/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading...</div>
+}

--- a/test/e2e/app-dir/ppr-navigations/prefetch-navigation/app/page.tsx
+++ b/test/e2e/app-dir/ppr-navigations/prefetch-navigation/app/page.tsx
@@ -4,6 +4,7 @@ export default function Page() {
   return (
     <div>
       <Link href="/catch-all/1">To Test Page</Link>
+      <Link href="/search-params?delay=1000">To Search Params Page</Link>
     </div>
   )
 }

--- a/test/e2e/app-dir/ppr-navigations/prefetch-navigation/app/search-params/page.tsx
+++ b/test/e2e/app-dir/ppr-navigations/prefetch-navigation/app/search-params/page.tsx
@@ -1,0 +1,33 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default function DynamicPPRPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ delay?: string }>
+}) {
+  return (
+    <div>
+      <h1 id="search-params-page">Search Params Page</h1>
+      <Suspense fallback={<div id="suspense-fallback">Loading...</div>}>
+        <DelayedLoad searchParams={searchParams} />
+      </Suspense>
+    </div>
+  )
+}
+
+const DelayedLoad = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{ delay?: string }>
+}) => {
+  const params = await searchParams
+  const delay = Number(params.delay) || 0
+  await connection()
+
+  return (
+    <div>
+      <p id="delay-value">Delay: {delay}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
When navigating to a PPR-ed page that contained search params, the router flows into a codepath that will construct a new CacheNode tree by copying over the `loading` segment(s) for the page being navigated to. The intent of this was to allow re-using an already prefetched loading state regardless of searchParam values. 

However, this code didn't consider the PPR code path, where the router would be looking for the prefetched data in `prefetchRsc`. As a result, navigating to the page would trigger the lazy fetching behavior in layout-router due to a cache miss. 

Most of this logic will be superseded by the `clientSegmentCache` work but since the fix is relatively straightforward I figured it's worth a short-term fix. 