### PR TITLE
[ts-next-plugin] perf: reuse existing virtual env

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -670,5 +670,6 @@
   "669": "Invariant: --turbopack is set but the build used Webpack",
   "670": "Invariant: --turbopack is not set but the build used Turbopack. Add --turbopack to \"next start\".",
   "671": "Specified images.remotePatterns must have protocol \"http\" or \"https\" received \"%s\".",
-  "672": "Expected `telemetry` to be set in globals"
+  "672": "Expected `telemetry` to be set in globals",
+  "673": "[next] Could not find virtual TypeScript environment. This is a bug in Next.js TypeScript plugin. Please report it by opening an issue at https://github.com/vercel/next.js/issues."
 }

--- a/packages/next/src/server/typescript/rules/metadata.ts
+++ b/packages/next/src/server/typescript/rules/metadata.ts
@@ -6,7 +6,7 @@ import {
   getTypeChecker,
   isPositionInsideNode,
   log,
-  virtualTsEnv,
+  getVirtualTsEnv,
 } from '../utils'
 
 import type tsModule from 'typescript/lib/tsserverlibrary'
@@ -86,6 +86,8 @@ function updateVirtualFileWithType(
     sourceText.slice(nodeEnd) +
     TYPE_IMPORT
 
+  const virtualTsEnv = getVirtualTsEnv()
+
   if (virtualTsEnv.getSourceFile(fileName)) {
     log('Updating file: ' + fileName)
     virtualTsEnv.updateFile(fileName, newSource)
@@ -108,6 +110,8 @@ function proxyDiagnostics(
   pos: number[],
   n: tsModule.VariableDeclaration | tsModule.FunctionDeclaration
 ) {
+  const virtualTsEnv = getVirtualTsEnv()
+
   // Get diagnostics
   const diagnostics =
     virtualTsEnv.languageService.getSemanticDiagnostics(fileName)
@@ -151,6 +155,7 @@ const metadata = {
 
     // Get completions
     const newPos = position <= pos[0] ? position : position + pos[1]
+    const virtualTsEnv = getVirtualTsEnv()
     const completions = virtualTsEnv.languageService.getCompletionsAtPosition(
       fileName,
       newPos,
@@ -382,6 +387,7 @@ const metadata = {
 
     const newPos = position <= pos[0] ? position : position + pos[1]
 
+    const virtualTsEnv = getVirtualTsEnv()
     const details = virtualTsEnv.languageService.getCompletionEntryDetails(
       fileName,
       newPos,
@@ -404,6 +410,7 @@ const metadata = {
     if (pos === undefined) return
 
     const newPos = position <= pos[0] ? position : position + pos[1]
+    const virtualTsEnv = getVirtualTsEnv()
     const insight = virtualTsEnv.languageService.getQuickInfoAtPosition(
       fileName,
       newPos
@@ -421,6 +428,7 @@ const metadata = {
     if (pos === undefined) return
     const newPos = position <= pos[0] ? position : position + pos[1]
 
+    const virtualTsEnv = getVirtualTsEnv()
     const definitionInfoAndBoundSpan =
       virtualTsEnv.languageService.getDefinitionAndBoundSpan(fileName, newPos)
 

--- a/packages/next/src/server/typescript/utils.ts
+++ b/packages/next/src/server/typescript/utils.ts
@@ -18,7 +18,7 @@ export function getVirtualTsEnv() {
   const virtualTsEnv = globalThis.__NEXT_TS_PLUGIN_VIRTUAL_ENV
   if (!virtualTsEnv) {
     throw new Error(
-      'Could not find virtual TypeScript environment. This is a bug in Next.js TypeScript plugin. Please report it by opening an issue at https://github.com/vercel/next.js/issues.'
+      '[next] Could not find virtual TypeScript environment. This is a bug in Next.js TypeScript plugin. Please report it by opening an issue at https://github.com/vercel/next.js/issues.'
     )
   }
   return virtualTsEnv


### PR DESCRIPTION
### What?

In a large monorepo where modules reference each other across different projects (each with its own `tsconfig.json` with the `next` plugin enabled), navigating between files using `Cmd + click` often initialized the plugin per project.

### Why?

This leads to unnecessary overhead. In the worst case, it can cause the IDE to freeze due to multiple plugin instances with their own virtual file system running simultaneously.

### How?

Since a single language service can maintain a shared global context, store the virtual environment reference in that context and reuse it across projects. This avoids redundant initialization and improves performance.
