### PR TITLE
Update 04-incremental-static-regeneration.mdx

### DIFF
--- a/docs/01-app/03-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
+++ b/docs/01-app/03-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
@@ -203,7 +203,7 @@ Here's how this example works:
 3. After 60 seconds has passed, the next request will still show the cached (stale) page
 4. The cache is invalidated and a new version of the page begins generating in the background
 5. Once generated successfully, Next.js will display and cache the updated page
-6. If `/blog/26` is requested, Next.js will generate and cache this page on-demand
+6. If `/blog/25` is requested, Next.js will generate and cache this page on-demand
 
 ## Reference
 


### PR DESCRIPTION
There is no 26th post in the given API, and I don't assume they meant the blog would be generated on the backend when a new ID is hit.