### PR TITLE
Ignore generated `@next/swc-wasm-nodejs` JS code during linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,6 +17,7 @@ examples/with-tigris/db/models/todoItems.ts
 packages/next/src/bundles/webpack/packages/*.runtime.js
 packages/next/src/bundles/webpack/packages/lazy-compilation-*.js
 packages/next/src/compiled/**/*
+packages/next/wasm/@next
 packages/react-refresh-utils/**/*.js
 packages/react-dev-overlay/lib/**
 **/__tmp__/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@ pnpm-lock.yaml
 
 packages/next/src/bundles/webpack/packages/*.runtime.js
 packages/next/src/bundles/webpack/packages/lazy-compilation-*.js
+packages/next/wasm/@next
 packages/next/errors.json
 
 .github/actions/next-stats-action/.work


### PR DESCRIPTION
[These files are already gitignored](https://github.com/vercel/next.js/blob/78523679d1d28b524ce6ec6a7af7e098df0ff3dd/.gitignore#L6). They don't successfully lint so it's noisy if you happen to have them locally. 

Can't remember how I got these files. Probably some combination of `build-error-code-plugin`, `build` or `swc-build-native`. Can't get these files back after I manually deleted them to shut up ESLint.