### PR TITLE
fix: bodySizeLimit error responses + limit for non-multipart actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -878,7 +878,7 @@ export async function handleAction({
           }
 
           const chunks: Buffer[] = []
-          for await (const chunk of req.body) {
+          for await (const chunk of sizeLimitedBody) {
             chunks.push(Buffer.from(chunk))
           }
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -752,7 +752,7 @@ export async function handleAction({
 
         temporaryReferences = createTemporaryReferenceSet()
 
-        const { Transform } =
+        const { Transform, pipeline } =
           require('node:stream') as typeof import('node:stream')
 
         const defaultBodySizeLimit = '1 MB'
@@ -766,26 +766,32 @@ export async function handleAction({
             : 1024 * 1024 // 1 MB
 
         let size = 0
-        const body = req.body.pipe(
-          new Transform({
-            transform(chunk, encoding, callback) {
-              size += Buffer.byteLength(chunk, encoding)
-              if (size > bodySizeLimitBytes) {
-                const { ApiError } = require('../api-utils')
+        const sizeLimitTransform = new Transform({
+          transform(chunk, encoding, callback) {
+            size += Buffer.byteLength(chunk, encoding)
+            if (size > bodySizeLimitBytes) {
+              const { ApiError } = require('../api-utils')
 
-                callback(
-                  new ApiError(
-                    413,
-                    `Body exceeded ${bodySizeLimit} limit.
-                To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
-                  )
+              callback(
+                new ApiError(
+                  413,
+                  `Body exceeded ${bodySizeLimit} limit.\n` +
+                    `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
                 )
-                return
-              }
+              )
+              return
+            }
 
-              callback(null, chunk)
-            },
-          })
+            callback(null, chunk)
+          },
+        })
+
+        const sizeLimitedBody = pipeline(
+          req.body,
+          sizeLimitTransform,
+          // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
+          // We'll propagate the errors properly when consuming the stream.
+          () => {}
         )
 
         if (isMultipartAction) {
@@ -796,7 +802,14 @@ export async function handleAction({
               limits: { fieldSize: bodySizeLimitBytes },
             })
 
-            body.pipe(busboy)
+            // We need to use `pipeline(one, two)` instead of `one.pipe(two)` to propagate size limit errors correctly.
+            pipeline(
+              sizeLimitedBody,
+              busboy,
+              // Avoid unhandled errors from `pipeline()` by passing an empty completion callback.
+              // We'll propagate the errors properly when consuming the stream.
+              () => {}
+            )
 
             boundActionArguments = await decodeReplyFromBusboy(
               busboy,
@@ -812,13 +825,13 @@ export async function handleAction({
               headers: { 'Content-Type': contentType },
               body: new ReadableStream({
                 start: (controller) => {
-                  body.on('data', (chunk) => {
+                  sizeLimitedBody.on('data', (chunk) => {
                     controller.enqueue(new Uint8Array(chunk))
                   })
-                  body.on('end', () => {
+                  sizeLimitedBody.on('end', () => {
                     controller.close()
                   })
-                  body.on('error', (err) => {
+                  sizeLimitedBody.on('error', (err) => {
                     controller.error(err)
                   })
                 },
@@ -1016,6 +1029,9 @@ export async function handleAction({
     }
 
     if (isFetchAction) {
+      // TODO: consider checking if the error is an `ApiError` and change status code
+      // so that we can respond with a 413 to requests that break the body size limit
+      // (but if we do that, we also need to make sure that whatever handles the non-fetch error path below does the same)
       res.statusCode = 500
       await executeRevalidates(workStore)
       const promise = Promise.reject(err)

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import { createRequestTracker } from 'e2e-utils/request-tracker'
 import stripAnsi from 'strip-ansi'
 import { accountForOverhead } from './account-for-overhead'
 
@@ -9,7 +10,6 @@ const CONFIG_ERROR =
 describe('app-dir action size limit invalid config', () => {
   const { next, isNextStart, isNextDeploy, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
     dependencies: {
       nanoid: '4.0.1',
@@ -17,11 +17,6 @@ describe('app-dir action size limit invalid config', () => {
     },
   })
   if (skipped) return
-
-  if (!isNextStart) {
-    it('skip test for development mode', () => {})
-    return
-  }
 
   const logs: string[] = []
 
@@ -40,93 +35,131 @@ describe('app-dir action size limit invalid config', () => {
     await next.stop()
   })
 
-  it('should error if serverActions.bodySizeLimit config is a negative number', async function () {
-    await next.patchFile(
-      'next.config.js',
-      `
+  if (isNextStart) {
+    it('should error if serverActions.bodySizeLimit config is a negative number', async function () {
+      await next.patchFile(
+        'next.config.js',
+        `
       module.exports = {
         experimental: {
           serverActions: { bodySizeLimit: -3000 }
         },
       }
       `
-    )
-    try {
-      await next.start()
-    } catch {}
-    expect(next.cliOutput).toContain(CONFIG_ERROR)
-  })
+      )
+      try {
+        await next.start()
+      } catch {}
+      expect(next.cliOutput).toContain(CONFIG_ERROR)
+    })
 
-  it('should error if serverActions.bodySizeLimit config is invalid', async function () {
-    await next.patchFile(
-      'next.config.js',
-      `
+    it('should error if serverActions.bodySizeLimit config is invalid', async function () {
+      await next.patchFile(
+        'next.config.js',
+        `
       module.exports = {
         experimental: {
           serverActions: { bodySizeLimit: 'testmb' }
         },
       }
       `
-    )
-    try {
-      await next.start()
-    } catch {}
-    expect(next.cliOutput).toContain(CONFIG_ERROR)
-  })
+      )
+      try {
+        await next.start()
+      } catch {}
+      expect(next.cliOutput).toContain(CONFIG_ERROR)
+    })
 
-  it('should error if serverActions.bodySizeLimit config is a negative size', async function () {
-    await next.patchFile(
-      'next.config.js',
-      `
+    it('should error if serverActions.bodySizeLimit config is a negative size', async function () {
+      await next.patchFile(
+        'next.config.js',
+        `
       module.exports = {
         experimental: {
           serverActions: { bodySizeLimit: '-3000mb' }
         },
       }
       `
-    )
-    try {
-      await next.start()
-    } catch {}
-    expect(next.cliOutput).toContain(CONFIG_ERROR)
-  })
+      )
+      try {
+        await next.start()
+      } catch {}
+      expect(next.cliOutput).toContain(CONFIG_ERROR)
+    })
+  }
 
-  if (!isNextDeploy) {
-    it('should respect the size set in serverActions.bodySizeLimit', async function () {
+  describe('should respect the size set in serverActions.bodySizeLimit for plaintext fetch actions', () => {
+    beforeEach(async () => {
       await next.patchFile(
         'next.config.js',
         `
-      module.exports = {
-        experimental: {
-          serverActions: { bodySizeLimit: '1.5mb' }
-        },
-      }
-      `
+        module.exports = {
+          experimental: {
+            serverActions: { bodySizeLimit: '1.5mb' }
+          },
+        }
+        `
       )
       await next.start()
-
-      const browser = await next.browser('/file')
-      await browser.elementByCss('#size-1mb').click()
-
-      await retry(() => {
-        expect(logs).toContainEqual(`size = ${accountForOverhead(1)}`)
-      })
-
-      await browser.elementByCss('#size-2mb').click()
-
-      await retry(() => {
-        expect(logs).toContainEqual(
-          expect.stringContaining('Error: Body exceeded 1.5mb limit')
-        )
-        expect(logs).toContainEqual(
-          expect.stringContaining(
-            'To configure the body size limit for Server Actions, see'
-          )
-        )
-      })
     })
 
-    it('should respect the size set in serverActions.bodySizeLimit when submitting form', async function () {
+    it('should not error for requests that stay below the size limit', async () => {
+      const browser = await next.browser('/file')
+      const requestTracker = createRequestTracker(browser)
+
+      // below the limit: ok
+      const [, actionResponse] = await requestTracker.captureResponse(
+        () => browser.elementByCss('#size-1mb').click(),
+        { request: { method: 'POST', pathname: '/file' } }
+      )
+      expect(actionResponse.status()).toBe(200)
+      expect(
+        await actionResponse.request().headerValue('content-type')
+      ).toStartWith('text/plain')
+
+      if (!isNextDeploy) {
+        await retry(() =>
+          expect(logs).toContainEqual(
+            expect.stringContaining(`size = ${accountForOverhead(1)}`)
+          )
+        )
+        expect(logs).not.toContainEqual(
+          expect.stringContaining('Error: Body exceeded 1.5mb limit')
+        )
+      }
+    })
+
+    it('should error for requests that exceed the size limit', async () => {
+      const browser = await next.browser('/file')
+      const requestTracker = createRequestTracker(browser)
+
+      const [, actionResponse] = await requestTracker.captureResponse(
+        () => browser.elementByCss('#size-2mb').click(),
+        { request: { method: 'POST', pathname: '/file' } }
+      )
+      expect(actionResponse.status()).toBe(500) // TODO: 413?
+      expect(
+        await actionResponse.request().headerValue('content-type')
+      ).toStartWith('text/plain')
+
+      if (!isNextDeploy) {
+        await retry(() => {
+          expect(logs).toContainEqual(
+            expect.stringContaining('Error: Body exceeded 1.5mb limit')
+          )
+          expect(logs).toContainEqual(
+            expect.stringContaining(
+              'To configure the body size limit for Server Actions, see'
+            )
+          )
+        })
+        expect(logs).not.toContainEqual(expect.stringMatching(/^size = /))
+      }
+    })
+  })
+
+  describe('should respect the size set in serverActions.bodySizeLimit for multipart fetch actions', () => {
+    beforeEach(async () => {
       await next.patchFile(
         'next.config.js',
         `
@@ -137,21 +170,85 @@ describe('app-dir action size limit invalid config', () => {
       }
       `
       )
-
       await next.start()
-
-      const browser = await next.browser('/form')
-      await browser.elementByCss('#size-1mb').click()
-
-      await retry(() => {
-        expect(logs).toContainEqual(`size = ${accountForOverhead(1)}`)
-      })
-
-      await browser.elementByCss('#size-2mb').click()
-
-      await retry(() => {
-        expect(logs).toContainEqual(`size = ${accountForOverhead(2)}`)
-      })
     })
-  }
+
+    it('should not error for requests that stay below the size limit', async () => {
+      const browser = await next.browser('/form')
+      const requestTracker = createRequestTracker(browser)
+
+      const [, actionResponse] = await requestTracker.captureResponse(
+        () => browser.elementByCss('#size-1mb').click(),
+        { request: { method: 'POST', pathname: '/form' } }
+      )
+      expect(actionResponse.status()).toBe(200)
+      expect(
+        await actionResponse.request().headerValue('content-type')
+      ).toStartWith('multipart/form-data')
+
+      if (!isNextDeploy) {
+        await retry(() =>
+          expect(logs).toContainEqual(
+            expect.stringContaining(`size = ${accountForOverhead(1)}`)
+          )
+        )
+        expect(logs).not.toContainEqual(
+          expect.stringContaining('Error: Body exceeded 2mb limit')
+        )
+      }
+    })
+
+    it('should not error for requests that are at the size limit', async () => {
+      const browser = await next.browser('/form')
+      const requestTracker = createRequestTracker(browser)
+
+      const [, actionResponse] = await requestTracker.captureResponse(
+        () => browser.elementByCss('#size-2mb').click(),
+        { request: { method: 'POST', pathname: '/form' } }
+      )
+      expect(actionResponse.status()).toBe(200)
+      expect(
+        await actionResponse.request().headerValue('content-type')
+      ).toStartWith('multipart/form-data')
+
+      if (!isNextDeploy) {
+        await retry(() =>
+          expect(logs).toContainEqual(
+            expect.stringContaining(`size = ${accountForOverhead(2)}`)
+          )
+        )
+        expect(logs).not.toContainEqual(
+          expect.stringContaining('Error: Body exceeded 2mb limit')
+        )
+      }
+    })
+
+    it('should error for requests that exceed the size limit', async () => {
+      const browser = await next.browser('/form')
+      const requestTracker = createRequestTracker(browser)
+
+      const [, actionResponse] = await requestTracker.captureResponse(
+        () => browser.elementByCss('#size-3mb').click(),
+        { request: { method: 'POST', pathname: '/form' } }
+      )
+      expect(actionResponse.status()).toBe(500) // TODO: 413?
+      expect(
+        await actionResponse.request().headerValue('content-type')
+      ).toStartWith('multipart/form-data')
+
+      if (!isNextDeploy) {
+        await retry(() => {
+          expect(logs).toContainEqual(
+            expect.stringContaining('Error: Body exceeded 2mb limit')
+          )
+          expect(logs).toContainEqual(
+            expect.stringContaining(
+              'To configure the body size limit for Server Actions, see'
+            )
+          )
+        })
+        expect(logs).not.toContainEqual(expect.stringMatching(/^size = /))
+      }
+    })
+  })
 })

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -135,6 +135,11 @@ describe('app-dir action size limit invalid config', () => {
         await actionResponse.request().headerValue('content-type')
       ).toStartWith('text/plain')
 
+      // The error should have been returned to the client and thrown, triggering the nearest error boundary.
+      expect(await browser.elementByCss('#error').text()).toBe(
+        'Something went wrong!'
+      )
+
       if (!isNextDeploy) {
         await retry(() => {
           expect(logs).toContainEqual(
@@ -218,6 +223,11 @@ describe('app-dir action size limit invalid config', () => {
       expect(
         await actionResponse.request().headerValue('content-type')
       ).toStartWith('multipart/form-data')
+
+      // The error should have been returned to the client and thrown, triggering the nearest error boundary.
+      expect(await browser.elementByCss('#error').text()).toBe(
+        'Something went wrong!'
+      )
 
       if (!isNextDeploy) {
         await retry(() => {

--- a/test/e2e/app-dir/actions/app/file/error.js
+++ b/test/e2e/app-dir/actions/app/file/error.js
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Error() {
+  return (
+    <div>
+      <h2 id="error">Something went wrong!</h2>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/actions/app/file/form.js
+++ b/test/e2e/app-dir/actions/app/file/form.js
@@ -10,8 +10,8 @@ export default function Form({ action }) {
       <button id="size-1mb" onClick={() => submit(1)}>
         1mb
       </button>
-      <button id="size-2mb" onClick={() => submit(2)}>
-        2mb
+      <button id="size-3mb" onClick={() => submit(3)}>
+        3mb
       </button>
     </>
   )

--- a/test/e2e/app-dir/actions/app/file/form.js
+++ b/test/e2e/app-dir/actions/app/file/form.js
@@ -1,16 +1,18 @@
 'use client'
+import { useActionState } from 'react'
 import { accountForOverhead } from '../../account-for-overhead'
 
 export default function Form({ action }) {
   const submit = (megaBytes) =>
     action('a'.repeat(accountForOverhead(megaBytes)))
-
+  const [, submit1] = useActionState(() => submit(1), undefined)
+  const [, submit3] = useActionState(() => submit(3), undefined)
   return (
     <>
-      <button id="size-1mb" onClick={() => submit(1)}>
+      <button id="size-1mb" onClick={submit1}>
         1mb
       </button>
-      <button id="size-3mb" onClick={() => submit(3)}>
+      <button id="size-3mb" onClick={submit3}>
         3mb
       </button>
     </>

--- a/test/e2e/app-dir/actions/app/form/error.js
+++ b/test/e2e/app-dir/actions/app/form/error.js
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Error() {
+  return (
+    <div>
+      <h2 id="error">Something went wrong!</h2>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/actions/next.config.js
+++ b/test/e2e/app-dir/actions/next.config.js
@@ -4,4 +4,7 @@ module.exports = {
   logging: {
     fetches: {},
   },
+  experimental: {
+    serverActions: { bodySizeLimit: '2mb' },
+  },
 }

--- a/test/lib/e2e-utils/request-tracker.ts
+++ b/test/lib/e2e-utils/request-tracker.ts
@@ -1,0 +1,176 @@
+import {
+  Request as PlaywrightRequest,
+  Response as PlaywrightResponse,
+} from 'playwright'
+import { inspect } from 'node:util'
+import { Playwright } from '../browsers/playwright'
+
+export type RequestMatcherObject = {
+  pathname: string
+  search?: string
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'HEAD' | 'OPTIONS'
+}
+
+export type RequestMatcher =
+  | RequestMatcherObject
+  | ((request: PlaywrightRequest) => Promise<boolean>)
+
+/** Allows capturing responses to requests that happened as a result of running a callback. */
+export function createRequestTracker(browser: Playwright) {
+  /** Run a callback and capture requests with the given `method` and `pathname`. */
+  async function captureResponse<T>(
+    action: () => Promise<T>,
+    {
+      request: requestMatcher,
+      timeoutMs = 5000,
+    }: {
+      request: RequestMatcher
+      timeoutMs?: number
+    }
+  ): Promise<[result: T, captured: PlaywrightResponse]> {
+    const isMatchingRequest = async (request: PlaywrightRequest) => {
+      if (typeof requestMatcher === 'function') {
+        // This can be async to allow matching on things like `request.allHeaders()` which is a promise.
+        return await requestMatcher(request)
+      } else {
+        const url = new URL(request.url())
+        if (requestMatcher.pathname !== url.pathname) {
+          return false
+        }
+        if (requestMatcher.search !== undefined) {
+          if (url.search !== requestMatcher.search) {
+            return false
+          }
+        }
+        if (requestMatcher.method !== undefined) {
+          if (request.method() !== requestMatcher.method) {
+            return false
+          }
+        }
+        return true
+      }
+    }
+
+    const responseCtrl = promiseWithResolvers<PlaywrightResponse>()
+    let isSettled = false
+
+    let capturedRequest: PlaywrightRequest | undefined
+
+    const cleanups: (() => void)[] = []
+
+    // Make sure we clean up all event listeners and timers after we're done.
+    responseCtrl.promise.finally(() => {
+      isSettled = true
+      cleanups.forEach((cb) => cb())
+    })
+
+    // Listen for requests that match the criteria.
+    const onRequest = async (request: PlaywrightRequest) => {
+      if (!(await isMatchingRequest(request))) {
+        return
+      }
+
+      // If `capturedRequest` is already set, then we've got multiple requests that match the criteria.
+      // This is currently not supported, though if needed, we could extend the API
+      // to allow capturing multiple requests and returning them as an array.
+      if (capturedRequest) {
+        const criteriaDescription =
+          typeof requestMatcher === 'function'
+            ? 'the specified criteria'
+            : inspect(requestMatcher)
+        return responseCtrl.reject(
+          new Error(
+            [
+              `Captured multiple requests that match ${criteriaDescription} during a \`captureResponse\` call:`,
+              ...[capturedRequest, request].map(
+                (req) => `  - ${req.method} ${req.url}`
+              ),
+              'This is currently not supported.',
+            ].join('\n')
+          )
+        )
+      }
+
+      // We found a request that matches our criteria. Now we'll wait for a response.
+      capturedRequest = request
+      console.log(
+        `[request-tracker] request: ${request.method()} ${request.url()}` +
+          (['POST', 'PUT', 'PATCH'].includes(request.method())
+            ? ` (content-type: ${request.headers()['content-type']})`
+            : '')
+      )
+      const onResponse = (response: PlaywrightResponse) => {
+        if (isSettled) {
+          return
+        }
+        if (response.request() === request) {
+          // We found a response to our request. We're done.
+          console.log(`[request-tracker] response: ${response.status()}`)
+          return responseCtrl.resolve(response)
+        }
+      }
+      browser.on('response', onResponse)
+      cleanups.push(() => browser.off('response', onResponse))
+    }
+
+    // Install the handler before running the action callback to avoid races.
+    browser.on('request', onRequest)
+    cleanups.push(() => browser.off('request', onRequest))
+
+    // Run the action callback. We expect this to result in requests being initiated.
+    // If this doesn't happen before the specified timeout, we'll error below.
+    const actionPromise = Promise.resolve().then(action)
+
+    const resultPromise = Promise.all([
+      actionPromise,
+      responseCtrl.promise,
+    ] as const)
+
+    actionPromise.then(
+      () => {
+        // The action callback and the request it triggered can finish before this gets the chance to run.
+        // In that case, we don't need to install the timeout at all.
+        if (isSettled) {
+          return
+        }
+
+        // After the action callback resolves, start a timer.
+        // If we don't capture a request/response pair within that time limit, error.
+        const abortTimeoutId = setTimeout(() => {
+          if (isSettled) {
+            return
+          }
+          return responseCtrl.reject(
+            new Error(
+              capturedRequest === undefined
+                ? `Did not intercept a request within ${timeoutMs}ms of the action callback finishing`
+                : `Did not intercept a response within ${timeoutMs}ms of the action callback finishing`
+            )
+          )
+        }, timeoutMs)
+        cleanups.push(() => clearTimeout(abortTimeoutId))
+      },
+      () => {
+        // If the action callback errored, we don't want to reject the response promise,
+        // because then jest would unnecessarily print both errors.
+        // We're returning a `Promise.all` that'll reject because `actionPromise` rejected,
+        // so we can just quietly resolve this with `null` -- it will never reach the caller anyway.
+        return responseCtrl.resolve(null!)
+      }
+    )
+
+    return resultPromise
+  }
+
+  return { captureResponse }
+}
+
+function promiseWithResolvers<T>() {
+  let resolve: (value: T) => void = undefined!
+  let reject: (error: unknown) => void = undefined!
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
+}


### PR DESCRIPTION
This PR fixes some bugs in our handling of `serverActions.bodySizeLimit`. There's a couple fixes here, which can be viewed commit by commit.

### 1. Uncaught exception error when exceeding the size limit
We were using `body.pipe(busboy)`, which does not forward errors from the source to the sink, so the busboy stream would just hang, and we'd log an error, but never produce a response. It seems like node is (usually) smart enough to abort the request when this happens (because it was triggering an uncaught exception), but we should be returning a proper response instead. This is fixed by using `require('node:stream').pipeline(body, busboy)`, which propagates errors correctly.

### 2. Apply size limit to non-multipart fetch actions

We have a separate codepath for non-multipart fetch actions. This can happen if the action arguments are simple enough that react doesn't need to use multiple rows to serialize them -- generally, this means that they're JSON-esque without any complex types like Promises, Maps, or Sets.

This codepath was consuming the original request body, not the one piped through the size limit transform. So we'd print the error (because the transform is subscribed to the body), but still execute the action.

### 3. Tests

The likely reason that these bugs slipped through is that the tests were only checking if an error was printed to the console, and not checking if the server actually responded with an error. To prevent this, I've added some assertions on the responses' status codes + checking whether an error boundary was triggered. I've also tweaked the tests so that the parts that submit actions can run in deploy mode.

The request interception code proved subtle/complicated enough that i decided to pull it out into a separate helper. We have a whole bunch of tests that intercept requests/responses using various ad-hoc tangles of `page/browser.on('request', ...)` which i'd like to migrate to this helper, because that'd make them easier to understand, but I'll leave that for a follow up when there's time.