### PR TITLE
Turbopack: asset ident instead of chunk item ID in CSS

### DIFF
--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -89,7 +89,7 @@ impl CssChunk {
                 &*this.chunking_context.minify_type().await?,
                 MinifyType::NoMinify
             ) {
-                let id = &*css_item.id().await?;
+                let id = css_item.asset_ident().to_string().await?;
                 writeln!(body, "/* {} */", id)?;
             }
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -59,7 +59,7 @@ impl SingleItemCssChunk {
             &*this.chunking_context.minify_type().await?,
             MinifyType::NoMinify
         ) {
-            let id = this.item.id().await?;
+            let id = this.item.asset_ident().to_string().await?;
             writeln!(code, "/* {} */", id)?;
         }
         let content = this.item.content().await?;

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{Chunk, ChunkItem, ChunkItemExt, ChunkingContext, MinifyType},
+    chunk::{Chunk, ChunkItem, ChunkingContext, MinifyType},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     introspect::Introspectable,


### PR DESCRIPTION
This is absolutely useless with numerical ids (prod build with `turbopackMinify: false`):
```css
/* 51318 */
.base2-module__zzC_ua__base {
  color: #ff0200;
}


/* 29244 */
.base2-scss-module-scss-module__JjfRsa__base {
  color: #ff0300;
}


/* 85234 */
.base-module__DNnTeq__base {
  color: red;
}


/* 29244 */
.base2-scss-module-scss-module__JjfRsa__base {
  color: #ff0300;
}
```

Closes PACK-4319