### PR TITLE
[test] consolidate missing tag dev test

### DIFF
--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -12,7 +12,7 @@ describe('app-dir - missing required html tags', () => {
 
   it('should display correct error count in dev indicator', async () => {
     const browser = await next.browser('/')
-
+    await assertHasRedbox(browser)
     retry(async () => {
       expect(await hasErrorToast(browser)).toBe(true)
     })


### PR DESCRIPTION
This test is flaky in headless mode but passing in browser mode. It was timeout on checking the toast. Adding an assertion for it seems resolve the issue