### PR TITLE
Turbopack: refactor resolve_url_reference to avoid chunk_path

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -330,6 +330,11 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
+    async fn chunk_root_path(&self) -> Vc<FileSystemPath> {
+        *self.chunk_root_path
+    }
+
+    #[turbo_tasks::function]
     async fn chunk_path(
         &self,
         ident: Vc<AssetIdent>,

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -123,17 +123,21 @@ pub struct ChunkingConfigs(FxHashMap<ResolvedVc<Box<dyn ChunkType>>, ChunkingCon
 pub trait ChunkingContext {
     fn name(self: Vc<Self>) -> Vc<RcStr>;
     fn should_use_file_source_map_uris(self: Vc<Self>) -> Vc<bool>;
-    // The root path of the project
+    /// The root path of the project
     fn root_path(self: Vc<Self>) -> Vc<FileSystemPath>;
-    // The output root path in the output filesystem
+    /// The output root path in the output filesystem
     fn output_root(self: Vc<Self>) -> Vc<FileSystemPath>;
-    // A relative path how to reach the root path from the output root. This is used to compute
-    // original paths at runtime relative to the output files. e. g. import.meta.url needs that.
+    /// A relative path how to reach the root path from the output root. This is used to compute
+    /// original paths at runtime relative to the output files. e. g. import.meta.url needs that.
     fn output_root_to_root_path(self: Vc<Self>) -> Vc<RcStr>;
 
     // TODO remove this, a chunking context should not be bound to a specific
     // environment since this can change due to transitions in the module graph
     fn environment(self: Vc<Self>) -> Vc<Environment>;
+
+    /// The path to the folder where all chunks are placed. This can be used to compute relative
+    /// paths.
+    fn chunk_root_path(self: Vc<Self>) -> Vc<FileSystemPath>;
 
     // TODO(alexkirsz) Remove this from the chunking context. This should be at the
     // discretion of chunking context implementors. However, we currently use this

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -11,7 +11,6 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
-    ident::AssetIdent,
     issue::IssueSource,
     output::OutputAsset,
     reference::ModuleReference,

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -103,18 +103,9 @@ pub async fn resolve_url_reference(
     url: Vc<UrlAssetReference>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
 ) -> Result<Vc<Option<RcStr>>> {
-    let this = url.await?;
-    // TODO(WEB-662) This is not the correct way to get the current chunk path. It
-    // currently works as all chunks are in the same directory.
-    let chunk_path = chunking_context.chunk_path(
-        AssetIdent::from_path(this.origin.origin_path()),
-        ".css".into(),
-    );
-    let context_path = chunk_path.parent().await?;
+    let context_path = chunking_context.chunk_root_path().await?;
 
     if let ReferencedAsset::Some(asset) = &*url.get_referenced_asset(chunking_context).await? {
-        // TODO(WEB-662) This is not the correct way to get the path of the asset.
-        // `asset` is on module-level, but we need the output-level asset instead.
         let path = asset.path().await?;
         let relative_path = context_path
             .get_relative_path_to(&path)

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -269,6 +269,11 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
+    async fn chunk_root_path(&self) -> Vc<FileSystemPath> {
+        *self.chunk_root_path
+    }
+
+    #[turbo_tasks::function]
     async fn chunk_path(
         &self,
         ident: Vc<AssetIdent>,


### PR DESCRIPTION
### What?

refactor resolve_url_reference to avoid chunk_path and use chunk_root_path instead

Closes PACK-4252