### PR TITLE
fix: flaky test detection needs to use new turbopack flag

### DIFF
--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -151,7 +151,7 @@ async function main() {
           ...process.env,
           NEXT_TEST_MODE: testMode,
           NEXT_TEST_VERSION: nextTestVersion,
-          TURBOPACK: '1',
+          IS_TURBOPACK_TEST: '1',
           TURBOPACK_BUILD: testMode === 'start' ? '1' : undefined,
           NEXT_EXTERNAL_TESTS_FILTERS:
             testMode === 'dev'


### PR DESCRIPTION
As of #77894, there's a new way to indicate Turbopack should run, which breaks flaky tests detection with Turbopack. This swaps out the flag to unblock my downstack PR.