### PR TITLE
Turbopack: pass asset to chunk_path to allow to use content hash later

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1293,8 +1293,11 @@ impl AppEndpoint {
         let next_package = get_next_package(project.project_path());
         let polyfill_source =
             FileSource::new(next_package.join("dist/build/polyfills/polyfill-nomodule.js".into()));
-        let polyfill_output_path =
-            client_chunking_context.chunk_path(polyfill_source.ident(), ".js".into());
+        let polyfill_output_path = client_chunking_context.chunk_path(
+            Some(Vc::upcast(polyfill_source)),
+            polyfill_source.ident(),
+            ".js".into(),
+        );
         let polyfill_output_asset = ResolvedVc::upcast(
             RawOutput::new(polyfill_output_path, Vc::upcast(polyfill_source))
                 .to_resolved()

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -4,6 +4,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Upcast, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    asset::Asset,
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
@@ -337,6 +338,7 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     async fn chunk_path(
         &self,
+        _asset: Option<Vc<Box<dyn Asset>>>,
         ident: Vc<AssetIdent>,
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -101,9 +101,12 @@ impl EcmascriptBrowserChunk {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptBrowserChunk {
     #[turbo_tasks::function]
-    fn path(&self) -> Vc<FileSystemPath> {
-        let ident = self.ident_for_path();
-        self.chunking_context.chunk_path(ident, ".js".into())
+    async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
+        let this = self.await?;
+        let ident = this.ident_for_path();
+        Ok(this
+            .chunking_context
+            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -244,7 +244,9 @@ impl OutputAsset for EcmascriptBrowserEvaluateChunk {
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
         let ident = self.ident_for_path();
-        Ok(this.chunking_context.chunk_path(ident, ".js".into()))
+        Ok(this
+            .chunking_context
+            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -91,11 +91,12 @@ fn chunk_key() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
-    async fn path(&self) -> Result<Vc<FileSystemPath>> {
-        let mut ident = self.ident.owned().await?;
+    async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
+        let this = self.await?;
+        let mut ident = this.ident.owned().await?;
         ident.add_modifier(modifier().to_resolved().await?);
 
-        match self.source {
+        match this.source {
             EcmascriptDevChunkListSource::Entry => {}
             EcmascriptDevChunkListSource::Dynamic => {
                 ident.add_modifier(dynamic_modifier().to_resolved().await?);
@@ -107,7 +108,9 @@ impl OutputAsset for EcmascriptDevChunkList {
         // removed from the list.
 
         let ident = AssetIdent::new(Value::new(ident));
-        Ok(self.chunking_context.chunk_path(ident, ".js".into()))
+        Ok(this
+            .chunking_context
+            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -8,6 +8,7 @@ use turbo_tasks_hash::DeterministicHash;
 
 use super::{availability_info::AvailabilityInfo, ChunkableModule, EvaluatableAssets};
 use crate::{
+    asset::Asset,
     chunk::{ChunkItem, ChunkType, ModuleId},
     environment::Environment,
     ident::AssetIdent,
@@ -143,7 +144,12 @@ pub trait ChunkingContext {
     // discretion of chunking context implementors. However, we currently use this
     // in a couple of places in `turbopack-css`, so we need to remove that
     // dependency first.
-    fn chunk_path(self: Vc<Self>, ident: Vc<AssetIdent>, extension: RcStr) -> Vc<FileSystemPath>;
+    fn chunk_path(
+        self: Vc<Self>,
+        asset: Option<Vc<Box<dyn Asset>>>,
+        ident: Vc<AssetIdent>,
+        extension: RcStr,
+    ) -> Vc<FileSystemPath>;
 
     /// Reference Source Map Assets for chunks
     fn reference_chunk_source_maps(self: Vc<Self>, chunk: Vc<Box<dyn OutputAsset>>) -> Vc<bool>;

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -77,7 +77,7 @@ impl OutputAsset for SourceMapAsset {
                 chunking_context,
                 ident_for_path,
             } => chunking_context
-                .chunk_path(*ident_for_path, ".js".into())
+                .chunk_path(Some(Vc::upcast(self)), *ident_for_path, ".js".into())
                 .append(".map".into()),
             PathType::Fixed { path } => path.append(".map".into()),
         })

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -323,7 +323,7 @@ impl OutputAsset for CssChunk {
         Ok(self
             .await?
             .chunking_context
-            .chunk_path(ident, ".css".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, ".css".into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -98,10 +98,11 @@ fn single_item_modifier() -> Vc<RcStr> {
 impl OutputAsset for SingleItemCssChunk {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self
-            .await?
-            .chunking_context
-            .chunk_path(self.ident_for_path(), ".single.css".into()))
+        Ok(self.await?.chunking_context.chunk_path(
+            Some(Vc::upcast(self)),
+            self.ident_for_path(),
+            ".single.css".into(),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -33,7 +33,11 @@ impl OutputAsset for SingleItemCssChunkSourceMapAsset {
             .chunk
             .await?
             .chunking_context
-            .chunk_path(this.chunk.ident_for_path(), ".single.css".into())
+            .chunk_path(
+                Some(Vc::upcast(self)),
+                this.chunk.ident_for_path(),
+                ".single.css".into(),
+            )
             .append(".map".into()))
     }
 }

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -34,7 +34,7 @@ impl OutputAsset for CssChunkSourceMapAsset {
             .chunk
             .await?
             .chunking_context
-            .chunk_path(ident, ".css".into())
+            .chunk_path(Some(Vc::upcast(self)), ident, ".css".into())
             .append(".map".into()))
     }
 }

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -256,7 +256,7 @@ pub async fn get_intermediate_asset(
     other_entries: Vc<EvaluatableAssets>,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
     Ok(Vc::upcast(chunking_context.root_entry_chunk_group_asset(
-        chunking_context.chunk_path(main_entry.ident(), ".js".into()),
+        chunking_context.chunk_path(None, main_entry.ident(), ".js".into()),
         other_entries.with_entry(*main_entry),
         ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(
                 other_entries

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -4,6 +4,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Upcast, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    asset::Asset,
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
@@ -276,6 +277,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     async fn chunk_path(
         &self,
+        _asset: Option<Vc<Box<dyn Asset>>>,
         ident: Vc<AssetIdent>,
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -78,9 +78,12 @@ impl EcmascriptBuildNodeChunk {
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
-    fn path(&self) -> Vc<FileSystemPath> {
-        let ident = self.chunk.ident().with_modifier(modifier());
-        self.chunking_context.chunk_path(ident, ".js".into())
+    async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
+        let this = self.await?;
+        let ident = this.chunk.ident().with_modifier(modifier());
+        Ok(this
+            .chunking_context
+            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -129,7 +129,9 @@ impl OutputAsset for EcmascriptBuildNodeRuntimeChunk {
         let this = self.await?;
         let ident = self.ident_for_path();
 
-        Ok(this.chunking_context.chunk_path(ident, ".js".into()))
+        Ok(this
+            .chunking_context
+            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -40,9 +41,12 @@ impl WebAssemblyAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for WebAssemblyAsset {
     #[turbo_tasks::function]
-    fn path(&self) -> Vc<FileSystemPath> {
-        let ident = self.source.ident().with_modifier(modifier());
-        self.chunking_context.chunk_path(ident, ".wasm".into())
+    async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
+        let this = self.await?;
+        let ident = this.source.ident().with_modifier(modifier());
+        Ok(this
+            .chunking_context
+            .chunk_path(Some(Vc::upcast(self)), ident, ".wasm".into()))
     }
 }
 


### PR DESCRIPTION
### What?

Change the signuture of `ChunkingContext::chunk_path` to take an `Asset` argument. The `content()` of the `Asset` might be used in future generate a content hash for the chunk path

Closes PACK-4276