### PR TITLE
[logging] improve logging of port retry

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -245,7 +245,9 @@ export async function startServer(
       port = typeof addr === 'object' ? addr?.port || port : port
 
       if (portRetryCount) {
-        Log.warn(`Port ${originalPort} is in use, using ${port} instead.`)
+        Log.warn(
+          `Port ${originalPort} is in use, using available port ${port} instead.`
+        )
       }
 
       const networkHostname =

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -203,6 +203,7 @@ export async function startServer(
   })
 
   let portRetryCount = 0
+  const originalPort = port
 
   server.on('error', (err: NodeJS.ErrnoException) => {
     if (
@@ -212,7 +213,6 @@ export async function startServer(
       err.code === 'EADDRINUSE' &&
       portRetryCount < 10
     ) {
-      Log.warn(`Port ${port} is in use, trying ${port + 1} instead.`)
       port += 1
       portRetryCount += 1
       server.listen(port, hostname)
@@ -243,6 +243,10 @@ export async function startServer(
             : formatHostname(hostname)
 
       port = typeof addr === 'object' ? addr?.port || port : port
+
+      if (portRetryCount) {
+        Log.warn(`Port ${originalPort} is in use, using ${port} instead.`)
+      }
 
       const networkHostname =
         hostname ?? getNetworkHost(isIPv6(actualHostname) ? 'IPv6' : 'IPv4')

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -675,7 +675,7 @@ describe('CLI Usage', () => {
         await killApp(appTwo).catch(console.error)
       }
 
-      expect(output).toMatch('⚠ Port 3000 is in use, trying 3001 instead.')
+      expect(output).toMatch('⚠ Port 3000 is in use, using 3001 instead.')
     })
 
     test('-p reserved', async () => {

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -675,7 +675,9 @@ describe('CLI Usage', () => {
         await killApp(appTwo).catch(console.error)
       }
 
-      expect(output).toMatch('⚠ Port 3000 is in use, using 3001 instead.')
+      expect(output).toMatch(
+        '⚠ Port 3000 is in use, using available port 3001 instead.'
+      )
     })
 
     test('-p reserved', async () => {


### PR DESCRIPTION
### What

Only log once of the port retries, with the original port and the final listening port.

| Before | After |
|:--|:--|
| ⚠ Port 3000 is in use, trying 3001 instead.<br>⚠ Port 3001 is in use, trying 3002 instead. | ⚠ Port 3000 is in use, using available port 3002 instead. |