### PR TITLE
Turbopack: write `.next/turbopack` to mark Turbopack builds

### DIFF
--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -88,6 +88,9 @@ export async function turbopackBuild(): Promise<{
     }
   )
 
+  // Write an empty file in a known location to signal this was built with Turbopack
+  await fs.writeFile(path.join(distDir, 'turbopack'), '')
+
   await fs.mkdir(path.join(distDir, 'server'), { recursive: true })
   await fs.mkdir(path.join(distDir, 'static', buildId), {
     recursive: true,


### PR DESCRIPTION


Closes PACK-4300