### PR TITLE
test(turbo-tasks-fs): Add a fuzzer for the filesystem watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -51,11 +51,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "serde",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -2587,8 +2587,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3817,7 +3829,7 @@ dependencies = [
  "cssparser-color",
  "dashmap 5.5.3",
  "data-encoding",
- "getrandom",
+ "getrandom 0.2.15",
  "indexmap 2.7.1",
  "itertools 0.10.5",
  "lazy_static",
@@ -4225,7 +4237,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -4237,7 +4249,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -4444,7 +4456,7 @@ dependencies = [
  "next-api",
  "next-core",
  "num_cpus",
- "rand",
+ "rand 0.9.0",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -4572,7 +4584,7 @@ dependencies = [
  "console-subscriber",
  "dashmap 6.1.0",
  "dhat",
- "getrandom",
+ "getrandom 0.2.15",
  "iana-time-zone",
  "indexmap 2.7.1",
  "lightningcss-napi",
@@ -4587,7 +4599,7 @@ dependencies = [
  "once_cell",
  "owo-colors 3.5.0",
  "par-core",
- "rand",
+ "rand 0.9.0",
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
@@ -5169,7 +5181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5332,7 +5344,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5637,6 +5649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,8 +5682,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5675,7 +5704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5684,7 +5723,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -5713,8 +5761,8 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "simd_helpers",
  "system-deps",
  "thiserror 1.0.69",
@@ -5992,7 +6040,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -6102,7 +6150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
  "quote",
- "rand",
+ "rand 0.8.5",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -8926,7 +8974,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -9095,7 +9143,7 @@ dependencies = [
  "http 0.2.11",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -9114,7 +9162,7 @@ dependencies = [
  "http 0.2.11",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -9133,7 +9181,7 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -9152,7 +9200,7 @@ dependencies = [
  "pot",
  "qfilter",
  "quick_cache",
- "rand",
+ "rand 0.9.0",
  "rayon",
  "rustc-hash 2.1.0",
  "serde",
@@ -9257,7 +9305,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pot",
- "rand",
+ "rand 0.9.0",
  "rayon",
  "regex",
  "rustc-hash 2.1.0",
@@ -9382,6 +9430,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbo-tasks-fuzz"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rand 0.9.0",
+ "rustc-hash 2.1.0",
+ "tokio",
+ "turbo-rcstr",
+ "turbo-tasks",
+ "turbo-tasks-backend",
+ "turbo-tasks-build",
+ "turbo-tasks-fs",
+]
+
+[[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
 dependencies = [
@@ -9448,7 +9512,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.0",
  "ref-cast",
  "regex",
  "rstest",
@@ -9532,7 +9596,7 @@ dependencies = [
  "owo-colors 3.5.0",
  "parking_lot",
  "portpicker",
- "rand",
+ "rand 0.9.0",
  "regex",
  "rustc-hash 2.1.0",
  "serde_json",
@@ -10136,7 +10200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -10146,7 +10210,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -10451,7 +10515,7 @@ dependencies = [
  "derivative",
  "dunce",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "indexmap 1.9.3",
  "lazy_static",
  "pin-project-lite",
@@ -10478,7 +10542,7 @@ dependencies = [
  "filetime",
  "fs_extra",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "indexmap 1.9.3",
  "lazy_static",
  "libc",
@@ -10659,12 +10723,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
- "getrandom",
+ "getrandom 0.2.15",
  "js-sys",
  "mdxjs",
  "next-custom-transforms",
@@ -10981,7 +11054,7 @@ dependencies = [
  "bytecheck 0.6.11",
  "enum-iterator",
  "enumset",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "indexmap 2.7.1",
  "more-asserts",
@@ -11037,7 +11110,7 @@ dependencies = [
  "dashmap 6.1.0",
  "derive_more 1.0.0",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "heapless",
  "hex",
  "http 1.1.0",
@@ -11051,7 +11124,7 @@ dependencies = [
  "petgraph 0.6.3",
  "pin-project",
  "pin-utils",
- "rand",
+ "rand 0.8.5",
  "rkyv 0.8.9",
  "rusty_pool",
  "semver 1.0.23",
@@ -11204,7 +11277,7 @@ dependencies = [
  "libc",
  "once_cell",
  "path-clean 1.0.1",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -11630,6 +11703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11730,7 +11812,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -11738,6 +11829,17 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,7 +385,7 @@ pretty_assertions = "1.3.0"
 proc-macro2 = "1.0.79"
 qstring = "0.7.2"
 quote = "1.0.23"
-rand = "0.8.5"
+rand = "0.9.0"
 rayon = "1.10.0"
 regex = "1.10.6"
 reqwest = { version = "=0.11.17", default-features = false }

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -466,7 +466,7 @@ async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completio
     ));
 
     let mut random_buffer = [0u8; 512];
-    rand::thread_rng().fill(&mut random_buffer[..]);
+    rand::rng().fill(&mut random_buffer[..]);
 
     // perform IO directly with tokio (skipping `tokio_tasks_fs`) to avoid the
     // additional noise/overhead of tasks caching, invalidation, file locks,

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -264,7 +264,7 @@ mod tests {
     fn simulate_compactions() {
         let mut rnd = rand::rngs::SmallRng::from_seed([0; 32]);
         let mut keys = (0..1000)
-            .map(|_| rnd.gen_range(0..10000))
+            .map(|_| rnd.random_range(0..10000))
             .collect::<Vec<_>>();
 
         let mut containers = keys
@@ -274,7 +274,7 @@ mod tests {
 
         let mut warm_keys = (0..100)
             .map(|_| {
-                let i = rnd.gen_range(0..keys.len());
+                let i = rnd.random_range(0..keys.len());
                 keys.swap_remove(i)
             })
             .collect::<Vec<_>>();
@@ -310,8 +310,8 @@ mod tests {
 
             // Change some warm keys
             for _ in 0..10 {
-                let i = rnd.gen_range(0..warm_keys.len());
-                let j = rnd.gen_range(0..keys.len());
+                let i = rnd.random_range(0..warm_keys.len());
+                let j = rnd.random_range(0..keys.len());
                 swap(&mut warm_keys[i], &mut keys[j]);
             }
         }

--- a/turbopack/crates/turbo-tasks-backend/src/utils/dash_map_multi.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/dash_map_multi.rs
@@ -215,7 +215,7 @@ mod tests {
         let indicies = (0..THREADS)
             .map(|_| {
                 let mut vec = (0..N).collect::<Vec<_>>();
-                vec.shuffle(&mut rand::thread_rng());
+                vec.shuffle(&mut rand::rng());
                 vec
             })
             .collect::<Vec<_>>();

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -474,7 +474,8 @@ impl DiskFileSystem {
     /// # Arguments
     ///
     /// * `name` - Name of the filesystem.
-    /// * `root` - Path to the given filesystem's root. Should be canonicalized.
+    /// * `root` - Path to the given filesystem's root. Should be
+    ///   [canonicalized][std::fs::canonicalize].
     /// * `ignored_subpaths` - A list of subpaths that should not trigger invalidation. This should
     ///   be a full path, since it is possible that root & project dir is different and requires to
     ///   ignore specific subpaths from each.

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -474,7 +474,7 @@ impl DiskFileSystem {
     /// # Arguments
     ///
     /// * `name` - Name of the filesystem.
-    /// * `root` - Path to the given filesystem's root.
+    /// * `root` - Path to the given filesystem's root. Should be canonicalized.
     /// * `ignored_subpaths` - A list of subpaths that should not trigger invalidation. This should
     ///   be a full path, since it is possible that root & project dir is different and requires to
     ///   ignore specific subpaths from each.

--- a/turbopack/crates/turbo-tasks-fuzz/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fuzz/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "turbo-tasks-fuzz"
+version = "0.0.0"
+description = "A collection of fuzzers for `turbo-tasks`"
+license = "MIT"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+rand = { workspace = true, features = ["thread_rng"] }
+rustc-hash = { workspace = true }
+tokio = { workspace = true }
+turbo-rcstr = { workspace = true }
+turbo-tasks = { workspace = true }
+turbo-tasks-backend = { workspace = true }
+turbo-tasks-fs = { workspace = true }
+
+[build-dependencies]
+turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fuzz/build.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/build.rs
@@ -1,0 +1,5 @@
+use turbo_tasks_build::generate_register;
+
+fn main() {
+    generate_register();
+}

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -1,0 +1,258 @@
+use std::{
+    fs::OpenOptions,
+    io::Write,
+    iter,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use clap::{Args, Parser, Subcommand};
+use rand::{Rng, RngCore, SeedableRng};
+use rustc_hash::FxHashSet;
+use tokio::time::sleep;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, TransientInstance, Vc};
+use turbo_tasks_backend::{noop_backing_storage, BackendOptions, TurboTasksBackend};
+use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
+
+/// A collection of fuzzers for `turbo-tasks`. These are not test cases as they're slow and (in many
+/// cases) non-deterministic.
+///
+/// It's recommend you build this with `--release`.
+///
+/// This is its own crate to avoid littering other crates with binary-only dependencies
+/// <https://github.com/rust-lang/cargo/issues/1982>.
+#[derive(Parser)]
+#[command()]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Continuously fuzzes the filesystem watcher until ctrl+c'd.
+    FsWatcher(FsWatcher),
+}
+
+#[derive(Args)]
+struct FsWatcher {
+    #[arg(long)]
+    fs_root: PathBuf,
+    #[arg(long, default_value_t = 4)]
+    depth: usize,
+    #[arg(long, default_value_t = 6)]
+    width: usize,
+    #[arg(long, default_value_t = 100)]
+    notify_timeout_ms: u64,
+    #[arg(long, default_value_t = 200)]
+    file_modifications: u32,
+    #[arg(long, default_value_t = 2)]
+    directory_modifications: u32,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    register();
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::FsWatcher(args) => fuzz_fs_watcher(args).await,
+    }
+}
+
+#[derive(Default, NonLocalValue, TraceRawVcs)]
+struct PathInvalidations(#[turbo_tasks(trace_ignore)] Arc<Mutex<FxHashSet<RcStr>>>);
+
+async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
+    std::fs::create_dir(&args.fs_root)?;
+    let fs_root = args.fs_root.canonicalize()?;
+    let _guard = FsCleanup {
+        path: &fs_root.clone(),
+    };
+
+    let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions::default(),
+        noop_backing_storage(),
+    ));
+    tt.run_once(async move {
+        let invalidations = TransientInstance::new(PathInvalidations::default());
+        let fs_root_rcstr = RcStr::from(fs_root.to_str().unwrap());
+        let project_fs = disk_file_system_operation(fs_root_rcstr.clone())
+            .resolve_strongly_consistent()
+            .await?;
+        let project_root = disk_file_system_root_operation(project_fs)
+            .resolve_strongly_consistent()
+            .await?;
+        create_directory_tree(&mut FxHashSet::default(), &fs_root, args.depth, args.width)?;
+
+        project_fs.await?.start_watching(None).await?;
+
+        let read_all_paths_op =
+            read_all_paths_operation(invalidations.clone(), project_root, args.depth, args.width);
+        read_all_paths_op.read_strongly_consistent().await?;
+        {
+            let mut invalidations = invalidations.0.lock().unwrap();
+            println!("read all {} files", invalidations.len());
+            invalidations.clear();
+        }
+
+        let mut rand_buf = [0; 16];
+        let mut rng = rand::rngs::SmallRng::from_rng(&mut rand::rng());
+        loop {
+            let mut modified_file_paths = FxHashSet::default();
+            for _ in 0..args.file_modifications {
+                let path = fs_root.join(pick_random_file(args.depth, args.width));
+                let mut f = OpenOptions::new().write(true).truncate(true).open(&path)?;
+                rng.fill_bytes(&mut rand_buf);
+                f.write_all(&rand_buf)?;
+                f.flush()?;
+                modified_file_paths.insert(path);
+            }
+            for _ in 0..args.directory_modifications {
+                let dir = pick_random_directory(args.depth, args.width);
+                let path = fs_root.join(dir.path);
+                std::fs::remove_dir_all(&path)?;
+                std::fs::create_dir(&path)?;
+                create_directory_tree(
+                    &mut modified_file_paths,
+                    &path,
+                    args.depth - dir.depth,
+                    args.width,
+                )?;
+            }
+            // there's no way to know when we've received all the pending events from the operating
+            // system, so just sleep and pray
+            sleep(Duration::from_millis(args.notify_timeout_ms)).await;
+            read_all_paths_op.read_strongly_consistent().await?;
+            {
+                let mut invalidations = invalidations.0.lock().unwrap();
+                println!(
+                    "modified {} files and found {} invalidations",
+                    modified_file_paths.len(),
+                    invalidations.len()
+                );
+                invalidations.clear();
+            }
+        }
+    })
+    .await
+}
+
+#[turbo_tasks::function(operation)]
+fn disk_file_system_operation(fs_root: RcStr) -> Vc<DiskFileSystem> {
+    DiskFileSystem::new("project".into(), fs_root, Vec::new())
+}
+
+#[turbo_tasks::function(operation)]
+fn disk_file_system_root_operation(fs: ResolvedVc<DiskFileSystem>) -> Vc<FileSystemPath> {
+    fs.root()
+}
+
+#[turbo_tasks::function]
+async fn read_path(
+    invalidations: TransientInstance<PathInvalidations>,
+    path: ResolvedVc<FileSystemPath>,
+) -> anyhow::Result<()> {
+    let path_str = path.await?.path.clone();
+    invalidations.0.lock().unwrap().insert(path_str);
+    let _ = path.track().await?;
+    Ok(())
+}
+
+#[turbo_tasks::function(operation)]
+async fn read_all_paths_operation(
+    invalidations: TransientInstance<PathInvalidations>,
+    root: ResolvedVc<FileSystemPath>,
+    depth: usize,
+    width: usize,
+) -> anyhow::Result<()> {
+    async fn read_all_paths_inner(
+        invalidations: TransientInstance<PathInvalidations>,
+        parent: ResolvedVc<FileSystemPath>,
+        depth: usize,
+        width: usize,
+    ) -> anyhow::Result<()> {
+        for child_id in 0..width {
+            let child_name = RcStr::from(child_id.to_string());
+            let child_path = parent.join(child_name).to_resolved().await?;
+            if depth == 1 {
+                read_path(invalidations.clone(), *child_path).await?;
+            } else {
+                Box::pin(read_all_paths_inner(
+                    invalidations.clone(),
+                    child_path,
+                    depth - 1,
+                    width,
+                ))
+                .await?;
+            }
+        }
+        Ok(())
+    }
+    read_all_paths_inner(invalidations, root, depth, width).await
+}
+
+fn create_directory_tree(
+    modified_file_paths: &mut FxHashSet<PathBuf>,
+    parent: &Path,
+    depth: usize,
+    width: usize,
+) -> anyhow::Result<()> {
+    let mut rng = rand::rng();
+    let mut rand_buf = [0; 16];
+    for child_id in 0..width {
+        let child_name = child_id.to_string();
+        let child_path = parent.join(&child_name);
+        if depth == 1 {
+            let mut f = std::fs::File::create(&child_path)?;
+            rng.fill_bytes(&mut rand_buf);
+            f.write_all(&rand_buf)?;
+            f.flush()?;
+            modified_file_paths.insert(child_path);
+        } else {
+            std::fs::create_dir(&child_path)?;
+            create_directory_tree(modified_file_paths, &child_path, depth - 1, width)?;
+        }
+    }
+    Ok(())
+}
+
+fn pick_random_file(depth: usize, width: usize) -> PathBuf {
+    let mut rng = rand::rng();
+    iter::repeat_with(|| rng.random_range(0..width).to_string())
+        .take(depth)
+        .collect()
+}
+
+struct RandomDirectory {
+    depth: usize,
+    path: PathBuf,
+}
+
+fn pick_random_directory(max_depth: usize, width: usize) -> RandomDirectory {
+    let mut rng = rand::rng();
+    // never use a depth of 0 because that would be the root directory
+    let depth = rng.random_range(1..(max_depth - 1));
+    let path = iter::repeat_with(|| rng.random_range(0..width).to_string())
+        .take(depth)
+        .collect();
+    RandomDirectory { depth, path }
+}
+
+struct FsCleanup<'a> {
+    path: &'a Path,
+}
+
+impl Drop for FsCleanup<'_> {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(self.path).unwrap();
+    }
+}
+
+fn register() {
+    turbo_tasks::register();
+    turbo_tasks_fs::register();
+    include!(concat!(env!("OUT_DIR"), "/register.rs"));
+}

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/loom_tests.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/loom_tests.rs
@@ -250,8 +250,8 @@ fn fuzzy_loom(#[case] seed: u32, #[case] count: u32) {
 
                 // setup graph
                 for _ in 0..20 {
-                    let parent = r.gen_range(0..nodes.len() - 1);
-                    let child = r.gen_range(parent + 1..nodes.len());
+                    let parent = r.random_range(0..nodes.len() - 1);
+                    let child = r.random_range(parent + 1..nodes.len());
                     let parent_node = nodes[parent].clone();
                     let child_node = nodes[child].clone();
                     parent_node.add_child(&ctx, child_node);
@@ -259,8 +259,8 @@ fn fuzzy_loom(#[case] seed: u32, #[case] count: u32) {
 
                 let mut edges = Vec::new();
                 for _ in 0..2 {
-                    let parent = r.gen_range(0..nodes.len() - 1);
-                    let child = r.gen_range(parent + 1..nodes.len());
+                    let parent = r.random_range(0..nodes.len() - 1);
+                    let child = r.random_range(parent + 1..nodes.len());
                     let parent_node = nodes[parent].clone();
                     let child_node = nodes[child].clone();
                     edges.push((parent_node, child_node));

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/tests.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/tests.rs
@@ -1035,14 +1035,14 @@ fn fuzzy(#[case] seed: u32, #[case] count: u32) {
     let mut edges = FxIndexSet::default();
 
     for _ in 0..1000 {
-        match r.gen_range(0..=2) {
+        match r.random_range(0..=2) {
             0 | 1 => {
                 // if x == 47 {
                 //     print_all(&ctx, nodes.iter().cloned().map(NodeRef), true);
                 // }
                 // add edge
-                let parent = r.gen_range(0..nodes.len() - 1);
-                let child = r.gen_range(parent + 1..nodes.len());
+                let parent = r.random_range(0..nodes.len() - 1);
+                let child = r.random_range(parent + 1..nodes.len());
                 // println!("add edge {} -> {}", parent, child);
                 if edges.insert((parent, child)) {
                     nodes[parent].add_child(&ctx, nodes[child].clone());
@@ -1053,7 +1053,7 @@ fn fuzzy(#[case] seed: u32, #[case] count: u32) {
                 if edges.is_empty() {
                     continue;
                 }
-                let i = r.gen_range(0..edges.len());
+                let i = r.random_range(0..edges.len());
                 let (parent, child) = edges.swap_remove_index(i).unwrap();
                 // println!("remove edge {} -> {}", parent, child);
                 nodes[parent].remove_child(&ctx, &nodes[child]);

--- a/turbopack/crates/turbopack-bench/src/util/module_picker.rs
+++ b/turbopack/crates/turbopack-bench/src/util/module_picker.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rand::{rngs::StdRng, seq::IndexedRandom, SeedableRng};
 use rustc_hash::FxHashMap;
 
 /// Picks modules at random, but with a fixed seed so runs are somewhat


### PR DESCRIPTION
Adds a very basic fuzzer for the filesystem watcher.

This already reveals that there's some undiagnosed bug with not re-watching deleted-and-recreated directories on Linux that does not occur on macos:

**Debian:**
![Screenshot 2025-04-14 at 11.59.14 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/e5b26a76-0f9e-4623-9d56-b97115314041.png)

**macos:**
![Screenshot 2025-04-14 at 12.03.19 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/ccbbf4b8-ab32-4489-b240-45206e9f0f66.png)

Closes PACK-4355