### PR TITLE
perf(turbopack): Apply minifier before bundling

### DIFF
--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -14,6 +14,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    chunk::MinifyType,
     file_source::FileSource,
     ident::AssetIdent,
     issue::{
@@ -285,6 +286,7 @@ pub async fn parse_segment_config_from_source(
             EcmascriptModuleAssetType::Ecmascript
         }),
         EcmascriptInputTransforms::empty(),
+        MinifyType::NoMinify,
     )
     .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -73,6 +73,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext, EvaluatableAsset,
+        MinifyType,
     },
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
@@ -165,6 +166,8 @@ pub struct EcmascriptOptions {
     /// parsing fails. This is useful to keep the module graph structure intact when syntax errors
     /// are temporarily introduced.
     pub keep_last_successful_parse: bool,
+
+    pub minify: MinifyType,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
@@ -568,8 +571,15 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub fn parse(&self) -> Vc<ParseResult> {
-        parse(*self.source, Value::new(self.ty), *self.transforms)
+    pub async fn parse(&self) -> Result<Vc<ParseResult>> {
+        let minify = self.options.await?.minify;
+
+        Ok(parse(
+            *self.source,
+            Value::new(self.ty),
+            *self.transforms,
+            minify,
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -516,6 +516,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let options = raw_module.options;
     let options = options.await?;
     let import_externals = options.import_externals;
+    let minify = options.minify;
 
     let origin = ResolvedVc::upcast::<Box<dyn ResolveOrigin>>(module);
 
@@ -530,7 +531,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     };
 
     let parsed = if let Some(part) = part {
-        let parsed = parse(*source, ty, *transforms);
+        let parsed = parse(*source, ty, *transforms, options.minify);
         let split_data = split(source.ident(), *source, parsed);
         part_of_module(split_data, part.clone())
     } else {
@@ -931,6 +932,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         request,
                         runtime,
                         transforms,
+                        minify,
                     }
                     .resolved_cell(),
                 );
@@ -941,6 +943,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                             source,
                             runtime,
                             transforms,
+                            minify,
                         }
                         .resolved_cell(),
                     );
@@ -952,6 +955,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                             chunk_id: chunk,
                             runtime,
                             transforms,
+                            minify,
                         }
                         .resolved_cell(),
                     );

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -14,7 +14,7 @@ use swc_core::{
 };
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::source::Source;
+use turbopack_core::{chunk::MinifyType, source::Source};
 
 use crate::{
     analyzer::{graph::EvalContext, JsValue},
@@ -205,6 +205,7 @@ pub async fn webpack_runtime(
         source,
         Value::new(EcmascriptModuleAssetType::Ecmascript),
         transforms,
+        MinifyType::NoMinify,
     )
     .await?;
     match &*parsed {

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -8,6 +8,7 @@ use swc_core::{
 };
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
+    chunk::MinifyType,
     reference::{ModuleReference, ModuleReferences},
     source::Source,
 };
@@ -24,11 +25,13 @@ pub async fn module_references(
     source: ResolvedVc<Box<dyn Source>>,
     runtime: ResolvedVc<WebpackRuntime>,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
+    minify: MinifyType,
 ) -> Result<Vc<ModuleReferences>> {
     let parsed = parse(
         *source,
         Value::new(EcmascriptModuleAssetType::Ecmascript),
         *transforms,
+        minify,
     )
     .await?;
     match &*parsed {
@@ -42,6 +45,7 @@ pub async fn module_references(
                 references: &mut references,
                 runtime,
                 transforms,
+                minify,
             };
             let (emitter, collector) = IssueEmitter::new(
                 source,
@@ -63,6 +67,7 @@ struct ModuleReferencesVisitor<'a> {
     runtime: ResolvedVc<WebpackRuntime>,
     references: &'a mut Vec<ResolvedVc<Box<dyn ModuleReference>>>,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
+    minify: MinifyType,
 }
 
 impl Visit for ModuleReferencesVisitor<'_> {
@@ -77,6 +82,7 @@ impl Visit for ModuleReferencesVisitor<'_> {
                                     chunk_id: lit.clone(),
                                     runtime: self.runtime,
                                     transforms: self.transforms,
+                                    minify: self.minify,
                                 }
                                 .resolved_cell(),
                             ));


### PR DESCRIPTION
### What?

The SWC minifier does not contend with turbopack; we can retry this.

Note: This will guard against most of the static analyzer issues of turbopack because the SWC minifier has a fully featured analyzer.

### Why?

The build is about 10% faster.

### How?



Closes PACK-4811