### PR TITLE
[font] prefix leading numeric google-font name with underscore

### DIFF
--- a/scripts/update-google-fonts.js
+++ b/scripts/update-google-fonts.js
@@ -66,10 +66,11 @@ const fetch = require('node-fetch')
     const weightTypes = [...weights]
     const styleTypes = [...styles]
 
-    fontFunctions += `export declare function ${family.replaceAll(
-      ' ',
-      '_'
-    )}<T extends CssVariable | undefined = undefined>(options${optionalIfVariableFont}: {
+    fontFunctions += `export declare function ${(/\d/.test(family[0])
+      ? '_' + family
+      : family
+    ).replaceAll(' ', '_')}
+    <T extends CssVariable | undefined = undefined>(options${optionalIfVariableFont}: {
     weight${optionalIfVariableFont}:${formatUnion(
       weightTypes
     )} | Array<${formatUnion(


### PR DESCRIPTION
Fixes #77488

Error: https://github.com/vercel/next.js/actions/runs/14414095731/job/40427803167 

> An identifier or keyword cannot immediately follow a numeric literal

Triggered by the [42dot Sans](https://fonts.google.com/specimen/42dot+Sans) font.

Note this leads `family[0]` to be `'4'` which triggers the error... 

> `function 42dot_Sans... // ⚠️⚠️ bad`

Fixed by prepending font names starting with digits (`/\d/.test()`) with an `_`.

(thanks to [this comment ](https://github.com/vercel/next.js/issues/77488#issuecomment-2798920312) from [MoSadie](https://github.com/MoSadie))