### PR TITLE
test: adjust default timeouts for [waitFor]elementByCss

### DIFF
--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -893,7 +893,7 @@ describe('app dir - navigation', () => {
         .elementByCss("[href='/metadata-await-promise/nested']")
         .click()
 
-      await waitFor(resolveMetadataDuration)
+      await waitFor(resolveMetadataDuration + 500)
 
       expect(await browser.elementById('page-content').text()).toBe('Content')
       expect(await browser.elementByCss('title').text()).toBe('Async Title')
@@ -912,9 +912,11 @@ describe('app dir - navigation', () => {
         .click()
 
       if (!isNextDev) {
-        expect(await browser.elementByCss('title').text()).toBe('Async Title')
-
-        await waitFor(resolveMetadataDuration + 500)
+        expect(
+          await browser
+            .waitForElementByCss('title', resolveMetadataDuration + 500)
+            .text()
+        ).toBe('Async Title')
       }
 
       expect(await browser.elementById('page-content').text()).toBe('Content')

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -427,7 +427,7 @@ export class Playwright extends BrowserInterface {
     )
   }
 
-  waitForElementByCss(selector, timeout?: number) {
+  waitForElementByCss(selector, timeout = 10_000) {
     return this.chain(() => {
       return page
         .waitForSelector(selector, { timeout, state: 'attached' })

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -348,7 +348,7 @@ export class Playwright extends BrowserInterface {
   }
 
   elementByCss(selector: string) {
-    return this.waitForElementByCss(selector)
+    return this.waitForElementByCss(selector, 5_000)
   }
 
   elementById(sel) {


### PR DESCRIPTION
Adjusts the default timeouts:
- elementByCss: 5s
- waitForElementByCss: 10s

Previously, we didn't pass an explicit value, so they both defaulted to playwright's default of 60s. This is _very_ slow, and if something is slow enough to require anything in that range, i'd say it deserves to be wrapped in `retry()` or something similar anyway, so it's fine to fail here.
The upside of this is that errors because of bad selectors (or missing elements) happen faster, which is a nice thing, and might also save CI time.

i could also see an argument for making these even shorter -- e.g. the default timeout for `retry()` is 3s, so maybe `retry` should be faster than that.
https://github.com/vercel/next.js/blob/717e54b0cd914a17314c470cd10d6af2b2d75787/test/lib/next-test-utils.ts#L796-L799
but then again, `retry` doesn't factor in the time `fn` took, so these don't really conflict.