### PR TITLE
test: remove "@testing-library/jest-dom" from default jest setup

### DIFF
--- a/test/integration/link-with-multiple-child/test/index.test.js
+++ b/test/integration/link-with-multiple-child/test/index.test.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import Link from 'next/link'
 
 test('single child', () => {

--- a/test/integration/link-without-router/test/index.test.js
+++ b/test/integration/link-without-router/test/index.test.js
@@ -3,6 +3,7 @@
  */
 import React from 'react'
 import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
 
 import Hello from '../components/hello'
 

--- a/test/jest-setup-after-env.ts
+++ b/test/jest-setup-after-env.ts
@@ -1,6 +1,4 @@
-// @ts-ignore
 import * as matchers from 'jest-extended'
-import '@testing-library/jest-dom'
 expect.extend(matchers)
 
 // A default max-timeout of 90 seconds is allowed

--- a/test/production/jest/rsc/app/client-component.test.jsx
+++ b/test/production/jest/rsc/app/client-component.test.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import Component from './client-component'
 
 it('works with client-only code', () => {

--- a/test/production/jest/rsc/app/component.test.jsx
+++ b/test/production/jest/rsc/app/component.test.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import Component from './component'
 
 it('works with client-only code', () => {

--- a/test/production/jest/rsc/app/page.test.jsx
+++ b/test/production/jest/rsc/app/page.test.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import Page from './page'
 
 it('works with server-only imported code', () => {

--- a/test/production/jest/rsc/app/server-action/page.test.jsx
+++ b/test/production/jest/rsc/app/server-action/page.test.jsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import Page from './page'
 
 it('works with client-only code', () => {

--- a/test/unit/link-warnings.test.tsx
+++ b/test/unit/link-warnings.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { act, render } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import Link from 'next/link'
 import React from 'react'
 

--- a/test/unit/next-dynamic.test.tsx
+++ b/test/unit/next-dynamic.test.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react'
 import { act, render } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import dynamic from 'next/dynamic'
 
 describe('next/dynamic', () => {


### PR DESCRIPTION
We aren't using `'@testing-library/jest-dom'` in 99% of the tests, so there's no point loading it for every test. I've removed it from `jest-setup-after-env` and added the import manually to each file that uses it.