### PR TITLE
make retry actually wait for the specified duration

### DIFF
--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -893,7 +893,7 @@ describe('app dir - navigation', () => {
         .elementByCss("[href='/metadata-await-promise/nested']")
         .click()
 
-      await waitFor(resolveMetadataDuration)
+      await waitFor(resolveMetadataDuration + 500)
 
       expect(await browser.elementById('page-content').text()).toBe('Content')
       expect(await browser.elementByCss('title').text()).toBe('Async Title')
@@ -912,9 +912,11 @@ describe('app dir - navigation', () => {
         .click()
 
       if (!isNextDev) {
-        expect(await browser.elementByCss('title').text()).toBe('Async Title')
-
-        await waitFor(resolveMetadataDuration + 500)
+        expect(
+          await browser
+            .waitForElementByCss('title', resolveMetadataDuration + 500)
+            .text()
+        ).toBe('Async Title')
       }
 
       expect(await browser.elementById('page-content').text()).toBe('Content')

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -427,7 +427,7 @@ export class Playwright extends BrowserInterface {
     )
   }
 
-  waitForElementByCss(selector, timeout?: number) {
+  waitForElementByCss(selector, timeout = 10_000) {
     return this.chain(() => {
       return page
         .waitForSelector(selector, { timeout, state: 'attached' })

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -348,7 +348,7 @@ export class Playwright extends BrowserInterface {
   }
 
   elementByCss(selector: string) {
-    return this.waitForElementByCss(selector)
+    return this.waitForElementByCss(selector, 5_000)
   }
 
   elementById(sel) {


### PR DESCRIPTION
this might make everything fail, but the current `retry()` timeout semantics are strange (effectively "rerun this {duration/interval} times and wait {interval} inbetween"), and i'd like to fix that to be "retry for at most {duration}, possibly waiting at {interval - operation time} inbetween"