### PR TITLE
Optimize server runtime bundles

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -40,7 +40,9 @@ const appExternals = [
   'next/dist/compiled/react-dom-experimental/cjs/react-dom-server-legacy.browser.production.js',
 ]
 
-function makeAppAliases(reactChannel = '') {
+function makeAppAliases({ experimental, bundler }) {
+  const reactChannel = experimental ? '-experimental' : ''
+
   return {
     react$: `next/dist/compiled/react${reactChannel}`,
     'react/react.react-server$': `next/dist/compiled/react${reactChannel}/react.react-server`,
@@ -61,18 +63,15 @@ function makeAppAliases(reactChannel = '') {
     'react-server-dom-turbopack/server.edge$': `next/dist/compiled/react-server-dom-turbopack${reactChannel}/server.edge`,
     'react-server-dom-turbopack/server.node$': `next/dist/compiled/react-server-dom-turbopack${reactChannel}/server.node`,
     'react-server-dom-turbopack/static.edge$': `next/dist/compiled/react-server-dom-turbopack${reactChannel}/static.edge`,
-    'react-server-dom-webpack/client$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/client`,
-    'react-server-dom-webpack/client.edge$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/client.edge`,
-    'react-server-dom-webpack/server.edge$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/server.edge`,
-    'react-server-dom-webpack/server.node$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/server.node`,
-    'react-server-dom-webpack/static.edge$': `next/dist/compiled/react-server-dom-webpack${reactChannel}/static.edge`,
+    'react-server-dom-webpack/client$': `next/dist/compiled/react-server-dom-${bundler}${reactChannel}/client`,
+    'react-server-dom-webpack/client.edge$': `next/dist/compiled/react-server-dom-${bundler}${reactChannel}/client.edge`,
+    'react-server-dom-webpack/server.edge$': `next/dist/compiled/react-server-dom-${bundler}${reactChannel}/server.edge`,
+    'react-server-dom-webpack/server.node$': `next/dist/compiled/react-server-dom-${bundler}${reactChannel}/server.node`,
+    'react-server-dom-webpack/static.edge$': `next/dist/compiled/react-server-dom-${bundler}${reactChannel}/static.edge`,
     '@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client.ts':
       'next/dist/client/dev/noop-turbopack-hmr',
   }
 }
-
-const appAliases = makeAppAliases()
-const appExperimentalAliases = makeAppAliases('-experimental')
 
 const sharedExternals = [
   'styled-jsx',
@@ -230,7 +229,7 @@ module.exports = ({ dev, turbo, bundleType, experimental, ...rest }) => {
           experimental ? true : false
         ),
         'process.env.NEXT_RUNTIME': JSON.stringify('nodejs'),
-        ...(!dev ? { 'process.env.TURBOPACK': JSON.stringify(turbo) } : {}),
+        'process.env.TURBOPACK': JSON.stringify(turbo),
       }),
       !!process.env.ANALYZE &&
         new BundleAnalyzerPlugin({
@@ -262,9 +261,10 @@ module.exports = ({ dev, turbo, bundleType, experimental, ...rest }) => {
     resolve: {
       alias:
         bundleType === 'app'
-          ? experimental
-            ? appExperimentalAliases
-            : appAliases
+          ? makeAppAliases({
+              experimental,
+              bundler: turbo ? 'turbopack' : 'webpack',
+            })
           : {},
     },
     module: {

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -99,7 +99,7 @@ interface UninlinedCssFile {
 export interface ClientReferenceManifest extends ClientReferenceManifestForRsc {
   readonly moduleLoading: {
     prefix: string
-    crossOrigin: string | null
+    crossOrigin?: 'use-credentials' | ''
   }
   ssrModuleMapping: {
     [moduleId: string]: ManifestNode
@@ -246,8 +246,8 @@ export class ClientReferenceManifestPlugin {
       typeof configuredCrossOriginLoading === 'string'
         ? configuredCrossOriginLoading === 'use-credentials'
           ? configuredCrossOriginLoading
-          : 'anonymous'
-        : null
+          : '' // === 'anonymous'
+        : undefined
 
     if (typeof compilation.outputOptions.publicPath !== 'string') {
       throw new Error(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4135,16 +4135,9 @@ export async function warmFlightResponse(
   flightStream: ReadableStream<Uint8Array>,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>
 ) {
-  let createFromReadableStream
-  if (process.env.TURBOPACK) {
-    createFromReadableStream =
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-turbopack/client.edge').createFromReadableStream
-  } else {
-    createFromReadableStream =
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client.edge').createFromReadableStream
-  }
+  const { createFromReadableStream } =
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    require('react-server-dom-webpack/client.edge') as typeof import('react-server-dom-webpack/client.edge')
 
   try {
     createFromReadableStream(flightStream, {

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -30,19 +30,11 @@ export function useFlightStream<T>(
   }
 
   // react-server-dom-webpack/client.edge must not be hoisted for require cache clearing to work correctly
-  let createFromReadableStream
-  // @TODO: investigate why the aliasing for turbopack doesn't pick this up, requiring this runtime check
-  if (process.env.TURBOPACK) {
-    createFromReadableStream =
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-turbopack/client.edge').createFromReadableStream
-  } else {
-    createFromReadableStream =
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client.edge').createFromReadableStream
-  }
+  const { createFromReadableStream } =
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    require('react-server-dom-webpack/client.edge') as typeof import('react-server-dom-webpack/client.edge')
 
-  const newResponse = createFromReadableStream(flightStream, {
+  const newResponse = createFromReadableStream<T>(flightStream, {
     serverConsumerManifest: {
       moduleLoading: clientReferenceManifest.moduleLoading,
       moduleMap: isEdgeRuntime

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -37,7 +37,7 @@ import {
 } from '../../client/components/react-dev-overlay/server/middleware-turbopack'
 import { PageNotFoundError } from '../../shared/lib/utils'
 import { debounce } from '../utils'
-import { deleteAppClientCache, deleteCache } from './require-cache'
+import { deleteCache, deleteFromRequireCache } from './require-cache'
 import {
   clearAllModuleContexts,
   clearModuleContext,
@@ -339,7 +339,16 @@ export async function createHotReloaderTurbopack(
     )
 
     if (hasAppPaths) {
-      deleteAppClientCache()
+      deleteFromRequireCache(
+        require.resolve(
+          'next/dist/compiled/next-server/app-page-turbo.runtime.dev.js'
+        )
+      )
+      deleteFromRequireCache(
+        require.resolve(
+          'next/dist/compiled/next-server/app-page-turbo-experimental.runtime.dev.js'
+        )
+      )
     }
 
     const serverPaths = writtenEndpoint.serverPaths.map(({ path: p }) =>

--- a/packages/next/src/server/dev/require-cache.ts
+++ b/packages/next/src/server/dev/require-cache.ts
@@ -2,7 +2,7 @@ import isError from '../../lib/is-error'
 import { realpathSync } from '../../lib/realpath'
 import { clearManifestCache } from '../load-manifest'
 
-function deleteFromRequireCache(filePath: string) {
+export function deleteFromRequireCache(filePath: string) {
   try {
     filePath = realpathSync(filePath)
   } catch (e) {
@@ -25,17 +25,6 @@ function deleteFromRequireCache(filePath: string) {
     return true
   }
   return false
-}
-
-export function deleteAppClientCache() {
-  deleteFromRequireCache(
-    require.resolve('next/dist/compiled/next-server/app-page.runtime.dev.js')
-  )
-  deleteFromRequireCache(
-    require.resolve(
-      'next/dist/compiled/next-server/app-page-experimental.runtime.dev.js'
-    )
-  )
 }
 
 export function deleteCache(filePath: string) {

--- a/packages/next/src/server/route-modules/app-page/module.compiled.js
+++ b/packages/next/src/server/route-modules/app-page/module.compiled.js
@@ -3,19 +3,31 @@ if (process.env.NEXT_RUNTIME === 'edge') {
 } else {
   if (process.env.__NEXT_EXPERIMENTAL_REACT) {
     if (process.env.NODE_ENV === 'development') {
-      module.exports = require('next/dist/compiled/next-server/app-page-experimental.runtime.dev.js')
-    } else if (process.env.TURBOPACK) {
-      module.exports = require('next/dist/compiled/next-server/app-page-turbo-experimental.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-page-turbo-experimental.runtime.dev.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-page-experimental.runtime.dev.js')
+      }
     } else {
-      module.exports = require('next/dist/compiled/next-server/app-page-experimental.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-page-turbo-experimental.runtime.prod.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-page-experimental.runtime.prod.js')
+      }
     }
   } else {
     if (process.env.NODE_ENV === 'development') {
-      module.exports = require('next/dist/compiled/next-server/app-page.runtime.dev.js')
-    } else if (process.env.TURBOPACK) {
-      module.exports = require('next/dist/compiled/next-server/app-page-turbo.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-page-turbo.runtime.dev.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-page.runtime.dev.js')
+      }
     } else {
-      module.exports = require('next/dist/compiled/next-server/app-page.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-page-turbo.runtime.prod.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-page.runtime.prod.js')
+      }
     }
   }
 }

--- a/packages/next/src/server/route-modules/app-route/module.compiled.js
+++ b/packages/next/src/server/route-modules/app-route/module.compiled.js
@@ -3,19 +3,31 @@ if (process.env.NEXT_RUNTIME === 'edge') {
 } else {
   if (process.env.__NEXT_EXPERIMENTAL_REACT) {
     if (process.env.NODE_ENV === 'development') {
-      module.exports = require('next/dist/compiled/next-server/app-route-experimental.runtime.dev.js')
-    } else if (process.env.TURBOPACK) {
-      module.exports = require('next/dist/compiled/next-server/app-route-turbo-experimental.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-route-turbo-experimental.runtime.dev.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-route-experimental.runtime.dev.js')
+      }
     } else {
-      module.exports = require('next/dist/compiled/next-server/app-route-experimental.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-route-turbo-experimental.runtime.prod.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-route-experimental.runtime.prod.js')
+      }
     }
   } else {
     if (process.env.NODE_ENV === 'development') {
-      module.exports = require('next/dist/compiled/next-server/app-route.runtime.dev.js')
-    } else if (process.env.TURBOPACK) {
-      module.exports = require('next/dist/compiled/next-server/app-route-turbo.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-route-turbo.runtime.dev.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-route.runtime.dev.js')
+      }
     } else {
-      module.exports = require('next/dist/compiled/next-server/app-route.runtime.prod.js')
+      if (process.env.TURBOPACK) {
+        module.exports = require('next/dist/compiled/next-server/app-route-turbo.runtime.prod.js')
+      } else {
+        module.exports = require('next/dist/compiled/next-server/app-route.runtime.prod.js')
+      }
     }
   }
 }

--- a/packages/next/src/server/route-modules/pages-api/module.compiled.js
+++ b/packages/next/src/server/route-modules/pages-api/module.compiled.js
@@ -2,10 +2,16 @@ if (process.env.NEXT_RUNTIME === 'edge') {
   module.exports = require('next/dist/server/route-modules/pages-api/module.js')
 } else {
   if (process.env.NODE_ENV === 'development') {
-    module.exports = require('next/dist/compiled/next-server/pages-api.runtime.dev.js')
-  } else if (process.env.TURBOPACK) {
-    module.exports = require('next/dist/compiled/next-server/pages-api-turbo.runtime.prod.js')
+    if (process.env.TURBOPACK) {
+      module.exports = require('next/dist/compiled/next-server/pages-api-turbo.runtime.dev.js')
+    } else {
+      module.exports = require('next/dist/compiled/next-server/pages-api.runtime.dev.js')
+    }
   } else {
-    module.exports = require('next/dist/compiled/next-server/pages-api.runtime.prod.js')
+    if (process.env.TURBOPACK) {
+      module.exports = require('next/dist/compiled/next-server/pages-api-turbo.runtime.prod.js')
+    } else {
+      module.exports = require('next/dist/compiled/next-server/pages-api.runtime.prod.js')
+    }
   }
 }

--- a/packages/next/src/server/route-modules/pages/module.compiled.js
+++ b/packages/next/src/server/route-modules/pages/module.compiled.js
@@ -2,10 +2,16 @@ if (process.env.NEXT_RUNTIME === 'edge') {
   module.exports = require('next/dist/server/route-modules/pages/module.js')
 } else {
   if (process.env.NODE_ENV === 'development') {
-    module.exports = require('next/dist/compiled/next-server/pages.runtime.dev.js')
-  } else if (process.env.TURBOPACK) {
-    module.exports = require('next/dist/compiled/next-server/pages-turbo.runtime.prod.js')
+    if (process.env.TURBOPACK) {
+      module.exports = require('next/dist/compiled/next-server/pages-turbo.runtime.dev.js')
+    } else {
+      module.exports = require('next/dist/compiled/next-server/pages.runtime.dev.js')
+    }
   } else {
-    module.exports = require('next/dist/compiled/next-server/pages.runtime.prod.js')
+    if (process.env.TURBOPACK) {
+      module.exports = require('next/dist/compiled/next-server/pages-turbo.runtime.prod.js')
+    } else {
+      module.exports = require('next/dist/compiled/next-server/pages.runtime.prod.js')
+    }
   }
 }

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2813,14 +2813,14 @@ export async function release(task) {
   await task.clear('dist').start('build')
 }
 
-export async function next_bundle_app_turbo(task, opts) {
+export async function next_bundle_app_prod_turbo(task, opts) {
   await task.source('dist').webpack({
     watch: opts.dev,
     config: require('./next-runtime.webpack-config')({
       turbo: true,
       bundleType: 'app',
     }),
-    name: 'next-bundle-app-turbo',
+    name: 'next-bundle-app-prod-turbo',
   })
 }
 
@@ -2835,6 +2835,18 @@ export async function next_bundle_app_prod(task, opts) {
   })
 }
 
+export async function next_bundle_app_dev_turbo(task, opts) {
+  await task.source('dist').webpack({
+    watch: opts.dev,
+    config: require('./next-runtime.webpack-config')({
+      turbo: true,
+      dev: true,
+      bundleType: 'app',
+    }),
+    name: 'next-bundle-app-dev-turbo',
+  })
+}
+
 export async function next_bundle_app_dev(task, opts) {
   await task.source('dist').webpack({
     watch: opts.dev,
@@ -2846,7 +2858,7 @@ export async function next_bundle_app_dev(task, opts) {
   })
 }
 
-export async function next_bundle_app_turbo_experimental(task, opts) {
+export async function next_bundle_app_prod_turbo_experimental(task, opts) {
   await task.source('dist').webpack({
     watch: opts.dev,
     config: require('./next-runtime.webpack-config')({
@@ -2854,7 +2866,7 @@ export async function next_bundle_app_turbo_experimental(task, opts) {
       bundleType: 'app',
       experimental: true,
     }),
-    name: 'next-bundle-app-turbo-experimental',
+    name: 'next-bundle-app-prod-turbo-experimental',
   })
 }
 
@@ -2867,6 +2879,19 @@ export async function next_bundle_app_prod_experimental(task, opts) {
       experimental: true,
     }),
     name: 'next-bundle-app-prod-experimental',
+  })
+}
+
+export async function next_bundle_app_dev_turbo_experimental(task, opts) {
+  await task.source('dist').webpack({
+    watch: opts.dev,
+    config: require('./next-runtime.webpack-config')({
+      turbo: true,
+      dev: true,
+      bundleType: 'app',
+      experimental: true,
+    }),
+    name: 'next-bundle-app-dev-turbo-experimental',
   })
 }
 
@@ -2904,14 +2929,26 @@ export async function next_bundle_pages_dev(task, opts) {
   })
 }
 
-export async function next_bundle_pages_turbo(task, opts) {
+export async function next_bundle_pages_prod_turbo(task, opts) {
   await task.source('dist').webpack({
     watch: opts.dev,
     config: require('./next-runtime.webpack-config')({
       turbo: true,
       bundleType: 'pages',
     }),
-    name: 'next-bundle-pages-turbo',
+    name: 'next-bundle-pages-prod-turbo',
+  })
+}
+
+export async function next_bundle_pages_dev_turbo(task, opts) {
+  await task.source('dist').webpack({
+    watch: opts.dev,
+    config: require('./next-runtime.webpack-config')({
+      turbo: true,
+      dev: true,
+      bundleType: 'pages',
+    }),
+    name: 'next-bundle-pages-dev-turbo',
   })
 }
 
@@ -2930,17 +2967,20 @@ export async function next_bundle(task, opts) {
   await task.parallel(
     [
       // builds the app (route/page) bundles
-      'next_bundle_app_turbo',
+      'next_bundle_app_prod_turbo',
       'next_bundle_app_prod',
+      'next_bundle_app_dev_turbo',
       'next_bundle_app_dev',
       // builds the app (route/page) bundles with react experimental
-      'next_bundle_app_turbo_experimental',
+      'next_bundle_app_prod_turbo_experimental',
       'next_bundle_app_prod_experimental',
+      'next_bundle_app_dev_turbo_experimental',
       'next_bundle_app_dev_experimental',
       // builds the pages (page/api) bundles
       'next_bundle_pages_prod',
       'next_bundle_pages_dev',
-      'next_bundle_pages_turbo',
+      'next_bundle_pages_prod_turbo',
+      'next_bundle_pages_dev_turbo',
       // builds the minimal server
       'next_bundle_server',
     ],


### PR DESCRIPTION
Previously, only the prod runtime bundles were split by bundler. In dev mode, a combined runtime bundle was used. As a consequence, both `react-server-dom-webpack` and `react-server-dom-turbopack` were included in this bundle.

This not only impacts the startup time for the dev server, but also impacts HMR times for Turbopack, because the runtime bundle is deleted from the require cache for every server component edit, and subsequently needs to be reevaluated.

In addition, even the prod runtime for Turbopack unnecessarily included `react-server-dom-webpack`, which was caused by incorrect import aliases.

This PR decreases the dev runtime bundle size for both Webpack and Turbopack by **16%**, and it decreases the prod runtime bundle size for Turbopack by **12%**.