### PR TITLE
[next-server] fix params duplicate in query after rewrite

### DIFF
--- a/test/e2e/app-dir/rewrite-with-search-params/app/[domain]/[...section]/page.tsx
+++ b/test/e2e/app-dir/rewrite-with-search-params/app/[domain]/[...section]/page.tsx
@@ -1,0 +1,25 @@
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ domain: string; section: string[] }>
+  searchParams: Promise<{ [key: string]: string | string[] }>
+}) {
+  const resolvedParams = await params
+  const resolvedSearchParams = await searchParams
+
+  return (
+    <>
+      <div>
+        <h2>Params:</h2>
+        <pre id="params-value">{JSON.stringify(resolvedParams, null, 2)}</pre>
+      </div>
+      <div>
+        <h2>Search Params:</h2>
+        <pre id="search-params-value">
+          {JSON.stringify(resolvedSearchParams, null, 2)}
+        </pre>
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/rewrite-with-search-params/app/layout.tsx
+++ b/test/e2e/app-dir/rewrite-with-search-params/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rewrite-with-search-params/next.config.js
+++ b/test/e2e/app-dir/rewrite-with-search-params/next.config.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/:path((?!sitemap.xml$).*)',
+        has: [
+          {
+            type: 'host',
+            value: '(?<subdomain>[^.]+)\\.(?<domain>.*)',
+          },
+        ],
+        destination: '/:subdomain/:path*',
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/rewrite-with-search-params/rewrite-with-search-params.test.ts
+++ b/test/e2e/app-dir/rewrite-with-search-params/rewrite-with-search-params.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('rewrite-with-search-params', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -25,6 +25,11 @@ describe('rewrite-with-search-params', () => {
 
     expect(searchParams).toEqual({
       param: 'value',
+    })
+
+    expect(params).toEqual({
+      domain: expect.stringMatching(/[\w-]+/),
+      section: ['galleries', '123'],
     })
   })
 })

--- a/test/e2e/app-dir/rewrite-with-search-params/rewrite-with-search-params.test.ts
+++ b/test/e2e/app-dir/rewrite-with-search-params/rewrite-with-search-params.test.ts
@@ -1,0 +1,30 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('rewrite-with-search-params', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not contain params in search params after rewrite', async () => {
+    const $ = await next.render$(
+      '/galleries/123',
+      {
+        param: 'value',
+      },
+      {
+        headers: isNextDeploy
+          ? undefined
+          : {
+              host: 'vercel-test.vercel.app',
+            },
+      }
+    )
+
+    const searchParams = JSON.parse($('#search-params-value').text())
+    const params = JSON.parse($('#params-value').text())
+
+    expect(searchParams).toEqual({
+      param: 'value',
+    })
+  })
+})


### PR DESCRIPTION
### What

In Vercel deployments, Next.js uses a special query to store the matched route params fr dynamic routes, which means. the matched dynamic params are stored in query. So we have a logic that stripping the route params from query params.

In #76177 we tried to solve a problem where a route param name exists both in search query and route params, e.g. the name `key` in `?key=` and `/[key]`. To keep the name being stripped out, #76177 used a different way to retain the route params.

This caused a regression on the rewrites logic. The server util `handleRewrites` might add more queries to the parsed url query, which can be the matched dynamic route params. Then it lead to that the route params showed up in search params. The logic was only related to minimal mode, so only Vercel deployment was impacted.

This PR fixed the issue by still stripping the route params from parsed url query, but we skip for the query name which was also used in route params.

Closes NEXT-4075