### PR TITLE
Revert standalone extension change for module type

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1687,7 +1687,7 @@ export async function copyTracedFiles(
   const serverOutputPath = path.join(
     outputPath,
     path.relative(tracingRoot, dir),
-    moduleType ? 'server.mjs' : 'server.js'
+    'server.js'
   )
   await fs.mkdir(path.dirname(serverOutputPath), { recursive: true })
 

--- a/test/production/standalone-mode/type-module/index.test.ts
+++ b/test/production/standalone-mode/type-module/index.test.ts
@@ -41,7 +41,7 @@ describe('type-module', () => {
 
     expect(fs.existsSync(join(standalonePath, 'package.json'))).toBe(true)
 
-    const serverFile = join(standalonePath, 'server.mjs')
+    const serverFile = join(standalonePath, 'server.js')
     const appPort = await findPort()
     const server = await initNextServerScript(
       serverFile,


### PR DESCRIPTION
We don't need to change the extension as the main fix is to ensure the `package.json` is copied to the standalone folder. The extension change was for more correctness but can cause breakage for anyone using `type: 'module'` as they will need to update their flows for the new `.mjs` extension. Since this is un-necessary breakage this reverts that piece of the fix. 

x-ref: https://github.com/vercel/next.js/pull/77944#discussion_r2035618277