### PR TITLE
Fix externals doc validation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,7 +100,7 @@ jobs:
     needs: ['build-next']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: pnpm lint-no-typescript && pnpm check-examples
+      afterBuild: pnpm lint-no-typescript && pnpm check-examples && pnpm validate-externals-doc
       stepName: 'lint'
     secrets: inherit
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint-eslint": "cross-env ESLINT_USE_FLAT_CONFIG=false eslint . --ext js,jsx,mjs,ts,tsx,mts,mdx --config .eslintrc.json --no-eslintrc",
     "lint-ast-grep": "ast-grep scan",
     "lint-no-typescript": "run-p prettier-check lint-eslint lint-language",
-    "types-and-precompiled": "run-p lint-typescript check-precompiled validate-externals-doc check-compiler-fixtures types:test-lib",
+    "types-and-precompiled": "run-p lint-typescript check-precompiled check-compiler-fixtures types:test-lib",
     "check-compiler-fixtures": "find crates/next-custom-transforms/tests/fixture -type f -name 'tsconfig.json' -exec /bin/sh -c 'echo \"project: $1\"; pnpm tsc --noEmit --project \"$1\"' -- {} \\;",
     "validate-externals-doc": "node ./scripts/validate-externals-doc.js",
     "lint": "run-p test-types lint-typescript prettier-check lint-eslint lint-ast-grep lint-language",

--- a/scripts/validate-externals-doc.js
+++ b/scripts/validate-externals-doc.js
@@ -58,7 +58,7 @@ const appRouterValid = validate(
   `docs/01-app/05-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx`
 )
 const pagesRouterValid = validate(
-  `docs/02-pages/03-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx`
+  `docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx`
 )
 
 if (appRouterValid && pagesRouterValid) {


### PR DESCRIPTION
This moves the `validate-externals-doc` job to the `lint` step so it's not skipped for docs only changes. 

x-ref: https://github.com/vercel/next.js/actions/runs/14475138181/job/40601279813