### PR TITLE
Lazily call `refreshTags` and `getExpiration` (alternative)

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -669,5 +669,6 @@
   "668": "Internal Next.js error: Router action dispatched before initialization.",
   "669": "Invariant: --turbopack is set but the build used Webpack",
   "670": "Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to \"next start\".",
-  "671": "Specified images.remotePatterns must have protocol \"http\" or \"https\" received \"%s\"."
+  "671": "Specified images.remotePatterns must have protocol \"http\" or \"https\" received \"%s\".",
+  "672": "\"use cache\" cannot be used outside of App Router."
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -714,7 +714,7 @@ async function warmupDevRender(
 
   const implicitTags = getImplicitTags(
     renderOpts.routeModule.definition.page,
-    new URL(req.url).pathname,
+    ctx.url.pathname,
     null
   )
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -14,15 +14,26 @@ import type {
   PrerenderResumeDataCache,
 } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
-import type { ImplicitTags } from '../lib/implicit-tags'
 import type { WorkStore } from './work-async-storage.external'
+import type { ScopedCacheHandler } from '../use-cache/handlers'
+import type { CacheHandler } from '../lib/cache-handlers/types'
 
 export type WorkUnitPhase = 'action' | 'render' | 'after'
 
 export interface CommonWorkUnitStore {
   /** NOTE: Will be mutated as phases change */
   phase: WorkUnitPhase
-  readonly implicitTags: ImplicitTags | undefined
+  readonly implicitTags: string[]
+
+  /**
+   * Cache handlers that are scoped to the work unit. They memoize the results
+   * of `refreshTags`, and `getExpiration` for the work unit's implicit tags
+   * (via `getImplicitTagsExpiration`). Currently, implicit tags are the same
+   * for all work units (inferred from the route), so they could theoretically
+   * be part of the work store. In the future we might change that though, which
+   * is why it makes more sense to scope them to the work unit.
+   */
+  readonly cacheHandlers: Map<string, ScopedCacheHandler | CacheHandler>
 }
 
 export interface RequestStore extends CommonWorkUnitStore {

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -23,7 +23,7 @@ import { splitCookiesString } from '../web/utils'
 import type { ServerComponentsHmrCache } from '../response-cache'
 import type { RenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
-import type { ImplicitTags } from '../lib/implicit-tags'
+import { createScopedCacheHandlers } from '../use-cache/handlers'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   const cleaned = HeadersAdapter.from(headers)
@@ -68,7 +68,7 @@ type RequestContext = RequestResponsePair & {
   renderOpts?: WrapperRenderOpts
   isHmrRefresh?: boolean
   serverComponentsHmrCache?: ServerComponentsHmrCache
-  implicitTags: ImplicitTags | undefined
+  implicitTags: string[]
 }
 
 type RequestResponsePair =
@@ -186,6 +186,7 @@ function createRequestStoreImpl(
     type: 'request',
     phase,
     implicitTags,
+    cacheHandlers: createScopedCacheHandlers(implicitTags),
     // Rather than just using the whole `url` here, we pull the parts we want
     // to ensure we don't use parts of the URL that we shouldn't. This also
     // lets us avoid requiring an empty string for `search` in the type.

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1441,7 +1441,9 @@ export default abstract class Server<
         await Promise.all(
           [...cacheHandlers].map(async (cacheHandler) => {
             if ('refreshTags' in cacheHandler) {
-              await cacheHandler.refreshTags()
+              // Note: cacheHandler.refreshTags() is called lazily before the
+              // first cache entry is retrieved. It allows us to skip the
+              // refresh request if no caches are read at all.
             } else {
               const previouslyRevalidatedTags = getPreviouslyRevalidatedTags(
                 req.headers,

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -753,7 +753,7 @@ export function createPatchedFetcher(
                   fetchUrl,
                   fetchIdx,
                   tags,
-                  softTags: implicitTags?.tags,
+                  softTags: implicitTags,
                 })
 
             if (hasNoExplicitCacheConfig) {

--- a/packages/next/src/server/use-cache/handlers.ts
+++ b/packages/next/src/server/use-cache/handlers.ts
@@ -1,11 +1,66 @@
 import DefaultCacheHandler from '../lib/cache-handlers/default'
-import type { CacheHandlerCompat } from '../lib/cache-handlers/types'
+import type {
+  CacheEntry,
+  CacheHandler,
+  CacheHandlerCompat,
+  CacheHandlerV2,
+  Timestamp,
+} from '../lib/cache-handlers/types'
 
 const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? (message: string, ...args: any[]) => {
       console.log(`use-cache: ${message}`, ...args)
     }
   : () => {}
+
+/**
+ * A cache handler that's scoped to a work unit. It memoizes the results of
+ * `refreshTags`, and `getExpiration` for the given implicit tags (via
+ * `getImplicitTagsExpiration`).
+ */
+export class ScopedCacheHandler implements CacheHandlerV2 {
+  private implicitTagsExpirationPromise: Promise<Timestamp> | undefined
+  private refreshTagsPromise: Promise<void> | undefined
+
+  constructor(
+    private readonly underlyingCacheHandler: CacheHandlerV2,
+    private readonly implicitTags: string[]
+  ) {}
+
+  get(cacheKey: string): Promise<undefined | CacheEntry> {
+    return this.underlyingCacheHandler.get(cacheKey)
+  }
+
+  set(cacheKey: string, pendingEntry: Promise<CacheEntry>): Promise<void> {
+    return this.underlyingCacheHandler.set(cacheKey, pendingEntry)
+  }
+
+  refreshTags(): Promise<void> {
+    this.refreshTagsPromise ??= this.underlyingCacheHandler.refreshTags()
+
+    return this.refreshTagsPromise
+  }
+
+  getExpiration(...tags: string[]): Promise<Timestamp> {
+    return this.underlyingCacheHandler.getExpiration(...tags)
+  }
+
+  getImplicitTagsExpiration(): Promise<Timestamp> {
+    this.implicitTagsExpirationPromise ??= (async () => {
+      if (this.implicitTags.length === 0) {
+        return 0
+      }
+
+      return this.underlyingCacheHandler.getExpiration(...this.implicitTags)
+    })()
+
+    return this.implicitTagsExpirationPromise
+  }
+
+  expireTags(...tags: string[]): Promise<void> {
+    return this.underlyingCacheHandler.expireTags(...tags)
+  }
+}
 
 const handlersSymbol = Symbol.for('@next/cache-handlers')
 const handlersMapSymbol = Symbol.for('@next/cache-handlers-map')
@@ -76,22 +131,9 @@ export function initializeCacheHandlers(): boolean {
 }
 
 /**
- * Get a cache handler by kind.
- * @param kind - The kind of cache handler to get.
- * @returns The cache handler, or `undefined` if it is not initialized or does not exist.
- */
-export function getCacheHandler(kind: string): CacheHandlerCompat | undefined {
-  // This should never be called before initializeCacheHandlers.
-  if (!reference[handlersMapSymbol]) {
-    throw new Error('Cache handlers not initialized')
-  }
-
-  return reference[handlersMapSymbol].get(kind)
-}
-
-/**
- * Get an iterator over the cache handlers.
- * @returns An iterator over the cache handlers, or `undefined` if they are not initialized.
+ * Get a set iterator over the cache handlers.
+ * @returns An iterator over the cache handlers, or `undefined` if they are not
+ * initialized.
  */
 export function getCacheHandlers():
   | SetIterator<CacheHandlerCompat>
@@ -120,4 +162,29 @@ export function setCacheHandler(
   debug('setting cache handler for "%s"', kind)
   reference[handlersMapSymbol].set(kind, cacheHandler)
   reference[handlersSetSymbol].add(cacheHandler)
+}
+
+/**
+ * Creates a map of cache handlers for all configured cache handlers that can be
+ * scoped to a work unit. Modern cache handlers are proxied to memoize the
+ * results of `refreshTags`, and `getExpiration` for the given implicit tags
+ * (via `getImplicitTagsExpiration`). Legacy cache handlers are used as-is.
+ */
+export function createScopedCacheHandlers(
+  implicitTags: string[]
+): Map<string, ScopedCacheHandler | CacheHandler> {
+  const cacheHandlers = new Map<string, ScopedCacheHandler | CacheHandler>()
+
+  if (reference[handlersMapSymbol]) {
+    for (const [kind, cacheHandler] of reference[handlersMapSymbol]) {
+      cacheHandlers.set(
+        kind,
+        'refreshTags' in cacheHandler
+          ? new ScopedCacheHandler(cacheHandler, implicitTags)
+          : cacheHandler
+      )
+    }
+  }
+
+  return cacheHandlers
 }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -707,17 +707,14 @@ export function cache(
         const implicitTags = workUnitStore?.implicitTags
         const forceRevalidate = shouldForceRevalidate(workStore, workUnitStore)
 
-        // Lazily refresh the tags for the cache handler that's associated with
-        // this cache function. This is only done once per request and cache
-        // handler, when it's called for the first time.
-        if ('refreshTags' in cacheHandler) {
-          await cacheHandler.refreshTags()
-        }
-
         let entry: CacheEntry | undefined
 
         if (!forceRevalidate) {
           if ('getExpiration' in cacheHandler) {
+            // Lazily refresh the tags for the cache handler. This is only sent
+            // out once per request to the underlying cache handler.
+            await cacheHandler.refreshTags()
+
             const cachedEntry = await cacheHandler.get(serializedCacheKey)
 
             if (cachedEntry) {

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -255,7 +255,7 @@ export async function adapter(
             const requestStore = createRequestStoreForAPI(
               request,
               request.nextUrl,
-              undefined,
+              [],
               onUpdateCookies,
               previewProps
             )

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -13,6 +13,7 @@ import {
   type CachedFetchData,
 } from '../../response-cache'
 import type { UnstableCacheStore } from '../../app-render/work-unit-async-storage.external'
+import { createScopedCacheHandlers } from '../../use-cache/handlers'
 
 type Callback = (...args: any[]) => Promise<any>
 
@@ -142,7 +143,7 @@ export function unstable_cache<T extends Callback>(
       const fetchIdx =
         (workStore ? workStore.nextFetchId : noStoreFetchIdx) ?? 1
 
-      const implicitTags = workUnitStore?.implicitTags
+      const implicitTags = workUnitStore?.implicitTags ?? []
 
       const innerCacheStore: UnstableCacheStore = {
         type: 'unstable-cache',
@@ -152,6 +153,9 @@ export function unstable_cache<T extends Callback>(
           workUnitStore &&
           workStore &&
           getDraftModeProviderForCacheScope(workStore, workUnitStore),
+        cacheHandlers:
+          workUnitStore?.cacheHandlers ??
+          createScopedCacheHandlers(implicitTags),
       }
 
       if (workStore) {
@@ -209,7 +213,7 @@ export function unstable_cache<T extends Callback>(
             kind: IncrementalCacheKind.FETCH,
             revalidate: options.revalidate,
             tags,
-            softTags: implicitTags?.tags,
+            softTags: implicitTags,
             fetchIdx,
             fetchUrl,
           })
@@ -302,7 +306,7 @@ export function unstable_cache<T extends Callback>(
             tags,
             fetchIdx,
             fetchUrl,
-            softTags: implicitTags?.tags,
+            softTags: implicitTags,
           })
 
           if (cacheEntry && cacheEntry.value) {

--- a/test/e2e/app-dir/use-cache-custom-handler/app/no-cache/page.tsx
+++ b/test/e2e/app-dir/use-cache-custom-handler/app/no-cache/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>This page does not use "use cache".</p>
+}

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -164,18 +164,12 @@ describe('use-cache-custom-handler', () => {
     await retry(async () => {
       const cliOutput = next.cliOutput.slice(outputIndex)
       expect(cliOutput).toInclude('ModernCustomCacheHandler::refreshTags')
-      expect(cliOutput).toInclude('ModernCustomCacheHandler::getExpiration')
       expect(cliOutput).not.toInclude('ModernCustomCacheHandler::expireTags')
     })
   })
 
   it('should not call getExpiration after an action', async () => {
     const browser = await next.browser(`/`)
-
-    await retry(async () => {
-      const cliOutput = next.cliOutput.slice(outputIndex)
-      expect(cliOutput).toInclude('ModernCustomCacheHandler::getExpiration')
-    })
 
     outputIndex = next.cliOutput.length
 

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -23,13 +23,9 @@ describe('use-cache-custom-handler', () => {
     const initialData = await browser.elementById('data').text()
     expect(initialData).toMatch(isoDateRegExp)
 
-    expect(next.cliOutput.slice(outputIndex)).toContain(
-      'ModernCustomCacheHandler::refreshTags'
-    )
+    const cliOutput = next.cliOutput.slice(outputIndex)
 
-    expect(next.cliOutput.slice(outputIndex)).toContain(
-      `ModernCustomCacheHandler::getExpiration ["_N_T_/layout","_N_T_/page","_N_T_/"]`
-    )
+    expect(cliOutput).toContain('ModernCustomCacheHandler::refreshTags')
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
       /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
@@ -39,12 +35,25 @@ describe('use-cache-custom-handler', () => {
       /ModernCustomCacheHandler::set \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
     )
 
+    // Since no existing cache entry was retrieved, we don't need to call
+    // getExpiration() to compare the cache entries timestamp with the
+    // expiration of the implicit tags.
+    expect(cliOutput).not.toContain(`ModernCustomCacheHandler::getExpiration`)
+
     // The data should be cached initially.
 
+    outputIndex = next.cliOutput.length
     await browser.refresh()
     let data = await browser.elementById('data').text()
     expect(data).toMatch(isoDateRegExp)
     expect(data).toEqual(initialData)
+
+    // Now that a cache entry exists, we expect that getExpiration() is called
+    // to compare the cache entries timestamp with the expiration of the
+    // implicit tags.
+    expect(next.cliOutput.slice(outputIndex)).toContain(
+      `ModernCustomCacheHandler::getExpiration ["_N_T_/layout","_N_T_/page","_N_T_/"]`
+    )
 
     // Because we use a low `revalidate` value for the "use cache" function, new
     // data should be returned eventually.
@@ -55,6 +64,19 @@ describe('use-cache-custom-handler', () => {
       expect(data).toMatch(isoDateRegExp)
       expect(data).not.toEqual(initialData)
     }, 5000)
+  })
+
+  it('calls neither refreshTags nor getExpiration if "use cache" is not used', async () => {
+    await next.fetch(`/no-cache`)
+    const cliOutput = next.cliOutput.slice(outputIndex)
+
+    expect(cliOutput).not.toContain('ModernCustomCacheHandler::refreshTags')
+    expect(cliOutput).not.toContain(`ModernCustomCacheHandler::getExpiration`)
+
+    // We don't optimize for legacy cache handlers though:
+    expect(cliOutput).toContain(
+      `LegacyCustomCacheHandler::receiveExpiredTags []`
+    )
   })
 
   it('should use a legacy custom cache handler if provided', async () => {
@@ -147,7 +169,7 @@ describe('use-cache-custom-handler', () => {
     })
   })
 
-  it('should not call getExpiration again after an action', async () => {
+  it('should not call getExpiration after an action', async () => {
     const browser = await next.browser(`/`)
 
     await retry(async () => {
@@ -161,10 +183,7 @@ describe('use-cache-custom-handler', () => {
 
     await retry(async () => {
       const cliOutput = next.cliOutput.slice(outputIndex)
-      expect(cliOutput).toIncludeRepeated(
-        'ModernCustomCacheHandler::getExpiration',
-        1
-      )
+      expect(cliOutput).not.toInclude('ModernCustomCacheHandler::getExpiration')
       expect(cliOutput).toIncludeRepeated(
         `ModernCustomCacheHandler::expireTags`,
         1


### PR DESCRIPTION
When `"use cache"` is not used on the current route, we don't need to call `refreshTags` for the configured cache handlers. So instead of calling it at the beginning of the request for every cache handler, we now call it lazily right before the first cache entry is retrieved for the respective cache handler (once per request).

Similarly, we now call `getExpiration` for the implicit tags of the current route lazily (also once per request) after an existing cache entry has been retrieved, and its timestamp needs to be compared with the expiration of the implicit tags.

This PR also fixes a bug where we didn't consider the implicit tags during the warmup render in dev mode.

_This is an alternative implementation of #77779._