### PR TITLE
[dev-overlay] sync horizontal scrollbar style

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/dialog/styles.ts
@@ -37,29 +37,30 @@ const styles = `
     outline: 0;
   }
 
-  [data-nextjs-dialog]::-webkit-scrollbar {
-    width: 6px;
-    border-radius: 0 0 1rem 1rem;
-    margin-bottom: 1rem;
+  [data-nextjs-dialog], [data-nextjs-dialog] * {
+    &::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+      border-radius: 0 0 1rem 1rem;
+      margin-bottom: 1rem;
+    }
+
+    &::-webkit-scrollbar-button {
+      display: none;
+    }
+
+    &::-webkit-scrollbar-track {
+      border-radius: 0 0 1rem 1rem;
+      background-color: var(--color-background-100);
+    }
+      
+    &::-webkit-scrollbar-thumb {
+      border-radius: 1rem;
+      background-color: var(--color-gray-500);
+    }
   }
 
-  [data-nextjs-dialog]::-webkit-scrollbar-button {
-    display: none;
-  }
-
-  [data-nextjs-dialog]::-webkit-scrollbar-track {
-    border-radius: 0 0 1rem 1rem;
-    background-color: var(--color-background-100);
-  }
-    
-  [data-nextjs-dialog]::-webkit-scrollbar-thumb {
-    border-radius: 1rem;
-    background-color: var(--color-gray-500);
-  }
-
-  ${
-    '' /* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */
-  }
+  /* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */
   [data-nextjs-dialog-sizer] {
     overflow: hidden;
     border-radius: inherit;


### PR DESCRIPTION
Following up on https://github.com/vercel/next.js/pull/76953.

In macOS, the scrollbar color is still light in dark mode. So, we modified the style for it at https://github.com/vercel/next.js/pull/76509. However, it didn't cover the scrollbars of the children of the dialog. Therefore, we sync the scrollbar of children to be dark in dark mode as well.

| Before | After |
|--------|--------|
| ![CleanShot 2025-04-03 at 09 59 01@2x](https://github.com/user-attachments/assets/244566ad-4c05-4045-891f-eff8a7acda17) | ![CleanShot 2025-04-03 at 09 57 18@2x](https://github.com/user-attachments/assets/6441251b-eb0d-450d-8a32-75d9a4d88f32) | 