### PR TITLE
[ci]: skip build-windows job for docs only change

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,6 +67,7 @@ jobs:
   build-native:
     name: build-native
     uses: ./.github/workflows/build_reusable.yml
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
       skipInstallBuild: 'yes'
       stepName: 'build-native'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,6 +67,7 @@ jobs:
   build-native:
     name: build-native
     uses: ./.github/workflows/build_reusable.yml
+    needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
       skipInstallBuild: 'yes'
@@ -76,6 +77,7 @@ jobs:
   build-native-windows:
     name: build-native-windows
     uses: ./.github/workflows/build_reusable.yml
+    needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
       skipInstallBuild: 'yes'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,6 +75,7 @@ jobs:
   build-native-windows:
     name: build-native-windows
     uses: ./.github/workflows/build_reusable.yml
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
       skipInstallBuild: 'yes'
       stepName: 'build-native-windows'


### PR DESCRIPTION
### What

Noticed the native binaries are still built when we only change docs

<img width="400" src="https://camo.githubusercontent.com/d78eae9e2ff385ff60be50f5f66ea612f0bcaed0afddb2eaccf26ce0987d1374/68747470733a2f2f67726170686974652d757365722d75706c6f616465642d6173736574732d70726f642e73332e616d617a6f6e6177732e636f6d2f32566b7231686a7862636c33624b366c544666372f63366538663165622d613131392d343638332d623262382d3237323264373432643334342e706e67">

Add docs-only check to skip `build-native` and `build-native-windwos` jobs, skip swc build for docs only updates.