### PR TITLE
Alternate bundler: fix react refresh and adjust sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@opentelemetry/api": "1.4.1",
     "@picocss/pico": "1.5.10",
     "@rspack/core": "1.3.2",
-    "@rspack/plugin-react-refresh": "1.1.0",
+    "@rspack/plugin-react-refresh": "1.1.1",
     "@svgr/webpack": "5.5.0",
     "@swc/cli": "0.1.55",
     "@swc/core": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@opentelemetry/api": "1.4.1",
     "@picocss/pico": "1.5.10",
     "@rspack/core": "1.3.2",
-    "@rspack/plugin-react-refresh": "1.1.1",
+    "@rspack/plugin-react-refresh": "1.2.0",
     "@svgr/webpack": "5.5.0",
     "@swc/cli": "0.1.55",
     "@swc/core": "1.9.3",

--- a/packages/next-rspack/package.json
+++ b/packages/next-rspack/package.json
@@ -8,7 +8,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "@rspack/core": "1.3.2",
-    "@rspack/plugin-react-refresh": "1.1.0",
+    "@rspack/plugin-react-refresh": "1.1.1",
     "react-refresh": "0.12.0"
   }
 }

--- a/packages/next-rspack/package.json
+++ b/packages/next-rspack/package.json
@@ -8,7 +8,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "@rspack/core": "1.3.2",
-    "@rspack/plugin-react-refresh": "1.1.1",
+    "@rspack/plugin-react-refresh": "1.2.0",
     "react-refresh": "0.12.0"
   }
 }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -671,15 +671,19 @@ export default async function getBaseWebpackConfig(
     '...',
   ]
 
+  const reactRefreshEntry = isRspack
+    ? getRspackReactRefresh().entry
+    : require.resolve(
+        `next/dist/compiled/@next/react-refresh-utils/dist/runtime`
+      )
+
   const clientEntries = isClient
     ? ({
         // Backwards compatibility
         'main.js': [],
         ...(dev
           ? {
-              [CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH]: require.resolve(
-                `next/dist/compiled/@next/react-refresh-utils/dist/runtime`
-              ),
+              [CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH]: reactRefreshEntry,
               [CLIENT_STATIC_FILES_RUNTIME_AMP]:
                 `./` +
                 path
@@ -705,9 +709,7 @@ export default async function getBaseWebpackConfig(
           ? {
               [CLIENT_STATIC_FILES_RUNTIME_MAIN_APP]: dev
                 ? [
-                    require.resolve(
-                      `next/dist/compiled/@next/react-refresh-utils/dist/runtime`
-                    ),
+                    reactRefreshEntry,
                     `./` +
                       path
                         .relative(
@@ -1902,7 +1904,11 @@ export default async function getBaseWebpackConfig(
         isClient &&
         (isRspack
           ? // eslint-disable-next-line
-            new (getRspackReactRefresh() as any)({ injectLoader: false })
+            new (getRspackReactRefresh() as any)({
+              injectLoader: false,
+              injectEntry: false,
+              overlay: false,
+            })
           : new ReactRefreshWebpackPlugin(webpack)),
       // Makes sure `Buffer` and `process` are polyfilled in client and flight bundles (same behavior as webpack 4)
       (isClient || isEdgeServer) &&

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -49,14 +49,6 @@ export const base = curry(function base(
       (ctx.productionBrowserSourceMaps && ctx.isClient)
     ) {
       config.devtool = 'source-map'
-      config.plugins ??= []
-      config.plugins.push(
-        new DevToolsIgnorePlugin({
-          // TODO: eval-source-map has different module paths than source-map.
-          // We're currently not actually ignore listing anything.
-          shouldIgnorePath,
-        })
-      )
     } else {
       config.devtool = false
     }
@@ -67,7 +59,7 @@ export const base = curry(function base(
   }
 
   config.plugins ??= []
-  if (config.devtool === 'source-map') {
+  if (config.devtool === 'source-map' && !process.env.NEXT_RSPACK) {
     config.plugins.push(
       new DevToolsIgnorePlugin({
         shouldIgnorePath,

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -34,8 +34,6 @@ export const base = curry(function base(
   if (ctx.isDevelopment) {
     if (process.env.__NEXT_TEST_MODE && !process.env.__NEXT_TEST_WITH_DEVTOOL) {
       config.devtool = false
-    } else if (process.env.NEXT_RSPACK) {
-      config.devtool = 'source-map'
     } else {
       // `eval-source-map` provides full-fidelity source maps for the
       // original source, including columns and original variable names.

--- a/packages/next/src/shared/lib/get-rspack.ts
+++ b/packages/next/src/shared/lib/get-rspack.ts
@@ -20,7 +20,12 @@ export function getRspackReactRefresh() {
   gateCanary()
   try {
     // eslint-disable-next-line import/no-extraneous-dependencies
-    return require('@rspack/plugin-react-refresh')
+    const plugin = require('@rspack/plugin-react-refresh')
+    const entry = require.resolve(
+      '@rspack/plugin-react-refresh/react-refresh-entry'
+    )
+    plugin.entry = entry
+    return plugin
   } catch (e) {
     if (e instanceof Error && 'code' in e && e.code === 'MODULE_NOT_FOUND') {
       throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 1.3.2
         version: 1.3.2(@swc/helpers@0.5.15)
       '@rspack/plugin-react-refresh':
-        specifier: 1.1.0
-        version: 1.1.0(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
+        specifier: 1.1.1
+        version: 1.1.1(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
       '@svgr/webpack':
         specifier: 5.5.0
         version: 5.5.0
@@ -1678,8 +1678,8 @@ importers:
         specifier: 1.3.2
         version: 1.3.2(@swc/helpers@0.5.15)
       '@rspack/plugin-react-refresh':
-        specifier: 1.1.0
-        version: 1.1.0(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
+        specifier: 1.1.1
+        version: 1.1.1(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
       react-refresh:
         specifier: 0.12.0
         version: 0.12.0
@@ -5319,8 +5319,8 @@ packages:
     resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
     engines: {node: '>=16.0.0'}
 
-  '@rspack/plugin-react-refresh@1.1.0':
-    resolution: {integrity: sha512-Aaqoa8VnpGjBMUrjE4+SeHaEKYZ/bvaPV20MBk/SLvivug4oRzIGbUn7QFROBSdxx0Sw0yPjK5cSZLTxySatCQ==}
+  '@rspack/plugin-react-refresh@1.1.1':
+    resolution: {integrity: sha512-kwH+k2CuJ1wbfQ6ciqSXmRtthPEszsr1H6tJTvurfLJg/HlhbkP8gJlBTS4kfhQTD6sev5G0d8+mRiYfzxPkUg==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
       webpack-hot-middleware: 2.x
@@ -21671,7 +21671,7 @@ snapshots:
 
   '@rspack/lite-tapable@1.0.1': {}
 
-  '@rspack/plugin-react-refresh@1.1.0(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)':
+  '@rspack/plugin-react-refresh@1.1.1(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)':
     dependencies:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 1.3.2
         version: 1.3.2(@swc/helpers@0.5.15)
       '@rspack/plugin-react-refresh':
-        specifier: 1.1.1
-        version: 1.1.1(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
+        specifier: 1.2.0
+        version: 1.2.0(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
       '@svgr/webpack':
         specifier: 5.5.0
         version: 5.5.0
@@ -1678,8 +1678,8 @@ importers:
         specifier: 1.3.2
         version: 1.3.2(@swc/helpers@0.5.15)
       '@rspack/plugin-react-refresh':
-        specifier: 1.1.1
-        version: 1.1.1(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
+        specifier: 1.2.0
+        version: 1.2.0(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)
       react-refresh:
         specifier: 0.12.0
         version: 0.12.0
@@ -5319,8 +5319,8 @@ packages:
     resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
     engines: {node: '>=16.0.0'}
 
-  '@rspack/plugin-react-refresh@1.1.1':
-    resolution: {integrity: sha512-kwH+k2CuJ1wbfQ6ciqSXmRtthPEszsr1H6tJTvurfLJg/HlhbkP8gJlBTS4kfhQTD6sev5G0d8+mRiYfzxPkUg==}
+  '@rspack/plugin-react-refresh@1.2.0':
+    resolution: {integrity: sha512-DTsbtggCfsiXE5QQtYMS8rKfEF8GIjwPDbgIT6Kg8BlAjpJY4jT5IisyhfIi7YOT3d5RIvu60iFB6Kr9sSMsnA==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
       webpack-hot-middleware: 2.x
@@ -21671,7 +21671,7 @@ snapshots:
 
   '@rspack/lite-tapable@1.0.1': {}
 
-  '@rspack/plugin-react-refresh@1.1.1(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)':
+  '@rspack/plugin-react-refresh@1.2.0(react-refresh@0.12.0)(webpack-hot-middleware@2.26.1)':
     dependencies:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0


### PR DESCRIPTION
- Fix failures in https://github.com/vercel/next.js/pull/77871 that introduced by https://github.com/rspack-contrib/rspack-plugin-react-refresh/pull/22#issuecomment-2781283399 🤦
- Align the inject entry logic with webpack
- Use eval-source-map for rspack (before use source-map due to a rspack bug https://github.com/vercel/next.js/pull/75981#discussion_r1953885026)
- Temporarily remove source-map ignoreList for rspack (will add it back once rspack has built-in support)

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
