### PR TITLE
Turbopack: dump graph

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -230,8 +230,7 @@ impl SingleModuleGraph {
                         continue;
                     }
                     Some(
-                        SingleModuleGraphBuilderNode::VisitedModule { .. }
-                        | SingleModuleGraphBuilderNode::Issues { .. },
+                        SingleModuleGraphBuilderNode::VisitedModule { .. }, /* | SingleModuleGraphBuilderNode::Issues { .. }, */
                     ) => unreachable!(),
                     None => None,
                 };
@@ -240,7 +239,7 @@ impl SingleModuleGraph {
                     SingleModuleGraphBuilderNode::Module {
                         module,
                         layer,
-                        ident: _,
+                        ident,
                     } => {
                         // Find the current node, if it was already added
                         let current_idx = if let Some(current_idx) = modules.get(&module) {
@@ -249,8 +248,9 @@ impl SingleModuleGraph {
                             let idx = graph.add_node(SingleModuleGraphNode::Module(
                                 SingleModuleGraphModuleNode {
                                     module,
-                                    issues: Default::default(),
                                     layer,
+                                    ident,
+                                    // issues: Default::default(),
                                 },
                             ));
                             number_of_modules += 1;
@@ -282,6 +282,7 @@ impl SingleModuleGraph {
                         target,
                         target_layer,
                         chunking_type,
+                        target_ident,
                         ..
                     } => {
                         // Find the current node, if it was already added
@@ -297,8 +298,9 @@ impl SingleModuleGraph {
                                 None => {
                                     SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
                                         module: target,
-                                        issues: Default::default(),
                                         layer: target_layer,
+                                        ident: target_ident,
+                                        // issues: Default::default(),
                                     })
                                 }
                             });
@@ -306,19 +308,17 @@ impl SingleModuleGraph {
                             idx
                         };
                         graph.add_edge(*modules.get(&source).unwrap(), target_idx, chunking_type);
-                    }
-                    SingleModuleGraphBuilderNode::Issues(new_issues) => {
-                        let (parent_idx, _) = parent_edge.unwrap();
-                        let SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
-                            issues,
-                            ..
-                        }) = graph.node_weight_mut(parent_idx).unwrap()
-                        else {
-                            bail!("Expected Module node");
-                        };
-
-                        issues.extend(new_issues);
-                    }
+                    } /* SingleModuleGraphBuilderNode::Issues(new_issues) => {
+                       * let (parent_idx, _) = parent_edge.unwrap();
+                       * let SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
+                       *     issues,
+                       *     ..
+                       * }) = graph.node_weight_mut(parent_idx).unwrap()
+                       * else {
+                       *     bail!("Expected Module node");
+                       * };
+                       * issues.extend(new_issues);
+                       * } */
                 }
             }
         }
@@ -326,17 +326,120 @@ impl SingleModuleGraph {
         graph.shrink_to_fit();
 
         #[cfg(debug_assertions)]
-        {
-            let mut duplicates = Vec::new();
-            let mut set = FxHashSet::default();
-            for &module in modules.keys() {
-                let ident = module.ident().to_string().await?;
-                if !set.insert(ident.clone()) {
-                    duplicates.push(ident);
+        if std::env::var("TURBOPACK_DUMP_GRAPH") == Ok("1".to_string()) {
+            use std::io::Write;
+
+            use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher};
+
+            struct Escaper<W>(W);
+            impl<W> std::fmt::Write for Escaper<W>
+            where
+                W: std::fmt::Write,
+            {
+                fn write_str(&mut self, s: &str) -> std::fmt::Result {
+                    for c in s.chars() {
+                        self.write_char(c)?;
+                    }
+                    Ok(())
+                }
+
+                fn write_char(&mut self, c: char) -> std::fmt::Result {
+                    match c {
+                        '"' | '\\' => self.0.write_char('\\')?,
+                        // \l is for left justified linebreak
+                        '\n' => return self.0.write_str("\\l"),
+                        _ => {}
+                    }
+                    self.0.write_char(c)
                 }
             }
+            struct Escaped<T>(T);
+            impl<T> std::fmt::Display for Escaped<T>
+            where
+                T: std::fmt::Display,
+            {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    use std::fmt::Write;
+                    if f.alternate() {
+                        writeln!(&mut Escaper(f), "{:#}", &self.0)
+                    } else {
+                        write!(&mut Escaper(f), "{}", &self.0)
+                    }
+                }
+            }
+
+            let mut hash = entries
+                .iter()
+                .flat_map(|e| e.entries())
+                .map(|e| e.ident().to_string())
+                .try_join()
+                .await?;
+            hash.sort();
+            let mut state = Xxh3Hash64Hasher::new();
+            hash.deterministic_hash(&mut state);
+            let filename = format!("module_graph_{:x}.dot", state.finish());
+            println!("writing graph to {:?}", filename);
+            let mut file = std::fs::File::create(filename)?;
+            let dot = petgraph::dot::Dot::with_attr_getters(
+                &graph,
+                &[
+                    petgraph::dot::Config::NodeNoLabel,
+                    petgraph::dot::Config::EdgeNoLabel,
+                ],
+                &|_, e| match e.weight() {
+                    ChunkingType::Parallel | ChunkingType::ParallelInheritAsync => String::new(),
+                    _ => format!(
+                        "label = \"{}\"",
+                        Escaped(match e.weight() {
+                            ChunkingType::Parallel => "Parallel",
+                            ChunkingType::ParallelInheritAsync => "ParallelInheritAsync",
+                            ChunkingType::Async => "Async",
+                            ChunkingType::Isolated { .. } => "Isolated",
+                            ChunkingType::Shared { .. } => "Shared",
+                            ChunkingType::Traced => "Traced",
+                        })
+                    ),
+                },
+                &|_, n| match n.1 {
+                    SingleModuleGraphNode::Module(m) => {
+                        format!("label = \"{}\"", Escaped(&m.ident))
+                    }
+                    SingleModuleGraphNode::VisitedModule { idx, .. } => {
+                        format!(
+                            "label = \"visited {} {}\"",
+                            idx.graph_idx,
+                            idx.node_idx.index()
+                        )
+                    }
+                },
+            );
+            write!(file, "{:?}", dot)?;
+            file.flush()?;
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            let mut set: FxHashMap<ReadRef<RcStr>, FxHashSet<_>> = FxHashMap::default();
+            for &module in modules.keys() {
+                let ident = module.ident().to_string().await?;
+                set.entry(ident).or_default().insert(module);
+            }
+            let duplicates = set
+                .into_iter()
+                .filter_map(|(k, v)| {
+                    if v.len() > 1 {
+                        Some((k, v.into_iter().collect::<Vec<_>>()))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
             if !duplicates.is_empty() {
-                panic!("Duplicate module idents in graph: {:#?}", duplicates);
+                if std::env::var("ABC") == Ok("1".to_string()) {
+                    println!("Duplicate module idents in graph: {:#?}", duplicates);
+                } else {
+                    bail!("Duplicate module idents in graph: {:#?}", duplicates);
+                }
             }
         }
 
@@ -1185,7 +1288,8 @@ impl SingleModuleGraph {
 pub struct SingleModuleGraphModuleNode {
     pub module: ResolvedVc<Box<dyn Module>>,
     pub layer: Option<ReadRef<RcStr>>,
-    pub issues: Vec<ResolvedVc<Box<dyn Issue>>>,
+    // pub issues: Vec<ResolvedVc<Box<dyn Issue>>>,
+    pub ident: ReadRef<RcStr>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
@@ -1251,9 +1355,8 @@ enum SingleModuleGraphBuilderNode {
         module: ResolvedVc<Box<dyn Module>>,
         idx: GraphNodeIndex,
     },
-    /// Issues to be added to the parent Module node
-    #[allow(dead_code)]
-    Issues(Vec<ResolvedVc<Box<dyn Issue>>>),
+    // Issues to be added to the parent Module node
+    // Issues(Vec<ResolvedVc<Box<dyn Issue>>>),
 }
 
 impl SingleModuleGraphBuilderNode {
@@ -1317,7 +1420,7 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
             // Module was already visited previously
             SingleModuleGraphBuilderNode::VisitedModule { .. } => VisitControlFlow::Skip(edge.to),
             // Issues doen't have any children
-            SingleModuleGraphBuilderNode::Issues(_) => VisitControlFlow::Skip(edge.to),
+            // SingleModuleGraphBuilderNode::Issues(_) => VisitControlFlow::Skip(edge.to),
         }
     }
 
@@ -1329,8 +1432,8 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
                 (None, Some(*target))
             }
             // These are always skipped in `visit()`
-            SingleModuleGraphBuilderNode::VisitedModule { .. }
-            | SingleModuleGraphBuilderNode::Issues(_) => unreachable!(),
+            SingleModuleGraphBuilderNode::VisitedModule { .. } => unreachable!(),
+            // SingleModuleGraphBuilderNode::Issues(_) => unreachable!(),
         };
         let visited_modules = self.visited_modules;
         async move {
@@ -1391,9 +1494,9 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
             SingleModuleGraphBuilderNode::Module { ident, .. } => {
                 tracing::info_span!("module", name = display(ident))
             }
-            SingleModuleGraphBuilderNode::Issues(_) => {
-                tracing::info_span!("issues")
-            }
+            // SingleModuleGraphBuilderNode::Issues(_) => {
+            //     tracing::info_span!("issues")
+            // }
             SingleModuleGraphBuilderNode::ChunkableReference {
                 chunking_type,
                 source_ident,


### PR DESCRIPTION
This is by itself only usable for turbopack-tests and reduced test cases, but it's a start.

![Bildschirmfoto 2025-04-15 um 14.15.05.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sjZSbv6AFeuDg7Gb9rma/2d546046-617c-4225-8788-5a34e79b1f91.png)

<!---
digraph {
    0 [ label = "[turbopack-node]/globals.ts [test] (ecmascript)"]
    1 [ label = "[turbopack-node]/ipc/evaluate.ts/evaluate.js { INNER => \"[project]/turbopack/crates/turbopack-tests/js/jest-entry.ts { TESTS => \\\"[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/index.js [test] (ecmascript)\\\" } [test] (ecmascript)\", RUNTIME => \"[turbopack-node]/ipc/evaluate.ts [test] (ecmascript)\" } [test] (ecmascript)"]
    2 [ label = "[turbopack-node]/ipc/evaluate.ts [test] (ecmascript)"]
    3 [ label = "[project]/turbopack/crates/turbopack-tests/js/jest-entry.ts { TESTS => \"[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/index.js [test] (ecmascript)\" } [test] (ecmascript)"]
    4 [ label = "[turbopack-node]/ipc/index.ts [test] (ecmascript)"]
    5 [ label = "[turbopack-node]/compiled/stacktrace-parser/index.js [test] (ecmascript)"]
    6 [ label = "[turbopack-node]/ipc/error.ts [test] (ecmascript)"]
    7 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/index.js [test] (ecmascript)"]
    8 [ label = "[externals]/jest-circus [external] (jest-circus, cjs)"]
    9 [ label = "[externals]/expect [external] (expect, cjs)"]
    10 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/a.js [test] (ecmascript)"]
    11 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/b.js [test] (ecmascript)"]
    12 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/x.js [test] (ecmascript) <export x as c>"]
    13 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/y.js [test] (ecmascript) <locals> <export y as d>"]
    14 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/x.js [test] (ecmascript) <export x as e>"]
    15 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/default.js [test] (ecmascript) <export default as def>"]
    16 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/a.js [test] (ecmascript)"]
    17 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/b.js [test] (ecmascript)"]
    18 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/x.js [test] (ecmascript) <export x as c>"]
    19 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/y.js [test] (ecmascript) <locals> <export y as d>"]
    20 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/x.js [test] (ecmascript) <export x as e>"]
    21 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/index.js [test] (ecmascript) <locals>"]
    22 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/default.js [test] (ecmascript) <export default as def>"]
    23 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-star/a.js [test] (ecmascript)"]
    24 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-star/b.js [test] (ecmascript)"]
    25 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport/index.js [test] (ecmascript) <module evaluation>"]
    26 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-star/index.js [test] (ecmascript) <locals>"]
    27 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport/index.js [test] (ecmascript) <locals>"]
    28 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-unused/index.js [test] (ecmascript) <module evaluation>"]
    29 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-unused/index.js [test] (ecmascript) <locals>"]
    30 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/c.js [test] (ecmascript)"]
    31 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-side-effect/index.js [test] (ecmascript) <module evaluation>"]
    32 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-side-effect/check-side-effect.js [test] (ecmascript)"]
    33 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-tla-side-effect/index.js [test] (ecmascript) <module evaluation>"]
    34 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-tla-side-effect/check-side-effect.js [test] (ecmascript)"]
    35 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-require-side-effect/check-side-effect.js [test] (ecmascript)"]
    36 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/index.js [test] (ecmascript) <module evaluation>"]
    37 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/a.js [test] (ecmascript)"]
    38 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/b.js [test] (ecmascript)"]
    39 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/effect.js [test] (ecmascript)"]
    40 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/local.js [test] (ecmascript)"]
    41 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/reexport.js [test] (ecmascript)"]
    42 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/both.js [test] (ecmascript)"]
    43 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/tla-reexported.js [test] (ecmascript) <export tlaReexported as tlaReexported2>"]
    44 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/index.js [test] (ecmascript)"]
    45 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-require-side-effect/index.js [test] (ecmascript)"]
    46 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/x.js [test] (ecmascript)"]
    47 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/y.js [test] (ecmascript) <locals>"]
    48 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named/default.js [test] (ecmascript)"]
    49 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/x.js [test] (ecmascript)"]
    50 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/y.js [test] (ecmascript) <locals>"]
    51 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-named-local/default.js [test] (ecmascript)"]
    52 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-side-effect/side-effect.js [test] (ecmascript)"]
    53 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-side-effect/side-effect2.js [test] (ecmascript)"]
    54 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-side-effect/index.js [test] (ecmascript) <locals>"]
    55 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-tla-side-effect/side-effect.js [test] (ecmascript)"]
    56 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-tla-side-effect/side-effect2.js [test] (ecmascript)"]
    57 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-reexport-tla-side-effect/index.js [test] (ecmascript) <locals>"]
    58 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/file.side.js [test] (ecmascript)"]
    59 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/sub/file.side.js [test] (ecmascript)"]
    60 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/sub/bare.js [test] (ecmascript)"]
    61 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/dir/file.js [test] (ecmascript)"]
    62 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-partial/index.js [test] (ecmascript) <locals>"]
    63 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/local.js [test] (ecmascript) <module evaluation>"]
    64 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/local.js [test] (ecmascript) <exports>"]
    65 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/reexport.js [test] (ecmascript) <module evaluation>"]
    66 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/reexport.js [test] (ecmascript) <exports>"]
    67 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/both.js [test] (ecmascript) <module evaluation>"]
    68 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/both.js [test] (ecmascript) <exports>"]
    69 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/tla-reexported.js [test] (ecmascript)"]
    70 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/local.js [test] (ecmascript) <locals>"]
    71 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/reexported.js [test] (ecmascript)"]
    72 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/reexport.js [test] (ecmascript) <locals>"]
    73 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/both.js [test] (ecmascript) <locals>"]
    74 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/index.js [test] (ecmascript) <module evaluation>"]
    75 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/index.js [test] (ecmascript) <exports>"]
    76 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-require-side-effect/index.js [test] (ecmascript) <module evaluation>"]
    77 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-require-side-effect/index.js [test] (ecmascript) <exports>"]
    78 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/index.js [test] (ecmascript) <locals>"]
    79 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/a.js [test] (ecmascript)"]
    80 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/b.js [test] (ecmascript)"]
    81 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/x.js [test] (ecmascript)"]
    82 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-full/default.js [test] (ecmascript)"]
    83 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-require-side-effect/side-effect.js [test] (ecmascript)"]
    84 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-require-side-effect/side-effect2.js [test] (ecmascript)"]
    85 [ label = "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-require-side-effect/index.js [test] (ecmascript) <locals>"]
    1 -> 2 [ ]
    1 -> 2 [ ]
    1 -> 3 [ label = "Async"]
    2 -> 4 [ ]
    2 -> 4 [ ]
    4 -> 5 [ ]
    4 -> 5 [ ]
    4 -> 6 [ ]
    4 -> 6 [ ]
    3 -> 7 [ label = "Async"]
    3 -> 8 [ ]
    3 -> 9 [ ]
    7 -> 10 [ ]
    7 -> 11 [ ]
    7 -> 12 [ ]
    7 -> 13 [ ]
    7 -> 14 [ ]
    7 -> 15 [ ]
    7 -> 16 [ ]
    7 -> 17 [ ]
    7 -> 18 [ ]
    7 -> 19 [ ]
    7 -> 20 [ ]
    7 -> 21 [ ]
    7 -> 21 [ ]
    7 -> 22 [ ]
    7 -> 23 [ ]
    7 -> 24 [ ]
    7 -> 25 [ ]
    7 -> 23 [ ]
    7 -> 24 [ ]
    7 -> 26 [ ]
    7 -> 27 [ ]
    7 -> 28 [ ]
    7 -> 29 [ ]
    7 -> 30 [ ]
    7 -> 31 [ ]
    7 -> 23 [ ]
    7 -> 32 [ ]
    7 -> 32 [ ]
    7 -> 33 [ ]
    7 -> 23 [ ]
    7 -> 34 [ ]
    7 -> 34 [ ]
    7 -> 35 [ ]
    7 -> 35 [ ]
    7 -> 36 [ ]
    7 -> 37 [ ]
    7 -> 38 [ ]
    7 -> 39 [ ]
    7 -> 40 [ ]
    7 -> 41 [ ]
    7 -> 42 [ ]
    7 -> 43 [ ]
    7 -> 43 [ ]
    7 -> 44 [ ]
    7 -> 45 [ ]
    7 -> 40 [ label = "Async"]
    7 -> 41 [ label = "Async"]
    7 -> 42 [ label = "Async"]
    12 -> 46 [ ]
    13 -> 47 [ ]
    14 -> 46 [ ]
    15 -> 48 [ ]
    18 -> 49 [ ]
    19 -> 50 [ ]
    20 -> 49 [ ]
    22 -> 51 [ ]
    25 -> 27 [ ]
    28 -> 29 [ ]
    31 -> 52 [ ]
    31 -> 53 [ ]
    31 -> 32 [ ]
    31 -> 54 [ ]
    33 -> 55 [ ]
    33 -> 56 [ ]
    33 -> 34 [ ]
    33 -> 57 [ ]
    36 -> 58 [ ]
    36 -> 59 [ ]
    36 -> 60 [ ]
    36 -> 61 [ ]
    36 -> 62 [ ]
    40 -> 63 [ ]
    40 -> 64 [ ]
    41 -> 65 [ ]
    41 -> 66 [ ]
    42 -> 67 [ ]
    42 -> 68 [ ]
    43 -> 69 [ ]
    52 -> 32 [ ]
    52 -> 32 [ ]
    53 -> 32 [ ]
    53 -> 32 [ ]
    54 -> 52 [ ]
    54 -> 53 [ ]
    54 -> 32 [ ]
    54 -> 32 [ ]
    55 -> 34 [ ]
    55 -> 34 [ ]
    56 -> 34 [ ]
    56 -> 34 [ ]
    57 -> 55 [ ]
    57 -> 56 [ ]
    57 -> 34 [ ]
    57 -> 34 [ ]
    58 -> 39 [ ]
    59 -> 39 [ ]
    60 -> 39 [ ]
    61 -> 39 [ ]
    62 -> 58 [ ]
    62 -> 59 [ ]
    62 -> 60 [ ]
    62 -> 61 [ ]
    63 -> 70 [ ]
    64 -> 71 [ ]
    64 -> 71 [ ]
    64 -> 70 [ ]
    65 -> 72 [ ]
    66 -> 69 [ ]
    66 -> 69 [ ]
    66 -> 72 [ ]
    67 -> 73 [ ]
    68 -> 69 [ ]
    68 -> 69 [ ]
    68 -> 73 [ ]
    44 -> 74 [ ]
    44 -> 75 [ ]
    45 -> 76 [ ]
    45 -> 77 [ ]
    74 -> 78 [ ]
    75 -> 79 [ ]
    75 -> 80 [ ]
    75 -> 30 [ ]
    75 -> 81 [ ]
    75 -> 82 [ ]
    75 -> 78 [ ]
    76 -> 83 [ ]
    76 -> 84 [ ]
    76 -> 35 [ ]
    76 -> 85 [ ]
    77 -> 83 [ ]
    77 -> 85 [ ]
    83 -> 35 [ ]
    83 -> 35 [ ]
    84 -> 35 [ ]
    84 -> 35 [ ]
    85 -> 83 [ ]
    85 -> 84 [ ]
    85 -> 35 [ ]
    85 -> 35 [ ]
}

--->