### PR TITLE
Revert "Fix: RESTORE_ACTION should not be thenable"

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -207,7 +207,7 @@ export function createMutableActionQueue(
     state: initialState,
     dispatch: (payload: ReducerActions, setState: DispatchStatePromise) =>
       dispatchAction(actionQueue, payload, setState),
-    action: (state: AppRouterState, action: ReducerActions) => {
+    action: async (state: AppRouterState, action: ReducerActions) => {
       const result = reducer(state, action)
       return result
     },


### PR DESCRIPTION
When testing this change internally, we observed a performance regression and are reverting it while we dig into it.

x-ref:
- [slack thread 1](https://vercel.slack.com/archives/C03S8ED1DKM/p1743891559028139)
- [slack thread 2](https://vercel.slack.com/archives/C04KC8A53T7/p1744114815040429)

Reverts vercel/next.js#77582