### PR TITLE
[test] Stop asserting on internal stackframes when features are working as intended

### DIFF
--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -10,14 +10,6 @@ describe('error-ignored-frames', () => {
     files: __dirname,
   })
 
-  if (
-    // Skip react 18 test as the call stacks are different
-    process.env.NEXT_TEST_REACT_VERSION === '18.3.1'
-  ) {
-    it('skip test', () => {})
-    return
-  }
-
   it('should be able to collapse ignored frames in server component', async () => {
     const browser = await next.browser('/')
     await assertHasRedbox(browser)
@@ -27,28 +19,12 @@ describe('error-ignored-frames', () => {
 
     await toggleCollapseCallStackFrames(browser)
 
-    const expendedStack = await getStackFramesContent(browser)
-    if (isTurbopack) {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at Page (app/page.tsx (2:9))
-       at resolveErrorDev ()
-       at processFullStringRow ()
-       at processFullBinaryRow ()
-       at progress ()
-       at InnerLayoutRouter ()
-       at OuterLayoutRouter ()"
-      `)
-    } else {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at Page (app/page.tsx (2:9))
-       at resolveErrorDev ()
-       at processFullStringRow ()
-       at processFullBinaryRow ()
-       at progress ()
-       at InnerLayoutRouter (../src/client/components/layout-router.tsx (415:5))
-       at OuterLayoutRouter (../src/client/components/layout-router.tsx (615:19))"
-      `)
-    }
+    const expandedStack = await getStackFramesContent(browser)
+    const ignoreListedStack = expandedStack.replace(defaultStack, '')
+    // We don't care about the exact stack trace that was ignore-listed.
+    // It'll contain implementation details that may change and
+    // shouldn't break this test.
+    expect(ignoreListedStack.trim()).toMatch(/at .*/)
   })
 
   it('should be able to collapse ignored frames in client component', async () => {
@@ -62,18 +38,12 @@ describe('error-ignored-frames', () => {
 
     await toggleCollapseCallStackFrames(browser)
 
-    const expendedStack = await getStackFramesContent(browser)
-    if (isTurbopack) {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at Page (app/client/page.tsx (4:9))
-       at ClientPageRoot ()"
-      `)
-    } else {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at Page (app/client/page.tsx (4:9))
-       at ClientPageRoot (../src/client/components/client-page.tsx (60:12))"
-      `)
-    }
+    const expandedStack = await getStackFramesContent(browser)
+    const ignoreListedStack = expandedStack.replace(defaultStack, '')
+    // We don't care about the exact stack trace that was ignore-listed.
+    // It'll contain implementation details that may change and
+    // shouldn't break this test.
+    expect(ignoreListedStack.trim()).toMatch(/at .*/)
   })
 
   it('should be able to collapse ignored frames in interleaved call stack', async () => {
@@ -95,22 +65,12 @@ describe('error-ignored-frames', () => {
 
     await toggleCollapseCallStackFrames(browser)
 
-    const expendedStack = await getStackFramesContent(browser)
-    if (isTurbopack) {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at <unknown> (app/interleaved/page.tsx (7:11))
-       at invokeCallback ()
-       at Page (app/interleaved/page.tsx (6:35))
-       at ClientPageRoot ()"
-      `)
-    } else {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at eval (app/interleaved/page.tsx (7:11))
-       at invokeCallback (node_modules/interleave/index.js (2:1))
-       at Page (app/interleaved/page.tsx (6:36))
-       at ClientPageRoot (../src/client/components/client-page.tsx (60:12))"
-      `)
-    }
+    const expandedStack = await getStackFramesContent(browser)
+    const ignoreListedStack = expandedStack.replace(defaultStack, '')
+    // We don't care about the exact stack trace that was ignore-listed.
+    // It'll contain implementation details that may change and
+    // shouldn't break this test.
+    expect(ignoreListedStack.trim()).toMatch(/at .*/)
   })
 
   it('should be able to collapse pages router ignored frames', async () => {
@@ -124,78 +84,11 @@ describe('error-ignored-frames', () => {
 
     await toggleCollapseCallStackFrames(browser)
 
-    const expendedStack = await getStackFramesContent(browser)
-    if (isTurbopack) {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at Page (pages/pages.tsx (2:9))
-       at react-stack-bottom-frame ()
-       at renderWithHooks ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at finishFunctionComponent ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderNode ()
-       at renderChildrenArray ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderNode ()
-       at renderChildrenArray ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at finishFunctionComponent ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()"
-      `)
-    } else {
-      expect(expendedStack).toMatchInlineSnapshot(`
-       "at Page (pages/pages.tsx (2:9))
-       at react-stack-bottom-frame ()
-       at renderWithHooks ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at finishFunctionComponent ()
-       at renderElement ()
-       at retryNode ()
-       at renderNodeDestructive ()
-       at renderNode ()
-       at renderChildrenArray ()"
-      `)
-    }
+    const expandedStack = await getStackFramesContent(browser)
+    const ignoreListedStack = expandedStack.replace(defaultStack, '')
+    // We don't care about the exact stack trace that was ignore-listed.
+    // It'll contain implementation details that may change and
+    // shouldn't break this test.
+    expect(ignoreListedStack.trim()).toMatch(/at .*/)
   })
 })


### PR DESCRIPTION
We don't care about the exact stack trace that was ignore-listed.
It'll contain implementation details that may change and shouldn't break tests that are asserting on working features.

We still see our internal frames in hydration diff parent stacks we assert on. But these don't have line numbers so they'll change less often. We can follow-up if these tests are also a common frustration.