### PR TITLE
Turbopack build: Move Turbopack marker to SERVER_FILES_MANIFEST

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -81,7 +81,6 @@ import {
   UNDERSCORE_NOT_FOUND_ROUTE,
   DYNAMIC_CSS_MANIFEST,
   TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST,
-  IS_TURBOPACK_BUILD_FILE,
 } from '../shared/lib/constants'
 import {
   getSortedRoutes,
@@ -560,6 +559,7 @@ interface RequiredServerFilesManifest {
   relativeAppDir: string
   files: string[]
   ignore: string[]
+  turbopack: boolean
 }
 
 async function writeRequiredServerFilesManifest(
@@ -2334,7 +2334,7 @@ export default async function build(
                   ]
                 : []),
               BUILD_ID_FILE,
-              turboNextBuild ? IS_TURBOPACK_BUILD_FILE : null,
+              SERVER_FILES_MANIFEST,
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.js'),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.json'),
               ...instrumentationHookEntryFiles,
@@ -2342,6 +2342,7 @@ export default async function build(
               .filter(nonNullable)
               .map((file) => path.join(config.distDir, file)),
             ignore: [] as string[],
+            turbopack: turboNextBuild,
           }
 
           return serverFilesManifest

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2278,6 +2278,7 @@ export default async function build(
 
                 // @ts-expect-error internal field TODO: fix this, should use a separate mechanism to pass the info.
                 isExperimentalCompile: isCompileMode,
+                isTurbopackBuild: turboNextBuild,
               },
             },
             appDir: dir,
@@ -2333,7 +2334,6 @@ export default async function build(
                   ]
                 : []),
               BUILD_ID_FILE,
-              SERVER_FILES_MANIFEST,
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.js'),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.json'),
               ...instrumentationHookEntryFiles,
@@ -2341,7 +2341,6 @@ export default async function build(
               .filter(nonNullable)
               .map((file) => path.join(config.distDir, file)),
             ignore: [] as string[],
-            turbopack: turboNextBuild,
           }
 
           return serverFilesManifest

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1453,7 +1453,6 @@ export default async function build(
       let shutdownPromise = Promise.resolve()
       if (!isGenerateMode) {
         if (turboNextBuild) {
-          await writeFileUtf8(path.join(distDir, IS_TURBOPACK_BUILD_FILE), '')
           const {
             duration: compilerDuration,
             shutdownPromise: p,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -559,7 +559,6 @@ interface RequiredServerFilesManifest {
   relativeAppDir: string
   files: string[]
   ignore: string[]
-  turbopack: boolean
 }
 
 async function writeRequiredServerFilesManifest(

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -42,7 +42,7 @@ import {
   PHASE_PRODUCTION_BUILD,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
   FUNCTIONS_CONFIG_MANIFEST,
-  IS_TURBOPACK_BUILD_FILE,
+  SERVER_FILES_MANIFEST,
 } from '../shared/lib/constants'
 import { findDir } from '../lib/find-pages-dir'
 import { NodeNextRequest, NodeNextResponse } from './base-http/node'
@@ -193,9 +193,10 @@ export default class NextNodeServer extends BaseServer<
     this.isDev = isDev
     this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
 
-    const isTurbopackBuild = this.isTurbopackBuild()
-
     if (!isDev) {
+      const isTurbopackBuild = require(
+        join(this.distDir, SERVER_FILES_MANIFEST)
+      ).turbopack
       if (process.env.TURBOPACK && !isTurbopackBuild) {
         throw new Error(
           `Invariant: --turbopack is set but the build used Webpack`
@@ -524,11 +525,6 @@ export default class NextNodeServer extends BaseServer<
 
       throw err
     }
-  }
-
-  private isTurbopackBuild(): boolean {
-    const isTurbopackBuildFile = join(this.distDir, IS_TURBOPACK_BUILD_FILE)
-    return fs.existsSync(isTurbopackBuildFile)
   }
 
   protected getEnabledDirectories(dev: boolean): NextEnabledDirectories {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -192,9 +192,9 @@ export default class NextNodeServer extends BaseServer<
     this.isDev = isDev
     this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
 
-    if (!isDev) {
-      // @ts-expect-error internal field not publicly exposed
-      const isTurbopackBuild = this.nextConfig.experimental?.isTurbopackBuild
+    // @ts-expect-error internal field not publicly exposed
+    const isTurbopackBuild = this.nextConfig.experimental?.isTurbopackBuild
+    if (!isDev && typeof isTurbopackBuild !== 'undefined') {
       if (process.env.TURBOPACK && !isTurbopackBuild) {
         throw new Error(
           `Invariant: --turbopack is set but the build used Webpack`

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -42,7 +42,6 @@ import {
   PHASE_PRODUCTION_BUILD,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
   FUNCTIONS_CONFIG_MANIFEST,
-  SERVER_FILES_MANIFEST,
 } from '../shared/lib/constants'
 import { findDir } from '../lib/find-pages-dir'
 import { NodeNextRequest, NodeNextResponse } from './base-http/node'
@@ -194,9 +193,8 @@ export default class NextNodeServer extends BaseServer<
     this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
 
     if (!isDev) {
-      const isTurbopackBuild = require(
-        join(this.distDir, SERVER_FILES_MANIFEST)
-      ).turbopack
+      // @ts-expect-error internal field not publicly exposed
+      const isTurbopackBuild = this.nextConfig.experimental.isTurbopackBuild
       if (process.env.TURBOPACK && !isTurbopackBuild) {
         throw new Error(
           `Invariant: --turbopack is set but the build used Webpack`

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -194,7 +194,7 @@ export default class NextNodeServer extends BaseServer<
 
     if (!isDev) {
       // @ts-expect-error internal field not publicly exposed
-      const isTurbopackBuild = this.nextConfig.experimental.isTurbopackBuild
+      const isTurbopackBuild = this.nextConfig.experimental?.isTurbopackBuild
       if (process.env.TURBOPACK && !isTurbopackBuild) {
         throw new Error(
           `Invariant: --turbopack is set but the build used Webpack`

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -234,7 +234,7 @@ export class NextServer implements NextWrapperServer {
     if (process.env.NODE_ENV === 'production') {
       try {
         const serializedConfig = require(
-          path.join(dir, '.next', SERVER_FILES_MANIFEST)
+          path.join(dir, config.distDir, SERVER_FILES_MANIFEST)
         ).config
 
         // @ts-expect-error internal field

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -240,6 +240,9 @@ export class NextServer implements NextWrapperServer {
         // @ts-expect-error internal field
         config.experimental.isExperimentalCompile =
           serializedConfig.experimental.isExperimentalCompile
+        // @ts-expect-error internal field
+        config.experimental.isTurbopackBuild =
+          serializedConfig.experimental.isTurbopackBuild
       } catch (_) {
         // if distDir is customized we don't know until we
         // load the config so fallback to loading the config

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -231,7 +231,7 @@ export class NextServer implements NextWrapperServer {
     )
 
     // check serialized build config when available
-    if (process.env.NODE_ENV === 'production') {
+    if (!this.options.dev) {
       try {
         const serializedConfig = require(
           path.join(dir, config.distDir, SERVER_FILES_MANIFEST)

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -56,7 +56,6 @@ export const CONFIG_FILES = [
   'next.config.ts',
 ]
 export const BUILD_ID_FILE = 'BUILD_ID'
-export const IS_TURBOPACK_BUILD_FILE = 'IS_TURBOPACK_BUILD'
 export const BLOCKED_PAGES = ['/_document', '/_app', '/_error']
 export const CLIENT_PUBLIC_FILES_PATH = 'public'
 export const CLIENT_STATIC_FILES_PATH = 'static'

--- a/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
+++ b/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
@@ -8,6 +8,8 @@ describe('turbopack-build-marker', () => {
     const requiredServerFilesManifest = await next.readJSON(
       '.next/required-server-files.json'
     )
-    expect(requiredServerFilesManifest.turbopack).toBe(!!process.env.TURBOPACK)
+    expect(
+      requiredServerFilesManifest.config.experimental.isTurbopackBuild
+    ).toBe(!!process.env.TURBOPACK)
   })
 })

--- a/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
+++ b/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
@@ -5,8 +5,9 @@ describe('turbopack-build-marker', () => {
   })
 
   it('should have Turbopack build marker', async () => {
-    expect(await next.hasFile('.next/IS_TURBOPACK_BUILD')).toBe(
-      !!process.env.TURBOPACK
+    const requiredServerFilesManifest = await next.readJSON(
+      '.next/required-server-files.json'
     )
+    expect(requiredServerFilesManifest.turbopack).toBe(!!process.env.TURBOPACK)
   })
 })


### PR DESCRIPTION
### What?

As recommended by @ijjk.

Replaces the `IS_TURBOPACK_BUILD_FILE` marker with a `turbopack` boolean property in the required server files manifest.

Would like a review of this because it does mean we have to ship the require server files manifest into the standalone output which seemingly did not happen before. If we'd want to avoid that the current approach of writing a small file is better.


### How?

- Added a `turbopack` boolean property to the `RequiredServerFilesManifest` interface
- Removed the `IS_TURBOPACK_BUILD_FILE` constant and related file operations
- Updated the server to check the manifest property instead of looking for the marker file
- Updated tests to verify the manifest property instead of the marker file


Closes PACK-4255