### PR TITLE
test: bodySizeLimit in MPA actions

### DIFF
--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -151,7 +151,7 @@ export default async function webdriver(
   browserTeardown.push(browser.close.bind(browser))
 
   // Wait for application to hydrate
-  if (waitHydration) {
+  if (waitHydration && !disableJavaScript) {
     console.log(`\n> Waiting hydration for ${fullUrl}\n`)
 
     const checkHydrated = async () => {


### PR DESCRIPTION
Adds tests for handling of bodySizeLimit in MPA actions (i.e. actions running without JS via form submissions).

This was originally part of #77746, but the tests are failing in CI for some reason. they're not essential to the original PR, so i split them out so i can debug them separately.