### PR TITLE
Turbopack: fix a bug where marking a task a completed causes a panic when reading the output

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -455,11 +455,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     Some(Ok(Err(listen_to_done_event(this, reader, done_event))))
                 }
                 Some(InProgressState::InProgress(box InProgressStateInner {
-                    completed,
+                    done,
                     done_event,
                     ..
                 })) => {
-                    if !*completed {
+                    if !*done {
                         Some(Ok(Err(listen_to_done_event(this, reader, done_event))))
                     } else {
                         None
@@ -1137,7 +1137,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     done_event,
                     session_dependent: false,
                     marked_as_completed: false,
-                    completed: false,
+                    done: false,
                     new_children: Default::default(),
                 })),
             });
@@ -1280,7 +1280,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         let &mut InProgressState::InProgress(box InProgressStateInner {
             stale,
-            ref mut completed,
+            ref mut done,
             ref done_event,
             ref mut new_children,
             ..
@@ -1321,7 +1321,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         // mark the task as completed, so dependent tasks can continue working
-        *completed = true;
+        *done = true;
         done_event.notify(usize::MAX);
 
         // take the children from the task to process them
@@ -1503,7 +1503,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             once_task: _,
             stale,
             session_dependent,
-            completed: _,
+            done: _,
             marked_as_completed: _,
             new_children,
         }) = in_progress

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -607,7 +607,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let (item, listener) =
             CachedDataItem::new_scheduled_with_listener(self.get_task_desc_fn(task_id), note);
         // It's not possible that the task is InProgress at this point. If it is InProgress {
-        // completed: true } it must have Output and would early return.
+        // done: true } it must have Output and would early return.
         task.add_new(item);
         turbo_tasks.schedule(task_id);
 

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -313,7 +313,7 @@ pub struct InProgressStateInner {
     /// task completion of the task for strongly consistent reads.
     pub marked_as_completed: bool,
     /// Task execution has completed and the output is available.
-    pub completed: bool,
+    pub done: bool,
     /// Event that is triggered when the task output is available (completed flag set).
     /// This is used to wait for completion when reading the task output before it's available.
     pub done_event: Event,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -309,7 +309,13 @@ pub struct InProgressStateInner {
     #[allow(dead_code)]
     pub once_task: bool,
     pub session_dependent: bool,
+    /// Early marking as completed. This is set before the output is available and will ignore full
+    /// task completion of the task for strongly consistent reads.
     pub marked_as_completed: bool,
+    /// Task execution has completed and the output is available.
+    pub completed: bool,
+    /// Event that is triggered when the task output is available (completed flag set).
+    /// This is used to wait for completion when reading the task output before it's available.
     pub done_event: Event,
     /// Children that should be connected to the task and have their active_count decremented
     /// once the task completes.


### PR DESCRIPTION
### What?

When using mark_finished() on a task, reading that task while it's still in progress will lead to a panic because it would try to schedule that task for recomputation, but it's already scheduled.

Closes PACK-4313