### PR TITLE
[ci] remove needs build-native for lint job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,8 +97,7 @@ jobs:
 
   lint:
     name: lint
-    needs: ['build-native', 'build-next']
-
+    needs: ['build-next']
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: pnpm lint-no-typescript && pnpm check-examples


### PR DESCRIPTION
`build-native` and `build-native-windows` were skipped for docs only changes in #77743, removing the native from the `needs:[]` dependencies of lint job to ensure lint will still be proceed for docs PR