### PR TITLE
perf(turbopack): Skip analysis for modules without external references

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -312,15 +312,13 @@ impl Module for EcmascriptModulePartAsset {
 
         let mut references = vec![];
 
-        let deps = {
-            let part_id = get_part_id(&split_data, &self.part)
-                .await
-                .with_context(|| format!("part {:?} is not found in the module", self.part))?;
+        let part_id = get_part_id(&split_data, &self.part)
+            .await
+            .with_context(|| format!("part {:?} is not found in the module", self.part))?;
 
-            match deps.get(&part_id) {
-                Some(v) => &**v,
-                None => &[],
-            }
+        let deps = match deps.get(&part_id) {
+            Some(v) => &**v,
+            None => &[],
         };
 
         references.extend(

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     ident::AssetIdent,
     module::Module,
     module_graph::ModuleGraph,
-    reference::{ModuleReference, ModuleReferences, SingleModuleReference},
+    reference::{ModuleReference, ModuleReferences},
     resolve::{origin::ResolveOrigin, ModulePart},
 };
 
@@ -24,7 +24,9 @@ use crate::{
         analyse_ecmascript_module, esm::FoundExportType, follow_reexports, FollowExportsResult,
     },
     side_effect_optimization::facade::module::EcmascriptModuleFacadeModule,
-    tree_shake::{side_effect_module::SideEffectsModule, Key},
+    tree_shake::{
+        reference::EcmascriptModulePartReference, side_effect_module::SideEffectsModule, Key,
+    },
     AnalyzeEcmascriptModuleResult, EcmascriptAnalyzable, EcmascriptModuleAsset,
     EcmascriptModuleAssetType, EcmascriptModuleContent, EcmascriptParsable,
 };
@@ -290,10 +292,7 @@ impl Module for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let part_dep = |part: ModulePart| -> Vc<Box<dyn ModuleReference>> {
-            Vc::upcast(SingleModuleReference::new(
-                Vc::upcast(EcmascriptModulePartAsset::new(*self.full_module, part)),
-                Vc::cell("ecmascript module part".into()),
-            ))
+            Vc::upcast(EcmascriptModulePartReference::new(*self.full_module, part))
         };
 
         if let ModulePart::Facade = self.part {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -306,12 +306,13 @@ impl Module for EcmascriptModulePartAsset {
 
         let split_data = split_module(*self.full_module).await?;
 
-        let analyze = analyze(*self.full_module, self.part.clone());
-
         let deps = match &*split_data {
             SplitResult::Ok { deps, .. } => deps,
-            SplitResult::Failed { .. } => return Ok(analyze.references()),
+            // If the module is not split, we don't need to add any references
+            SplitResult::Failed { .. } => return Ok(Vc::cell(vec![])),
         };
+
+        let analyze = analyze(*self.full_module, self.part.clone());
 
         let mut references = analyze.references().owned().await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -449,6 +449,9 @@ pub(crate) enum SplitResult {
         modules: Vec<ResolvedVc<ParseResult>>,
 
         #[turbo_tasks(trace_ignore)]
+        metadata: FxHashMap<u32, PartMetadata>,
+
+        #[turbo_tasks(trace_ignore)]
         deps: FxHashMap<u32, Vec<PartId>>,
 
         #[turbo_tasks(debug_ignore, trace_ignore)]
@@ -457,6 +460,11 @@ pub(crate) enum SplitResult {
     Failed {
         parse_result: ResolvedVc<ParseResult>,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct PartMetadata {
+    pub have_external_references: bool,
 }
 
 impl PartialEq for SplitResult {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -559,6 +559,7 @@ pub(super) async fn split(
             let SplitModuleResult {
                 entrypoints,
                 part_deps,
+                metadata,
                 modules,
                 star_reexports,
             } = dep_graph.split_module(&directives, &items);
@@ -600,6 +601,7 @@ pub(super) async fn split(
                 asset_ident: ident,
                 entrypoints,
                 deps: part_deps,
+                metadata,
                 modules,
                 star_reexports,
             }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -27,6 +27,7 @@ pub mod chunk_item;
 mod graph;
 pub mod merge;
 mod optimizations;
+pub mod reference;
 pub mod side_effect_module;
 #[cfg(test)]
 mod tests;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/reference.rs
@@ -1,0 +1,54 @@
+use anyhow::Result;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbopack_core::{
+    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    reference::ModuleReference,
+    resolve::{ModulePart, ModuleResolveResult},
+};
+
+use crate::{tree_shake::asset::EcmascriptModulePartAsset, EcmascriptModuleAsset};
+
+/// A reference to the [EcmascriptModuleLocalsModule] variant of an original
+/// module.
+#[turbo_tasks::value]
+pub struct EcmascriptModulePartReference {
+    pub module: ResolvedVc<EcmascriptModuleAsset>,
+    pub part: ModulePart,
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptModulePartReference {
+    #[turbo_tasks::function]
+    pub fn new(module: ResolvedVc<EcmascriptModuleAsset>, part: ModulePart) -> Vc<Self> {
+        EcmascriptModulePartReference { module, part }.cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for EcmascriptModulePartReference {
+    #[turbo_tasks::function]
+    async fn to_string(&self) -> Result<Vc<RcStr>> {
+        Ok(Vc::cell(self.part.to_string().into()))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ModuleReference for EcmascriptModulePartReference {
+    #[turbo_tasks::function]
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        let module = EcmascriptModulePartAsset::new(*self.module, self.part.clone())
+            .to_resolved()
+            .await?;
+
+        Ok(*ModuleResolveResult::module(ResolvedVc::upcast(module)))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModuleReference for EcmascriptModulePartReference {
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::ParallelInheritAsync))
+    }
+}


### PR DESCRIPTION
### What?

Do not call `analyzer` for `EcmascriptModulePartAsset` in `references` if the fragment does not have an external reference.

### Why?

It's a waste of time for obvious reason - they don't have external references.

### How?


Closes PACK-4395