### PR TITLE
Revert Rust upgrade to nightly-2025-04-10

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-04-10"
+channel = "nightly-2025-02-12"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-static/src/main.rs
+++ b/turbopack/crates/turbo-static/src/main.rs
@@ -194,7 +194,6 @@ fn resolve_concurrency(
 
     for (ident, references) in dep_tree {
         for reference in references {
-            #[allow(clippy::map_entry)] // This doesn't insert into dep_tree, so entry isn't useful
             if !dep_tree.contains_key(&reference.identifier) {
                 // this is a task that is not in the task list
                 // so we can't resolve it

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(hash_extract_if)]
+
 pub mod map;
 pub mod set;
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 #![feature(trivial_bounds)]
+#![feature(hash_extract_if)]
 #![feature(min_specialization)]
 #![feature(iter_advance_by)]
 #![feature(io_error_more)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
@@ -4,15 +4,6 @@ error: methods taking `self` are not supported with `operation`
 13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
    |                            ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
-  --> tests/function/fail_operation_method_self_type.rs:13:34
-   |
-13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
-   |                                  ^^^^^^^^^^^^^^^^^
-   |
-   = note: type of `self` must be `Self` or some type implementing `Receiver`
-   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
-
 error[E0277]: the trait bound `fn(...) -> ... {...::arbitrary_self_type_turbo_tasks_function_inline}: IntoTaskFnWithThis<_, _, _>` is not satisfied
   --> tests/function/fail_operation_method_self_type.rs:10:1
    |
@@ -31,3 +22,12 @@ note: required by a bound in `NativeFunction::new_method`
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NativeFunction::new_method`
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the attribute macro `turbo_tasks::value_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
+  --> tests/function/fail_operation_method_self_type.rs:13:34
+   |
+13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
+   |                                  ^^^^^^^^^^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or some type implementing `Receiver`
+   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`

--- a/turbopack/crates/turbo-tasks-memory/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(hash_extract_if)]
 #![feature(type_alias_impl_trait)]
 #![feature(box_patterns)]
 #![feature(int_roundings)]

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -29,6 +29,7 @@
 #![feature(trivial_bounds)]
 #![feature(min_specialization)]
 #![feature(try_trait_v2)]
+#![feature(hash_extract_if)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(result_flattening)]
 #![feature(error_generic_member_access)]

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -112,7 +112,6 @@ impl StyleSheetLike<'_, '_> {
 pub struct UnresolvedUrlReferences(pub Vec<(String, ResolvedVc<UrlAssetReference>)>);
 
 #[turbo_tasks::value(shared, serialization = "none", eq = "manual", cell = "new")]
-#[allow(clippy::large_enum_variant)] // This is a turbo-tasks value
 pub enum ParseCssResult {
     Ok {
         code: ResolvedVc<FileContent>,

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(min_specialization)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![feature(extract_if)]
 
 use std::{iter::once, thread::available_parallelism};
 


### PR DESCRIPTION
Reverts most of #78039, I've kept the applied clippy suggestions though.

Unfortunately, a rustc ICE crash that was rare before now happens constantly, both when building and inside rust-analyzer, making everything just unusable.

Closes PACK-4333