### PR TITLE
[test] Remove global styled-components install 

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,6 @@
     "semver": "7.3.7",
     "shell-quote": "1.7.3",
     "strip-ansi": "6.0.0",
-    "styled-components": "6.0.0-rc.3",
     "styled-jsx": "5.1.6",
     "styled-jsx-plugin-postcss": "3.0.2",
     "swr": "^2.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,9 +549,6 @@ importers:
       strip-ansi:
         specifier: 6.0.0
         version: 6.0.0
-      styled-components:
-        specifier: 6.0.0-rc.3
-        version: 6.0.0-rc.3(react-dom@19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409))(react@19.2.0-canary-3fbfb9ba-20250409)
       styled-jsx:
         specifier: 5.1.6
         version: 5.1.6(@babel/core@7.22.5)(babel-plugin-macros@3.1.0)(react@19.2.0-canary-3fbfb9ba-20250409)
@@ -1937,13 +1934,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     hasBin: true
 
-  '@babel/cli@7.21.5':
-    resolution: {integrity: sha512-TOKytQ9uQW9c4np8F+P7ZfPINy5Kv+pizDIUwSVH8X5zHgYHV4AA8HE5LA450xXeu4jEfmUckTYvv1I4S26M/g==}
-    engines: {node: '>=6.9.0'}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': 7.22.5
-
   '@babel/code-frame@7.12.11':
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
 
@@ -2134,10 +2124,6 @@ packages:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.21.4':
-    resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.22.15':
@@ -2383,12 +2369,6 @@ packages:
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.9':
     resolution: {integrity: sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': 7.22.5
-
-  '@babel/plugin-external-helpers@7.18.6':
-    resolution: {integrity: sha512-wNqc87qjLvsD1PIMQBzLn1bMuTlGzqLzM/1VGQ22Wm51cbCWS9k71ydp5iZS4hjwQNuTWSn/xbZkkusNENwtZg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': 7.22.5
@@ -4966,9 +4946,6 @@ packages:
 
   '@napi-rs/triples@1.2.0':
     resolution: {integrity: sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==}
-
-  '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
-    resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -7948,10 +7925,6 @@ packages:
   commander@3.0.2:
     resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
 
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -9999,9 +9972,6 @@ packages:
   fs-monkey@1.0.6:
     resolution: {integrity: sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==}
 
-  fs-readdir-recursive@1.1.0:
-    resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -10198,10 +10168,6 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
-
-  glob@7.2.0:
-    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
@@ -15399,9 +15365,6 @@ packages:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
 
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
-
   sharp@0.34.1:
     resolution: {integrity: sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -15472,10 +15435,6 @@ packages:
   slash@1.0.0:
     resolution: {integrity: sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==}
     engines: {node: '>=0.10.0'}
-
-  slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
-    engines: {node: '>=6'}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -15905,17 +15864,6 @@ packages:
 
   style-to-object@0.4.1:
     resolution: {integrity: sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==}
-
-  styled-components@6.0.0-rc.3:
-    resolution: {integrity: sha512-5FbCTxynopck99GRwM5Ey0+VRp8pkQq69TwGOJJeYtR7gPvwGjNx8yBPLN7/dfxwwvn9ymOZYB19eQkv2k70wQ==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      babel-plugin-styled-components: '>= 2'
-      react: 19.2.0-canary-3fbfb9ba-20250409
-      react-dom: 19.2.0-canary-3fbfb9ba-20250409
-    peerDependenciesMeta:
-      babel-plugin-styled-components:
-        optional: true
 
   styled-jsx-plugin-postcss@3.0.2:
     resolution: {integrity: sha512-6xuteERUhLSLbztb2l2zhrxJpcW3eb7ooSMc3j5D51jiao6HZNaJoimmSnpUMji1qWxbAZD0Lee0ftB4atxoRA==}
@@ -16368,9 +16316,6 @@ packages:
 
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-
-  tslib@2.5.3:
-    resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -17585,20 +17530,6 @@ snapshots:
       '@ast-grep/cli-win32-ia32-msvc': 0.31.0
       '@ast-grep/cli-win32-x64-msvc': 0.31.0
 
-  '@babel/cli@7.21.5(@babel/core@7.22.5)':
-    dependencies:
-      '@babel/core': 7.22.5
-      '@jridgewell/trace-mapping': 0.3.22
-      commander: 4.1.1
-      convert-source-map: 1.9.0
-      fs-readdir-recursive: 1.1.0
-      glob: 7.2.0
-      make-dir: 2.1.0
-      slash: 2.0.0
-    optionalDependencies:
-      '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents.3
-      chokidar: 3.6.0
-
   '@babel/code-frame@7.12.11':
     dependencies:
       '@babel/highlight': 7.22.20
@@ -17893,10 +17824,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  '@babel/helper-module-imports@7.21.4':
-    dependencies:
-      '@babel/types': 7.22.5
 
   '@babel/helper-module-imports@7.22.15':
     dependencies:
@@ -18202,11 +18129,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  '@babel/plugin-external-helpers@7.18.6(@babel/core@7.22.5)':
-    dependencies:
-      '@babel/core': 7.22.5
-      '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-proposal-class-properties@7.12.1(@babel/core@7.22.5)':
     dependencies:
@@ -21390,9 +21312,6 @@ snapshots:
   '@napi-rs/cli@2.18.0': {}
 
   '@napi-rs/triples@1.2.0': {}
-
-  '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
-    optional: true
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
@@ -24932,8 +24851,6 @@ snapshots:
 
   commander@3.0.2: {}
 
-  commander@4.1.1: {}
-
   commander@7.2.0: {}
 
   commander@8.3.0: {}
@@ -27788,8 +27705,6 @@ snapshots:
 
   fs-monkey@1.0.6: {}
 
-  fs-readdir-recursive@1.1.0: {}
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.1.3:
@@ -28025,15 +27940,6 @@ snapshots:
       inflight: 1.0.6
       inherits: 2.0.4
       minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
-  glob@7.2.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -34630,8 +34536,6 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
-  shallowequal@1.1.0: {}
-
   sharp@0.34.1:
     dependencies:
       color: 4.2.3
@@ -34719,8 +34623,6 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@1.0.0: {}
-
-  slash@2.0.0: {}
 
   slash@3.0.0: {}
 
@@ -35210,29 +35112,6 @@ snapshots:
   style-to-object@0.4.1:
     dependencies:
       inline-style-parser: 0.1.1
-
-  styled-components@6.0.0-rc.3(react-dom@19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409))(react@19.2.0-canary-3fbfb9ba-20250409):
-    dependencies:
-      '@babel/cli': 7.21.5(@babel/core@7.22.5)
-      '@babel/core': 7.22.5
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/plugin-external-helpers': 7.18.6(@babel/core@7.22.5)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.22.5)
-      '@babel/preset-env': 7.22.5(@babel/core@7.22.5)
-      '@babel/preset-react': 7.22.5(@babel/core@7.22.5)
-      '@babel/preset-typescript': 7.22.5(@babel/core@7.22.5)
-      '@babel/traverse': 7.22.5
-      '@emotion/unitless': 0.8.1
-      css-to-react-native: 3.2.0
-      postcss: 8.4.31
-      react: 19.2.0-canary-3fbfb9ba-20250409
-      react-dom: 19.2.0-canary-3fbfb9ba-20250409(react@19.2.0-canary-3fbfb9ba-20250409)
-      shallowequal: 1.1.0
-      stylis: 4.2.0
-      tslib: 2.5.3
-    transitivePeerDependencies:
-      - supports-color
 
   styled-jsx-plugin-postcss@3.0.2:
     dependencies:
@@ -35743,8 +35622,6 @@ snapshots:
   tslib@2.3.1: {}
 
   tslib@2.4.0: {}
-
-  tslib@2.5.3: {}
 
   tslib@2.8.1: {}
 

--- a/test/development/basic/styled-components-disabled.test.ts
+++ b/test/development/basic/styled-components-disabled.test.ts
@@ -5,7 +5,7 @@ import { NextInstance } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 // TODO: Somehow the warning doesn't show up with Turbopack, even though the transform is not enabled.
-// TODO: It no longer shows up with Webpack either in tests. Manual repro does work though.
+// TODO: It no longer shows up with Webpack either in tests.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe.skip)(
   'styled-components SWC transform',
   () => {

--- a/test/development/basic/styled-components-disabled/.gitignore
+++ b/test/development/basic/styled-components-disabled/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/test/development/basic/styled-components-disabled/package.json
+++ b/test/development/basic/styled-components-disabled/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "styled-components-disabled",
+  "private": true,
+  "dependencies": {
+    "styled-components": "6.1.16"
+  }
+}

--- a/test/development/basic/styled-components-disabled/pages/index.js
+++ b/test/development/basic/styled-components-disabled/pages/index.js
@@ -13,7 +13,7 @@ const Button = styled.a`
   /* The GitHub button is a primary button
    * edit this to target it specifically! */
   ${(props) =>
-    props.primary &&
+    props.$primary &&
     css`
       background: white;
       color: black;
@@ -27,7 +27,7 @@ export default function Home() {
         href="https://github.com/styled-components/styled-components"
         target="_blank"
         rel="noopener"
-        primary
+        $primary
       >
         GitHub
       </Button>

--- a/test/development/basic/styled-components/.gitignore
+++ b/test/development/basic/styled-components/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/test/development/basic/styled-components/package.json
+++ b/test/development/basic/styled-components/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "styled-components",
+  "private": true,
+  "dependencies": {
+    "styled-components": "6.1.16"
+  }
+}

--- a/test/development/basic/styled-components/pages/index.js
+++ b/test/development/basic/styled-components/pages/index.js
@@ -13,7 +13,7 @@ const Button = styled.a`
   /* The GitHub button is a primary button
    * edit this to target it specifically! */
   ${(props) =>
-    props.primary &&
+    props.$primary &&
     css`
       background: white;
       color: black;
@@ -33,7 +33,7 @@ export default function Home() {
         href="https://github.com/styled-components/styled-components"
         target="_blank"
         rel="noopener"
-        primary
+        $primary
       >
         GitHub
       </Button>


### PR DESCRIPTION
It's only used for running `pnpm next <test-dir>` locally. However, it doesn't necessarily reflect the actual `styled-components` version of the test project in question so it's a footgun.

It also slows down all installs which is not negligible given the large package graph we could remove in this PR.

If you want to run a test project locally that requires some additional packages, use `pnpm --ignore-workspace --no-lockfile install` instead.
For tests that don't have a dedicated package.json, use `pnpm --ignore-workspace --no-lockfile add styled-components@<version>.`.

A dedicated package.json for each fixture should be preferred for ergonomics.
It's still duplicated but at least the tested version in `dependencies` is closer to the one in the `package.json`.
Having a single version in the monorepo is too far away causing drift.