### PR TITLE
[next-server] preserve rsc query for rsc redirects

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -401,6 +401,7 @@ export async function initialize(opts: {
 
       // handle redirect
       if (!bodyStream && statusCode && statusCode > 300 && statusCode < 400) {
+        console.log('handle redirect', statusCode, parsedUrl)
         const destination = url.format(parsedUrl)
         res.statusCode = statusCode
         res.setHeader('location', destination)

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -401,7 +401,6 @@ export async function initialize(opts: {
 
       // handle redirect
       if (!bodyStream && statusCode && statusCode > 300 && statusCode < 400) {
-        console.log('handle redirect', statusCode, parsedUrl)
         const destination = url.format(parsedUrl)
         res.statusCode = statusCode
         res.setHeader('location', destination)

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -11,7 +11,6 @@ import {
   INTERCEPTION_ROUTE_MARKERS,
   isInterceptionRouteAppPath,
 } from './interception-routes'
-import { NEXT_RSC_UNION_QUERY } from '../../../../client/components/app-router-headers'
 import { getCookieParser } from '../../../../server/api-utils/get-cookie-parser'
 import type { Params } from '../../../../server/request/params'
 
@@ -210,8 +209,6 @@ export function prepareDestination(args: {
   query: NextParsedUrlQuery
 }) {
   const query = Object.assign({}, args.query)
-  delete query[NEXT_RSC_UNION_QUERY]
-
   const parsedDestination = parseDestination(args)
 
   const { hostname: destHostname, query: destQuery } = parsedDestination

--- a/test/e2e/app-dir/rsc-query-routing/app/layout.tsx
+++ b/test/e2e/app-dir/rsc-query-routing/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rsc-query-routing/app/redirect/dest/page.tsx
+++ b/test/e2e/app-dir/rsc-query-routing/app/redirect/dest/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>Redirect Dest</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-query-routing/app/redirect/page.tsx
+++ b/test/e2e/app-dir/rsc-query-routing/app/redirect/page.tsx
@@ -3,7 +3,12 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <div>
-      Go to <Link href="/redirect/source">Redirect Link</Link>
+      {/* disable prefetch to align the dev/prod fetching behavior,
+       it's easier for writing tests */}
+      Go to{' '}
+      <Link prefetch={false} href="/redirect/source">
+        Redirect Link
+      </Link>
     </div>
   )
 }

--- a/test/e2e/app-dir/rsc-query-routing/app/redirect/page.tsx
+++ b/test/e2e/app-dir/rsc-query-routing/app/redirect/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      Go to <Link href="/redirect/source">Redirect Link</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-query-routing/app/rewrite/dest/page.tsx
+++ b/test/e2e/app-dir/rsc-query-routing/app/rewrite/dest/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>Rewrite Dest</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-query-routing/app/rewrite/page.tsx
+++ b/test/e2e/app-dir/rsc-query-routing/app/rewrite/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      Go to <Link href="/rewrite/source">Rewrite Link</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-query-routing/app/rewrite/page.tsx
+++ b/test/e2e/app-dir/rsc-query-routing/app/rewrite/page.tsx
@@ -3,7 +3,12 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <div>
-      Go to <Link href="/rewrite/source">Rewrite Link</Link>
+      {/* disable prefetch to align the dev/prod fetching behavior,
+       it's easier for writing tests */}
+      Go to{' '}
+      <Link prefetch={false} href="/rewrite/source">
+        Rewrite Link
+      </Link>
     </div>
   )
 }

--- a/test/e2e/app-dir/rsc-query-routing/next.config.js
+++ b/test/e2e/app-dir/rsc-query-routing/next.config.js
@@ -1,0 +1,25 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: '/redirect/source',
+        destination: '/redirect/dest',
+        permanent: true,
+      },
+    ]
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/rewrite/source',
+        destination: '/rewrite/dest',
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts
+++ b/test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts
@@ -1,0 +1,56 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { Request } from 'playwright'
+
+describe('rsc-query-routing', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should contain rsc query in rsc request when redirect the page', async () => {
+    const browser = await next.browser('/redirect')
+
+    const rscRequestUrls: string[] = []
+    browser.on('request', (req: Request) => {
+      if (req.url().includes('?_rsc=')) {
+        rscRequestUrls.push(req.url())
+      }
+    })
+
+    // Click redirect link
+    const link = await browser.elementByCss('a')
+    await link.click()
+
+    // Wait for the page load to be completed
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('Redirect Dest')
+    })
+
+    // The redirect source and dest urls should both contain the rsc query
+    expect(rscRequestUrls[0]).toContain('/redirect/source')
+    expect(rscRequestUrls[1]).toContain('/redirect/dest')
+  })
+
+  it('should contain rsc query in rsc request when rewrite the page', async () => {
+    const browser = await next.browser('/rewrite')
+
+    const rscRequestUrls: string[] = []
+    browser.on('request', (req: Request) => {
+      if (req.url().includes('?_rsc=')) {
+        rscRequestUrls.push(req.url())
+      }
+    })
+
+    // Click redirect link
+    const link = await browser.elementByCss('a')
+    await link.click()
+
+    // Wait for the page load to be completed
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('Rewrite Dest')
+    })
+
+    // The rewrite source url should contain the rsc query
+    expect(rscRequestUrls[0]).toContain('/rewrite/source')
+  })
+})


### PR DESCRIPTION
### What

Remove the rsc query stripping logic when preparing destation for redirects & rewrites

### Why

When the redirects from `next.config.js` are applied, the RSC request of navigation will be redirected to the destation path with `_rsc` query stripped out. But this might cause browser cache the RSC response as html response, which leads to display the RSC payload itself rather than the content while navigating between pages. Hence we need to preserve the query to ensure browser won't cache the wrong content for the same path. e.g. for a server component page `/abc`, `/abc` should be the content url, `/abc?_rsc=xxx` should be the RSC payload url.

This deleted query stripping case was already covered in existing test `test/e2e/app-dir/navigation/navigation.test.ts`, safe to delete.


Closes NDX-1002
Fixes #76925