### PR TITLE
Skip failing test via manifest instead

### DIFF
--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -3,6 +3,8 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
+
+// Skip on Turbopack because the user should create the layout manually
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'app-dir create root layout',
   () => {

--- a/test/production/app-dir/browser-chunks/browser-chunks.test.ts
+++ b/test/production/app-dir/browser-chunks/browser-chunks.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup } from 'e2e-utils'
 import { SourceMapPayload } from 'module'
 

--- a/test/production/edge-config-validations/index.test.ts
+++ b/test/production/edge-config-validations/index.test.ts
@@ -1,39 +1,31 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('Edge config validations', () => {
-  let next: NextInstance
-
-  afterAll(() => next.destroy())
-  ;(process.env.IS_TURBOPACK_TEST ? it.skip : it)(
-    'fails to build when unstable_allowDynamic is not a string',
-    async () => {
-      next = await createNext({
-        skipStart: true,
-        files: {
-          'pages/index.js': `
+  const { next } = nextTestSetup({
+    skipStart: true,
+    skipDeployment: true,
+    files: {
+      'pages/index.js': `
           export default function Page() { 
             return <p>hello world</p>
           } 
         `,
-          'middleware.js': `
+      'middleware.js': `
           import { NextResponse } from 'next/server'
           export default async function middleware(request) {
             return NextResponse.next()
           }
 
-          eval('toto')
-
           export const config = { unstable_allowDynamic: true }
         `,
-        },
-      })
-      // eslint-disable-next-line jest/no-standalone-expect
-      await expect(next.start()).rejects.toThrow('next build failed')
-      // eslint-disable-next-line jest/no-standalone-expect
-      expect(next.cliOutput).toMatch(
-        '/middleware contains invalid middleware config: Expected string, received boolean at "unstable_allowDynamic", or Expected array, received boolean at "unstable_allowDynamic"'
-      )
-    }
-  )
+    },
+  })
+
+  it('fails to build when unstable_allowDynamic is not a string', async () => {
+    const res = await next.build()
+    expect(res.exitCode).toBe(1)
+    expect(res.cliOutput).toContain(
+      '/middleware contains invalid middleware config: Expected string, received boolean at "unstable_allowDynamic", or Expected array, received boolean at "unstable_allowDynamic"'
+    )
+  })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -18486,10 +18486,10 @@
   },
   "test/production/edge-config-validations/index.test.ts": {
     "passed": [],
-    "failed": [],
-    "pending": [
+    "failed": [
       "Edge config validations fails to build when unstable_allowDynamic is not a string"
     ],
+    "pending": [],
     "flakey": [],
     "runtimeError": false
   },


### PR DESCRIPTION
Skip another test via the manifest instead

Turbopack still doesn't print the `middleware contains invalid middleware config: Expected string` error

Closes #76979

Closes PACK-4360