### PR TITLE
[test] Assert on all errors in Redbox matchers

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -48,7 +48,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'dns'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -62,7 +61,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'dns'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -97,7 +95,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -111,7 +108,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -147,7 +143,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -161,7 +156,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -195,7 +189,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve './non-existent.css'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -209,7 +202,6 @@ describe('ReactRefreshLogBox-builtins app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve './non-existent.css'",
          "environmentLabel": null,
          "label": "Build Error",

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -90,7 +90,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: no",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -105,27 +104,48 @@ describe('ReactRefreshLogBox app', () => {
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "Error: no",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (3:7) @ eval
+       [
+         {
+           "description": "Error: no",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "index.js (3:7) @ eval
        > 3 | throw new Error('no')
            |       ^",
-         "stack": [
-           "eval index.js (3:7)",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "eval ./app/page.js",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-         ],
-       }
+           "stack": [
+             "eval index.js (3:7)",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "eval ./app/page.js",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+           ],
+         },
+         {
+           "description": "Error: no",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "index.js (3:7) @ eval
+       > 3 | throw new Error('no')
+           |       ^",
+           "stack": [
+             "eval index.js (3:7)",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "eval ./app/page.js",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+           ],
+         },
+       ]
       `)
     }
   })
@@ -252,7 +272,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -266,7 +285,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
          "environmentLabel": null,
          "label": "Build Error",
@@ -350,7 +368,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: ",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -410,7 +427,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing css source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -424,7 +440,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Syntax error: <FIXME-project-root>/index.module.css Unknown word",
          "environmentLabel": null,
          "label": "Build Error",
@@ -444,7 +459,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing css source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -457,7 +471,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Syntax error: Selector "button" is not pure (pure selectors must contain at least one local class or id)",
          "environmentLabel": null,
          "label": "Build Error",
@@ -499,7 +512,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -519,7 +531,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -584,7 +595,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -604,7 +614,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -668,7 +677,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -688,7 +696,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -752,7 +759,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -772,7 +778,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -946,7 +951,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: test",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -963,7 +967,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: test",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1049,7 +1052,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: Component error",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1065,7 +1067,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: Component error",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1103,7 +1104,6 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Client error",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -1135,7 +1135,6 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Server error",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -1175,7 +1174,6 @@ describe('ReactRefreshLogBox app', () => {
       // TODO(veil): investigate the column number is off by 1 between turbo and webpack
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: This is an error from an anonymous function",
          "environmentLabel": "Server",
          "label": "Runtime Error",
@@ -1191,7 +1189,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: This is an error from an anonymous function",
          "environmentLabel": "Server",
          "label": "Runtime Error",
@@ -1226,7 +1223,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "TypeError: Invalid URL",
          "environmentLabel": "Server",
          "label": "Runtime Error",
@@ -1241,7 +1237,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "TypeError: Invalid URL",
          "environmentLabel": "Server",
          "label": "Runtime Error",
@@ -1276,7 +1271,6 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Server component error",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -1316,7 +1310,6 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Server component error!",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -1357,7 +1350,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'non-existing-module'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -1371,7 +1363,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'non-existing-module'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -1414,7 +1405,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve './boom.css'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -1428,7 +1418,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve './boom.css'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -1458,7 +1447,6 @@ describe('ReactRefreshLogBox app', () => {
       } else {
         await expect({ browser, next }).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: module error",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -1519,7 +1507,6 @@ export default function Home() {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: server action was here",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -1568,7 +1555,6 @@ export default function Home() {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: server action was here",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -1613,7 +1599,6 @@ export default function Home() {
       // FIXME: display the sourcemapped stack frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: utils error",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1629,27 +1614,48 @@ export default function Home() {
     } else {
       // FIXME: Webpack stack frames are not source mapped
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "Error: utils error",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "app/utils.ts (1:7) @ eval
+       [
+         {
+           "description": "Error: utils error",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "app/utils.ts (1:7) @ eval
        > 1 | throw new Error('utils error')
            |       ^",
-         "stack": [
-           "eval app/utils.ts (1:7)",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "eval ./app/page.js",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-           "<FIXME-next-dist-dir>",
-         ],
-       }
+           "stack": [
+             "eval app/utils.ts (1:7)",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "eval ./app/page.js",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+           ],
+         },
+         {
+           "description": "Error: utils error",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "app/utils.ts (1:7) @ eval
+       > 1 | throw new Error('utils error')
+           |       ^",
+           "stack": [
+             "eval app/utils.ts (1:7)",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "eval ./app/page.js",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+             "<FIXME-next-dist-dir>",
+           ],
+         },
+       ]
       `)
     }
   })

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -34,7 +34,6 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Ecmascript file had an error",
          "environmentLabel": null,
          "label": "Build Error",
@@ -48,7 +47,6 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching",
          "environmentLabel": null,
          "label": "Build Error",

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -43,7 +43,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -57,7 +56,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Unexpected eof",
          "environmentLabel": null,
          "label": "Build Error",
@@ -117,7 +115,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -131,7 +128,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -183,7 +179,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -197,7 +192,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -269,7 +263,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -290,7 +283,6 @@ describe('Error recovery app', () => {
       // TODO(veil): Location of Page should be app/page.js
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -385,7 +377,6 @@ describe('Error recovery app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: oops",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -461,7 +452,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -478,7 +468,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -550,7 +539,6 @@ describe('Error recovery app', () => {
     await browser.eval('window.triggerError()')
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "Error: no 1",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -584,7 +572,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -598,7 +585,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -623,7 +609,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -637,7 +622,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -705,7 +689,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: React is not defined",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -722,7 +705,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: React is not defined",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -795,7 +777,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -809,7 +790,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '{', got 'return'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -853,7 +833,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -867,7 +846,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '{', got 'throw'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -912,7 +890,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: nooo",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -928,7 +905,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: nooo",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -954,7 +930,6 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -968,7 +943,6 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -23,7 +23,6 @@ describe('Error overlay - RSC runtime errors', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "TypeError: useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -56,7 +55,6 @@ describe('Error overlay - RSC runtime errors', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: \`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -71,7 +69,6 @@ describe('Error overlay - RSC runtime errors', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: \`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -100,7 +97,6 @@ describe('Error overlay - RSC runtime errors', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "ReferenceError: alert is not defined",
        "environmentLabel": "Server",
        "label": "Runtime Error",

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -20,7 +20,6 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: The default export is not a React Component in "/specific-path/server/page"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -46,7 +45,6 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: The default export is not a React Component in "/specific-path/server/layout"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -75,7 +73,6 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: The default export is not a React Component in "/will-not-found/not-found"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -97,7 +94,6 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: The default export is not a React Component in "/page"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -122,7 +118,6 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: The default export is not a React Component in "/server-with-errors/page-export-initial-error/page"",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -19,7 +19,6 @@ describe('ReactRefreshLogBox _app _document', () => {
     const { browser, session } = sandbox
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: The default export is not a React Component in page: "/_app"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -52,7 +51,6 @@ describe('ReactRefreshLogBox _app _document', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: The default export is not a React Component in page: "/_document"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -111,7 +109,6 @@ describe('ReactRefreshLogBox _app _document', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -125,7 +122,6 @@ describe('ReactRefreshLogBox _app _document', () => {
     } else if (isRspack) {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "  × Module build failed:",
          "environmentLabel": null,
          "label": "Build Error",
@@ -158,7 +154,6 @@ describe('ReactRefreshLogBox _app _document', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expression expected",
          "environmentLabel": null,
          "label": "Build Error",
@@ -235,7 +230,6 @@ describe('ReactRefreshLogBox _app _document', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -249,7 +243,6 @@ describe('ReactRefreshLogBox _app _document', () => {
     } else if (isRspack) {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "  × Module build failed:",
          "environmentLabel": null,
          "label": "Build Error",
@@ -275,7 +268,6 @@ describe('ReactRefreshLogBox _app _document', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key",
          "environmentLabel": null,
          "label": "Build Error",

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -47,7 +47,6 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'dns'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -61,7 +60,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'dns'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -97,7 +95,6 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -111,7 +108,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -147,7 +143,6 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -161,7 +156,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve 'b'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -204,7 +198,6 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve './non-existent.css'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -218,7 +211,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Module not found: Can't resolve './non-existent.css'",
          "environmentLabel": null,
          "label": "Build Error",

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -46,7 +46,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: idk",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -63,7 +62,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: idk",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -124,7 +122,6 @@ describe('ReactRefreshLogBox', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: no",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -142,7 +139,6 @@ describe('ReactRefreshLogBox', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: no",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -171,7 +167,6 @@ describe('ReactRefreshLogBox', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: no",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -189,7 +184,6 @@ describe('ReactRefreshLogBox', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: no",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -275,26 +269,40 @@ describe('ReactRefreshLogBox', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "Error: no",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "FunctionDefault.js (1:51) @ FunctionDefault
+       [
+         {
+           "description": "Error: no",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "FunctionDefault.js (1:51) @ FunctionDefault
        > 1 | export default function FunctionDefault() { throw new Error('no'); }
            |                                                   ^",
-         "stack": [
-           "FunctionDefault FunctionDefault.js (1:51)",
-           "Set.forEach <anonymous> (0:0)",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-         ],
-       }
+           "stack": [
+             "FunctionDefault FunctionDefault.js (1:51)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+         {
+           "description": "Error: no",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "FunctionDefault.js (1:51) @ FunctionDefault
+       > 1 | export default function FunctionDefault() { throw new Error('no'); }
+           |                                                   ^",
+           "stack": [
+             "FunctionDefault FunctionDefault.js (1:51)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: no",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -370,7 +378,6 @@ describe('ReactRefreshLogBox', () => {
     if (process.env.IS_TURBOPACK_TEST) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -384,7 +391,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
          "environmentLabel": null,
          "label": "Build Error",
@@ -464,26 +470,40 @@ describe('ReactRefreshLogBox', () => {
     // TODO(veil): Don't bail in Turbopack for sources outside of the project (https://linear.app/vercel/issue/NDX-944)
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "Error: ",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "Child.js (4:11) @ ClickCount.render
+       [
+         {
+           "description": "Error: ",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "Child.js (4:11) @ ClickCount.render
        > 4 |     throw new Error()
            |           ^",
-         "stack": [
-           "ClickCount.render Child.js (4:11)",
-           "Set.forEach <anonymous> (0:0)",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-         ],
-       }
+           "stack": [
+             "ClickCount.render Child.js (4:11)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+         {
+           "description": "Error: ",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "Child.js (4:11) @ ClickCount.render
+       > 4 |     throw new Error()
+           |           ^",
+           "stack": [
+             "ClickCount.render Child.js (4:11)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: ",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -545,7 +565,6 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing css source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -559,7 +578,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Syntax error: <FIXME-project-root>/index.module.css Unknown word",
          "environmentLabel": null,
          "label": "Build Error",
@@ -579,7 +597,6 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing css source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -592,7 +609,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Syntax error: Selector "button" is not pure (pure selectors must contain at least one local class or id)",
          "environmentLabel": null,
          "label": "Build Error",
@@ -634,7 +650,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -651,7 +666,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -691,7 +705,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -708,7 +721,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -748,7 +760,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -765,7 +776,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -805,7 +815,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -822,7 +831,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -862,7 +870,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: multiple https://nextjs.org links (http://example.com)",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -879,7 +886,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: multiple https://nextjs.org links (http://example.com)",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -915,7 +921,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: {"a":1,"b":"x"}",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -926,7 +931,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: {"a":1,"b":"x"}",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -965,7 +969,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: class Hello {
        }",
          "environmentLabel": null,
@@ -977,7 +980,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: class Hello {
        }",
          "environmentLabel": null,
@@ -1015,7 +1017,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: string error",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1026,7 +1027,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: string error",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1063,7 +1063,6 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1074,7 +1073,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1111,18 +1109,37 @@ describe('ReactRefreshLogBox', () => {
           expect(await getRedboxTotalErrorCount(browser)).toBe(3)
         })
         await expect(browser).toDisplayRedbox(`
-         {
-           "count": 3,
-           "description": "Error: Client error",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/index.js (3:11) @ Page
+         [
+           {
+             "description": "Error: Client error",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "pages/index.js (3:11) @ Page
          > 3 |     throw new Error('Client error')
              |           ^",
-           "stack": [
-             "Page pages/index.js (3:11)",
-           ],
-         }
+             "stack": [
+               "Page pages/index.js (3:11)",
+             ],
+           },
+           {
+             "description": "Error: Client error",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "pages/index.js (3:11) @ Page
+         > 3 |     throw new Error('Client error')
+             |           ^",
+             "stack": [
+               "Page pages/index.js (3:11)",
+             ],
+           },
+           {
+             "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": null,
+             "stack": [],
+           },
+         ]
         `)
       } else {
         // Wait for the error to reach the correct count
@@ -1130,24 +1147,42 @@ describe('ReactRefreshLogBox', () => {
           expect(await getRedboxTotalErrorCount(browser)).toBe(3)
         })
         await expect(browser).toDisplayRedbox(`
-         {
-           "count": 3,
-           "description": "Error: Client error",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/index.js (3:11) @ Page
+         [
+           {
+             "description": "Error: Client error",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "pages/index.js (3:11) @ Page
          > 3 |     throw new Error('Client error')
              |           ^",
-           "stack": [
-             "Page pages/index.js (3:11)",
-           ],
-         }
+             "stack": [
+               "Page pages/index.js (3:11)",
+             ],
+           },
+           {
+             "description": "Error: Client error",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "pages/index.js (3:11) @ Page
+         > 3 |     throw new Error('Client error')
+             |           ^",
+             "stack": [
+               "Page pages/index.js (3:11)",
+             ],
+           },
+           {
+             "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": null,
+             "stack": [],
+           },
+         ]
         `)
       }
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: Client error",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1193,7 +1228,6 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: anonymous error!",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1210,7 +1244,6 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: anonymous error!",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1252,7 +1285,6 @@ describe('ReactRefreshLogBox', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "TypeError: Invalid URL",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -284,7 +284,6 @@ describe('ReactRefreshRegression', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: boom",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -300,7 +299,6 @@ describe('ReactRefreshRegression', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: boom",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -45,7 +45,6 @@ describe('pages/ error recovery', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -59,7 +58,6 @@ describe('pages/ error recovery', () => {
     } else if (process.env.NEXT_RSPACK) {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "  × Module build failed:",
          "environmentLabel": null,
          "label": "Build Error",
@@ -82,7 +80,6 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Unexpected eof",
          "environmentLabel": null,
          "label": "Build Error",
@@ -162,7 +159,6 @@ describe('pages/ error recovery', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: oops",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -254,26 +250,40 @@ describe('pages/ error recovery', () => {
     // Somehow we end up with two in React 18 due to React's attempt to recover from this error.
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "Error: oops",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "child.js (3:9) @ Child
+       [
+         {
+           "description": "Error: oops",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "child.js (3:9) @ Child
        > 3 |   throw new Error('oops')
            |         ^",
-         "stack": [
-           "Child child.js (3:9)",
-           "Set.forEach <anonymous> (0:0)",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-         ],
-       }
+           "stack": [
+             "Child child.js (3:9)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+         {
+           "description": "Error: oops",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "child.js (3:9) @ Child
+       > 3 |   throw new Error('oops')
+           |         ^",
+           "stack": [
+             "Child child.js (3:9)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: oops",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -349,7 +359,6 @@ describe('pages/ error recovery', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -363,7 +372,6 @@ describe('pages/ error recovery', () => {
     } else if (process.env.NEXT_RSPACK) {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "  × Module build failed:",
          "environmentLabel": null,
          "label": "Build Error",
@@ -392,7 +400,6 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '{', got 'return'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -437,7 +444,6 @@ describe('pages/ error recovery', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -451,7 +457,6 @@ describe('pages/ error recovery', () => {
     } else if (process.env.NEXT_RSPACK) {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "  × Module build failed:",
          "environmentLabel": null,
          "label": "Build Error",
@@ -481,7 +486,6 @@ describe('pages/ error recovery', () => {
     } else {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '{', got 'throw'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -534,27 +538,41 @@ describe('pages/ error recovery', () => {
     // Somehow we end up with two in React 18 due to React's attempt to recover from this error.
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "Error: nooo",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "index.js (5:11) @ ClassDefault.render
+       [
+         {
+           "description": "Error: nooo",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "index.js (5:11) @ ClassDefault.render
        > 5 |     throw new Error('nooo');
            |           ^",
-         "stack": [
-           "ClassDefault.render index.js (5:11)",
-           "Set.forEach <anonymous> (0:0)",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-         ],
-       }
+           "stack": [
+             "ClassDefault.render index.js (5:11)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+         {
+           "description": "Error: nooo",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "index.js (5:11) @ ClassDefault.render
+       > 5 |     throw new Error('nooo');
+           |           ^",
+           "stack": [
+             "ClassDefault.render index.js (5:11)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+       ]
       `)
     } else {
       if (process.env.NEXT_RSPACK) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: nooo",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -569,7 +587,6 @@ describe('pages/ error recovery', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: nooo",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -637,26 +654,40 @@ describe('pages/ error recovery', () => {
     // Somehow we end up with two in React 18 due to React's attempt to recover from this error.
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "ReferenceError: React is not defined",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "Foo.js (3:3) @ Foo
+       [
+         {
+           "description": "ReferenceError: React is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
-         "stack": [
-           "Foo Foo.js (3:3)",
-           "Set.forEach <anonymous> (0:0)",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-           "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-         ],
-       }
+           "stack": [
+             "Foo Foo.js (3:3)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+         {
+           "description": "ReferenceError: React is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "Foo.js (3:3) @ Foo
+       > 3 |   return React.createElement('h1', null, 'Foo');
+           |   ^",
+           "stack": [
+             "Foo Foo.js (3:3)",
+             "Set.forEach <anonymous> (0:0)",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+           ],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "ReferenceError: React is not defined",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -724,7 +755,6 @@ describe('pages/ error recovery', () => {
     if (process.env.NEXT_RSPACK) {
       await expect(browser).toDisplayRedbox(`
             {
-              "count": 1,
               "description": "Error: no 1",
               "environmentLabel": null,
               "label": "Runtime Error",
@@ -739,7 +769,6 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: no 1",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -773,7 +802,6 @@ describe('pages/ error recovery', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -787,7 +815,6 @@ describe('pages/ error recovery', () => {
     } else if (process.env.NEXT_RSPACK) {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "  × Module build failed:",
          "environmentLabel": null,
          "label": "Build Error",
@@ -814,7 +841,6 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
@@ -844,7 +870,6 @@ describe('pages/ error recovery', () => {
       // TODO: Remove this branching once import traces are implemented in Turbopack
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Parsing ecmascript source code failed",
          "environmentLabel": null,
          "label": "Build Error",
@@ -858,7 +883,6 @@ describe('pages/ error recovery', () => {
     } else if (process.env.NEXT_RSPACK) {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "  × Module build failed:",
          "environmentLabel": null,
          "label": "Build Error",
@@ -885,7 +909,6 @@ describe('pages/ error recovery', () => {
     } else {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -81,19 +81,32 @@ describe('Error overlay for hydration errors in Pages router', () => {
     // Pages Router uses React version without Owner Stacks hence the empty `stack`
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Mismatch>
+       [
+         {
+           "componentStack": "<Mismatch>
            <div>
              <main>
        +       "server"
        -       "client"",
-         "count": 2,
-         "description": "Text content did not match. Server: "server" Client: "client"",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Text content did not match. Server: "server" Client: "client"",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+           <div>
+             <main>
+       +       "server"
+       -       "client"",
+           "description": "Text content did not match. Server: "server" Client: "client"",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -112,7 +125,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        -                     server
                      ...
                  ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -172,17 +184,38 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Mismatch>
+       [
+         {
+           "componentStack": "<Mismatch>
        >   <div>
        >     <main>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <main> in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+       >   <div>
+       >     <main>",
+           "description": "Expected server HTML to contain a matching <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+       >   <div>
+       >     <main>",
+           "description": "Expected server HTML to contain a matching <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -199,7 +232,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        +                   <main className="only">
                      ...
                  ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -244,18 +276,41 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Mismatch>
+       [
+         {
+           "componentStack": "<Mismatch>
            <div>
        >     <div>
        >       "second"",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching text node for "second" in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching text node for "second" in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+           <div>
+       >     <div>
+       >       "second"",
+           "description": "Expected server HTML to contain a matching text node for "second" in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+           <div>
+       >     <div>
+       >       "second"",
+           "description": "Expected server HTML to contain a matching text node for "second" in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -275,7 +330,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
                            ...
                      ...
                  ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -314,16 +368,26 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Mismatch>
+       [
+         {
+           "componentStack": "<Mismatch>
        >   <div>",
-         "count": 2,
-         "description": "Did not expect server HTML to contain a <main> in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Did not expect server HTML to contain a <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+       >   <div>",
+           "description": "Did not expect server HTML to contain a <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -341,7 +405,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        -                   <main className="only">
                      ...
                  ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -376,18 +439,30 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Mismatch>
+       [
+         {
+           "componentStack": "<Mismatch>
            <div>
        >     <div>
        >       "only"",
-         "count": 2,
-         "description": "Did not expect server HTML to contain the text node "only" in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Did not expect server HTML to contain the text node "only" in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+           <div>
+       >     <div>
+       >       "only"",
+           "description": "Did not expect server HTML to contain the text node "only" in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -405,7 +480,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        -                   only
                      ...
                  ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -454,16 +528,35 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Page>
+       [
+         {
+           "componentStack": "<Page>
        >   <table>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <table> in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <table> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <table>",
+           "description": "Expected server HTML to contain a matching <table> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <table>",
+           "description": "Expected server HTML to contain a matching <table> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -481,7 +574,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        -                 test
                      ...
                  ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -524,16 +616,35 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Page>
+       [
+         {
+           "componentStack": "<Page>
        >   <table>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <table> in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <table> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <table>",
+           "description": "Expected server HTML to contain a matching <table> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <table>",
+           "description": "Expected server HTML to contain a matching <table> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -551,7 +662,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        -                 {" 123"}
                      ...
                  ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -599,18 +709,41 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Mismatch>
+       [
+         {
+           "componentStack": "<Mismatch>
        >   <div>
              <Suspense>
        >       <main>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <main> in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+       >   <div>
+             <Suspense>
+       >       <main>",
+           "description": "Expected server HTML to contain a matching <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Mismatch>
+       >   <div>
+             <Suspense>
+       >       <main>",
+           "description": "Expected server HTML to contain a matching <main> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -629,7 +762,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
                          ...
                  ...
              ...",
-         "count": 1,
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -704,17 +836,38 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Page>
+       [
+         {
+           "componentStack": "<Page>
        >   <p>
        >     <p>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <p> in <p>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <p> in <p>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <p>
+       >     <p>",
+           "description": "Expected server HTML to contain a matching <p> in <p>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <p>
+       >     <p>",
+           "description": "Expected server HTML to contain a matching <p> in <p>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -732,7 +885,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >                   <p>
                      ...
                  ...",
-         "count": 1,
          "description": "In HTML, <p> cannot be a descendant of <p>.
        This will cause a hydration error.",
          "environmentLabel": null,
@@ -779,19 +931,44 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Page>
+       [
+         {
+           "componentStack": "<Page>
            <div>
              <div>
        >       <p>
        >         <div>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <div> in <p>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <div> in <p>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+           <div>
+             <div>
+       >       <p>
+       >         <div>",
+           "description": "Expected server HTML to contain a matching <div> in <p>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+           <div>
+             <div>
+       >       <p>
+       >         <div>",
+           "description": "Expected server HTML to contain a matching <div> in <p>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -809,7 +986,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >                     <div>
                    ...
                ...",
-         "count": 1,
          "description": "In HTML, <div> cannot be a descendant of <p>.
        This will cause a hydration error.",
          "environmentLabel": null,
@@ -848,17 +1024,38 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Page>
+       [
+         {
+           "componentStack": "<Page>
        >   <div>
        >     <tr>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <tr> in <div>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <tr> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <div>
+       >     <tr>",
+           "description": "Expected server HTML to contain a matching <tr> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+       >   <div>
+       >     <tr>",
+           "description": "Expected server HTML to contain a matching <tr> in <div>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -876,7 +1073,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >                   <tr>
                      ...
                  ...",
-         "count": 1,
          "description": "In HTML, <tr> cannot be a child of <div>.
        This will cause a hydration error.",
          "environmentLabel": null,
@@ -917,21 +1113,50 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
-       {
-         "componentStack": "<Page>
+       [
+         {
+           "componentStack": "<Page>
            <p>
              <span>
                <span>
                  <span>
        >           <span>
        >             <p>",
-         "count": 3,
-         "description": "Expected server HTML to contain a matching <p> in <span>.",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": null,
-         "stack": [],
-       }
+           "description": "Expected server HTML to contain a matching <p> in <span>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+           <p>
+             <span>
+               <span>
+                 <span>
+       >           <span>
+       >             <p>",
+           "description": "Expected server HTML to contain a matching <p> in <span>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+         {
+           "componentStack": "<Page>
+           <p>
+             <span>
+               <span>
+                 <span>
+       >           <span>
+       >             <p>",
+           "description": "Expected server HTML to contain a matching <p> in <span>.",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": null,
+           "stack": [],
+         },
+       ]
       `)
     } else {
       await expect(browser).toDisplayRedbox(`
@@ -953,7 +1178,6 @@ describe('Error overlay for hydration errors in Pages router', () => {
        >                           <p>
                      ...
                  ...",
-         "count": 1,
          "description": "In HTML, <p> cannot be a descendant of <p>.
        This will cause a hydration error.",
          "environmentLabel": null,

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -12,7 +12,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "trigger an console <error>",
        "environmentLabel": null,
        "label": "Console Error",
@@ -33,7 +32,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "trigger an console.error in render",
        "environmentLabel": null,
        "label": "Console Error",
@@ -52,7 +50,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "trigger an console.error in render",
        "environmentLabel": null,
        "label": "Console Error",
@@ -71,7 +68,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "ssr console error:client",
        "environmentLabel": null,
        "label": "Console Error",
@@ -90,7 +86,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "Error: page error",
        "environmentLabel": null,
        "label": "Console Error",
@@ -109,7 +104,6 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: boom",
          "environmentLabel": "Server",
          "label": "Console Error",

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -13,7 +13,6 @@ describe('app dir - dynamic error trace', () => {
     // TODO(veil): Where is the stackframe for app/page.js?
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Route / with \`dynamic = "error"\` couldn't be rendered statically because it used \`headers\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
        "environmentLabel": "Server",
        "label": "Runtime Error",

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -14,7 +14,6 @@ describe('Dynamic IO Dev Errors', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
          "environmentLabel": "Server",
          "label": "Console Error",
@@ -41,7 +40,6 @@ describe('Dynamic IO Dev Errors', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
          "environmentLabel": "Server",
          "label": "Console Error",
@@ -102,7 +100,6 @@ describe('Dynamic IO Dev Errors', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "count": 1,
          "description": "Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
          "environmentLabel": "Server",
          "label": "Console Error",
@@ -141,7 +138,6 @@ describe('Dynamic IO Dev Errors', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Ecmascript file had an error",
            "environmentLabel": null,
            "label": "Build Error",
@@ -155,7 +151,6 @@ describe('Dynamic IO Dev Errors', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.experimental.dynamicIO\`. Please remove it.",
          "environmentLabel": null,
          "label": "Build Error",

--- a/test/development/app-dir/error-overlay/async-client-component/async-client-component.test.ts
+++ b/test/development/app-dir/error-overlay/async-client-component/async-client-component.test.ts
@@ -15,14 +15,22 @@ describe('app-dir - async-client-component', () => {
     // Ideally, it would be issued from the async Component instead but that's
     // harder to implement.
     await expect(browser).toDisplayCollapsedRedbox(`
-     {
-       "count": 2,
-       "description": "<Page> is an async Client Component. Only Server Components can be async at the moment. This error is often caused by accidentally adding \`'use client'\` to a module that was originally written for the server.",
-       "environmentLabel": null,
-       "label": "Console Error",
-       "source": null,
-       "stack": [],
-     }
+     [
+       {
+         "description": "<Page> is an async Client Component. Only Server Components can be async at the moment. This error is often caused by accidentally adding \`'use client'\` to a module that was originally written for the server.",
+         "environmentLabel": null,
+         "label": "Console Error",
+         "source": null,
+         "stack": [],
+       },
+       {
+         "description": "A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework.",
+         "environmentLabel": null,
+         "label": "Console Error",
+         "source": null,
+         "stack": [],
+       },
+     ]
     `)
   })
 

--- a/test/development/app-dir/hook-function-names/hook-function-names.test.ts
+++ b/test/development/app-dir/hook-function-names/hook-function-names.test.ts
@@ -12,7 +12,6 @@ describe('hook-function-names', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "Error: Kaputt!",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -34,7 +33,6 @@ describe('hook-function-names', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: error in useEffect",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -1,17 +1,4 @@
 import { nextTestSetup } from 'e2e-utils'
-import {
-  hasErrorToast,
-  getToastErrorCount,
-  retry,
-  openRedbox,
-  getRedboxDescription,
-  getRedboxComponentStack,
-  goToNextErrorView,
-  getRedboxDescriptionWarning,
-  getHighlightedDiffLines,
-  assertHasRedbox,
-} from 'next-test-utils'
-import { BrowserInterface } from 'next-webdriver'
 
 describe('hydration-error-count', () => {
   const { next } = nextTestSetup({
@@ -21,44 +8,113 @@ describe('hydration-error-count', () => {
   it('should have correct hydration error count for bad nesting', async () => {
     const browser = await next.browser('/bad-nesting')
 
-    await retry(async () => {
-      await hasErrorToast(browser)
-      const totalErrorCount = await getToastErrorCount(browser)
-
-      // One hydration error and one warning
-      expect(totalErrorCount).toBe(2)
-    })
+    await expect(browser).toDisplayCollapsedRedbox(`
+     [
+       {
+         "componentStack": "...
+         <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/bad-nesting" tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
+     >                             <p>
+                             ...",
+         "description": "In HTML, <p> cannot be a descendant of <p>.
+     This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Console Error",
+         "source": "app/bad-nesting/page.tsx (6:7) @ Page
+     > 6 |       <p>nest</p>
+         |       ^",
+         "stack": [
+           "p <anonymous> (0:0)",
+           "Page app/bad-nesting/page.tsx (6:7)",
+         ],
+       },
+       {
+         "componentStack": "...
+         <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/bad-nesting" tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
+     >                             <p>
+                             ...",
+         "description": "In HTML, <p> cannot be a descendant of <p>.
+     This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/bad-nesting/page.tsx (6:7) @ Page
+     > 6 |       <p>nest</p>
+         |       ^",
+         "stack": [
+           "p <anonymous> (0:0)",
+           "Page app/bad-nesting/page.tsx (6:7)",
+         ],
+       },
+     ]
+    `)
   })
 
   it('should have correct hydration error count for html diff', async () => {
     const browser = await next.browser('/html-diff')
 
-    await retry(async () => {
-      await hasErrorToast(browser)
-      const totalErrorCount = await getToastErrorCount(browser)
-
-      // One hydration error and one warning
-      expect(totalErrorCount).toBe(1)
-    })
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "componentStack": "...
+         <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/html-diff" tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+                                 <p>
+     +                             client
+     -                             server
+                             ...",
+       "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+       "environmentLabel": null,
+       "label": "Runtime Error",
+       "source": "app/html-diff/page.tsx (4:10) @ Page
+     > 4 |   return <p>{typeof window === 'undefined' ? 'server' : 'client'}</p>
+         |          ^",
+       "stack": [
+         "p <anonymous> (0:0)",
+         "Page app/html-diff/page.tsx (4:10)",
+       ],
+     }
+    `)
   })
 
   it('should display correct hydration info in each hydration error view', async () => {
     const browser = await next.browser('/two-issues')
 
-    await openRedbox(browser)
-
-    const firstError = await getHydrationErrorSnapshot(browser)
-    await goToNextErrorView(browser)
-    const secondError = await getHydrationErrorSnapshot(browser)
-
-    // Hydration runtime error
-    // - contains a diff
-    // - has notes
-    expect(firstError).toMatchInlineSnapshot(`
-     {
-       "description": "In HTML, <p> cannot be a descendant of <p>.
-     This will cause a hydration error.",
-       "diff": "...
+    await expect(browser).toDisplayCollapsedRedbox(`
+     [
+       {
+         "componentStack": "...
          <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
            <RenderFromTemplateContext>
              <ScrollAndFocusHandler segmentPath={[...]}>
@@ -74,27 +130,20 @@ describe('hydration-error-count', () => {
      >                           <p className="client">
      >                             <p>
                              ...",
-       "highlightedLines": [
-         [
-           "error",
-           ">",
+         "description": "In HTML, <p> cannot be a descendant of <p>.
+     This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Console Error",
+         "source": "app/two-issues/page.tsx (10:7) @ Page
+     > 10 |       <p>nest</p>
+          |       ^",
+         "stack": [
+           "p <anonymous> (0:0)",
+           "Page app/two-issues/page.tsx (10:7)",
          ],
-         [
-           "error",
-           ">",
-         ],
-       ],
-       "notes": null,
-     }
-    `)
-
-    // Hydration console.error
-    // - contains a diff
-    // - no notes
-    expect(secondError).toMatchInlineSnapshot(`
-     {
-       "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
-       "diff": "...
+       },
+       {
+         "componentStack": "...
          <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
            <RenderFromTemplateContext>
              <ScrollAndFocusHandler segmentPath={[...]}>
@@ -112,37 +161,28 @@ describe('hydration-error-count', () => {
      -                             className="server"
                                  >
                              ...",
-       "highlightedLines": [
-         [
-           "add",
-           "+",
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/two-issues/page.tsx (10:7) @ Page
+     > 10 |       <p>nest</p>
+          |       ^",
+         "stack": [
+           "p <anonymous> (0:0)",
+           "Page app/two-issues/page.tsx (10:7)",
          ],
-         [
-           "remove",
-           "-",
-         ],
-       ],
-       "notes": "- A server/client branch \`if (typeof window !== 'undefined')\`.
-     - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
-     - Date formatting in a user's locale which doesn't match the server.
-     - External changing data without sending a snapshot of it along with the HTML.
-     - Invalid HTML tag nesting.
-
-     It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.",
-     }
+       },
+     ]
     `)
   })
 
   it('should display runtime error separately from hydration errors', async () => {
     const browser = await next.browser('/hydration-with-runtime-errors')
-    await assertHasRedbox(browser)
-    expect(await getToastErrorCount(browser)).toBe(3)
 
-    // Move to the last hydration error
-    await goToNextErrorView(browser)
-    expect(browser).toDisplayRedbox(`
-     {
-       "componentStack": "...
+    await expect(browser).toDisplayRedbox(`
+     [
+       {
+         "componentStack": "...
          <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
            <RenderFromTemplateContext>
              <ScrollAndFocusHandler segmentPath={[...]}>
@@ -158,49 +198,59 @@ describe('hydration-error-count', () => {
      >                           <p>
      >                             <p>
                              ...",
-       "count": 3,
-       "description": "In HTML, <p> cannot be a descendant of <p>.
+         "description": "In HTML, <p> cannot be a descendant of <p>.
      This will cause a hydration error.",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
+         "environmentLabel": null,
+         "label": "Console Error",
+         "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
      > 12 |       sneaky <p>very sneaky</p>
           |              ^",
-       "stack": [
-         "p <anonymous> (0:0)",
-         "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
-       ],
-     }
-    `)
-
-    await goToNextErrorView(browser)
-    expect(browser).toDisplayRedbox(`
-     {
-       "count": 3,
-       "description": "Error: runtime error",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": "app/hydration-with-runtime-errors/page.tsx (7:11) @ Page.useEffect
+         "stack": [
+           "p <anonymous> (0:0)",
+           "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
+         ],
+       },
+       {
+         "componentStack": "...
+         <OuterLayoutRouter parallelRouterKey="children" template={<RenderFromTemplateContext>}>
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/hydration..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
+     >                             <p>
+                             ...",
+         "description": "In HTML, <p> cannot be a descendant of <p>.
+     This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
+     > 12 |       sneaky <p>very sneaky</p>
+          |              ^",
+         "stack": [
+           "p <anonymous> (0:0)",
+           "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
+         ],
+       },
+       {
+         "description": "Error: runtime error",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/hydration-with-runtime-errors/page.tsx (7:11) @ Page.useEffect
      >  7 |     throw new Error('runtime error')
           |           ^",
-       "stack": [
-         "Page.useEffect app/hydration-with-runtime-errors/page.tsx (7:11)",
-       ],
-     }
+         "stack": [
+           "Page.useEffect app/hydration-with-runtime-errors/page.tsx (7:11)",
+         ],
+       },
+     ]
     `)
   })
 })
-
-async function getHydrationErrorSnapshot(browser: BrowserInterface) {
-  const description = await getRedboxDescription(browser)
-  const notes = await getRedboxDescriptionWarning(browser)
-  const diff = await getRedboxComponentStack(browser)
-  const highlightedLines = await getHighlightedDiffLines(browser)
-
-  return {
-    description,
-    notes,
-    diff,
-    highlightedLines,
-  }
-}

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -25,7 +25,6 @@ describe('app-dir - missing required html tags', () => {
     await assertHasRedbox(browser)
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Missing <html> and <body> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,
@@ -47,7 +46,6 @@ describe('app-dir - missing required html tags', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Missing <html> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -10,7 +10,6 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
 
      Check the render method of \`BrowserOnly\`.",
@@ -33,7 +32,6 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
 
      Check the render method of \`Inner\`.",
@@ -55,7 +53,6 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
 
      Check the render method of \`Inner\`.",

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -55,7 +55,6 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: browser error",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -92,7 +91,6 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "Error: browser error",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -141,7 +139,6 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "count": 1,
        "description": "Error: ssr error",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -171,7 +168,6 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "Error: string in rejected promise",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -12,7 +12,6 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -27,7 +26,6 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -48,7 +46,6 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -63,7 +60,6 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -89,7 +85,6 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -104,7 +99,6 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -126,7 +120,6 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -141,7 +134,6 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -12,7 +12,6 @@ describe('ssr-only-error', () => {
     // TODO(veil): Missing Owner Stack
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "count": 1,
        "description": "Error: SSR only error",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -274,7 +274,6 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: Additional keys were returned from \`getStaticProps\`. Properties intended for your component must be nested under the \`props\` key, e.g.:
 
        	return { props: { title: 'My Title', content: '...' } }
@@ -316,7 +315,6 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: custom oops",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -54,7 +54,6 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: boom",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -70,7 +69,6 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: boom",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -204,7 +202,6 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: test is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -221,7 +218,6 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: test is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -289,7 +285,6 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -304,7 +299,6 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -432,7 +426,6 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Parsing ecmascript source code failed",
            "environmentLabel": null,
            "label": "Build Error",
@@ -446,7 +439,6 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error:   x Expected '{', got '}'",
            "environmentLabel": null,
            "label": "Build Error",
@@ -500,7 +492,6 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Parsing ecmascript source code failed",
            "environmentLabel": null,
            "label": "Build Error",
@@ -514,7 +505,6 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error:   x Expected '{', got '}'",
            "environmentLabel": null,
            "label": "Build Error",

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -267,7 +267,6 @@ describe('Client Navigation', () => {
       await browser.elementByCss('#empty-props').click()
       await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: "EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -1252,9 +1251,43 @@ describe('Client Navigation', () => {
       await retry(async () => {
         expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
       })
-      await expect(browser).toDisplayRedbox(`
+      if (isReact18) {
+        await expect(browser).toDisplayRedbox(`
+         [
+           {
+             "description": "Error: An Expected error occurred",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "pages/error-inside-browser-page.js (5:13) @ ErrorInRenderPage.render
+         > 5 |       throw new Error('An Expected error occurred')
+             |             ^",
+             "stack": [
+               "ErrorInRenderPage.render pages/error-inside-browser-page.js (5:13)",
+             ],
+           },
+           {
+             "description": "Error: An Expected error occurred",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "pages/error-inside-browser-page.js (5:13) @ ErrorInRenderPage.render
+         > 5 |       throw new Error('An Expected error occurred')
+             |             ^",
+             "stack": [
+               "ErrorInRenderPage.render pages/error-inside-browser-page.js (5:13)",
+             ],
+           },
+           {
+             "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": null,
+             "stack": [],
+           },
+         ]
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
          {
-           "count": ${isReact18 ? 3 : 1},
            "description": "Error: An Expected error occurred",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -1266,6 +1299,7 @@ describe('Client Navigation', () => {
            ],
          }
         `)
+      }
       expect(pageErrors).toEqual(
         isReact18
           ? [
@@ -1298,7 +1332,6 @@ describe('Client Navigation', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
            {
-             "count": 1,
              "description": "Error: An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",
@@ -1313,7 +1346,6 @@ describe('Client Navigation', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
            {
-             "count": 1,
              "description": "Error: An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -131,7 +131,6 @@ describe('Client Navigation rendering', () => {
       if (isReact18 && isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -144,7 +143,6 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -163,7 +161,6 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: "InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://nextjs.org/docs/messages/get-initial-props-as-an-instance-method for more information.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -178,7 +175,6 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: "EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -222,7 +218,6 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: The default export is not a React Component in page: "/no-default-export"",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -238,7 +233,6 @@ describe('Client Navigation rendering', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: This is an expected error",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -254,7 +248,6 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: This is an expected error",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -278,7 +271,6 @@ describe('Client Navigation rendering', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: aa is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -294,7 +286,6 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: aa is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -422,7 +413,6 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: An undefined error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -176,7 +176,6 @@ describe('app-dir - errors', () => {
       if (isNextDev) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "Error: this is a test",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -216,7 +215,6 @@ describe('app-dir - errors', () => {
       if (isNextDev) {
         await expect(browser).toDisplayRedbox(`
           {
-            "count": 1,
             "description": "Error: custom server error",
             "environmentLabel": "Server",
             "label": "Runtime Error",

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -15,7 +15,6 @@ describe('app dir - global-error - error-in-global-error', () => {
       await assertHasRedbox(browser)
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: error in page",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -40,19 +39,31 @@ describe('app dir - global-error - error-in-global-error', () => {
     if (isNextDev) {
       await assertHasRedbox(browser)
       await expect(browser).toDisplayRedbox(`
-       {
-         "count": 2,
-         "description": "Error: error in global error",
-         "environmentLabel": null,
-         "label": "Runtime Error",
-         "source": "app/global-error.js (10:11) @ InnerGlobalError
+       [
+         {
+           "description": "Error: error in global error",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "app/global-error.js (10:11) @ InnerGlobalError
        > 10 |     throw new Error('error in global error')
             |           ^",
-         "stack": [
-           "InnerGlobalError app/global-error.js (10:11)",
-           "GlobalError app/global-error.js (26:7)",
-         ],
-       }
+           "stack": [
+             "InnerGlobalError app/global-error.js (10:11)",
+             "GlobalError app/global-error.js (26:7)",
+           ],
+         },
+         {
+           "description": "Error: error in page",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "app/page.js (7:11) @ Page.useEffect
+       >  7 |     throw new Error('error in page')
+            |           ^",
+           "stack": [
+             "Page.useEffect app/page.js (7:11)",
+           ],
+         },
+       ]
       `)
     }
   })

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -218,7 +218,6 @@ describe('app-dir - server source maps', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: Boom",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -16,7 +16,6 @@ describe('next-link', () => {
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: Failed prop type: The prop \`href\` expects a \`string\` or \`object\` in \`<Link>\`, but got \`undefined\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
@@ -43,7 +42,6 @@ describe('next-link', () => {
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: No children were passed to <Link> with \`href\` of \`/about\` but one child is required https://nextjs.org/docs/messages/link-no-children",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -68,7 +66,6 @@ describe('next-link', () => {
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "count": 1,
          "description": "Error: Multiple children were passed to <Link> with \`href\` of \`/\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children 
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -90,7 +90,6 @@ describe('server-side dev errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -105,7 +104,6 @@ describe('server-side dev errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -169,7 +167,6 @@ describe('server-side dev errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -184,7 +181,6 @@ describe('server-side dev errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -248,7 +244,6 @@ describe('server-side dev errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -263,7 +258,6 @@ describe('server-side dev errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -326,7 +320,6 @@ describe('server-side dev errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -341,7 +334,6 @@ describe('server-side dev errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -360,7 +352,6 @@ describe('server-side dev errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -375,7 +366,6 @@ describe('server-side dev errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -438,7 +428,6 @@ describe('server-side dev errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -453,7 +442,6 @@ describe('server-side dev errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -472,7 +460,6 @@ describe('server-side dev errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -487,7 +474,6 @@ describe('server-side dev errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "count": 1,
            "description": "ReferenceError: missingVar is not defined",
            "environmentLabel": null,
            "label": "Runtime Error",

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -934,27 +934,6 @@ export async function openRedbox(browser: BrowserInterface): Promise<void> {
   await assertHasRedbox(browser)
 }
 
-export async function goToNextErrorView(
-  browser: BrowserInterface
-): Promise<void> {
-  try {
-    const currentErrorIndex = await browser
-      .elementByCss('[data-nextjs-dialog-error-index]')
-      .text()
-    await browser.elementByCss('[data-nextjs-dialog-error-next]').click()
-    await retry(async () => {
-      const nextErrorIndex = await browser
-        .elementByCss('[data-nextjs-dialog-error-index]')
-        .text()
-      expect(nextErrorIndex).not.toBe(currentErrorIndex)
-    })
-  } catch (cause) {
-    const error = new Error('No Redbox to open.', { cause })
-    Error.captureStackTrace(error, openRedbox)
-    throw error
-  }
-}
-
 export async function openDevToolsIndicatorPopover(
   browser: BrowserInterface
 ): Promise<void> {


### PR DESCRIPTION
Makes it more obvious where hydration errors currently go wrong.

Failed tests in the test-flaky jobs are known to be flaky.

- [Error recovery app stuck error](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3A%22test%2Fdevelopment%2Facceptance-app%2Ferror-recovery.test.ts%22%20%40test.name%3A%22Error%20recovery%20app%20stuck%20error%22%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2C%40test_session.name%2C%40test.type%2C%40test.status%2C%40test.source.file%2C%40git.branch&currentTab=overview&eventStack=AwAAAZYAw-4Ys8PxewAAABhBWllBdy00WUFBRHdBVE9ITDhmOWgtOEYAAAAkMDE5NjAxMTEtYzBmMy00MTA3LThhMDMtMzI0YzZiM2FjMWUzAAXaag&fromUser=false&graphType=flamegraph&index=citest&testId=AwAAAZYAw-4Ys8PxewAAABhBWllBdy00WUFBRHdBVE9ITDhmOWgtOEYAAAAkMDE5NjAxMTEtYzBmMy00MTA3LThhMDMtMzI0YzZiM2FjMWUzAAXaag&trace=AwAAAZYAw-4Ys8PxewAAABhBWllBdy00WUFBRHdBVE9ITDhmOWgtOEYAAAAkMDE5NjAxMTEtYzBmMy00MTA3LThhMDMtMzI0YzZiM2FjMWUzAAXaag&start=1743501620761&end=1744106420761&paused=false)
- [ReactRefreshLogBox app Server component errors should open up in fullscreen](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.status%3Afail%20%40test.name%3A%22ReactRefreshLogBox%20app%20Server%20component%20errors%20should%20open%20up%20in%20fullscreen%22&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2C%40test_session.name%2C%40test.type%2C%40test.status%2C%40test.source.file%2C%40git.branch&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1743501681145&end=1744106481145&paused=false)
- [ReactRefreshLogBox app server component can recover from error thrown in the module](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3A%22ReactRefreshLogBox%20app%20server%20component%20can%20recover%20from%20error%20thrown%20in%20the%20module%22&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2C%40test_session.name%2C%40test.type%2C%40test.status%2C%40test.source.file%2C%40git.branch&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1743501681145&end=1744106481145&paused=false)