### PR TITLE
[dev-overlay] Read `issueCount` from non-async `errors` array

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/render-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/render-error.tsx
@@ -108,7 +108,12 @@ const RenderRuntimeError = ({ children, state, isAppDir }: Props) => {
     }
   }, [nextError, isAppDir])
 
-  const totalErrorCount = runtimeErrors.length
+  const totalErrorCount = errors.filter((err, idx) => {
+    const prev = errors[idx - 1]
+    // Check for duplicates
+    if (idx > 0) return getErrorSignature(prev) !== getErrorSignature(err)
+    return true
+  }).length
 
   return children({ runtimeErrors, totalErrorCount })
 }


### PR DESCRIPTION
This PR improves how we read the `issueCount` property for the Next.js Dev Indicator. Data for `runtimeErrors` is loaded in batches so the error count also jumps with it, but really we should be able to determine how many errors are going to be displayed _before_ the data loads for all of them.

Before the changes the issue count was very volatile, leading to UI jank as the errors data loads in:


https://github.com/user-attachments/assets/86b99053-303c-46d7-b097-f687fa3b2756


After the changes we still load the errors in batches, but the issue count is stable:


https://github.com/user-attachments/assets/fd9d14ae-6a01-446f-bc3c-66b2f64c9720

