### PR TITLE
fix(types): Activity seems to exist now

### DIFF
--- a/test/e2e/app-dir/back-forward-cache/app/page.tsx
+++ b/test/e2e/app-dir/back-forward-cache/app/page.tsx
@@ -3,7 +3,6 @@
 // TODO: "use client" is required in this module because Activity is not
 // exported from the server entrypoint of React
 
-// @ts-expect-error: Not yet part of the TypeScript types
 import { unstable_Activity as Activity } from 'react'
 
 export default function Page() {


### PR DESCRIPTION
`test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts` is failing on canary, i guess `Activity` got added to the react types?
```
Type error: Unused '@ts-expect-error' directive.

  4 | // exported from the server entrypoint of React
  5 |
> 6 | // @ts-expect-error: Not yet part of the TypeScript types
    | ^
  7 | import { unstable_Activity as Activity } from 'react'
  8 |
  9 | export default function Page() {
```
https://github.com/vercel/next.js/actions/runs/14417903198/job/40443794399#step:33:180