### PR TITLE
Turbopack: fix duplicate facade module

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3144,7 +3144,6 @@ async fn error_severity(resolve_options: Vc<ResolveOptions>) -> Result<ResolvedV
     })
 }
 
-// TODO this should become a TaskInput instead of a Vc
 /// ModulePart represents a part of a module.
 ///
 /// Currently this is used only for ESMs.

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -828,7 +828,7 @@ impl EcmascriptModuleContent {
                 if let EcmascriptExports::EsmExports(exports) = *exports.await? {
                     Some(
                         exports
-                            .code_generation(*module_graph, *chunking_context, *parsed)
+                            .code_generation(*module_graph, *chunking_context, Some(*parsed))
                             .await?,
                     )
                 } else {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -68,11 +68,7 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
 
         let esm_code_gens = self
             .module
-            .code_generation(
-                *self.module_graph,
-                *chunking_context,
-                *self.module.await?.parsed,
-            )
+            .code_generation(*self.module_graph, *chunking_context)
             .await?;
         let additional_code_gens = [
             self.module
@@ -84,11 +80,7 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
                 )
                 .await?,
             exports
-                .code_generation(
-                    *self.module_graph,
-                    *chunking_context,
-                    *self.module.await?.parsed,
-                )
+                .code_generation(*self.module_graph, *chunking_context, None)
                 .await?,
         ];
         let code_gens = esm_code_gens.iter().chain(additional_code_gens.iter());

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -17,7 +17,7 @@ use super::{
     facade::module::EcmascriptModuleFacadeModule, locals::module::EcmascriptModuleLocalsModule,
 };
 use crate::{
-    chunk::EcmascriptChunkPlaceable, code_gen::CodeGeneration, parse::ParseResult,
+    chunk::EcmascriptChunkPlaceable, code_gen::CodeGeneration,
     references::esm::base::ReferencedAsset, runtime_functions::TURBOPACK_IMPORT,
     utils::module_id_to_lit,
 };
@@ -27,7 +27,6 @@ use crate::{
 #[turbo_tasks::value]
 pub struct EcmascriptModulePartReference {
     pub module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-    pub parsed: ResolvedVc<ParseResult>,
     pub part: Option<ModulePart>,
 }
 
@@ -36,28 +35,18 @@ impl EcmascriptModulePartReference {
     #[turbo_tasks::function]
     pub fn new_part(
         module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-        parsed: ResolvedVc<ParseResult>,
         part: ModulePart,
     ) -> Vc<Self> {
         EcmascriptModulePartReference {
             module,
-            parsed,
             part: Some(part),
         }
         .cell()
     }
 
     #[turbo_tasks::function]
-    pub fn new(
-        module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-        parsed: ResolvedVc<ParseResult>,
-    ) -> Vc<Self> {
-        EcmascriptModulePartReference {
-            module,
-            parsed,
-            part: None,
-        }
-        .cell()
+    pub fn new(module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>) -> Vc<Self> {
+        EcmascriptModulePartReference { module, part: None }.cell()
     }
 }
 
@@ -92,7 +81,7 @@ impl ModuleReference for EcmascriptModulePartReference {
                 | ModulePart::Facade
                 | ModulePart::RenamedExport { .. }
                 | ModulePart::RenamedNamespace { .. } => Vc::upcast(
-                    EcmascriptModuleFacadeModule::new(*self.module, *self.parsed, part.clone()),
+                    EcmascriptModuleFacadeModule::new(*self.module, part.clone()),
                 ),
                 ModulePart::Export(..)
                 | ModulePart::Internal(..)

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -162,7 +162,6 @@ impl EcmascriptModulePartAsset {
                     export_name: new_export,
                     ..
                 } = &*result.await?;
-                let parsed = module.parse();
                 let final_module = if let Some(new_export) = new_export {
                     if *new_export == export {
                         *final_module
@@ -170,7 +169,6 @@ impl EcmascriptModulePartAsset {
                         ResolvedVc::upcast(
                             EcmascriptModuleFacadeModule::new(
                                 **final_module,
-                                parsed,
                                 ModulePart::renamed_export(new_export.clone(), export.clone()),
                             )
                             .to_resolved()
@@ -181,7 +179,6 @@ impl EcmascriptModulePartAsset {
                     ResolvedVc::upcast(
                         EcmascriptModuleFacadeModule::new(
                             **final_module,
-                            parsed,
                             ModulePart::renamed_namespace(export.clone()),
                         )
                         .to_resolved()

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -54,7 +54,6 @@ use turbopack_core::{
 pub use turbopack_css as css;
 pub use turbopack_ecmascript as ecmascript;
 use turbopack_ecmascript::{
-    parse::ParseResult,
     references::external_module::{CachedExternalModule, CachedExternalType},
     tree_shake::asset::EcmascriptModulePartAsset,
 };
@@ -167,7 +166,6 @@ async fn apply_module_type(
                         ))
                     }
                     Some(TreeShakingMode::ReexportsOnly) => {
-                        let parsed = module.parse();
                         if let Some(part) = part {
                             match part {
                                 ModulePart::Evaluation => {
@@ -196,14 +194,12 @@ async fn apply_module_type(
                                                 .resolve()
                                                 .await?,
                                             ),
-                                            parsed,
                                             part,
                                             side_effect_free_packages,
                                         )
                                     } else {
                                         apply_reexport_tree_shaking(
                                             Vc::upcast(module.resolve().await?),
-                                            parsed,
                                             part,
                                             side_effect_free_packages,
                                         )
@@ -280,7 +276,6 @@ async fn apply_module_type(
 #[turbo_tasks::function]
 async fn apply_reexport_tree_shaking(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-    parsed: Vc<ParseResult>,
     part: ModulePart,
     side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<Box<dyn Module>>> {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -174,7 +174,6 @@ async fn apply_module_type(
                                     if *module.get_exports().needs_facade().await? {
                                         Vc::upcast(EcmascriptModuleFacadeModule::new(
                                             Vc::upcast(module),
-                                            parsed,
                                             part,
                                         ))
                                     } else {
@@ -192,7 +191,6 @@ async fn apply_module_type(
                                             Vc::upcast(
                                                 EcmascriptModuleFacadeModule::new(
                                                     Vc::upcast(module),
-                                                    parsed,
                                                     ModulePart::exports(),
                                                 )
                                                 .resolve()
@@ -220,7 +218,6 @@ async fn apply_module_type(
                         } else if *module.get_exports().needs_facade().await? {
                             Vc::upcast(EcmascriptModuleFacadeModule::new(
                                 Vc::upcast(module),
-                                parsed,
                                 ModulePart::facade(),
                             ))
                         } else {
@@ -299,14 +296,12 @@ async fn apply_reexport_tree_shaking(
             } else {
                 Vc::upcast(EcmascriptModuleFacadeModule::new(
                     **final_module,
-                    parsed,
                     ModulePart::renamed_export(new_export.clone(), export.clone()),
                 ))
             }
         } else {
             Vc::upcast(EcmascriptModuleFacadeModule::new(
                 **final_module,
-                parsed,
                 ModulePart::renamed_namespace(export.clone()),
             ))
         };


### PR DESCRIPTION
Previously, the `[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/tla/tla-reexported.js [test] (ecmascript) <export tlaReexported as tlaReexported2>` module was duplicated.

A regression from https://github.com/vercel/next.js/pull/73544
In all of these synthetic modules reexporting modules, the AST isn't actually needed.

Closes PACK-4365