### PR TITLE
[metadata] skip head cache in default slot

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -20,7 +20,19 @@ function findHeadInCacheImpl(
     return [cache, keyPrefix]
   }
 
-  for (const key in parallelRoutes) {
+  // First try the 'children' parallel route if it exists
+  // when starting from the "root", this corresponds with the main page component
+  const parallelRoutesKeys = Object.keys(parallelRoutes).filter(
+    (key) => key !== 'children'
+  )
+
+  // if we are at the root, we need to check the children slot first
+  if ('children' in parallelRoutes) {
+    parallelRoutesKeys.unshift('children')
+  }
+
+  // if we didn't find metadata in the page slot, check the other parallel routes
+  for (const key of parallelRoutesKeys) {
     const [segment, childParallelRoutes] = parallelRoutes[key]
     const childSegmentMap = cache.parallelRoutes.get(key)
     if (!childSegmentMap) {

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -20,29 +20,7 @@ function findHeadInCacheImpl(
     return [cache, keyPrefix]
   }
 
-  // First try the 'children' parallel route if it exists
-  // when starting from the "root", this corresponds with the main page component
-  if (parallelRoutes.children) {
-    const [segment, childParallelRoutes] = parallelRoutes.children
-    const childSegmentMap = cache.parallelRoutes.get('children')
-    if (childSegmentMap) {
-      const cacheKey = createRouterCacheKey(segment)
-      const cacheNode = childSegmentMap.get(cacheKey)
-      if (cacheNode) {
-        const item = findHeadInCacheImpl(
-          cacheNode,
-          childParallelRoutes,
-          keyPrefix + '/' + cacheKey
-        )
-        if (item) return item
-      }
-    }
-  }
-
-  // if we didn't find metadata in the page slot, check the other parallel routes
   for (const key in parallelRoutes) {
-    if (key === 'children') continue // already checked above
-
     const [segment, childParallelRoutes] = parallelRoutes[key]
     const childSegmentMap = cache.parallelRoutes.get(key)
     if (!childSegmentMap) {

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -1,5 +1,6 @@
 import type { FlightRouterState } from '../../../../server/app-render/types'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import { DEFAULT_SEGMENT_KEY } from '../../../../shared/lib/segment'
 import { createRouterCacheKey } from '../create-router-cache-key'
 
 export function findHeadInCache(
@@ -33,6 +34,11 @@ function findHeadInCacheImpl(
 
   for (const key of parallelRoutesKeys) {
     const [segment, childParallelRoutes] = parallelRoutes[key]
+    // If the parallel is not matched and using the default segment,
+    // skip searching the head from it.
+    if (segment === DEFAULT_SEGMENT_KEY) {
+      continue
+    }
     const childSegmentMap = cache.parallelRoutes.get(key)
     if (!childSegmentMap) {
       continue

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -31,7 +31,6 @@ function findHeadInCacheImpl(
     parallelRoutesKeys.unshift('children')
   }
 
-  // if we didn't find metadata in the page slot, check the other parallel routes
   for (const key of parallelRoutesKeys) {
     const [segment, childParallelRoutes] = parallelRoutes[key]
     const childSegmentMap = cache.parallelRoutes.get(key)

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -206,9 +206,11 @@ export function createMetadataComponents({
     const promise = resolveFinalMetadata()
     if (serveStreamingMetadata) {
       return (
-        <Suspense fallback={null}>
-          <AsyncMetadata promise={promise} />
-        </Suspense>
+        <div hidden>
+          <Suspense fallback={null}>
+            <AsyncMetadata promise={promise} />
+          </Suspense>
+        </div>
       )
     }
     const metadataState = await promise

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -503,13 +503,6 @@ async function generateDynamicRSCPayload(
       serveStreamingMetadata,
     })
 
-    // const { StreamingMetadata, StaticMetadata } =
-    //   createRootMetadata(() => {
-    //     return (
-
-    //     )
-    //   }, serveStreamingMetadata)
-
     flightData = (
       await walkTreeWithFlightRouterState({
         ctx,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -245,6 +245,8 @@ interface ParseRequestHeadersOptions {
 }
 
 const flightDataPathHeadKey = 'h'
+const getFlightViewportKey = (requestId: string) => requestId + 'v'
+const getFlightMetadataKey = (requestId: string) => requestId + 'm'
 
 interface ParsedRequestHeaders {
   /**
@@ -519,9 +521,9 @@ async function generateDynamicRSCPayload(
               isPossibleServerAction={ctx.isPossibleServerAction}
             />
             {/* Adding requestId as react key to make metadata remount for each render */}
-            <ViewportTree key={requestId} />
+            <ViewportTree key={getFlightViewportKey(requestId)} />
             {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
-            <MetadataTree />
+            <MetadataTree key={getFlightMetadataKey(requestId)} />
           </React.Fragment>
         ),
         injectedCSS: new Set(),
@@ -855,7 +857,7 @@ async function getRSCPayload(
         statusCode={ctx.res.statusCode}
         isPossibleServerAction={ctx.isPossibleServerAction}
       />
-      <ViewportTree key={ctx.requestId} />
+      <ViewportTree key={getFlightViewportKey(ctx.requestId)} />
       {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
       <MetadataTree />
     </React.Fragment>
@@ -944,12 +946,8 @@ async function getErrorRSCPayload(
     serveStreamingMetadata: serveStreamingMetadata,
   })
 
-  const metadata = (
-    <React.Fragment key={flightDataPathHeadKey}>
-      {/* Adding requestId as react key to make metadata remount for each render */}
-      <MetadataTree key={requestId} />
-    </React.Fragment>
-  )
+  // {/* Adding requestId as react key to make metadata remount for each render */}
+  const metadata = <MetadataTree key={getFlightMetadataKey(requestId)} />
 
   const initialHead = (
     <React.Fragment key={flightDataPathHeadKey}>
@@ -959,7 +957,7 @@ async function getErrorRSCPayload(
         isPossibleServerAction={ctx.isPossibleServerAction}
       />
       {/* Adding requestId as react key to make metadata remount for each render */}
-      <ViewportTree key={requestId} />
+      <ViewportTree key={getFlightViewportKey(requestId)} />
       {process.env.NODE_ENV === 'development' && (
         <meta name="next-error" content="not-found" />
       )}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -39,7 +39,6 @@ export function createComponentTree(props: {
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  StreamingMetadata: React.ComponentType | null
   StreamingMetadataOutlet: React.ComponentType
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
@@ -76,7 +75,6 @@ async function createComponentTreeInternal({
   missingSlots,
   preloadCallbacks,
   authInterrupts,
-  StreamingMetadata,
   StreamingMetadataOutlet,
 }: {
   loaderTree: LoaderTree
@@ -91,7 +89,6 @@ async function createComponentTreeInternal({
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  StreamingMetadata: React.ComponentType | null
   StreamingMetadataOutlet: React.ComponentType | null
 }): Promise<CacheNodeSeedData> {
   const {
@@ -390,7 +387,6 @@ async function createComponentTreeInternal({
 
   // Resolve the segment param
   const actualSegment = segmentParam ? segmentParam.treeSegment : segment
-  const metadata = StreamingMetadata ? <StreamingMetadata /> : undefined
 
   // Use the same condition to render metadataOutlet as metadata
   const metadataOutlet = StreamingMetadataOutlet ? (
@@ -513,7 +509,6 @@ async function createComponentTreeInternal({
             missingSlots,
             preloadCallbacks,
             authInterrupts,
-            StreamingMetadata: isChildrenRouteKey ? StreamingMetadata : null,
             // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
             // but we only want to throw on the first one.
             StreamingMetadataOutlet: isChildrenRouteKey
@@ -699,12 +694,6 @@ async function createComponentTreeInternal({
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
         {pageElement}
-        {/*
-         * The order here matters since a parent might call findDOMNode().
-         * findDOMNode() will return the first child if multiple children are rendered.
-         * But React will hoist metadata into <head> which breaks scroll handling.
-         */}
-        {metadata}
         {layerAssets}
         <OutletBoundary>
           <MetadataOutlet ready={getViewportReady} />

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -202,7 +202,6 @@ export async function walkTreeWithFlightRouterState({
         getMetadataReady,
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
-        StreamingMetadata: null,
         StreamingMetadataOutlet,
       }
     )

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/layout.tsx
@@ -14,6 +14,11 @@ export default function Root({ children }: { children: ReactNode }) {
             {`to /parallel-routes-default`}
           </Link>
           <br />
+
+          <Link href="/parallel-routes-no-children" id="to-no-children">
+            {`to /parallel-routes-no-children`}
+          </Link>
+          <br />
         </div>
         {children}
       </body>

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/default.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/default.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'default @bar'
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/first/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/first/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return <p id="bar-page">test-page @bar - 1</p>
+}
+
+export const metadata = {
+  title: 'first page - @bar',
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h2>@bar Layout</h2>
+      <div id="bar-children">{children}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'page @bar'
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/second/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@bar/second/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return <p id="bar-page">test-page @bar - 2</p>
+}
+
+export const metadata = {
+  title: 'second page - @bar',
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/default.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/default.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'default @foo'
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h2>@foo Layout</h2>
+      <div id="foo-children">{children}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/no-bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/no-bar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'no-bar @foo'
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'page @foo'
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/test-page/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/@foo/test-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'test-page @foo'
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes-no-children/layout.tsx
@@ -1,0 +1,34 @@
+import { connection } from 'next/server'
+import Link from 'next/link'
+
+// skip rendering children
+export default function Layout({ bar, foo }) {
+  return (
+    <div>
+      <h1>Parallel Routes Layout - No Children</h1>
+
+      <Link href="/parallel-routes-no-children/first" id="to-no-children-first">
+        {`to /parallel-routes-no-children/first`}
+      </Link>
+      <br />
+      <Link
+        href="/parallel-routes-no-children/second"
+        id="to-no-children-second"
+      >
+        {`to /parallel-routes-no-children/second`}
+      </Link>
+      <br />
+
+      <div id="foo-slot">{foo}</div>
+      <div id="bar-slot">{bar}</div>
+    </div>
+  )
+}
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  return {
+    title: 'parallel-routes-default layout title',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
@@ -57,4 +57,29 @@ describe('app-dir - metadata-streaming', () => {
     expect($('title').length).toBe(1)
     expect($('body title').text()).toBe('parallel-routes-default layout title')
   })
+
+  it('should change metadata when navigating between two pages under a slot when children is not rendered', async () => {
+    // first page is /parallel-routes-no-children/first,
+    // second page is /parallel-routes-no-children/second
+    // navigating between them should change the title metadata
+    const browser = await next.browser('/parallel-routes-no-children/first')
+    await retry(async () => {
+      expect(await browser.elementByCss('title').text()).toBe(
+        'first page - @bar'
+      )
+    })
+    // go to second page
+    await browser
+      .elementByCss('[href="/parallel-routes-no-children/second"]')
+      .click()
+    // wait for navigation to finish
+    await retry(async () => {
+      expect(await browser.elementByCss('#bar-page').text()).toBe(
+        'test-page @bar - 2'
+      )
+    })
+    expect(await browser.elementByCss('title').text()).toBe(
+      'second page - @bar'
+    )
+  })
 })

--- a/test/e2e/esm-externals/app/client/page.js
+++ b/test/e2e/esm-externals/app/client/page.js
@@ -6,8 +6,8 @@ import World3 from 'app-cjs-esm-package/entry'
 
 export default function Index() {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/app/server/page.js
+++ b/test/e2e/esm-externals/app/server/page.js
@@ -4,8 +4,8 @@ import World3 from 'app-cjs-esm-package/entry'
 
 export default function Page() {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/esm-externals.test.ts
+++ b/test/e2e/esm-externals/esm-externals.test.ts
@@ -28,15 +28,13 @@ describe('esm-externals', () => {
 
     it('should return the correct SSR HTML', async () => {
       const $ = await next.render$(url)
-      const body = $('body > div > div').html()
+      const body = $('body p').html()
       expect(normalize(body)).toEqual(expectedHtml)
     })
 
     it('should render the correct page', async () => {
       const browser = await next.browser(url)
-      expect(await browser.elementByCss('body > div').text()).toEqual(
-        expectedText
-      )
+      expect(await browser.elementByCss('body p').text()).toEqual(expectedText)
     })
   })
 
@@ -54,13 +52,13 @@ describe('esm-externals', () => {
 
     it('should return the correct SSR HTML', async () => {
       const $ = await next.render$(url)
-      const body = $('body > div').html()
+      const body = $('body > p').html()
       expect(normalize(body)).toEqual(expectedHtml)
     })
 
     it('should render the correct page', async () => {
       const browser = await next.browser(url)
-      expect(await browser.elementByCss('body > div').text()).toEqual(
+      expect(await browser.elementByCss('body > p').text()).toEqual(
         expectedText
       )
     })

--- a/test/e2e/esm-externals/pages/ssg.js
+++ b/test/e2e/esm-externals/pages/ssg.js
@@ -13,8 +13,8 @@ export async function getStaticProps() {
 
 export default function Index({ worlds }) {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}+{worlds}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/pages/ssr.js
+++ b/test/e2e/esm-externals/pages/ssr.js
@@ -13,8 +13,8 @@ export function getServerSideProps() {
 
 export default function Index({ worlds }) {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}+{worlds}
-    </div>
+    </p>
   )
 }

--- a/test/e2e/esm-externals/pages/static.js
+++ b/test/e2e/esm-externals/pages/static.js
@@ -7,8 +7,8 @@ const worlds = 'World+World+World'
 
 export default function Index() {
   return (
-    <div>
+    <p>
       Hello {World1}+{World2}+{World3}+{worlds}
-    </div>
+    </p>
   )
 }


### PR DESCRIPTION
### What

When the parallel routes have multiple named slots but not the `children` slot, the page slot can be located in of the named slots.

For instance:
```
@bar - page with metadata
@foo - default
@children - default (it's missing)
```

In this case when we searching the head from client cache, we need to find the head cache in the actual page. Since we're taking children slot as priority, it could accidentally end up in the empty metadata of children slot. But in the repro case where children slot page segment is not defined, which only contains a default segment. We need to skip searching for the default segment as it mostly means not matching, and there're some other page segments matched.