### PR TITLE
Remove canary-gate and add experimental warning for alternate bundler

### DIFF
--- a/packages/next-rspack/README.md
+++ b/packages/next-rspack/README.md
@@ -1,7 +1,7 @@
 # next-rspack (EXPERIMENTAL)
 
 > [!WARNING]
-> This package is currently experimental and actively developed and supported in Next.js’ `canary` branch. To use this, you must be using a published canary build of Next.js.
+> This package is currently experimental. It's not an official Next.js plugin, and is supported by the Rspack team in partnership with Next.js. Help improve Next.js and Rspack by providing feedback at https://github.com/vercel/next.js/discussions/77800
 
 This plugin allows you to use [Rspack](https://rspack.dev) in place of webpack with Next.js.
 

--- a/packages/next-rspack/package.json
+++ b/packages/next-rspack/package.json
@@ -3,7 +3,7 @@
   "version": "15.3.0-canary.41",
   "repository": {
     "url": "vercel/next.js",
-    "directory": "packages/next-plugin-rspack"
+    "directory": "packages/next-rspack"
   },
   "types": "index.d.ts",
   "dependencies": {

--- a/packages/next/src/shared/lib/get-rspack.ts
+++ b/packages/next/src/shared/lib/get-rspack.ts
@@ -1,7 +1,7 @@
-import { CanaryOnlyError, isStableBuild } from './canary-only'
+import { warnOnce } from '../../build/output/log'
 
 export function getRspackCore() {
-  gateCanary()
+  warnRspack()
   try {
     // eslint-disable-next-line import/no-extraneous-dependencies
     return require('@rspack/core')
@@ -17,7 +17,7 @@ export function getRspackCore() {
 }
 
 export function getRspackReactRefresh() {
-  gateCanary()
+  warnRspack()
   try {
     // eslint-disable-next-line import/no-extraneous-dependencies
     const plugin = require('@rspack/plugin-react-refresh')
@@ -37,10 +37,8 @@ export function getRspackReactRefresh() {
   }
 }
 
-function gateCanary() {
-  if (isStableBuild()) {
-    throw new CanaryOnlyError(
-      'Rspack support is only available in Next.js canary.'
-    )
-  }
+function warnRspack() {
+  warnOnce(
+    `\`next-rspack\` is currently experimental. It's not an official Next.js plugin, and is supported by the Rspack team in partnership with Next.js. Help improve Next.js and Rspack by providing feedback at https://github.com/vercel/next.js/discussions/77800`
+  )
 }


### PR DESCRIPTION
This:
- Removes the Rspack canary gate
- Adds a warning that Rspack support is driven by the community and is experimental.
- Links to the discussion page for feedback

Test Plan: Installed and used in an app. Verified the link is valid.


Closes PACK-4286