### PR TITLE
[test] temporarily disable flaky test for react 18

### DIFF
--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -1161,7 +1161,10 @@ describe('ReactRefreshLogBox', () => {
       `)
     }
 
-    await toggleCollapseCallStackFrames(browser)
+    // TODO: fix the broken collapsing in callstack
+    if (!isReact18) {
+      await toggleCollapseCallStackFrames(browser)
+    }
 
     // Expect more than the default amount of frames
     // The default stackTraceLimit results in max 9 [data-nextjs-call-stack-frame] elements


### PR DESCRIPTION
temporarily disable the react 18 tests for toggling the frames, it's not a quick fix so I'll follow up in another PR.