### PR TITLE
[test] fix bad test fixuture for perf test

### DIFF
--- a/test/e2e/pages-performance-mark/pages/_document.js
+++ b/test/e2e/pages-performance-mark/pages/_document.js
@@ -4,7 +4,6 @@ export default function Document() {
   return (
     <Html>
       <Head />
-      <Head />
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
### What

Notice the test failing with error
```
[Error: The `<head>` tag may only be rendered once.]
Error occurred prerendering page "/404". Read more: https://nextjs.org/docs/messages/prerender-error
Error: The `<head>` tag may only be rendered once.
    at pushStartInstance (/private/var/folders/wv/xyy9xyz10sl4twdx_hp25mjc0000gn/T/next-install-774bc5a37376114
1677200de6e06e9fd9908f6aa5d9bf1124d02f79d153de089/node_modules/.pnpm/react-dom@19.1.0_react@19.1.0/node_modules
/react-dom/cjs/react-dom-server.edge.production.js:2161:17)
```
Turns out we had an extra `<head>` in the html