### PR TITLE
chore(turbo-tasks): Audit all remaining uses of `Vc` in a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9692,6 +9692,7 @@ dependencies = [
  "serde",
  "smallvec",
  "swc_core",
+ "tokio",
  "tracing",
  "turbo-rcstr",
  "turbo-tasks",

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1267,7 +1267,7 @@ impl AppEndpoint {
         if emit_manifests != EmitManifests::None {
             let app_build_manifest = AppBuildManifest {
                 pages: fxindexmap!(
-                    app_entry.original_name.clone() => Vc::cell(entry_client_chunks
+                    app_entry.original_name.clone() => ResolvedVc::cell(entry_client_chunks
                         .iter()
                         .chain(client_shared_chunks.iter())
                         .copied()

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1138,7 +1138,7 @@ impl PageEndpoint {
     #[turbo_tasks::function]
     async fn build_manifest(
         &self,
-        client_chunks: Vc<OutputAssets>,
+        client_chunks: ResolvedVc<OutputAssets>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let node_root = self.pages_project.project().node_root();
         let client_relative_path = self.pages_project.project().client_relative_path();

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -34,8 +34,8 @@ pub struct AppPageLoaderTreeBuilder {
 
 impl AppPageLoaderTreeBuilder {
     fn new(
-        module_asset_context: Vc<ModuleAssetContext>,
-        server_component_transition: Vc<Box<dyn Transition>>,
+        module_asset_context: ResolvedVc<ModuleAssetContext>,
+        server_component_transition: ResolvedVc<Box<dyn Transition>>,
         base_path: Option<RcStr>,
     ) -> Self {
         AppPageLoaderTreeBuilder {
@@ -195,7 +195,7 @@ impl AppPageLoaderTreeBuilder {
                     .push(format!("import {identifier} from \"{inner_module_id}\";").into());
 
                 let source = dynamic_image_metadata_source(
-                    Vc::upcast(self.base.module_asset_context),
+                    *ResolvedVc::upcast(self.base.module_asset_context),
                     **path,
                     name.into(),
                     app_page.clone(),
@@ -240,7 +240,7 @@ impl AppPageLoaderTreeBuilder {
         let module = Vc::upcast(StructuredImageModuleType::create_module(
             Vc::upcast(FileSource::new(path)),
             BlurPlaceholderMode::None,
-            self.base.module_asset_context,
+            *self.base.module_asset_context,
         ));
         let module = self.base.process_module(module).to_resolved().await?;
         self.base
@@ -422,8 +422,8 @@ pub struct AppPageLoaderTreeModule {
 impl AppPageLoaderTreeModule {
     pub async fn build(
         loader_tree: Vc<AppPageLoaderTree>,
-        module_asset_context: Vc<ModuleAssetContext>,
-        server_component_transition: Vc<Box<dyn Transition>>,
+        module_asset_context: ResolvedVc<ModuleAssetContext>,
+        server_component_transition: ResolvedVc<Box<dyn Transition>>,
         base_path: Option<RcStr>,
     ) -> Result<Self> {
         AppPageLoaderTreeBuilder::new(module_asset_context, server_component_transition, base_path)

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -16,8 +16,8 @@ pub struct BaseLoaderTreeBuilder {
     pub inner_assets: FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>,
     counter: usize,
     pub imports: Vec<RcStr>,
-    pub module_asset_context: Vc<ModuleAssetContext>,
-    pub server_component_transition: Vc<Box<dyn Transition>>,
+    pub module_asset_context: ResolvedVc<ModuleAssetContext>,
+    pub server_component_transition: ResolvedVc<Box<dyn Transition>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -53,8 +53,8 @@ impl AppDirModuleType {
 
 impl BaseLoaderTreeBuilder {
     pub fn new(
-        module_asset_context: Vc<ModuleAssetContext>,
-        server_component_transition: Vc<Box<dyn Transition>>,
+        module_asset_context: ResolvedVc<ModuleAssetContext>,
+        server_component_transition: ResolvedVc<Box<dyn Transition>>,
     ) -> Self {
         BaseLoaderTreeBuilder {
             inner_assets: FxIndexMap::default(),
@@ -77,13 +77,13 @@ impl BaseLoaderTreeBuilder {
         ));
 
         self.server_component_transition
-            .process(source, self.module_asset_context, reference_type)
+            .process(source, *self.module_asset_context, reference_type)
             .module()
     }
 
     pub fn process_module(&self, module: Vc<Box<dyn Module>>) -> Vc<Box<dyn Module>> {
         self.server_component_transition
-            .process_module(module, self.module_asset_context)
+            .process_module(module, *self.module_asset_context)
     }
 
     pub async fn create_module_tuple_code(

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -33,8 +33,8 @@ use crate::{
 /// Computes the entry for a Next.js app page.
 #[turbo_tasks::function]
 pub async fn get_app_page_entry(
-    nodejs_context: Vc<ModuleAssetContext>,
-    edge_context: Vc<ModuleAssetContext>,
+    nodejs_context: ResolvedVc<ModuleAssetContext>,
+    edge_context: ResolvedVc<ModuleAssetContext>,
     loader_tree: Vc<AppPageLoaderTree>,
     page: AppPage,
     project_root: Vc<FileSystemPath>,
@@ -48,7 +48,8 @@ pub async fn get_app_page_entry(
         nodejs_context
     };
 
-    let server_component_transition = Vc::upcast(NextServerComponentTransition::new());
+    let server_component_transition =
+        ResolvedVc::upcast(NextServerComponentTransition::new().to_resolved().await?);
 
     let base_path = next_config.await?.base_path.clone();
     let loader_tree = AppPageLoaderTreeModule::build(
@@ -123,7 +124,7 @@ pub async fn get_app_page_entry(
 
     if is_edge {
         rsc_entry = wrap_edge_page(
-            Vc::upcast(module_asset_context),
+            *ResolvedVc::upcast(module_asset_context),
             project_root,
             rsc_entry,
             page,

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -29,7 +29,7 @@ pub struct PagesManifest {
 pub struct BuildManifest {
     pub polyfill_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
     pub root_main_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
-    pub pages: FxIndexMap<RcStr, Vc<OutputAssets>>,
+    pub pages: FxIndexMap<RcStr, ResolvedVc<OutputAssets>>,
 }
 
 impl BuildManifest {
@@ -111,12 +111,7 @@ impl BuildManifest {
             ..Default::default()
         };
 
-        let chunks: Vec<ReadRef<OutputAssets>> = self
-            .pages
-            .values()
-            // rustc struggles here, so be very explicit
-            .try_join()
-            .await?;
+        let chunks: Vec<ReadRef<OutputAssets>> = self.pages.values().try_join().await?;
 
         let references = chunks
             .into_iter()
@@ -420,7 +415,7 @@ pub struct FontManifestEntry {
 
 #[derive(Default, Debug)]
 pub struct AppBuildManifest {
-    pub pages: FxIndexMap<RcStr, Vc<OutputAssets>>,
+    pub pages: FxIndexMap<RcStr, ResolvedVc<OutputAssets>>,
 }
 
 impl AppBuildManifest {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -666,7 +666,7 @@ pub async fn get_server_module_options_context(
             foreign_next_server_rules.extend(internal_custom_rules);
 
             custom_source_transform_rules.push(
-                get_next_react_server_components_transform_rule(next_config, false, Some(*app_dir))
+                get_next_react_server_components_transform_rule(next_config, false, Some(app_dir))
                     .await?,
             );
 
@@ -736,7 +736,7 @@ pub async fn get_server_module_options_context(
             {
                 custom_source_transform_rules.push(get_ecma_transform_rule(
                     Box::new(ClientDirectiveTransformer::new(
-                        *ecmascript_client_reference_transition_name,
+                        ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
                     true,
@@ -747,7 +747,7 @@ pub async fn get_server_module_options_context(
             foreign_next_server_rules.extend(internal_custom_rules);
 
             custom_source_transform_rules.push(
-                get_next_react_server_components_transform_rule(next_config, true, Some(*app_dir))
+                get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
                     .await?,
             );
 
@@ -803,7 +803,7 @@ pub async fn get_server_module_options_context(
             next_server_rules.extend(source_transform_rules);
 
             let mut common_next_server_rules = vec![
-                get_next_react_server_components_transform_rule(next_config, true, Some(*app_dir))
+                get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
                     .await?,
             ];
 
@@ -812,7 +812,7 @@ pub async fn get_server_module_options_context(
             {
                 common_next_server_rules.push(get_ecma_transform_rule(
                     Box::new(ClientDirectiveTransformer::new(
-                        *ecmascript_client_reference_transition_name,
+                        ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
                     true,
@@ -890,7 +890,7 @@ pub async fn get_server_module_options_context(
             {
                 custom_source_transform_rules.push(get_ecma_transform_rule(
                     Box::new(ClientDirectiveTransformer::new(
-                        *ecmascript_client_reference_transition_name,
+                        ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
                     true,
@@ -906,12 +906,7 @@ pub async fn get_server_module_options_context(
             }
 
             custom_source_transform_rules.push(
-                get_next_react_server_components_transform_rule(
-                    next_config,
-                    true,
-                    app_dir.as_deref().copied(),
-                )
-                .await?,
+                get_next_react_server_components_transform_rule(next_config, true, app_dir).await?,
             );
 
             internal_custom_rules.extend(custom_source_transform_rules.iter().cloned());

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -5,7 +5,7 @@ use swc_core::{
     common::FileName,
     ecma::{ast::Program, visit::VisitWith},
 };
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -31,7 +31,7 @@ use crate::next_config::NextConfig;
 pub async fn get_next_react_server_components_transform_rule(
     next_config: Vc<NextConfig>,
     is_react_server_layer: bool,
-    app_dir: Option<Vc<FileSystemPath>>,
+    app_dir: Option<ResolvedVc<FileSystemPath>>,
 ) -> Result<ModuleRule> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
@@ -53,7 +53,7 @@ struct NextJsReactServerComponents {
     is_react_server_layer: bool,
     dynamic_io_enabled: bool,
     use_cache_enabled: bool,
-    app_dir: Option<Vc<FileSystemPath>>,
+    app_dir: Option<ResolvedVc<FileSystemPath>>,
 }
 
 impl NextJsReactServerComponents {
@@ -61,7 +61,7 @@ impl NextJsReactServerComponents {
         is_react_server_layer: bool,
         dynamic_io_enabled: bool,
         use_cache_enabled: bool,
-        app_dir: Option<Vc<FileSystemPath>>,
+        app_dir: Option<ResolvedVc<FileSystemPath>>,
     ) -> Self {
         Self {
             is_react_server_layer,

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -147,11 +147,11 @@ pub async fn make_chunk_group(
     // Pass chunk items to chunking algorithm
     let chunks = make_chunks(
         module_graph,
-        *chunking_context,
+        chunking_context,
         chunk_items,
         chunk_item_batch_groups,
         "".into(),
-        Vc::cell(referenced_output_assets),
+        ResolvedVc::cell(referenced_output_assets),
     )
     .await?;
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
@@ -5,7 +5,7 @@ use either::Either;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use tracing::Level;
-use turbo_tasks::{FxIndexMap, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TryJoinIterExt, ValueToString};
 
 use crate::chunk::{
     chunking::{make_chunk, ChunkItemOrBatchWithInfo, SplitContext},
@@ -39,7 +39,7 @@ async fn handle_split_group<'l>(
 pub async fn expand_batches(
     chunk_items: Vec<&ChunkItemOrBatchWithInfo>,
     ty: ResolvedVc<Box<dyn ChunkType>>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 ) -> Result<Vec<ChunkItemOrBatchWithInfo>> {
     let mut expanded = Vec::new();
     for item in chunk_items {
@@ -55,7 +55,7 @@ pub async fn expand_batches(
                         .iter()
                         .map(async |item| {
                             let size = ty.chunk_item_size(
-                                chunking_context,
+                                *chunking_context,
                                 *item.chunk_item,
                                 item.async_info.map(|i| *i),
                             );

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -15,7 +15,7 @@ pub async fn make_style_production_chunks(
     chunk_items: Vec<&ChunkItemOrBatchWithInfo>,
     _batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
     module_graph: Vc<ModuleGraph>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     chunking_config: &ChunkingConfig,
     mut split_context: SplitContext<'_>,
 ) -> Result<()> {
@@ -26,7 +26,7 @@ pub async fn make_style_production_chunks(
     async move {
         let style_groups = module_graph
             .style_groups(
-                chunking_context,
+                *chunking_context,
                 StyleGroupsConfig {
                     max_chunk_size: chunking_config.max_merge_chunk_size,
                 },

--- a/turbopack/crates/turbopack-css/Cargo.toml
+++ b/turbopack/crates/turbopack-css/Cargo.toml
@@ -29,6 +29,7 @@ swc_core = { workspace = true, features = [
   "common",
   "common_concurrent",
 ] }
+tokio = { workspace = true }
 tracing = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -8,7 +8,7 @@ use lightningcss::{
     visitor::{Visit, Visitor},
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbopack_core::{
     issue::IssueSource,
     reference::ModuleReference,
@@ -32,16 +32,16 @@ pub(crate) mod internal;
 pub(crate) mod url;
 
 pub type AnalyzedRefs = (
-    Vec<Vc<Box<dyn ModuleReference>>>,
-    Vec<(String, Vc<UrlAssetReference>)>,
+    Vec<ResolvedVc<Box<dyn ModuleReference>>>,
+    Vec<(String, ResolvedVc<UrlAssetReference>)>,
 );
 
 /// Returns `(all_references, urls)`.
-pub fn analyze_references(
+pub async fn analyze_references(
     stylesheet: &mut StyleSheetLike<'static, 'static>,
     source: ResolvedVc<Box<dyn Source>>,
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    import_context: Option<Vc<ImportContext>>,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    import_context: Option<ResolvedVc<ImportContext>>,
 ) -> Result<AnalyzedRefs> {
     let mut references = Vec::new();
     let mut urls = Vec::new();
@@ -50,13 +50,20 @@ pub fn analyze_references(
         ModuleReferencesVisitor::new(source, origin, import_context, &mut references, &mut urls);
     stylesheet.0.visit(&mut visitor).unwrap();
 
-    Ok((references, urls))
+    tokio::try_join!(
+        references.into_iter().map(|v| v.to_resolved()).try_join(),
+        urls.into_iter()
+            .map(|(k, v)| async move { Ok((k, v.to_resolved().await?)) })
+            .try_join(),
+    )
 }
 
 struct ModuleReferencesVisitor<'a> {
     source: ResolvedVc<Box<dyn Source>>,
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    import_context: Option<Vc<ImportContext>>,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    import_context: Option<ResolvedVc<ImportContext>>,
+    // `references` and `urls` must be resolved later (in `analyze_references`), as they're
+    // collected inside of a synchronous visitor
     references: &'a mut Vec<Vc<Box<dyn ModuleReference>>>,
     urls: &'a mut Vec<(String, Vc<UrlAssetReference>)>,
 }
@@ -64,8 +71,8 @@ struct ModuleReferencesVisitor<'a> {
 impl<'a> ModuleReferencesVisitor<'a> {
     fn new(
         source: ResolvedVc<Box<dyn Source>>,
-        origin: Vc<Box<dyn ResolveOrigin>>,
-        import_context: Option<Vc<ImportContext>>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        import_context: Option<ResolvedVc<ImportContext>>,
         references: &'a mut Vec<Vc<Box<dyn ModuleReference>>>,
         urls: &'a mut Vec<(String, Vc<UrlAssetReference>)>,
     ) -> Self {
@@ -94,10 +101,10 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
                 let issue_span = i.loc;
 
                 self.references.push(Vc::upcast(ImportAssetReference::new(
-                    self.origin,
+                    *self.origin,
                     Request::parse(Value::new(RcStr::from(src).into())),
                     ImportAttributes::new_from_lightningcss(&i.clone().into_owned()).into(),
-                    self.import_context,
+                    self.import_context.map(|ctx| *ctx),
                     IssueSource::from_line_col(
                         ResolvedVc::upcast(self.source),
                         SourcePos {
@@ -113,8 +120,8 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
 
                 *rule = CssRule::Ignored;
 
-                // let res = i.visit_children(self);
-                // res
+                // This node type has no children worth visiting.
+                // i.visit_children(self)
                 Ok(())
             }
 
@@ -131,7 +138,7 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
             let issue_span = u.loc;
 
             let vc = UrlAssetReference::new(
-                self.origin,
+                *self.origin,
                 Request::parse(Value::new(RcStr::from(src).into())),
                 IssueSource::from_line_col(
                     ResolvedVc::upcast(self.source),
@@ -150,8 +157,8 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
             self.urls.push((u.url.to_string(), vc));
         }
 
+        // This node type has no children worth visiting.
         // u.visit_children(self)?;
-
         Ok(())
     }
 

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -173,6 +173,8 @@ impl DevServerBuilder {
                             uri: request.uri().clone(),
                         };
                         run_once_with_reason(tt.clone(), reason, async move {
+                            // TODO: `get_issue_reporter` should be an `OperationVc`, as there's a
+                            // risk it could be a task-local Vc, which is not safe for us to await.
                             let issue_reporter = get_issue_reporter();
 
                             if hyper_tungstenite::is_upgrade_request(&request) {

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
@@ -2,18 +2,18 @@ use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::ecma::{ast::Program, transforms::base::resolver, visit::VisitMutWith};
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::ResolvedVc;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 use super::{is_client_module, server_to_client_proxy::create_proxy_module};
 
 #[derive(Debug)]
 pub struct ClientDirectiveTransformer {
-    transition_name: Vc<RcStr>,
+    transition_name: ResolvedVc<RcStr>,
 }
 
 impl ClientDirectiveTransformer {
-    pub fn new(transition_name: Vc<RcStr>) -> Self {
+    pub fn new(transition_name: ResolvedVc<RcStr>) -> Self {
         Self { transition_name }
     }
 }


### PR DESCRIPTION
I suspect the test failures in https://github.com/vercel/next.js/pull/77661 are related to a `Vc` that should be an `OperationVc`.

I realized that we have so few uses of `Vc` inside structs and enums that it might be easier to work off of that list than to carefully audit my changes in my other PR, though it doesn't look like anything's a smoking gun here.

Either way, while it's totally valid for non-`VcValueType` structs and enums to contain unresolved `Vc`s, it's usually suboptimal, and there should probably at least be a comment explaining the choice to use an unresolved `Vc`.

I still have a long-term goal of renaming `ResolvedVc` to `Vc` and the current version of `Vc` to `UnresolvedVc`, so for that reason alone, I want everything to prefer using `ResolvedVc` "by default".

Closes PACK-4256