### PR TITLE
docs: update prefix two-digit number in routing section

### DIFF
--- a/docs/04-community/01-contribution-guide.mdx
+++ b/docs/04-community/01-contribution-guide.mdx
@@ -79,17 +79,17 @@ For example, in the [functions API Reference](/docs/app/api-reference/functions)
 └── ...
 ```
 
-But, in the [routing section](/docs/app), the files are prefixed with a two-digit number, sorted in the order developers should learn these concepts:
+But, in the [app router section](/docs/app), the files are prefixed with a two-digit number, sorted in the order developers should learn these concepts:
 
 ```txt
-01-routing
-├── 01-defining-routes.mdx
-├── 02-pages.mdx
-├── 03-layouts-and-templates.mdx
+01-getting-started
+├── 01-installation.mdx
+├── 02-project-structure.mdx
+├── 03-layouts-and-pages.mdx
 └── ...
 ```
 
-To quickly find a page, you can use `⌘ + P` (Mac) or `Ctrl + P` (Windows) to open the search bar on VSCode. Then, type the slug of the page you're looking for. E.g. `defining-routes`
+To quickly find a page, you can use `⌘ + P` (Mac) or `Ctrl + P` (Windows) to open the search bar on VSCode. Then, type the slug of the page you're looking for. E.g. `installation`
 
 > **Why not use a manifest?**
 >


### PR DESCRIPTION
## Description

The current [routing documents](https://github.com/vercel/next.js/tree/canary/docs/01-app/03-building-your-application/01-routing) are missing `01` and `02` prefix.

This PR changes the numbering of them and update [contribution-guide docs](https://github.com/vercel/next.js/blob/canary/docs/04-community/01-contribution-guide.mdx).

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors


