### PR TITLE
Alternate bundler example: use `canary` version

### DIFF
--- a/examples/with-rspack/package.json
+++ b/examples/with-rspack/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@next/plugin-rspack": "latest",
+    "@next/plugin-rspack": "canary",
     "@types/node": "^22.10.1",
     "@types/react": "^18.3.12",
     "typescript": "^5.7.2"


### PR DESCRIPTION
The `latest` version is old and we now canary-gate Rspack support. Some folks are referencing this example now, so make it work using canary.

This can be set back to `latest` once 15.3.0 is published.


Closes PACK-4254