### PR TITLE
[test] Enable `strictNullChecks` in test utils

### DIFF
--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -19,6 +19,7 @@ declare namespace NodeJS {
   }
 
   interface ProcessEnv {
+    // TODO: Should be optional and possibly undefined
     readonly NODE_ENV: 'development' | 'production' | 'test'
   }
 

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -63,12 +63,12 @@ declare global {
 }
 
 interface ErrorSnapshot {
-  environmentLabel: string
-  label: string
-  description: string
+  environmentLabel: string | null
+  label: string | null
+  description: string | null
   componentStack?: string
-  source: string
-  stack: string[]
+  source: string | null
+  stack: string[] | null
 }
 
 async function createErrorSnapshot(
@@ -145,7 +145,7 @@ async function createErrorSnapshot(
         : description,
     source: focusedSource,
     stack:
-      next !== null
+      next !== null && stack !== null
         ? stack.map((stackframe) => {
             return stackframe.replace(next.testDir, '<FIXME-project-root>')
           })
@@ -202,7 +202,7 @@ expect.extend({
     expectedRedboxSnapshot?: string
   ) {
     let browser: BrowserInterface
-    let next: NextInstance
+    let next: NextInstance | null
     if ('browser' in browserOrContext && 'next' in browserOrContext) {
       browser = browserOrContext.browser
       next = browserOrContext.next

--- a/test/lib/browsers/base.ts
+++ b/test/lib/browsers/base.ts
@@ -12,7 +12,7 @@ export abstract class BrowserInterface<TCurrent = any> {
   readonly [Symbol.toStringTag]: string = 'BrowserInterface'
 
   protected chain<TNext>(
-    nextCall: (current: TCurrent) => TNext | Promise<TNext>
+    nextCall: (current: TCurrent | undefined) => TNext | Promise<TNext>
   ): BrowserInterface<TNext> & Promise<TNext> {
     const syncError = new Error('next-browser-base-chain-error')
     const promise = Promise.resolve(this.promise)
@@ -23,7 +23,7 @@ export abstract class BrowserInterface<TCurrent = any> {
           typeof reason === 'object' &&
           'stack' in reason
         ) {
-          const syncCallStack = syncError.stack.split(syncError.message)[1]
+          const syncCallStack = syncError.stack!.split(syncError.message)[1]
           reason.stack += `\n${syncCallStack}`
         }
         throw reason
@@ -100,12 +100,7 @@ export abstract class BrowserInterface<TCurrent = any> {
   abstract off(event: Event, cb: (...args: any[]) => void): void
   abstract loadPage(
     url: string,
-    {
-      disableCache,
-      cpuThrottleRate,
-      beforePageLoad,
-      pushErrorAsConsoleLog,
-    }?: {
+    options?: {
       disableCache?: boolean
       cpuThrottleRate?: number
       beforePageLoad?: Function
@@ -114,7 +109,7 @@ export abstract class BrowserInterface<TCurrent = any> {
   ): Promise<void>
   abstract get(url: string): Promise<void>
   abstract getValue(): Promise<string>
-  abstract getAttribute(name: string): Promise<string>
+  abstract getAttribute(name: string): Promise<string | null>
   abstract eval(snippet: string | Function, ...args: any[]): Promise<any>
   abstract evalAsync(snippet: string | Function, ...args: any[]): Promise<any>
   abstract text(): Promise<string>

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -16,8 +16,8 @@ import path from 'path'
 type PageLog = { source: string; message: string; args: unknown[] }
 
 let page: Page
-let browser: Browser
-let context: BrowserContext
+let browser: Browser | undefined
+let context: BrowserContext | undefined
 let contextHasJSEnabled: boolean = true
 let pageLogs: Array<Promise<PageLog> | PageLog> = []
 let websocketFrames: Array<{ payload: string | Buffer }> = []
@@ -34,7 +34,7 @@ const defaultTimeout = process.env.NEXT_E2E_TEST_TIMEOUT
 // This is due to `quit` can be called anytime outside of BrowserInterface's lifecycle,
 // which can create corrupted state by terminating the context.
 // [TODO] global `quit` might need to be removed, instead should introduce per-instance teardown
-const pendingTeardown = []
+const pendingTeardown: Array<() => Promise<void>> = []
 export async function quit() {
   await Promise.all(pendingTeardown.map((fn) => fn()))
   await context?.close()
@@ -90,13 +90,13 @@ export class Playwright extends BrowserInterface {
       const traceOutputPath = path.join(
         traceDir,
         `${path
-          .relative(path.join(__dirname, '../../'), process.env.TEST_FILE_PATH)
+          .relative(path.join(__dirname, '../../'), process.env.TEST_FILE_PATH!)
           .replace(/\//g, '-')}`,
         `playwright-${this.activeTrace}-${Date.now()}.zip`
       )
 
       await fs.remove(traceOutputPath)
-      await context.tracing.stop({
+      await context!.tracing.stop({
         path: traceOutputPath,
       })
     } catch (e) {
@@ -214,12 +214,12 @@ export class Playwright extends BrowserInterface {
     await this.close()
 
     // clean-up existing pages
-    for (const oldPage of context.pages()) {
+    for (const oldPage of context!.pages()) {
       await oldPage.close()
     }
 
-    await this.initContextTracing(url, context)
-    page = await context.newPage()
+    await this.initContextTracing(url, context!)
+    page = await context!.newPage()
 
     page.setDefaultTimeout(defaultTimeout)
     page.setDefaultNavigationTimeout(defaultTimeout)
@@ -255,12 +255,12 @@ export class Playwright extends BrowserInterface {
 
     if (opts?.disableCache) {
       // TODO: this doesn't seem to work (dev tools does not check the box as expected)
-      const session = await context.newCDPSession(page)
+      const session = await context!.newCDPSession(page)
       session.send('Network.setCacheDisabled', { cacheDisabled: true })
     }
 
     if (opts?.cpuThrottleRate) {
-      const session = await context.newCDPSession(page)
+      const session = await context!.newCDPSession(page)
       // https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setCPUThrottlingRate
       session.send('Emulation.setCPUThrottlingRate', {
         rate: opts.cpuThrottleRate,
@@ -315,7 +315,7 @@ export class Playwright extends BrowserInterface {
   }
   addCookie(opts: { name: string; value: string }) {
     return this.chain(async () =>
-      context.addCookies([
+      context!.addCookies([
         {
           path: '/',
           domain: await page.evaluate('window.location.hostname'),
@@ -325,7 +325,7 @@ export class Playwright extends BrowserInterface {
     )
   }
   deleteCookies() {
-    return this.chain(async () => context.clearCookies())
+    return this.chain(async () => context!.clearCookies())
   }
 
   focusPage() {
@@ -336,7 +336,7 @@ export class Playwright extends BrowserInterface {
     function getComputedCss(prop: string) {
       return page.evaluate(
         function (args) {
-          const style = getComputedStyle(document.querySelector(args.selector))
+          const style = getComputedStyle(document.querySelector(args.selector)!)
           return style[args.prop] || null
         },
         { selector, prop }

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -31,6 +31,19 @@ async function installDependencies(cwd, tmpDir) {
   })
 }
 
+/**
+ *
+ * @param {object} param0
+ * @param {import('@next/telemetry').Span} param0.parentSpan
+ * @param {object} [param0.dependencies]
+ * @param {object | null} [param0.resolutions]
+ * @param { ((ctx: { dependencies: { [key: string]: string } }) => string) | string | null} [param0.installCommand]
+ * @param {object} [param0.packageJson]
+ * @param {string} [param0.dirSuffix]
+ * @param {boolean} [param0.keepRepoDir]
+ * @param {(span: import('@next/telemetry').Span, installDir: string) => Promise<void>} param0.beforeInstall
+ * @returns {Promise<{installDir: string, pkgPaths: Map<string, string>, tmpRepoDir: string | undefined}>}
+ */
 async function createNextInstall({
   parentSpan,
   dependencies = {},

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -35,7 +35,7 @@ export async function createSandbox(
   next: NextInstance,
   initialFiles?: Map<string, string | ((contents: string) => string)>,
   initialUrl: string = '/',
-  webDriverOptions: WebdriverOptions = undefined
+  webDriverOptions: WebdriverOptions | undefined = undefined
 ) {
   let unwrappedByTypeScriptUsingKeyword = false
 

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -71,7 +71,7 @@ if (testModeFromFile === 'e2e') {
     testMode = 'start'
   }
   assert(
-    validE2EModes.includes(testMode),
+    validE2EModes.includes(testMode!),
     `NEXT_TEST_MODE must be one of ${validE2EModes.join(
       ', '
     )} for e2e tests but received ${testMode}`
@@ -194,6 +194,8 @@ export async function createNext(
         })
       }
 
+      nextInstance = nextInstance!
+
       nextInstance.on('destroy', () => {
         nextInstance = undefined
       })
@@ -204,7 +206,7 @@ export async function createNext(
         await rootSpan
           .traceChild('start next instance')
           .traceAsyncFn(async () => {
-            await nextInstance.start()
+            await nextInstance!.start()
           })
       }
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -79,12 +79,12 @@ export class NextInstance {
   protected childProcess?: ChildProcess
   protected _url: string
   protected _parsedUrl: URL
-  protected packageJson?: PackageJson = {}
+  protected packageJson: PackageJson = {}
   protected basePath?: string
   public env: Record<string, string>
   public forcedPort?: string
   public dirSuffix: string = ''
-  public serverReadyPattern?: RegExp = / ✓ Ready in /
+  public serverReadyPattern: RegExp = / ✓ Ready in /
   patchFileDelay: number = 0
 
   constructor(opts: NextInstanceOpts) {
@@ -96,7 +96,8 @@ export class NextInstance {
         ...this.env,
         // remove node_modules/.bin repo path from env
         // to match CI $PATH value and isolate further
-        PATH: process.env.PATH.split(path.delimiter)
+        PATH: process.env
+          .PATH!.split(path.delimiter)
           .filter((part) => {
             return !part.includes(path.join('node_modules', '.bin'))
           })
@@ -279,7 +280,7 @@ export class NextInstance {
                 await this.beforeInstall(span)
               },
             })
-            this.tmpRepoDir = tmpRepoDir
+            this.tmpRepoDir = tmpRepoDir!
           }
         }
 
@@ -296,7 +297,7 @@ export class NextInstance {
         }
 
         if (this.nextConfig || (isNextDeploy && !nextConfigFile)) {
-          const functions = []
+          const functions: string[] = []
           const exportDeclare =
             this.packageJson?.type === 'module'
               ? 'export default'
@@ -308,7 +309,7 @@ export class NextInstance {
                 {
                   ...this.nextConfig,
                 } as NextConfig,
-                (key, val) => {
+                (key, val: unknown) => {
                   if (typeof val === 'function') {
                     functions.push(
                       val
@@ -324,7 +325,7 @@ export class NextInstance {
                 },
                 2
               ).replace(/"__func_[\d]{1,}"/g, function (str) {
-                return functions.shift()
+                return functions.shift()!
               })
           )
         }
@@ -428,7 +429,10 @@ export class NextInstance {
     await this.writeInitialFiles()
   }
 
-  public async build(): Promise<{ exitCode?: number; cliOutput?: string }> {
+  public async build(): Promise<{
+    exitCode: NodeJS.Signals | number | null
+    cliOutput: string
+  }> {
     throw new Error('Not implemented')
   }
 
@@ -455,7 +459,7 @@ export class NextInstance {
       this.isStopping = true
       const closePromise = once(this.childProcess, 'close')
       await new Promise<void>((resolve) => {
-        treeKill(this.childProcess.pid, signal, (err) => {
+        treeKill(this.childProcess!.pid!, signal, (err) => {
           if (err) {
             require('console').error('tree-kill', err)
           }
@@ -491,7 +495,7 @@ export class NextInstance {
               `${path
                 .relative(
                   path.join(__dirname, '../../'),
-                  process.env.TEST_FILE_PATH
+                  process.env.TEST_FILE_PATH!
                 )
                 .replace(/\//g, '-')}`,
               `next-trace`
@@ -576,7 +580,7 @@ export class NextInstance {
 
   public async patchFile(
     filename: string,
-    content: string | ((content: string) => string),
+    content: string | ((content: string | undefined) => string),
     runWithTempContent?: (context: { newFile: boolean }) => Promise<void>
   ): Promise<{ newFile: boolean }> {
     const outputPath = path.join(this.testDir, filename)

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -36,7 +36,7 @@ export class NextDeployInstance extends NextInstance {
       })
     }
 
-    const vercelFlags = []
+    const vercelFlags: string[] = []
 
     // If the team name is available in the environment, use it as the scope.
     if (TEST_TEAM_NAME) {
@@ -87,7 +87,7 @@ export class NextDeployInstance extends NextInstance {
     }
     require('console').log(`Deploying project at ${this.testDir}`)
 
-    const additionalEnv = []
+    const additionalEnv: string[] = []
 
     for (const key of Object.keys(this.env || {})) {
       additionalEnv.push('--build-env')

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -71,13 +71,13 @@ export class NextDevInstance extends NextInstance {
 
         this._cliOutput = ''
 
-        this.childProcess.stdout.on('data', (chunk) => {
+        this.childProcess.stdout!.on('data', (chunk) => {
           const msg = chunk.toString()
           if (!process.env.CI) process.stdout.write(chunk)
           this._cliOutput += msg
           this.emit('stdout', [msg])
         })
-        this.childProcess.stderr.on('data', (chunk) => {
+        this.childProcess.stderr!.on('data', (chunk) => {
           const msg = chunk.toString()
           if (!process.env.CI) process.stderr.write(chunk)
           this._cliOutput += msg

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -102,7 +102,7 @@ export class NextStartInstance extends NextInstance {
         )
         this.handleStdio(this.childProcess)
         this.childProcess.on('exit', (code, signal) => {
-          this.childProcess = null
+          this.childProcess = undefined
           if (code || signal)
             reject(
               new Error(`next build failed with code/signal ${code || signal}`)
@@ -163,7 +163,7 @@ export class NextStartInstance extends NextInstance {
             this._parsedUrl = new URL(this._url)
           }
 
-          if (this.serverReadyPattern.test(colorStrippedMsg)) {
+          if (this.serverReadyPattern!.test(colorStrippedMsg)) {
             clearTimeout(serverReadyTimeoutId)
             resolve()
             this.off('stdout', readyCb)
@@ -190,7 +190,10 @@ export class NextStartInstance extends NextInstance {
         __NEXT_TEST_MODE: 'e2e',
       },
     }
-    return new Promise((resolve) => {
+    return new Promise<{
+      exitCode: NodeJS.Signals | number | null
+      cliOutput: string
+    }>((resolve) => {
       const curOutput = this._cliOutput.length
       const exportArgs = ['pnpm', 'next', 'build']
 

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -97,12 +97,12 @@ export function initNextServerScript(
       })
     }
 
-    instance.stdout.on('data', handleStdout)
-    instance.stderr.on('data', handleStderr)
+    instance.stdout!.on('data', handleStdout)
+    instance.stderr!.on('data', handleStderr)
 
     instance.on('close', () => {
-      instance.stdout.removeListener('data', handleStdout)
-      instance.stderr.removeListener('data', handleStderr)
+      instance.stdout!.removeListener('data', handleStdout)
+      instance.stderr!.removeListener('data', handleStderr)
     })
 
     instance.on('error', (err) => {
@@ -230,8 +230,8 @@ export function runNextCommand(
   argv: string[],
   options: NextOptions = {}
 ): Promise<{
-  code: number
-  signal: NodeJS.Signals
+  code: number | null
+  signal: NodeJS.Signals | null
   stdout: string
   stderr: string
 }> {
@@ -241,7 +241,8 @@ export function runNextCommand(
   // Let Next.js decide the environment
   const env = {
     ...process.env,
-    NODE_ENV: undefined,
+    // @ts-ignore packages/next/types/global.d.ts should allow undefined NODE_ENV
+    NODE_ENV: undefined as NodeJS.ProcessEnv['NODE_ENV'],
     __NEXT_TEST_MODE: 'true',
     ...options.env,
   }
@@ -267,7 +268,7 @@ export function runNextCommand(
 
     let stderrOutput = ''
     if (options.stderr || options.onStderr) {
-      instance.stderr.on('data', function (chunk) {
+      instance.stderr!.on('data', function (chunk) {
         mergedStdio += chunk
         stderrOutput += chunk
 
@@ -279,14 +280,14 @@ export function runNextCommand(
         }
       })
     } else {
-      instance.stderr.on('data', function (chunk) {
+      instance.stderr!.on('data', function (chunk) {
         mergedStdio += chunk
       })
     }
 
     let stdoutOutput = ''
     if (options.stdout || options.onStdout) {
-      instance.stdout.on('data', function (chunk) {
+      instance.stdout!.on('data', function (chunk) {
         mergedStdio += chunk
         stdoutOutput += chunk
 
@@ -298,7 +299,7 @@ export function runNextCommand(
         }
       })
     } else {
-      instance.stdout.on('data', function (chunk) {
+      instance.stdout!.on('data', function (chunk) {
         mergedStdio += chunk
       })
     }
@@ -363,7 +364,8 @@ export function runNextCommandDev(
   const cwd = opts.cwd || nextDir
   const env = {
     ...process.env,
-    NODE_ENV: undefined,
+    // @ts-ignore packages/next/types/global.d.ts should allow undefined NODE_ENV
+    NODE_ENV: undefined as NodeJS.ProcessEnv['NODE_ENV'],
     __NEXT_TEST_MODE: 'true',
     ...opts.env,
   }
@@ -425,12 +427,12 @@ export function runNextCommandDev(
       }
     }
 
-    instance.stderr.on('data', handleStderr)
-    instance.stdout.on('data', handleStdout)
+    instance.stderr!.on('data', handleStderr)
+    instance.stdout!.on('data', handleStdout)
 
     instance.on('close', () => {
-      instance.stderr.removeListener('data', handleStderr)
-      instance.stdout.removeListener('data', handleStdout)
+      instance.stderr!.removeListener('data', handleStderr)
+      instance.stdout!.removeListener('data', handleStdout)
       if (!didResolve) {
         didResolve = true
         resolve(undefined)
@@ -460,7 +462,7 @@ export function launchApp(
       port as string,
       '--hostname',
       '::',
-    ].filter(Boolean),
+    ].filter((flag: string | undefined): flag is string => Boolean(flag)),
     undefined,
     { ...options, turbo: useTurbo }
   )
@@ -534,8 +536,8 @@ export function buildTS(
       output += chunk.toString()
     }
 
-    instance.stdout.on('data', handleData)
-    instance.stderr.on('data', handleData)
+    instance.stdout!.on('data', handleData)
+    instance.stderr!.on('data', handleData)
 
     instance.on('exit', (code) => {
       if (code) {
@@ -741,7 +743,7 @@ export async function check(
 
 export class File {
   path: string
-  originalContent: string
+  originalContent: string | null
 
   constructor(path: string) {
     this.path = path
@@ -789,7 +791,7 @@ export class File {
   }
 
   restore() {
-    this.write(this.originalContent)
+    this.write(this.originalContent!)
   }
 }
 
@@ -823,6 +825,8 @@ export async function retry<T>(
       await waitFor(interval)
     }
   }
+
+  throw new Error('Duration cannot be less than 0.')
 }
 
 export async function assertHasRedbox(browser: BrowserInterface) {
@@ -1241,7 +1245,7 @@ function runSuite(
     stderr: string
     stdout: string
     appPort: number
-    code: number
+    code: number | null
     server: ChildProcess
   }>,
   options: {
@@ -1340,7 +1344,7 @@ export function findAllTelemetryEvents(output: string, eventName: string) {
   const regex = /\[telemetry\] ({.+?^})/gms
   // Pop the last element of each entry to retrieve contents of the capturing group
   const events = [...output.matchAll(regex)].map((entry) =>
-    JSON.parse(entry.pop())
+    JSON.parse(entry.pop()!)
   )
   return events.filter((e) => e.eventName === eventName).map((e) => e.payload)
 }
@@ -1493,7 +1497,7 @@ export function colorToRgb(color) {
 }
 
 export function getUrlFromBackgroundImage(backgroundImage: string) {
-  const matches = backgroundImage.match(/url\("[^)]+"\)/g).map((match) => {
+  const matches = backgroundImage.match(/url\("[^)]+"\)/g)!.map((match) => {
     // Extract the URL part from each match. The match includes 'url("' and '"")', so we remove those.
     return match.slice(5, -2)
   })

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import { BrowserInterface } from './browsers/base'
 
 if (!process.env.TEST_FILE_PATH) {
-  process.env.TEST_FILE_PATH = module.parent.filename
+  process.env.TEST_FILE_PATH = module.parent!.filename
 }
 
 let deviceIP: string
@@ -15,7 +15,7 @@ if (isBrowserStack) {
   for (const key of Object.keys(nets)) {
     let done = false
 
-    for (const item of nets[key]) {
+    for (const item of nets[key]!) {
       if (item.family === 'IPv4' && !item.internal) {
         deviceIP = item.address
         done = true
@@ -123,9 +123,9 @@ export default async function webdriver(
   const browserName = process.env.BROWSER_NAME || 'chrome'
   await browser.setup(
     browserName,
-    locale,
+    locale!,
     !disableJavaScript,
-    ignoreHTTPSErrors,
+    Boolean(ignoreHTTPSErrors),
     // allow headless to be overwritten for a particular test
     typeof headless !== 'undefined' ? headless : !!process.env.HEADLESS,
     userAgent

--- a/test/lib/test-data-service/writer.ts
+++ b/test/lib/test-data-service/writer.ts
@@ -34,7 +34,7 @@ export function createTestDataServer(
   onRequest: (key: string, response: TestDataResponse) => any
 ): TestDataServer {
   const httpServer = http.createServer(async (req, res) => {
-    const searchParams = new URL(req.url, 'http://n').searchParams
+    const searchParams = new URL(req.url!, 'http://n').searchParams
     const key = searchParams.get('key')
 
     if (typeof key !== 'string') {

--- a/test/lib/test-log.ts
+++ b/test/lib/test-log.ts
@@ -9,7 +9,7 @@
 //
 // Based on the Scheduler.log pattern used in the React repo.
 export function createTestLog() {
-  let events = []
+  let events: unknown[] = []
 
   // Represents a pending waitFor call.
   let pendingExpectation: null | {
@@ -19,7 +19,7 @@ export function createTestLog() {
     error: Error
   } = null
 
-  function log(value: any) {
+  function log(value: unknown) {
     // Add to the event log.
     events.push(value)
 

--- a/test/lib/tsconfig.json
+++ b/test/lib/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["./**/*.ts"],
   "compilerOptions": {
-    "strictNullChecks": false
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
Does not affect existing test utils at runtime. Up to new code to decide whether to be compatible or not. 

Original motivation was to catch `if (page.isClosed)` which should've been `if (page.isClosed())`.