### PR TITLE
[dynamicIO] only abort once per prerender

### DIFF
--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -15,7 +15,7 @@ export function io(expression: string, type: ApiType) {
       const prerenderSignal = workUnitStore.controller.signal
       if (prerenderSignal.aborted === false) {
         // If the prerender signal is already aborted we don't need to construct any stacks
-        // becuase something else actually terminated the prerender.
+        // because something else actually terminated the prerender.
         const workStore = workAsyncStorage.getStore()
         if (workStore) {
           let message: string

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -12,32 +12,37 @@ export function io(expression: string, type: ApiType) {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     if (workUnitStore.type === 'prerender') {
-      const workStore = workAsyncStorage.getStore()
-      if (workStore) {
-        let message: string
-        switch (type) {
-          case 'time':
-            message = `Route "${workStore.route}" used ${expression} instead of using \`performance\` or without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time`
-            break
-          case 'random':
-            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random`
-            break
-          case 'crypto':
-            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto`
-            break
-          default:
-            throw new InvariantError(
-              'Unknown expression type in abortOnSynchronousPlatformIOAccess.'
-            )
-        }
-        const errorWithStack = new Error(message)
+      const prerenderSignal = workUnitStore.controller.signal
+      if (prerenderSignal.aborted === false) {
+        // If the prerender signal is already aborted we don't need to construct any stacks
+        // becuase something else actually terminated the prerender.
+        const workStore = workAsyncStorage.getStore()
+        if (workStore) {
+          let message: string
+          switch (type) {
+            case 'time':
+              message = `Route "${workStore.route}" used ${expression} instead of using \`performance\` or without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time`
+              break
+            case 'random':
+              message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random`
+              break
+            case 'crypto':
+              message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto`
+              break
+            default:
+              throw new InvariantError(
+                'Unknown expression type in abortOnSynchronousPlatformIOAccess.'
+              )
+          }
+          const errorWithStack = new Error(message)
 
-        abortOnSynchronousPlatformIOAccess(
-          workStore.route,
-          expression,
-          errorWithStack,
-          workUnitStore
-        )
+          abortOnSynchronousPlatformIOAccess(
+            workStore.route,
+            expression,
+            errorWithStack,
+            workUnitStore
+          )
+        }
       }
     } else if (
       workUnitStore.type === 'request' &&


### PR DESCRIPTION
Prior to this change multiple sync dynamic APIs could trigger multiple aborts. Generally this isn't a problem however it is wasteful compute and blocks a later refactor where we stop explicitly tracking whether the sync dynamic access is what caused the prerender to abort or not. To achieve better perf and future semantics we now only abort if the prerender is not yet aborted. In effect this means that there can only be one sync abort error per prerender in RSC and SSR respectively.