### PR TITLE
Include types in published `eslint-plugin-next`

### DIFF
--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -3,6 +3,7 @@
   "version": "15.3.1-canary.7",
   "description": "ESLint plugin for Next.js.",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "repository": {
     "url": "vercel/next.js",
@@ -18,7 +19,8 @@
     "eslint": "8.56.0"
   },
   "scripts": {
-    "build": "swc -d dist src",
+    "build": "swc -d dist src && pnpm types",
+    "types": "tsc src/index.ts --skipLibCheck --declaration --emitDeclarationOnly --declarationDir dist",
     "prepublishOnly": "cd ../../ && turbo run build"
   }
 }

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -66,8 +66,7 @@ const plugin = {
   },
 }
 
-module.exports = plugin
-module.exports.flatConfig = {
+const flatConfig = {
   recommended: {
     name: 'next/recommended',
     plugins: {
@@ -86,3 +85,7 @@ module.exports.flatConfig = {
     },
   },
 }
+
+export default plugin
+export const { rules, configs } = plugin
+export { flatConfig }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

[@next/eslint-plugin-next](https://github.com/vercel/next.js/tree/canary/packages/eslint-plugin-next)
### What?
1. Set types export to `dist/index.d.ts` in `package.json`.
2. Added `types` script to generate type declarations similar to that in the [next-env](https://github.com/vercel/next.js/blob/canary/packages/next-env/package.json) package. Types script run after swc build.

### Why?
When using ESLint v9 flat config with `eslint-plugin-next` you get eslint errors when checking config file itself.
```ts
    plugins: {
      "@next/next": nextPlugin,
    },
    rules: {
      ...nextPlugin.configs.recommended.rules,
      ...nextPlugin.configs["core-web-vitals"].rules,
    },
```
examples: [my boilerplate](https://github.com/OreQr/next-clean-boilerplate/blob/main/eslint.config.mjs), [create-t3-turbo](https://github.com/t3-oss/create-t3-turbo/blob/main/tooling/eslint/nextjs.js)

Closes https://github.com/vercel/next.js/discussions/74957