### PR TITLE
Turbopack: include query and fragment in request pattern

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2200,14 +2200,16 @@ async fn resolve_relative_request(
     }
 
     let mut new_path = path_pattern.clone();
+    let mut need_normalize = false;
 
     let fragment_val = fragment.await?;
     if !fragment_val.is_empty() {
         new_path.push(Pattern::Alternatives(
             once(Pattern::Constant("".into()))
-                .chain(once(Pattern::Constant(format!("#{fragment_val}").into())))
+                .chain(once(Pattern::Constant(format!("{fragment_val}").into())))
                 .collect(),
         ));
+        need_normalize = true;
     }
 
     if !options_value.fully_specified {
@@ -2223,7 +2225,7 @@ async fn resolve_relative_request(
                 )
                 .collect(),
         ));
-        new_path.normalize();
+        need_normalize = true;
     };
 
     if options_value.enable_typescript_with_output_extension {
@@ -2264,6 +2266,10 @@ async fn resolve_relative_request(
                 ]))
             }
         });
+        need_normalize = true;
+    }
+
+    if need_normalize {
         new_path.normalize();
     }
 

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -142,6 +142,14 @@ impl Pattern {
         }
     }
 
+    pub fn is_empty_constant(&self) -> bool {
+        if let Pattern::Constant(c) = self {
+            c.is_empty()
+        } else {
+            false
+        }
+    }
+
     pub fn constant_prefix(&self) -> &str {
         // The normalized pattern is an Alternative of maximally merged
         // Concatenations, so extracting the first/only Concatenation child
@@ -367,6 +375,9 @@ impl Pattern {
 
     /// Appends something to end the pattern.
     pub fn push(&mut self, pat: Pattern) {
+        if pat.is_empty_constant() {
+            return;
+        }
         match (self, pat) {
             (Pattern::Concatenation(list), Pattern::Concatenation(more)) => {
                 concatenation_extend_or_merge_items(list, more.into_iter());
@@ -391,6 +402,9 @@ impl Pattern {
 
     /// Prepends something to front of the pattern.
     pub fn push_front(&mut self, pat: Pattern) {
+        if pat.is_empty_constant() {
+            return;
+        }
         match (self, pat) {
             (Pattern::Concatenation(list), Pattern::Concatenation(mut more)) => {
                 concatenation_extend_or_merge_items(&mut more, take(list).into_iter());


### PR DESCRIPTION
### What?

Improve `Can't find module '...'` error message by including querystring and fragment to make it a complete request