### PR TITLE
[dev-overlay] Move `error.name` to label

### DIFF
--- a/packages/next/src/client/components/errors/console-error.ts
+++ b/packages/next/src/client/components/errors/console-error.ts
@@ -1,12 +1,10 @@
 // To distinguish from React error.digest, we use a different symbol here to determine if the error is from console.error or unhandled promise rejection.
 const digestSym = Symbol.for('next.console.error.digest')
-const consoleTypeSym = Symbol.for('next.console.error.type')
 
 // Represent non Error shape unhandled promise rejections or console.error errors.
 // Those errors will be captured and displayed in Error Overlay.
 export type ConsoleError = Error & {
   [digestSym]: 'NEXT_CONSOLE_ERROR'
-  [consoleTypeSym]: 'string' | 'error'
   environmentName: string
 }
 
@@ -18,7 +16,6 @@ export function createConsoleError(
     typeof message === 'string' ? new Error(message) : message
   ) as ConsoleError
   error[digestSym] = 'NEXT_CONSOLE_ERROR'
-  error[consoleTypeSym] = typeof message === 'string' ? 'string' : 'error'
 
   if (environmentName && !error.environmentName) {
     error.environmentName = environmentName
@@ -29,8 +26,4 @@ export function createConsoleError(
 
 export const isConsoleError = (error: any): error is ConsoleError => {
   return error && error[digestSym] === 'NEXT_CONSOLE_ERROR'
-}
-
-export const getConsoleErrorType = (error: ConsoleError) => {
-  return error[consoleTypeSym]
 }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-type-label/error-type-label.tsx
@@ -1,8 +1,8 @@
 export type ErrorType =
   | 'Build Error'
-  | 'Runtime Error'
-  | 'Console Error'
-  | 'Recoverable Error'
+  | `Runtime ${string}`
+  | `Console ${string}`
+  | `Recoverable ${string}`
 
 type ErrorTypeLabelProps = {
   errorType: ErrorType

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/build-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/build-error.tsx
@@ -19,7 +19,11 @@ const getErrorTextFromBuildErrorMessage = (multiLineMessage: string) => {
   // SyntaxError: ...
   // > 1 | con st foo =
   // ...
-  return stripAnsi(lines[1] || '')
+  return (
+    stripAnsi(lines[1] || '')
+      // label will already say that it's an error
+      .replace(/^Error: /, '')
+  )
 }
 
 export const BuildError: React.FC<BuildErrorProps> = function BuildError({

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -5,10 +5,7 @@ import { RuntimeError } from './runtime-error'
 import { getErrorSource } from '../../../../../shared/lib/error-source'
 import { HotlinkedText } from '../components/hot-linked-text'
 import { PseudoHtmlDiff } from './runtime-error/component-stack-pseudo-html'
-import {
-  isConsoleError,
-  getConsoleErrorType,
-} from '../../../errors/console-error'
+import { isConsoleError } from '../../../errors/console-error'
 import { extractNextErrorCode } from '../../../../../lib/error-telemetry-utils'
 import {
   ErrorOverlayLayout,
@@ -41,14 +38,6 @@ function HydrationErrorDescription({ message }: { message: string }) {
 }
 
 function GenericErrorDescription({ error }: { error: Error }) {
-  const unhandledErrorType = isConsoleError(error)
-    ? getConsoleErrorType(error)
-    : null
-  const isConsoleErrorStringMessage = unhandledErrorType === 'string'
-  // Displaying Error: would be redundant for console.error(message)
-  // since we already have the label
-  const title = isConsoleErrorStringMessage ? '' : error.name + ': '
-
   const environmentName =
     'environmentName' in error ? error.environmentName : ''
   const envPrefix = environmentName ? `[ ${environmentName} ] ` : ''
@@ -62,7 +51,6 @@ function GenericErrorDescription({ error }: { error: Error }) {
 
   return (
     <>
-      {title}
       <HotlinkedText text={message} matcher={isNextjsLink} />
     </>
   )
@@ -70,12 +58,12 @@ function GenericErrorDescription({ error }: { error: Error }) {
 
 function getErrorType(error: Error): ErrorOverlayLayoutProps['errorType'] {
   if (isRecoverableError(error)) {
-    return 'Recoverable Error'
+    return `Recoverable ${error.name}`
   }
   if (isConsoleError(error)) {
-    return 'Console Error'
+    return `Console ${error.name}`
   }
-  return 'Runtime Error'
+  return `Runtime ${error.name}`
 }
 
 const noErrorDetails = {

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -90,7 +90,7 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: no",
+         "description": "no",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (3:7) @ [project]/index.js [app-client] (ecmascript)
@@ -106,7 +106,7 @@ describe('ReactRefreshLogBox app', () => {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (3:7) @ eval
@@ -126,7 +126,7 @@ describe('ReactRefreshLogBox app', () => {
            ],
          },
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (3:7) @ eval
@@ -285,7 +285,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
+         "description": "  x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -368,7 +368,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: ",
+         "description": "",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "Child.js (4:11) @ ClickCount.render
@@ -512,7 +512,7 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: end https://nextjs.org",
+         "description": "end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -531,7 +531,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: end https://nextjs.org",
+         "description": "end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -595,7 +595,7 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: https://nextjs.org start",
+         "description": "https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -614,7 +614,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: https://nextjs.org start",
+         "description": "https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -677,7 +677,7 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: middle https://nextjs.org end",
+         "description": "middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -696,7 +696,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: middle https://nextjs.org end",
+         "description": "middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -759,7 +759,7 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: multiple https://nextjs.org links http://example.com",
+         "description": "multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -778,7 +778,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: multiple https://nextjs.org links http://example.com",
+         "description": "multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -953,7 +953,7 @@ describe('ReactRefreshLogBox app', () => {
       // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: test",
+         "description": "test",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (3:11) @
@@ -972,7 +972,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: test",
+         "description": "test",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (3:11) @ default
@@ -1059,7 +1059,7 @@ describe('ReactRefreshLogBox app', () => {
       // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: Component error",
+         "description": "Component error",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (2:44) @ Index
@@ -1077,7 +1077,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: Component error",
+         "description": "Component error",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (2:44) @ Index
@@ -1114,7 +1114,7 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Client error",
+       "description": "Client error",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "app/page.js (4:11) @ Page
@@ -1145,7 +1145,7 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Server error",
+       "description": "Server error",
        "environmentLabel": "Server",
        "label": "Runtime Error",
        "source": "app/page.js (2:9) @ Page
@@ -1184,7 +1184,7 @@ describe('ReactRefreshLogBox app', () => {
       // TODO(veil): investigate the column number is off by 1 between turbo and webpack
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: This is an error from an anonymous function",
+         "description": "This is an error from an anonymous function",
          "environmentLabel": "Server",
          "label": "Runtime Error",
          "source": "app/page.js (4:13) @ <anonymous>
@@ -1199,7 +1199,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: This is an error from an anonymous function",
+         "description": "This is an error from an anonymous function",
          "environmentLabel": "Server",
          "label": "Runtime Error",
          "source": "app/page.js (4:13) @ eval
@@ -1233,9 +1233,9 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "TypeError: Invalid URL",
+         "description": "Invalid URL",
          "environmentLabel": "Server",
-         "label": "Runtime Error",
+         "label": "Runtime TypeError",
          "source": "app/page.js (2:3) @ Page
        > 2 |   new URL("/", "invalid");
            |   ^",
@@ -1247,9 +1247,9 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "TypeError: Invalid URL",
+         "description": "Invalid URL",
          "environmentLabel": "Server",
-         "label": "Runtime Error",
+         "label": "Runtime TypeError",
          "source": "app/page.js (2:3) @ Page
        > 2 |   new URL("/", "invalid");
            |   ^",
@@ -1281,7 +1281,7 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Server component error",
+       "description": "Server component error",
        "environmentLabel": "Server",
        "label": "Runtime Error",
        "source": "app/page.js (2:9) @ Page
@@ -1320,7 +1320,7 @@ describe('ReactRefreshLogBox app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Server component error!",
+       "description": "Server component error!",
        "environmentLabel": "Server",
        "label": "Runtime Error",
        "source": "app/page.js (2:9) @ Page
@@ -1457,7 +1457,7 @@ describe('ReactRefreshLogBox app', () => {
       } else {
         await expect({ browser, next }).toDisplayRedbox(`
          {
-           "description": "Error: module error",
+           "description": "module error",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (1:7) @ eval
@@ -1517,7 +1517,7 @@ export default function Home() {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: server action was here",
+       "description": "server action was here",
        "environmentLabel": "Server",
        "label": "Runtime Error",
        "source": "app/actions.ts (4:9) @ serverAction
@@ -1565,7 +1565,7 @@ export default function Home() {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: server action was here",
+       "description": "server action was here",
        "environmentLabel": "Server",
        "label": "Runtime Error",
        "source": "app/actions.ts (4:9) @ serverAction
@@ -1609,7 +1609,7 @@ export default function Home() {
       // FIXME: display the sourcemapped stack frames
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: utils error",
+         "description": "utils error",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "app/utils.ts (1:7) @ [project]/app/utils.ts [app-client] (ecmascript)
@@ -1626,7 +1626,7 @@ export default function Home() {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "Error: utils error",
+           "description": "utils error",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "app/utils.ts (1:7) @ eval
@@ -1646,7 +1646,7 @@ export default function Home() {
            ],
          },
          {
-           "description": "Error: utils error",
+           "description": "utils error",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "app/utils.ts (1:7) @ eval

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -47,7 +47,7 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching",
+         "description": "  x "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -56,7 +56,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Unexpected eof",
+         "description": "  x Unexpected eof",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -128,7 +128,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/server/page.js
@@ -192,7 +192,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/client/page.js
@@ -264,7 +264,7 @@ describe('Error recovery app', () => {
       // TODO(veil): Location of Page should be app/page.js
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: oops",
+         "description": "oops",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (7:11) @ Index.useCallback[increment]
@@ -283,7 +283,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: oops",
+         "description": "oops",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (7:11) @ Index.useCallback[increment]
@@ -377,7 +377,7 @@ describe('Error recovery app', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: oops",
+       "description": "oops",
        "environmentLabel": "Server",
        "label": "Runtime Error",
        "source": "child.js (3:9) @ Child
@@ -454,7 +454,7 @@ describe('Error recovery app', () => {
       // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: oops",
+         "description": "oops",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "child.js (3:9) @ Child
@@ -473,7 +473,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: oops",
+         "description": "oops",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "child.js (3:9) @ Child
@@ -544,7 +544,7 @@ describe('Error recovery app', () => {
     await browser.eval('window.triggerError()')
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "description": "Error: no 1",
+       "description": "no 1",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "index.js (7:11) @ eval
@@ -590,7 +590,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -627,7 +627,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -696,9 +696,9 @@ describe('Error recovery app', () => {
       // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "ReferenceError: React is not defined",
+         "description": "React is not defined",
          "environmentLabel": null,
-         "label": "Runtime Error",
+         "label": "Runtime ReferenceError",
          "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -715,9 +715,9 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "ReferenceError: React is not defined",
+         "description": "React is not defined",
          "environmentLabel": null,
-         "label": "Runtime Error",
+         "label": "Runtime ReferenceError",
          "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -800,7 +800,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '{', got 'return'",
+         "description": "  x Expected '{', got 'return'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -856,7 +856,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '{', got 'throw'",
+         "description": "  x Expected '{', got 'throw'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -903,7 +903,7 @@ describe('Error recovery app', () => {
       // <FIXME-file-protocol>: https://linear.app/vercel/issue/NDX-920/
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: nooo",
+         "description": "nooo",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ ClassDefault.render
@@ -921,7 +921,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: nooo",
+         "description": "nooo",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ ClassDefault.render
@@ -959,7 +959,7 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -23,9 +23,9 @@ describe('Error overlay - RSC runtime errors', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "TypeError: useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component",
+       "description": "useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component",
        "environmentLabel": "Server",
-       "label": "Runtime Error",
+       "label": "Runtime TypeError",
        "source": "app/server/page.js (3:16) @ Page
      > 3 |   callClientApi()
          |                ^",
@@ -55,7 +55,7 @@ describe('Error overlay - RSC runtime errors', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: \`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
+         "description": "\`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "app/client/page.js (4:15) @ Page
@@ -69,7 +69,7 @@ describe('Error overlay - RSC runtime errors', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: \`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
+         "description": "\`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "app/client/page.js (4:16) @ Page
@@ -97,9 +97,9 @@ describe('Error overlay - RSC runtime errors', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "ReferenceError: alert is not defined",
+       "description": "alert is not defined",
        "environmentLabel": "Server",
-       "label": "Runtime Error",
+       "label": "Runtime ReferenceError",
        "source": "app/server/page.js (2:16) @ Page
      > 2 |   return <div>{alert('warn')}</div>
          |                ^",

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -20,7 +20,7 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: The default export is not a React Component in "/specific-path/server/page"",
+       "description": "The default export is not a React Component in "/specific-path/server/page"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
@@ -45,7 +45,7 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: The default export is not a React Component in "/specific-path/server/layout"",
+       "description": "The default export is not a React Component in "/specific-path/server/layout"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
@@ -73,7 +73,7 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: The default export is not a React Component in "/will-not-found/not-found"",
+       "description": "The default export is not a React Component in "/will-not-found/not-found"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
@@ -94,7 +94,7 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: The default export is not a React Component in "/page"",
+       "description": "The default export is not a React Component in "/page"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
@@ -118,7 +118,7 @@ describe('Undefined default export', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: The default export is not a React Component in "/server-with-errors/page-export-initial-error/page"",
+       "description": "The default export is not a React Component in "/server-with-errors/page-export-initial-error/page"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -19,16 +19,13 @@ describe('ReactRefreshLogBox _app _document', () => {
     const { browser, session } = sandbox
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: The default export is not a React Component in page: "/_app"",
+       "description": "The default export is not a React Component in page: "/_app"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
        "stack": [],
      }
     `)
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
-      `"Error: The default export is not a React Component in page: "/_app""`
-    )
 
     await session.patch(
       'pages/_app.js',
@@ -51,7 +48,7 @@ describe('ReactRefreshLogBox _app _document', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: The default export is not a React Component in page: "/_document"",
+       "description": "The default export is not a React Component in page: "/_document"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
@@ -154,7 +151,7 @@ describe('ReactRefreshLogBox _app _document', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expression expected",
+         "description": "  x Expression expected",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_app.js
@@ -247,7 +244,7 @@ describe('ReactRefreshLogBox _app _document', () => {
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_document.js
-         × Module build failed:
+         Error: × Module build failed:
          ├─▶   ×
          │     │   x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
          │     │    ,-[<FIXME-project-root>/pages/_document.js:3:1]
@@ -268,7 +265,7 @@ describe('ReactRefreshLogBox _app _document', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key",
+         "description": "  x Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_document.js

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -46,7 +46,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: idk",
+         "description": "idk",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (8:27) @ onClick
@@ -62,7 +62,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: idk",
+         "description": "idk",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (8:27) @ onClick
@@ -122,7 +122,7 @@ describe('ReactRefreshLogBox', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (3:7) @ [project]/index.js [ssr] (ecmascript)
@@ -139,7 +139,7 @@ describe('ReactRefreshLogBox', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (3:7) @ eval
@@ -167,7 +167,7 @@ describe('ReactRefreshLogBox', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (3:7) @ [project]/index.js [ssr] (ecmascript)
@@ -184,7 +184,7 @@ describe('ReactRefreshLogBox', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (3:7) @ eval
@@ -271,7 +271,7 @@ describe('ReactRefreshLogBox', () => {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "FunctionDefault.js (1:51) @ FunctionDefault
@@ -285,7 +285,7 @@ describe('ReactRefreshLogBox', () => {
            ],
          },
          {
-           "description": "Error: no",
+           "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "FunctionDefault.js (1:51) @ FunctionDefault
@@ -303,7 +303,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: no",
+         "description": "no",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "FunctionDefault.js (1:51) @ FunctionDefault
@@ -391,7 +391,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
+         "description": "  x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -472,7 +472,7 @@ describe('ReactRefreshLogBox', () => {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "Error: ",
+           "description": "",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "Child.js (4:11) @ ClickCount.render
@@ -486,7 +486,7 @@ describe('ReactRefreshLogBox', () => {
            ],
          },
          {
-           "description": "Error: ",
+           "description": "",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "Child.js (4:11) @ ClickCount.render
@@ -504,7 +504,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: ",
+         "description": "",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "Child.js (4:11) @ ClickCount.render
@@ -650,7 +650,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: end https://nextjs.org",
+         "description": "end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -666,7 +666,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: end https://nextjs.org",
+         "description": "end https://nextjs.org",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -705,7 +705,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: https://nextjs.org start",
+         "description": "https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -721,7 +721,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: https://nextjs.org start",
+         "description": "https://nextjs.org start",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -760,7 +760,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: middle https://nextjs.org end",
+         "description": "middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -776,7 +776,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: middle https://nextjs.org end",
+         "description": "middle https://nextjs.org end",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -815,7 +815,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: multiple https://nextjs.org links http://example.com",
+         "description": "multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -831,7 +831,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: multiple https://nextjs.org links http://example.com",
+         "description": "multiple https://nextjs.org links http://example.com",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -870,7 +870,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: multiple https://nextjs.org links (http://example.com)",
+         "description": "multiple https://nextjs.org links (http://example.com)",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -886,7 +886,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: multiple https://nextjs.org links (http://example.com)",
+         "description": "multiple https://nextjs.org links (http://example.com)",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:11) @ Index.useCallback[boom]
@@ -921,7 +921,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: {"a":1,"b":"x"}",
+         "description": "{"a":1,"b":"x"}",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -931,7 +931,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: {"a":1,"b":"x"}",
+         "description": "{"a":1,"b":"x"}",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -969,7 +969,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: class Hello {
+         "description": "class Hello {
        }",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -980,7 +980,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: class Hello {
+         "description": "class Hello {
        }",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1017,7 +1017,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: string error",
+         "description": "string error",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -1027,7 +1027,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: string error",
+         "description": "string error",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -1063,7 +1063,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
+         "description": "A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -1073,7 +1073,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
+         "description": "A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -1111,7 +1111,7 @@ describe('ReactRefreshLogBox', () => {
         await expect(browser).toDisplayRedbox(`
          [
            {
-             "description": "Error: Client error",
+             "description": "Client error",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/index.js (3:11) @ Page
@@ -1122,7 +1122,7 @@ describe('ReactRefreshLogBox', () => {
              ],
            },
            {
-             "description": "Error: Client error",
+             "description": "Client error",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/index.js (3:11) @ Page
@@ -1133,7 +1133,7 @@ describe('ReactRefreshLogBox', () => {
              ],
            },
            {
-             "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+             "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
              "environmentLabel": null,
              "label": "Recoverable Error",
              "source": null,
@@ -1149,7 +1149,7 @@ describe('ReactRefreshLogBox', () => {
         await expect(browser).toDisplayRedbox(`
          [
            {
-             "description": "Error: Client error",
+             "description": "Client error",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/index.js (3:11) @ Page
@@ -1160,7 +1160,7 @@ describe('ReactRefreshLogBox', () => {
              ],
            },
            {
-             "description": "Error: Client error",
+             "description": "Client error",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/index.js (3:11) @ Page
@@ -1171,7 +1171,7 @@ describe('ReactRefreshLogBox', () => {
              ],
            },
            {
-             "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+             "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
              "environmentLabel": null,
              "label": "Recoverable Error",
              "source": null,
@@ -1183,7 +1183,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: Client error",
+         "description": "Client error",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "pages/index.js (3:11) @ Page
@@ -1228,7 +1228,7 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: anonymous error!",
+         "description": "anonymous error!",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "pages/index.js (3:11) @ <unknown>
@@ -1244,7 +1244,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: anonymous error!",
+         "description": "anonymous error!",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "pages/index.js (3:11) @ eval
@@ -1285,9 +1285,9 @@ describe('ReactRefreshLogBox', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "TypeError: Invalid URL",
+       "description": "Invalid URL",
        "environmentLabel": null,
-       "label": "Runtime Error",
+       "label": "Runtime TypeError",
        "source": "pages/index.js (4:3) @ createURL
      > 4 |   new URL("/", "invalid")
          |   ^",

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -284,7 +284,7 @@ describe('ReactRefreshRegression', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: boom",
+         "description": "boom",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "pages/index.js (1:36) @
@@ -299,7 +299,7 @@ describe('ReactRefreshRegression', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: boom",
+         "description": "boom",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "pages/index.js (1:36) @ default

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -80,7 +80,7 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Unexpected eof",
+         "description": "  x Unexpected eof",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -159,7 +159,7 @@ describe('pages/ error recovery', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: oops",
+       "description": "oops",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "index.js (7:11) @ Index.useCallback[increment]
@@ -252,7 +252,7 @@ describe('pages/ error recovery', () => {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "Error: oops",
+           "description": "oops",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "child.js (3:9) @ Child
@@ -266,7 +266,7 @@ describe('pages/ error recovery', () => {
            ],
          },
          {
-           "description": "Error: oops",
+           "description": "oops",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "child.js (3:9) @ Child
@@ -284,7 +284,7 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: oops",
+         "description": "oops",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "child.js (3:9) @ Child
@@ -400,7 +400,7 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '{', got 'return'",
+         "description": "  x Expected '{', got 'return'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -486,7 +486,7 @@ describe('pages/ error recovery', () => {
     } else {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '{', got 'throw'",
+         "description": "  x Expected '{', got 'throw'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -540,7 +540,7 @@ describe('pages/ error recovery', () => {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "Error: nooo",
+           "description": "nooo",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (5:11) @ ClassDefault.render
@@ -554,7 +554,7 @@ describe('pages/ error recovery', () => {
            ],
          },
          {
-           "description": "Error: nooo",
+           "description": "nooo",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (5:11) @ ClassDefault.render
@@ -573,7 +573,7 @@ describe('pages/ error recovery', () => {
       if (process.env.NEXT_RSPACK) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: nooo",
+           "description": "nooo",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (5:11) @ ClassDefault.render
@@ -587,7 +587,7 @@ describe('pages/ error recovery', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: nooo",
+           "description": "nooo",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "index.js (5:11) @ ClassDefault.render
@@ -656,9 +656,9 @@ describe('pages/ error recovery', () => {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "ReferenceError: React is not defined",
+           "description": "React is not defined",
            "environmentLabel": null,
-           "label": "Runtime Error",
+           "label": "Runtime ReferenceError",
            "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -670,9 +670,9 @@ describe('pages/ error recovery', () => {
            ],
          },
          {
-           "description": "ReferenceError: React is not defined",
+           "description": "React is not defined",
            "environmentLabel": null,
-           "label": "Runtime Error",
+           "label": "Runtime ReferenceError",
            "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -688,9 +688,9 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "ReferenceError: React is not defined",
+         "description": "React is not defined",
          "environmentLabel": null,
-         "label": "Runtime Error",
+         "label": "Runtime ReferenceError",
          "source": "Foo.js (3:3) @ Foo
        > 3 |   return React.createElement('h1', null, 'Foo');
            |   ^",
@@ -755,7 +755,7 @@ describe('pages/ error recovery', () => {
     if (process.env.NEXT_RSPACK) {
       await expect(browser).toDisplayRedbox(`
             {
-              "description": "Error: no 1",
+              "description": "no 1",
               "environmentLabel": null,
               "label": "Runtime Error",
               "source": "index.js (5:9) @ <unknown>
@@ -769,7 +769,7 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: no 1",
+         "description": "no 1",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "index.js (5:9) @ eval
@@ -841,7 +841,7 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
@@ -909,7 +909,7 @@ describe('pages/ error recovery', () => {
     } else {
       await expect({ browser, next }).toDisplayRedbox(`
        {
-         "description": "Error:   x Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -90,7 +90,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -196,7 +196,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -287,7 +287,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -362,7 +362,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -433,7 +433,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -525,7 +525,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -612,7 +612,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -709,7 +709,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating this Suspense boundary. Switched to client rendering.",
+           "description": "There was an error while hydrating this Suspense boundary. Switched to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -830,7 +830,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -926,7 +926,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -1010,7 +1010,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,
@@ -1104,7 +1104,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
            "stack": [],
          },
          {
-           "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+           "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
            "environmentLabel": null,
            "label": "Recoverable Error",
            "source": null,

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -86,7 +86,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "description": "Error: page error",
+       "description": "page error",
        "environmentLabel": null,
        "label": "Console Error",
        "source": "app/ssr-error-instance/page.js (4:17) @ Page
@@ -104,7 +104,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: boom",
+         "description": "boom",
          "environmentLabel": "Server",
          "label": "Console Error",
          "source": "app/rsc/page.js (2:17) @ Page

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -13,7 +13,7 @@ describe('app dir - dynamic error trace', () => {
     // TODO(veil): Where is the stackframe for app/page.js?
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Route / with \`dynamic = "error"\` couldn't be rendered statically because it used \`headers\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
+       "description": "Route / with \`dynamic = "error"\` couldn't be rendered statically because it used \`headers\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
        "environmentLabel": "Server",
        "label": "Runtime Error",
        "source": "app/lib.js (4:13) @ Foo

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -14,7 +14,7 @@ describe('Dynamic IO Dev Errors', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
+         "description": "Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
          "environmentLabel": "Server",
          "label": "Console Error",
          "source": "app/error/page.tsx (2:23) @ Page
@@ -40,7 +40,7 @@ describe('Dynamic IO Dev Errors', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
+         "description": "Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
          "environmentLabel": "Server",
          "label": "Console Error",
          "source": "app/error/page.tsx (2:23) @ Page
@@ -100,7 +100,7 @@ describe('Dynamic IO Dev Errors', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
          "environmentLabel": "Server",
          "label": "Console Error",
          "source": null,
@@ -151,7 +151,7 @@ describe('Dynamic IO Dev Errors', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.experimental.dynamicIO\`. Please remove it.",
+         "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.experimental.dynamicIO\`. Please remove it.",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.tsx

--- a/test/development/app-dir/hook-function-names/hook-function-names.test.ts
+++ b/test/development/app-dir/hook-function-names/hook-function-names.test.ts
@@ -12,7 +12,7 @@ describe('hook-function-names', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "description": "Error: Kaputt!",
+       "description": "Kaputt!",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "app/button/page.tsx (7:11) @ Button.useCallback[handleClick]
@@ -33,7 +33,7 @@ describe('hook-function-names', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: error in useEffect",
+       "description": "error in useEffect",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "app/page.tsx (7:11) @ Page.useEffect

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -206,7 +206,7 @@ describe('hydration-error-count', () => {
          ],
        },
        {
-         "description": "Error: runtime error",
+         "description": "runtime error",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "app/hydration-with-runtime-errors/page.tsx (7:11) @ Page.useEffect

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -25,7 +25,7 @@ describe('app-dir - missing required html tags', () => {
     await assertHasRedbox(browser)
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Missing <html> and <body> tags in the root layout.
+       "description": "Missing <html> and <body> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -46,7 +46,7 @@ describe('app-dir - missing required html tags', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Missing <html> tags in the root layout.
+       "description": "Missing <html> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
+++ b/test/development/app-dir/owner-stack-invalid-element-type/owner-stack-invalid-element-type.test.ts
@@ -10,7 +10,7 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
+       "description": "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
 
      Check the render method of \`BrowserOnly\`.",
        "environmentLabel": null,
@@ -32,7 +32,7 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
+       "description": "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
 
      Check the render method of \`Inner\`.",
        "environmentLabel": null,
@@ -53,7 +53,7 @@ describe('app-dir - owner-stack-invalid-element-type', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
+       "description": "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
 
      Check the render method of \`Inner\`.",
        "environmentLabel": null,

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -58,7 +58,7 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: browser error",
+       "description": "browser error",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "app/browser/uncaught/page.js (5:11) @ useThrowError
@@ -93,7 +93,7 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "description": "Error: browser error",
+       "description": "browser error",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "app/browser/caught/page.js (34:11) @ useThrowError
@@ -130,7 +130,7 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "Error: ssr error",
+       "description": "ssr error",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "app/ssr/page.js (4:9) @ useThrowError
@@ -158,7 +158,7 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "description": "Error: string in rejected promise",
+       "description": "string in rejected promise",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -1,9 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import {
-  assertNoRedbox,
-  assertHasRedbox,
-  getRedboxDescription,
-} from 'next-test-utils'
+import { assertNoRedbox } from 'next-test-utils'
 
 describe('serialize-circular-error', () => {
   const { next } = nextTestSetup({
@@ -12,13 +8,16 @@ describe('serialize-circular-error', () => {
 
   it('should serialize the object from server component in console correctly', async () => {
     const browser = await next.browser('/')
-    await assertHasRedbox(browser)
 
-    const description = await getRedboxDescription(browser)
-    expect(description).toBe(
-      `Error: An error occurred but serializing the error message failed.`
-    )
-
+    await expect(browser).toDisplayRedbox(`
+     {
+       "description": "An error occurred but serializing the error message failed.",
+       "environmentLabel": "Server",
+       "label": "Runtime Error",
+       "source": null,
+       "stack": [],
+     }
+    `)
     const output = next.cliOutput
     expect(output).toContain(
       'Error: {"objA":{"other":{"a":"[Circular]"}},"objB":"[Circular]"}'

--- a/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
+++ b/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
@@ -37,7 +37,7 @@ describe('app-dir - server-component-next-dynamic-ssr-false', () => {
         `)
     } else {
       expect(redbox.description).toMatchInlineSnapshot(
-        `"Error:   x \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a Client Component."`
+        `"  x \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a Client Component."`
       )
       expect(redbox.source).toMatchInlineSnapshot(`
          "./app/page.js

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -12,7 +12,7 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
+           "description": "Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "pages/pages/redirect.tsx (4:11) @ Page
@@ -26,7 +26,7 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
+           "description": "Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "pages/pages/redirect.tsx (4:11) @ Page
@@ -46,7 +46,7 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
+           "description": "Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "pages/pages/not-found.tsx (4:11) @ Page
@@ -60,7 +60,7 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Pages Router.",
+           "description": "Next.js navigation API is not allowed to be used in Pages Router.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "pages/pages/not-found.tsx (4:11) @ Page
@@ -85,7 +85,7 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
+           "description": "Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.ts (8:12) @ middleware
@@ -99,7 +99,7 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
+           "description": "Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.ts (8:13) @ middleware
@@ -120,7 +120,7 @@ describe('server-navigation-error', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
+           "description": "Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.ts (6:12) @ middleware
@@ -134,7 +134,7 @@ describe('server-navigation-error', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Next.js navigation API is not allowed to be used in Middleware.",
+           "description": "Next.js navigation API is not allowed to be used in Middleware.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.ts (6:13) @ middleware

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -284,7 +284,7 @@ describe('react-dom/server in React Server environment', () => {
       // Observed: `./node_modules/.pnpm/next@file+..+next-repo.../page.js?__next_edge_ssr_entry__
       expect(browser).toDisplayRedbox(`
        {
-         "description": "Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
+         "description": "  x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "<FIXME-nextjs-internal-source>

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -326,7 +326,7 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (1:1) @ [project]/app/exports/app-code/react-dom-server-node-explicit/page.js [app-rsc] (ecmascript)
 
           > 1 | import * as ReactDOMServerNode from 'react-dom/server.node'
@@ -339,7 +339,7 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "description": "react-dom/server is not supported in React Server Components.",
             "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (1:1) @ [project]/app/exports/app-code/react-dom-server-node-explicit/page.js [app-rsc] (ecmascript)
 
           > 1 | import * as ReactDOMServerNode from 'react-dom/server.node'
@@ -354,14 +354,14 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": null,
           }
         `)
       } else {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "description": "react-dom/server is not supported in React Server Components.",
             "source": null,
           }
         `)
@@ -400,7 +400,7 @@ describe('react-dom/server in React Server environment', () => {
     } else {
       expect(redbox).toMatchInlineSnapshot(`
        {
-         "description": "Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
+         "description": "  x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
          "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js
        Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
@@ -439,7 +439,7 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
           > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
@@ -452,7 +452,7 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "description": "react-dom/server is not supported in React Server Components.",
             "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
           > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
@@ -467,14 +467,14 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": null,
           }
         `)
       } else {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "description": "react-dom/server is not supported in React Server Components.",
             "source": null,
           }
         `)
@@ -737,7 +737,7 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
           > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
@@ -750,7 +750,7 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "description": "react-dom/server is not supported in React Server Components.",
             "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
           > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
@@ -765,14 +765,14 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": null,
           }
         `)
       } else {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "description": "react-dom/server is not supported in React Server Components.",
             "source": null,
           }
         `)
@@ -795,7 +795,7 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
           > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
@@ -808,7 +808,7 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(redbox).toMatchInlineSnapshot(`
          {
-           "description": "Error: react-dom/server is not supported in React Server Components.",
+           "description": "react-dom/server is not supported in React Server Components.",
            "source": "internal-pkg/server.node.js (1:1) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
          > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
@@ -823,14 +823,14 @@ describe('react-dom/server in React Server environment', () => {
       if (isReact18) {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "description": "Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
             "source": null,
           }
         `)
       } else {
         expect(redbox).toMatchInlineSnapshot(`
           {
-            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "description": "react-dom/server is not supported in React Server Components.",
             "source": null,
           }
         `)

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -12,7 +12,7 @@ describe('ssr-only-error', () => {
     // TODO(veil): Missing Owner Stack (NDX-905)
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "description": "Error: SSR only error",
+       "description": "SSR only error",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": "app/page.tsx (5:11) @ Component

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -274,7 +274,7 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: Additional keys were returned from \`getStaticProps\`. Properties intended for your component must be nested under the \`props\` key, e.g.:
+         "description": "Additional keys were returned from \`getStaticProps\`. Properties intended for your component must be nested under the \`props\` key, e.g.:
 
        	return { props: { title: 'My Title', content: '...' } }
 
@@ -315,7 +315,7 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: custom oops",
+         "description": "custom oops",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "pages/index.js (18:9) @ getStaticProps

--- a/test/development/basic/hmr/error-recovery.test.ts
+++ b/test/development/basic/hmr/error-recovery.test.ts
@@ -440,7 +440,7 @@ describe.each([
 
         await assertHasRedbox(browser)
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-          `"Error: The default export is not a React Component in page: "/hmr/about5""`
+          `"The default export is not a React Component in page: "/hmr/about5""`
         )
 
         await next.patchFile(aboutPage, aboutContent)
@@ -530,7 +530,7 @@ describe.each([
 
         await assertHasRedbox(browser)
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-          `"Error: The default export is not a React Component in page: "/hmr/about7""`
+          `"The default export is not a React Component in page: "/hmr/about7""`
         )
 
         await next.patchFile(aboutPage, aboutContent)
@@ -756,7 +756,7 @@ describe.each([
 
         await assertHasRedbox(browser)
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-          `"Error: an-expected-error-in-gip"`
+          `"an-expected-error-in-gip"`
         )
 
         await next.patchFile(
@@ -795,7 +795,7 @@ describe.each([
       try {
         await assertHasRedbox(browser)
         expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-          `"Error: an-expected-error-in-gip"`
+          `"an-expected-error-in-gip"`
         )
 
         const erroredPage = join('pages', 'hmr', 'error-in-gip.js')

--- a/test/development/basic/hmr/full-reload.test.ts
+++ b/test/development/basic/hmr/full-reload.test.ts
@@ -63,9 +63,7 @@ describe.each([
       'Fast Refresh had to perform a full reload due to a runtime error.'
 
     await retry(async () => {
-      expect(await getRedboxHeader(browser)).toMatch(
-        /ReferenceError: whoops is not defined/
-      )
+      expect(await getRedboxHeader(browser)).toMatch(/whoops is not defined/)
     })
     expect(next.cliOutput.slice(start)).not.toContain(cliWarning)
 

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -54,7 +54,7 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: boom",
+           "description": "boom",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.js (3:15) @
@@ -69,7 +69,7 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: boom",
+           "description": "boom",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.js (3:15) @ default
@@ -202,9 +202,9 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "ReferenceError: test is not defined",
+           "description": "test is not defined",
            "environmentLabel": null,
-           "label": "Runtime Error",
+           "label": "Runtime ReferenceError",
            "source": "middleware.js (4:9) @ eval
          > 4 |         eval('test')
              |         ^",
@@ -218,9 +218,9 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "ReferenceError: test is not defined",
+           "description": "test is not defined",
            "environmentLabel": null,
-           "label": "Runtime Error",
+           "label": "Runtime ReferenceError",
            "source": "middleware.js (4:9) @ eval
          > 4 |         eval('test')
              |         ^",
@@ -285,7 +285,7 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: booooom!",
+           "description": "booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.js (3:13) @ [project]/middleware.js [middleware-edge] (ecmascript)
@@ -299,7 +299,7 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: booooom!",
+           "description": "booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "middleware.js (3:13) @ eval
@@ -439,7 +439,7 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error:   x Expected '{', got '}'",
+           "description": "  x Expected '{', got '}'",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./middleware.js
@@ -505,7 +505,7 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error:   x Expected '{', got '}'",
+           "description": "  x Expected '{', got '}'",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./middleware.js

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -267,7 +267,7 @@ describe('Client Navigation', () => {
       await browser.elementByCss('#empty-props').click()
       await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: "EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
+           "description": ""EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": null,
@@ -1255,7 +1255,7 @@ describe('Client Navigation', () => {
         await expect(browser).toDisplayRedbox(`
          [
            {
-             "description": "Error: An Expected error occurred",
+             "description": "An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/error-inside-browser-page.js (5:13) @ ErrorInRenderPage.render
@@ -1266,7 +1266,7 @@ describe('Client Navigation', () => {
              ],
            },
            {
-             "description": "Error: An Expected error occurred",
+             "description": "An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/error-inside-browser-page.js (5:13) @ ErrorInRenderPage.render
@@ -1277,7 +1277,7 @@ describe('Client Navigation', () => {
              ],
            },
            {
-             "description": "Error: There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
+             "description": "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.",
              "environmentLabel": null,
              "label": "Recoverable Error",
              "source": null,
@@ -1288,7 +1288,7 @@ describe('Client Navigation', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: An Expected error occurred",
+           "description": "An Expected error occurred",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "pages/error-inside-browser-page.js (5:13) @ ErrorInRenderPage.render
@@ -1332,7 +1332,7 @@ describe('Client Navigation', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
            {
-             "description": "Error: An Expected error occurred",
+             "description": "An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/error-in-the-browser-global-scope.js (2:9) @ [project]/pages/error-in-the-browser-global-scope.js [client] (ecmascript)
@@ -1346,7 +1346,7 @@ describe('Client Navigation', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
            {
-             "description": "Error: An Expected error occurred",
+             "description": "An Expected error occurred",
              "environmentLabel": null,
              "label": "Runtime Error",
              "source": "pages/error-in-the-browser-global-scope.js (2:9) @ eval

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -131,7 +131,7 @@ describe('Client Navigation rendering', () => {
       if (isReact18 && isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
+           "description": "Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": null,
@@ -143,7 +143,7 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
+           "description": "Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": null,
@@ -161,7 +161,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: "InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://nextjs.org/docs/messages/get-initial-props-as-an-instance-method for more information.",
+         "description": ""InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://nextjs.org/docs/messages/get-initial-props-as-an-instance-method for more information.",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -175,7 +175,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: "EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
+         "description": ""EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -218,7 +218,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: The default export is not a React Component in page: "/no-default-export"",
+         "description": "The default export is not a React Component in page: "/no-default-export"",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,
@@ -233,7 +233,7 @@ describe('Client Navigation rendering', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: This is an expected error",
+           "description": "This is an expected error",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "pages/error-inside-page.js (2:9) @
@@ -248,7 +248,7 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: This is an expected error",
+           "description": "This is an expected error",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "pages/error-inside-page.js (2:9) @ default
@@ -271,9 +271,9 @@ describe('Client Navigation rendering', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "ReferenceError: aa is not defined",
+           "description": "aa is not defined",
            "environmentLabel": null,
-           "label": "Runtime Error",
+           "label": "Runtime ReferenceError",
            "source": "pages/error-in-the-global-scope.js (1:1) @ [project]/pages/error-in-the-global-scope.js [ssr] (ecmascript)
          > 1 | aa = 10 //eslint-disable-line
              | ^",
@@ -286,9 +286,9 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "ReferenceError: aa is not defined",
+           "description": "aa is not defined",
            "environmentLabel": null,
-           "label": "Runtime Error",
+           "label": "Runtime ReferenceError",
            "source": "pages/error-in-the-global-scope.js (1:1) @ eval
          > 1 | aa = 10 //eslint-disable-line
              | ^",
@@ -413,7 +413,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: An undefined error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
+         "description": "An undefined error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": null,

--- a/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
@@ -1,5 +1,4 @@
 import { nextTestSetup } from 'e2e-utils'
-import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
 
 describe('dynamic-href', () => {
   const {
@@ -19,11 +18,19 @@ describe('dynamic-href', () => {
     it('should error when using dynamic href.pathname in app dir', async () => {
       const browser = await next.browser('/object')
 
-      // Error should show up
-      await assertHasRedbox(browser)
-      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-        `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
-      )
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/object/page.js (5:5) @ HomePage
+       > 5 |     <Link
+           |     ^",
+         "stack": [
+           "HomePage app/object/page.js (5:5)",
+         ],
+       }
+      `)
 
       // Fix error
       const pageContent = await next.readFile('app/object/page.js')
@@ -47,11 +54,19 @@ describe('dynamic-href', () => {
     it('should error when using dynamic href in app dir', async () => {
       const browser = await next.browser('/string')
 
-      // Error should show up
-      await assertHasRedbox(browser)
-      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-        `"Error: Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href"`
-      )
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/string/page.js (5:5) @ HomePage
+       > 5 |     <Link id="link" href="/object/[slug]">
+           |     ^",
+         "stack": [
+           "HomePage app/string/page.js (5:5)",
+         ],
+       }
+      `)
     })
   } else {
     it('should not error on /object in prod', async () => {

--- a/test/e2e/app-dir/dynamic-io-segment-configs/dynamic-io-segment-configs.test.ts
+++ b/test/e2e/app-dir/dynamic-io-segment-configs/dynamic-io-segment-configs.test.ts
@@ -38,7 +38,7 @@ describe('dynamic-io-segment-configs', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.experimental.dynamicIO\`. Please remove it."`
+          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.experimental.dynamicIO\`. Please remove it."`
         )
       }
       expect(redbox.source).toContain(
@@ -99,7 +99,7 @@ describe('dynamic-io-segment-configs', () => {
             )
           } else {
             expect(redbox.description).toMatchInlineSnapshot(
-              `"Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.dynamicIO\`. Please remove it."`
+              `"  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.dynamicIO\`. Please remove it."`
             )
           }
           expect(redbox.source).toContain(

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -176,7 +176,7 @@ describe('app-dir - errors', () => {
       if (isNextDev) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Error: this is a test",
+           "description": "this is a test",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "app/global-error-boundary/client/page.js (8:11) @ Page
@@ -215,7 +215,7 @@ describe('app-dir - errors', () => {
       if (isNextDev) {
         await expect(browser).toDisplayRedbox(`
           {
-            "description": "Error: custom server error",
+            "description": "custom server error",
             "environmentLabel": "Server",
             "label": "Runtime Error",
             "source": "app/global-error-boundary/server/page.js (2:9) @ Page

--- a/test/e2e/app-dir/global-error/basic/index.test.ts
+++ b/test/e2e/app-dir/global-error/basic/index.test.ts
@@ -1,4 +1,3 @@
-import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app dir - global-error', () => {
@@ -14,9 +13,19 @@ describe('app dir - global-error', () => {
       .click()
 
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: Client error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Client error",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/client/page.js (8:11) @ Page
+       >  8 |     throw new Error('Client error')
+            |           ^",
+         "stack": [
+           "Page app/client/page.js (8:11)",
+         ],
+       }
+      `)
     }
     expect(await browser.elementByCss('#error').text()).toBe(
       'Global error: Client error'
@@ -28,9 +37,19 @@ describe('app dir - global-error', () => {
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')
 
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: server page error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "server page error",
+         "environmentLabel": "Server",
+         "label": "Runtime Error",
+         "source": "app/rsc/page.js (2:9) @ page
+       > 2 |   throw new Error('server page error')
+           |         ^",
+         "stack": [
+           "page app/rsc/page.js (2:9)",
+         ],
+       }
+      `)
     }
     // Show original error message in dev mode, but hide with the react fallback RSC error message in production mode
     expect(await browser.elementByCss('#error').text()).toBe(
@@ -45,9 +64,19 @@ describe('app dir - global-error', () => {
     const browser = await next.browser('/ssr')
 
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: client page error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "client page error",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/ssr/page.js (4:9) @ page
+       > 4 |   throw new Error('client page error')
+           |         ^",
+         "stack": [
+           "page app/ssr/page.js (4:9)",
+         ],
+       }
+      `)
     }
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')
     expect(await browser.elementByCss('#error').text()).toBe(
@@ -70,9 +99,20 @@ describe('app dir - global-error', () => {
     const browser = await next.browser('/metadata-error-without-boundary')
 
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: Metadata error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Metadata error",
+         "environmentLabel": "Server",
+         "label": "Runtime Error",
+         "source": "app/metadata-error-without-boundary/page.js (4:9) @ Module.generateMetadata
+       > 4 |   throw new Error('Metadata error')
+           |         ^",
+         "stack": [
+           "Module.generateMetadata app/metadata-error-without-boundary/page.js (4:9)",
+           "JSON.parse <anonymous> (0:0)",
+         ],
+       }
+      `)
     }
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')
     expect(await browser.elementByCss('#error').text()).toBe(
@@ -85,9 +125,19 @@ describe('app dir - global-error', () => {
   it('should catch the client error thrown in the nested routes', async () => {
     const browser = await next.browser('/nested/nested')
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: nested error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "nested error",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/nested/nested/page.js (15:11) @ ClientPage
+       > 15 |     throw Error('nested error')
+            |           ^",
+         "stack": [
+           "ClientPage app/nested/nested/page.js (15:11)",
+         ],
+       }
+      `)
     }
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')
     expect(await browser.elementByCss('#error').text()).toBe(

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -15,7 +15,7 @@ describe('app dir - global-error - error-in-global-error', () => {
       await assertHasRedbox(browser)
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: error in page",
+         "description": "error in page",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "app/page.js (7:11) @ Page.useEffect
@@ -41,7 +41,7 @@ describe('app dir - global-error - error-in-global-error', () => {
       await expect(browser).toDisplayRedbox(`
        [
          {
-           "description": "Error: error in global error",
+           "description": "error in global error",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "app/global-error.js (10:11) @ InnerGlobalError
@@ -53,7 +53,7 @@ describe('app dir - global-error - error-in-global-error', () => {
            ],
          },
          {
-           "description": "Error: error in page",
+           "description": "error in page",
            "environmentLabel": null,
            "label": "Runtime Error",
            "source": "app/page.js (7:11) @ Page.useEffect

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -1,4 +1,3 @@
-import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app dir - global error - layout error', () => {
@@ -15,9 +14,19 @@ describe('app dir - global error - layout error', () => {
     const browser = await next.browser('/')
 
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      const description = await getRedboxDescription(browser)
-      expect(description).toMatchInlineSnapshot(`"Error: layout error"`)
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "layout error",
+         "environmentLabel": "Server",
+         "label": "Runtime Error",
+         "source": "app/layout.js (2:9) @ layout
+       > 2 |   throw new Error('layout error')
+           |         ^",
+         "stack": [
+           "layout app/layout.js (2:9)",
+         ],
+       }
+      `)
     }
 
     expect(await browser.elementByCss('h1').text()).toBe('Global Error')

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -1,9 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import {
-  assertHasRedbox,
-  assertNoRedbox,
-  getRedboxDescription,
-} from 'next-test-utils'
+import { assertNoRedbox } from 'next-test-utils'
 
 describe('app dir - not found with default 404 page', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -21,10 +17,16 @@ describe('app dir - not found with default 404 page', () => {
     await browser.elementByCss('#trigger-not-found').click()
 
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      expect(await getRedboxDescription(browser)).toMatch(
-        /notFound\(\) is not allowed to use in root layout/
-      )
+      // TODO: Either allow or include original stack
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "notFound() is not allowed to use in root layout",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": null,
+         "stack": [],
+       }
+      `)
     }
   })
 
@@ -46,10 +48,16 @@ describe('app dir - not found with default 404 page', () => {
     const browser = await next.browser('/?root-not-found=1')
 
     if (isNextDev) {
-      await assertHasRedbox(browser)
-      expect(await getRedboxDescription(browser)).toBe(
-        'Error: notFound() is not allowed to use in root layout'
-      )
+      // TODO: Either allow or include original stack
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "notFound() is not allowed to use in root layout",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": null,
+         "stack": [],
+       }
+      `)
     }
   })
 

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -218,7 +218,7 @@ describe('app-dir - server source maps', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: Boom",
+         "description": "Boom",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "app/ssr-throw/Thrower.js (4:9) @ throwError

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -29,7 +29,7 @@ describe('use-cache-close-over-function', () => {
       const errorSource = await getRedboxSource(browser)
 
       expect(errorDescription).toMatchInlineSnapshot(`
-        "Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+        "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)
@@ -87,7 +87,7 @@ describe('use-cache-close-over-function', () => {
       const errorSource = await getRedboxSource(browser)
 
       expect(errorDescription).toMatchInlineSnapshot(`
-        "Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
+        "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
           [function fn]
            ^^^^^^^^^^^"
       `)

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -13,7 +13,7 @@ import stripAnsi from 'strip-ansi'
 const isExperimentalReact = process.env.__NEXT_EXPERIMENTAL_PPR
 
 const expectedErrorMessage =
-  'Error: Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".'
+  'Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".'
 
 describe('use-cache-hanging-inputs', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
@@ -52,7 +52,7 @@ describe('use-cache-hanging-inputs', () => {
 
           expect(errorSource).toBe(null)
 
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at [project]/app/search-params/page.tsx [app-rsc] (ecmascript)`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
@@ -67,7 +67,7 @@ describe('use-cache-hanging-inputs', () => {
              6 |   searchParams: Promise<{ n: string }>"
           `)
 
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at eval (app/search-params/page.tsx:3:15)`)
         }
       }, 180_000)
@@ -82,7 +82,7 @@ describe('use-cache-hanging-inputs', () => {
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
-        expect(cliOutput).not.toContain(expectedErrorMessage)
+        expect(cliOutput).not.toContain(`Error: ${expectedErrorMessage}`)
       })
     })
 
@@ -111,7 +111,7 @@ describe('use-cache-hanging-inputs', () => {
 
           expect(errorSource).toBe(null)
 
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at [project]/app/uncached-promise/page.tsx [app-rsc] (ecmascript)`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
@@ -126,7 +126,7 @@ describe('use-cache-hanging-inputs', () => {
              13 |   return ("
           `)
 
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at eval (app/uncached-promise/page.tsx:10:12)`)
         }
       }, 180_000)
@@ -157,7 +157,7 @@ describe('use-cache-hanging-inputs', () => {
 
           expect(errorSource).toBe(null)
 
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at [project]/app/uncached-promise-nested/page.tsx [app-rsc] (ecmascript)`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
@@ -172,7 +172,7 @@ describe('use-cache-hanging-inputs', () => {
              19 |   return getCachedData(promise)"
           `)
 
-          expect(cliOutput).toContain(`${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at eval (app/uncached-promise-nested/page.tsx:16:0)`)
         }
       }, 180_000)
@@ -201,7 +201,7 @@ describe('use-cache-hanging-inputs', () => {
           // key.
 
           const expectedErrorMessagePpr =
-            'Error: Route "/bound-args": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don\'t have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense'
+            'Route "/bound-args": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don\'t have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense'
 
           expect(errorDescription).toBe(expectedErrorMessagePpr)
 
@@ -219,7 +219,7 @@ describe('use-cache-hanging-inputs', () => {
 
             expect(errorSource).toBe(null)
 
-            expect(cliOutput).toContain(`${expectedErrorMessage}
+            expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at [project]/app/bound-args/page.tsx [app-rsc] (ecmascript)`)
           } else {
             expect(errorSource).toMatchInlineSnapshot(`
@@ -234,7 +234,7 @@ describe('use-cache-hanging-inputs', () => {
                16 |     return ("
             `)
 
-            expect(cliOutput).toContain(`${expectedErrorMessage}
+            expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at eval (app/bound-args/page.tsx:13:14)`)
           }
         }
@@ -254,7 +254,7 @@ describe('use-cache-hanging-inputs', () => {
         expect({ count, title, description }).toEqual({
           count: 1,
           title: 'Runtime Error\nCache',
-          description: 'Error: kaputt!',
+          description: 'kaputt!',
         })
       })
     })
@@ -262,7 +262,7 @@ describe('use-cache-hanging-inputs', () => {
     it('should fail the build with errors after a timeout', async () => {
       const { cliOutput } = await next.build()
 
-      expect(cliOutput).toInclude(expectedErrorMessage)
+      expect(cliOutput).toInclude(`Error: ${expectedErrorMessage}`)
 
       expect(cliOutput).toInclude(
         'Error occurred prerendering page "/bound-args"'

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -36,7 +36,7 @@ describe('use-cache-segment-configs', () => {
         // FIXME: Fix broken import trace for Webpack loader resource.
         expect(browser).toDisplayRedbox(`
          {
-           "description": "Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
+           "description": "  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "<FIXME-nextjs-internal-source>

--- a/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-standalone-search-params/use-cache-standalone-search-params.test.ts
@@ -8,7 +8,7 @@ import {
 import stripAnsi from 'strip-ansi'
 
 const getExpectedErrorMessage = (route: string) =>
-  `Error: Route ${route} used "searchParams" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "searchParams" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+  `Route ${route} used "searchParams" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "searchParams" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
 
 describe('use-cache-standalone-search-params', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -55,7 +55,7 @@ describe('use-cache-standalone-search-params', () => {
            11 | }"
         `)
 
-        expect(cliOutput).toContain(`${expectedErrorMessage}
+        expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at Page (app/search-params-used/page.tsx:8:17)`)
       })
     })
@@ -91,7 +91,7 @@ describe('use-cache-standalone-search-params', () => {
            14 |   return <p>param: {param}</p>"
         `)
 
-        expect(cliOutput).toContain(`${expectedErrorMessage}
+        expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
     at Page (app/search-params-caught/page.tsx:11:4)`)
       })
 

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -134,7 +134,7 @@ describe('use-cache-unknown-cache-kind', () => {
         )
       } else {
         expect(errorDescription).toMatchInlineSnapshot(
-          `"Error:   x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config."`
+          `"  x Unknown cache kind "custom". Please configure a cache handler for this kind in the "experimental.cacheHandlers" object in your Next.js config."`
         )
       }
 

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -89,7 +89,7 @@ describe('use-cache-without-experimental-flag', () => {
         )
       } else {
         expect(errorDescription).toMatchInlineSnapshot(
-          `"Error:   x To use "use cache", please enable the experimental feature flag "useCache" in your Next.js config."`
+          `"  x To use "use cache", please enable the experimental feature flag "useCache" in your Next.js config."`
         )
       }
 

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -42,9 +42,9 @@ describe('fetch failures have good stack traces in edge runtime', () => {
       // TODO(veil): Why column off by one?
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "TypeError: fetch failed",
+         "description": "fetch failed",
          "environmentLabel": null,
-         "label": "Runtime Error",
+         "label": "Runtime TypeError",
          "source": "src/fetcher.js (6:16) @ anotherFetcher
        > 6 |   return await fetch(...args)
            |                ^",

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -1,5 +1,4 @@
 import { createNext, FileRef, isNextDev } from 'e2e-utils'
-import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
@@ -25,13 +24,21 @@ describe('New Link Behavior with <a> child', () => {
   it('should throw error with <a> child', async () => {
     const browser = await webdriver(next.url, `/`)
     const link = await browser.elementsByCss('a[href="/about"]')
-    const msg =
-      'Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>'
 
     if (isNextDev) {
-      expect(next.cliOutput).toContain(msg)
-      await assertHasRedbox(browser)
-      expect(await getRedboxDescription(browser)).toContain(msg)
+      expect(next.cliOutput).toContain(
+        'Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>'
+      )
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>.
+       Learn more: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": null,
+         "stack": [],
+       }
+      `)
       expect(link.length).toBe(0)
     } else {
       expect(link.length).toBeGreaterThan(0)

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -16,7 +16,7 @@ describe('next-link', () => {
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: Failed prop type: The prop \`href\` expects a \`string\` or \`object\` in \`<Link>\`, but got \`undefined\` instead.
+         "description": "Failed prop type: The prop \`href\` expects a \`string\` or \`object\` in \`<Link>\`, but got \`undefined\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -42,7 +42,7 @@ describe('next-link', () => {
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: No children were passed to <Link> with \`href\` of \`/about\` but one child is required https://nextjs.org/docs/messages/link-no-children",
+         "description": "No children were passed to <Link> with \`href\` of \`/about\` but one child is required https://nextjs.org/docs/messages/link-no-children",
          "environmentLabel": null,
          "label": "Runtime Error",
          "source": "app/no-children/page.js (7:10) @ Page
@@ -66,7 +66,7 @@ describe('next-link', () => {
       // TODO(veil): https://linear.app/vercel/issue/NDX-554/hide-the-anonymous-frames-which-are-between-2-ignored-frames
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Error: Multiple children were passed to <Link> with \`href\` of \`/\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children 
+         "description": "Multiple children were passed to <Link> with \`href\` of \`/\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children 
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/integration/next-image-new/invalid-image-import/test/index.test.ts
+++ b/test/integration/next-image-new/invalid-image-import/test/index.test.ts
@@ -28,7 +28,7 @@ function runTests({ isDev }) {
         expect(description).toMatchInlineSnapshot(`"Processing image failed"`)
       } else {
         expect(description).toMatchInlineSnapshot(
-          `"Error: Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format."`
+          `"Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format."`
         )
       }
       const source = await getRedboxSource(browser)

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -33,10 +33,10 @@ describe('server-side dev errors', () => {
     app = await launchApp(appDir, appPort, {
       onStderr(msg) {
         stderr += msg
-        // All tests cause runtime errors which may lead to this message which
+        // All tests cause Runtime ReferenceErrors which may lead to this message which
         // is not relevant to this test.
         stderr = stderr.replace(
-          ' ⚠ Fast Refresh had to perform a full reload due to a runtime error.',
+          ' ⚠ Fast Refresh had to perform a full reload due to a Runtime ReferenceError.',
           ''
         )
       },
@@ -77,9 +77,9 @@ describe('server-side dev errors', () => {
 
       await expect(browser).toDisplayRedbox(`
         {
-          "description": "ReferenceError: missingVar is not defined",
+          "description": "missingVar is not defined",
           "environmentLabel": null,
-          "label": "Runtime Error",
+          "label": "Runtime ReferenceError",
           "source": "pages/gsp.js (6:3) @ getStaticProps
         > 6 |   missingVar;return {
             |   ^",
@@ -125,9 +125,9 @@ describe('server-side dev errors', () => {
 
       await expect(browser).toDisplayRedbox(`
         {
-          "description": "ReferenceError: missingVar is not defined",
+          "description": "missingVar is not defined",
           "environmentLabel": null,
-          "label": "Runtime Error",
+          "label": "Runtime ReferenceError",
           "source": "pages/gssp.js (6:3) @ getServerSideProps
         > 6 |   missingVar;return {
             |   ^",
@@ -173,9 +173,9 @@ describe('server-side dev errors', () => {
 
       await expect(browser).toDisplayRedbox(`
         {
-          "description": "ReferenceError: missingVar is not defined",
+          "description": "missingVar is not defined",
           "environmentLabel": null,
-          "label": "Runtime Error",
+          "label": "Runtime ReferenceError",
           "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
         > 6 |   missingVar;return {
             |   ^",
@@ -233,9 +233,9 @@ describe('server-side dev errors', () => {
 
       await expect(browser).toDisplayRedbox(`
         {
-          "description": "ReferenceError: missingVar is not defined",
+          "description": "missingVar is not defined",
           "environmentLabel": null,
-          "label": "Runtime Error",
+          "label": "Runtime ReferenceError",
           "source": "pages/api/hello.js (2:3) @ handler
         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
             |   ^",
@@ -249,9 +249,9 @@ describe('server-side dev errors', () => {
 
       await expect(browser).toDisplayRedbox(`
         {
-          "description": "ReferenceError: missingVar is not defined",
+          "description": "missingVar is not defined",
           "environmentLabel": null,
-          "label": "Runtime Error",
+          "label": "Runtime ReferenceError",
           "source": "pages/api/hello.js (2:3) @ handler
         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
             |   ^",
@@ -307,9 +307,9 @@ describe('server-side dev errors', () => {
 
       await expect(browser).toDisplayRedbox(`
         {
-          "description": "ReferenceError: missingVar is not defined",
+          "description": "missingVar is not defined",
           "environmentLabel": null,
-          "label": "Runtime Error",
+          "label": "Runtime ReferenceError",
           "source": "pages/api/blog/[slug].js (2:3) @ handler
         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
             |   ^",
@@ -323,9 +323,9 @@ describe('server-side dev errors', () => {
 
       await expect(browser).toDisplayRedbox(`
         {
-          "description": "ReferenceError: missingVar is not defined",
+          "description": "missingVar is not defined",
           "environmentLabel": null,
-          "label": "Runtime Error",
+          "label": "Runtime ReferenceError",
           "source": "pages/api/blog/[slug].js (2:3) @ handler
         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
             |   ^",
@@ -349,7 +349,7 @@ describe('server-side dev errors', () => {
 
     const stderrOutput = stripAnsi(stderr.slice(stderrIdx))
       .replace(
-        '⚠ Fast Refresh had to perform a full reload due to a runtime error.',
+        '⚠ Fast Refresh had to perform a full reload due to a Runtime ReferenceError.',
         ''
       )
       .trim()
@@ -428,7 +428,7 @@ describe('server-side dev errors', () => {
 
     const stderrOutput = stripAnsi(stderr.slice(stderrIdx))
       .replace(
-        '⚠ Fast Refresh had to perform a full reload due to a runtime error.',
+        '⚠ Fast Refresh had to perform a full reload due to a Runtime ReferenceError.',
         ''
       )
       .trim()
@@ -506,7 +506,7 @@ describe('server-side dev errors', () => {
 
     const stderrOutput = stripAnsi(stderr.slice(stderrIdx))
       .replace(
-        '⚠ Fast Refresh had to perform a full reload due to a runtime error.',
+        '⚠ Fast Refresh had to perform a full reload due to a Runtime ReferenceError.',
         ''
       )
       .trim()
@@ -584,7 +584,7 @@ describe('server-side dev errors', () => {
 
     const stderrOutput = stripAnsi(stderr.slice(stderrIdx))
       .replace(
-        '⚠ Fast Refresh had to perform a full reload due to a runtime error.',
+        '⚠ Fast Refresh had to perform a full reload due to a Runtime ReferenceError.',
         ''
       )
       .trim()


### PR DESCRIPTION
It's somewhat redundant to label errors with e.g. "Runtime Error" and then also prefix the body with "Error: ".

Now we just show the error name in the label, and keep the body clean.

This should also teach better to look at the label e.g. when you encounter `ReferenceError` you get "Runtime ReferenceError" in the label.

Failing tests are known to be flaky:
- [pages/ error recovery render error not shown right after syntax error](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3A%22test%2Fdevelopment%2Facceptance%2Ferror-recovery.test.ts%22%20%40test.status%3Afail%20%40test.name%3A%22pages%2F%20error%20recovery%20render%20error%20not%20shown%20right%20after%20syntax%20error%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1744718891157&end=1745323691157&paused=false)
- [Error recovery app server component can recover from a component error](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3A%22test%2Fdevelopment%2Facceptance-app%2Ferror-recovery.test.ts%22%20%40test.status%3Afail%20%40test.name%3A%22Error%20recovery%20app%20server%20component%20can%20recover%20from%20a%20component%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2C%40test_session.name%2C%40test.type%2C%40test.status%2C%40test.source.file%2C%40git.branch&currentTab=overview&eventStack=&fromUser=true&graphType=flamegraph&index=citest&start=1744793174953&end=1745397974953&paused=true)