### PR TITLE
docs: mention env option in the environment variables docs

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/03-environment-variables.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/03-environment-variables.mdx
@@ -178,7 +178,7 @@ const env = process.env
 setupAnalyticsService(env.NEXT_PUBLIC_ANALYTICS_ID)
 ```
 
-> **Good to know**: Bundled environment variables can also be set using the [`env`](/docs/app/api-reference/config/next-config-js/env) option in `next.config.js`. These do not require the `NEXT_PUBLIC_` prefix.
+> **Note**: Bundled environment variables can also be set using the [`env`](/docs/app/api-reference/config/next-config-js/env) option in `next.config.js`. These do not require the `NEXT_PUBLIC_` prefix. (not recommended)
 
 ### Runtime Environment Variables
 

--- a/docs/01-app/03-building-your-application/07-configuring/03-environment-variables.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/03-environment-variables.mdx
@@ -178,6 +178,8 @@ const env = process.env
 setupAnalyticsService(env.NEXT_PUBLIC_ANALYTICS_ID)
 ```
 
+> **Good to know**: Bundled environment variables can also be set using the [`env`](/docs/app/api-reference/config/next-config-js/env) option in `next.config.js`. These do not require the `NEXT_PUBLIC_` prefix.
+
 ### Runtime Environment Variables
 
 Next.js can support both build time and runtime environment variables.


### PR DESCRIPTION
## Summary

Mention env option of the next config on [the environment variables docs page](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables)

Came up here; https://github.com/vercel/next.js/discussions/21850#discussioncomment-12705620

cc: @delbaoliveira @leerob @samcx  :)