### PR TITLE
Turbopack: persist and compare errors and panics

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1456,7 +1456,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     fn task_execution_result(
         &self,
         task_id: TaskId,
-        result: Result<RawVc, Arc<TurboTasksExecutionError>>,
+        result: Result<RawVc, TurboTasksExecutionError>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
         operation::UpdateOutputOperation::run(task_id, result, self.execute_context(turbo_tasks));
@@ -2566,7 +2566,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
     fn task_execution_result(
         &self,
         task_id: TaskId,
-        result: Result<RawVc, Arc<TurboTasksExecutionError>>,
+        result: Result<RawVc, TurboTasksExecutionError>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) {
         self.0.task_execution_result(task_id, result, turbo_tasks);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -564,36 +564,38 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         if let Some(output) = get!(task, Output) {
             let result = match output {
-                OutputValue::Cell(cell) => Some(Ok(Ok(RawVc::TaskCell(cell.task, cell.cell)))),
-                OutputValue::Output(task) => Some(Ok(Ok(RawVc::TaskOutput(*task)))),
-                OutputValue::Error => get!(task, Error).map(|error| Err(error.clone().into())),
+                OutputValue::Cell(cell) => Ok(Ok(RawVc::TaskCell(cell.task, cell.cell))),
+                OutputValue::Output(task) => Ok(Ok(RawVc::TaskOutput(*task))),
+                OutputValue::Error(error) => {
+                    let err: anyhow::Error = error.clone().into();
+                    Err(err.context(format!(
+                        "Execution of {} failed",
+                        ctx.get_task_description(task_id)
+                    )))
+                }
             };
-            if let Some(result) = result {
-                if self.should_track_dependencies() {
-                    if let Some(reader) = reader {
-                        let _ = task.add(CachedDataItem::OutputDependent {
-                            task: reader,
+            if self.should_track_dependencies() {
+                if let Some(reader) = reader {
+                    let _ = task.add(CachedDataItem::OutputDependent {
+                        task: reader,
+                        value: (),
+                    });
+                    drop(task);
+
+                    let mut reader_task = ctx.task(reader, TaskDataCategory::Data);
+                    if reader_task
+                        .remove(&CachedDataItemKey::OutdatedOutputDependency { target: task_id })
+                        .is_none()
+                    {
+                        let _ = reader_task.add(CachedDataItem::OutputDependency {
+                            target: task_id,
                             value: (),
                         });
-                        drop(task);
-
-                        let mut reader_task = ctx.task(reader, TaskDataCategory::Data);
-                        if reader_task
-                            .remove(&CachedDataItemKey::OutdatedOutputDependency {
-                                target: task_id,
-                            })
-                            .is_none()
-                        {
-                            let _ = reader_task.add(CachedDataItem::OutputDependency {
-                                target: task_id,
-                                value: (),
-                            });
-                        }
                     }
                 }
-
-                return result;
             }
+
+            return result;
         }
 
         let reader_desc = reader.map(|r| self.get_task_desc_fn(r));

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -4,9 +4,9 @@ use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     CellId, KeyValuePair, SessionId, TaskId, TraitTypeId, TypedSharedReference, ValueTypeId,
+    backend::TurboTasksExecutionError,
     event::{Event, EventListener},
     registry,
-    util::SharedError,
 };
 
 use crate::{
@@ -56,7 +56,7 @@ pub struct CollectiblesRef {
 pub enum OutputValue {
     Cell(CellRef),
     Output(TaskId),
-    Error(SharedError),
+    Error(TurboTasksExecutionError),
 }
 impl OutputValue {
     fn is_transient(&self) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -52,18 +52,18 @@ pub struct CollectiblesRef {
     pub collectible_type: TraitTypeId,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OutputValue {
     Cell(CellRef),
     Output(TaskId),
-    Error,
+    Error(SharedError),
 }
 impl OutputValue {
     fn is_transient(&self) -> bool {
         match self {
             OutputValue::Cell(cell) => cell.task.is_transient(),
             OutputValue::Output(task) => task.is_transient(),
-            OutputValue::Error => false,
+            OutputValue::Error(_) => false,
         }
     }
 }
@@ -482,12 +482,6 @@ pub enum CachedDataItem {
         target: CollectiblesRef,
         value: (),
     },
-
-    // Transient Error State
-    #[serde(skip)]
-    Error {
-        value: SharedError,
-    },
 }
 
 impl CachedDataItem {
@@ -523,7 +517,6 @@ impl CachedDataItem {
             CachedDataItem::OutdatedOutputDependency { .. } => false,
             CachedDataItem::OutdatedCellDependency { .. } => false,
             CachedDataItem::OutdatedCollectiblesDependency { .. } => false,
-            CachedDataItem::Error { .. } => false,
         }
     }
 
@@ -578,7 +571,6 @@ impl CachedDataItem {
             | Self::OutdatedCollectiblesDependency { .. }
             | Self::InProgressCell { .. }
             | Self::InProgress { .. }
-            | Self::Error { .. }
             | Self::Activeness { .. } => TaskDataCategory::All,
         }
     }
@@ -621,7 +613,6 @@ impl CachedDataItemKey {
             CachedDataItemKey::OutdatedOutputDependency { .. } => false,
             CachedDataItemKey::OutdatedCellDependency { .. } => false,
             CachedDataItemKey::OutdatedCollectiblesDependency { .. } => false,
-            CachedDataItemKey::Error { .. } => false,
         }
     }
 
@@ -660,7 +651,6 @@ impl CachedDataItemType {
             | Self::OutdatedCollectiblesDependency { .. }
             | Self::InProgressCell { .. }
             | Self::InProgress { .. }
-            | Self::Error { .. }
             | Self::Activeness { .. } => TaskDataCategory::All,
         }
     }
@@ -693,8 +683,7 @@ impl CachedDataItemType {
             | Self::OutdatedCollectible
             | Self::OutdatedOutputDependency
             | Self::OutdatedCellDependency
-            | Self::OutdatedCollectiblesDependency
-            | Self::Error => false,
+            | Self::OutdatedCollectiblesDependency => false,
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/panics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/panics.rs
@@ -1,7 +1,7 @@
 use core::panic;
 use std::{
     panic::{set_hook, take_hook},
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
 };
 
 use anyhow::Result;
@@ -28,11 +28,11 @@ async fn test_panics_include_location() {
     let error = result.unwrap_err();
     let root_cause = error.root_cause();
 
-    let Some(panic) = root_cause.downcast_ref::<Arc<TurboTasksExecutionError>>() else {
+    let Some(panic) = root_cause.downcast_ref::<TurboTasksExecutionError>() else {
         panic!("Expected a TurboTasksExecutionError");
     };
 
-    let TurboTasksExecutionError::Panic(panic) = &**panic else {
+    let TurboTasksExecutionError::Panic(panic) = &*panic else {
         panic!("Expected a TurboTasksExecutionError::Panic");
     };
 

--- a/turbopack/crates/turbo-tasks-backend/tests/panics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/panics.rs
@@ -32,7 +32,7 @@ async fn test_panics_include_location() {
         panic!("Expected a TurboTasksExecutionError");
     };
 
-    let TurboTasksExecutionError::Panic(panic) = &*panic else {
+    let TurboTasksExecutionError::Panic(panic) = panic else {
         panic!("Expected a TurboTasksExecutionError::Panic");
     };
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -43,7 +43,7 @@ use crate::{
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
     trait_helpers::get_trait_method,
-    util::{IdFactory, SharedError, StaticOrArc},
+    util::{IdFactory, StaticOrArc},
     vc::ReadVcFuture,
 };
 
@@ -711,10 +711,8 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
                         let result = match result {
                             Ok(Ok(raw_vc)) => Ok(raw_vc),
-                            Ok(Err(err)) => Err(Arc::new(err.into())),
-                            Err(err) => {
-                                Err(Arc::new(TurboTasksExecutionError::Panic(Arc::new(err))))
-                            }
+                            Ok(Err(err)) => Err(err.into()),
+                            Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
                         };
 
                         this.backend.task_execution_result(task_id, result, &*this);
@@ -807,24 +805,14 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
                 let result = match result {
                     Ok(Ok(raw_vc)) => Ok(raw_vc),
-                    Ok(Err(err)) => Err(Arc::new(err.into())),
-                    Err(err) => Err(Arc::new(TurboTasksExecutionError::Panic(Arc::new(err)))),
+                    Ok(Err(err)) => Err(err.into()),
+                    Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
                 };
 
                 let local_task = LocalTask::Done {
                     output: match result {
                         Ok(raw_vc) => OutputContent::Link(raw_vc),
-                        Err(err) => match &*err {
-                            TurboTasksExecutionError::Error { .. } => {
-                                OutputContent::Error(SharedError::new(
-                                    anyhow::Error::new(err)
-                                        .context(format!("Execution of {ty} failed")),
-                                ))
-                            }
-                            TurboTasksExecutionError::Panic(err) => {
-                                OutputContent::Panic(err.clone())
-                            }
-                        },
+                        Err(err) => OutputContent::Error(err.task_context(ty)),
                     },
                 };
 

--- a/turbopack/crates/turbo-tasks/src/output.rs
+++ b/turbopack/crates/turbo-tasks/src/output.rs
@@ -1,18 +1,14 @@
-use std::{
-    fmt::{self, Display},
-    sync::Arc,
-};
+use std::fmt::{self, Display};
 
 use anyhow::anyhow;
 
-use crate::{RawVc, TurboTasksPanic, util::SharedError};
+use crate::{RawVc, backend::TurboTasksExecutionError};
 
 /// A helper type representing the output of a resolved task.
 #[derive(Clone, Debug)]
 pub enum OutputContent {
     Link(RawVc),
-    Error(SharedError),
-    Panic(Arc<TurboTasksPanic>),
+    Error(TurboTasksExecutionError),
 }
 
 impl OutputContent {
@@ -20,7 +16,6 @@ impl OutputContent {
         match &self {
             Self::Error(err) => Err(anyhow!(err.clone())),
             Self::Link(raw_vc) => Ok(*raw_vc),
-            Self::Panic(err) => Err(anyhow!(err.clone())),
         }
     }
 }
@@ -30,7 +25,6 @@ impl Display for OutputContent {
         match self {
             Self::Link(raw_vc) => write!(f, "link {raw_vc:?}"),
             Self::Error(err) => write!(f, "error {err}"),
-            Self::Panic(err) => write!(f, "panic {err}"),
         }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/util.rs
+++ b/turbopack/crates/turbo-tasks/src/util.rs
@@ -32,8 +32,10 @@ impl SharedError {
             inner: Arc::new(err),
         }
     }
+}
 
-    pub fn as_ref(&self) -> &(dyn StdError + 'static) {
+impl AsRef<dyn StdError> for SharedError {
+    fn as_ref(&self) -> &(dyn StdError + 'static) {
         let err: &anyhow::Error = &self.inner;
         err.as_ref()
     }

--- a/turbopack/crates/turbo-tasks/src/util.rs
+++ b/turbopack/crates/turbo-tasks/src/util.rs
@@ -32,6 +32,27 @@ impl SharedError {
             inner: Arc::new(err),
         }
     }
+
+    pub fn eq_stack(&self, other: &anyhow::Error) -> bool {
+        if self.to_string() != other.to_string() {
+            return false;
+        }
+        let mut source = self.source();
+        let mut other_source = other.source();
+        loop {
+            if source.is_none() && other_source.is_none() {
+                return true;
+            }
+            let (Some(source_err), Some(other_source_err)) = (source, other_source) else {
+                return false;
+            };
+            if source_err.to_string() != other_source_err.to_string() {
+                return false;
+            }
+            source = source_err.source();
+            other_source = other_source_err.source();
+        }
+    }
 }
 
 impl StdError for SharedError {

--- a/turbopack/crates/turbo-tasks/src/util.rs
+++ b/turbopack/crates/turbo-tasks/src/util.rs
@@ -33,25 +33,9 @@ impl SharedError {
         }
     }
 
-    pub fn eq_stack(&self, other: &anyhow::Error) -> bool {
-        if self.to_string() != other.to_string() {
-            return false;
-        }
-        let mut source = self.source();
-        let mut other_source = other.source();
-        loop {
-            if source.is_none() && other_source.is_none() {
-                return true;
-            }
-            let (Some(source_err), Some(other_source_err)) = (source, other_source) else {
-                return false;
-            };
-            if source_err.to_string() != other_source_err.to_string() {
-                return false;
-            }
-            source = source_err.source();
-            other_source = other_source_err.source();
-        }
+    pub fn as_ref(&self) -> &(dyn StdError + 'static) {
+        let err: &anyhow::Error = &self.inner;
+        err.as_ref()
     }
 }
 


### PR DESCRIPTION
### What?

Allow errors and panics to be serialized and store them in the task output.

Compare errors when setting them to avoid unnecessary invalidations when tasks error again.

Closes PACK-4712