### PR TITLE
Document Turbopack trace viewer

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -382,7 +382,7 @@ pub async fn project_new(
             thread::spawn(move || {
                 turbopack_trace_server::start_turbopack_trace_server(trace_file);
             });
-            println!("Turbopack trace server started. View trace at https://turbo-trace-viewer.vercel.app/");
+            println!("Turbopack trace server started. View trace at https://trace.nextjs.org");
         }
 
         subscriber.init();

--- a/docs/01-app/03-building-your-application/06-optimizing/14-local-development.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/14-local-development.mdx
@@ -78,6 +78,8 @@ module.exports = {
 }
 ```
 
+Turbopack automatically analyzes imports and optimizes them. It does not require this configuration.
+
 ### 4. Check your Tailwind CSS setup
 
 If you're using Tailwind CSS, make sure it's set up correctly.
@@ -140,15 +142,36 @@ Use this command to see more detailed information about what's happening during 
 next dev --verbose
 ```
 
-## Still having problems?
+## Turbopack tracing
 
-If you've tried everything and still have issues:
+Turbopack tracing is a tool that helps you understand the performance of your application during local development.
+It provides detailed information about the time taken for each module to compile and how they are related.
 
-1. Create a simple version of your app that shows the problem.
-2. Generate a special file that shows what's happening:
+1. Make sure you have the latest version of Next.js installed.
+1. Generate a Turbopack trace file:
 
    ```bash
-   NEXT_CPU_PROF=1 npm run dev
+   NEXT_TURBOPACK_TRACING=1 npm run dev
    ```
 
-3. Share this file (found in your project's main folder) and the `.next/trace` file on GitHub as a new issue.
+1. Navigate around your application or make edits to files to reproduce the problem.
+1. Stop the Next.js development server.
+1. A file called `trace-turbopack` will be available in the `.next` folder.
+1. You can interpret the file using `next internal trace [path-to-file]`:
+
+   ```bash
+   next internal trace .next/trace-turbopack
+   ```
+
+   On versions where `trace` is not available, the command was named `turbo-trace-server`:
+
+   ```bash
+   next internal turbo-trace-server .next/trace-turbopack
+   ```
+
+1. Once the trace server is running you can view the trace at https://trace.nextjs.org/.
+1. By default the trace viewer will aggregate timings, in order to see each individual time you can switch from "Aggregated in order" to "Spans in order" at the top right of the viewer.
+
+## Still having problems?
+
+Share the trace file generated in the [Turbopack Tracing](#turbopack-tracing) section and share it on [GitHub Discussions](https://github.com/vercel/next.js/discussions) or [Discord](https://nextjs.org/discord).

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -421,7 +421,8 @@ const internal = program
   )
 
 internal
-  .command('turbo-trace-server')
+  .command('trace')
+  .alias('turbo-trace-server')
   .argument('[file]', 'Trace file to serve.')
   .action((file: string) => {
     return import('../cli/internal/turbo-trace-server.js').then((mod) =>

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1250,7 +1250,7 @@ function loadNative(importPath?: string) {
         createProject: bindingToApi(customBindings ?? bindings, false),
         startTurbopackTraceServer(traceFilePath) {
           Log.warn(
-            'Turbopack trace server started. View trace at https://turbo-trace-viewer.vercel.app/'
+            'Turbopack trace server started. View trace at https://trace.nextjs.org'
           )
           ;(customBindings ?? bindings).startTurbopackTraceServer(traceFilePath)
         },


### PR DESCRIPTION
Explains how to run the Turbopack trace viewer. This tool is focused on low-level observability. We use it to optimize Turbopack performance and memory usage. It's also useful for finding slowdowns caused by customization like postcss / custom loaders and such.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-4364