### PR TITLE
compile-time error for useLinkStatus imports in server components

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -626,6 +626,7 @@ impl ReactServerComponentValidator {
                         "ServerInsertedHTMLContext",
                     ],
                 ),
+                ("next/link", vec!["useLinkStatus"]),
             ]),
             deprecated_apis_mapping: FxHashMap::from_iter([("next/server", vec!["ImageResponse"])]),
 

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -532,4 +532,37 @@ describe('Error Overlay for server components', () => {
       )
     })
   })
+
+  describe('Next.js link client hooks called in Server Component', () => {
+    it.each([['useLinkStatus']])(
+      'should show error when %s is called',
+      async (hook: string) => {
+        await using sandbox = await createSandbox(
+          next,
+          new Map([
+            [
+              'app/page.js',
+              outdent`
+              import { ${hook} } from 'next/link'
+              export default function Page() {
+                return "Hello world"
+              }
+            `,
+            ],
+          ])
+        )
+        const { session } = sandbox
+        await session.assertHasRedbox()
+        // In webpack when the message too long it gets truncated with `  | ` with new lines.
+        // So we need to check for the first part of the message.
+        const normalizedSource = await session.getRedboxSource()
+        expect(normalizedSource).toContain(
+          `You're importing a component that needs \`${hook}\`. This React hook only works in a client component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
+        )
+        expect(normalizedSource).toContain(
+          `import { ${hook} } from 'next/link'`
+        )
+      }
+    )
+  })
 })


### PR DESCRIPTION
Adds `useLinkStatus` to the list of APIs that can't be imported in server components.