### PR TITLE
fix(turbopack-cli): Make turbopack_cli::dev::source a persistent (non-transient) task

### DIFF
--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt::Debug, future::Future, hash::Hash, time::Duration};
+use std::{any::Any, fmt::Debug, future::Future, hash::Hash, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use either::Either;
@@ -86,6 +86,23 @@ where
 
     async fn resolve_input(&self) -> Result<Self> {
         Ok(Box::new(Box::pin(self.as_ref().resolve_input()).await?))
+    }
+}
+
+impl<T> TaskInput for Arc<T>
+where
+    T: TaskInput,
+{
+    fn is_resolved(&self) -> bool {
+        self.as_ref().is_resolved()
+    }
+
+    fn is_transient(&self) -> bool {
+        self.as_ref().is_transient()
+    }
+
+    async fn resolve_input(&self) -> Result<Self> {
+        Ok(Arc::new(Box::pin(self.as_ref().resolve_input()).await?))
     }
 }
 

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -209,7 +209,7 @@ impl TurbopackDevServerBuilder {
             log_detail,
             log_level: self.log_level,
         });
-        let entry_requests = TransientInstance::new(self.entry_requests);
+        let entry_requests = Arc::new(self.entry_requests);
         let tasks = turbo_tasks.clone();
         let issue_provider = self.issue_reporter.unwrap_or_else(|| {
             // Initialize a ConsoleUi reporter if no custom reporter was provided
@@ -220,7 +220,7 @@ impl TurbopackDevServerBuilder {
         struct ServerSourceProvider {
             root_dir: RcStr,
             project_dir: RcStr,
-            entry_requests: TransientInstance<Vec<EntryRequest>>,
+            entry_requests: Arc<Vec<EntryRequest>>,
             eager_compile: bool,
             browserslist_query: RcStr,
         }
@@ -252,7 +252,7 @@ impl TurbopackDevServerBuilder {
 async fn source(
     root_dir: RcStr,
     project_dir: RcStr,
-    entry_requests: TransientInstance<Vec<EntryRequest>>,
+    entry_requests: Arc<Vec<EntryRequest>>,
     eager_compile: bool,
     browserslist_query: RcStr,
 ) -> Result<Vc<Box<dyn ContentSource>>> {


### PR DESCRIPTION
This was identified using the extra checks in #77760 and debugged using the tracing in #77798.

![Screenshot 2025-04-03 at 1.30.53 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/a576884b-f8ab-4266-b9df-916e9733bc85.png)

Closes PACK-4280