### PR TITLE
fix: after(callback) from a after(promise) should always run

### DIFF
--- a/test/e2e/app-dir/next-after-app-deploy/app/edge/server-action-promise/page.js
+++ b/test/e2e/app-dir/next-after-app-deploy/app/edge/server-action-promise/page.js
@@ -1,0 +1,1 @@
+export { default } from '../../nodejs/server-action-promise/page'

--- a/test/e2e/app-dir/next-after-app-deploy/app/nodejs/server-action-promise/page.js
+++ b/test/e2e/app-dir/next-after-app-deploy/app/nodejs/server-action-promise/page.js
@@ -1,0 +1,32 @@
+import { after } from 'next/server'
+import { revalidateTimestampPage } from '../../timestamp/revalidate'
+import { pathPrefix } from '../../path-prefix'
+
+export default function Page() {
+  return (
+    <div>
+      <form
+        action={async () => {
+          'use server'
+
+          // This test checks if revalidates issued from `after(promise)` are executed
+          // if no `after(callback)` calls occurred.
+          // We had a bug where we'd only execute revalidates from `after(promise)` if an `after(callback)` call also happened,
+          // because execution of revalidations was only triggered when running callbacks.
+
+          const promise = (async () => {
+            // hackily wait for the response to close
+            await new Promise((resolve) => setTimeout(resolve, 500))
+
+            console.log('promise: calling revalidatePath')
+            await revalidateTimestampPage(pathPrefix + `/server-action-promise`)
+          })()
+
+          after(promise)
+        }}
+      >
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/next-after-app-deploy/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-deploy/index.test.ts
@@ -72,7 +72,7 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
     )
   })
 
-  it('triggers revalidate from a server action', async () => {
+  it('triggers revalidate from a server action via after(callback)', async () => {
     const path = pathPrefix + '/server-action'
     const dataBefore = await getInitialTimestampPageData(path)
 
@@ -86,6 +86,24 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
       },
       retryDuration,
       1000,
+      'check if timestamp page updated'
+    )
+  })
+
+  it('triggers revalidate from a server action via after(promise)', async () => {
+    const path = pathPrefix + '/server-action-promise'
+    const dataBefore = await getInitialTimestampPageData(path)
+
+    const session = await next.browser(path)
+    await session.elementByCss('button[type="submit"]').click() // trigger revalidate
+
+    await retry(
+      async () => {
+        const dataAfter = await getTimestampPageData(path)
+        expect(dataAfter.timestamp).toBeGreaterThan(dataBefore.timestamp)
+      },
+      retryDuration + 500, // the test has an artificial delay to wait for the response to close
+      500,
       'check if timestamp page updated'
     )
   })

--- a/test/e2e/app-dir/next-after-app/app/edge/nested-after-from-slow-promise/page.js
+++ b/test/e2e/app-dir/next-after-app/app/edge/nested-after-from-slow-promise/page.js
@@ -1,0 +1,1 @@
+export { default } from '../../nodejs/nested-after-from-slow-promise/page'

--- a/test/e2e/app-dir/next-after-app/app/nodejs/nested-after-from-slow-promise/page.js
+++ b/test/e2e/app-dir/next-after-app/app/nodejs/nested-after-from-slow-promise/page.js
@@ -1,0 +1,27 @@
+import { after, connection } from 'next/server'
+import { cliLog } from '../../../utils/log'
+
+export default async function Index() {
+  await connection()
+
+  // This test checks if `after` callbacks scheduled from `after(promise)` are executed if
+  // - the promise resolves after the response ended
+  // - no `after(callback)` calls occurred before the response ended
+  // We had a bug where the after callback queue wouldn't start if no `after(callback)` calls occured during the response,
+  // so the callback scheduled from the promise would never run.
+
+  const promise = (async () => {
+    // hackily wait for the response to finish
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    after(() => {
+      cliLog({
+        source: '[page] /nested-after-from-slow-promise',
+      })
+    })
+  })()
+
+  after(promise)
+
+  return <div>Page with nested after() called from a slow promise</div>
+}

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -96,6 +96,16 @@ describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
     })
   })
 
+  it('runs callbacks from nested after calls that happened within a slow promise', async () => {
+    await next.browser(pathPrefix + '/nested-after-from-slow-promise')
+
+    await retry(() => {
+      expect(getLogs()).toContainEqual({
+        source: `[page] /nested-after-from-slow-promise`,
+      })
+    })
+  })
+
   describe('interrupted RSC renders', () => {
     // This is currently broken with Turbopack.
     // https://github.com/vercel/next.js/pull/75989


### PR DESCRIPTION
This PR fixes multiple bugs related to `after(promise)`.

### `after(callback)` called from a `after(promise)` after the response is closed

The scenario is as follows (assume no other `after()` calls occurred)

```ts
const promise = (async () => {
  await slow() // resolves after the response closes
  after(callback)
})();

after(promise);
```

Previously, `callback` would never execute. This is because we were only starting the callback queue if an `after(anotherCallback)` call happened during the request (i.e. if `AfterContext.addCallback` was called). So If no callbacks were ever added, we'd never schedule `runCallbacksOnClose`, the queue would never start, and thus `callback` would never run.

As a slightly hacky solution to this problem, we now wrap promises in callbacks and queue them, which ensures that the queue will always be running. 

TBH I'm not super happy about having to do it this way, but it solves all three issues described here with a pretty small change. Solving it properly would require a whole bunch of deeper changes (e.g. replacing `p-queue` with our own task queue implementation to have more control), so I'll follow up with that later, when we land the fix.

### `revalidatePath` called from `after(promise)` after the response is closed

We were also only calling `executeRevalidates` after running callbacks, but not if after was *only* called with promises. This means that `revalidatePath/Tag` calls would silently do nothing for revalidates from promises. By wrapping each promise in a callback, we now ensure that `executeRevalidates` also happens for promises.
(note that this only affects promises that resolved after the response closes --
if they resolved earlier, it'd be handled by an earlier `executeRevalidates` in the action/route handler codepaths.)

### `workUnitStore.phase` not switched to 'action' for `after(promise)`

This is another bug that occured if we only got `after(promise)` and no `after(callback)`. Similarly to the revalidates bug, setting the `workUnitStore` is done in `runCallback`, so if we received no callbacks, we wouldn't switch the phase.

Note that for promises, phases are racy -- the promise is already running, so it could see different phases depending on the timing. But we can't really do anything about that.
(I'm considering if there's good ways of warning against racy calls to request APIs,
but i'm leaving that for a follow up as well)