### PR TITLE
Experiment: Run tests with debug assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ opt-level = 1
 opt-level = 3
 
 [profile.release]
+debug-assertions = true
 
 [profile.release.package]
 


### PR DESCRIPTION
A one-off run of the e2e tests with Rust debug assertions enabled to see where it fails

Part of PACK-4578

- [x] Various duplicate modules
- [x] `test/development/basic/styled-components/styled-components.test.ts` panic: `_StyledDiv#0 should be resolved` PACK-4376
- [ ] `test/e2e/app-dir/css-order/css-order.test.ts` : duplicate `[project]/app/base2-scss.module.scss.module.css [app-client] (css)` https://github.com/vercel/next.js/pull/78058
- [x] `test/e2e/app-dir/app-external/app-external.test.ts` : duplicate `[externals]/next/dist/server/app-render/work-unit-async-storage.external.js [external] (next/dist/server/app-render/work-unit-async-storage.external.js, cjs)` https://github.com/vercel/next.js/pull/78241
- [x] `test/e2e/on-request-error/isr/isr.test.ts`: duplicate `[project]/ [instrumentation-edge] (ecmascript)` https://github.com/vercel/next.js/pull/78236
- [x] `joined path tests/node-file-trace/node_modules/.pnpm/resolve@1.22.1/node_modules/resolve/lib\\/ must not contain a Windows directory '\', it must be normalized to Unix '/'`