### PR TITLE
Add debug logging to default cache handler and `"use cache"` wrapper

### DIFF
--- a/packages/next/src/server/use-cache/handlers.ts
+++ b/packages/next/src/server/use-cache/handlers.ts
@@ -5,7 +5,7 @@ const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? (message: string, ...args: any[]) => {
       console.log(`use-cache: ${message}`, ...args)
     }
-  : () => {}
+  : undefined
 
 const handlersSymbol = Symbol.for('@next/cache-handlers')
 const handlersMapSymbol = Symbol.for('@next/cache-handlers-map')
@@ -32,40 +32,40 @@ const reference: typeof globalThis & {
 export function initializeCacheHandlers(): boolean {
   // If the cache handlers have already been initialized, don't do it again.
   if (reference[handlersMapSymbol]) {
-    debug('cache handlers already initialized')
+    debug?.('cache handlers already initialized')
     return false
   }
 
-  debug('initializing cache handlers')
+  debug?.('initializing cache handlers')
   reference[handlersMapSymbol] = new Map<string, CacheHandlerCompat>()
 
   // Initialize the cache from the symbol contents first.
   if (reference[handlersSymbol]) {
     let fallback: CacheHandlerCompat
     if (reference[handlersSymbol].DefaultCache) {
-      debug('setting "default" cache handler from symbol')
+      debug?.('setting "default" cache handler from symbol')
       fallback = reference[handlersSymbol].DefaultCache
     } else {
-      debug('setting "default" cache handler from default')
+      debug?.('setting "default" cache handler from default')
       fallback = DefaultCacheHandler
     }
 
     reference[handlersMapSymbol].set('default', fallback)
 
     if (reference[handlersSymbol].RemoteCache) {
-      debug('setting "remote" cache handler from symbol')
+      debug?.('setting "remote" cache handler from symbol')
       reference[handlersMapSymbol].set(
         'remote',
         reference[handlersSymbol].RemoteCache
       )
     } else {
-      debug('setting "remote" cache handler from default')
+      debug?.('setting "remote" cache handler from default')
       reference[handlersMapSymbol].set('remote', fallback)
     }
   } else {
-    debug('setting "default" cache handler from default')
+    debug?.('setting "default" cache handler from default')
     reference[handlersMapSymbol].set('default', DefaultCacheHandler)
-    debug('setting "remote" cache handler from default')
+    debug?.('setting "remote" cache handler from default')
     reference[handlersMapSymbol].set('remote', DefaultCacheHandler)
   }
 
@@ -135,7 +135,7 @@ export function setCacheHandler(
     throw new Error('Cache handlers not initialized')
   }
 
-  debug('setting cache handler for "%s"', kind)
+  debug?.('setting cache handler for "%s"', kind)
   reference[handlersMapSymbol].set(kind, cacheHandler)
   reference[handlersSetSymbol].add(cacheHandler)
 }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -68,7 +68,7 @@ const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
 const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   ? console.debug.bind(console, 'use-cache:')
-  : () => {}
+  : undefined
 
 function generateCacheEntry(
   workStore: WorkStore,
@@ -720,7 +720,7 @@ export function cache(
           entry &&
           (await shouldDiscardCacheEntry(entry, workStore, implicitTags))
         ) {
-          debug('discarding stale entry', serializedCacheKey)
+          debug?.('discarding stale entry', serializedCacheKey)
           entry = undefined
         }
 
@@ -763,14 +763,14 @@ export function cache(
 
           if (entry) {
             if (currentTime > entry.timestamp + entry.expire * 1000) {
-              debug('entry is expired', serializedCacheKey)
+              debug?.('entry is expired', serializedCacheKey)
             }
 
             if (
               workStore.isStaticGeneration &&
               currentTime > entry.timestamp + entry.revalidate * 1000
             ) {
-              debug('static generation, entry is stale', serializedCacheKey)
+              debug?.('static generation, entry is stale', serializedCacheKey)
             }
           }
 
@@ -960,7 +960,7 @@ async function shouldDiscardCacheEntry(
     // If the cache entry was created before any of the implicit tags were
     // revalidated last, we also need to discard it.
     if (entry.timestamp <= (await implicitTags.expiration)) {
-      debug(
+      debug?.(
         'entry was created at',
         entry.timestamp,
         'before implicit tags were revalidated at',
@@ -987,7 +987,7 @@ function isRecentlyRevalidatedTag(tag: string, workStore: WorkStore): boolean {
 
   // Was the tag previously revalidated (e.g. by a redirecting server action)?
   if (previouslyRevalidatedTags.includes(tag)) {
-    debug('tag', tag, 'was previously revalidated')
+    debug?.('tag', tag, 'was previously revalidated')
 
     return true
   }
@@ -996,7 +996,7 @@ function isRecentlyRevalidatedTag(tag: string, workStore: WorkStore): boolean {
   // In this case the revalidation might not have been propagated to the cache
   // handler yet, so we read it from the pending tags in the work store.
   if (pendingRevalidatedTags?.includes(tag)) {
-    debug('tag', tag, 'was just revalidated')
+    debug?.('tag', tag, 'was just revalidated')
 
     return true
   }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -66,6 +66,10 @@ export interface UseCachePageComponentProps {
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
+const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
+  ? console.debug.bind(console, 'use-cache:')
+  : () => {}
+
 function generateCacheEntry(
   workStore: WorkStore,
   outerWorkUnitStore: WorkUnitStore | undefined,
@@ -716,6 +720,7 @@ export function cache(
           entry &&
           (await shouldDiscardCacheEntry(entry, workStore, implicitTags))
         ) {
+          debug('discarding stale entry', serializedCacheKey)
           entry = undefined
         }
 
@@ -755,6 +760,19 @@ export function cache(
           // might include request specific things like cookies() inside a React.cache().
           // Note: It is important that we await at least once before this because it lets us
           // pop out of any stack specific contexts as well - aka "Sync" Local Storage.
+
+          if (entry) {
+            if (currentTime > entry.timestamp + entry.expire * 1000) {
+              debug('entry is expired', serializedCacheKey)
+            }
+
+            if (
+              workStore.isStaticGeneration &&
+              currentTime > entry.timestamp + entry.revalidate * 1000
+            ) {
+              debug('static generation, entry is stale', serializedCacheKey)
+            }
+          }
 
           const [newStream, pendingCacheEntry] = await generateCacheEntry(
             workStore,
@@ -942,6 +960,13 @@ async function shouldDiscardCacheEntry(
     // If the cache entry was created before any of the implicit tags were
     // revalidated last, we also need to discard it.
     if (entry.timestamp <= (await implicitTags.expiration)) {
+      debug(
+        'entry was created at',
+        entry.timestamp,
+        'before implicit tags were revalidated at',
+        implicitTags.expiration
+      )
+
       return true
     }
 
@@ -962,6 +987,8 @@ function isRecentlyRevalidatedTag(tag: string, workStore: WorkStore): boolean {
 
   // Was the tag previously revalidated (e.g. by a redirecting server action)?
   if (previouslyRevalidatedTags.includes(tag)) {
+    debug('tag', tag, 'was previously revalidated')
+
     return true
   }
 
@@ -969,6 +996,8 @@ function isRecentlyRevalidatedTag(tag: string, workStore: WorkStore): boolean {
   // In this case the revalidation might not have been propagated to the cache
   // handler yet, so we read it from the pending tags in the work store.
   if (pendingRevalidatedTags?.includes(tag)) {
+    debug('tag', tag, 'was just revalidated')
+
     return true
   }
 


### PR DESCRIPTION
When the env variable `NEXT_PRIVATE_DEBUG_CACHE` is defined (see https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration#verifying-correct-production-behavior), the default cache handler and the `"use cache"` wrapper will now emit debug logs.

Note: This variable can already be used for `"use cache"` debug logging when deploying to Vercel.