### PR TITLE
add build script for next-error-code-swc-plugin

### DIFF
--- a/crates/next-error-code-swc-plugin/README.md
+++ b/crates/next-error-code-swc-plugin/README.md
@@ -9,7 +9,7 @@ This plugin transforms Next.js source code by:
 
 ## Error Code Mapping
 
-- **File Location:** `/packages/next/errors.json`
+- **File Location:** `packages/next/errors.json`
 - **Structure:** Append-only, increment-based mapping of error codes to messages.
 - **Automation:**
   - Running `pnpm build` automatically updates `errors.json` if new errors are introduced.
@@ -20,10 +20,10 @@ This plugin transforms Next.js source code by:
 - **Two-Pass Build:**
 
   1. **First Pass:**
-     - Extracts new errors and temporarily stores them in `/packages/next/.errors/*.json`.
+     - Extracts new errors and temporarily stores them in `packages/next/.errors/*.json`.
      - In CI, a build with new errors will fail.
   2. **Second Pass:**
-     - Updates `/packages/next/errors.json` and reruns the build step to confirm no further new errors.
+     - Updates `packages/next/errors.json` and reruns the build step to confirm no further new errors.
      - Inspired by React's [error mapping mechanism](https://github.com/facebook/react/tree/main/scripts/error-codes).
 
 - **Concurrency Handling:** The two-pass system ensures reliable ordering of inserted error codes during concurrent builds.
@@ -32,20 +32,7 @@ This plugin transforms Next.js source code by:
 
 - **WASM Rebuild Required:**
 
-  - After modifying the plugin, rebuild the WASM file and commit it to the repository.
-  - **Reason:** Pre-built artefacts simplify the build process (`pnpm build` runs without requiring `cargo`).
+  - After modifying the plugin, rebuild the WASM file via `pnpm build-error-code-plugin` and commit it to the repository.
+  - **Reason:** Pre-built artifacts simplify the build process (`pnpm build` runs without requiring `cargo`).
 
-- **Rebuild Script Example:**
-
-  ```bash
-  #!/usr/bin/env bash
-  set -e
-  NEXT_JS_ROOT="/Users/judegao/repos/next.js"
-  cd "$NEXT_JS_ROOT/crates/next-error-code-swc-plugin"
-  rustup target add wasm32-wasip1
-  CARGO_PROFILE_RELEASE_STRIP=true CARGO_PROFILE_RELEASE_LTO=true cargo build --target wasm32-wasip1 --release
-  mv "$NEXT_JS_ROOT/crates/next-error-code-swc-plugin/target/wasm32-wasip1/release/next_error_code_swc_plugin.wasm" "$NEXT_JS_ROOT/packages/next/"
-  echo "✨ Successfully built and moved WASM plugin! 🚀"
-  ```
-
-- **Testing:** Navigate to `/crates/next-error-code-swc-plugin` and run `cargo test` to test the plugin
+- **Testing:** Run `cargo test` inside the `crates/next-error-code-swc-plugin` directory to test the plugin.

--- a/crates/next-error-code-swc-plugin/build-and-move.sh
+++ b/crates/next-error-code-swc-plugin/build-and-move.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+echo "Building next-error-code-swc-plugin..." >&2
+
+# assumes this script sits in the root of the plugin directory
+plugin_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+repo_root="$(realpath "${plugin_dir}/../..")"
+
+nextjs_dir="$repo_root/packages/next"
+if ! [ -d "$nextjs_dir" ]; then
+  echo "Expected to find next.js directory at '$nextjs_dir'" >&2
+  echo "(based on computed repository root '$repo_root')" >&2
+  exit 1
+fi
+
+BUILD_TARGET='wasm32-wasip1'
+
+cd "$plugin_dir"
+rustup target add "$BUILD_TARGET"
+CARGO_PROFILE_RELEASE_STRIP=true CARGO_PROFILE_RELEASE_LTO=true cargo build --target "$BUILD_TARGET" --release
+output_file="$nextjs_dir/next_error_code_swc_plugin.wasm"
+mv "$plugin_dir/target/$BUILD_TARGET/release/next_error_code_swc_plugin.wasm" "$output_file"
+
+echo "✨ Plugin built successfully 🚀" >&2
+echo "   (Don't forget to commit the generated .wasm file!)" >&2
+echo "$output_file"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "sweep": "tsx scripts/sweep.cjs",
     "check-error-codes": "node packages/next/check-error-codes.js",
     "update-error-codes": "cd packages/next && pnpm taskr compile check_error_codes",
+    "build-error-code-plugin": "crates/next-error-code-swc-plugin/build-and-move.sh",
     "storybook": "turbo run storybook",
     "build-storybook": "turbo run build-storybook",
     "test-storybook": "turbo run test-storybook",


### PR DESCRIPTION
Adds a build script for `next-error-code-swc-plugin`, runnable via `pnpm build-error-code-plugin`. The script compiles the plugin and moves the result to its expected location in `packages/next/next_error_code_swc_plugin.wasm`.

I've also rebuilt the plugin and committed it -- i was getting a different compiled output that what's currently there. Not sure if the build is non-deterministic, a dependency changed, or if someone forgot to recompile it, but it can't hurt.