### PR TITLE
Migrate pages API routes to handler interface

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -673,5 +673,6 @@
   "672": "Expected `telemetry` to be set in globals",
   "673": "Thrown value was ignored. This is a bug in Next.js.",
   "674": "Route \"%s\" has a \\`generateViewport\\` that depends on Request data (\\`cookies()\\`, etc...) or uncached external data (\\`fetch(...)\\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
-  "675": "Expected `generateMetadata` not to block the application shell but it did."
+  "675": "Expected `generateMetadata` not to block the application shell but it did.",
+  "676": "Invariant: missing internal router-server-methods this is an internal bug"
 }

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -67,7 +67,7 @@ async function loadManifest(key: string, loader: () => Promise<any>) {
 export async function handler(
   req: IncomingMessage,
   res: ServerResponse,
-  _ctx: {
+  ctx: {
     waitUntil?: (prom: Promise<void>) => void
   }
 ): Promise<void> {
@@ -270,5 +270,10 @@ export async function handler(
     // this is technically an invariant as error handling
     // should be done inside of api-resolver onError
     sendError(res as NextApiResponse, 500, 'Internal Server Error')
+  } finally {
+    // We don't allow any waitUntil work in pages API routes currently
+    // so if callback is present return with resolved promise since no
+    // pending work
+    ctx.waitUntil?.(Promise.resolve())
   }
 }

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -1,10 +1,36 @@
-import { PagesAPIRouteModule } from '../../server/route-modules/pages-api/module.compiled'
+import type { NextApiResponse } from '../../types'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
 import { RouteKind } from '../../server/route-kind'
+import { sendError } from '../../server/api-utils'
+import { PagesAPIRouteModule } from '../../server/route-modules/pages-api/module.compiled'
+import fs from 'node:fs'
+import path from 'node:path'
+import { parse } from 'node:url'
 
 import { hoist } from './helpers'
 
 // Import the userland code.
 import * as userland from 'VAR_USERLAND'
+import { getTracer, SpanKind } from '../../server/lib/trace/tracer'
+import type { Span } from '../../server/lib/trace/tracer'
+import { BaseServerSpan } from '../../server/lib/trace/constants'
+import {
+  ensureInstrumentationRegistered,
+  instrumentationOnRequestError,
+} from '../../server/lib/router-utils/instrumentation-globals.external'
+import type { InstrumentationOnRequestError } from '../../server/instrumentation/types'
+import { getUtils } from '../../server/server-utils'
+import { PRERENDER_MANIFEST, ROUTES_MANIFEST } from '../../api/constants'
+import { isDynamicRoute } from '../../shared/lib/router/utils'
+import type { BaseNextRequest } from '../../server/base-http'
+import {
+  RouterServerContextSymbol,
+  routerServerGlobal,
+} from '../../server/lib/router-utils/router-server-context'
+import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
+import { normalizeLocalePath } from '../../shared/lib/i18n/normalize-locale-path'
+import type { PrerenderManifest, RoutesManifest } from '..'
 
 // Re-export the handler (should be the default export).
 export default hoist(userland, 'default')
@@ -13,7 +39,7 @@ export default hoist(userland, 'default')
 export const config = hoist(userland, 'config')
 
 // Create and export the route module that will be consumed.
-export const routeModule = new PagesAPIRouteModule({
+const routeModule = new PagesAPIRouteModule({
   definition: {
     kind: RouteKind.PAGES_API,
     page: 'VAR_DEFINITION_PAGE',
@@ -24,3 +50,225 @@ export const routeModule = new PagesAPIRouteModule({
   },
   userland,
 })
+
+const loadedManifests = new Map<string, any>()
+
+async function loadManifest(key: string, loader: () => Promise<any>) {
+  const cached = loadedManifests.get(key)
+
+  if (cached) {
+    return cached
+  }
+  const currentManifest = await loader()
+  loadedManifests.set(key, currentManifest)
+  return currentManifest
+}
+
+export async function handler(
+  req: IncomingMessage,
+  res: ServerResponse,
+  _ctx: {
+    waitUntil?: (prom: Promise<void>) => void
+  }
+): Promise<void> {
+  const dir =
+    routerServerGlobal[RouterServerContextSymbol]?.dir || process.cwd()
+  const distDir = process.env.__NEXT_RELATIVE_DIST_DIR || ''
+  const isDev = process.env.NODE_ENV === 'development'
+
+  const routesManifest: RoutesManifest = await loadManifest(
+    ROUTES_MANIFEST,
+    async () =>
+      JSON.parse(
+        await fs.promises.readFile(
+          path.join(dir, distDir, ROUTES_MANIFEST),
+          'utf8'
+        )
+      )
+  )
+  const prerenderManifest: PrerenderManifest = await loadManifest(
+    PRERENDER_MANIFEST,
+    async () =>
+      JSON.parse(
+        await fs.promises.readFile(
+          path.join(dir, distDir, PRERENDER_MANIFEST),
+          'utf8'
+        )
+      )
+  )
+  let srcPage = 'VAR_DEFINITION_PAGE'
+
+  // turbopack doesn't normalize `/index` in the page name
+  // so we need to to process dynamic routes properly
+  if (process.env.TURBOPACK) {
+    srcPage = srcPage.replace(/\/index$/, '')
+  }
+
+  // We need to parse dynamic route params
+  // and do URL normalization here.
+  // TODO: move this into server-utils for re-use
+  const { basePath, i18n, rewrites } = routesManifest
+
+  if (basePath) {
+    req.url = removePathPrefix(req.url || '/', basePath)
+  }
+
+  if (i18n) {
+    const urlParts = (req.url || '/').split('?')
+    const localeResult = normalizeLocalePath(urlParts[0] || '/', i18n.locales)
+
+    if (localeResult.detectedLocale) {
+      req.url = `${localeResult.pathname}${
+        urlParts[1] ? `?${urlParts[1]}` : ''
+      }`
+    }
+  }
+
+  const parsedUrl = parse(req.url || '/', true)
+  const pageIsDynamic = isDynamicRoute(srcPage)
+
+  const serverUtils = getUtils({
+    page: srcPage,
+    i18n,
+    basePath,
+    rewrites: Array.isArray(rewrites)
+      ? { beforeFiles: [], afterFiles: rewrites, fallback: [] }
+      : rewrites || {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [],
+        },
+    pageIsDynamic,
+    trailingSlash: process.env.__NEXT_TRAILING_SLASH as any as boolean,
+    caseSensitive: Boolean(routesManifest.caseSensitive),
+  })
+  const rewriteParamKeys = Object.keys(
+    serverUtils.handleRewrites(req as any as BaseNextRequest, parsedUrl)
+  )
+  serverUtils.normalizeCdnUrl(req as any as BaseNextRequest, [
+    ...rewriteParamKeys,
+    ...Object.keys(serverUtils.defaultRouteRegex?.groups || {}),
+  ])
+
+  const params: Record<string, undefined | string | string[]> =
+    serverUtils.dynamicRouteMatcher
+      ? serverUtils.dynamicRouteMatcher(parsedUrl.pathname || '') || {}
+      : {}
+
+  const query = {
+    ...parsedUrl.query,
+    ...params,
+  }
+  serverUtils.normalizeQueryParams(query)
+
+  if (pageIsDynamic) {
+    const result = serverUtils.normalizeDynamicRouteParams(query, true)
+
+    if (result.hasValidParams) {
+      Object.assign(query, result.params)
+    }
+  }
+
+  // ensure instrumentation is registered and pass
+  // onRequestError below
+  const absoluteDistDir = path.join(dir, distDir)
+  await ensureInstrumentationRegistered(absoluteDistDir)
+
+  try {
+    const method = req.method || 'GET'
+    const tracer = getTracer()
+
+    const activeSpan = tracer.getActiveScopeSpan()
+
+    const invokeRouteModule = async (span?: Span) => {
+      await routeModule
+        .render(req, res, {
+          query,
+          params,
+          allowedRevalidateHeaderKeys: process.env
+            .__NEXT_ALLOWED_REVALIDATE_HEADERS as any as string[],
+          multiZoneDraftMode: Boolean(process.env.__NEXT_MULTI_ZONE_DRAFT_MODE),
+          trustHostHeader: process.env
+            .__NEXT_TRUST_HOST_HEADER as any as boolean,
+          // TODO: get this from from runtime env so manifest
+          // doesn't need to load
+          previewProps: prerenderManifest.preview,
+          propagateError: false,
+          dev: isDev,
+          page: 'VAR_DEFINITION_PAGE',
+
+          onError: (...args: Parameters<InstrumentationOnRequestError>) =>
+            instrumentationOnRequestError(absoluteDistDir, ...args),
+        })
+        .finally(() => {
+          if (!span) return
+
+          span.setAttributes({
+            'http.status_code': res.statusCode,
+            'next.rsc': false,
+          })
+
+          const rootSpanAttributes = tracer.getRootSpanAttributes()
+          // We were unable to get attributes, probably OTEL is not enabled
+          if (!rootSpanAttributes) {
+            return
+          }
+
+          if (
+            rootSpanAttributes.get('next.span_type') !==
+            BaseServerSpan.handleRequest
+          ) {
+            console.warn(
+              `Unexpected root span type '${rootSpanAttributes.get(
+                'next.span_type'
+              )}'. Please report this Next.js issue https://github.com/vercel/next.js`
+            )
+            return
+          }
+
+          const route = rootSpanAttributes.get('next.route')
+          if (route) {
+            const name = `${method} ${route}`
+
+            span.setAttributes({
+              'next.route': route,
+              'http.route': route,
+              'next.span_name': name,
+            })
+            span.updateName(name)
+          } else {
+            span.updateName(`${method} ${req.url}`)
+          }
+        })
+    }
+
+    // TODO: activeSpan code path is for when wrapped by
+    // next-server can be removed when this is no longer used
+    if (activeSpan) {
+      await invokeRouteModule(activeSpan)
+    } else {
+      await tracer.withPropagatedContext(req.headers, () =>
+        tracer.trace(
+          BaseServerSpan.handleRequest,
+          {
+            spanName: `${method} ${req.url}`,
+            kind: SpanKind.SERVER,
+            attributes: {
+              'http.method': method,
+              'http.target': req.url,
+            },
+          },
+          invokeRouteModule
+        )
+      )
+    }
+  } catch (err) {
+    // we re-throw in dev to show the error overlay
+    if (isDev) {
+      throw err
+    }
+    // this is technically an invariant as error handling
+    // should be done inside of api-resolver onError
+    sendError(res as NextApiResponse, 500, 'Internal Server Error')
+  }
+}

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -120,7 +120,7 @@ export async function webpackBuildImpl(
     reactProductionProfiling: NextBuildContext.reactProductionProfiling!,
     noMangling: NextBuildContext.noMangling!,
     clientRouterFilters: NextBuildContext.clientRouterFilters!,
-    previewModeId: NextBuildContext.previewModeId!,
+    previewProps: NextBuildContext.previewProps!,
     allowedRevalidateHeaderKeys: NextBuildContext.allowedRevalidateHeaderKeys!,
     fetchCacheKeyPrefix: NextBuildContext.fetchCacheKeyPrefix!,
   }
@@ -156,14 +156,6 @@ export async function webpackBuildImpl(
           middlewareMatchers: entrypoints.middlewareMatchers,
           compilerType: COMPILER_NAMES.edgeServer,
           entrypoints: entrypoints.edgeServer,
-          edgePreviewProps: {
-            __NEXT_PREVIEW_MODE_ID:
-              NextBuildContext.previewProps!.previewModeId,
-            __NEXT_PREVIEW_MODE_ENCRYPTION_KEY:
-              NextBuildContext.previewProps!.previewModeEncryptionKey,
-            __NEXT_PREVIEW_MODE_SIGNING_KEY:
-              NextBuildContext.previewProps!.previewModeSigningKey,
-          },
           ...info,
         }),
       ])

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -96,6 +96,7 @@ import {
 import { getRspackCore, getRspackReactRefresh } from '../shared/lib/get-rspack'
 import { RspackProfilingPlugin } from './webpack/plugins/rspack-profiling-plugin'
 import getWebpackBundler from '../shared/lib/get-webpack-bundler'
+import type { NextBuildContext } from './build-context'
 
 type ExcludesFalse = <T>(x: T | false) => x is T
 type ClientEntries = {
@@ -312,9 +313,10 @@ export default async function getBaseWebpackConfig(
     supportedBrowsers,
     clientRouterFilters,
     fetchCacheKeyPrefix,
-    edgePreviewProps,
     isCompileMode,
+    previewProps,
   }: {
+    previewProps: NonNullable<(typeof NextBuildContext)['previewProps']>
     isCompileMode?: boolean
     buildId: string
     encryptionKey: string
@@ -336,7 +338,6 @@ export default async function getBaseWebpackConfig(
     jsConfigPath?: string
     resolvedBaseUrl: ResolvedBaseUrl
     supportedBrowsers: string[] | undefined
-    edgePreviewProps?: Record<string, string>
     clientRouterFilters?: {
       staticFilter: ReturnType<
         import('../shared/lib/bloom-filter').BloomFilter['export']
@@ -2010,7 +2011,10 @@ export default async function getBaseWebpackConfig(
           edgeEnvironments: {
             __NEXT_BUILD_ID: buildId,
             NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: encryptionKey,
-            ...edgePreviewProps,
+            __NEXT_PREVIEW_MODE_ID: previewProps.previewModeId,
+            __NEXT_PREVIEW_MODE_SIGNING_KEY: previewProps.previewModeSigningKey,
+            __NEXT_PREVIEW_MODE_ENCRYPTION_KEY:
+              previewProps.previewModeEncryptionKey,
           },
         }),
       isClient &&

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -265,6 +265,21 @@ export function getDefineEnv({
             needsExperimentalReact(config),
         }
       : undefined),
+
+    'process.env.__NEXT_MULTI_ZONE_DRAFT_MODE': JSON.stringify(
+      config.experimental.multiZoneDraftMode
+    ),
+    'process.env.__NEXT_TRUST_HOST_HEADER': JSON.stringify(
+      config.experimental.trustHostHeader
+    ),
+    'process.env.__NEXT_ALLOWED_REVALIDATE_HEADERS': JSON.stringify(
+      config.experimental.allowedRevalidateHeaderKeys
+    ),
+    ...(isNodeServer
+      ? {
+          'process.env.__NEXT_RELATIVE_DIST_DIR': config.distDir,
+        }
+      : {}),
   }
 
   const userDefines = config.compiler?.define ?? {}

--- a/packages/next/src/server/api-utils/node/api-resolver.ts
+++ b/packages/next/src/server/api-utils/node/api-resolver.ts
@@ -3,7 +3,6 @@ import type { NextApiRequest, NextApiResponse } from '../../../shared/lib/utils'
 import type { PageConfig, ResponseLimit } from '../../../types'
 import type { __ApiPreviewProps } from '../.'
 import type { CookieSerializeOptions } from 'next/dist/compiled/cookie'
-import type { ServerOnInstrumentationRequestError } from '../../app-render/types'
 
 import bytes from 'next/dist/compiled/bytes'
 import { generateETag } from '../../lib/etag'
@@ -30,18 +29,16 @@ import {
 } from '../../../lib/constants'
 import { tryGetPreviewData } from './try-get-preview-data'
 import { parseBody } from './parse-body'
-
-type RevalidateFn = (config: {
-  urlPath: string
-  revalidateHeaders: { [key: string]: string | string[] }
-  opts: { unstable_onlyGenerated?: boolean }
-}) => Promise<void>
+import {
+  RouterServerContextSymbol,
+  routerServerGlobal,
+} from '../../lib/router-utils/router-server-context'
+import type { InstrumentationOnRequestError } from '../../instrumentation/types'
 
 type ApiContext = __ApiPreviewProps & {
   trustHostHeader?: boolean
   allowedRevalidateHeaderKeys?: string[]
   hostname?: string
-  revalidate?: RevalidateFn
   multiZoneDraftMode?: boolean
   dev: boolean
 }
@@ -288,7 +285,21 @@ async function revalidate(
     }
   }
 
+  const internalRevalidate =
+    routerServerGlobal[RouterServerContextSymbol]?.revalidate
+
   try {
+    // We use the revalidate in router-server if available.
+    // If we are operating without router-server (serverless)
+    // we must go through network layer with fetch request
+    if (internalRevalidate) {
+      return await internalRevalidate({
+        urlPath,
+        revalidateHeaders,
+        opts,
+      })
+    }
+
     if (context.trustHostHeader) {
       const res = await fetch(`https://${req.headers.host}${urlPath}`, {
         method: 'HEAD',
@@ -307,15 +318,9 @@ async function revalidate(
       ) {
         throw new Error(`Invalid response ${res.status}`)
       }
-    } else if (context.revalidate) {
-      await context.revalidate({
-        urlPath,
-        revalidateHeaders,
-        opts,
-      })
     } else {
       throw new Error(
-        `Invariant: required internal revalidate method not passed to api-utils`
+        `Invariant: missing internal router-server-methods this is an internal bug`
       )
     }
   } catch (err: unknown) {
@@ -334,7 +339,7 @@ export async function apiResolver(
   propagateError: boolean,
   dev?: boolean,
   page?: string,
-  onError?: ServerOnInstrumentationRequestError
+  onError?: InstrumentationOnRequestError
 ): Promise<void> {
   const apiReq = req as NextApiRequest
   const apiRes = res as NextApiResponse
@@ -445,12 +450,20 @@ export async function apiResolver(
       }
     }
   } catch (err) {
-    onError?.(err, req, {
-      routerKind: 'Pages Router',
-      routePath: page || '',
-      routeType: 'route',
-      revalidateReason: undefined,
-    })
+    await onError?.(
+      err,
+      {
+        method: req.method || 'GET',
+        headers: req.headers,
+        path: req.url || '/',
+      },
+      {
+        routerKind: 'Pages Router',
+        routePath: page || '',
+        routeType: 'route',
+        revalidateReason: undefined,
+      }
+    )
 
     if (err instanceof ApiError) {
       sendError(apiRes, err.statusCode, err.message)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1389,7 +1389,7 @@ export default abstract class Server<
           }
 
           if (pageIsDynamic || didRewrite) {
-            utils.normalizeVercelUrl(req, [
+            utils.normalizeCdnUrl(req, [
               ...rewriteParamKeys,
               ...Object.keys(utils.defaultRouteRegex?.groups || {}),
             ])

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -653,6 +653,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
         originalRedirects: this.config._originalRedirects,
         runWebpackSpan: this.hotReloaderSpan,
         appDir: this.appDir,
+        previewProps: this.previewProps,
       }
 
       return webpackConfigSpan
@@ -697,6 +698,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       dev: true,
     })
     const fallbackConfig = await getBaseWebpackConfig(this.dir, {
+      previewProps: this.previewProps,
       runWebpackSpan: this.hotReloaderSpan,
       dev: true,
       compilerType: COMPILER_NAMES.client,

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -51,6 +51,10 @@ import type { ServerInitResult } from './render-server'
 import { filterInternalHeaders } from './server-ipc/utils'
 import { blockCrossSite } from './router-utils/block-cross-site'
 import { traceGlobals } from '../../trace/shared'
+import {
+  RouterServerContextSymbol,
+  routerServerGlobal,
+} from './router-utils/router-server-context'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -645,6 +649,14 @@ export async function initialize(opts: {
 
   // pre-initialize workers
   const handlers = await renderServer.instance.initialize(renderServerOpts)
+
+  // this must come after initialize of render server since it's
+  // using initialized methods
+  routerServerGlobal[RouterServerContextSymbol] = {
+    dir: opts.dir,
+    hostname: handlers.server.hostname,
+    revalidate: handlers.server.revalidate.bind(handlers.server),
+  }
 
   const logError = async (
     type: 'uncaughtException' | 'unhandledRejection',

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -73,24 +73,30 @@ export const buildCustomRoute = <T>(
   item: T & { source: string },
   basePath?: string,
   caseSensitive?: boolean
-): T & { match: PatchMatcher; check?: boolean } => {
+): T & { match: PatchMatcher; check?: boolean; regex: string } => {
   const restrictedRedirectPaths = ['/_next'].map((p) =>
     basePath ? `${basePath}${p}` : p
   )
+  let builtRegex = ''
   const match = getPathMatch(item.source, {
     strict: true,
     removeUnnamedParams: true,
-    regexModifier: !(item as any).internal
-      ? (regex: string) =>
-          modifyRouteRegex(
-            regex,
-            type === 'redirect' ? restrictedRedirectPaths : undefined
-          )
-      : undefined,
+    regexModifier: (regex: string) => {
+      if (!(item as any).internal) {
+        regex = modifyRouteRegex(
+          regex,
+          type === 'redirect' ? restrictedRedirectPaths : undefined
+        )
+      }
+      builtRegex = regex
+      return builtRegex
+    },
     sensitive: caseSensitive,
   })
+
   return {
     ...item,
+    regex: builtRegex,
     ...(type === 'rewrite' ? { check: true } : {}),
     match,
   }

--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -1,0 +1,75 @@
+import path from 'node:path'
+import isError from '../../../lib/is-error'
+import { INSTRUMENTATION_HOOK_FILENAME } from '../../../lib/constants'
+import type {
+  InstrumentationModule,
+  InstrumentationOnRequestError,
+} from '../../instrumentation/types'
+import { interopDefault } from '../../../lib/interop-default'
+
+let cachedInstrumentationModule: InstrumentationModule
+
+export async function getInstrumentationModule(
+  distDir: string
+): Promise<InstrumentationModule | undefined> {
+  if (cachedInstrumentationModule && process.env.NODE_ENV === 'production') {
+    return cachedInstrumentationModule
+  }
+
+  try {
+    cachedInstrumentationModule = interopDefault(
+      await require(
+        path.join(distDir, 'server', `${INSTRUMENTATION_HOOK_FILENAME}.js`)
+      )
+    )
+    return cachedInstrumentationModule
+  } catch (err: unknown) {
+    if (
+      isError(err) &&
+      err.code !== 'ENOENT' &&
+      err.code !== 'MODULE_NOT_FOUND' &&
+      err.code !== 'ERR_MODULE_NOT_FOUND'
+    ) {
+      throw err
+    }
+  }
+}
+
+let instrumentationModulePromise: Promise<any> | null = null
+async function registerInstrumentation(distDir: string) {
+  // Ensure registerInstrumentation is not called in production build
+  if (process.env.NEXT_PHASE === 'phase-production-build') return
+  if (!instrumentationModulePromise) {
+    instrumentationModulePromise = getInstrumentationModule(distDir)
+  }
+  const instrumentation = await instrumentationModulePromise
+  if (instrumentation?.register) {
+    try {
+      await instrumentation.register()
+    } catch (err: any) {
+      err.message = `An error occurred while loading instrumentation hook: ${err.message}`
+      throw err
+    }
+  }
+}
+
+export async function instrumentationOnRequestError(
+  distDir: string,
+  ...args: Parameters<InstrumentationOnRequestError>
+) {
+  const instrumentation = await getInstrumentationModule(distDir)
+  try {
+    await instrumentation?.onRequestError?.(...args)
+  } catch (err) {
+    // Log the soft error and continue, since the original error has already been thrown
+    console.error('Error in instrumentation.onRequestError:', err)
+  }
+}
+
+let registerInstrumentationPromise: Promise<void> | null = null
+export function ensureInstrumentationRegistered(distDir: string) {
+  if (!registerInstrumentationPromise) {
+    registerInstrumentationPromise = registerInstrumentation(distDir)
+  }
+  return registerInstrumentationPromise
+}

--- a/packages/next/src/server/lib/router-utils/router-server-context.ts
+++ b/packages/next/src/server/lib/router-utils/router-server-context.ts
@@ -1,0 +1,25 @@
+export type RevalidateFn = (config: {
+  urlPath: string
+  revalidateHeaders: { [key: string]: string | string[] }
+  opts: { unstable_onlyGenerated?: boolean }
+}) => Promise<void>
+
+// The RouterServerContext contains instance specific
+// information that isn't available/relevant when
+// deployed in serverless environments
+export interface RouterServerContext {
+  dir?: string
+  // hostname the server is started with
+  hostname?: string
+  // revalidate function to bypass going through network
+  // to invoke revalidate request (uses mocked req/res)
+  revalidate?: RevalidateFn
+}
+
+export const RouterServerContextSymbol = Symbol.for(
+  '@next/router-server-methods'
+)
+
+export const routerServerGlobal = globalThis as typeof globalThis & {
+  [RouterServerContextSymbol]?: RouterServerContext
+}

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -18,7 +18,6 @@ import type { Params } from './request/params'
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 import type { RouteMatch } from './route-matches/route-match'
 import type { IncomingMessage, ServerResponse } from 'http'
-import type { PagesAPIRouteModule } from './route-modules/pages-api/module'
 import type { UrlWithParsedQuery } from 'url'
 import type { ParsedUrlQuery } from 'querystring'
 import type { ParsedUrl } from '../shared/lib/router/utils/parse-url'
@@ -39,7 +38,6 @@ import {
   APP_PATHS_MANIFEST,
   SERVER_DIRECTORY,
   NEXT_FONT_MANIFEST,
-  PHASE_PRODUCTION_BUILD,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
   FUNCTIONS_CONFIG_MANIFEST,
 } from '../shared/lib/constants'
@@ -96,7 +94,6 @@ import { pipeToNodeResponse } from './pipe-readable'
 import { createRequestResponseMocks } from './lib/mock-request'
 import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
 import { signalFromNodeResponse } from './web/spec-extension/adapters/next-request'
-import { RouteModuleLoader } from './lib/module-loader/route-module-loader'
 import { loadManifest } from './load-manifest'
 import { lazyRenderAppPage } from './route-modules/app-page/module.render'
 import { lazyRenderPagesPage } from './route-modules/pages/module.render'
@@ -113,6 +110,7 @@ import { initializeCacheHandlers, setCacheHandler } from './use-cache/handlers'
 import type { UnwrapPromise } from '../lib/coalesced-function'
 import { populateStaticEnv } from '../lib/static-env'
 import { isPostpone } from './lib/router-utils/is-postpone'
+import { NodeModuleLoader } from './lib/module-loader/node-module-loader'
 
 export * from './base-server'
 
@@ -654,30 +652,24 @@ export default class NextNodeServer extends BaseServer<
         }
       }
     }
-
     // The module supports minimal mode, load the minimal module.
-    const module = await RouteModuleLoader.load<PagesAPIRouteModule>(
-      match.definition.filename
-    )
+    // Restore original URL as the handler handles it's own parsing
+    const parsedInitUrl = parseUrl(getRequestMeta(req, 'initURL') || req.url)
+    req.url = `${parsedInitUrl.pathname}${parsedInitUrl.search || ''}`
 
-    query = { ...query, ...match.params }
-
-    await module.render(req.originalRequest, res.originalResponse, {
-      previewProps: this.renderOpts.previewProps,
-      revalidate: this.revalidate.bind(this),
-      trustHostHeader: this.nextConfig.experimental.trustHostHeader,
-      allowedRevalidateHeaderKeys:
-        this.nextConfig.experimental.allowedRevalidateHeaderKeys,
-      hostname: this.fetchHostname,
-      minimalMode: this.minimalMode,
-      dev: this.renderOpts.dev === true,
-      query,
-      params: match.params,
-      page: match.definition.pathname,
-      onError: this.instrumentationOnRequestError.bind(this),
-      multiZoneDraftMode: this.nextConfig.experimental.multiZoneDraftMode,
+    const loader = new NodeModuleLoader()
+    const module = (await loader.load(match.definition.filename)) as {
+      handler: (
+        req: IncomingMessage,
+        res: ServerResponse,
+        ctx: {
+          waitUntil: ReturnType<BaseServer['getWaitUntil']>
+        }
+      ) => Promise<void>
+    }
+    await module.handler(req.originalRequest, res.originalResponse, {
+      waitUntil: this.getWaitUntil(),
     })
-
     return true
   }
 
@@ -1847,29 +1839,6 @@ export default class NextNodeServer extends BaseServer<
   private _cachedPreviewManifest: PrerenderManifest | undefined
   protected getPrerenderManifest(): PrerenderManifest {
     if (this._cachedPreviewManifest) {
-      return this._cachedPreviewManifest
-    }
-    if (
-      this.renderOpts?.dev ||
-      this.serverOptions?.dev ||
-      process.env.NODE_ENV === 'development' ||
-      process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
-    ) {
-      this._cachedPreviewManifest = {
-        version: 4,
-        routes: {},
-        dynamicRoutes: {},
-        notFoundRoutes: [],
-        preview: {
-          previewModeId: require('crypto').randomBytes(16).toString('hex'),
-          previewModeSigningKey: require('crypto')
-            .randomBytes(32)
-            .toString('hex'),
-          previewModeEncryptionKey: require('crypto')
-            .randomBytes(32)
-            .toString('hex'),
-        },
-      }
       return this._cachedPreviewManifest
     }
 

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -78,6 +78,10 @@ interface NextWrapperServer {
 
   logError(...args: Parameters<NextNodeServer['logError']>): void
 
+  revalidate(
+    ...args: Parameters<NextNodeServer['revalidate']>
+  ): ReturnType<NextNodeServer['revalidate']>
+
   render(
     ...args: Parameters<NextNodeServer['render']>
   ): ReturnType<NextNodeServer['render']>
@@ -155,6 +159,11 @@ export class NextServer implements NextWrapperServer {
     if (this.server) {
       this.server.logError(...args)
     }
+  }
+
+  async revalidate(...args: Parameters<NextWrapperServer['revalidate']>) {
+    const server = await this.getServer()
+    return server.revalidate(...args)
   }
 
   async render(...args: Parameters<NextWrapperServer['render']>) {
@@ -422,6 +431,10 @@ class NextCustomServer implements NextWrapperServer {
 
   logError(...args: Parameters<NextWrapperServer['logError']>) {
     this.server.logError(...args)
+  }
+
+  async revalidate(...args: Parameters<NextWrapperServer['revalidate']>) {
+    return this.server.revalidate(...args)
   }
 
   async renderToHTML(...args: Parameters<NextWrapperServer['renderToHTML']>) {

--- a/packages/next/src/server/route-modules/pages-api/module.ts
+++ b/packages/next/src/server/route-modules/pages-api/module.ts
@@ -43,17 +43,6 @@ type PagesAPIRouteHandlerContext = RouteModuleHandleContext & {
   res?: ServerResponse
 
   /**
-   * The revalidate method used by the `revalidate` API.
-   *
-   * @param config the configuration for the revalidation
-   */
-  revalidate: (config: {
-    urlPath: string
-    revalidateHeaders: { [key: string]: string | string[] }
-    opts: { unstable_onlyGenerated?: boolean }
-  }) => Promise<void>
-
-  /**
    * The hostname for the request.
    */
   hostname?: string
@@ -84,9 +73,10 @@ type PagesAPIRouteHandlerContext = RouteModuleHandleContext & {
   dev: boolean
 
   /**
-   * True if the server is in minimal mode.
+   * Whether errors should be left uncaught to handle
+   * higher up
    */
-  minimalMode: boolean
+  propagateError: boolean
 
   /**
    * The page that's being rendered.
@@ -149,14 +139,13 @@ export class PagesAPIRouteModule extends RouteModule<
       this.userland,
       {
         ...context.previewProps,
-        revalidate: context.revalidate,
         trustHostHeader: context.trustHostHeader,
         allowedRevalidateHeaderKeys: context.allowedRevalidateHeaderKeys,
         hostname: context.hostname,
         multiZoneDraftMode: context.multiZoneDraftMode,
         dev: context.dev,
       },
-      context.minimalMode,
+      context.propagateError,
       context.dev,
       context.page,
       context.onError

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -21,7 +21,7 @@ import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-
 import { isDynamicRoute } from '../shared/lib/router/utils'
 import {
   interpolateDynamicPath,
-  normalizeVercelUrl,
+  normalizeCdnUrl,
   normalizeDynamicRouteParams,
 } from './server-utils'
 import { getNamedRouteRegex } from '../shared/lib/router/utils/route-regex'
@@ -186,7 +186,7 @@ export default class NextWebServer extends BaseServer<
           normalizedParams,
           routeRegex
         )
-        normalizeVercelUrl(req, Object.keys(routeRegex.routeKeys), routeRegex)
+        normalizeCdnUrl(req, Object.keys(routeRegex.routeKeys), routeRegex)
       }
     }
 

--- a/packages/next/src/server/web/get-edge-preview-props.ts
+++ b/packages/next/src/server/web/get-edge-preview-props.ts
@@ -5,10 +5,7 @@
  */
 export function getEdgePreviewProps() {
   return {
-    previewModeId:
-      process.env.NODE_ENV === 'production'
-        ? process.env.__NEXT_PREVIEW_MODE_ID!
-        : 'development-id',
+    previewModeId: process.env.__NEXT_PREVIEW_MODE_ID || '',
     previewModeSigningKey: process.env.__NEXT_PREVIEW_MODE_SIGNING_KEY || '',
     previewModeEncryptionKey:
       process.env.__NEXT_PREVIEW_MODE_ENCRYPTION_KEY || '',

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -65,29 +65,51 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-
-      expect(stderrOutput).toStartWith(
-        '⨯ ReferenceError: missingVar is not defined' +
-          '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
-          '\n  4 |' +
-          '\n  5 | export async function getStaticProps() {' +
-          '\n> 6 |   missingVar;return {' +
-          '\n    |  ^'
+      if (isTurbopack) {
+        expect(stderrOutput).toContain(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)'
+        )
+      } else {
+        expect(stderrOutput).toStartWith(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)'
+        )
+      }
+      expect(stderr).toContain(
+        '\n  5 | export async function getStaticProps() {' +
+          '\n> 6 |   missingVar;return {'
       )
 
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "ReferenceError: missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime Error",
-          "source": "pages/gsp.js (6:3) @ getStaticProps
-        > 6 |   missingVar;return {
-            |   ^",
-          "stack": [
-            "getStaticProps pages/gsp.js (6:3)",
-          ],
-        }
-      `)
+      if (isTurbopack) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/gsp.js (6:3) @ getStaticProps
+         > 6 |   missingVar;return {
+             |   ^",
+           "stack": [
+             "getStaticProps pages/gsp.js (6:3)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/gsp.js (6:3) @ getStaticProps
+         > 6 |   missingVar;return {
+             |   ^",
+           "stack": [
+             "getStaticProps pages/gsp.js (6:3)",
+           ],
+         }
+        `)
+      }
 
       await fs.writeFile(gspPage, content, { flush: true })
       await assertNoRedbox(browser)
@@ -114,28 +136,51 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      expect(stderrOutput).toStartWith(
-        '⨯ ReferenceError: missingVar is not defined' +
-          '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
-          '\n  4 |' +
-          '\n  5 | export async function getServerSideProps() {' +
-          '\n> 6 |   missingVar;return {' +
-          '\n    |  ^'
+      if (isTurbopack) {
+        expect(stderrOutput).toContain(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)'
+        )
+      } else {
+        expect(stderrOutput).toStartWith(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)'
+        )
+      }
+      expect(stderrOutput).toContain(
+        '\n  5 | export async function getServerSideProps() {' +
+          '\n> 6 |   missingVar;return {'
       )
 
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "ReferenceError: missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime Error",
-          "source": "pages/gssp.js (6:3) @ getServerSideProps
-        > 6 |   missingVar;return {
-            |   ^",
-          "stack": [
-            "getServerSideProps pages/gssp.js (6:3)",
-          ],
-        }
-      `)
+      if (isTurbopack) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/gssp.js (6:3) @ getServerSideProps
+         > 6 |   missingVar;return {
+             |   ^",
+           "stack": [
+             "getServerSideProps pages/gssp.js (6:3)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/gssp.js (6:3) @ getServerSideProps
+         > 6 |   missingVar;return {
+             |   ^",
+           "stack": [
+             "getServerSideProps pages/gssp.js (6:3)",
+           ],
+         }
+        `)
+      }
 
       await fs.writeFile(gsspPage, content)
       await assertNoRedbox(browser)
@@ -162,28 +207,51 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      expect(stderrOutput).toStartWith(
-        '⨯ ReferenceError: missingVar is not defined' +
-          '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
-          '\n  4 |' +
-          '\n  5 | export async function getServerSideProps() {' +
-          '\n> 6 |   missingVar;return {' +
-          '\n    |  ^'
+      if (isTurbopack) {
+        expect(stderrOutput).toContain(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)'
+        )
+      } else {
+        expect(stderrOutput).toStartWith(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)'
+        )
+      }
+      expect(stderrOutput).toContain(
+        '\n  5 | export async function getServerSideProps() {' +
+          '\n> 6 |   missingVar;return {'
       )
 
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "ReferenceError: missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime Error",
-          "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
-        > 6 |   missingVar;return {
-            |   ^",
-          "stack": [
-            "getServerSideProps pages/blog/[slug].js (6:3)",
-          ],
-        }
-      `)
+      if (isTurbopack) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
+         > 6 |   missingVar;return {
+             |   ^",
+           "stack": [
+             "getServerSideProps pages/blog/[slug].js (6:3)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
+         > 6 |   missingVar;return {
+             |   ^",
+           "stack": [
+             "getServerSideProps pages/blog/[slug].js (6:3)",
+           ],
+         }
+        `)
+      }
 
       await fs.writeFile(dynamicGsspPage, content)
     } finally {
@@ -209,44 +277,83 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-
-      expect(stderrOutput).toStartWith(
-        '⨯ ReferenceError: missingVar is not defined' +
-          '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
-          '\n  1 | export default function handler(req, res) {' +
-          "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })" +
-          '\n    |  ^'
+      if (isTurbopack) {
+        expect(stderrOutput).toContain(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)'
+        )
+      } else {
+        expect(stderrOutput).toStartWith(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)'
+        )
+      }
+      expect(stderrOutput).toContain(
+        '\n  1 | export default function handler(req, res) {' +
+          "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })"
       )
 
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "ReferenceError: missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime Error",
-          "source": "pages/api/hello.js (2:3) @ handler
-        > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-            |   ^",
-          "stack": [
-            "handler pages/api/hello.js (2:3)",
-          ],
-        }
-      `)
+      if (isTurbopack) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/hello.js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+             |   ^",
+           "stack": [
+             "handler pages/api/hello.js (2:3)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/hello.js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+             |   ^",
+           "stack": [
+             "handler pages/api/hello.js (2:3)",
+           ],
+         }
+        `)
+      }
 
       await fs.writeFile(apiPage, content)
 
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "ReferenceError: missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime Error",
-          "source": "pages/api/hello.js (2:3) @ handler
-        > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-            |   ^",
-          "stack": [
-            "handler pages/api/hello.js (2:3)",
-          ],
-        }
-      `)
+      if (isTurbopack) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/hello.js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+             |   ^",
+           "stack": [
+             "handler pages/api/hello.js (2:3)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/hello.js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+             |   ^",
+           "stack": [
+             "handler pages/api/hello.js (2:3)",
+           ],
+         }
+        `)
+      }
     } finally {
       await fs.writeFile(apiPage, content)
     }
@@ -270,43 +377,85 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      expect(stderrOutput).toStartWith(
-        '⨯ ReferenceError: missingVar is not defined' +
-          '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
-          '\n  1 | export default function handler(req, res) {' +
-          '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })' +
-          '\n    |  ^'
+      // FIXME(veil): error repeated
+      if (isTurbopack) {
+        expect(stderrOutput).toContain(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)'
+        )
+      } else {
+        expect(stderrOutput).toContain(
+          '⨯ ReferenceError: missingVar is not defined' +
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)'
+        )
+      }
+
+      expect(stderrOutput).toContain(
+        '\n  1 | export default function handler(req, res) {' +
+          '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })'
       )
 
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "ReferenceError: missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime Error",
-          "source": "pages/api/blog/[slug].js (2:3) @ handler
-        > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-            |   ^",
-          "stack": [
-            "handler pages/api/blog/[slug].js (2:3)",
-          ],
-        }
-      `)
+      if (isTurbopack) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/blog/[slug].js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+             |   ^",
+           "stack": [
+             "handler pages/api/blog/[slug].js (2:3)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/blog/[slug].js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+             |   ^",
+           "stack": [
+             "handler pages/api/blog/[slug].js (2:3)",
+           ],
+         }
+        `)
+      }
 
       await fs.writeFile(dynamicApiPage, content)
 
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "ReferenceError: missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime Error",
-          "source": "pages/api/blog/[slug].js (2:3) @ handler
-        > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-            |   ^",
-          "stack": [
-            "handler pages/api/blog/[slug].js (2:3)",
-          ],
-        }
-      `)
+      if (isTurbopack) {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/blog/[slug].js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+             |   ^",
+           "stack": [
+             "handler pages/api/blog/[slug].js (2:3)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "ReferenceError: missingVar is not defined",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "pages/api/blog/[slug].js (2:3) @ handler
+         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+             |   ^",
+           "stack": [
+             "handler pages/api/blog/[slug].js (2:3)",
+           ],
+         }
+        `)
+      }
     } finally {
       await fs.writeFile(dynamicApiPage, content)
     }

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -65,51 +65,29 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)'
-        )
-      } else {
-        expect(stderrOutput).toStartWith(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)'
-        )
-      }
-      expect(stderr).toContain(
-        '\n  5 | export async function getStaticProps() {' +
-          '\n> 6 |   missingVar;return {'
+
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
+          '\n  4 |' +
+          '\n  5 | export async function getStaticProps() {' +
+          '\n> 6 |   missingVar;return {' +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gsp.js (6:3) @ getStaticProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getStaticProps pages/gsp.js (6:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gsp.js (6:3) @ getStaticProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getStaticProps pages/gsp.js (6:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/gsp.js (6:3) @ getStaticProps
+        > 6 |   missingVar;return {
+            |   ^",
+          "stack": [
+            "getStaticProps pages/gsp.js (6:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(gspPage, content, { flush: true })
       await assertNoRedbox(browser)
@@ -136,51 +114,28 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)'
-        )
-      } else {
-        expect(stderrOutput).toStartWith(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)'
-        )
-      }
-      expect(stderrOutput).toContain(
-        '\n  5 | export async function getServerSideProps() {' +
-          '\n> 6 |   missingVar;return {'
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
+          '\n  4 |' +
+          '\n  5 | export async function getServerSideProps() {' +
+          '\n> 6 |   missingVar;return {' +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gssp.js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/gssp.js (6:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gssp.js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/gssp.js (6:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/gssp.js (6:3) @ getServerSideProps
+        > 6 |   missingVar;return {
+            |   ^",
+          "stack": [
+            "getServerSideProps pages/gssp.js (6:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(gsspPage, content)
       await assertNoRedbox(browser)
@@ -207,51 +162,28 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)'
-        )
-      } else {
-        expect(stderrOutput).toStartWith(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)'
-        )
-      }
-      expect(stderrOutput).toContain(
-        '\n  5 | export async function getServerSideProps() {' +
-          '\n> 6 |   missingVar;return {'
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
+          '\n  4 |' +
+          '\n  5 | export async function getServerSideProps() {' +
+          '\n> 6 |   missingVar;return {' +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/blog/[slug].js (6:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/blog/[slug].js (6:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
+        > 6 |   missingVar;return {
+            |   ^",
+          "stack": [
+            "getServerSideProps pages/blog/[slug].js (6:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(dynamicGsspPage, content)
     } finally {
@@ -278,82 +210,56 @@ describe('server-side dev errors', () => {
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
       if (isTurbopack) {
-        expect(stderrOutput).toContain(
+        expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)'
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
+            '\n  1 | export default function handler(req, res) {' +
+            "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })" +
+            '\n    |  ^'
         )
       } else {
         expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)'
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
+            // TODO(veil): Why not ignore-listed?
+            '\n    at '
+        )
+        expect(stderrOutput).toContain(
+          '\n  1 | export default function handler(req, res) {' +
+            "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })" +
+            '\n    |  ^'
         )
       }
-      expect(stderrOutput).toContain(
-        '\n  1 | export default function handler(req, res) {' +
-          "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })"
-      )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/hello.js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+            |   ^",
+          "stack": [
+            "handler pages/api/hello.js (2:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(apiPage, content)
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/hello.js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+            |   ^",
+          "stack": [
+            "handler pages/api/hello.js (2:3)",
+          ],
+        }
+      `)
     } finally {
       await fs.writeFile(apiPage, content)
     }
@@ -377,85 +283,57 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      // FIXME(veil): error repeated
       if (isTurbopack) {
-        expect(stderrOutput).toContain(
+        expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)'
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
+            '\n  1 | export default function handler(req, res) {' +
+            '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })' +
+            '\n    |  ^'
         )
       } else {
-        expect(stderrOutput).toContain(
+        expect(stderrOutput).toStartWith(
           '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)'
+            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
+            // TODO(veil): Why not ignore-listed?
+            '\n    at'
+        )
+        expect(stderrOutput).toContain(
+          '\n  1 | export default function handler(req, res) {' +
+            '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })' +
+            '\n    |  ^'
         )
       }
 
-      expect(stderrOutput).toContain(
-        '\n  1 | export default function handler(req, res) {' +
-          '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })'
-      )
-
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/blog/[slug].js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+            |   ^",
+          "stack": [
+            "handler pages/api/blog/[slug].js (2:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(dynamicApiPage, content)
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/blog/[slug].js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+            |   ^",
+          "stack": [
+            "handler pages/api/blog/[slug].js (2:3)",
+          ],
+        }
+      `)
     } finally {
       await fs.writeFile(dynamicApiPage, content)
     }


### PR DESCRIPTION
This is one of the intial migrations for https://github.com/vercel/next.js/discussions/77740 which starts by adding the `handler` signature for pages API routes. This new `handler` signature will be added for all route types and allows a consistent way to invoke entries. 

This also aims to align all logic to no longer be special cased between minimal mode, standalone mode, and just normal `next start`. All modes will behave and process requests the same at the entry level after this is done. 

Once all route types are migrated `next-server`, `web-server`, and `base-server` will no longer be necessary and a minimal matching layer will be provided to process rewrites/dynamic routes to the related entry instead. 

The changes here we validated against the `vercel/vercel` [test suite here](https://github.com/vercel/vercel/pull/13231) and 