### PR TITLE
Add experimental.routerBFCache to NextConfig

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -730,6 +730,7 @@ pub struct ExperimentalConfig {
     ppr: Option<ExperimentalPartialPrerendering>,
     taint: Option<bool>,
     react_owner_stack: Option<bool>,
+    router_bfcache: Option<bool>,
     proxy_timeout: Option<f64>,
     /// enables the minification of server code.
     server_minification: Option<bool>,
@@ -1426,6 +1427,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_react_owner_stack(&self) -> Vc<bool> {
         Vc::cell(self.experimental.react_owner_stack.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
+    pub fn enable_router_bfcache(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.router_bfcache.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -730,6 +730,7 @@ pub struct ExperimentalConfig {
     ppr: Option<ExperimentalPartialPrerendering>,
     taint: Option<bool>,
     react_owner_stack: Option<bool>,
+    #[serde(rename = "routerBFCache")]
     router_bfcache: Option<bool>,
     proxy_timeout: Option<f64>,
     /// enables the minification of server code.

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -700,8 +700,9 @@ async fn rsc_aliases(
     let ppr = *next_config.enable_ppr().await?;
     let taint = *next_config.enable_taint().await?;
     let react_owner_stack = *next_config.enable_react_owner_stack().await?;
+    let router_bfcache = *next_config.enable_router_bfcache().await?;
     let view_transition = *next_config.enable_view_transition().await?;
-    let react_channel = if ppr || taint || react_owner_stack || view_transition {
+    let react_channel = if ppr || taint || react_owner_stack || view_transition || router_bfcache {
         "-experimental"
     } else {
         ""

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -122,6 +122,7 @@ pub async fn get_next_client_import_map(
                 || *next_config.enable_taint().await?
                 || *next_config.enable_react_owner_stack().await?
                 || *next_config.enable_view_transition().await?
+                || *next_config.enable_router_bfcache().await?
             {
                 "-experimental"
             } else {

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -190,6 +190,9 @@ export function getDefineEnv({
     'process.env.__NEXT_DYNAMIC_ON_HOVER': Boolean(
       config.experimental.dynamicOnHover
     ),
+    'process.env.__NEXT_ROUTER_BF_CACHE': Boolean(
+      config.experimental.routerBFCache
+    ),
     'process.env.__NEXT_OPTIMISTIC_CLIENT_CACHE':
       config.experimental.optimisticClientCache ?? true,
     'process.env.__NEXT_MIDDLEWARE_PREFETCH':

--- a/packages/next/src/lib/needs-experimental-react.ts
+++ b/packages/next/src/lib/needs-experimental-react.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from '../server/config-shared'
 
 export function needsExperimentalReact(config: NextConfig) {
-  const { ppr, taint, viewTransition } = config.experimental || {}
-  return Boolean(ppr || taint || viewTransition)
+  const { ppr, taint, viewTransition, routerBFCache } =
+    config.experimental || {}
+  return Boolean(ppr || taint || viewTransition || routerBFCache)
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -347,6 +347,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         taint: z.boolean().optional(),
         prerenderEarlyExit: z.boolean().optional(),
         proxyTimeout: z.number().gte(0).optional(),
+        routerBFCache: z.boolean().optional(),
         scrollRestoration: z.boolean().optional(),
         sri: z
           .object({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -471,6 +471,11 @@ export interface ExperimentalConfig {
    */
   taint?: boolean
 
+  /**
+   * Enables the Back/Forward Cache for the router.
+   */
+  routerBFCache?: boolean
+
   serverActions?: {
     /**
      * Allows adjusting body parser size limit for server actions.
@@ -1258,6 +1263,7 @@ export const defaultConfig: NextConfig = {
     optimizeServerReact: true,
     useEarlyImport: false,
     viewTransition: false,
+    routerBFCache: false,
     staleTimes: {
       dynamic: 0,
       static: 300,

--- a/test/e2e/app-dir/back-forward-cache/app/layout.tsx
+++ b/test/e2e/app-dir/back-forward-cache/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/back-forward-cache/app/page.tsx
+++ b/test/e2e/app-dir/back-forward-cache/app/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+// TODO: "use client" is required in this module because Activity is not
+// exported from the server entrypoint of React
+
+// @ts-expect-error: Not yet part of the TypeScript types
+import { unstable_Activity as Activity } from 'react'
+
+export default function Page() {
+  return (
+    <Activity mode="hidden">
+      <div id="activity-content">Hello</div>
+    </Activity>
+  )
+}

--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('back/forward cache', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('Activity component is renderable when the routerBFCache flag is on', async () => {
+    // None of the back/forward behavior has been implemented yet; this just
+    // tests that when the flag is enabled, we're able to successfully render
+    // an Activity component.
+    const browser = await next.browser('/')
+    const activityContent = await browser.elementById('activity-content')
+    expect(await activityContent.innerHTML()).toBe('Hello')
+    expect(await activityContent.getComputedCss('display')).toBe('none')
+  })
+})

--- a/test/e2e/app-dir/back-forward-cache/next.config.js
+++ b/test/e2e/app-dir/back-forward-cache/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    routerBFCache: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Sets up a flag that will depend on an experimental React feature (Activity). I based this on the existing code for the `viewTransition` flag.

I haven't implemented anything behind this flag yet; this only wires up the flag itself. I added a basic test that renders the Activity component to verify that it's available when the flag is on.