### PR TITLE
Add onInvalidate option to router.prefetch

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -321,7 +321,8 @@ export const publicAppRouterInstance: AppRouterInstance = {
           href,
           actionQueue.state.nextUrl,
           actionQueue.state.tree,
-          options?.kind === PrefetchKind.FULL
+          options?.kind === PrefetchKind.FULL,
+          options?.onInvalidate ?? null
         )
       }
     : (href: string, options?: PrefetchOptions) => {

--- a/packages/next/src/client/components/segment-cache-impl/prefetch.ts
+++ b/packages/next/src/client/components/segment-cache-impl/prefetch.ts
@@ -9,17 +9,27 @@ import { PrefetchPriority } from '../segment-cache'
  * @param href - The URL to prefetch. Typically this will come from a <Link>,
  * or router.prefetch. It must be validated before we attempt to prefetch it.
  * @param nextUrl - A special header used by the server for interception routes.
- * Roughly  corresponds to the current URL.
+ * Roughly corresponds to the current URL.
  * @param treeAtTimeOfPrefetch - The FlightRouterState at the time the prefetch
  * was requested. This is only used when PPR is disabled.
  * @param includeDynamicData - Whether to prefetch dynamic data, in addition to
  * static data. This is used by <Link prefetch={true}>.
+ * @param onInvalidate - A callback that will be called when the prefetch cache
+ * When called, it signals to the listener that the data associated with the
+ * prefetch may have been invalidated from the cache. This is not a live
+ * subscription — it's called at most once per `prefetch` call. The only
+ * supported use case is to trigger a new prefetch inside the listener, if
+ * desired. It also may be called even in cases where the associated data is
+ * still cached. Prefetching is a poll-based (pull) operation, not an event-
+ * based (push) one. Rather than subscribe to specific cache entries, you
+ * occasionally poll the prefetch cache to check if anything is missing.
  */
 export function prefetch(
   href: string,
   nextUrl: string | null,
   treeAtTimeOfPrefetch: FlightRouterState,
-  includeDynamicData: boolean
+  includeDynamicData: boolean,
+  onInvalidate: null | (() => void)
 ) {
   const url = createPrefetchURL(href)
   if (url === null) {
@@ -31,6 +41,7 @@ export function prefetch(
     cacheKey,
     treeAtTimeOfPrefetch,
     includeDynamicData,
-    PrefetchPriority.Default
+    PrefetchPriority.Default,
+    onInvalidate
   )
 }

--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -85,6 +85,15 @@ export const reschedulePrefetchTask: typeof import('./segment-cache-impl/schedul
       }
     : notEnabled
 
+export const isPrefetchTaskDirty: typeof import('./segment-cache-impl/scheduler').isPrefetchTaskDirty =
+  process.env.__NEXT_CLIENT_SEGMENT_CACHE
+    ? function (...args) {
+        return require('./segment-cache-impl/scheduler').isPrefetchTaskDirty(
+          ...args
+        )
+      }
+    : notEnabled
+
 export const createCacheKey: typeof import('./segment-cache-impl/cache-key').createCacheKey =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -122,6 +122,7 @@ export interface NavigateOptions {
 
 export interface PrefetchOptions {
   kind: PrefetchKind
+  onInvalidate?: () => void
 }
 
 export interface AppRouterInstance {

--- a/test/e2e/app-dir/segment-cache/revalidation/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/page.tsx
@@ -1,5 +1,9 @@
 import { revalidatePath, revalidateTag } from 'next/cache'
-import { LinkAccordion, FormAccordion } from '../components/link-accordion'
+import {
+  LinkAccordion,
+  FormAccordion,
+  ManualPrefetchLinkAccordion,
+} from '../components/link-accordion'
 import Link from 'next/link'
 
 export default async function Page() {
@@ -35,6 +39,12 @@ export default async function Page() {
           <FormAccordion action="/greeting">
             Form pointing to target page with prefetching enabled
           </FormAccordion>
+        </li>
+        <li>
+          <ManualPrefetchLinkAccordion href="/greeting">
+            Manual link (router.prefetch) to target page with prefetching
+            enabled
+          </ManualPrefetchLinkAccordion>
         </li>
         <li>
           <Link prefetch={false} href="/greeting">

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -149,6 +149,57 @@ describe('segment cache (revalidation)', () => {
     }, 'no-requests')
   })
 
+  it('call router.prefetch(..., {onInvalidate}) after cache is revalidated', async () => {
+    // This is the similar to the previous tests, but uses a custom Link
+    // implementation that calls router.prefetch manually. It demonstrates it's
+    // possible to simulate the revalidating behavior of Link using the manual
+    // prefetch API.
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    const linkVisibilityToggle = await browser.elementByCss(
+      'input[data-manual-prefetch-link-accordion="/greeting"]'
+    )
+
+    // Reveal the link that points to the target page to trigger a prefetch
+    await act(
+      async () => {
+        await linkVisibilityToggle.click()
+      },
+      {
+        includes: 'random-greeting',
+      }
+    )
+
+    // Perform an action that calls revalidatePath. This should cause the
+    // corresponding entry to be evicted from the client cache, and a new
+    // prefetch to be requested.
+    await act(
+      async () => {
+        const revalidateByPath = await browser.elementById('revalidate-by-path')
+        await revalidateByPath.click()
+      },
+      {
+        includes: 'random-greeting [1]',
+      }
+    )
+    TestLog.assert(['REQUEST: random-greeting'])
+
+    // Navigate to the target page.
+    await act(async () => {
+      const link = await browser.elementByCss('a[href="/greeting"]')
+      await link.click()
+      // Navigation should finish immedately because the page is
+      // fully prefetched.
+      const greeting = await browser.elementById('greeting')
+      expect(await greeting.innerHTML()).toBe('random-greeting [1]')
+    }, 'no-requests')
+  })
+
   it('evict client cache when Server Action calls revalidateTag', async () => {
     let act: ReturnType<typeof createRouterAct>
     const browser = await next.browser('/', {


### PR DESCRIPTION
This commit adds an `onInvalidate` callback to `router.prefetch()` so custom `<Link>` implementations can re-prefetch data when it becomes stale.

The callback is invoked when the data associated with the prefetch may have been invalidated (e.g. by `revalidatePath` or `revalidateTag`).

This is not a live subscription and should not be treated as one. It's a one-time callback per prefetch request that acts as a signal: "If you care about the freshness of this data, now would be a good time to re-prefetch."

The supported use case is for advanced clients who opt out of rendering the built-in `<Link>` component (e.g. to customize visibility tracking or polling behavior) but still want to retain proper cache integration. When the callback is fired, the component can trigger a new call to `router.prefetch()` with the same parameters, including a new `onInvalidate` callback to continue the cycle.

(For reference, `<Link>` handles this automatically. This API exists to give custom implementations access to the same underlying behavior.)

Note that the callback *may* be invoked even if the prefetched data is still cached. This is intentional—prefetching in the app router is a pull-based mechanism, not a push-based one. Rather than subscribing to the lifecycle of specific cache entries, the app occasionally polls the prefetch layer to check for missing or stale data.

Calling `router.prefetch()` does not necessarily result in a network request. If the data is already cached, the call is a no-op. This makes polling a practical way to check cache freshness over time without incurring unnecessary requests.