### PR TITLE
test: attempt to unflake useLinkStatus interrupted navigation test

### DIFF
--- a/test/e2e/use-link-status/index.test.ts
+++ b/test/e2e/use-link-status/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { waitFor } from 'next-test-utils'
+import { retry, waitFor } from 'next-test-utils'
 
 describe('useLinkStatus', () => {
   const { next } = nextTestSetup({
@@ -38,6 +38,13 @@ describe('useLinkStatus', () => {
 
     // Trigger shallow routing by clicking debug mode button
     await browser.elementById('enable-debug-btn').click()
+
+    // Wait for the new render to commit to make sure that the navigation transition is interrupted
+    await retry(async () => {
+      expect(
+        await browser.elementByCss('[data-testid="debug-mode"]').text()
+      ).toBe('Debug Mode Enabled')
+    })
 
     // Pending state should be gone
     const post1LoadingElements = await browser.elementsByCss('#post-1-loading')


### PR DESCRIPTION
This test flaked for me here: https://github.com/vercel/next.js/actions/runs/14353556171/job/40239845657#step:33:678

I suspect this is because \[the assertion that the pending state should disappear\] sometimes runs too soon.
To fix this, I made it wait until the side-effect of clicking the "debug mode" button becomes visible before checking if the pending state is gone. If the test is still flaky after this, it indicates a bug in `useLinkStatus`, because the pending state is still hanging around for some reason.

(i chose not to just wrap the assertion in a `retry()`, because we want to ensure that the indicator disappears immediately, not at some unspecified point in the future)
