### PR TITLE
test: attempt to de-flake rsc-basic

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { check } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
+import { Page } from 'playwright'
 
 // TODO: We should decide on an established pattern for gating test assertions
 // on experimental flags. For example, as a first step we could all the common
@@ -161,27 +162,28 @@ describe('app dir - rsc basics', () => {
   })
 
   it('should reuse the inline flight response without sending extra requests', async () => {
-    let hasFlightRequest = false
+    const flightRequests: string[] = []
     let requestsCount = 0
-    await next.browser('/root', {
-      beforePageLoad(page) {
+    const browser = await next.browser('/root', {
+      beforePageLoad(page: Page) {
         page.on('request', (request) => {
           requestsCount++
-          return request.allHeaders().then((headers) => {
-            if (
-              headers['RSC'.toLowerCase()] === '1' &&
-              // Prefetches also include `RSC`
-              headers['Next-Router-Prefetch'.toLowerCase()] !== '1'
-            ) {
-              hasFlightRequest = true
-            }
-          })
+          const headers = request.headers()
+          if (
+            headers['RSC'.toLowerCase()] === '1' &&
+            // Prefetches also include `RSC`
+            headers['Next-Router-Prefetch'.toLowerCase()] !== '1'
+          ) {
+            flightRequests.push(request.url())
+          }
         })
       },
     })
 
+    await browser.waitForIdleNetwork()
+
     expect(requestsCount).toBeGreaterThan(0)
-    expect(hasFlightRequest).toBe(false)
+    expect(flightRequests).toEqual([])
   })
 
   it('should support multi-level server component imports', async () => {


### PR DESCRIPTION
I've been seeing this test flake with some regularity:

---
● app dir - rsc basics › should be able to navigate between rsc routes

```
request.allHeaders: Target page, context or browser has been closed

  168 |         page.on('request', (request) => {
  169 |           requestsCount++
> 170 |           return request.allHeaders().then((headers) => {
      |                          ^
  171 |             if (
  172 |               headers['RSC'.toLowerCase()] === '1' &&
  173 |               // Prefetches also include `RSC`

  at Page.allHeaders (e2e/app-dir/rsc-basic/rsc-basic.test.ts:170:26)
```
---

[Example test run here](https://github.com/vercel/next.js/actions/runs/14313872710/job/40115445718?pr=77898#step:33:3431)

The error is actually unrelated to `should be able to navigate between rsc routes`, and is coming from async operations (that haven't completed in time) in another test in the same suite, `should reuse the inline flight response without sending extra requests` .

I've de-asyncified the test's `page.on('request')` handler -- we don't need the async `allHeaders()`, `headers()` is enough.
(I verified this by adding a client component that manually sends a request with `RSC: 1`, and that does indeed trigger our request listener).
I've also added a `waitForIdleNetwork` to hopefully make it complete all requests before the test ends.