### PR TITLE
Turbopack Build: Optimize instrumentation hook generation

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -948,6 +948,15 @@ export async function createHotReloaderTurbopack(
       isApp,
       url: requestUrl,
     }) {
+      // When there is no route definition this is an internal file not a route the user added.
+      // Middleware and instrumentation are handled in turbpack-utils.ts handleEntrypoints instead.
+      if (!definition) {
+        if (inputPage === '/middleware') return
+        if (inputPage === '/src/middleware') return
+        if (inputPage === '/instrumentation') return
+        if (inputPage === '/src/instrumentation') return
+      }
+
       return hotReloaderSpan
         .traceChild('ensure-page', {
           inputPage,

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -663,11 +663,21 @@ export async function handleEntrypoints({
       name: string,
       prop: 'nodeJs' | 'edge'
     ) => {
+      const prettyName = {
+        nodeJs: 'Node.js',
+        edge: 'Edge',
+      }
+      const finishBuilding = dev.hooks.startBuilding(
+        `instrumentation ${prettyName[prop]}`,
+        undefined,
+        true
+      )
       const key = getEntryKey('root', 'server', name)
 
       const writtenEndpoint = await instrumentation[prop].writeToDisk()
       dev.hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
       processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
+      finishBuilding()
     }
     await processInstrumentation('instrumentation.nodeJs', 'nodeJs')
     await processInstrumentation('instrumentation.edge', 'edge')
@@ -700,6 +710,11 @@ export async function handleEntrypoints({
     const endpoint = middleware.endpoint
 
     async function processMiddleware() {
+      const finishBuilding = dev.hooks.startBuilding(
+        'middleware',
+        undefined,
+        true
+      )
       const writtenEndpoint = await endpoint.writeToDisk()
       dev.hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
       processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
@@ -714,6 +729,7 @@ export async function handleEntrypoints({
           matchers: middlewareConfig.matchers,
         }
       }
+      finishBuilding()
     }
     await processMiddleware()
 


### PR DESCRIPTION
### What?

- Add `compiled in` for middleware and instrumentation in Turbopack dev.
- Fixed a bug where instrumentation.js was being compiled like a page file, local testing moves bootup from 2.5s to 700ms when you have a instrumentation file.

### How?
- Added early returns in `hot-reloader-turbopack.ts` for middleware and instrumentation paths when there's no route definition, those cases are handled separately already.
- Added build status indicators in `turbopack-utils.ts` for middleware and instrumentation using `startBuilding` and `finishBuilding` hooks
- Added proper naming for Node.js and Edge instrumentation in the build status

Closes PACK-4278