### PR TITLE
fix: allow multiple declarations of GoogleTagManager, fixes issue whe…

### DIFF
--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -40,7 +40,7 @@ export function GoogleTagManager(props: GTMParams) {
   return (
     <>
       <Script
-        id="_next-gtm-init"
+        id={`_next-gtm-init-${gtmId}`}
         dangerouslySetInnerHTML={{
           __html: `
       (function(w,l){
@@ -52,7 +52,7 @@ export function GoogleTagManager(props: GTMParams) {
         nonce={nonce}
       />
       <Script
-        id="_next-gtm"
+        id={`_next-gtm-${gtmId}`}
         data-ntpc="GTM"
         src={`${gtmScriptUrl}?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
         nonce={nonce}


### PR DESCRIPTION
…n GTM is defined multiple times and scripts are not being fired, when navigating between pages #77946

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

GoogleTagManager fix when navigating between pages within client side app will not execute GTM loaded scripts, due to html tag attribute of id collision.

### Why?

I would like to execute multiple GTM scripts, loaded from different GTM containers.

### How?

By appending gtmId into html tag id attribute.

Closes NEXT-
Fixes #77946 
