### PR TITLE
Revert "[next-lint] test: remove eslint config snapshot testing"

### DIFF
--- a/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
+++ b/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
@@ -1,0 +1,1073 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Next Build production mode first time setup - ESLint v8 1`] = `
+{
+  "env": {
+    "browser": true,
+    "node": true,
+  },
+  "globals": {},
+  "ignorePatterns": [],
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "babelOptions": {
+      "caller": {
+        "supportsTopLevelAwait": true,
+      },
+      "presets": [
+        "next/babel",
+      ],
+    },
+    "ecmaFeatures": {
+      "jsx": true,
+    },
+    "requireConfigFile": false,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "react-hooks",
+    "jsx-a11y",
+    "react",
+    "import",
+    "@next/next",
+  ],
+  "rules": {
+    "@next/next/google-font-display": [
+      "warn",
+    ],
+    "@next/next/google-font-preconnect": [
+      "warn",
+    ],
+    "@next/next/inline-script-id": [
+      "error",
+    ],
+    "@next/next/next-script-for-ga": [
+      "warn",
+    ],
+    "@next/next/no-assign-module-variable": [
+      "error",
+    ],
+    "@next/next/no-async-client-component": [
+      "warn",
+    ],
+    "@next/next/no-before-interactive-script-outside-document": [
+      "warn",
+    ],
+    "@next/next/no-css-tags": [
+      "warn",
+    ],
+    "@next/next/no-document-import-in-page": [
+      "error",
+    ],
+    "@next/next/no-duplicate-head": [
+      "error",
+    ],
+    "@next/next/no-head-element": [
+      "warn",
+    ],
+    "@next/next/no-head-import-in-document": [
+      "error",
+    ],
+    "@next/next/no-html-link-for-pages": [
+      "error",
+    ],
+    "@next/next/no-img-element": [
+      "warn",
+    ],
+    "@next/next/no-page-custom-font": [
+      "warn",
+    ],
+    "@next/next/no-script-component-in-head": [
+      "error",
+    ],
+    "@next/next/no-styled-jsx-in-document": [
+      "warn",
+    ],
+    "@next/next/no-sync-scripts": [
+      "error",
+    ],
+    "@next/next/no-title-in-document-head": [
+      "warn",
+    ],
+    "@next/next/no-typos": [
+      "warn",
+    ],
+    "@next/next/no-unwanted-polyfillio": [
+      "warn",
+    ],
+    "import/no-anonymous-default-export": [
+      "warn",
+    ],
+    "jsx-a11y/alt-text": [
+      "warn",
+      {
+        "elements": [
+          "img",
+        ],
+        "img": [
+          "Image",
+        ],
+      },
+    ],
+    "jsx-a11y/aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/aria-proptypes": [
+      "warn",
+    ],
+    "jsx-a11y/aria-unsupported-elements": [
+      "warn",
+    ],
+    "jsx-a11y/role-has-required-aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/role-supports-aria-props": [
+      "warn",
+    ],
+    "react-hooks/exhaustive-deps": [
+      "warn",
+    ],
+    "react-hooks/rules-of-hooks": [
+      "error",
+    ],
+    "react/display-name": [
+      2,
+    ],
+    "react/jsx-key": [
+      2,
+    ],
+    "react/jsx-no-comment-textnodes": [
+      2,
+    ],
+    "react/jsx-no-duplicate-props": [
+      2,
+    ],
+    "react/jsx-no-target-blank": [
+      "off",
+    ],
+    "react/jsx-no-undef": [
+      2,
+    ],
+    "react/jsx-uses-react": [
+      2,
+    ],
+    "react/jsx-uses-vars": [
+      2,
+    ],
+    "react/no-children-prop": [
+      2,
+    ],
+    "react/no-danger-with-children": [
+      2,
+    ],
+    "react/no-deprecated": [
+      2,
+    ],
+    "react/no-direct-mutation-state": [
+      2,
+    ],
+    "react/no-find-dom-node": [
+      2,
+    ],
+    "react/no-is-mounted": [
+      2,
+    ],
+    "react/no-render-return-value": [
+      2,
+    ],
+    "react/no-string-refs": [
+      2,
+    ],
+    "react/no-unescaped-entities": [
+      2,
+    ],
+    "react/no-unknown-property": [
+      "off",
+    ],
+    "react/no-unsafe": [
+      0,
+    ],
+    "react/prop-types": [
+      "off",
+    ],
+    "react/react-in-jsx-scope": [
+      "off",
+    ],
+    "react/require-render-return": [
+      2,
+    ],
+  },
+}
+`;
+
+exports[`Next Build production mode first time setup - ESLint v9 1`] = `
+{
+  "env": {
+    "browser": true,
+    "node": true,
+  },
+  "globals": {},
+  "ignorePatterns": [],
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "babelOptions": {
+      "caller": {
+        "supportsTopLevelAwait": true,
+      },
+      "presets": [
+        "next/babel",
+      ],
+    },
+    "ecmaFeatures": {
+      "jsx": true,
+    },
+    "requireConfigFile": false,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "react-hooks",
+    "jsx-a11y",
+    "react",
+    "import",
+    "@next/next",
+  ],
+  "rules": {
+    "@next/next/google-font-display": [
+      "warn",
+    ],
+    "@next/next/google-font-preconnect": [
+      "warn",
+    ],
+    "@next/next/inline-script-id": [
+      "error",
+    ],
+    "@next/next/next-script-for-ga": [
+      "warn",
+    ],
+    "@next/next/no-assign-module-variable": [
+      "error",
+    ],
+    "@next/next/no-async-client-component": [
+      "warn",
+    ],
+    "@next/next/no-before-interactive-script-outside-document": [
+      "warn",
+    ],
+    "@next/next/no-css-tags": [
+      "warn",
+    ],
+    "@next/next/no-document-import-in-page": [
+      "error",
+    ],
+    "@next/next/no-duplicate-head": [
+      "error",
+    ],
+    "@next/next/no-head-element": [
+      "warn",
+    ],
+    "@next/next/no-head-import-in-document": [
+      "error",
+    ],
+    "@next/next/no-html-link-for-pages": [
+      "error",
+    ],
+    "@next/next/no-img-element": [
+      "warn",
+    ],
+    "@next/next/no-page-custom-font": [
+      "warn",
+    ],
+    "@next/next/no-script-component-in-head": [
+      "error",
+    ],
+    "@next/next/no-styled-jsx-in-document": [
+      "warn",
+    ],
+    "@next/next/no-sync-scripts": [
+      "error",
+    ],
+    "@next/next/no-title-in-document-head": [
+      "warn",
+    ],
+    "@next/next/no-typos": [
+      "warn",
+    ],
+    "@next/next/no-unwanted-polyfillio": [
+      "warn",
+    ],
+    "import/no-anonymous-default-export": [
+      "warn",
+    ],
+    "jsx-a11y/alt-text": [
+      "warn",
+      {
+        "elements": [
+          "img",
+        ],
+        "img": [
+          "Image",
+        ],
+      },
+    ],
+    "jsx-a11y/aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/aria-proptypes": [
+      "warn",
+    ],
+    "jsx-a11y/aria-unsupported-elements": [
+      "warn",
+    ],
+    "jsx-a11y/role-has-required-aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/role-supports-aria-props": [
+      "warn",
+    ],
+    "react-hooks/exhaustive-deps": [
+      "warn",
+    ],
+    "react-hooks/rules-of-hooks": [
+      "error",
+    ],
+    "react/display-name": [
+      2,
+    ],
+    "react/jsx-key": [
+      2,
+    ],
+    "react/jsx-no-comment-textnodes": [
+      2,
+    ],
+    "react/jsx-no-duplicate-props": [
+      2,
+    ],
+    "react/jsx-no-target-blank": [
+      "off",
+    ],
+    "react/jsx-no-undef": [
+      2,
+    ],
+    "react/jsx-uses-react": [
+      2,
+    ],
+    "react/jsx-uses-vars": [
+      2,
+    ],
+    "react/no-children-prop": [
+      2,
+    ],
+    "react/no-danger-with-children": [
+      2,
+    ],
+    "react/no-deprecated": [
+      2,
+    ],
+    "react/no-direct-mutation-state": [
+      2,
+    ],
+    "react/no-find-dom-node": [
+      2,
+    ],
+    "react/no-is-mounted": [
+      2,
+    ],
+    "react/no-render-return-value": [
+      2,
+    ],
+    "react/no-string-refs": [
+      2,
+    ],
+    "react/no-unescaped-entities": [
+      2,
+    ],
+    "react/no-unknown-property": [
+      "off",
+    ],
+    "react/no-unsafe": [
+      0,
+    ],
+    "react/prop-types": [
+      "off",
+    ],
+    "react/react-in-jsx-scope": [
+      "off",
+    ],
+    "react/require-render-return": [
+      2,
+    ],
+  },
+}
+`;
+
+exports[`Next Build production mode first time setup with TypeScript - ESLint v8 1`] = `
+{
+  "env": {
+    "browser": true,
+    "node": true,
+  },
+  "globals": {},
+  "ignorePatterns": [],
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "babelOptions": {
+      "caller": {
+        "supportsTopLevelAwait": true,
+      },
+      "presets": [
+        "next/babel",
+      ],
+    },
+    "ecmaFeatures": {
+      "jsx": true,
+    },
+    "requireConfigFile": false,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "react-hooks",
+    "jsx-a11y",
+    "react",
+    "import",
+    "@next/next",
+    "@typescript-eslint",
+  ],
+  "rules": {
+    "@next/next/google-font-display": [
+      "warn",
+    ],
+    "@next/next/google-font-preconnect": [
+      "warn",
+    ],
+    "@next/next/inline-script-id": [
+      "error",
+    ],
+    "@next/next/next-script-for-ga": [
+      "warn",
+    ],
+    "@next/next/no-assign-module-variable": [
+      "error",
+    ],
+    "@next/next/no-async-client-component": [
+      "warn",
+    ],
+    "@next/next/no-before-interactive-script-outside-document": [
+      "warn",
+    ],
+    "@next/next/no-css-tags": [
+      "warn",
+    ],
+    "@next/next/no-document-import-in-page": [
+      "error",
+    ],
+    "@next/next/no-duplicate-head": [
+      "error",
+    ],
+    "@next/next/no-head-element": [
+      "warn",
+    ],
+    "@next/next/no-head-import-in-document": [
+      "error",
+    ],
+    "@next/next/no-html-link-for-pages": [
+      "error",
+    ],
+    "@next/next/no-img-element": [
+      "warn",
+    ],
+    "@next/next/no-page-custom-font": [
+      "warn",
+    ],
+    "@next/next/no-script-component-in-head": [
+      "error",
+    ],
+    "@next/next/no-styled-jsx-in-document": [
+      "warn",
+    ],
+    "@next/next/no-sync-scripts": [
+      "error",
+    ],
+    "@next/next/no-title-in-document-head": [
+      "warn",
+    ],
+    "@next/next/no-typos": [
+      "warn",
+    ],
+    "@next/next/no-unwanted-polyfillio": [
+      "warn",
+    ],
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+    ],
+    "@typescript-eslint/no-array-constructor": [
+      "error",
+    ],
+    "@typescript-eslint/no-duplicate-enum-values": [
+      "error",
+    ],
+    "@typescript-eslint/no-empty-object-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-explicit-any": [
+      "error",
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [
+      "error",
+    ],
+    "@typescript-eslint/no-misused-new": [
+      "error",
+    ],
+    "@typescript-eslint/no-namespace": [
+      "error",
+    ],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [
+      "error",
+    ],
+    "@typescript-eslint/no-require-imports": [
+      "error",
+    ],
+    "@typescript-eslint/no-this-alias": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-type-constraint": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-declaration-merging": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-function-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+    ],
+    "@typescript-eslint/no-wrapper-object-types": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-as-const": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-namespace-keyword": [
+      "error",
+    ],
+    "@typescript-eslint/triple-slash-reference": [
+      "error",
+    ],
+    "constructor-super": [
+      "off",
+    ],
+    "getter-return": [
+      "off",
+    ],
+    "import/no-anonymous-default-export": [
+      "warn",
+    ],
+    "jsx-a11y/alt-text": [
+      "warn",
+      {
+        "elements": [
+          "img",
+        ],
+        "img": [
+          "Image",
+        ],
+      },
+    ],
+    "jsx-a11y/aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/aria-proptypes": [
+      "warn",
+    ],
+    "jsx-a11y/aria-unsupported-elements": [
+      "warn",
+    ],
+    "jsx-a11y/role-has-required-aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/role-supports-aria-props": [
+      "warn",
+    ],
+    "no-array-constructor": [
+      "off",
+    ],
+    "no-class-assign": [
+      "off",
+    ],
+    "no-const-assign": [
+      "off",
+    ],
+    "no-dupe-args": [
+      "off",
+    ],
+    "no-dupe-class-members": [
+      "off",
+    ],
+    "no-dupe-keys": [
+      "off",
+    ],
+    "no-func-assign": [
+      "off",
+    ],
+    "no-import-assign": [
+      "off",
+    ],
+    "no-new-native-nonconstructor": [
+      "off",
+    ],
+    "no-new-symbol": [
+      "off",
+    ],
+    "no-obj-calls": [
+      "off",
+    ],
+    "no-redeclare": [
+      "off",
+    ],
+    "no-setter-return": [
+      "off",
+    ],
+    "no-this-before-super": [
+      "off",
+    ],
+    "no-undef": [
+      "off",
+    ],
+    "no-unreachable": [
+      "off",
+    ],
+    "no-unsafe-negation": [
+      "off",
+    ],
+    "no-unused-expressions": [
+      "off",
+    ],
+    "no-unused-vars": [
+      "off",
+    ],
+    "no-var": [
+      "error",
+    ],
+    "prefer-const": [
+      "error",
+    ],
+    "prefer-rest-params": [
+      "error",
+    ],
+    "prefer-spread": [
+      "error",
+    ],
+    "react-hooks/exhaustive-deps": [
+      "warn",
+    ],
+    "react-hooks/rules-of-hooks": [
+      "error",
+    ],
+    "react/display-name": [
+      2,
+    ],
+    "react/jsx-key": [
+      2,
+    ],
+    "react/jsx-no-comment-textnodes": [
+      2,
+    ],
+    "react/jsx-no-duplicate-props": [
+      2,
+    ],
+    "react/jsx-no-target-blank": [
+      "off",
+    ],
+    "react/jsx-no-undef": [
+      2,
+    ],
+    "react/jsx-uses-react": [
+      2,
+    ],
+    "react/jsx-uses-vars": [
+      2,
+    ],
+    "react/no-children-prop": [
+      2,
+    ],
+    "react/no-danger-with-children": [
+      2,
+    ],
+    "react/no-deprecated": [
+      2,
+    ],
+    "react/no-direct-mutation-state": [
+      2,
+    ],
+    "react/no-find-dom-node": [
+      2,
+    ],
+    "react/no-is-mounted": [
+      2,
+    ],
+    "react/no-render-return-value": [
+      2,
+    ],
+    "react/no-string-refs": [
+      2,
+    ],
+    "react/no-unescaped-entities": [
+      2,
+    ],
+    "react/no-unknown-property": [
+      "off",
+    ],
+    "react/no-unsafe": [
+      0,
+    ],
+    "react/prop-types": [
+      "off",
+    ],
+    "react/react-in-jsx-scope": [
+      "off",
+    ],
+    "react/require-render-return": [
+      2,
+    ],
+  },
+}
+`;
+
+exports[`Next Build production mode first time setup with TypeScript - ESLint v9 1`] = `
+{
+  "env": {
+    "browser": true,
+    "node": true,
+  },
+  "globals": {},
+  "ignorePatterns": [],
+  "parserOptions": {
+    "allowImportExportEverywhere": true,
+    "babelOptions": {
+      "caller": {
+        "supportsTopLevelAwait": true,
+      },
+      "presets": [
+        "next/babel",
+      ],
+    },
+    "ecmaFeatures": {
+      "jsx": true,
+    },
+    "requireConfigFile": false,
+    "sourceType": "module",
+  },
+  "plugins": [
+    "react-hooks",
+    "jsx-a11y",
+    "react",
+    "import",
+    "@next/next",
+    "@typescript-eslint",
+  ],
+  "rules": {
+    "@next/next/google-font-display": [
+      "warn",
+    ],
+    "@next/next/google-font-preconnect": [
+      "warn",
+    ],
+    "@next/next/inline-script-id": [
+      "error",
+    ],
+    "@next/next/next-script-for-ga": [
+      "warn",
+    ],
+    "@next/next/no-assign-module-variable": [
+      "error",
+    ],
+    "@next/next/no-async-client-component": [
+      "warn",
+    ],
+    "@next/next/no-before-interactive-script-outside-document": [
+      "warn",
+    ],
+    "@next/next/no-css-tags": [
+      "warn",
+    ],
+    "@next/next/no-document-import-in-page": [
+      "error",
+    ],
+    "@next/next/no-duplicate-head": [
+      "error",
+    ],
+    "@next/next/no-head-element": [
+      "warn",
+    ],
+    "@next/next/no-head-import-in-document": [
+      "error",
+    ],
+    "@next/next/no-html-link-for-pages": [
+      "error",
+    ],
+    "@next/next/no-img-element": [
+      "warn",
+    ],
+    "@next/next/no-page-custom-font": [
+      "warn",
+    ],
+    "@next/next/no-script-component-in-head": [
+      "error",
+    ],
+    "@next/next/no-styled-jsx-in-document": [
+      "warn",
+    ],
+    "@next/next/no-sync-scripts": [
+      "error",
+    ],
+    "@next/next/no-title-in-document-head": [
+      "warn",
+    ],
+    "@next/next/no-typos": [
+      "warn",
+    ],
+    "@next/next/no-unwanted-polyfillio": [
+      "warn",
+    ],
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+    ],
+    "@typescript-eslint/no-array-constructor": [
+      "error",
+    ],
+    "@typescript-eslint/no-duplicate-enum-values": [
+      "error",
+    ],
+    "@typescript-eslint/no-empty-object-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-explicit-any": [
+      "error",
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [
+      "error",
+    ],
+    "@typescript-eslint/no-misused-new": [
+      "error",
+    ],
+    "@typescript-eslint/no-namespace": [
+      "error",
+    ],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [
+      "error",
+    ],
+    "@typescript-eslint/no-require-imports": [
+      "error",
+    ],
+    "@typescript-eslint/no-this-alias": [
+      "error",
+    ],
+    "@typescript-eslint/no-unnecessary-type-constraint": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-declaration-merging": [
+      "error",
+    ],
+    "@typescript-eslint/no-unsafe-function-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+    ],
+    "@typescript-eslint/no-wrapper-object-types": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-as-const": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-namespace-keyword": [
+      "error",
+    ],
+    "@typescript-eslint/triple-slash-reference": [
+      "error",
+    ],
+    "constructor-super": [
+      "off",
+    ],
+    "getter-return": [
+      "off",
+    ],
+    "import/no-anonymous-default-export": [
+      "warn",
+    ],
+    "jsx-a11y/alt-text": [
+      "warn",
+      {
+        "elements": [
+          "img",
+        ],
+        "img": [
+          "Image",
+        ],
+      },
+    ],
+    "jsx-a11y/aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/aria-proptypes": [
+      "warn",
+    ],
+    "jsx-a11y/aria-unsupported-elements": [
+      "warn",
+    ],
+    "jsx-a11y/role-has-required-aria-props": [
+      "warn",
+    ],
+    "jsx-a11y/role-supports-aria-props": [
+      "warn",
+    ],
+    "no-array-constructor": [
+      "off",
+    ],
+    "no-class-assign": [
+      "off",
+    ],
+    "no-const-assign": [
+      "off",
+    ],
+    "no-dupe-args": [
+      "off",
+    ],
+    "no-dupe-class-members": [
+      "off",
+    ],
+    "no-dupe-keys": [
+      "off",
+    ],
+    "no-func-assign": [
+      "off",
+    ],
+    "no-import-assign": [
+      "off",
+    ],
+    "no-new-native-nonconstructor": [
+      "off",
+    ],
+    "no-new-symbol": [
+      "off",
+    ],
+    "no-obj-calls": [
+      "off",
+    ],
+    "no-redeclare": [
+      "off",
+    ],
+    "no-setter-return": [
+      "off",
+    ],
+    "no-this-before-super": [
+      "off",
+    ],
+    "no-undef": [
+      "off",
+    ],
+    "no-unreachable": [
+      "off",
+    ],
+    "no-unsafe-negation": [
+      "off",
+    ],
+    "no-unused-expressions": [
+      "off",
+    ],
+    "no-unused-vars": [
+      "off",
+    ],
+    "no-var": [
+      "error",
+    ],
+    "prefer-const": [
+      "error",
+    ],
+    "prefer-rest-params": [
+      "error",
+    ],
+    "prefer-spread": [
+      "error",
+    ],
+    "react-hooks/exhaustive-deps": [
+      "warn",
+    ],
+    "react-hooks/rules-of-hooks": [
+      "error",
+    ],
+    "react/display-name": [
+      2,
+    ],
+    "react/jsx-key": [
+      2,
+    ],
+    "react/jsx-no-comment-textnodes": [
+      2,
+    ],
+    "react/jsx-no-duplicate-props": [
+      2,
+    ],
+    "react/jsx-no-target-blank": [
+      "off",
+    ],
+    "react/jsx-no-undef": [
+      2,
+    ],
+    "react/jsx-uses-react": [
+      2,
+    ],
+    "react/jsx-uses-vars": [
+      2,
+    ],
+    "react/no-children-prop": [
+      2,
+    ],
+    "react/no-danger-with-children": [
+      2,
+    ],
+    "react/no-deprecated": [
+      2,
+    ],
+    "react/no-direct-mutation-state": [
+      2,
+    ],
+    "react/no-find-dom-node": [
+      2,
+    ],
+    "react/no-is-mounted": [
+      2,
+    ],
+    "react/no-render-return-value": [
+      2,
+    ],
+    "react/no-string-refs": [
+      2,
+    ],
+    "react/no-unescaped-entities": [
+      2,
+    ],
+    "react/no-unknown-property": [
+      "off",
+    ],
+    "react/no-unsafe": [
+      0,
+    ],
+    "react/prop-types": [
+      "off",
+    ],
+    "react/react-in-jsx-scope": [
+      "off",
+    ],
+    "react/require-render-return": [
+      2,
+    ],
+  },
+}
+`;

--- a/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
+++ b/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
@@ -142,9 +142,6 @@ exports[`Next Build production mode first time setup - ESLint v8 1`] = `
     "react/jsx-no-duplicate-props": [
       2,
     ],
-    "react/jsx-no-target-blank": [
-      "off",
-    ],
     "react/jsx-no-undef": [
       2,
     ],
@@ -180,18 +177,6 @@ exports[`Next Build production mode first time setup - ESLint v8 1`] = `
     ],
     "react/no-unescaped-entities": [
       2,
-    ],
-    "react/no-unknown-property": [
-      "off",
-    ],
-    "react/no-unsafe": [
-      0,
-    ],
-    "react/prop-types": [
-      "off",
-    ],
-    "react/react-in-jsx-scope": [
-      "off",
     ],
     "react/require-render-return": [
       2,
@@ -342,9 +327,6 @@ exports[`Next Build production mode first time setup - ESLint v9 1`] = `
     "react/jsx-no-duplicate-props": [
       2,
     ],
-    "react/jsx-no-target-blank": [
-      "off",
-    ],
     "react/jsx-no-undef": [
       2,
     ],
@@ -380,18 +362,6 @@ exports[`Next Build production mode first time setup - ESLint v9 1`] = `
     ],
     "react/no-unescaped-entities": [
       2,
-    ],
-    "react/no-unknown-property": [
-      "off",
-    ],
-    "react/no-unsafe": [
-      0,
-    ],
-    "react/prop-types": [
-      "off",
-    ],
-    "react/react-in-jsx-scope": [
-      "off",
     ],
     "react/require-render-return": [
       2,
@@ -556,12 +526,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
     "@typescript-eslint/triple-slash-reference": [
       "error",
     ],
-    "constructor-super": [
-      "off",
-    ],
-    "getter-return": [
-      "off",
-    ],
     "import/no-anonymous-default-export": [
       "warn",
     ],
@@ -590,63 +554,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
     ],
     "jsx-a11y/role-supports-aria-props": [
       "warn",
-    ],
-    "no-array-constructor": [
-      "off",
-    ],
-    "no-class-assign": [
-      "off",
-    ],
-    "no-const-assign": [
-      "off",
-    ],
-    "no-dupe-args": [
-      "off",
-    ],
-    "no-dupe-class-members": [
-      "off",
-    ],
-    "no-dupe-keys": [
-      "off",
-    ],
-    "no-func-assign": [
-      "off",
-    ],
-    "no-import-assign": [
-      "off",
-    ],
-    "no-new-native-nonconstructor": [
-      "off",
-    ],
-    "no-new-symbol": [
-      "off",
-    ],
-    "no-obj-calls": [
-      "off",
-    ],
-    "no-redeclare": [
-      "off",
-    ],
-    "no-setter-return": [
-      "off",
-    ],
-    "no-this-before-super": [
-      "off",
-    ],
-    "no-undef": [
-      "off",
-    ],
-    "no-unreachable": [
-      "off",
-    ],
-    "no-unsafe-negation": [
-      "off",
-    ],
-    "no-unused-expressions": [
-      "off",
-    ],
-    "no-unused-vars": [
-      "off",
     ],
     "no-var": [
       "error",
@@ -677,9 +584,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
     ],
     "react/jsx-no-duplicate-props": [
       2,
-    ],
-    "react/jsx-no-target-blank": [
-      "off",
     ],
     "react/jsx-no-undef": [
       2,
@@ -716,18 +620,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
     ],
     "react/no-unescaped-entities": [
       2,
-    ],
-    "react/no-unknown-property": [
-      "off",
-    ],
-    "react/no-unsafe": [
-      0,
-    ],
-    "react/prop-types": [
-      "off",
-    ],
-    "react/react-in-jsx-scope": [
-      "off",
     ],
     "react/require-render-return": [
       2,
@@ -892,12 +784,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
     "@typescript-eslint/triple-slash-reference": [
       "error",
     ],
-    "constructor-super": [
-      "off",
-    ],
-    "getter-return": [
-      "off",
-    ],
     "import/no-anonymous-default-export": [
       "warn",
     ],
@@ -926,63 +812,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
     ],
     "jsx-a11y/role-supports-aria-props": [
       "warn",
-    ],
-    "no-array-constructor": [
-      "off",
-    ],
-    "no-class-assign": [
-      "off",
-    ],
-    "no-const-assign": [
-      "off",
-    ],
-    "no-dupe-args": [
-      "off",
-    ],
-    "no-dupe-class-members": [
-      "off",
-    ],
-    "no-dupe-keys": [
-      "off",
-    ],
-    "no-func-assign": [
-      "off",
-    ],
-    "no-import-assign": [
-      "off",
-    ],
-    "no-new-native-nonconstructor": [
-      "off",
-    ],
-    "no-new-symbol": [
-      "off",
-    ],
-    "no-obj-calls": [
-      "off",
-    ],
-    "no-redeclare": [
-      "off",
-    ],
-    "no-setter-return": [
-      "off",
-    ],
-    "no-this-before-super": [
-      "off",
-    ],
-    "no-undef": [
-      "off",
-    ],
-    "no-unreachable": [
-      "off",
-    ],
-    "no-unsafe-negation": [
-      "off",
-    ],
-    "no-unused-expressions": [
-      "off",
-    ],
-    "no-unused-vars": [
-      "off",
     ],
     "no-var": [
       "error",
@@ -1013,9 +842,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
     ],
     "react/jsx-no-duplicate-props": [
       2,
-    ],
-    "react/jsx-no-target-blank": [
-      "off",
     ],
     "react/jsx-no-undef": [
       2,
@@ -1052,18 +878,6 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
     ],
     "react/no-unescaped-entities": [
       2,
-    ],
-    "react/no-unknown-property": [
-      "off",
-    ],
-    "react/no-unsafe": [
-      0,
-    ],
-    "react/prop-types": [
-      "off",
-    ],
-    "react/react-in-jsx-scope": [
-      "off",
     ],
     "react/require-render-return": [
       2,

--- a/test/production/eslint/test/next-build-and-lint.test.ts
+++ b/test/production/eslint/test/next-build-and-lint.test.ts
@@ -54,7 +54,9 @@ describe('Next Build', () => {
             eslintConfigAfterSetupJSON
           )
 
-          expect(eslintConfigAfterSetup).toMatchSnapshot()
+          expect(
+            getEslintConfigSnapshot(eslintConfigAfterSetup)
+          ).toMatchSnapshot()
           expect({
             parser,
             settings,
@@ -137,7 +139,9 @@ describe('Next Build', () => {
             eslintConfigAfterSetupJSON
           )
 
-          expect(eslintConfigAfterSetup).toMatchSnapshot()
+          expect(
+            getEslintConfigSnapshot(eslintConfigAfterSetup)
+          ).toMatchSnapshot()
           expect({
             parser,
             settings,
@@ -218,7 +222,9 @@ describe('Next Build', () => {
             eslintConfigAfterSetupJSON
           )
 
-          expect(eslintConfigAfterSetup).toMatchSnapshot()
+          expect(
+            getEslintConfigSnapshot(eslintConfigAfterSetup)
+          ).toMatchSnapshot()
           expect({
             parser,
             settings,
@@ -301,7 +307,9 @@ describe('Next Build', () => {
             eslintConfigAfterSetupJSON
           )
 
-          expect(eslintConfigAfterSetup).toMatchSnapshot()
+          expect(
+            getEslintConfigSnapshot(eslintConfigAfterSetup)
+          ).toMatchSnapshot()
           expect({
             parser,
             settings,
@@ -342,3 +350,23 @@ describe('Next Build', () => {
     }
   )
 })
+
+/**
+ * Rules being turned off (i.e. remove from snapshot) would be breaking change (requires removal of eslint-disable directive)
+ * Rules being added that are turned off would not be a breaking change (no eslint-disable directive required)
+ * Rules being added with a severity would be a breaking change (requires addition of eslint-disable directive)
+ */
+function getEslintConfigSnapshot(eslintConfig: any) {
+  return {
+    ...eslintConfig,
+    rules: Object.fromEntries(
+      Object.entries(eslintConfig.rules).filter(
+        ([, config]: [ruleName: string, config: [severity: unknown]]) => {
+          const [severity] = config
+
+          return severity !== 0 && severity !== 'off'
+        }
+      )
+    ),
+  }
+}

--- a/test/production/eslint/test/next-build-and-lint.test.ts
+++ b/test/production/eslint/test/next-build-and-lint.test.ts
@@ -50,24 +50,17 @@ describe('Next Build', () => {
               stdio: ['pipe', 'pipe', 'inherit'],
             }
           )
-          const { parser, plugins, settings } = JSON.parse(
+          const { parser, settings, ...eslintConfigAfterSetup } = JSON.parse(
             eslintConfigAfterSetupJSON
           )
 
+          expect(eslintConfigAfterSetup).toMatchSnapshot()
           expect({
             parser,
-            plugins,
             settings,
           }).toEqual({
             // parser: require.resolve('eslint-config-next')
             parser: expect.stringContaining('eslint-config-next'),
-            plugins: [
-              'react-hooks',
-              'jsx-a11y',
-              'react',
-              'import',
-              '@next/next',
-            ],
             settings: {
               'import/parsers': expect.any(Object),
               'import/resolver': expect.any(Object),
@@ -140,24 +133,17 @@ describe('Next Build', () => {
               stdio: ['pipe', 'pipe', 'inherit'],
             }
           )
-          const { parser, plugins, settings } = JSON.parse(
+          const { parser, settings, ...eslintConfigAfterSetup } = JSON.parse(
             eslintConfigAfterSetupJSON
           )
 
+          expect(eslintConfigAfterSetup).toMatchSnapshot()
           expect({
             parser,
-            plugins,
             settings,
           }).toEqual({
             // parser: require.resolve('eslint-config-next')
             parser: expect.stringContaining('eslint-config-next'),
-            plugins: [
-              'react-hooks',
-              'jsx-a11y',
-              'react',
-              'import',
-              '@next/next',
-            ],
             settings: {
               'import/parsers': expect.any(Object),
               'import/resolver': expect.any(Object),
@@ -228,25 +214,17 @@ describe('Next Build', () => {
               stdio: ['pipe', 'pipe', 'inherit'],
             }
           )
-          const { parser, plugins, settings } = JSON.parse(
+          const { parser, settings, ...eslintConfigAfterSetup } = JSON.parse(
             eslintConfigAfterSetupJSON
           )
 
+          expect(eslintConfigAfterSetup).toMatchSnapshot()
           expect({
             parser,
-            plugins,
             settings,
           }).toEqual({
             // parser: require.resolve('@typescript-eslint/parser')
             parser: expect.stringContaining('@typescript-eslint/parser'),
-            plugins: [
-              'react-hooks',
-              'jsx-a11y',
-              'react',
-              'import',
-              '@next/next',
-              '@typescript-eslint',
-            ],
             settings: {
               'import/parsers': expect.any(Object),
               'import/resolver': expect.any(Object),
@@ -319,25 +297,17 @@ describe('Next Build', () => {
               stdio: ['pipe', 'pipe', 'inherit'],
             }
           )
-          const { parser, plugins, settings } = JSON.parse(
+          const { parser, settings, ...eslintConfigAfterSetup } = JSON.parse(
             eslintConfigAfterSetupJSON
           )
 
+          expect(eslintConfigAfterSetup).toMatchSnapshot()
           expect({
             parser,
-            plugins,
             settings,
           }).toEqual({
             // parser: require.resolve('@typescript-eslint/parser')
             parser: expect.stringContaining('@typescript-eslint/parser'),
-            plugins: [
-              'react-hooks',
-              'jsx-a11y',
-              'react',
-              'import',
-              '@next/next',
-              '@typescript-eslint',
-            ],
             settings: {
               'import/parsers': expect.any(Object),
               'import/resolver': expect.any(Object),


### PR DESCRIPTION
Reverts vercel/next.js#77818 due to https://github.com/vercel/next.js/pull/77818#issuecomment-2778026161