### PR TITLE
remove `draft.isEnabled` setter from exotic draftMode wrappers

### DIFF
--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -131,13 +131,6 @@ function createExoticDraftMode(
     get() {
       return instance.isEnabled
     },
-    set(newValue) {
-      Object.defineProperty(promise, 'isEnabled', {
-        value: newValue,
-        writable: true,
-        enumerable: true,
-      })
-    },
     enumerable: true,
     configurable: true,
   })
@@ -159,13 +152,6 @@ function createExoticDraftModeWithDevWarnings(
       const expression = '`draftMode().isEnabled`'
       syncIODev(route, expression)
       return instance.isEnabled
-    },
-    set(newValue) {
-      Object.defineProperty(promise, 'isEnabled', {
-        value: newValue,
-        writable: true,
-        enumerable: true,
-      })
     },
     enumerable: true,
     configurable: true,


### PR DESCRIPTION
For some reason `createExoticDraftMode[WithDevWarnings]` defines a setter for `draft.isEnabled`. As far as i can tell, this setter is unnecessary.

It doesn't seem like we ever allowed this:
```js
const draft = await draftMode()
draft.isEnabled = false
```
The `DraftMode` class had `isEnabled` as a pure getter from the start, see #49096. You can also see that the previous implementation did the same.

(also, the setter wasn't doing anything useful anyway, and arguably was misleading -- it was defining the `isEnabled` property on the promise itself, without actually performing `enable()/disable()`, so i can't see how anyone could be relying on this)