### PR TITLE
docs: improve file tree

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/05-mdx.mdx
@@ -156,13 +156,13 @@ Navigating to the `/mdx-page` route should display your rendered MDX page.
 Create a new page within the `/app` directory and an MDX file wherever you'd like:
 
 ```txt
-  my-project
-  ├── app
-  │   └── mdx-page
+  .
+  ├── app/
+  │   └── mdx-page/
   │       └── page.(tsx/js)
-  ├── markdown
+  ├── markdown/
   │   └── welcome.(mdx/md)
-  |── mdx-components.(tsx/js)
+  ├── mdx-components.(tsx/js)
   └── package.json
 ```
 
@@ -173,12 +173,12 @@ Create a new page within the `/app` directory and an MDX file wherever you'd lik
 Create a new page within the `/pages` directory and an MDX file wherever you'd like:
 
 ```txt
-  my-project
-  ├── pages
-  │   └── mdx-page.(tsx/js)
-  ├── markdown
+  .
+  ├── markdown/
   │   └── welcome.(mdx/md)
-  |── mdx-components.(tsx/js)
+  ├── pages/
+  │   └── mdx-page.(tsx/js)
+  ├── mdx-components.(tsx/js)
   └── package.json
 ```
 

--- a/errors/prerender-error.mdx
+++ b/errors/prerender-error.mdx
@@ -22,13 +22,14 @@ In the Pages Router, only special files are allowed to generate pages. You canno
 Correct structure:
 
 ```
-pages/
-├── index.js
-└── about.js
-components/
-└── Header.js
-styles/
-└── globals.css
+  .
+  ├── components/
+  │   └── Header.js
+  ├── pages/
+  │   ├── about.js
+  │   └── index.js
+  └── styles/
+      └── globals.css
 ```
 
 #### App Router (Next.js 13+)
@@ -38,14 +39,15 @@ The App Router allows [colocation](/docs/app/getting-started/project-structure#c
 Example folder structure:
 
 ```
-app/
-├── layout.tsx
-├── page.tsx
-├── about/
-│   └── page.tsx
-└── blog/
-    ├── page.tsx
-    └── PostCard.tsx
+  .
+  └── app/
+      ├── about/
+      │   └── page.tsx
+      ├── blog/
+      │   ├── page.tsx
+      │   └── PostCard.tsx
+      ├── layout.tsx
+      └── page.tsx
 ```
 
 ### 2. Handle undefined props and missing data

--- a/errors/prerender-error.mdx
+++ b/errors/prerender-error.mdx
@@ -21,7 +21,7 @@ In the Pages Router, only special files are allowed to generate pages. You canno
 
 Correct structure:
 
-```
+```txt
   .
   ├── components/
   │   └── Header.js
@@ -38,7 +38,7 @@ The App Router allows [colocation](/docs/app/getting-started/project-structure#c
 
 Example folder structure:
 
-```
+```txt
   .
   └── app/
       ├── about/

--- a/errors/static-dir-deprecated.mdx
+++ b/errors/static-dir-deprecated.mdx
@@ -15,24 +15,22 @@ You can move your `static` directory inside of the `public` directory and all UR
 **Before**
 
 ```
-static/
-  my-image.jpg
-pages/
-  index.js
-components/
-  my-image.js
+.
+├── pages/
+│   └── index.js
+└── static/
+    └── my-image.jpg
 ```
 
 **After**
 
 ```
-public/
-  static/
-    my-image.jpg
-pages/
-  index.js
-components/
-  my-image.js
+.
+├── pages/
+│   └── index.js
+└── public/
+    └── static/
+        └── my-image.jpg
 ```
 
 ## Useful Links

--- a/errors/static-dir-deprecated.mdx
+++ b/errors/static-dir-deprecated.mdx
@@ -14,7 +14,7 @@ You can move your `static` directory inside of the `public` directory and all UR
 
 **Before**
 
-```
+```txt
   .
   ├── pages/
   │   └── index.js
@@ -24,7 +24,7 @@ You can move your `static` directory inside of the `public` directory and all UR
 
 **After**
 
-```
+```txt
   .
   ├── pages/
   │   └── index.js

--- a/errors/static-dir-deprecated.mdx
+++ b/errors/static-dir-deprecated.mdx
@@ -15,22 +15,22 @@ You can move your `static` directory inside of the `public` directory and all UR
 **Before**
 
 ```
-.
-├── pages/
-│   └── index.js
-└── static/
-    └── my-image.jpg
+  .
+  ├── pages/
+  │   └── index.js
+  └── static/
+      └── my-image.jpg
 ```
 
 **After**
 
 ```
-.
-├── pages/
-│   └── index.js
-└── public/
-    └── static/
-        └── my-image.jpg
+  .
+  ├── pages/
+  │   └── index.js
+  └── public/
+      └── static/
+          └── my-image.jpg
 ```
 
 ## Useful Links


### PR DESCRIPTION
The file tree can be improved and share the same convention:

- Use the `txt` file extension.
- One tab indented.
- Use file tree with root `.` and trailing slash for folders.

x-ref: https://tree.nathanfriend.io