### PR TITLE
[ts-next-plugin] fix: properly exit when failed to initialize

### DIFF
--- a/packages/next/src/server/typescript/index.ts
+++ b/packages/next/src/server/typescript/index.ts
@@ -39,7 +39,12 @@ export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
     // The default user config is { "name": "next" }
     const isPluginEnabled = info.config.enabled ?? true
 
-    if (!isPluginEnabled) {
+    const isPluginInitialized = init({
+      ts,
+      info,
+    })
+
+    if (!isPluginEnabled || !isPluginInitialized) {
       return info.languageService
     }
 
@@ -50,11 +55,6 @@ export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
       // @ts-expect-error - JS runtime trickery which is tricky to type tersely
       proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args)
     }
-
-    init({
-      ts,
-      info,
-    })
 
     // Auto completion
     proxy.getCompletionsAtPosition = (

--- a/packages/next/src/server/typescript/utils.ts
+++ b/packages/next/src/server/typescript/utils.ts
@@ -23,7 +23,7 @@ export function log(message: string) {
 export function init(opts: {
   ts: TypeScript
   info: tsModule.server.PluginCreateInfo
-}) {
+}): boolean {
   const projectDir = opts.info.project.getCurrentDirectory()
   ts = opts.ts
   info = opts.info
@@ -48,14 +48,15 @@ export function init(opts: {
     compilerOptions
   )
 
-  if (virtualTsEnv) {
+  if (!virtualTsEnv) {
     log(
       'Failed to create virtual TypeScript environment. This is a bug in Next.js TypeScript plugin. Please report it by opening an issue at https://github.com/vercel/next.js/issues.'
     )
-    return
+    return false
   }
 
   log('Successfully initialized Next.js TypeScript plugin!')
+  return true
 }
 
 export function getTs() {


### PR DESCRIPTION
### Why?

The plugin false-negatively logged that the initialization failed. Also, it didn't properly exit when it failed.