### PR TITLE
Docs: Improve `"use cache"` and `cacheLife` API references

### DIFF
--- a/docs/01-app/05-api-reference/01-directives/use-cache.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-cache.mdx
@@ -14,11 +14,11 @@ related:
     - app/api-reference/functions/revalidateTag
 ---
 
-The `use cache` directive designates a component and/or a function to be cached. It can be used at the top of a file to indicate that all exports in the file are cacheable, or inline at the top of a function or component to inform Next.js the return value should be cached and reused for subsequent requests. This is an experimental Next.js feature, and not a native React feature like [`use client`](/docs/app/api-reference/directives/use-client) or [`use server`](/docs/app/api-reference/directives/use-server).
+The `use cache` directive allows you to mark a route, React component, or a function as cacheable. It can be used at the top of a file to indicate that all exports in the file should be cached, or inline at the top of function or component to cache the return value.
 
 ## Usage
 
-Enable support for the `use cache` directive with the [`useCache`](/docs/app/api-reference/config/next-config-js/useCache) flag in your `next.config.ts` file:
+`use cache` is currently an experimental feature. To enable it, add the [`useCache`](/docs/app/api-reference/config/next-config-js/useCache) option to your `next.config.ts` file:
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -43,9 +43,9 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-Additionally, `use cache` directives are also enabled when the [`dynamicIO`](/docs/app/api-reference/config/next-config-js/dynamicIO) flag is set.
+> **Good to know:** `use cache` can also be enabled with the [`dynamicIO`](/docs/app/api-reference/config/next-config-js/dynamicIO) option.
 
-Then, you can use the `use cache` directive at the file, component, or function level:
+Then, add `use cache` at the file, component, or function level:
 
 ```tsx
 // File level
@@ -69,20 +69,68 @@ export async function getData() {
 }
 ```
 
-## Good to know
+## How `use cache` works
 
-- `use cache` is an experimental Next.js feature, and not a native React feature like [`use client`](/docs/app/api-reference/directives/use-client) or [`use server`](/docs/app/api-reference/directives/use-server).
-- Any [serializable](https://react.dev/reference/rsc/use-server#serializable-parameters-and-return-values) arguments (or props) passed to the cached function, as well as any serializable values it reads from the parent scope, will be converted to a format like JSON and automatically become a part of the cache key.
-- Any non-serializable arguments, props, or closed-over values will turn into opaque references inside the cached function, and can be only passed through and not inspected nor modified. These non-serializable values will be filled in at the request time and won't become a part of the cache key.
-  - For example, a cached function can take in JSX as a `children` prop and return `<div>{children}</div>`, but it won't be able to introspect the actual `children` object.
-- The return value of the cacheable function must also be serializable. This ensures that the cached data can be stored and retrieved correctly.
-- Functions that use the `use cache` directive must not have any side-effects, such as modifying state, directly manipulating the DOM, or setting timers to execute code at intervals.
-- If used alongside [Partial Prerendering](/docs/app/building-your-application/rendering/partial-prerendering), segments that have `use cache` will be prerendered as part of the static HTML shell.
-- Unlike [`unstable_cache`](/docs/app/api-reference/functions/unstable_cache) which only supports JSON data, `use cache` can cache any serializable data React can render, including the render output of components.
+### Cache keys
+
+A cache entry's key is generated using a serialized version of its inputs, which includes:
+
+- Build ID (generated for each build)
+- Function ID (a secure identifier unique to the function)
+- The [serializable](https://react.dev/reference/rsc/use-server#serializable-parameters-and-return-values) function arguments (or props).
+
+The arguments passed to the cached function, as well as any values it reads from the parent scope automatically become a part of the key. This means, the same cache entry will be reused as long as its inputs are the same.
+
+## Non-serializable arguments
+
+Any non-serializable arguments, props, or closed-over values will turn into references inside the cached function, and can be only passed through and not inspected nor modified. These non-serializable values will be filled in at the request time and won't become a part of the cache key.
+
+For example, a cached function can take in JSX as a `children` prop and return `<div>{children}</div>`, but it won't be able to introspect the actual `children` object. This allows you to nest uncached content inside a cached component.
+
+```tsx filename="app/ui/cached-component.tsx" switcher
+function CachedComponent({ children }: { children: ReactNode }) {
+  'use cache'
+  return <div>{children}</div>
+}
+```
+
+```jsx filename="app/ui/cached-component.js" switcher
+function CachedComponent({ children }) {
+  'use cache'
+  return <div>{children}</div>
+}
+```
+
+## Return values
+
+The return value of the cacheable function must be serializable. This ensures that the cached data can be stored and retrieved correctly.
+
+## `use cache` at build time
+
+When used at the top of a [layout](/docs/app/api-reference/file-conventions/layout) or [page](/docs/app/api-reference/file-conventions/page), the route segment will be prerendered, allowing it to later be [revalidated](#during-revalidation).
+
+This means `use cache` cannot be used with [request-time APIs](/docs/app/getting-started/caching-and-revalidating#dynamic-apis) like `cookies` or `headers`.
+
+## `use cache` at runtime
+
+On the **server**, the cache entries of individual components or functions will be cached in-memory.
+
+Then, on the **client**, any content returned from the server cache will be stored in the browser's memory for the duration of the session or until [revalidated](#during-revalidation).
+
+## During revalidation
+
+By default, `use cache` has server-side revalidation period of **15 minutes**. While this period may be useful for content that doesn't require frequent updates, you can use the `cacheLife` and `cacheTag` APIs to configure when the individual cache entries should be revalidated.
+
+- [`cacheLife`](/docs/app/api-reference/functions/cacheLife): Configure the cache entry lifetime.
+- [`cacheTag`](/docs/app/api-reference/functions/cacheTag): Create tags for on-demand revalidation.
+
+Both of these APIs integrate across the client and server caching layers, meaning you can configure your caching semantics in one place and have them apply everywhere.
+
+See the [`cacheLife`](/docs/app/api-reference/functions/cacheLife) and [`cacheTag`](/docs/app/api-reference/functions/cacheTag) API docs for more information.
 
 ## Examples
 
-### Caching entire routes with `use cache`
+### Caching an entire route with `use cache`
 
 To prerender an entire route, add `use cache` to the top of **both** the `layout` and `page` files. Each of these segments are treated as separate entry points in your application, and will be cached independently.
 
@@ -138,13 +186,14 @@ export default function Page() {
 }
 ```
 
-> This is recommended for applications that previously used the [`export const dynamic = "force-static"`](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option, and will ensure the entire route is prerendered.
+> **Good to know**:
+>
+> - If `use cache` is added only to the `layout` or the `page`, only that route segment and any components imported into it will be cached.
+> - If any of the nested children in the route use [Dynamic APIs](/docs/app/getting-started/caching-and-revalidating#dynamic-apis), then the route will opt out of prerendering.
 
-### Caching component output with `use cache`
+### Caching a component's output with `use cache`
 
-You can use `use cache` at the component level to cache any fetches or computations performed within that component. When you reuse the component throughout your application it can share the same cache entry as long as the props maintain the same structure.
-
-The props are serialized and form part of the cache key, and the cache entry will be reused as long as the serialized props produce the same value in each instance.
+You can use `use cache` at the component level to cache any fetches or computations performed within that component. The cache entry will be reused as long as the serialized props produce the same value in each instance.
 
 ```tsx filename="app/components/bookings.tsx" highlight={2} switcher
 export async function Bookings({ type = 'haircut' }: BookingsProps) {
@@ -174,7 +223,7 @@ export async function Bookings({ type = 'haircut' }) {
 
 ### Caching function output with `use cache`
 
-Since you can add `use cache` to any asynchronous function, you aren't limited to caching components or routes only. You might want to cache a network request or database query or compute something that is very slow. By adding `use cache` to a function containing this type of work it becomes cacheable, and when reused, will share the same cache entry.
+Since you can add `use cache` to any asynchronous function, you aren't limited to caching components or routes only. You might want to cache a network request, a database query, or a slow computation.
 
 ```tsx filename="app/actions.ts" highlight={2} switcher
 export async function getData() {
@@ -193,25 +242,6 @@ export async function getData() {
   return data
 }
 ```
-
-### Revalidating
-
-By default, Next.js sets a **[revalidation period](/docs/app/building-your-application/data-fetching/fetching#revalidating-cached-data) of 15 minutes** when you use the `use cache` directive. Next.js sets a near-infinite expiration duration, meaning it's suitable for content that doesn't need frequent updates.
-
-While this revalidation period may be useful for content you don't expect to change often, you can use the `cacheLife` and `cacheTag` APIs to configure the cache behavior:
-
-- [`cacheLife`](/docs/app/api-reference/functions/cacheLife): For time-based revalidation periods.
-- [`cacheTag`](/docs/app/api-reference/functions/cacheTag): For tagging cached data.
-
-Both of these APIs integrate across the client and server caching layers, meaning you can configure your caching semantics in one place and have them apply everywhere.
-
-See the [`cacheLife`](/docs/app/api-reference/functions/cacheLife) and [`cacheTag`](/docs/app/api-reference/functions/cacheTag) docs for more information.
-
-### Invalidating
-
-To invalidate the cached data, you can use the [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) function.
-
-See the [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) docs for more information.
 
 ### Interleaving
 

--- a/docs/01-app/05-api-reference/01-directives/use-cache.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-cache.mdx
@@ -109,7 +109,7 @@ The return value of the cacheable function must be serializable. This ensures th
 
 When used at the top of a [layout](/docs/app/api-reference/file-conventions/layout) or [page](/docs/app/api-reference/file-conventions/page), the route segment will be prerendered, allowing it to later be [revalidated](#during-revalidation).
 
-This means `use cache` cannot be used with [request-time APIs](/docs/app/getting-started/caching-and-revalidating#dynamic-apis) like `cookies` or `headers`.
+This means `use cache` cannot be used with [request-time APIs](/docs/app/building-your-application/rendering/server-components#dynamic-apis) like `cookies` or `headers`.
 
 ## `use cache` at runtime
 
@@ -189,7 +189,7 @@ export default function Page() {
 > **Good to know**:
 >
 > - If `use cache` is added only to the `layout` or the `page`, only that route segment and any components imported into it will be cached.
-> - If any of the nested children in the route use [Dynamic APIs](/docs/app/getting-started/caching-and-revalidating#dynamic-apis), then the route will opt out of prerendering.
+> - If any of the nested children in the route use [Dynamic APIs](/docs/app/building-your-application/rendering/server-components#dynamic-apis), then the route will opt out of prerendering.
 
 ### Caching a component's output with `use cache`
 

--- a/docs/01-app/05-api-reference/04-functions/cacheLife.mdx
+++ b/docs/01-app/05-api-reference/04-functions/cacheLife.mdx
@@ -66,21 +66,23 @@ export default async function Page() {
 
 ### Default cache profiles
 
-Next.js provides a set of named cache profiles modeled on various timescales. If you don't specify a cache profile in the `cacheLife` function alongside the `use cache` directive, Next.js will automatically apply the “default” cache profile.
+Next.js provides a set of named cache profiles modeled on various timescales. If you don't specify a cache profile in the `cacheLife` function alongside the `use cache` directive, Next.js will automatically apply the `default` cache profile.
 
 However, we recommend always adding a cache profile when using the `use cache` directive to explicitly define caching behavior.
 
-| **Profile** | **Stale** | **Revalidate** | **Expire**     | **Description**                                                          |
-| ----------- | --------- | -------------- | -------------- | ------------------------------------------------------------------------ |
-| `default`   | undefined | 15 minutes     | INFINITE_CACHE | Default profile, suitable for content that doesn't need frequent updates |
-| `seconds`   | undefined | 1 second       | 1 minute       | For rapidly changing content requiring near real-time updates            |
-| `minutes`   | 5 minutes | 1 minute       | 1 hour         | For content that updates frequently within an hour                       |
-| `hours`     | 5 minutes | 1 hour         | 1 day          | For content that updates daily but can be slightly stale                 |
-| `days`      | 5 minutes | 1 day          | 1 week         | For content that updates weekly but can be a day old                     |
-| `weeks`     | 5 minutes | 1 week         | 1 month        | For content that updates monthly but can be a week old                   |
-| `max`       | 5 minutes | 1 month        | INFINITE_CACHE | For very stable content that rarely needs updating                       |
+| **Profile** | `stale`   | `revalidate` | `expire` | **Description**                                                          |
+| ----------- | --------- | ------------ | -------- | ------------------------------------------------------------------------ |
+| `default`   | 5 minutes | 15 minutes   | 1 year   | Default profile, suitable for content that doesn't need frequent updates |
+| `seconds`   | 0         | 1 second     | 1 second | For rapidly changing content requiring near real-time updates            |
+| `minutes`   | 5 minutes | 1 minute     | 1 hour   | For content that updates frequently within an hour                       |
+| `hours`     | 5 minutes | 1 hour       | 1 day    | For content that updates daily but can be slightly stale                 |
+| `days`      | 5 minutes | 1 day        | 1 week   | For content that updates weekly but can be a day old                     |
+| `weeks`     | 5 minutes | 1 week       | 30 days  | For content that updates monthly but can be a week old                   |
+| `max`       | 5 minutes | 30 days      | 1 year   | For very stable content that rarely needs updating                       |
 
 The string values used to reference cache profiles don't carry inherent meaning; instead they serve as semantic labels. This allows you to better understand and manage your cached content within your codebase.
+
+> **Good to know:** Updating the [`staleTimes`](/docs/app/api-reference/config/next-config-js/staleTimes) and [`expireTime`](/docs/app/api-reference/config/next-config-js/expireTime) config options also updates the `stale` and `expire` properties of the `default` cache profile.
 
 ### Custom cache profiles
 


### PR DESCRIPTION
Decoupling from: https://github.com/vercel/next.js/pull/73437


- Add "How `use cache` works" section
  - Clarify cache keys inputs
  - Describe what happens during build, runtime, and revalidation
- Correct the default values for the `cacheLife` profiles
- Add the default time for `expireTime`
- Add note about `staleTimes` and `expireTime` affecting the default cache profile
