### PR TITLE
Cleanup `config.experimental.reactOwnerstack`

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -725,7 +725,6 @@ pub struct ExperimentalConfig {
     /// directory.
     ppr: Option<ExperimentalPartialPrerendering>,
     taint: Option<bool>,
-    react_owner_stack: Option<bool>,
     #[serde(rename = "routerBFCache")]
     router_bfcache: Option<bool>,
     proxy_timeout: Option<f64>,
@@ -1415,11 +1414,6 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_taint(&self) -> Vc<bool> {
         Vc::cell(self.experimental.taint.unwrap_or(false))
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_react_owner_stack(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.react_owner_stack.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -120,7 +120,6 @@ pub async fn get_next_client_import_map(
         ClientContextType::App { app_dir } => {
             let react_flavor = if *next_config.enable_ppr().await?
                 || *next_config.enable_taint().await?
-                || *next_config.enable_react_owner_stack().await?
                 || *next_config.enable_view_transition().await?
                 || *next_config.enable_router_bfcache().await?
             {
@@ -700,10 +699,9 @@ async fn rsc_aliases(
 ) -> Result<()> {
     let ppr = *next_config.enable_ppr().await?;
     let taint = *next_config.enable_taint().await?;
-    let react_owner_stack = *next_config.enable_react_owner_stack().await?;
     let router_bfcache = *next_config.enable_router_bfcache().await?;
     let view_transition = *next_config.enable_view_transition().await?;
-    let react_channel = if ppr || taint || react_owner_stack || view_transition || router_bfcache {
+    let react_channel = if ppr || taint || view_transition || router_bfcache {
         "-experimental"
     } else {
         ""


### PR DESCRIPTION
Removed in https://github.com/vercel/next.js/pull/76021

Had some leftovers in Turbopack that I missed due to different casing.