### PR TITLE
Output server.mjs for standalone with type: module

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1544,8 +1544,19 @@ export async function copyTracedFiles(
   }
   try {
     const packageJsonPath = path.join(distDir, '../package.json')
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'))
+    const packageJsonContent = await fs.readFile(packageJsonPath, 'utf8')
+    const packageJson = JSON.parse(packageJsonContent)
     moduleType = packageJson.type === 'module'
+
+    // we always copy the package.json to the standalone
+    // folder to ensure any resolving logic is maintained
+    const packageJsonOutputPath = path.join(
+      outputPath,
+      path.relative(tracingRoot, dir),
+      'package.json'
+    )
+    await fs.mkdir(path.dirname(packageJsonOutputPath), { recursive: true })
+    await fs.writeFile(packageJsonOutputPath, packageJsonContent)
   } catch {}
   const copiedFiles = new Set()
   await fs.rm(outputPath, { recursive: true, force: true })
@@ -1676,7 +1687,7 @@ export async function copyTracedFiles(
   const serverOutputPath = path.join(
     outputPath,
     path.relative(tracingRoot, dir),
-    'server.js'
+    moduleType ? 'server.mjs' : 'server.js'
   )
   await fs.mkdir(path.dirname(serverOutputPath), { recursive: true })
 

--- a/test/production/standalone-mode/type-module/index.test.ts
+++ b/test/production/standalone-mode/type-module/index.test.ts
@@ -39,7 +39,9 @@ describe('type-module', () => {
 
     await fs.move(staticSrc, staticDest)
 
-    const serverFile = join(standalonePath, 'server.js')
+    expect(fs.existsSync(join(standalonePath, 'package.json'))).toBe(true)
+
+    const serverFile = join(standalonePath, 'server.mjs')
     const appPort = await findPort()
     const server = await initNextServerScript(
       serverFile,


### PR DESCRIPTION
This ensures we output `server.mjs` when `type: 'module'` is configured for a project using `standalone` mode. This also ensures we copy the `package.json` to the standalone folder as we were previously only copying it if it was included in the traced assets. 