### PR TITLE
[dev-overlay] Stop stashing React error details on error instances

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -670,5 +670,6 @@
   "669": "Invariant: --turbopack is set but the build used Webpack",
   "670": "Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to \"next start\".",
   "671": "Specified images.remotePatterns must have protocol \"http\" or \"https\" received \"%s\".",
-  "672": "Expected `telemetry` to be set in globals"
+  "672": "Expected `telemetry` to be set in globals",
+  "673": "Thrown value was ignored. This is a bug in Next.js."
 }

--- a/packages/next/src/client/components/react-dev-overlay/utils/parse-stack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/parse-stack.ts
@@ -3,7 +3,7 @@ import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 
 const regexNextStatic = /\/_next(\/static\/.+)/
 
-export function parseStack(stack: string | undefined): StackFrame[] {
+export function parseStack(stack: string): StackFrame[] {
   if (!stack) return []
 
   // throw away eval information that stacktrace-parser doesn't support

--- a/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
+++ b/packages/next/src/client/react-client-callbacks/error-boundary-callbacks.ts
@@ -1,7 +1,10 @@
 // This file is only used in app router due to the specific error state handling.
 
 import type { ErrorInfo } from 'react'
-import { getReactStitchedError } from '../components/errors/stitched-error'
+import {
+  getReactStitchedError,
+  setComponentStack,
+} from '../components/errors/stitched-error'
 import { handleClientError } from '../components/errors/use-error-handler'
 import { isNextRouterError } from '../components/is-next-router-error'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
@@ -73,7 +76,7 @@ export function onCaughtError(
     // TODO: change to passing down errorInfo later
     // In development mode, pass along the component stack to the error
     if (errorInfo.componentStack) {
-      ;(stitchedError as any)._componentStack = errorInfo.componentStack
+      setComponentStack(stitchedError, errorInfo.componentStack)
     }
 
     // Log and report the error with location but without modifying the error stack
@@ -94,7 +97,7 @@ export function onUncaughtError(err: unknown, errorInfo: React.ErrorInfo) {
     // TODO: change to passing down errorInfo later
     // In development mode, pass along the component stack to the error
     if (errorInfo.componentStack) {
-      ;(stitchedError as any)._componentStack = errorInfo.componentStack
+      setComponentStack(stitchedError, errorInfo.componentStack)
     }
 
     // TODO: Add an adendum to the overlay telling people about custom error boundaries.

--- a/packages/next/src/client/react-client-callbacks/on-recoverable-error.ts
+++ b/packages/next/src/client/react-client-callbacks/on-recoverable-error.ts
@@ -3,7 +3,10 @@
 import type { HydrationOptions } from 'react-dom/client'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { reportGlobalError } from './report-global-error'
-import { getReactStitchedError } from '../components/errors/stitched-error'
+import {
+  getReactStitchedError,
+  setComponentStack,
+} from '../components/errors/stitched-error'
 import isError from '../../lib/is-error'
 
 export const onRecoverableError: HydrationOptions['onRecoverableError'] = (
@@ -13,9 +16,8 @@ export const onRecoverableError: HydrationOptions['onRecoverableError'] = (
   // x-ref: https://github.com/facebook/react/pull/28736
   const cause = isError(error) && 'cause' in error ? error.cause : error
   const stitchedError = getReactStitchedError(cause)
-  // In development mode, pass along the component stack to the error
   if (process.env.NODE_ENV === 'development' && errorInfo.componentStack) {
-    ;(stitchedError as any)._componentStack = errorInfo.componentStack
+    setComponentStack(stitchedError, errorInfo.componentStack)
   }
   // Skip certain custom errors which are not expected to be reported on client
   if (isBailoutToCSRError(cause)) return

--- a/packages/next/src/lib/error-telemetry-utils.ts
+++ b/packages/next/src/lib/error-telemetry-utils.ts
@@ -22,21 +22,6 @@ export const createDigestWithErrorCode = (
   return originalDigest
 }
 
-/**
- * Copies the error code from one error to another by setting the __NEXT_ERROR_CODE property.
- * This allows error codes to be preserved when wrapping or transforming errors.
- */
-export const copyNextErrorCode = (source: unknown, target: unknown): void => {
-  const errorCode = extractNextErrorCode(source)
-  if (errorCode && typeof target === 'object' && target !== null) {
-    Object.defineProperty(target, '__NEXT_ERROR_CODE', {
-      value: errorCode,
-      enumerable: false,
-      configurable: true,
-    })
-  }
-}
-
 export const extractNextErrorCode = (error: unknown): string | undefined => {
   if (
     typeof error === 'object' &&

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -949,6 +949,8 @@ describe('ReactRefreshLogBox app', () => {
     )
 
     if (isTurbopack) {
+      // Set.forEach: https://linear.app/vercel/issue/NDX-554/
+      // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
          "description": "Error: test",
@@ -960,6 +962,9 @@ describe('ReactRefreshLogBox app', () => {
            |           ^",
          "stack": [
            "{default export} index.js (3:11)",
+           "Set.forEach <anonymous> (0:0)",
+           "<FIXME-file-protocol>",
+           "<FIXME-file-protocol>",
            "Page app/page.js (2:1)",
          ],
        }
@@ -1050,6 +1055,8 @@ describe('ReactRefreshLogBox app', () => {
     // Render error should "win" and show up in fullscreen
     // TODO(veil): Why Owner Stack location different?
     if (isTurbopack) {
+      // Set.forEach: https://linear.app/vercel/issue/NDX-554/
+      // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
          "description": "Error: Component error",
@@ -1060,6 +1067,9 @@ describe('ReactRefreshLogBox app', () => {
            |                                            ^",
          "stack": [
            "Index index.js (2:44)",
+           "Set.forEach <anonymous> (0:0)",
+           "<FIXME-file-protocol>",
+           "<FIXME-file-protocol>",
            "Page index.js (16:8)",
          ],
        }

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -261,6 +261,7 @@ describe('Error recovery app', () => {
     ).toBe('1')
 
     if (isTurbopack) {
+      // TODO(veil): Location of Page should be app/page.js
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "description": "Error: oops",
@@ -280,7 +281,6 @@ describe('Error recovery app', () => {
        }
       `)
     } else {
-      // TODO(veil): Location of Page should be app/page.js
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "description": "Error: oops",
@@ -450,6 +450,8 @@ describe('Error recovery app', () => {
     )
 
     if (isTurbopack) {
+      // Set.forEach: https://linear.app/vercel/issue/NDX-554/
+      // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
          "description": "Error: oops",
@@ -460,6 +462,9 @@ describe('Error recovery app', () => {
            |         ^",
          "stack": [
            "Child child.js (3:9)",
+           "Set.forEach <anonymous> (0:0)",
+           "<FIXME-file-protocol>",
+           "<FIXME-file-protocol>",
            "Index index.js (6:7)",
            "<FIXME-file-protocol>",
          ],
@@ -687,9 +692,11 @@ describe('Error recovery app', () => {
 
     // We get an error because Foo didn't import React. Fair.
     if (isTurbopack) {
+      // Set.forEach: https://linear.app/vercel/issue/NDX-554/
+      // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: React is not defined",
+         "description": "ReferenceError: React is not defined",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "Foo.js (3:3) @ Foo
@@ -697,6 +704,9 @@ describe('Error recovery app', () => {
            |   ^",
          "stack": [
            "Foo Foo.js (3:3)",
+           "Set.forEach <anonymous> (0:0)",
+           "<FIXME-file-protocol>",
+           "<FIXME-file-protocol>",
            "FunctionDefault index.js (4:10)",
            "<FIXME-file-protocol>",
          ],
@@ -705,7 +715,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: React is not defined",
+         "description": "ReferenceError: React is not defined",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "Foo.js (3:3) @ Foo
@@ -888,6 +898,9 @@ describe('Error recovery app', () => {
       `
     )
     if (isTurbopack) {
+      // TODO(veil): Location of Page should be app/page.js
+      // Set.forEach: https://linear.app/vercel/issue/NDX-554/
+      // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
          "description": "Error: nooo",
@@ -898,6 +911,9 @@ describe('Error recovery app', () => {
            |           ^",
          "stack": [
            "ClassDefault.render index.js (5:11)",
+           "Set.forEach <anonymous> (0:0)",
+           "<FIXME-file-protocol>",
+           "<FIXME-file-protocol>",
            "Page index.js (10:16)",
          ],
        }

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -1,19 +1,22 @@
 import { nextTestSetup } from 'e2e-utils'
 import { assertNoRedbox, retry } from 'next-test-utils'
 
-// Remove the location `()` part in every line of stack trace;
-// Remove the leading spaces in every line of stack trace;
-// Remove the trailing spaces in every line of stack trace;
 // These stacks are not sourcemapped and therefore not ignore-listed.
 // Feel free to update internal frames in assertions.
 function normalizeBrowserConsoleStackTrace(trace: unknown) {
   if (typeof trace !== 'string') {
     return trace
   }
-  return trace
-    .replace(/\(.*\)/g, '')
-    .replace(/^\s+/gm, '')
-    .trim()
+  return (
+    trace
+      // Removes React's internals i.e. incomplete ignore-listing
+      .split(/at react-stack-bottom-frame.*/m)[0]
+      // Remove the location `()` part in every line of stack trace;
+      .replace(/\(.*\)/g, '')
+      // Remove the leading spaces in every line of stack trace;
+      .replace(/^\s+/gm, '')
+      .trim()
+  )
 }
 
 describe('app-dir - owner-stack', () => {
@@ -74,8 +77,7 @@ describe('app-dir - owner-stack', () => {
      "Error: browser error
      at useThrowError 
      at useErrorHook 
-     at Page 
-     at ClientPageRoot"
+     at Page"
     `)
   })
 
@@ -108,22 +110,11 @@ describe('app-dir - owner-stack', () => {
     `)
 
     expect(normalizeBrowserConsoleStackTrace(errorLog)).toMatchInlineSnapshot(`
-      "%o
-      %s Error: browser error
-      at useThrowError 
-      at useErrorHook 
-      at Thrower 
-      at react-stack-bottom-frame 
-      at renderWithHooks 
-      at updateFunctionComponent 
-      at beginWork 
-      at runWithFiberInDEV 
-      at performUnitOfWork 
-      at workLoopSync 
-      at renderRootSync 
-      at performWorkOnRoot 
-      at performWorkOnRootViaSchedulerTask 
-      at MessagePort.performWorkUntilDeadline  The above error occurred in the <Thrower> component. It was handled by the <MyErrorBoundary> error boundary."
+     "%o
+     %s Error: browser error
+     at useThrowError 
+     at useErrorHook 
+     at Thrower"
     `)
   })
 
@@ -158,8 +149,7 @@ describe('app-dir - owner-stack', () => {
      "Error: ssr error
      at useThrowError 
      at useErrorHook 
-     at Page 
-     at ClientPageRoot"
+     at Page"
     `)
   })
 


### PR DESCRIPTION
Stashing makes type checking harder since we have to assert on the shape not the instance. That way we can get rid of the `ConsoleError` wrapper later when actual error instances are logged.

It's also not trivial to correctly clone errors so that we don't mutate the original error which already caused bugs where the actual error type was masked (e.g. when a `ReferenceError` was thrown but we displayed it as a generic `Error` which an existing test caught).

https://github.com/vercel/next.js/actions/runs/14381251663/job/40325459097?pr=77975#step:33:767

- [React 18 test run](https://github.com/vercel/next.js/actions/runs/14417853294?pr=77975)
- [React 19 test run](https://github.com/vercel/next.js/actions/runs/14422515117?pr=77975)

Failed test in flaky detection job are known:
- [Error recovery app client component can recover from a component error](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3A%22test%2Fdevelopment%2Facceptance-app%2Ferror-recovery.test.ts%22%20%40test.name%3A%22Error%20recovery%20app%20client%20component%20can%20recover%20from%20a%20component%20error%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1743684389673&end=1744289189673&paused=false)