### PR TITLE
Turbopack: remove CSS comments when minifying

### DIFF
--- a/test/e2e/app-dir/scss/compilation-and-prefixing/compilation-and-prefixing.test.ts
+++ b/test/e2e/app-dir/scss/compilation-and-prefixing/compilation-and-prefixing.test.ts
@@ -87,53 +87,25 @@ describe.each([
         if (process.env.IS_TURBOPACK_TEST) {
           if (dependencies.sass) {
             expect(sourceMapContentParsed).toMatchInlineSnapshot(`
-              {
-                "sections": [
-                  {
-                    "map": {
-                      "mappings": "AAAA,iCAAiC",
-                      "names": [],
-                      "sources": [
-                        "turbopack:///[project]/styles/global.scss.css",
-                      ],
-                      "sourcesContent": [
-                        ".redText ::placeholder{color:red}.flex-parsing{flex:0 0 calc(50% - var(--vertical-gutter))}",
-                      ],
-                      "version": 3,
-                    },
-                    "offset": {
-                      "column": 0,
-                      "line": 1,
-                    },
-                  },
-                ],
-                "version": 3,
-              }
+             {
+               "mappings": "AAAA,iCAAiC",
+               "names": [],
+               "sourcesContent": [
+                 ".redText ::placeholder{color:red}.flex-parsing{flex:0 0 calc(50% - var(--vertical-gutter))}",
+               ],
+               "version": 3,
+             }
             `)
           } else {
             expect(sourceMapContentParsed).toMatchInlineSnapshot(`
-              {
-                "sections": [
-                  {
-                    "map": {
-                      "mappings": "AAAA,iCAAiC",
-                      "names": [],
-                      "sources": [
-                        "turbopack:///[project]/styles/global.scss.css",
-                      ],
-                      "sourcesContent": [
-                        ".redText ::placeholder{color:red}.flex-parsing{flex:0 0 calc(50% - var(--vertical-gutter))}",
-                      ],
-                      "version": 3,
-                    },
-                    "offset": {
-                      "column": 0,
-                      "line": 1,
-                    },
-                  },
-                ],
-                "version": 3,
-              }
+             {
+               "mappings": "AAAA,iCAAiC",
+               "names": [],
+               "sourcesContent": [
+                 ".redText ::placeholder{color:red}.flex-parsing{flex:0 0 calc(50% - var(--vertical-gutter))}",
+               ],
+               "version": 3,
+             }
             `)
           }
         } else {

--- a/test/integration/css-minify/test/index.test.js
+++ b/test/integration/css-minify/test/index.test.js
@@ -21,12 +21,9 @@ function runTests() {
     const href = $('link').attr('href')
     const css = await renderViaHTTP(appPort, href)
     if (process.env.IS_TURBOPACK_TEST) {
-      expect(css).toMatchInlineSnapshot(`
-       "/* [project]/test/integration/css-minify/styles/global.css [client] (css) */
-       .a{--var-1:-50%;--var-2:-50%}.b{--var-1:0;--var-2:-50%}
-
-       /*# sourceMappingURL=5c046e82fcc94f24.css.map*/"
-      `)
+      expect(css).toContain(
+        '.a{--var-1:-50%;--var-2:-50%}.b{--var-1:0;--var-2:-50%}'
+      )
     } else {
       expect(css).toMatchInlineSnapshot(
         `".a{--var-1:0;--var-2:0;--var-1:-50%;--var-2:-50%}.b{--var-1:0;--var-2:0;--var-2:-50%}"`

--- a/test/integration/css-modules/test/index.test.js
+++ b/test/integration/css-modules/test/index.test.js
@@ -706,12 +706,11 @@ describe('Catch-all Route CSS Module Usage', () => {
         )
 
         if (process.env.IS_TURBOPACK_TEST) {
-          expect(cssContent.replace(/\/\*.*?\*\//g, '').trim())
+          expect(cssContent.replace(/\/\*.*?\*\/\n?/g, '').trim())
             .toMatchInlineSnapshot(`
-            ".index-module___rV4CG__home{background:red}
+           ".index-module___rV4CG__home{background:red}
 
-
-            .\\35 5css-module__qe774W__home{color:green}"
+           .\\35 5css-module__qe774W__home{color:green}"
           `)
         } else {
           expect(

--- a/test/integration/css/test/basic-global-support.test.js
+++ b/test/integration/css/test/basic-global-support.test.js
@@ -308,7 +308,6 @@ module.exports = {
                "/_next/static/chunks/HASH.css:
              .red-text{color:red}
 
-
              .blue-text{color:#00f}",
              ]
             `)
@@ -317,7 +316,6 @@ module.exports = {
              [
                "/_next/static/chunks/HASH.css:
              .red-text{color:red}
-
 
              .blue-text{color:#00f}",
              ]
@@ -394,12 +392,9 @@ module.exports = {
                "/_next/static/chunks/HASH.css:
              .red-text{color:purple;font-weight:bolder}
 
-
              .red-text{color:red}
 
-
              .blue-text{color:orange;font-weight:bolder}
-
 
              .blue-text{color:#00f}",
              ]
@@ -410,12 +405,9 @@ module.exports = {
                "/_next/static/chunks/HASH.css:
              .red-text{color:purple;font-weight:bolder}
 
-
              .red-text{color:red}
 
-
              .blue-text{color:orange;font-weight:bolder}
-
 
              .blue-text{color:#00f}",
              ]
@@ -493,7 +485,6 @@ module.exports = {
                "/_next/static/chunks/HASH.css:
              .blue-text{color:#00f}
 
-
              .red-text{color:red}",
              ]
             `)
@@ -502,7 +493,6 @@ module.exports = {
              [
                "/_next/static/chunks/HASH.css:
              .blue-text{color:#00f}
-
 
              .red-text{color:red}",
              ]
@@ -579,9 +569,7 @@ module.exports = {
                "/_next/static/chunks/HASH.css:
              .red-text{color:red;background-image:url(../media/dark.993bedd3.svg),url(../media/dark2.993bedd3.svg)}
 
-
              .blue-text{color:orange;background-image:url(../media/light.180573e4.svg);font-weight:bolder}
-
 
              .blue-text{color:#00f}",
              ]
@@ -592,9 +580,7 @@ module.exports = {
                "/_next/static/chunks/HASH.css:
              .red-text{color:red;background-image:url(../media/dark.993bedd3.svg),url(../media/dark2.993bedd3.svg)}
 
-
              .blue-text{color:orange;background-image:url(../media/light.180573e4.svg);font-weight:bolder}
-
 
              .blue-text{color:#00f}",
              ]
@@ -656,9 +642,7 @@ describe('CSS URL via `file-loader` and asset prefix (1)', () => {
              "/_next/static/chunks/HASH.css:
            .red-text{color:red;background-image:url(../media/dark.993bedd3.svg) url(../media/dark2.993bedd3.svg)}
 
-
            .blue-text{color:orange;background-image:url(../media/light.180573e4.svg);font-weight:bolder}
-
 
            .blue-text{color:#00f}",
            ]
@@ -712,9 +696,7 @@ describe('CSS URL via `file-loader` and asset prefix (2)', () => {
              "/_next/static/chunks/HASH.css:
            .red-text{color:red;background-image:url(../media/dark.993bedd3.svg) url(../media/dark2.993bedd3.svg)}
 
-
            .blue-text{color:orange;background-image:url(../media/light.180573e4.svg);font-weight:bolder}
-
 
            .blue-text{color:#00f}",
            ]
@@ -745,7 +727,7 @@ async function getStylesheetContents($, appPort, items) {
       `${href.replace(
         /[0-9a-f]{8,}/g,
         'HASH'
-      )}:\n${text.replace(/\/\*.*?\*\//g, '').trim()}`
+      )}:\n${text.replace(/\/\*.*?\*\/\n?/g, '').trim()}`
     )
   }
   return results

--- a/test/integration/css/test/css-compilation.test.js
+++ b/test/integration/css/test/css-compilation.test.js
@@ -74,7 +74,7 @@ module.exports = {
               ).then((res) => res.text())
 
               const cssContentWithoutSourceMap = cssContent
-                .replace(/\/\*.*?\*\//g, '')
+                .replace(/\/\*.*?\*\/\n?/g, '')
                 .trim()
 
               if (process.env.IS_TURBOPACK_TEST && useLightningcss) {
@@ -431,10 +431,10 @@ module.exports = {
                   res.text()
                 )
               )
-                .replace(/\/\*.*?\*\//g, '')
+                .replace(/\/\*.*?\*\/\n?/g, '')
                 .trim()
 
-              expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatch(
+              expect(cssContent.replace(/\/\*.*?\*\/\n?/g, '').trim()).toMatch(
                 /nprogress/
               )
             })
@@ -491,32 +491,30 @@ module.exports = {
                   res.text()
                 )
               )
-                .replace(/\/\*.*?\*\//g, '')
+                .replace(/\/\*.*?\*\/\n?/g, '')
                 .trim()
 
               if (process.env.IS_TURBOPACK_TEST && useLightningcss) {
-                expect(cssContent.replace(/\/\*.*?\*\//g, '').trim())
+                expect(cssContent.replace(/\/\*.*?\*\/\n?/g, '').trim())
                   .toMatchInlineSnapshot(`
                  ".other{color:#00f}
-
 
                  .test{color:red}"
                 `)
               } else if (process.env.IS_TURBOPACK_TEST && !useLightningcss) {
-                expect(cssContent.replace(/\/\*.*?\*\//g, '').trim())
+                expect(cssContent.replace(/\/\*.*?\*\/\n?/g, '').trim())
                   .toMatchInlineSnapshot(`
                  ".other{color:#00f}
-
 
                  .test{color:red}"
                 `)
               } else if (useLightningcss) {
                 expect(
-                  cssContent.replace(/\/\*.*?\*\//g, '').trim()
+                  cssContent.replace(/\/\*.*?\*\/\n?/g, '').trim()
                 ).toMatchInlineSnapshot(`".other{color:#00f}.test{color:red}"`)
               } else {
                 expect(
-                  cssContent.replace(/\/\*.*?\*\//g, '').trim()
+                  cssContent.replace(/\/\*.*?\*\/\n?/g, '').trim()
                 ).toMatchInlineSnapshot(`".other{color:blue}.test{color:red}"`)
               }
             })

--- a/test/integration/css/test/css-compilation.test.js
+++ b/test/integration/css/test/css-compilation.test.js
@@ -118,95 +118,67 @@ module.exports = {
 
               if (process.env.IS_TURBOPACK_TEST && useLightningcss) {
                 expect(sourceMapContentParsed).toMatchInlineSnapshot(`
-                  {
-                    "sections": [
-                      {
-                        "map": {
-                          "mappings": "AAAA,4BACE,2BAKF,0DAIA,kDAIA,uCAIA",
-                          "names": [],
-                          "sources": [
-                            "turbopack:///[project]/test/integration/css-fixtures/compilation-and-prefixing/styles/global.css",
-                          ],
-                          "sourcesContent": [
-                            "@media (480px <= width < 768px) {
-                    ::placeholder {
-                      color: green;
-                    }
-                  }
+                 {
+                   "mappings": "AAAA,4BACE,2BAKF,0DAIA,kDAIA,uCAIA",
+                   "names": [],
+                   "sourcesContent": [
+                     "@media (480px <= width < 768px) {
+                   ::placeholder {
+                     color: green;
+                   }
+                 }
 
-                  .flex-parsing {
-                    flex: 0 0 calc(50% - var(--vertical-gutter));
-                  }
+                 .flex-parsing {
+                   flex: 0 0 calc(50% - var(--vertical-gutter));
+                 }
 
-                  .transform-parsing {
-                    transform: translate3d(0px, 0px);
-                  }
+                 .transform-parsing {
+                   transform: translate3d(0px, 0px);
+                 }
 
-                  .css-grid-shorthand {
-                    grid-column: span 2;
-                  }
+                 .css-grid-shorthand {
+                   grid-column: span 2;
+                 }
 
-                  .g-docs-sidenav .filter::-webkit-input-placeholder {
-                    opacity: 80%;
-                  }
-                  ",
-                          ],
-                          "version": 3,
-                        },
-                        "offset": {
-                          "column": 0,
-                          "line": 1,
-                        },
-                      },
-                    ],
-                    "version": 3,
-                  }
+                 .g-docs-sidenav .filter::-webkit-input-placeholder {
+                   opacity: 80%;
+                 }
+                 ",
+                   ],
+                   "version": 3,
+                 }
                 `)
               } else if (process.env.IS_TURBOPACK_TEST && !useLightningcss) {
                 expect(sourceMapContentParsed).toMatchInlineSnapshot(`
-                  {
-                    "sections": [
-                      {
-                        "map": {
-                          "mappings": "AAAA,4BACE,2BAKF,0DAIA,kDAIA,uCAIA",
-                          "names": [],
-                          "sources": [
-                            "turbopack:///[project]/test/integration/css-fixtures/compilation-and-prefixing/styles/global.css",
-                          ],
-                          "sourcesContent": [
-                            "@media (480px <= width < 768px) {
-                    ::placeholder {
-                      color: green;
-                    }
-                  }
+                 {
+                   "mappings": "AAAA,4BACE,2BAKF,0DAIA,kDAIA,uCAIA",
+                   "names": [],
+                   "sourcesContent": [
+                     "@media (480px <= width < 768px) {
+                   ::placeholder {
+                     color: green;
+                   }
+                 }
 
-                  .flex-parsing {
-                    flex: 0 0 calc(50% - var(--vertical-gutter));
-                  }
+                 .flex-parsing {
+                   flex: 0 0 calc(50% - var(--vertical-gutter));
+                 }
 
-                  .transform-parsing {
-                    transform: translate3d(0px, 0px);
-                  }
+                 .transform-parsing {
+                   transform: translate3d(0px, 0px);
+                 }
 
-                  .css-grid-shorthand {
-                    grid-column: span 2;
-                  }
+                 .css-grid-shorthand {
+                   grid-column: span 2;
+                 }
 
-                  .g-docs-sidenav .filter::-webkit-input-placeholder {
-                    opacity: 80%;
-                  }
-                  ",
-                          ],
-                          "version": 3,
-                        },
-                        "offset": {
-                          "column": 0,
-                          "line": 1,
-                        },
-                      },
-                    ],
-                    "version": 3,
-                  }
+                 .g-docs-sidenav .filter::-webkit-input-placeholder {
+                   opacity: 80%;
+                 }
+                 ",
+                   ],
+                   "version": 3,
+                 }
                 `)
               } else if (useLightningcss) {
                 expect(sourceMapContentParsed).toMatchInlineSnapshot(`

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -281,7 +281,7 @@ impl BrowserChunkingContext {
         *self.chunk_suffix_path
     }
 
-    /// Returns the minify type.
+    /// Returns the source map type.
     pub fn source_maps_type(&self) -> SourceMapsType {
         self.source_maps_type
     }
@@ -508,6 +508,11 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     fn is_tracing_enabled(&self) -> Vc<bool> {
         Vc::cell(self.enable_tracing)
+    }
+
+    #[turbo_tasks::function]
+    pub fn minify_type(&self) -> Vc<MinifyType> {
+        self.minify_type.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -37,20 +37,8 @@ pub enum MangleType {
     Deterministic,
 }
 
-#[derive(
-    Debug,
-    TaskInput,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    TraceRawVcs,
-    DeterministicHash,
-    NonLocalValue,
-)]
+#[turbo_tasks::value(shared)]
+#[derive(Debug, TaskInput, Clone, Copy, Hash, DeterministicHash)]
 pub enum MinifyType {
     // TODO instead of adding a new property here,
     // refactor that to Minify(MinifyOptions) to allow defaults on MinifyOptions
@@ -207,6 +195,10 @@ pub trait ChunkingContext {
 
     fn is_tracing_enabled(self: Vc<Self>) -> Vc<bool> {
         Vc::cell(false)
+    }
+
+    fn minify_type(self: Vc<Self>) -> Vc<MinifyType> {
+        MinifyType::NoMinify.cell()
     }
 
     fn async_loader_chunk_item(

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -337,9 +337,4 @@ impl CssChunkItem for CssModuleChunkItem {
             .into())
         }
     }
-
-    #[turbo_tasks::function]
-    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *self.chunking_context
-    }
 }

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{Chunk, ChunkItem, ChunkItemExt, ChunkingContext},
+    chunk::{Chunk, ChunkItem, ChunkItemExt, ChunkingContext, MinifyType},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     introspect::Introspectable,
@@ -55,9 +55,13 @@ impl SingleItemCssChunk {
             .await?;
         let mut code = CodeBuilder::new(source_maps);
 
-        let id = this.item.id().await?;
-
-        writeln!(code, "/* {} */", id)?;
+        if matches!(
+            &*this.chunking_context.minify_type().await?,
+            MinifyType::NoMinify
+        ) {
+            let id = this.item.id().await?;
+            writeln!(code, "/* {} */", id)?;
+        }
         let content = this.item.content().await?;
         let close = write_import_context(&mut code, content.import_context).await?;
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{Chunk, ChunkItem, ChunkingContext},
+    chunk::{Chunk, ChunkItem, ChunkItemExt, ChunkingContext},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     introspect::Introspectable,
@@ -55,7 +55,7 @@ impl SingleItemCssChunk {
             .await?;
         let mut code = CodeBuilder::new(source_maps);
 
-        let id = &*this.item.id().await?;
+        let id = this.item.id().await?;
 
         writeln!(code, "/* {} */", id)?;
         let content = this.item.content().await?;

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -249,6 +249,11 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
+    pub fn minify_type(&self) -> Vc<MinifyType> {
+        self.minify_type.cell()
+    }
+
+    #[turbo_tasks::function]
     async fn asset_url(&self, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
         let asset_path = ident.await?.to_string();
         let asset_path = asset_path


### PR DESCRIPTION
Remove these comments when minification is enabled (= production)
```css
/* [project]/test/integration/css-minify/styles/global.css [client] (css) */
.a{--var-1:-50%;--var-2:-50%}.b{--var-1:0;--var-2:-50%}
```

Closes PACK-4298