### PR TITLE
Add back Turbopack flag in `required-server-files.json`

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -229,7 +229,6 @@ module.exports = ({ dev, turbo, bundleType, experimental, ...rest }) => {
           experimental ? true : false
         ),
         'process.env.NEXT_RUNTIME': JSON.stringify('nodejs'),
-        'process.turbopack': JSON.stringify(turbo),
         'process.env.TURBOPACK': JSON.stringify(turbo),
       }),
       !!process.env.ANALYZE &&

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2275,6 +2275,7 @@ export default async function build(
 
                 // @ts-expect-error internal field TODO: fix this, should use a separate mechanism to pass the info.
                 isExperimentalCompile: isCompileMode,
+                isTurbopackBuild: isTurbopack,
               },
             },
             appDir: dir,

--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -33,6 +33,16 @@ const nextStart = async (options: NextStartOptions, directory?: string) => {
     printAndExit(getReservedPortExplanation(port), 1)
   }
 
+  const isTurbopack = Boolean(
+    options.turbo ||
+      options.turbopack ||
+      // TODO: Used for Testing in Next.js CI. Rename to something better like `NEXT_TEST_TURBOPACK`.
+      process.env.TURBOPACK
+  )
+  if (isTurbopack) {
+    process.env.TURBOPACK = '1'
+  }
+
   await startServer({
     dir,
     isDev: false,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -192,20 +192,6 @@ export default class NextNodeServer extends BaseServer<
     this.isDev = isDev
     this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
 
-    // @ts-expect-error internal field not publicly exposed
-    const isTurbopackBuild = this.nextConfig.experimental?.isTurbopackBuild
-    if (!isDev && typeof isTurbopackBuild !== 'undefined') {
-      if (process.env.TURBOPACK && !isTurbopackBuild) {
-        throw new Error(
-          `Invariant: --turbopack is set but the build used Webpack`
-        )
-      } else if (!process.env.TURBOPACK && isTurbopackBuild) {
-        throw new Error(
-          `Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to "next start".`
-        )
-      }
-    }
-
     /**
      * This sets environment variable to be used at the time of SSR by head.tsx.
      * Using this from process.env allows targeting SSR by calling

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -192,6 +192,20 @@ export default class NextNodeServer extends BaseServer<
     this.isDev = isDev
     this.sriEnabled = Boolean(options.conf.experimental?.sri?.algorithm)
 
+    // @ts-expect-error internal field not publicly exposed
+    const isTurbopackBuild = this.nextConfig.experimental?.isTurbopackBuild
+    if (!isDev && typeof isTurbopackBuild !== 'undefined') {
+      if (process.env.TURBOPACK && !isTurbopackBuild) {
+        throw new Error(
+          `Invariant: --turbopack is set but the build used Webpack`
+        )
+      } else if (!process.env.TURBOPACK && isTurbopackBuild) {
+        throw new Error(
+          `Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to "next start".`
+        )
+      }
+    }
+
     /**
      * This sets environment variable to be used at the time of SSR by head.tsx.
      * Using this from process.env allows targeting SSR by calling

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -240,6 +240,9 @@ export class NextServer implements NextWrapperServer {
         // @ts-expect-error internal field
         config.experimental.isExperimentalCompile =
           serializedConfig.experimental.isExperimentalCompile
+        // @ts-expect-error internal field
+        config.experimental.isTurbopackBuild =
+          serializedConfig.experimental.isTurbopackBuild
       } catch (_) {
         // if distDir is customized we don't know until we
         // load the config so fallback to loading the config

--- a/test/production/app-dir/turbopack-build-marker/app/layout.tsx
+++ b/test/production/app-dir/turbopack-build-marker/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/turbopack-build-marker/app/page.tsx
+++ b/test/production/app-dir/turbopack-build-marker/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/turbopack-build-marker/next.config.js
+++ b/test/production/app-dir/turbopack-build-marker/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
+++ b/test/production/app-dir/turbopack-build-marker/turbopack-build-marker.test.ts
@@ -1,0 +1,15 @@
+import { nextTestSetup } from 'e2e-utils'
+describe('turbopack-build-marker', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should have Turbopack build marker', async () => {
+    const requiredServerFilesManifest = await next.readJSON(
+      '.next/required-server-files.json'
+    )
+    expect(
+      requiredServerFilesManifest.config.experimental.isTurbopackBuild
+    ).toBe(!!process.env.TURBOPACK)
+  })
+})


### PR DESCRIPTION
`next start` still doesn't read the config and set `process.env.TURBOPACK: "1"` though

Closes PACK-4315