### PR TITLE
build: Update `swc_core` to `v22.3.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75fa4ddc354a7e46572bc5e745d19245fc1a4c980cd8a6a82debffdca13f39"
+checksum = "6f87629c740dbd5bd8ebcd82afbd8eaf835a3cf871e6762c1aa157df1d748345"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2962,7 +2962,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4081,8 +4081,8 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.3.3"
-source = "git+https://github.com/kdy1/mdxjs-rs?branch=swc-core-21#477c41dd9cb462fa31f91359c9930b14fa920d67"
+version = "0.3.4"
+source = "git+https://github.com/kdy1/mdxjs-rs?branch=swc-core-22#a1f16cee2f3350c68a7bebbf74b88e0bac02c9fa"
 dependencies = [
  "markdown",
  "rustc-hash 2.1.0",
@@ -4243,9 +4243,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.80.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216b54b877bf3f39bd39ba72ed94f4db6eb51832cf6259fee42c592a8b95d34"
+checksum = "9f98628300d2edbdbfebf0f485cf72bfdbcbc38c92b95dc16d06c2f82cabd54e"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -5377,9 +5377,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07852df2dda2f0ab8c3407a6fd19e9389563af11c20f6c299bd07ff9fc96d6ae"
+checksum = "9f0d30c7b8edcf218dd85ceacd8412f0c99a9c36419b81ea7fb97b569316d92a"
 dependencies = [
  "anyhow",
  "browserslist-rs",
@@ -5764,9 +5764,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21596ac4c46d13af94ad83662e689118721b17faf82f04b8af294286d946b546"
+checksum = "7d38677d73adca7f69dbeac0a098b5f5693240cb1c728286eabb77d69e3383fe"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5882,9 +5882,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92fdad4c3efa4d17866c535cdbf0d18e89151f2d23deee137509c017125c0f9"
+checksum = "e255699d8b0846e20166e5ca8aba0afdb44b6e5396b7a4a059e42b910f9776b5"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6942,9 +6942,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.108.0"
+version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36ce3c43b2274eb050e25be507147a0fd9ba2def42f8631f9115b82648ffe39"
+checksum = "f1658e5ef489275175f72dc8e425aa1bbcc43eb6f4d1224ece959d962b8e4fc2"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -6961,9 +6961,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.84.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a3e56055d66000e98dbc5dbd490fcce5206e1c264c597c2c9070b86076e2a"
+checksum = "ef2ba10d271cd1927ab4379907b26e482e6c20b3b3ee3e285d304a2072162cf1"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -6981,7 +6981,7 @@ dependencies = [
  "swc_css_prefixer",
  "swc_css_visit",
  "swc_ecma_ast",
- "swc_ecma_minifier 14.0.0",
+ "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -7004,9 +7004,9 @@ checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
 
 [[package]]
 name = "swc"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1311db8bbe20ad5374dd10a92d2dba3bf5ac59ade06292bdd381d1897c74664a"
+checksum = "3809091d5035036db41f5212697b10e492a6c97d50bf76839ac52481547a0528"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7033,11 +7033,11 @@ dependencies = [
  "swc_compiler_base",
  "swc_config",
  "swc_ecma_ast",
- "swc_ecma_codegen 10.0.0",
+ "swc_ecma_codegen",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier 16.0.0",
+ "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
@@ -7121,7 +7121,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_codegen 10.0.0",
+ "swc_ecma_codegen",
  "swc_ecma_loader",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -7148,9 +7148,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "8.0.1"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4a932c152e7142de2d5dba1c393e5523c47cd8fe656e5b0d411954bbaf1810"
+checksum = "7d96ac5d021c7c20acb3073940b4ee59b62989a705f855783c4a452e0737a2e6"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7182,9 +7182,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc96c4a212a3120deeefbc180bd7a4fed3d076af87d452d0b5773cc98b3934f6"
+checksum = "3516918cdce803f6c175aeefefbf3a05b4064eadc2a772f98da63d4282f85497"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7201,8 +7201,8 @@ dependencies = [
  "swc_common",
  "swc_config",
  "swc_ecma_ast",
- "swc_ecma_codegen 10.0.0",
- "swc_ecma_minifier 16.0.0",
+ "swc_ecma_codegen",
+ "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_visit",
  "swc_timer",
@@ -7237,9 +7237,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "21.0.1"
+version = "22.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e035b38b98cbfa1950ca38f7cae673e3377ce80ed4e1dc58242a0f81dd8b8"
+checksum = "f0396ffa44f6f0319b3451c689081c05d69ce4b3496fa17df8fa65a9f6960fed"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7249,10 +7249,10 @@ dependencies = [
  "swc_cached",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_codegen 10.0.0",
+ "swc_ecma_codegen",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier 16.0.0",
+ "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
@@ -7360,9 +7360,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac1e4bfc032749c2521ea63972e59bf3472a2897d6bbfa7747566eb7ccf7b89"
+checksum = "9a67829afb8e4ecec3aea8091cf0c901d8bb289787aaa3c25feed093e82c70a8"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -7407,17 +7407,19 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "8.1.0"
+version = "8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f80679b1afc52ae0663eed0a2539cc3c108d48c287b5601712f9850d9fa9c2"
+checksum = "4062a54522a9c02d2b68cc09282774b87121cd48693b0e67ae8c18b31b709866"
 dependencies = [
  "bitflags 2.5.0",
  "bytecheck 0.8.0",
  "is-macro",
  "num-bigint",
+ "once_cell",
  "phf",
  "rancor",
  "rkyv 0.8.9",
+ "rustc-hash 2.1.0",
  "scoped-tls",
  "serde",
  "shrink-to-fit",
@@ -7426,29 +7428,6 @@ dependencies = [
  "swc_common",
  "swc_visit",
  "unicode-id-start",
-]
-
-[[package]]
-name = "swc_ecma_codegen"
-version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f131ade75f9a3cfea38dbce11893f5636b0954de973ad29a2556124322a08372"
-dependencies = [
- "ascii",
- "compact_str",
- "memchr",
- "num-bigint",
- "once_cell",
- "regex",
- "rustc-hash 2.1.0",
- "serde",
- "sourcemap",
- "swc_allocator",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen_macros 1.0.1",
- "tracing",
 ]
 
 [[package]]
@@ -7470,20 +7449,8 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_codegen_macros 2.0.0",
+ "swc_ecma_codegen_macros",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_codegen_macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac2ff0957329e0dfcde86a1ac465382e189bf42a5989720d3476bea78eaa31a"
-dependencies = [
- "proc-macro2",
- "quote",
- "swc_macros_common",
- "syn 2.0.95",
 ]
 
 [[package]]
@@ -7575,9 +7542,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "12.0.0"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2d327146bb2b7b936b0d78e4212b039b1aa4149bbc187fd76db1ee3176e755"
+checksum = "4936daca5640131219e06945de1f22d7ef818d2e01ebbf615fc1d524d33ab888"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7711,9 +7678,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "12.0.0"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac89356dc7ab49dc30e9219fdb57cfc35a80aec3c0ae2e12c2a3488f9cfce7dd"
+checksum = "d86c9a647230352f00452699472e16fa76ec54a9e4acfe7fb8c0c93ec3d0ee07"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -7755,9 +7722,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "14.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6c3ea74a80bf1d21bba94f823aa9e90f903b81b345f99c1595faf87d732c63"
+checksum = "996ab0475502825584922ed02a5a457b1538afab511be57ae69434b5eda5762f"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -7779,44 +7746,7 @@ dependencies = [
  "swc_common",
  "swc_config",
  "swc_ecma_ast",
- "swc_ecma_codegen 8.1.0",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
- "swc_ecma_usage_analyzer",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_timer",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_minifier"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96929d4669712d21609fbd1ba24461c964d93ed23702bd87cc530f4b307ecc34"
-dependencies = [
- "arrayvec 0.7.4",
- "indexmap 2.7.1",
- "num-bigint",
- "num_cpus",
- "once_cell",
- "par-core",
- "par-iter",
- "parking_lot",
- "phf",
- "radix_fmt",
- "regex",
- "rustc-hash 2.1.0",
- "ryu-js",
- "serde",
- "serde_json",
- "swc_allocator",
- "swc_atoms",
- "swc_common",
- "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen 10.0.0",
+ "swc_ecma_codegen",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
@@ -7829,10 +7759,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "11.0.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e06ecaef86a547831f7f01f342434e4b0d0f363762f8e7a2b84da7a0a5f92e"
+checksum = "18757f2b1656db8b10d7fd153871d969d87e2909f4150378a4ae925fa6cc6768"
 dependencies = [
+ "arrayvec 0.7.4",
+ "bitflags 2.5.0",
  "either",
  "new_debug_unreachable",
  "num-bigint",
@@ -7852,9 +7784,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6e90087fe511cde69e3648bceb90b04be01236451ced67486371f827d691e1"
+checksum = "dcdb997223f2c92bb31278cf25b37398209fe5ce6a5cf276cf0cdc264386124b"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -7895,9 +7827,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e72a43b7acd904fa0c6d244a72aeda66febbc5a9720975481cb836d6804b604"
+checksum = "cb63358ab7094db21eb0c90eba89161bbe3c35e39c27f414ecdc9f4ffc8bc601"
 dependencies = [
  "anyhow",
  "hex",
@@ -7929,9 +7861,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "12.0.0"
+version = "12.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b747f04a004d9b56b903305e4567e1d30c9cd226a8310a29cac06f7ac8173a"
+checksum = "b46e3a36213d78fb4233e596b8a5c81c6cdafe02d03d780eed006c983aa0a724"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
@@ -8071,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "12.0.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048ba8acaa043f9468bb3bd1f5aae6f2e6b06865119226f9c45a971a012cc2d8"
+checksum = "5265158f5134b7b37dd2d53e7730921b8b5f567f6baddcc52129c2eb55927214"
 dependencies = [
  "either",
  "rustc-hash 2.1.0",
@@ -8091,9 +8023,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "13.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b66c31438de864f9694493d3f3a08744a5604b59df03774d09e0f541f29976c"
+checksum = "d8e7635afe1e1e798d61ff3107b8d27e437e61f243dd226a47fb10724693be66"
 dependencies = [
  "base64 0.22.1",
  "dashmap 5.5.3",
@@ -8118,9 +8050,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001e32bba70b2456a495dc7394673b233a19f76cdb46d7b0ce52ef1af8ecc573"
+checksum = "3f1e112d74cbf146d419b4df60de430fd8db4fef99df0443d7a96a3b30bd5878"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8133,7 +8065,7 @@ dependencies = [
  "swc_allocator",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_codegen 10.0.0",
+ "swc_ecma_codegen",
  "swc_ecma_parser",
  "swc_ecma_testing",
  "swc_ecma_transforms_base",
@@ -8219,9 +8151,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.84.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ed6d006839d82e7afee335b71ef02689baf985dc5774f2fe499d37c0f56126"
+checksum = "519b8a9e3b6e5d08694a4cca90771cd54733329b87e7f5c524f92996a91b4c66"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8234,7 +8166,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_codegen 8.1.0",
+ "swc_ecma_codegen",
  "swc_ecma_transforms",
  "swc_ecma_utils",
  "swc_ecma_visit",
@@ -8255,9 +8187,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "9.1.2"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc812b793a12b737b6cb949a6e8c87dfcd006c07d9490a5c4529d61e890003dc"
+checksum = "499cf6a20e6acb36f15e22cca18dadc108d7046ae062840b7371ae02eac4dfde"
 dependencies = [
  "anyhow",
  "miette",
@@ -8321,9 +8253,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0917ccfdcd3fa6cf41bdacef2388702a3b274f9ea708d930e1e8db37c7c3e1c6"
+checksum = "ace467dfafbbdf3aecff786b8605b35db57d945e92fd88800569aa2cba0cdf61"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8349,9 +8281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132317a7245b344d654da8cd3c6cdb6fcd72d1e7d028d1085aa679cfb5e9801a"
+checksum = "f59e5549019cd28b972e59d756404aa13dd4b4b3b21dfedc3f871804c6a6cc77"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8361,6 +8293,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
+ "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_plugin_proxy",
@@ -8377,9 +8310,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3798e23ffcc216dc177f12ff184163adc6e546fd02888c5ac3bf9af46c6c4ec9"
+checksum = "3774c807e74211f9fd3b95c38657372652f6c9a43700ed5cbdef850e4a86b90f"
 dependencies = [
  "once_cell",
  "regex",
@@ -8613,9 +8546,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d32ddc0e2ebd072cbffe7424087267da990708a5bc3ae29e075904468450275"
+checksum = "e32a1c95775a4077dbfc66d9d6e33576c142bd9bff457289d124037a79f72786"
 dependencies = [
  "ansi_term",
  "cargo_metadata 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,21 +296,21 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "21.0.1", features = [
+swc_core = { version = "22.3.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "8.0.0" }
+testing = { version = "9.0.0" }
 
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.17.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.3.3"
-modularize_imports = { version = "0.80.0" }
-styled_components = { version = "0.108.0" }
-styled_jsx = { version = "0.84.0" }
-swc_emotion = { version = "0.84.0" }
-swc_relay = { version = "0.54.0" }
+modularize_imports = { version = "0.82.0" }
+styled_components = { version = "0.110.0" }
+styled_jsx = { version = "0.86.0" }
+swc_emotion = { version = "0.86.0" }
+swc_relay = { version = "0.56.0" }
 
 # General Deps
 chromiumoxide = { version = "0.5.4", features = [
@@ -433,4 +433,4 @@ wasmer-cache = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
 wasmer-compiler-cranelift = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
 wasmer-wasix = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
 
-mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-21" }
+mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-22" }

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -95,6 +95,7 @@ impl Task for MinifyTask {
                 })
             },
         )
+        .map_err(|e| e.to_pretty_error())
         .convert_err()
     }
 
@@ -170,5 +171,6 @@ pub fn minify_sync(input: Buffer, opts: Buffer) -> napi::Result<TransformOutput>
             })
         },
     )
+    .map_err(|e| e.to_pretty_error())
     .convert_err()
 }

--- a/crates/napi/src/parse.rs
+++ b/crates/napi/src/parse.rs
@@ -53,6 +53,7 @@ impl Task for ParseTask {
                     )
                 },
             )
+            .map_err(|e| e.to_pretty_error())
             .convert_err()?;
 
             let ast_json = serde_json::to_string(&program)

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -177,6 +177,7 @@ impl Task for TransformTask {
                                 .into_inner(),
                         )
                     })
+                    .map_err(|e| e.to_pretty_error())
                     .convert_err(),
                 Err(err) => Err(napi::Error::new(
                     Status::GenericFailure,

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -32,8 +32,8 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
-react_remove_properties = "0.34.0"
-remove_console = "0.35.0"
+react_remove_properties = "0.36.0"
+remove_console = "0.37.0"
 itertools = { workspace = true }
 auto-hash-map = { workspace = true }
 percent-encoding = "2.3.1"

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -63,9 +63,9 @@ turbopack-ecmascript-plugins = { workspace = true, optional = true }
 turbo-rcstr = { workspace = true }
 urlencoding = { workspace = true }
 
-react_remove_properties = "0.34.0"
-remove_console = "0.35.0"
-preset_env_base = "2.0.1"
+react_remove_properties = "0.36.0"
+remove_console = "0.37.0"
+preset_env_base = "3.0.0"
 
 [dev-dependencies]
 swc_core = { workspace = true, features = ["testing_transform"]}

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -165,7 +165,7 @@ where
                     .css_env
                     .as_ref()
                     .map(|env| {
-                        targets_to_versions(env.targets.clone())
+                        targets_to_versions(env.targets.clone(), None)
                             .expect("failed to parse env.targets")
                     })
                     .unwrap_or_default();

--- a/crates/next-custom-transforms/src/transforms/page_static_info/mod.rs
+++ b/crates/next-custom-transforms/src/transforms/page_static_info/mod.rs
@@ -286,6 +286,7 @@ mod tests {
                     )
                 },
             )
+            .map_err(|e| e.to_pretty_error())
             .map(|p| (p, comments))
         })
     }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -49,6 +49,7 @@ pub fn minify_sync(s: JsString, opts: JsValue) -> Result<JsValue, JsValue> {
             })
         },
     )
+    .map_err(|e| e.to_pretty_error())
     .map_err(convert_err)?;
 
     Ok(serde_wasm_bindgen::to_value(&value)?)
@@ -125,6 +126,7 @@ pub fn transform_sync(s: JsValue, opts: JsValue) -> Result<JsValue, JsValue> {
             })
         },
     )
+    .map_err(|e| e.to_pretty_error())
     .map_err(convert_err)?;
 
     Ok(serde_wasm_bindgen::to_value(&out)?)
@@ -178,6 +180,7 @@ pub fn parse_sync(s: JsString, opts: JsValue) -> Result<JsValue, JsValue> {
             })
         },
     )
+    .map_err(|e| e.to_pretty_error())
     .map_err(convert_err)
 }
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -206,6 +206,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                                 ctx.source_map,
                                 &ctx.unresolved_mark,
                                 &transform_metadata_context,
+                                None,
                                 plugin_module,
                                 Some(plugin_config),
                                 runtime,

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -121,7 +121,8 @@ pub fn minify(code: &Code, source_maps: bool, mangle: Option<MangleType>) -> Res
                     &comments as &dyn Comments,
                 ))))
             })
-        })?;
+        })
+        .map_err(|e| e.to_pretty_error())?;
 
         print_program(cm.clone(), program, source_maps.is_some())?
     };

--- a/turbopack/crates/turbopack-swc-ast-explorer/src/main.rs
+++ b/turbopack/crates/turbopack-swc-ast-explorer/src/main.rs
@@ -39,16 +39,18 @@ fn main() -> Result<()> {
     });
 
     let compiler = Compiler::new(sm.clone());
-    let res = GLOBALS.set(&Globals::new(), || {
-        try_with_handler(
-            sm,
-            HandlerOpts {
-                color: ColorConfig::Always,
-                skip_filename: false,
-            },
-            |handler| compiler.parse_js(file, handler, target, syntax, IsModule::Unknown, None),
-        )
-    });
+    let res = GLOBALS
+        .set(&Globals::new(), || {
+            try_with_handler(
+                sm,
+                HandlerOpts {
+                    color: ColorConfig::Always,
+                    skip_filename: false,
+                },
+                |handler| compiler.parse_js(file, handler, target, syntax, IsModule::Unknown, None),
+            )
+        })
+        .map_err(|e| e.to_pretty_error());
 
     let print = format!("{:#?}", res?);
 

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -98,7 +98,8 @@ impl IssueEmitter {
 }
 
 impl Emitter for IssueEmitter {
-    fn emit(&mut self, db: &DiagnosticBuilder<'_>) {
+    fn emit(&mut self, db: &mut DiagnosticBuilder<'_>) {
+        let db = db.take();
         let level = db.level;
         let mut message = db
             .message


### PR DESCRIPTION
### What?

Update `swc_core` to `v22.3.1`

ChangeLog: https://github.com/swc-project/swc/compare/swc_core%40v21.0.1...swc_core%40v22.3.1

### Why?

To keep in sync and apply recent parser performance optimizations

### How?

Closes PACK-4340