### PR TITLE
add data url css tests

### DIFF
--- a/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
@@ -1,0 +1,11 @@
+// @ts-expect-error
+// .client{font-weight:700}
+import styles from 'data:text/css+module;base64,LmNsaWVudHtmb250LXdlaWdodDo3MDB9Cg=='
+
+export const ClientComponent = () => {
+  return (
+    <div id="client" className={`${styles.client}`}>
+      This text should be bold
+    </div>
+  )
+}

--- a/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
@@ -1,3 +1,4 @@
+'use client'
 // @ts-expect-error
 // .client{font-weight:700}
 import styles from 'data:text/css+module;base64,LmNsaWVudHtmb250LXdlaWdodDo3MDB9Cg=='

--- a/test/e2e/app-dir/css-modules-data-urls/app/layout.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
@@ -1,0 +1,15 @@
+// @ts-expect-error
+// .home{font-weight:700}
+import styles from 'data:text/css+module;base64,LmhvbWV7Zm9udC13ZWlnaHQ6NzAwfQo='
+import { ClientComponent } from './client'
+
+export default function Home() {
+  return (
+    <>
+      <div id="rsc" className={`${styles.home}`}>
+        This text should be bold
+      </div>
+      <ClientComponent />
+    </>
+  )
+}

--- a/test/e2e/app-dir/css-modules-data-urls/css-modules-data-urls.test.ts
+++ b/test/e2e/app-dir/css-modules-data-urls/css-modules-data-urls.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('css-modules-data-urls', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should apply rsc class name from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const clientElementClass =
+      (await browser.elementByCss('#client').getAttribute('class')) || ''
+
+    expect(clientElementClass).not.toBe('')
+  })
+
+  it('should apply rsc styles from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const rscElement = await browser
+      .elementByCss('#rsc')
+      .getComputedCss('font-weight')
+
+    expect(rscElement).toBe('700')
+  })
+
+  it('should apply client class name from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const clientElementClass =
+      (await browser.elementByCss('#client').getAttribute('class')) || ''
+
+    expect(clientElementClass).not.toBe('')
+  })
+
+  it('should apply client styles from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const clientElement = await browser
+      .elementByCss('#client')
+      .getComputedCss('font-weight')
+
+    expect(clientElement).toBe('700')
+  })
+})

--- a/test/e2e/app-dir/css-modules-data-urls/next.config.ts
+++ b/test/e2e/app-dir/css-modules-data-urls/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  /* config options here */
+}
+
+export default nextConfig


### PR DESCRIPTION
### Adding a feature

This PR adds e2e tests for CSS Modules in Data URLs, a feature that was recently merged in PR #78040.

### Why?

After the feature was merged, @dlehmhus reported an issue (#78096) where CSS Modules in Data URLs don't work properly in Server Components. These tests will help verify the functionality and serve as regression tests once the issue is fixed.

### How?

- Added comprehensive e2e tests that verify both client and server component behavior with CSS Modules in Data URLs
- Tests ensure that class names are applied correctly and styles are rendered properly
- The tests covers base64-encoded CSS module data URLs

These tests don't fix the issue reported in #78096 but provide test coverage for the feature.

Current results:

`webpack`: Tests:       4 failed, 0 passed, 4 total
`turbopack`: Tests:       1 failed, 3 passed, 4 total

![preview of the e2e test](https://github.com/user-attachments/assets/23a4bb5f-8f98-4fce-b07c-40289474a764)

Relates to #78096