### PR TITLE
Turbopack: fix instrumentation asset context name

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1460,7 +1460,7 @@ impl Project {
                 self.next_config(),
                 self.execution_context(),
             ),
-            Vc::cell("instrumentation-edge".into()),
+            Vc::cell("instrumentation".into()),
         )))
     }
 
@@ -1515,7 +1515,7 @@ impl Project {
                 self.next_config(),
                 self.execution_context(),
             ),
-            Vc::cell("instrumentation".into()),
+            Vc::cell("instrumentation-edge".into()),
         )))
     }
 


### PR DESCRIPTION
🙈 

Closes PACK-4308