### PR TITLE
Pass display name to cache handlers

### DIFF
--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -71,7 +71,7 @@ pub async fn get_next_client_transforms_rules(
                 rules.push(get_next_page_config_rule(enable_mdx_rs, pages_dir.await?));
             }
         }
-        ClientContextType::App { .. } => {
+        ClientContextType::App { app_dir, .. } => {
             is_app_dir = true;
             rules.push(
                 get_server_actions_transform_rule(
@@ -81,6 +81,7 @@ pub async fn get_next_client_transforms_rules(
                     enable_mdx_rs,
                     use_cache_enabled,
                     cache_kinds,
+                    app_dir,
                 )
                 .await?,
             );

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -109,7 +109,7 @@ pub async fn get_next_server_transforms_rules(
             }
             false
         }
-        ServerContextType::AppSSR { .. } => {
+        ServerContextType::AppSSR { app_dir, .. } => {
             // Yah, this is SSR, but this is still treated as a Client transform layer.
             // need to apply to foreign code too
             rules.push(
@@ -120,6 +120,7 @@ pub async fn get_next_server_transforms_rules(
                     mdx_rs,
                     use_cache_enabled,
                     cache_kinds,
+                    app_dir,
                 )
                 .await?,
             );
@@ -128,7 +129,7 @@ pub async fn get_next_server_transforms_rules(
 
             false
         }
-        ServerContextType::AppRSC { .. } => {
+        ServerContextType::AppRSC { app_dir, .. } => {
             rules.push(
                 get_server_actions_transform_rule(
                     mode,
@@ -137,6 +138,7 @@ pub async fn get_next_server_transforms_rules(
                     mdx_rs,
                     use_cache_enabled,
                     cache_kinds,
+                    app_dir,
                 )
                 .await?,
             );
@@ -145,7 +147,7 @@ pub async fn get_next_server_transforms_rules(
 
             true
         }
-        ServerContextType::AppRoute { .. } => {
+        ServerContextType::AppRoute { app_dir, .. } => {
             rules.push(
                 get_server_actions_transform_rule(
                     mode,
@@ -154,6 +156,7 @@ pub async fn get_next_server_transforms_rules(
                     mdx_rs,
                     use_cache_enabled,
                     cache_kinds,
+                    app_dir,
                 )
                 .await?,
             );

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -327,7 +327,7 @@ where
                 Some(config) => Either::Left(crate::transforms::server_actions::server_actions(
                     FileInfo {
                         path: file.name.to_string().into(),
-                        relative_path: relative_file_name(&opts.app_dir, &file.name),
+                        relative_path: relative_file_path(&opts.app_dir, &file.name),
                         query: None,
                     },
                     config.clone(),
@@ -456,28 +456,12 @@ where
     }
 }
 
-pub fn relative_file_name(app_dir: &Option<PathBuf>, file: &FileName) -> Option<RcStr> {
-    let project_dir = match app_dir.as_deref() {
-        Some(app_dir) => app_dir.parent(),
-        _ => None,
-    };
+pub fn relative_file_path(app_dir: &Option<PathBuf>, file: &FileName) -> Option<RcStr> {
+    let base = app_dir.as_deref()?.parent()?;
 
-    let base = match project_dir {
-        Some(path) => path,
-        None => return None,
-    };
-
-    let file = match file {
-        FileName::Real(path) => path,
-        _ => {
-            return None;
-        }
-    };
-
-    let rel_path = diff_paths(file, base);
-
-    match rel_path {
-        Some(relative) => Some(relative.display().to_string().into()),
-        None => None,
+    if let FileName::Real(path) = file {
+        diff_paths(path, base).map(|relative| relative.display().to_string().into())
+    } else {
+        None
     }
 }

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2395,6 +2395,7 @@ fn retain_names_from_declared_idents(
     *child_names = retained_names;
 }
 
+/// `$$cache__("default", "id", "myFn (filename:47:11)", 0, expr)`
 fn wrap_cache_expr(
     expr: Box<Expr>,
     cache_kind: &str,
@@ -2413,7 +2414,6 @@ fn wrap_cache_expr(
         loc.col_display + 1
     );
 
-    // expr -> $$cache__("default", "id", "myFn (filename:47:11)", 0, expr)
     Box::new(Expr::Call(CallExpr {
         span: DUMMY_SP,
         callee: quote_ident!("$$cache__").as_callee(),
@@ -2452,8 +2452,8 @@ fn create_var_declarator(ident: &Ident, extra_items: &mut Vec<ModuleItem>) {
     })))));
 }
 
+/// Assign a name with `Object.defineProperty($$ACTION_0, 'name', {value: 'default'})`
 fn assign_name_to_ident(ident: &Ident, name: &str, extra_items: &mut Vec<ModuleItem>) {
-    // Assign a name with `Object.defineProperty($$ACTION_0, 'name', {value: 'default'})`
     extra_items.push(quote!(
         // WORKAROUND for https://github.com/microsoft/TypeScript/issues/61165
         // This should just be
@@ -2486,8 +2486,8 @@ fn assign_arrow_expr(ident: &Ident, expr: Expr) -> Expr {
     }
 }
 
+/// `registerServerReference(ident, id, null)`
 fn annotate_ident_as_server_reference(ident: Ident, action_id: Atom, original_span: Span) -> Expr {
-    // registerServerReference(reference, id, null)
     Expr::Call(CallExpr {
         span: original_span,
         callee: quote_ident!("registerServerReference").as_callee(),
@@ -2509,11 +2509,11 @@ fn annotate_ident_as_server_reference(ident: Ident, action_id: Atom, original_sp
     })
 }
 
+/// `expr.bind(null, [encryptActionBoundArgs("id", arg1, arg2, ...)])`
 fn bind_args_to_ref_expr(expr: Expr, bound: Vec<Option<ExprOrSpread>>, action_id: Atom) -> Expr {
     if bound.is_empty() {
         expr
     } else {
-        // expr.bind(null, [encryptActionBoundArgs("id", arg1, arg2, ...)])
         Expr::Call(CallExpr {
             span: DUMMY_SP,
             callee: Expr::Member(MemberExpr {

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -2404,7 +2404,7 @@ fn wrap_cache_expr(
     loc: Loc,
     bound_args_len: usize,
 ) -> Box<Expr> {
-    let display_name = format!(
+    let location = format!(
         "{} ({}:{}:{})",
         name.unwrap_or("<anonymous>"),
         file_name,
@@ -2428,7 +2428,7 @@ fn wrap_cache_expr(
             },
             ExprOrSpread {
                 spread: None,
-                expr: Box::new(display_name.into()),
+                expr: Box::new(location.into()),
             },
             Number::from(bound_args_len).as_arg(),
             expr.as_arg(),

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -6,7 +6,7 @@ use next_custom_transforms::transforms::{
     fonts::{next_font_loaders, Config as FontLoaderConfig},
     next_ssg::next_ssg,
     react_server_components::server_components,
-    server_actions::{self, server_actions, ServerActionsMode},
+    server_actions::{self, server_actions, FileInfo, ServerActionsMode},
     strip_page_exports::{next_transform_strip_page_exports, ExportFilter},
 };
 use rustc_hash::FxHashSet;
@@ -160,9 +160,11 @@ fn react_server_actions_errors(input: PathBuf) {
                     None,
                 ),
                 server_actions(
-                    &FileName::Real("/app/item.js".into()),
-                    "./app/item.js".into(),
-                    None,
+                    FileInfo {
+                        path: "/app/item.js".into(),
+                        relative_path: Some("app/item.js".into()),
+                        query: None,
+                    },
                     server_actions::Config {
                         is_react_server_layer,
                         is_development: true,
@@ -225,9 +227,11 @@ fn use_cache_not_allowed(input: PathBuf) {
                     None,
                 ),
                 server_actions(
-                    &FileName::Real("/app/item.js".into()),
-                    "./app/item.js".into(),
-                    None,
+                    FileInfo {
+                        path: "/app/item.js".into(),
+                        relative_path: Some("app/item.js".into()),
+                        query: None,
+                    },
                     server_actions::Config {
                         is_react_server_layer: true,
                         is_development: true,

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -161,6 +161,7 @@ fn react_server_actions_errors(input: PathBuf) {
                 ),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
+                    "./app/item.js".into(),
                     None,
                     server_actions::Config {
                         is_react_server_layer,
@@ -225,6 +226,7 @@ fn use_cache_not_allowed(input: PathBuf) {
                 ),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
+                    "./app/item.js".into(),
                     None,
                     server_actions::Config {
                         is_react_server_layer: true,

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -18,7 +18,7 @@ use next_custom_transforms::transforms::{
     page_config::page_config_test,
     pure::pure_magic,
     react_server_components::server_components,
-    server_actions::{self, server_actions, ServerActionsMode},
+    server_actions::{self, server_actions, FileInfo, ServerActionsMode},
     shake_exports::{shake_exports, Config as ShakeExportsConfig},
     strip_page_exports::{next_transform_strip_page_exports, ExportFilter},
     warn_for_edge_runtime::warn_for_edge_runtime,
@@ -553,9 +553,11 @@ fn server_actions_fixture(input: PathBuf) {
             (
                 resolver(Mark::new(), Mark::new(), false),
                 server_actions(
-                    &FileName::Real("/app/item.js".into()),
-                    "./app/item.js".into(),
-                    None,
+                    FileInfo {
+                        path: "/app/item.js".into(),
+                        relative_path: Some("app/item.js".into()),
+                        query: None,
+                    },
                     server_actions::Config {
                         is_react_server_layer,
                         is_development,
@@ -592,9 +594,11 @@ fn next_font_with_directive_fixture(input: PathBuf) {
                     font_loaders: vec!["@next/font/google".into()],
                 }),
                 server_actions(
-                    &FileName::Real("/app/test.tsx".into()),
-                    "./app/test.tsx".into(),
-                    None,
+                    FileInfo {
+                        path: "/app/test.tsx".into(),
+                        relative_path: Some("app/test.tsx".into()),
+                        query: None,
+                    },
                     server_actions::Config {
                         is_react_server_layer: true,
                         is_development: true,
@@ -906,9 +910,11 @@ fn test_source_maps(input: PathBuf) {
             (
                 resolver(Mark::new(), Mark::new(), false),
                 server_actions(
-                    &FileName::Real("/app/item.js".into()),
-                    "./app/item.js".into(),
-                    None,
+                    FileInfo {
+                        path: "/app/item.js".into(),
+                        relative_path: Some("app/item.js".into()),
+                        query: None,
+                    },
                     server_actions::Config {
                         is_react_server_layer,
                         is_development,

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -554,6 +554,7 @@ fn server_actions_fixture(input: PathBuf) {
                 resolver(Mark::new(), Mark::new(), false),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
+                    "./app/item.js".into(),
                     None,
                     server_actions::Config {
                         is_react_server_layer,
@@ -592,6 +593,7 @@ fn next_font_with_directive_fixture(input: PathBuf) {
                 }),
                 server_actions(
                     &FileName::Real("/app/test.tsx".into()),
+                    "./app/test.tsx".into(),
                     None,
                     server_actions::Config {
                         is_react_server_layer: true,
@@ -905,6 +907,7 @@ fn test_source_maps(input: PathBuf) {
                 resolver(Mark::new(), Mark::new(), false),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
+                    "./app/item.js".into(),
                     None,
                     server_actions::Config {
                         is_react_server_layer,

--- a/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
+++ b/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
@@ -3,7 +3,7 @@ import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import React from 'react';
 import inter from '@next/font/google/target.css?{"path":"app/test.tsx","import":"Inter","arguments":[],"variableName":"inter"}';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", "Cached (./app/test.tsx:7:8)", 0, async function Cached({ children }) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", "Cached (app/test.tsx:7:8)", 0, async function Cached({ children }) {
     return <div className={inter.className}>{children}</div>;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
+++ b/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
@@ -3,7 +3,7 @@ import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import React from 'react';
 import inter from '@next/font/google/target.css?{"path":"app/test.tsx","import":"Inter","arguments":[],"variableName":"inter"}';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", 0, async function Cached({ children }) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", "Cached (./app/test.tsx:7:8)", 0, async function Cached({ children }) {
     return <div className={inter.className}>{children}</div>;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/next.d.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/next.d.ts
@@ -43,6 +43,7 @@ declare module 'private-next-rsc-cache-wrapper' {
   export function cache<TFn extends (...args: any[]) => Promise<any>>(
     kind: string,
     id: string,
+    location: string,
     boundArgsLength: number,
     fn: TFn
   ): TFn

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 const v = 'world';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:3:1)", 0, async function fn() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fn (app/item.js:3:1)", 0, async function fn() {
     return 'hello, ' + v;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 const v = 'world';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function fn() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:3:1)", 0, async function fn() {
     return 'hello, ' + v;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"8012a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","8069348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:13)", 0, async function() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (app/item.js:3:13)", 0, async function() {
     return 'foo';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -10,7 +10,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
 });
 const foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 export { bar };
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (./app/item.js:9:1)", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (app/item.js:9:1)", 0, async function bar() {
     return 'bar';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
@@ -22,7 +22,7 @@ var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b7
 const qux = async function qux() {
     return 'qux';
 };
-export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", "baz (./app/item.js:18:13)", 0, async function baz() {
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", "baz (app/item.js:18:13)", 0, async function baz() {
     return qux() + 'baz';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
@@ -30,7 +30,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     writable: false
 });
 const baz = registerServerReference($$RSC_SERVER_CACHE_2, "8069348c79fce073bae2f70f139565a2fda1c74c74", null);
-export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", "quux (./app/item.js:22:14)", 0, async function() {
+export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", "quux (app/item.js:22:14)", 0, async function() {
     return 'quux';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"8012a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","8069348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:13)", 0, async function() {
     return 'foo';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -10,7 +10,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
 });
 const foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 export { bar };
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (./app/item.js:9:1)", 0, async function bar() {
     return 'bar';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
@@ -22,7 +22,7 @@ var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b7
 const qux = async function qux() {
     return 'qux';
 };
-export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", 0, async function baz() {
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", "baz (./app/item.js:18:13)", 0, async function baz() {
     return qux() + 'baz';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
@@ -30,7 +30,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     writable: false
 });
 const baz = registerServerReference($$RSC_SERVER_CACHE_2, "8069348c79fce073bae2f70f139565a2fda1c74c74", null);
-export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, async function() {
+export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", "quux (./app/item.js:22:14)", 0, async function() {
     return 'quux';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "my_fn (./app/item.js:3:22)", 0, async function() {
     return 'data';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "my_fn (./app/item.js:3:22)", 0, async function() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "my_fn (app/item.js:3:22)", 0, async function() {
     return 'data';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"8012a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1","c069348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:8)", 0, async function foo() {
     return 'data A';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -9,7 +9,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     writable: false
 });
 export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (./app/item.js:7:8)", 0, async function bar() {
     return 'data B';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
@@ -17,7 +17,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
     writable: false
 });
 export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
-export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", 0, async function Cached({ children }) {
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", "Cached (./app/item.js:11:16)", 0, async function Cached({ children }) {
     return children;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
@@ -25,7 +25,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     writable: false
 });
 export default registerServerReference($$RSC_SERVER_CACHE_2, "c069348c79fce073bae2f70f139565a2fda1c74c74", null);
-export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, async function baz() {
+export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", "baz (./app/item.js:15:20)", 0, async function baz() {
     return 'data C';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"8012a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1","c069348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:8)", 0, async function foo() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (app/item.js:3:8)", 0, async function foo() {
     return 'data A';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -9,7 +9,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     writable: false
 });
 export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (./app/item.js:7:8)", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (app/item.js:7:8)", 0, async function bar() {
     return 'data B';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
@@ -17,7 +17,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
     writable: false
 });
 export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
-export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", "Cached (./app/item.js:11:16)", 0, async function Cached({ children }) {
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", "Cached (app/item.js:11:16)", 0, async function Cached({ children }) {
     return children;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
@@ -25,7 +25,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
     writable: false
 });
 export default registerServerReference($$RSC_SERVER_CACHE_2, "c069348c79fce073bae2f70f139565a2fda1c74c74", null);
-export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", "baz (./app/item.js:15:20)", 0, async function baz() {
+export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", "baz (app/item.js:15:20)", 0, async function baz() {
     return 'data C';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:3:1)", 0, async function fn() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fn (app/item.js:3:1)", 0, async function fn() {
     return 'foo';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function fn() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:3:1)", 0, async function fn() {
     return 'foo';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:8)", 0, async function foo() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (app/item.js:3:8)", 0, async function foo() {
     return 'data';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:8)", 0, async function foo() {
     return 'data';
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function fn([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:6:3)", 2, async function fn([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     console.log($$ACTION_ARG_0);
     return {
         foo: $$ACTION_ARG_1

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:6:3)", 2, async function fn([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "fn (app/item.js:6:3)", 2, async function fn([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     console.log($$ACTION_ARG_0);
     return {
         foo: $$ACTION_ARG_1

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import { Form } from 'components';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "cache (./app/item.js:10:5)", 2, async function cache([$$ACTION_ARG_0, $$ACTION_ARG_1], e) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "cache (app/item.js:10:5)", 2, async function cache([$$ACTION_ARG_0, $$ACTION_ARG_1], e) {
     const f = $$ACTION_ARG_0 + e;
     return [
         f,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import { Form } from 'components';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function cache([$$ACTION_ARG_0, $$ACTION_ARG_1], e) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "cache (./app/item.js:10:5)", 2, async function cache([$$ACTION_ARG_0, $$ACTION_ARG_1], e) {
     const f = $$ACTION_ARG_0 + e;
     return [
         f,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
@@ -8,7 +8,7 @@ export const $$RSC_SERVER_ACTION_0 = async function fn($$ACTION_CLOSURE_BOUND) {
         foo: $$ACTION_ARG_1
     };
 };
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", "Component (./app/item.js:3:8)", 0, async function Component({ foo }) {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", "Component (app/item.js:3:8)", 0, async function Component({ foo }) {
     const a = 123;
     var fn = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", a, foo));
     const data = await fn();

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
@@ -8,7 +8,7 @@ export const $$RSC_SERVER_ACTION_0 = async function fn($$ACTION_CLOSURE_BOUND) {
         foo: $$ACTION_ARG_1
     };
 };
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function Component({ foo }) {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", "Component (./app/item.js:3:8)", 0, async function Component({ foo }) {
     const a = 123;
     var fn = registerServerReference($$RSC_SERVER_ACTION_0, "406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", a, foo));
     const data = await fn();

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:6:14)", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     console.log($$ACTION_ARG_0);
     return {
         foo: $$ACTION_ARG_1

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "fn (./app/item.js:6:14)", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "fn (app/item.js:6:14)", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     console.log($$ACTION_ARG_0);
     return {
         foo: $$ACTION_ARG_1

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
@@ -7,7 +7,7 @@ export const $$RSC_SERVER_ACTION_0 = async function action($$ACTION_CLOSURE_BOUN
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_CLOSURE_BOUND);
     console.log(secret, $$ACTION_ARG_0);
 };
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "e0951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function getCachedRandom(x, children) {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "e0951c375b4a6a6e89d67b743ec5808127cfde405d", "getCachedRandom (./app/item.js:5:1)", 0, async function getCachedRandom(x, children) {
     return {
         x,
         y: Math.random(),

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
@@ -7,7 +7,7 @@ export const $$RSC_SERVER_ACTION_0 = async function action($$ACTION_CLOSURE_BOUN
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("406a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_CLOSURE_BOUND);
     console.log(secret, $$ACTION_ARG_0);
 };
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "e0951c375b4a6a6e89d67b743ec5808127cfde405d", "getCachedRandom (./app/item.js:5:1)", 0, async function getCachedRandom(x, children) {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "e0951c375b4a6a6e89d67b743ec5808127cfde405d", "getCachedRandom (app/item.js:5:1)", 0, async function getCachedRandom(x, children) {
     return {
         x,
         y: Math.random(),

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
@@ -7,7 +7,7 @@ function Foo() {
     console.log(v);
     return v;
 }
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "bar (./app/item.js:10:8)", 0, async function bar() {
     return <Foo/>;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
@@ -7,7 +7,7 @@ function Foo() {
     console.log(v);
     return v;
 }
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "bar (./app/item.js:10:8)", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "bar (app/item.js:10:8)", 0, async function bar() {
     return <Foo/>;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
@@ -3,7 +3,7 @@
 /* __next_internal_action_entry_do_not_use__ {"6090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","7c9ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","7ea9b2939c1f39073a6bed227fd20233064c8b7869":"$$RSC_SERVER_ACTION_4","e03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","ff471a5eb0be1c31686dd4ba938a80328b80b1615d":"$$RSC_SERVER_CACHE_5","ff69348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "f1 (./app/item.js:4:1)", 0, async function f1(a, b) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "f1 (app/item.js:4:1)", 0, async function f1(a, b) {
     return [
         a,
         b
@@ -23,7 +23,7 @@ $$RSC_SERVER_ACTION_1 = async function f2(a, b) {
 };
 var f2 = registerServerReference($$RSC_SERVER_ACTION_1, "6090b5db271335765a4b0eab01f044b381b5ebd5cd", null);
 export var // Should be 1 111111 1, which is "ff" in hex.
-$$RSC_SERVER_CACHE_2 = $$cache__("default", "ff69348c79fce073bae2f70f139565a2fda1c74c74", "f3 (./app/item.js:16:1)", 0, async function f3(a, b, ...rest) {
+$$RSC_SERVER_CACHE_2 = $$cache__("default", "ff69348c79fce073bae2f70f139565a2fda1c74c74", "f3 (app/item.js:16:1)", 0, async function f3(a, b, ...rest) {
     return [
         a,
         b,
@@ -59,7 +59,7 @@ $$RSC_SERVER_ACTION_4 = async function f5(a, b, c, d, e, f) {
 };
 var f5 = registerServerReference($$RSC_SERVER_ACTION_4, "7ea9b2939c1f39073a6bed227fd20233064c8b7869", null);
 export var // Should be 1 111111 1, which is "ff" in hex.
-$$RSC_SERVER_CACHE_5 = $$cache__("default", "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", "f6 (./app/item.js:34:1)", 0, async function f6(a, b, c, d, e, f, g) {
+$$RSC_SERVER_CACHE_5 = $$cache__("default", "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", "f6 (app/item.js:34:1)", 0, async function f6(a, b, c, d, e, f, g) {
     return [
         a,
         b,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
@@ -3,7 +3,7 @@
 /* __next_internal_action_entry_do_not_use__ {"6090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","7c9ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","7ea9b2939c1f39073a6bed227fd20233064c8b7869":"$$RSC_SERVER_ACTION_4","e03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","ff471a5eb0be1c31686dd4ba938a80328b80b1615d":"$$RSC_SERVER_CACHE_5","ff69348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, async function f1(a, b) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "f1 (./app/item.js:4:1)", 0, async function f1(a, b) {
     return [
         a,
         b
@@ -23,7 +23,7 @@ $$RSC_SERVER_ACTION_1 = async function f2(a, b) {
 };
 var f2 = registerServerReference($$RSC_SERVER_ACTION_1, "6090b5db271335765a4b0eab01f044b381b5ebd5cd", null);
 export var // Should be 1 111111 1, which is "ff" in hex.
-$$RSC_SERVER_CACHE_2 = $$cache__("default", "ff69348c79fce073bae2f70f139565a2fda1c74c74", 0, async function f3(a, b, ...rest) {
+$$RSC_SERVER_CACHE_2 = $$cache__("default", "ff69348c79fce073bae2f70f139565a2fda1c74c74", "f3 (./app/item.js:16:1)", 0, async function f3(a, b, ...rest) {
     return [
         a,
         b,
@@ -59,7 +59,7 @@ $$RSC_SERVER_ACTION_4 = async function f5(a, b, c, d, e, f) {
 };
 var f5 = registerServerReference($$RSC_SERVER_ACTION_4, "7ea9b2939c1f39073a6bed227fd20233064c8b7869", null);
 export var // Should be 1 111111 1, which is "ff" in hex.
-$$RSC_SERVER_CACHE_5 = $$cache__("default", "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", 0, async function f6(a, b, c, d, e, f, g) {
+$$RSC_SERVER_CACHE_5 = $$cache__("default", "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", "f6 (./app/item.js:34:1)", 0, async function f6(a, b, c, d, e, f, g) {
     return [
         a,
         b,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
@@ -24,7 +24,7 @@ export async function action3(a, b) {
       {b}
     </div>;
 }
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, async function cache(a, b) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "cache (./app/item.js:37:8)", 0, async function cache(a, b) {
     return <div>
       {a}
       {b}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
@@ -24,7 +24,7 @@ export async function action3(a, b) {
       {b}
     </div>;
 }
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "cache (./app/item.js:37:8)", 0, async function cache(a, b) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "cache (app/item.js:37:8)", 0, async function cache(a, b) {
     return <div>
       {a}
       {b}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/49/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/49/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"f03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", "default (./app/item.js:3:16)", 0, async function(a, b, c) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", "default (app/item.js:3:16)", 0, async function(a, b, c) {
     return <div>
       {a}
       {b}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/49/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/49/output.js
@@ -1,11 +1,15 @@
 /* __next_internal_action_entry_do_not_use__ {"f03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", 0, async function(a, b, c) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", "default (./app/item.js:3:16)", 0, async function(a, b, c) {
     return <div>
       {a}
       {b}
       {c}
     </div>;
+});
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
+    value: "default",
+    writable: false
 });
 export default registerServerReference($$RSC_SERVER_CACHE_0, "f03128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"f03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", "default (./app/item.js:3:16)", 0, async function(a, b, c) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", "default (app/item.js:3:16)", 0, async function(a, b, c) {
     return <div>
       {a}
       {b}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"f03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", 0, async function(a, b, c) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", "default (./app/item.js:3:16)", 0, async function(a, b, c) {
     return <div>
       {a}
       {b}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
@@ -2,14 +2,14 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import { Client } from 'components';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "fn1 (./app/item.js:10:12)", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1], c) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "fn1 (app/item.js:10:12)", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1], c) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1 + c;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fn1",
     writable: false
 });
-export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", "fn2 (./app/item.js:17:12)", 2, async function // Should be 1 100000 0, which is "c0" in hex (counts as one param,
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", "fn2 (app/item.js:17:12)", 2, async function // Should be 1 100000 0, which is "c0" in hex (counts as one param,
 // because of the encrypted bound args param)
 fn2([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
@@ -2,14 +2,14 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import { Client } from 'components';
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1], c) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", "fn1 (./app/item.js:10:12)", 2, async function([$$ACTION_ARG_0, $$ACTION_ARG_1], c) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1 + c;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "fn1",
     writable: false
 });
-export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", 2, async function // Should be 1 100000 0, which is "c0" in hex (counts as one param,
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", "fn2 (./app/item.js:17:12)", 2, async function // Should be 1 100000 0, which is "c0" in hex (counts as one param,
 // because of the encrypted bound args param)
 fn2([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {});
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:2:3)", 0, async function foo() {});
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:2:3)", 0, async function foo() {});
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (app/item.js:2:3)", 0, async function foo() {});
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:5:5)", 2, async function foo([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "foo (app/item.js:5:5)", 2, async function foo([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 * $$ACTION_ARG_1;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, async function foo([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:5:5)", 2, async function foo([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 * $$ACTION_ARG_1;
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fetch (./app/item.js:3:5)", 0, async function fetch1() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fetch (app/item.js:3:5)", 0, async function fetch1() {
     return fetch('https://example.com').then((res)=>res.json());
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function fetch1() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "fetch (./app/item.js:3:5)", 0, async function fetch1() {
     return fetch('https://example.com').then((res)=>res.json());
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:2:3)", 0, async function foo() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (app/item.js:2:3)", 0, async function foo() {
     return fetch('https://example.com').then((res)=>res.json());
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"0090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function foo() {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:2:3)", 0, async function foo() {
     return fetch('https://example.com').then((res)=>res.json());
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "<anonymous> (./app/item.js:6:10)", 1, async function([$$ACTION_ARG_0]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "<anonymous> (app/item.js:6:10)", 1, async function([$$ACTION_ARG_0]) {
     return $$ACTION_ARG_0();
 });
 function createCachedFn(start) {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"401c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 1, async function([$$ACTION_ARG_0]) {
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", "<anonymous> (./app/item.js:6:10)", 1, async function([$$ACTION_ARG_0]) {
     return $$ACTION_ARG_0();
 });
 function createCachedFn(start) {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/9/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/9/output.js
@@ -2,11 +2,11 @@
 /* __next_internal_action_entry_do_not_use__ {"7f050e3854b72b19e3c7e3966a67535543a90bf7e0":"baz","7fab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","7fc18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 async function foo() {}
-export { /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ foo };
+export { foo };
 async function bar() {}
-export { /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ bar as baz };
+export { bar as baz };
 async function qux() {}
-export { /*#__TURBOPACK_DISABLE_EXPORT_MERGING__*/ qux as default };
+export { qux as default };
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo,

--- a/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.js
@@ -1,13 +1,13 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function() {});
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:13)", 0, async function() {});
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });
 const foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (./app/item.js:7:8)", 0, async function bar() {
     return foo();
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {

--- a/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.js
@@ -1,13 +1,13 @@
 /* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","80951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (./app/item.js:3:13)", 0, async function() {});
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", "foo (app/item.js:3:13)", 0, async function() {});
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
     value: "foo",
     writable: false
 });
 const foo = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (./app/item.js:7:8)", 0, async function bar() {
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", "bar (app/item.js:7:8)", 0, async function bar() {
     return foo();
 });
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {

--- a/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.map
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["input.js"],"sourcesContent":["'use cache'\n\nconst foo = async () => {\n  'use cache'\n}\n\nexport async function bar() {\n  return foo()\n}\n"],"names":[],"mappings":";;;WAEY,+GAEZ;;;;;AAFA,MAAM,MAAM;WAIL,6FAAA,eAAe;IACpB,OAAO;AACT;;;;;AAFA,WAAsB,MAAf"}
+{"version":3,"sources":["input.js"],"sourcesContent":["'use cache'\n\nconst foo = async () => {\n  'use cache'\n}\n\nexport async function bar() {\n  return foo()\n}\n"],"names":[],"mappings":";;;WAEY,2IAEZ;;;;;AAFA,MAAM,MAAM;WAIL,wHAAA,eAAe;IACpB,OAAO;AACT;;;;;AAFA,WAAsB,MAAf"}

--- a/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.map
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["input.js"],"sourcesContent":["'use cache'\n\nconst foo = async () => {\n  'use cache'\n}\n\nexport async function bar() {\n  return foo()\n}\n"],"names":[],"mappings":";;;WAEY,2IAEZ;;;;;AAFA,MAAM,MAAM;WAIL,wHAAA,eAAe;IACpB,OAAO;AACT;;;;;AAFA,WAAsB,MAAf"}
+{"version":3,"sources":["input.js"],"sourcesContent":["'use cache'\n\nconst foo = async () => {\n  'use cache'\n}\n\nexport async function bar() {\n  return foo()\n}\n"],"names":[],"mappings":";;;WAEY,yIAEZ;;;;;AAFA,MAAM,MAAM;WAIL,sHAAA,eAAe;IACpB,OAAO;AACT;;;;;AAFA,WAAsB,MAAf"}

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -48,7 +48,7 @@ const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
 const DefaultCacheHandler: CacheHandlerV2 = {
   async get(cacheKey, metaData) {
     const pendingPromise = pendingSets.get(cacheKey)
-    const { displayName } = metaData
+    const displayName = metaData?.displayName
 
     if (pendingPromise) {
       debug?.('get', displayName, cacheKey, 'pending')
@@ -97,7 +97,7 @@ const DefaultCacheHandler: CacheHandlerV2 = {
   },
 
   async set(cacheKey, pendingEntry, metaData) {
-    const { displayName } = metaData
+    const displayName = metaData?.displayName
     debug?.('set', displayName, cacheKey, 'start')
 
     let resolvePending: () => void = () => {}

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -46,18 +46,19 @@ const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   : undefined
 
 const DefaultCacheHandler: CacheHandlerV2 = {
-  async get(cacheKey) {
+  async get(cacheKey, metaData) {
     const pendingPromise = pendingSets.get(cacheKey)
+    const { displayName } = metaData
 
     if (pendingPromise) {
-      debug?.('get', cacheKey, 'pending')
+      debug?.('get', displayName, cacheKey, 'pending')
       await pendingPromise
     }
 
     const privateEntry = memoryCache.get(cacheKey)
 
     if (!privateEntry) {
-      debug?.('get', cacheKey, 'not found')
+      debug?.('get', displayName, cacheKey, 'not found')
       return undefined
     }
 
@@ -69,20 +70,20 @@ const DefaultCacheHandler: CacheHandlerV2 = {
       // In-memory caches should expire after revalidate time because it is
       // unlikely that a new entry will be able to be used before it is dropped
       // from the cache.
-      debug?.('get', cacheKey, 'expired')
+      debug?.('get', displayName, cacheKey, 'expired')
 
       return undefined
     }
 
     if (isStale(entry.tags, entry.timestamp)) {
-      debug?.('get', cacheKey, 'had stale tag')
+      debug?.('get', displayName, cacheKey, 'had stale tag')
 
       return undefined
     }
     const [returnStream, newSaved] = entry.value.tee()
     entry.value = newSaved
 
-    debug?.('get', cacheKey, 'found', {
+    debug?.('get', displayName, cacheKey, 'found', {
       tags: entry.tags,
       timestamp: entry.timestamp,
       revalidate: entry.revalidate,
@@ -95,8 +96,9 @@ const DefaultCacheHandler: CacheHandlerV2 = {
     }
   },
 
-  async set(cacheKey, pendingEntry) {
-    debug?.('set', cacheKey, 'start')
+  async set(cacheKey, pendingEntry, metaData) {
+    const { displayName } = metaData
+    debug?.('set', displayName, cacheKey, 'start')
 
     let resolvePending: () => void = () => {}
     const pendingPromise = new Promise<void>((resolve) => {
@@ -124,10 +126,10 @@ const DefaultCacheHandler: CacheHandlerV2 = {
         size,
       })
 
-      debug?.('set', cacheKey, 'done')
+      debug?.('set', displayName, cacheKey, 'done')
     } catch (err) {
       // TODO: store partial buffer with error after we retry 3 times
-      debug?.('set', cacheKey, 'failed', err)
+      debug?.('set', displayName, cacheKey, 'failed', err)
     } finally {
       resolvePending()
       pendingSets.delete(cacheKey)

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -46,9 +46,9 @@ const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
   : undefined
 
 const DefaultCacheHandler: CacheHandlerV2 = {
-  async get(cacheKey, metaData) {
+  async get(cacheKey, metadata) {
     const pendingPromise = pendingSets.get(cacheKey)
-    const displayName = metaData?.displayName
+    const displayName = metadata?.displayName
 
     if (pendingPromise) {
       debug?.('get', displayName, cacheKey, 'pending')
@@ -96,8 +96,8 @@ const DefaultCacheHandler: CacheHandlerV2 = {
     }
   },
 
-  async set(cacheKey, pendingEntry, metaData) {
-    const displayName = metaData?.displayName
+  async set(cacheKey, pendingEntry, metadata) {
+    const displayName = metadata?.displayName
     debug?.('set', displayName, cacheKey, 'start')
 
     let resolvePending: () => void = () => {}

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -75,11 +75,18 @@ export interface CacheHandler {
   receiveExpiredTags(...tags: string[]): Promise<void>
 }
 
+export interface CacheHandlerMetaData {
+  readonly displayName: string
+}
+
 export interface CacheHandlerV2 {
   /**
    * Retrieve a cache entry for the given cache key, if available.
    */
-  get(cacheKey: string): Promise<undefined | CacheEntry>
+  get(
+    cacheKey: string,
+    metaData: CacheHandlerMetaData
+  ): Promise<undefined | CacheEntry>
 
   /**
    * Store a cache entry for the given cache key. When this is called, the entry
@@ -89,7 +96,11 @@ export interface CacheHandlerV2 {
    * `set` operation to finish, before returning the entry, instead of returning
    * undefined.
    */
-  set(cacheKey: string, pendingEntry: Promise<CacheEntry>): Promise<void>
+  set(
+    cacheKey: string,
+    pendingEntry: Promise<CacheEntry>,
+    metaData: CacheHandlerMetaData
+  ): Promise<void>
 
   /**
    * Next.js will call this method periodically, but always before starting a

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -75,7 +75,7 @@ export interface CacheHandler {
   receiveExpiredTags(...tags: string[]): Promise<void>
 }
 
-export interface CacheHandlerMetaData {
+export interface CacheHandlerMetadata {
   readonly displayName: string
 }
 
@@ -85,7 +85,7 @@ export interface CacheHandlerV2 {
    */
   get(
     cacheKey: string,
-    metaData?: CacheHandlerMetaData
+    metadata?: CacheHandlerMetadata
   ): Promise<undefined | CacheEntry>
 
   /**
@@ -99,7 +99,7 @@ export interface CacheHandlerV2 {
   set(
     cacheKey: string,
     pendingEntry: Promise<CacheEntry>,
-    metaData?: CacheHandlerMetaData
+    metadata?: CacheHandlerMetadata
   ): Promise<void>
 
   /**

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -85,7 +85,7 @@ export interface CacheHandlerV2 {
    */
   get(
     cacheKey: string,
-    metaData: CacheHandlerMetaData
+    metaData?: CacheHandlerMetaData
   ): Promise<undefined | CacheEntry>
 
   /**
@@ -99,7 +99,7 @@ export interface CacheHandlerV2 {
   set(
     cacheKey: string,
     pendingEntry: Promise<CacheEntry>,
-    metaData: CacheHandlerMetaData
+    metaData?: CacheHandlerMetaData
   ): Promise<void>
 
   /**

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -509,10 +509,13 @@ function createTrackedReadableStream(
   })
 }
 
+/**
+ * @param location Similar to a V8 stack frame location e.g. `"myFn (./app/page.tsx:47:11)"`
+ */
 export function cache(
   kind: string,
   id: string,
-  displayName: string,
+  location: string,
   boundArgsLength: number,
   originalFn: (...args: unknown[]) => Promise<unknown>
 ) {
@@ -526,6 +529,8 @@ export function cache(
   Error.captureStackTrace(timeoutError, cache)
 
   const name = originalFn.name
+  const displayName = `use-cache ${location}`
+
   const cachedFn = {
     [name]: async function (...args: any[]) {
       const workStore = workAsyncStorage.getStore()

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -512,6 +512,7 @@ function createTrackedReadableStream(
 export function cache(
   kind: string,
   id: string,
+  displayName: string,
   boundArgsLength: number,
   originalFn: (...args: unknown[]) => Promise<unknown>
 ) {
@@ -710,7 +711,7 @@ export function cache(
         let entry = shouldForceRevalidate(workStore, workUnitStore)
           ? undefined
           : 'getExpiration' in cacheHandler
-            ? await cacheHandler.get(serializedCacheKey)
+            ? await cacheHandler.get(serializedCacheKey, { displayName })
             : // Legacy cache handlers require implicit tags to be passed in,
               // instead of checking their staleness here, as we do for modern
               // cache handlers (see below).
@@ -826,7 +827,8 @@ export function cache(
 
             const promise = cacheHandler.set(
               serializedCacheKey,
-              savedCacheEntry
+              savedCacheEntry,
+              { displayName }
             )
 
             workStore.pendingRevalidateWrites ??= []
@@ -887,7 +889,8 @@ export function cache(
 
             const promise = cacheHandler.set(
               serializedCacheKey,
-              savedCacheEntry
+              savedCacheEntry,
+              { displayName }
             )
 
             if (!workStore.pendingRevalidateWrites) {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -510,7 +510,7 @@ function createTrackedReadableStream(
 }
 
 /**
- * @param location Similar to a V8 stack frame location e.g. `"myFn (./app/page.tsx:47:11)"`
+ * @param location Similar to a V8 stack frame location e.g. `"myFn (app/page.tsx:47:11)"`
  */
 export function cache(
   kind: string,

--- a/test/e2e/app-dir/use-cache-custom-handler/handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/handler.js
@@ -7,13 +7,13 @@ const defaultCacheHandler =
  * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandlerV2}
  */
 const cacheHandler = {
-  async get(cacheKey) {
-    console.log('ModernCustomCacheHandler::get', cacheKey)
+  async get(cacheKey, metaData) {
+    console.log('ModernCustomCacheHandler::get', metaData.displayName, cacheKey)
     return defaultCacheHandler.get(cacheKey)
   },
 
-  async set(cacheKey, pendingEntry) {
-    console.log('ModernCustomCacheHandler::set', cacheKey)
+  async set(cacheKey, pendingEntry, metaData) {
+    console.log('ModernCustomCacheHandler::set', metaData.displayName, cacheKey)
     return defaultCacheHandler.set(cacheKey, pendingEntry)
   },
 

--- a/test/e2e/app-dir/use-cache-custom-handler/handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/handler.js
@@ -7,13 +7,13 @@ const defaultCacheHandler =
  * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandlerV2}
  */
 const cacheHandler = {
-  async get(cacheKey, metaData) {
-    console.log('ModernCustomCacheHandler::get', metaData.displayName, cacheKey)
+  async get(cacheKey, metadata) {
+    console.log('ModernCustomCacheHandler::get', metadata.displayName, cacheKey)
     return defaultCacheHandler.get(cacheKey)
   },
 
-  async set(cacheKey, pendingEntry, metaData) {
-    console.log('ModernCustomCacheHandler::set', metaData.displayName, cacheKey)
+  async set(cacheKey, pendingEntry, metadata) {
+    console.log('ModernCustomCacheHandler::set', metadata.displayName, cacheKey)
     return defaultCacheHandler.set(cacheKey, pendingEntry)
   },
 

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -28,11 +28,11 @@ describe('use-cache-custom-handler', () => {
     expect(cliOutput).toContain('ModernCustomCacheHandler::refreshTags')
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::get use-cache getData \(\.\/app\/page.tsx:12:1\) \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::get use-cache getData \(app\/page.tsx:12:1\) \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
     )
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::set use-cache getData \(\.\/app\/page.tsx:12:1\) \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::set use-cache getData \(app\/page.tsx:12:1\) \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
     )
 
     // Since no existing cache entry was retrieved, we don't need to call

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -28,11 +28,11 @@ describe('use-cache-custom-handler', () => {
     expect(cliOutput).toContain('ModernCustomCacheHandler::refreshTags')
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::get use-cache getData \(\.\/app\/page.tsx:12:1\) \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
     )
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::set \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::set use-cache getData \(\.\/app\/page.tsx:12:1\) \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
     )
 
     // Since no existing cache entry was retrieved, we don't need to call


### PR DESCRIPTION
As an alternative approach to #75908, this PR changes the server function transform to pass the function location string directly into the `"use cache"` wrapper. The wrapper transforms it into a display name and passes it as metadata to the cache handler's `get` and `set` methods. The cache handler might use the display name for logging, observability, etc.

The format for the location string is the same as in V8 stack frames, which we already show in other places like the dev overlay, e.g. `Page (app/page.tsx:14:1)` – just without the leading `  at `.

The display name prefixes the location with `use-cache ` so that it can be clearly identified when parsing the display names of cache entries from different sources. For example, the display name (aka `fetchUrl`) for `unstable_cache` starts with an `unstable_cache ` string.

Note: This works even when source maps are not produced and the app is built for production with mangling enabled (the default).