### PR TITLE
Turbopack Build: Remove cases of process.env.TURBOPACK

### DIFF
--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -72,7 +72,8 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
     printAndExit(`> No such directory exists as the project root: ${dir}`)
   }
 
-  if (options.turbo || options.turbopack) {
+  const isTurbopack = Boolean(options.turbo || options.turbopack)
+  if (isTurbopack) {
     process.env.TURBOPACK = '1'
   }
 
@@ -83,7 +84,7 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
     lint,
     !mangling,
     experimentalAppOnly,
-    !!process.env.TURBOPACK,
+    isTurbopack,
     experimentalBuildMode,
     traceUploadUrl
   )

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -72,7 +72,12 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
     printAndExit(`> No such directory exists as the project root: ${dir}`)
   }
 
-  const isTurbopack = Boolean(options.turbo || options.turbopack)
+  const isTurbopack = Boolean(
+    options.turbo ||
+      options.turbopack ||
+      // TODO: Used for Testing in Next.js CI. Rename to something better like `NEXT_TEST_TURBOPACK`.
+      process.env.TURBOPACK
+  )
   if (isTurbopack) {
     process.env.TURBOPACK = '1'
   }

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -236,11 +236,12 @@ const nextDev = async (
     hostname: host,
   }
 
-  if (options.turbo || options.turbopack) {
+  const isTurbopack = Boolean(options.turbo || options.turbopack)
+  if (isTurbopack) {
     process.env.TURBOPACK = '1'
   }
 
-  isTurboSession = !!process.env.TURBOPACK
+  isTurboSession = isTurbopack
 
   const distDir = path.join(dir, config.distDir ?? '.next')
   setGlobal('phase', PHASE_DEVELOPMENT_SERVER)

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -236,7 +236,12 @@ const nextDev = async (
     hostname: host,
   }
 
-  const isTurbopack = Boolean(options.turbo || options.turbopack)
+  const isTurbopack = Boolean(
+    options.turbo ||
+      options.turbopack ||
+      // TODO: Used for Testing in Next.js CI. Rename to something better like `NEXT_TEST_TURBOPACK`.
+      process.env.TURBOPACK
+  )
   if (isTurbopack) {
     process.env.TURBOPACK = '1'
   }
@@ -285,7 +290,7 @@ const nextDev = async (
         stdio: 'inherit',
         env: {
           ...defaultEnv,
-          TURBOPACK: process.env.TURBOPACK,
+          ...(isTurbopack ? { TURBOPACK: '1' } : undefined),
           NEXT_PRIVATE_WORKER: '1',
           NEXT_PRIVATE_TRACE_ID: traceId,
           NODE_EXTRA_CA_CERTS: startServerOptions.selfSignedCertificate

--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -33,7 +33,13 @@ const nextStart = async (options: NextStartOptions, directory?: string) => {
     printAndExit(getReservedPortExplanation(port), 1)
   }
 
-  if (options.turbo || options.turbopack) {
+  const isTurbopack = Boolean(
+    options.turbo ||
+      options.turbopack ||
+      // TODO: Used for Testing in Next.js CI. Rename to something better like `NEXT_TEST_TURBOPACK`.
+      process.env.TURBOPACK
+  )
+  if (isTurbopack) {
     process.env.TURBOPACK = '1'
   }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -170,7 +170,7 @@ export async function createHotReloaderTurbopack(
 
   // For the debugging purpose, check if createNext or equivalent next instance setup in test cases
   // works correctly. Normally `run-test` hides output so only will be visible when `--debug` flag is used.
-  if (process.env.TURBOPACK && isTestMode) {
+  if (isTestMode) {
     require('console').log('Creating turbopack project', {
       dir: projectPath,
       testMode: isTestMode,


### PR DESCRIPTION
## What?

Gets rid of a bunch of cases where `process.env.TURBOPACK` is used where it could just use the available variable referring to Turbopack being in use.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-4259