### PR TITLE
Turbopack: use hashbrown HashMaps instead of now-removed std raw entry api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10145,6 +10145,7 @@ dependencies = [
  "anyhow",
  "either",
  "flate2",
+ "hashbrown 0.14.5",
  "indexmap 2.7.1",
  "itertools 0.10.5",
  "postcard",

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(hash_raw_entry)]
 #![feature(hash_extract_if)]
 
 pub mod map;

--- a/turbopack/crates/turbopack-trace-server/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-server/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 anyhow = { workspace = true, features = ["backtrace"] }
 either = { workspace = true }
 flate2 = { version = "1.0.28" }
+hashbrown = { workspace = true, features = ["raw"] }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 postcard = { workspace = true }

--- a/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
+++ b/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
@@ -1,6 +1,6 @@
 use std::{env, sync::Arc};
 
-use rustc_hash::FxHashMap;
+use hashbrown::HashMap;
 
 use crate::{
     span::{SpanBottomUp, SpanIndex},
@@ -10,7 +10,7 @@ use crate::{
 pub struct SpanBottomUpBuilder {
     // These values won't change after creation:
     pub self_spans: Vec<SpanIndex>,
-    pub children: FxHashMap<String, SpanBottomUpBuilder>,
+    pub children: HashMap<String, SpanBottomUpBuilder>,
     pub example_span: SpanIndex,
 }
 
@@ -18,7 +18,7 @@ impl SpanBottomUpBuilder {
     pub fn new(example_span: SpanIndex) -> Self {
         Self {
             self_spans: vec![],
-            children: FxHashMap::default(),
+            children: HashMap::default(),
             example_span,
         }
     }
@@ -42,7 +42,7 @@ pub fn build_bottom_up_graph<'a>(
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(usize::MAX);
-    let mut roots = FxHashMap::default();
+    let mut roots: HashMap<String, SpanBottomUpBuilder> = HashMap::default();
 
     // unfortunately there is a rustc bug that fails the typechecking here
     // when using Either<impl Iterator, impl Iterator>. This error appears

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(iter_intersperse)]
-#![feature(hash_raw_entry)]
 #![feature(box_patterns)]
 
 use std::{hash::BuildHasherDefault, path::PathBuf, sync::Arc};

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -1,5 +1,4 @@
 #![feature(iter_intersperse)]
-#![feature(hash_raw_entry)]
 #![feature(box_patterns)]
 
 use std::{hash::BuildHasherDefault, sync::Arc};

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use rustc_hash::FxHashMap;
+use hashbrown::HashMap;
 
 use crate::timestamp::Timestamp;
 
@@ -64,7 +64,7 @@ pub struct SpanTimeData {
 pub struct SpanExtra {
     pub graph: OnceLock<Vec<SpanGraphEvent>>,
     pub bottom_up: OnceLock<Vec<Arc<SpanBottomUp>>>,
-    pub search_index: OnceLock<FxHashMap<String, Vec<SpanIndex>>>,
+    pub search_index: OnceLock<HashMap<String, Vec<SpanIndex>>>,
 }
 
 #[derive(Default)]

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -5,8 +5,9 @@ use std::{
     vec,
 };
 
+use hashbrown::HashMap;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use crate::{
     bottom_up::build_bottom_up_graph,
@@ -414,9 +415,9 @@ impl<'a> SpanRef<'a> {
         })
     }
 
-    fn search_index(&self) -> &FxHashMap<String, Vec<SpanIndex>> {
+    fn search_index(&self) -> &HashMap<String, Vec<SpanIndex>> {
         self.extra().search_index.get_or_init(|| {
-            let mut index: FxHashMap<String, Vec<SpanIndex>> = FxHashMap::default();
+            let mut index: HashMap<String, Vec<SpanIndex>> = HashMap::default();
             let mut queue = VecDeque::with_capacity(8);
             queue.push_back(*self);
             while let Some(span) = queue.pop_front() {


### PR DESCRIPTION
[HashMap’s raw_entry api](https://github.com/rust-lang/rust/issues/56167), an unstable nightly feature, was removed from the Rust compiler entirely.

This migrates us to use the equivalent API in HashBrown’s HashMap.


Closes PACK-4328