### PR TITLE
Turbopack: Avoid depending on specific error types in next/font

### DIFF
--- a/crates/next-core/src/next_font/local/errors.rs
+++ b/crates/next-core/src/next_font/local/errors.rs
@@ -1,8 +1,0 @@
-use thiserror::Error;
-use turbo_rcstr::RcStr;
-
-#[derive(Debug, Error)]
-pub enum FontError {
-    #[error("could not find font file")]
-    FontFileNotFound(RcStr),
-}

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -120,7 +120,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
                     return Ok(ResolveResultOption::some(*ResolveResult::primary(
                         ResolveResultItem::Error(ResolvedVc::cell(
-                            format!("Failed to resolve next/font file").into(),
+                            "Failed to resolve next/font file".into(),
                         )),
                     )));
                 }

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -8,6 +8,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     asset::AssetContent,
+    error::PrettyPrintError,
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     reference_type::ReferenceType,
     resolve::{
@@ -31,12 +32,11 @@ use super::{
 use crate::{
     next_app::metadata::split_extension,
     next_font::{
-        local::{errors::FontError, options::FontWeight},
+        local::options::FontWeight,
         util::{get_request_hash, get_request_id},
     },
 };
 
-mod errors;
 pub mod font_fallback;
 pub mod options;
 pub mod request;
@@ -111,25 +111,18 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
                 let lookup_path = lookup_path.to_resolved().await?;
                 if let Err(e) = &properties {
-                    for source_error in e.chain() {
-                        if let Some(FontError::FontFileNotFound(font_path)) =
-                            source_error.downcast_ref::<FontError>()
-                        {
-                            FontResolvingIssue {
-                                origin_path: lookup_path,
-                                font_path: ResolvedVc::cell(font_path.clone()),
-                            }
-                            .resolved_cell()
-                            .emit();
-
-                            return Ok(ResolveResultOption::some(*ResolveResult::primary(
-                                ResolveResultItem::Error(ResolvedVc::cell(
-                                    format!("Font file not found: Can't resolve {}'", font_path)
-                                        .into(),
-                                )),
-                            )));
-                        }
+                    FontResolvingIssue {
+                        origin_path: lookup_path,
+                        error: PrettyPrintError(e).to_string().into(),
                     }
+                    .resolved_cell()
+                    .emit();
+
+                    return Ok(ResolveResultOption::some(*ResolveResult::primary(
+                        ResolveResultItem::Error(ResolvedVc::cell(
+                            format!("Failed to resolve next/font file").into(),
+                        )),
+                    )));
                 }
 
                 let properties = properties?;
@@ -318,8 +311,8 @@ async fn font_file_options_from_query_map(
 
 #[turbo_tasks::value(shared)]
 struct FontResolvingIssue {
-    font_path: ResolvedVc<RcStr>,
     origin_path: ResolvedVc<FileSystemPath>,
+    error: RcStr,
 }
 
 #[turbo_tasks::value_impl]
@@ -342,10 +335,9 @@ impl Issue for FontResolvingIssue {
     #[turbo_tasks::function]
     async fn title(self: Vc<Self>) -> Result<Vc<StyledString>> {
         let this = self.await?;
-        Ok(StyledString::Line(vec![
-            StyledString::Text("Font file not found: Can't resolve '".into()),
-            StyledString::Code(this.font_path.owned().await?),
-            StyledString::Text("'".into()),
+        Ok(StyledString::Stack(vec![
+            StyledString::Text("Failed to resolve next/font file".into()),
+            StyledString::Text(this.error.clone()),
         ])
         .cell())
     }

--- a/test/e2e/app-dir/next-font/next-font.test.ts
+++ b/test/e2e/app-dir/next-font/next-font.test.ts
@@ -457,9 +457,15 @@ describe('app dir - next/font', () => {
             )
           )
           await assertHasRedbox(browser)
-          expect(await getRedboxSource(browser)).toInclude(
-            "Can't resolve './does-not-exist.woff2'"
-          )
+          if (process.env.TURBOPACK) {
+            expect(await getRedboxSource(browser)).toInclude(
+              "File [project]/fonts/does-not-exist.woff2 doesn't exist"
+            )
+          } else {
+            expect(await getRedboxSource(browser)).toInclude(
+              "Can't resolve './does-not-exist.woff2'"
+            )
+          }
 
           // Fix file
           await next.patchFile('fonts/index.js', font1Content)

--- a/test/e2e/app-dir/next-font/next-font.test.ts
+++ b/test/e2e/app-dir/next-font/next-font.test.ts
@@ -23,6 +23,7 @@ describe('app dir - next/font', () => {
       next,
       isNextDev: isDev,
       skipped,
+      isTurbopack,
     } = nextTestSetup({
       files: {
         app: new FileRef(join(__dirname, 'app')),
@@ -47,10 +48,10 @@ describe('app dir - next/font', () => {
         // layout
         expect(JSON.parse($('#root-layout').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           variable: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_variable$/ : /^__variable_.*/
+            isTurbopack ? /.*_variable$/ : /^__variable_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font1', 'font1 Fallback'$/),
@@ -59,10 +60,10 @@ describe('app dir - next/font', () => {
         // page
         expect(JSON.parse($('#root-page').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           variable: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_variable$/ : /^__variable_.*/
+            isTurbopack ? /.*_variable$/ : /^__variable_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font2', 'font2 Fallback'$/),
@@ -71,7 +72,7 @@ describe('app dir - next/font', () => {
         // Comp
         expect(JSON.parse($('#root-comp').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font3', 'font3 Fallback'$/),
@@ -87,10 +88,10 @@ describe('app dir - next/font', () => {
         // root layout
         expect(JSON.parse($('#root-layout').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           variable: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_variable$/ : /^__variable_.*/
+            isTurbopack ? /.*_variable$/ : /^__variable_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font1', 'font1 Fallback'$/),
@@ -100,7 +101,7 @@ describe('app dir - next/font', () => {
         // layout
         expect(JSON.parse($('#client-layout').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font4', 'font4 Fallback'$/),
@@ -110,7 +111,7 @@ describe('app dir - next/font', () => {
         // page
         expect(JSON.parse($('#client-page').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font5', 'font5 Fallback'$/),
@@ -120,7 +121,7 @@ describe('app dir - next/font', () => {
         // Comp
         expect(JSON.parse($('#client-comp').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font6', 'font6 Fallback'$/),
@@ -132,13 +133,13 @@ describe('app dir - next/font', () => {
         const $ = await next.render$('/third-party')
         expect(JSON.parse($('#third-party-page').text())).toEqual({
           className: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_className$/ : /^__className_.*/
+            isTurbopack ? /.*_className$/ : /^__className_.*/
           ),
           style: {
             fontFamily: expect.stringMatching(/^'font1', 'font1 Fallback'$/),
           },
           variable: expect.stringMatching(
-            process.env.IS_TURBOPACK_TEST ? /.*_variable$/ : /^__variable_.*/
+            isTurbopack ? /.*_variable$/ : /^__variable_.*/
           ),
         })
       })
@@ -313,7 +314,7 @@ describe('app dir - next/font', () => {
           for (const link of links) {
             expect(link.as).toBe('font')
             expect(link.crossorigin).toBe('')
-            if (process.env.IS_TURBOPACK_TEST) {
+            if (isTurbopack) {
               expect(link.href).toMatch(
                 /\/_next\/static\/media\/(.*)-s.p.(.*)\.woff2/
               )
@@ -338,7 +339,7 @@ describe('app dir - next/font', () => {
           for (const link of links) {
             expect(link.as).toBe('font')
             expect(link.crossorigin).toBe('')
-            if (process.env.IS_TURBOPACK_TEST) {
+            if (isTurbopack) {
               expect(link.href).toMatch(
                 /\/_next\/static\/media\/(.*)-s.p.(.*)\.woff2/
               )
@@ -363,7 +364,7 @@ describe('app dir - next/font', () => {
           for (const link of links) {
             expect(link.as).toBe('font')
             expect(link.crossorigin).toBe('')
-            if (process.env.IS_TURBOPACK_TEST) {
+            if (isTurbopack) {
               expect(link.href).toMatch(
                 /\/_next\/static\/media\/(.*)-s.p.(.*)\.woff2/
               )
@@ -416,7 +417,7 @@ describe('app dir - next/font', () => {
           await browser.elementsByCss('link[as="font"]')
         expect(preloadBeforeNavigation.length).toBe(1)
         const href = await preloadBeforeNavigation[0].getAttribute('href')
-        if (process.env.IS_TURBOPACK_TEST) {
+        if (isTurbopack) {
           expect(href).toMatch(/\/_next\/static\/media\/(.*)-s\.p\.(.*)\.woff2/)
         } else {
           expect(href).toMatch(/\/_next\/static\/media\/(.*)-s\.p\.woff2/)
@@ -432,7 +433,7 @@ describe('app dir - next/font', () => {
         expect(preloadAfterNavigation.length).toBe(1)
 
         const href2 = await preloadAfterNavigation[0].getAttribute('href')
-        if (process.env.IS_TURBOPACK_TEST) {
+        if (isTurbopack) {
           expect(href2).toMatch(
             /\/_next\/static\/media\/(.*)-s\.p\.(.*)\.woff2/
           )
@@ -457,7 +458,7 @@ describe('app dir - next/font', () => {
             )
           )
           await assertHasRedbox(browser)
-          if (process.env.TURBOPACK) {
+          if (isTurbopack) {
             expect(await getRedboxSource(browser)).toInclude(
               "File [project]/fonts/does-not-exist.woff2 doesn't exist"
             )


### PR DESCRIPTION
### What?

Avoid downcasting the error.

This would prevent serialization of errors for Persistent Caching
