### PR TITLE
Update postcss config

### DIFF
--- a/packages/create-next-app/templates/app-tw-empty/js/postcss.config.mjs
+++ b/packages/create-next-app/templates/app-tw-empty/js/postcss.config.mjs
@@ -1,7 +1,5 @@
 const config = {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
+  plugins: ["@tailwindcss/postcss"],
 };
 
 export default config;

--- a/packages/create-next-app/templates/app-tw-empty/ts/postcss.config.mjs
+++ b/packages/create-next-app/templates/app-tw-empty/ts/postcss.config.mjs
@@ -1,7 +1,5 @@
 const config = {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
+  plugins: ["@tailwindcss/postcss"],
 };
 
 export default config;


### PR DESCRIPTION
fixes #78099

This PR updates the `postcss.config.mjs` file in the `app-tw-empty` template of the `create-next-app` package. It replaces the legacy object syntax with the concise array syntax used in current Next.js templates.