### PR TITLE
[test] Get rid of unrelated "Invalid hook call" error from tests using `styled-components`

### DIFF
--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -9,7 +9,7 @@ describe('ReactRefreshRegression app', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     dependencies: {
-      'styled-components': '5.1.0',
+      'styled-components': '6.1.16',
       '@next/mdx': 'canary',
       '@mdx-js/loader': '2.2.1',
       '@mdx-js/react': '2.2.1',

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -10,7 +10,7 @@ describe('ReactRefreshRegression', () => {
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     skipStart: true,
     dependencies: {
-      'styled-components': '5.1.0',
+      'styled-components': '6.1.16',
       '@next/mdx': 'canary',
       '@mdx-js/loader': '2.2.1',
       '@mdx-js/react': '2.2.1',

--- a/test/development/basic/styled-components-disabled.test.ts
+++ b/test/development/basic/styled-components-disabled.test.ts
@@ -22,7 +22,7 @@ import { retry } from 'next-test-utils'
           ),
         },
         dependencies: {
-          'styled-components': '5.3.3',
+          'styled-components': '6.1.16',
         },
       })
     })

--- a/test/development/basic/styled-components/styled-components.test.ts
+++ b/test/development/basic/styled-components/styled-components.test.ts
@@ -6,7 +6,7 @@ describe('styled-components SWC transform', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      'styled-components': '5.3.3',
+      'styled-components': '6.1.16',
     },
   })
   async function matchLogs$(browser) {


### PR DESCRIPTION
Basically just needed to get https://github.com/styled-components/styled-components/pull/3521 (odd to revisit a 3yr old PR of mine the week styled-components gets sunset).

Was flushed out in https://github.com/vercel/next.js/actions/runs/14222952948/job/39855501172?pr=77326#step:33:508