### PR TITLE
Turbopack Persistent Caching: Use SmallVec to avoid allocations for small values written to DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9204,6 +9204,7 @@ dependencies = [
  "rayon",
  "rustc-hash 2.1.0",
  "serde",
+ "smallvec",
  "tempfile",
  "thread_local",
  "twox-hash 2.1.0",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -22,6 +22,7 @@ quick_cache = { version = "0.6.9" }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
+smallvec = { workspace = true}
 thread_local = { workspace = true }
 twox-hash = { version = "2.0.1", features = ["xxhash64"] }
 zstd = { version = "0.13.2", features = ["zdict_builder"] }

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use smallvec::SmallVec;
+
 use crate::{
     key::StoreKey,
     static_sorted_file_builder::{Entry, EntryValue},
@@ -11,7 +13,7 @@ pub struct CollectorEntry<K: StoreKey> {
 }
 
 pub enum CollectorEntryValue {
-    Small { value: Vec<u8> },
+    Small { value: SmallVec<[u8; 16]> },
     Medium { value: Vec<u8> },
     Large { blob: u32 },
     Deleted,

--- a/turbopack/crates/turbo-persistence/src/key.rs
+++ b/turbopack/crates/turbo-persistence/src/key.rs
@@ -4,6 +4,9 @@ use std::{cmp::min, hash::Hasher};
 pub trait KeyBase {
     /// Returns the length of the key in bytes.
     fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
     /// Hashes the key. It should not include the structure of the key, only the data. E.g. `([1,
     /// 2], [3, 4])` should hash the same as `[1, 2, 3, 4]`.
     fn hash<H: Hasher>(&self, state: &mut H);
@@ -12,6 +15,10 @@ pub trait KeyBase {
 impl KeyBase for &'_ [u8] {
     fn len(&self) -> usize {
         <[u8]>::len(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        <[u8]>::is_empty(self)
     }
 
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -23,7 +30,11 @@ impl KeyBase for &'_ [u8] {
 
 impl<const N: usize> KeyBase for [u8; N] {
     fn len(&self) -> usize {
-        self[..].len()
+        N
+    }
+
+    fn is_empty(&self) -> bool {
+        N > 0
     }
 
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -38,6 +49,10 @@ impl KeyBase for Vec<u8> {
         self.len()
     }
 
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
     fn hash<H: Hasher>(&self, state: &mut H) {
         for item in self {
             state.write_u8(*item);
@@ -48,6 +63,10 @@ impl KeyBase for Vec<u8> {
 impl KeyBase for u8 {
     fn len(&self) -> usize {
         1
+    }
+
+    fn is_empty(&self) -> bool {
+        false
     }
 
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -61,6 +80,11 @@ impl<A: KeyBase, B: KeyBase> KeyBase for (A, B) {
         a.len() + b.len()
     }
 
+    fn is_empty(&self) -> bool {
+        let (a, b) = self;
+        a.is_empty() && b.is_empty()
+    }
+
     fn hash<H: Hasher>(&self, state: &mut H) {
         let (a, b) = self;
         KeyBase::hash(a, state);
@@ -71,6 +95,10 @@ impl<A: KeyBase, B: KeyBase> KeyBase for (A, B) {
 impl<T: KeyBase> KeyBase for &'_ T {
     fn len(&self) -> usize {
         (*self).len()
+    }
+
+    fn is_empty(&self) -> bool {
+        (*self).is_empty()
     }
 
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -17,8 +17,10 @@ mod write_batch;
 
 #[cfg(test)]
 mod tests;
+mod value_buf;
 
 pub use arc_slice::ArcSlice;
 pub use db::TurboPersistence;
-pub use key::{QueryKey, StoreKey};
+pub use key::{KeyBase, QueryKey, StoreKey};
+pub use value_buf::ValueBuffer;
 pub use write_batch::WriteBatch;

--- a/turbopack/crates/turbo-persistence/src/value_buf.rs
+++ b/turbopack/crates/turbo-persistence/src/value_buf.rs
@@ -1,0 +1,66 @@
+use std::{borrow::Cow, ops::Deref};
+
+use smallvec::SmallVec;
+
+pub enum ValueBuffer<'l> {
+    Borrowed(&'l [u8]),
+    Vec(Vec<u8>),
+    SmallVec(SmallVec<[u8; 16]>),
+}
+
+impl ValueBuffer<'_> {
+    pub fn into_vec(self) -> Vec<u8> {
+        match self {
+            ValueBuffer::Borrowed(b) => b.to_vec(),
+            ValueBuffer::Vec(v) => v,
+            ValueBuffer::SmallVec(sv) => sv.into_vec(),
+        }
+    }
+
+    pub fn into_small_vec(self) -> SmallVec<[u8; 16]> {
+        match self {
+            ValueBuffer::Borrowed(b) => SmallVec::from_slice(b),
+            ValueBuffer::Vec(v) => SmallVec::from_vec(v),
+            ValueBuffer::SmallVec(sv) => sv,
+        }
+    }
+}
+
+impl<'l> From<&'l [u8]> for ValueBuffer<'l> {
+    fn from(b: &'l [u8]) -> Self {
+        ValueBuffer::Borrowed(b)
+    }
+}
+
+impl From<Vec<u8>> for ValueBuffer<'_> {
+    fn from(v: Vec<u8>) -> Self {
+        ValueBuffer::Vec(v)
+    }
+}
+
+impl From<SmallVec<[u8; 16]>> for ValueBuffer<'_> {
+    fn from(sv: SmallVec<[u8; 16]>) -> Self {
+        ValueBuffer::SmallVec(sv)
+    }
+}
+
+impl<'l> From<Cow<'l, [u8]>> for ValueBuffer<'l> {
+    fn from(c: Cow<'l, [u8]>) -> Self {
+        match c {
+            Cow::Borrowed(b) => ValueBuffer::Borrowed(b),
+            Cow::Owned(o) => ValueBuffer::Vec(o),
+        }
+    }
+}
+
+impl Deref for ValueBuffer<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ValueBuffer::Borrowed(b) => b,
+            ValueBuffer::Vec(v) => v,
+            ValueBuffer::SmallVec(sv) => sv,
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     fs,
     path::Path,
     sync::atomic::{AtomicBool, Ordering},
@@ -9,7 +8,9 @@ use anyhow::Result;
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},
-    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch},
+    write_batch::{
+        BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch, WriteBuffer,
+    },
 };
 
 pub fn is_fresh(path: &Path) -> bool {
@@ -124,11 +125,16 @@ impl<'a, B: BaseWriteBatch<'a>> BaseWriteBatch<'a> for FreshDbOptimizationWriteB
 }
 
 impl<'a, B: SerialWriteBatch<'a>> SerialWriteBatch<'a> for FreshDbOptimizationWriteBatch<'a, B> {
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &mut self,
+        key_space: KeySpace,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
+    ) -> Result<()> {
         self.write_batch.put(key_space, key, value)
     }
 
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+    fn delete(&mut self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.delete(key_space, key)
     }
 }
@@ -136,11 +142,11 @@ impl<'a, B: SerialWriteBatch<'a>> SerialWriteBatch<'a> for FreshDbOptimizationWr
 impl<'a, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a>
     for FreshDbOptimizationWriteBatch<'a, B>
 {
-    fn put(&self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+    fn put(&self, key_space: KeySpace, key: WriteBuffer<'_>, value: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.put(key_space, key, value)
     }
 
-    fn delete(&self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+    fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.delete(key_space, key)
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fs::create_dir_all, path::Path, thread::available_parallelism};
+use std::{fs::create_dir_all, path::Path, thread::available_parallelism};
 
 use anyhow::{Context, Result};
 use lmdb::{
@@ -8,7 +8,7 @@ use lmdb::{
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},
-    write_batch::{BaseWriteBatch, SerialWriteBatch, WriteBatch},
+    write_batch::{BaseWriteBatch, SerialWriteBatch, WriteBatch, WriteBuffer},
 };
 
 mod extended_key;
@@ -164,7 +164,12 @@ impl<'a> BaseWriteBatch<'a> for LmbdWriteBatch<'a> {
 }
 
 impl<'a> SerialWriteBatch<'a> for LmbdWriteBatch<'a> {
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &mut self,
+        key_space: KeySpace,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
+    ) -> Result<()> {
         extended_key::put(
             &mut self.tx,
             self.this.db(key_space),
@@ -175,7 +180,7 @@ impl<'a> SerialWriteBatch<'a> for LmbdWriteBatch<'a> {
         Ok(())
     }
 
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+    fn delete(&mut self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         extended_key::delete(
             &mut self.tx,
             self.this.db(key_space),

--- a/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
@@ -1,10 +1,10 @@
-use std::borrow::Cow;
-
 use anyhow::Result;
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},
-    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch},
+    write_batch::{
+        BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch, WriteBuffer,
+    },
 };
 
 pub struct NoopKvDb;
@@ -78,21 +78,31 @@ impl<'a> BaseWriteBatch<'a> for NoopWriteBatch {
 }
 
 impl SerialWriteBatch<'_> for NoopWriteBatch {
-    fn put(&mut self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &mut self,
+        _key_space: KeySpace,
+        _key: WriteBuffer<'_>,
+        _value: WriteBuffer<'_>,
+    ) -> Result<()> {
         Ok(())
     }
 
-    fn delete(&mut self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+    fn delete(&mut self, _key_space: KeySpace, _key: WriteBuffer<'_>) -> Result<()> {
         Ok(())
     }
 }
 
 impl ConcurrentWriteBatch<'_> for NoopWriteBatch {
-    fn put(&self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &self,
+        _key_space: KeySpace,
+        _key: WriteBuffer<'_>,
+        _value: WriteBuffer<'_>,
+    ) -> Result<()> {
         Ok(())
     }
 
-    fn delete(&self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+    fn delete(&self, _key_space: KeySpace, _key: WriteBuffer<'_>) -> Result<()> {
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
@@ -7,7 +7,9 @@ use thread_local::ThreadLocal;
 
 use crate::database::{
     key_value_database::KeyValueDatabase,
-    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch},
+    write_batch::{
+        BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch, WriteBuffer,
+    },
 };
 
 struct ThreadLocalReadTransactionsContainer<T: KeyValueDatabase + 'static>(
@@ -184,15 +186,15 @@ impl<'a, T: KeyValueDatabase, B: SerialWriteBatch<'a>> SerialWriteBatch<'a>
     fn put(
         &mut self,
         key_space: super::key_value_database::KeySpace,
-        key: std::borrow::Cow<[u8]>,
-        value: std::borrow::Cow<[u8]>,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
     ) -> Result<()> {
         self.write_batch.put(key_space, key, value)
     }
     fn delete(
         &mut self,
         key_space: super::key_value_database::KeySpace,
-        key: std::borrow::Cow<[u8]>,
+        key: WriteBuffer<'_>,
     ) -> Result<()> {
         self.write_batch.delete(key_space, key)
     }
@@ -204,15 +206,15 @@ impl<'a, T: KeyValueDatabase, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<
     fn put(
         &self,
         key_space: super::key_value_database::KeySpace,
-        key: std::borrow::Cow<[u8]>,
-        value: std::borrow::Cow<[u8]>,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
     ) -> Result<()> {
         self.write_batch.put(key_space, key, value)
     }
     fn delete(
         &self,
         key_space: super::key_value_database::KeySpace,
-        key: std::borrow::Cow<[u8]>,
+        key: WriteBuffer<'_>,
     ) -> Result<()> {
         self.write_batch.delete(key_space, key)
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     path::PathBuf,
     sync::Arc,
     thread::{spawn, JoinHandle},
@@ -7,11 +6,11 @@ use std::{
 
 use anyhow::Result;
 use parking_lot::Mutex;
-use turbo_persistence::{ArcSlice, TurboPersistence};
+use turbo_persistence::{ArcSlice, KeyBase, StoreKey, TurboPersistence, ValueBuffer};
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},
-    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, WriteBatch},
+    write_batch::{BaseWriteBatch, ConcurrentWriteBatch, WriteBatch, WriteBuffer},
 };
 
 const COMPACT_MAX_COVERAGE: f32 = 20.0;
@@ -104,7 +103,7 @@ impl KeyValueDatabase for TurboKeyValueDatabase {
 }
 
 pub struct TurboWriteBatch<'a> {
-    batch: turbo_persistence::WriteBatch<Vec<u8>, 5>,
+    batch: turbo_persistence::WriteBatch<WriteBuffer<'static>, 5>,
     db: &'a Arc<TurboPersistence>,
     compact_join_handle: &'a Mutex<Option<JoinHandle<Result<()>>>>,
 }
@@ -137,11 +136,60 @@ impl<'a> BaseWriteBatch<'a> for TurboWriteBatch<'a> {
 }
 
 impl<'a> ConcurrentWriteBatch<'a> for TurboWriteBatch<'a> {
-    fn put(&self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
-        self.batch.put(key_space as usize, key.into_owned(), value)
+    fn put(&self, key_space: KeySpace, key: WriteBuffer<'_>, value: WriteBuffer<'_>) -> Result<()> {
+        self.batch
+            .put(key_space as usize, key.into_static(), value.into())
     }
 
-    fn delete(&self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
-        self.batch.delete(key_space as usize, key.into_owned())
+    fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
+        self.batch.delete(key_space as usize, key.into_static())
+    }
+}
+
+impl KeyBase for WriteBuffer<'_> {
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for item in &**self {
+            state.write_u8(*item);
+        }
+    }
+}
+
+impl StoreKey for WriteBuffer<'_> {
+    fn write_to(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&**self);
+    }
+}
+
+impl PartialEq for WriteBuffer<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl Eq for WriteBuffer<'_> {}
+
+impl Ord for WriteBuffer<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (**self).cmp(&**other)
+    }
+}
+
+impl PartialOrd for WriteBuffer<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'l> Into<ValueBuffer<'l>> for WriteBuffer<'l> {
+    fn into(self) -> ValueBuffer<'l> {
+        match self {
+            WriteBuffer::Borrowed(b) => ValueBuffer::Borrowed(b),
+            WriteBuffer::Vec(v) => ValueBuffer::Vec(v),
+            WriteBuffer::SmallVec(sv) => ValueBuffer::SmallVec(sv),
+        }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -160,7 +160,7 @@ impl KeyBase for WriteBuffer<'_> {
 
 impl StoreKey for WriteBuffer<'_> {
     fn write_to(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&**self);
+        buf.extend_from_slice(self);
     }
 }
 
@@ -184,9 +184,9 @@ impl PartialOrd for WriteBuffer<'_> {
     }
 }
 
-impl<'l> Into<ValueBuffer<'l>> for WriteBuffer<'l> {
-    fn into(self) -> ValueBuffer<'l> {
-        match self {
+impl<'l> From<WriteBuffer<'l>> for ValueBuffer<'l> {
+    fn from(val: WriteBuffer<'l>) -> Self {
+        match val {
             WriteBuffer::Borrowed(b) => ValueBuffer::Borrowed(b),
             WriteBuffer::Vec(v) => ValueBuffer::Vec(v),
             WriteBuffer::SmallVec(sv) => ValueBuffer::SmallVec(sv),

--- a/turbopack/crates/turbo-tasks-backend/src/database/write_batch.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/write_batch.rs
@@ -1,9 +1,11 @@
 use std::{
     borrow::{Borrow, Cow},
     marker::PhantomData,
+    ops::Deref,
 };
 
 use anyhow::Result;
+use smallvec::SmallVec;
 
 use crate::database::key_value_database::KeySpace;
 
@@ -19,14 +21,56 @@ pub trait BaseWriteBatch<'a> {
     fn commit(self) -> Result<()>;
 }
 
+pub enum WriteBuffer<'a> {
+    Borrowed(&'a [u8]),
+    Vec(Vec<u8>),
+    SmallVec(smallvec::SmallVec<[u8; 16]>),
+}
+
+impl WriteBuffer<'_> {
+    pub fn into_static(self) -> WriteBuffer<'static> {
+        match self {
+            WriteBuffer::Borrowed(b) => WriteBuffer::SmallVec(SmallVec::from_slice(b)),
+            WriteBuffer::Vec(v) => WriteBuffer::Vec(v),
+            WriteBuffer::SmallVec(sv) => WriteBuffer::Vec(sv.into_vec()),
+        }
+    }
+}
+
+impl Deref for WriteBuffer<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            WriteBuffer::Borrowed(b) => b,
+            WriteBuffer::Vec(v) => v,
+            WriteBuffer::SmallVec(sv) => sv,
+        }
+    }
+}
+
+impl<'l> From<Cow<'l, [u8]>> for WriteBuffer<'l> {
+    fn from(c: Cow<'l, [u8]>) -> Self {
+        match c {
+            Cow::Borrowed(b) => WriteBuffer::Borrowed(b),
+            Cow::Owned(o) => WriteBuffer::Vec(o),
+        }
+    }
+}
+
 pub trait SerialWriteBatch<'a>: BaseWriteBatch<'a> {
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()>;
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()>;
+    fn put(
+        &mut self,
+        key_space: KeySpace,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
+    ) -> Result<()>;
+    fn delete(&mut self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()>;
 }
 
 pub trait ConcurrentWriteBatch<'a>: BaseWriteBatch<'a> + Sync + Send {
-    fn put(&self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()>;
-    fn delete(&self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()>;
+    fn put(&self, key_space: KeySpace, key: WriteBuffer<'_>, value: WriteBuffer<'_>) -> Result<()>;
+    fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()>;
 }
 
 pub enum WriteBatch<'a, S, C>
@@ -102,14 +146,19 @@ where
     S: SerialWriteBatch<'a>,
     C: ConcurrentWriteBatch<'a>,
 {
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &mut self,
+        key_space: KeySpace,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
+    ) -> Result<()> {
         match self {
             WriteBatch::Serial(s) => s.put(key_space, key, value),
             WriteBatch::Concurrent(c, _) => c.put(key_space, key, value),
         }
     }
 
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+    fn delete(&mut self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         match self {
             WriteBatch::Serial(s) => s.delete(key_space, key),
             WriteBatch::Concurrent(c, _) => c.delete(key_space, key),
@@ -174,14 +223,19 @@ where
     S: SerialWriteBatch<'a>,
     C: ConcurrentWriteBatch<'a>,
 {
-    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &mut self,
+        key_space: KeySpace,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
+    ) -> Result<()> {
         match self {
             WriteBatchRef::Serial(s) => s.put(key_space, key, value),
             WriteBatchRef::Concurrent(c, _) => c.put(key_space, key, value),
         }
     }
 
-    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+    fn delete(&mut self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         match self {
             WriteBatchRef::Serial(s) => s.delete(key_space, key),
             WriteBatchRef::Concurrent(c, _) => c.delete(key_space, key),
@@ -210,19 +264,29 @@ impl<'a> BaseWriteBatch<'a> for UnimplementedWriteBatch {
 }
 
 impl SerialWriteBatch<'_> for UnimplementedWriteBatch {
-    fn put(&mut self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &mut self,
+        _key_space: KeySpace,
+        _key: WriteBuffer<'_>,
+        _value: WriteBuffer<'_>,
+    ) -> Result<()> {
         todo!()
     }
-    fn delete(&mut self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+    fn delete(&mut self, _key_space: KeySpace, _key: WriteBuffer<'_>) -> Result<()> {
         todo!()
     }
 }
 
 impl ConcurrentWriteBatch<'_> for UnimplementedWriteBatch {
-    fn put(&self, _key_space: KeySpace, _key: Cow<[u8]>, _value: Cow<[u8]>) -> Result<()> {
+    fn put(
+        &self,
+        _key_space: KeySpace,
+        _key: WriteBuffer<'_>,
+        _value: WriteBuffer<'_>,
+    ) -> Result<()> {
         todo!()
     }
-    fn delete(&self, _key_space: KeySpace, _key: Cow<[u8]>) -> Result<()> {
+    fn delete(&self, _key_space: KeySpace, _key: WriteBuffer<'_>) -> Result<()> {
         todo!()
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -26,7 +26,7 @@ const POT_CONFIG: pot::Config = pot::Config::new().compatibility(pot::Compatibil
 
 fn pot_serialize_small_vec<T: Serialize>(value: &T) -> pot::Result<SmallVec<[u8; 16]>> {
     struct SmallVecWrite<'l>(&'l mut SmallVec<[u8; 16]>);
-    impl<'l> std::io::Write for SmallVecWrite<'l> {
+    impl std::io::Write for SmallVecWrite<'_> {
         #[inline]
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
             self.0.extend_from_slice(buf);
@@ -349,7 +349,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
                             .put(
                                 key_space,
                                 WriteBuffer::Borrowed(IntKey::new(*task_id).as_ref()),
-                                value.into(),
+                                value,
                             )
                             .with_context(|| anyhow!("Unable to write data items for {task_id}"))?;
                     }


### PR DESCRIPTION
### What?

Use SmallVec to avoid allocations for small values written to DB


Closes PACK-4370