### PR TITLE
Ensure `searchParams` access in `"use cache"` triggers error when caught

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1428,6 +1428,9 @@ async function renderToHTMLOrFlightImpl(
 
     // If we encountered any unexpected errors during build we fail the
     // prerendering phase and the build.
+    if (workStore.invalidUsageError) {
+      throw workStore.invalidUsageError
+    }
     if (response.digestErrorsMap.size) {
       const buildFailingError = response.digestErrorsMap.values().next().value
       if (buildFailingError) throw buildFailingError
@@ -1611,6 +1614,10 @@ async function renderToHTMLOrFlightImpl(
       formState,
       postponedState
     )
+
+    if (workStore.invalidUsageError) {
+      throw workStore.invalidUsageError
+    }
 
     // If we have pending revalidates, wait until they are all resolved.
     if (

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -329,11 +329,6 @@ async function createComponentTreeInternal({
   const isPossiblyPartialResponse =
     isStaticGeneration && experimental.isRoutePPREnabled === true
 
-  // If there's a dynamic usage error attached to the store, throw it.
-  if (workStore.dynamicUsageErr) {
-    throw workStore.dynamicUsageErr
-  }
-
   const LayoutOrPage: React.ComponentType<any> | undefined = layoutOrPageMod
     ? interopDefault(layoutOrPageMod)
     : undefined

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -1,6 +1,5 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { IncrementalCache } from '../lib/incremental-cache'
-import type { DynamicServerError } from '../../client/components/hooks-server-context'
 import type { FetchMetrics } from '../base-http'
 import type { FallbackRouteParams } from '../request/fallback-params'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
@@ -49,7 +48,14 @@ export interface WorkStore {
 
   dynamicUsageDescription?: string
   dynamicUsageStack?: string
-  dynamicUsageErr?: DynamicServerError
+
+  /**
+   * Invalid usage errors might be caught in userland. We attach them to the
+   * work store to ensure we can still fail the build or dev render.
+   */
+  // TODO: Collect an array of errors, and throw as AggregateError when
+  // `serializeError` and the Dev Overlay support it.
+  invalidUsageError?: Error
 
   nextFetchId?: number
   pathWasRevalidated?: boolean

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -462,7 +462,7 @@ export function makeErroringExoticSearchParamsForUseCache(
         typeof prop === 'string' &&
         (prop === 'then' || !wellKnownProperties.has(prop))
       ) {
-        throwForSearchParamsAccessInUseCache(workStore.route)
+        throwForSearchParamsAccessInUseCache(workStore)
       }
 
       return ReflectAdapter.get(target, prop, receiver)
@@ -476,13 +476,13 @@ export function makeErroringExoticSearchParamsForUseCache(
         typeof prop === 'string' &&
         (prop === 'then' || !wellKnownProperties.has(prop))
       ) {
-        throwForSearchParamsAccessInUseCache(workStore.route)
+        throwForSearchParamsAccessInUseCache(workStore)
       }
 
       return ReflectAdapter.has(target, prop)
     },
     ownKeys() {
-      throwForSearchParamsAccessInUseCache(workStore.route)
+      throwForSearchParamsAccessInUseCache(workStore)
     },
   })
 

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -1,5 +1,6 @@
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { afterTaskAsyncStorage } from '../app-render/after-task-async-storage.external'
+import type { WorkStore } from '../app-render/work-async-storage.external'
 
 export function throwWithStaticGenerationBailoutError(
   route: string,
@@ -19,10 +20,16 @@ export function throwWithStaticGenerationBailoutErrorWithDynamicError(
   )
 }
 
-export function throwForSearchParamsAccessInUseCache(route: string): never {
-  throw new Error(
-    `Route ${route} used "searchParams" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "searchParams" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+export function throwForSearchParamsAccessInUseCache(
+  workStore: WorkStore
+): never {
+  const error = new Error(
+    `Route ${workStore.route} used "searchParams" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "searchParams" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
   )
+
+  workStore.invalidUsageError ??= error
+
+  throw error
 }
 
 export function isRequestAPICallableInsideAfter() {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -514,7 +514,7 @@ export function cache(
   kind: string,
   id: string,
   boundArgsLength: number,
-  fn: (...args: unknown[]) => Promise<unknown>
+  originalFn: (...args: unknown[]) => Promise<unknown>
 ) {
   const cacheHandler = getCacheHandler(kind)
   if (cacheHandler === undefined) {
@@ -525,7 +525,7 @@ export function cache(
   const timeoutError = new UseCacheTimeoutError()
   Error.captureStackTrace(timeoutError, cache)
 
-  const name = fn.name
+  const name = originalFn.name
   const cachedFn = {
     [name]: async function (...args: any[]) {
       const workStore = workAsyncStorage.getStore()
@@ -534,6 +534,8 @@ export function cache(
           '"use cache" cannot be used outside of App Router. Expected a WorkStore.'
         )
       }
+
+      let fn = originalFn
 
       const workUnitStore = workUnitAsyncStorage.getStore()
 
@@ -572,8 +574,6 @@ export function cache(
         const [{ params, searchParams }] = args
         // Overwrite the props to omit $$isPageComponent.
         args = [{ params, searchParams }]
-
-        const originalFn = fn
 
         fn = {
           [name]: async ({

--- a/test/e2e/app-dir/use-cache-standalone-search-params/app/search-params-caught/page.tsx
+++ b/test/e2e/app-dir/use-cache-standalone-search-params/app/search-params-caught/page.tsx
@@ -1,0 +1,15 @@
+'use cache'
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  let param: string | string[] | undefined
+
+  try {
+    param = (await searchParams).foo
+  } catch {}
+
+  return <p>param: {param}</p>
+}

--- a/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
@@ -11,7 +11,7 @@ const getExpectedErrorMessage = (route: string) =>
   `Error: Route ${route} used "searchParams" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "searchParams" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
 
 describe('use-cache-standalone-search-params', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
@@ -43,29 +43,20 @@ describe('use-cache-standalone-search-params', () => {
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
-        if (isTurbopack) {
-          // TODO(veil): Should have a mapped error source.
-          expect(errorSource).toBe(null)
+        expect(errorSource).toMatchInlineSnapshot(`
+         "app/search-params-used/page.tsx (8:17) @ Page
 
-          // TODO(veil): Should be a relative filename.
-          expect(cliOutput).toContain(`${expectedErrorMessage}
-    at Page (file:/`)
-        } else {
-          expect(errorSource).toMatchInlineSnapshot(`
-           "app/search-params-used/page.tsx (8:17) @ Page
+            6 |   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+            7 | }) {
+         >  8 |   const param = (await searchParams).foo
+              |                 ^
+            9 |
+           10 |   return <p>param: {param}</p>
+           11 | }"
+        `)
 
-              6 |   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
-              7 | }) {
-           >  8 |   const param = (await searchParams).foo
-                |                 ^
-              9 |
-             10 |   return <p>param: {param}</p>
-             11 | }"
-          `)
-
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+        expect(cliOutput).toContain(`${expectedErrorMessage}
     at Page (app/search-params-used/page.tsx:8:17)`)
-        }
       })
     })
 
@@ -88,29 +79,20 @@ describe('use-cache-standalone-search-params', () => {
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
-        if (isTurbopack) {
-          // TODO(veil): Should have a mapped error source.
-          expect(errorSource).toBe(null)
+        expect(errorSource).toMatchInlineSnapshot(`
+         "app/search-params-caught/page.tsx (11:5) @ Page
 
-          // TODO(veil): Should be a relative filename.
-          expect(cliOutput).toContain(`${expectedErrorMessage}
-    at Page (file:/`)
-        } else {
-          expect(errorSource).toMatchInlineSnapshot(`
-           "app/search-params-caught/page.tsx (11:5) @ Page
+            9 |
+           10 |   try {
+         > 11 |     param = (await searchParams).foo
+              |     ^
+           12 |   } catch {}
+           13 |
+           14 |   return <p>param: {param}</p>"
+        `)
 
-              9 |
-             10 |   try {
-           > 11 |     param = (await searchParams).foo
-                |     ^
-             12 |   } catch {}
-             13 |
-             14 |   return <p>param: {param}</p>"
-          `)
-
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+        expect(cliOutput).toContain(`${expectedErrorMessage}
     at Page (app/search-params-caught/page.tsx:11:4)`)
-        }
       })
 
       it('should also show an error after the second reload', async () => {


### PR DESCRIPTION
Accessing search params in `"use cache"` functions is not allowed. We need to make sure that a build or dev error is still triggered even when the `searchParams` access is wrapped in a try/catch block.

This also fixes a bug where the errors were not correctly source-mapped with Turbopack.

related: #75662
closes NAR-86