### PR TITLE
[ts-next-plugin] fix: use `getSourceFile` instead of `fileExists` to check file existence

### DIFF
--- a/packages/next/src/server/typescript/rules/metadata.ts
+++ b/packages/next/src/server/typescript/rules/metadata.ts
@@ -86,12 +86,9 @@ function updateVirtualFileWithType(
     sourceText.slice(nodeEnd) +
     TYPE_IMPORT
 
-  if (virtualTsEnv.sys.fileExists(fileName)) {
+  if (virtualTsEnv.getSourceFile(fileName)) {
     log('Updating file: ' + fileName)
-    // FIXME: updateFile() breaks as the file doesn't exists, which is weird.
-    // virtualTsEnv.updateFile(fileName, newSource)
-    virtualTsEnv.deleteFile(fileName)
-    virtualTsEnv.createFile(fileName, newSource)
+    virtualTsEnv.updateFile(fileName, newSource)
   } else {
     log('Creating file: ' + fileName)
     virtualTsEnv.createFile(fileName, newSource)


### PR DESCRIPTION
### Why?

The Next.js TypeScript plugin was doing a workaround for updating the virtual file with `deleteFile()` then `createFile()` since `updateFile()` failed even though `env.sys.fileExists()` passed.

It is because the system was created based on the FS system via `createFSBackedSystem()`, which falls back to read from the actual file system if the file doesn't exist on the current virtual file system.

https://github.com/microsoft/TypeScript-Website/blob/9d447358e4fc67c881202fb40115cd8adf70daad/packages/typescript-vfs/src/index.ts#L544

![CleanShot 2025-04-05 at 17 39 35@2x](https://github.com/user-attachments/assets/96b3ec2e-3b6d-407d-877f-bdd3224b156b)

### How?

Use `getSourceFile()` to check if the file actually exists. This is what`@typescript/vfs` uses to check before running the `updateFile()`.

https://github.com/microsoft/TypeScript-Website/blob/9d447358e4fc67c881202fb40115cd8adf70daad/packages/typescript-vfs/src/index.ts#L83-L87


