### PR TITLE
Turbopack: fix dynamic request lookup with only a single match

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -410,7 +410,7 @@ impl PatternMapping {
                 request_to_string(request).await?.to_string(),
             ))
             .cell()),
-            1 => {
+            1 if !request.request_pattern().await?.has_dynamic_parts() => {
                 let resolve_item = &result.primary.first().unwrap().1;
                 let single_pattern_mapping =
                     to_single_pattern_mapping(origin, chunking_context, resolve_item, resolve_type)

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/dynamic-requests/basic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/dynamic-requests/basic/input/index.js
@@ -11,6 +11,8 @@ const importAddSuffix = (key) => import("./dir/" + key + ".js");
 const importConcat = (key) => import("./dir/".concat(key));
 const importConcatSuffix = (key) => import("./dir/".concat(key, ".js"));
 
+const requireSingleSuffix = (key) => require(`./dir/${key}.ts`);
+
 it("should support dynamic requests in require with template literals", () => {
   expect(requireTemplate("a.js")).toBe(a);
   expect(requireTemplate("b.ts")).toBe(b);
@@ -102,4 +104,9 @@ it("should not support dynamic requests with double extension", async () => {
   await expect(importAddSuffix("d.js")).rejects.toThrowError();
   await expect(importConcatSuffix("a.js")).rejects.toThrowError();
   await expect(importConcatSuffix("d.js")).rejects.toThrowError();
+});
+
+it("should still interpolate even with a single match", async () => {
+  expect(requireSingleSuffix("b")).toBe(b)
+  expect(() => requireSingleSuffix("non-existent")).toThrowError()
 });


### PR DESCRIPTION
Previously, if `require("./dynamic-files/"+name)` had only a single match, it would always return that one, regardless of whether `name` was equal to the matches' filename or not.

Closes https://github.com/vercel/next.js/issues/74664
Closes PACK-4309