### PR TITLE
fix(turbo-tasks-fs): Update notify-rs, handle recursive symlinks in realpath implementation, add an e2e test for symlinked files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -777,9 +777,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitreader"
@@ -3354,11 +3354,11 @@ checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.0",
  "inotify-sys",
  "libc",
 ]
@@ -3823,7 +3823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84f971730745f4aaac013b6cf4328baf1548efc973c0d95cfd843a3c1ca07af"
 dependencies = [
  "ahash 0.8.11",
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "const-str",
  "cssparser",
  "cssparser-color",
@@ -4310,7 +4310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "214f07a80874bb96a8433b3cdfc84980d56c7b02e1a0d7ba4ba0db5cef785e2b"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -4647,7 +4647,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4680,22 +4680,28 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.5.0",
- "crossbeam-channel",
+ "bitflags 2.9.0",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio 1.0.3",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4993,7 +4999,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dccbc6fb560df303a44e511618256029410efbc87779018f751ef12c488271fe"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "cssparser",
  "log",
  "phf",
@@ -6211,7 +6217,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -7339,7 +7345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f75578c97d9338cb6ae4007bda693690bac1c5b5d0bf817d43cd0b0e08632a1"
 dependencies = [
  "auto_impl",
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "rustc-hash 2.1.0",
  "serde",
  "swc_atoms",
@@ -7367,7 +7373,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfec0694cca0950515b8d87dd8dda991e45d36e257f5efd8cb7682e7617c125"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "once_cell",
  "serde",
  "serde_json",
@@ -7459,7 +7465,7 @@ version = "8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4062a54522a9c02d2b68cc09282774b87121cd48693b0e67ae8c18b31b709866"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "bytecheck 0.8.0",
  "is-macro",
  "num-bigint",
@@ -7812,7 +7818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18757f2b1656db8b10d7fd153871d969d87e2909f4150378a4ae925fa6cc6768"
 dependencies = [
  "arrayvec 0.7.4",
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "either",
  "new_debug_unreachable",
  "num-bigint",
@@ -7914,7 +7920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b46e3a36213d78fb4233e596b8a5c81c6cdafe02d03d780eed006c983aa0a724"
 dependencies = [
  "better_scoped_tls",
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "indexmap 2.7.1",
  "once_cell",
  "par-core",
@@ -8004,7 +8010,7 @@ checksum = "d0cf50886962aa3d7d20317a486971b91002a930b236c1e4af1f1050280b4070"
 dependencies = [
  "Inflector",
  "anyhow",
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "indexmap 2.7.1",
  "is-macro",
  "path-clean 1.0.1",
@@ -8414,7 +8420,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8538a8b2e8d8a3ebbf58fe7f933d7b4bb01a291fbd7356352ea255cc15bbc70"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "petgraph 0.7.1",
  "rustc-hash 2.1.0",
  "swc_atoms",
@@ -11203,7 +11209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcdee6bea3619d311fb4b299721e89a986c3470f804b6d534340e412589028e3"
 dependencies = [
  "ahash 0.8.11",
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
  "hashbrown 0.14.5",
  "indexmap 2.7.1",
  "semver 1.0.23",
@@ -11708,7 +11714,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,7 +370,7 @@ lightningcss-napi = { version = "0.4.3", default-features = false, features = [
 markdown = "1.0.0-alpha.18"
 mime = "0.3.16"
 nohash-hasher = "0.2.0"
-notify = "6.1.1"
+notify = "8.0.0"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
 par-core = { version = "1.0.3", features = ["rayon"] }

--- a/test/development/app-dir/hmr-symlink/app/layout.tsx
+++ b/test/development/app-dir/hmr-symlink/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-symlink/app/symlink-chain/page.tsx
+++ b/test/development/app-dir/hmr-symlink/app/symlink-chain/page.tsx
@@ -1,0 +1,1 @@
+../symlink-link/page.tsx

--- a/test/development/app-dir/hmr-symlink/app/symlink-link/page.tsx
+++ b/test/development/app-dir/hmr-symlink/app/symlink-link/page.tsx
@@ -1,0 +1,1 @@
+../symlink-target/page.tsx

--- a/test/development/app-dir/hmr-symlink/app/symlink-target/page.tsx
+++ b/test/development/app-dir/hmr-symlink/app/symlink-target/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>This is the symlink target</h1>
+}

--- a/test/development/app-dir/hmr-symlink/app/symlink-target2/page.tsx
+++ b/test/development/app-dir/hmr-symlink/app/symlink-target2/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>This is the second symlink target</h1>
+}

--- a/test/development/app-dir/hmr-symlink/hmr-symlink.test.ts
+++ b/test/development/app-dir/hmr-symlink/hmr-symlink.test.ts
@@ -1,0 +1,94 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox, retry } from 'next-test-utils'
+
+// This tests file symlinks, but not directory symlinks. Directory symlinks are
+// known to break route manifest generation:
+// https://github.com/vercel/next.js/discussions/77463
+describe('HMR symlinks', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('tracks updates to symlinked target', async () => {
+    const browser = await next.browser('/symlink-link')
+
+    expect(await browser.elementByCss('h1').text()).toBe(
+      'This is the symlink target'
+    )
+
+    await next.patchFile(
+      'app/symlink-target/page.tsx',
+      (content) => content.replace('symlink target', 'updated symlink target'),
+      async () => {
+        await retry(async () => {
+          await assertNoRedbox(browser)
+          expect(await browser.elementByCss('h1').text()).toBe(
+            'This is the updated symlink target'
+          )
+        })
+      }
+    )
+  })
+
+  /* eslint-disable jest/no-standalone-expect */
+  // This works in Turbopack and Rspack, but is broken in webpack!
+  ;(process.env.IS_TURBOPACK_TEST || process.env.NEXT_RSPACK ? it : it.skip)(
+    'tracks updates to the symlink',
+    async () => {
+      const browser = await next.browser('/symlink-link')
+
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'This is the symlink target'
+      )
+
+      try {
+        await next.symlink(
+          'app/symlink-target2/page.tsx',
+          'app/symlink-link/page.tsx'
+        )
+        await retry(async () => {
+          await assertNoRedbox(browser)
+          expect(await browser.elementByCss('h1').text()).toBe(
+            'This is the second symlink target'
+          )
+        })
+      } finally {
+        await next.symlink(
+          'app/symlink-target/page.tsx',
+          'app/symlink-link/page.tsx'
+        )
+      }
+    }
+  )
+
+  // This works in Turbopack, but is broken in webpack!
+  ;(process.env.IS_TURBOPACK_TEST ? it : it.skip)(
+    'tracks updates to the middle of a symlink chain',
+    async () => {
+      const browser = await next.browser('/symlink-chain')
+
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'This is the symlink target'
+      )
+
+      try {
+        await next.symlink(
+          'app/symlink-target2/page.tsx',
+          'app/symlink-link/page.tsx'
+        )
+        await retry(async () => {
+          await assertNoRedbox(browser)
+          expect(await browser.elementByCss('h1').text()).toBe(
+            'This is the second symlink target'
+          )
+        })
+      } finally {
+        await next.symlink(
+          'app/symlink-target/page.tsx',
+          'app/symlink-link/page.tsx'
+        )
+      }
+    }
+  )
+  /* eslint-enable jest/no-standalone-expect */
+})

--- a/test/development/app-dir/hmr-symlink/next.config.js
+++ b/test/development/app-dir/hmr-symlink/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -620,6 +620,23 @@ export class NextInstance {
     )
   }
 
+  /**
+   * Makes `linkFilename` point to `targetFilename`.
+   *
+   * Performs an atomic update to the symlink:
+   * https://blog.moertel.com/posts/2005-08-22-how-to-change-symlinks-atomically.html
+   */
+  public async symlink(targetFilename: string, linkFilename: string) {
+    const tmpLinkPath = path.join(this.testDir, linkFilename + '.tmp')
+    try {
+      await fs.symlink(path.join(this.testDir, targetFilename), tmpLinkPath)
+      await fs.rename(tmpLinkPath, path.join(this.testDir, linkFilename))
+    } catch (e) {
+      await fs.unlink(tmpLinkPath)
+      throw e
+    }
+  }
+
   public async renameFolder(foldername: string, newFoldername: string) {
     await fs.rename(
       path.join(this.testDir, foldername),

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -2468,6 +2468,17 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/development/app-dir/hmr-symlink/hmr-symlink.test.ts": {
+    "passed": [
+      "HMR symlinks tracks updates to symlinked target",
+      "HMR symlinks tracks updates to the symlink",
+      "HMR symlinks tracks updates to the middle of a symlink chain"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/development/app-dir/hook-function-names/hook-function-names.test.ts": {
     "passed": [
       "hook-function-names should show readable hook names in stacks",

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -37,10 +37,11 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use auto_hash_map::AutoMap;
+use auto_hash_map::{AutoMap, AutoSet};
 use bitflags::bitflags;
 use dunce::simplified;
 use glob::Glob;
+use indexmap::IndexSet;
 use invalidation::InvalidateFilesystem;
 use invalidator_map::InvalidatorMap;
 use jsonc_parser::{parse_to_serde_value, ParseOptions};
@@ -1563,46 +1564,85 @@ impl FileSystemPath {
 
     #[turbo_tasks::function]
     pub async fn realpath_with_links(self: ResolvedVc<Self>) -> Result<Vc<RealPathResult>> {
-        let this = self.await?;
-        if this.is_root() {
-            return Ok(RealPathResult {
-                path: self,
-                symlinks: Vec::new(),
+        let mut current_vc = self;
+        let mut symlinks: IndexSet<ResolvedVc<FileSystemPath>> = IndexSet::new();
+        let mut visited: AutoSet<RcStr> = AutoSet::new();
+        // Pick some arbitrary symlink depth limit... similar to the ELOOP logic for realpath(3).
+        // SYMLOOP_MAX is 40 for Linux: https://unix.stackexchange.com/q/721724
+        for _i in 0..40 {
+            let current = current_vc.await?;
+            if current.is_root() {
+                // fast path
+                return Ok(RealPathResult {
+                    path: self,
+                    symlinks: symlinks.into_iter().collect(),
+                }
+                .cell());
             }
-            .cell());
-        }
-        let parent = self.parent().to_resolved().await?;
-        let parent_result = parent.realpath_with_links().owned().await?;
-        let basename = this
-            .path
-            .rsplit_once('/')
-            .map_or(this.path.as_str(), |(_, name)| name);
-        let real_self = if parent_result.path != parent {
-            parent_result
+
+            if !visited.insert(current.path.clone()) {
+                break; // we detected a cycle
+            }
+
+            // see if a parent segment of the path is a symlink and resolve that first
+            let parent = self.parent().to_resolved().await?;
+            let parent_result = parent.realpath_with_links().owned().await?;
+            let basename = current
                 .path
-                .join(basename.into())
-                .to_resolved()
-                .await?
-        } else {
-            self
-        };
-        let mut result = parent_result;
-        if matches!(*real_self.get_type().await?, FileSystemEntryType::Symlink) {
-            if let LinkContent::Link { target, link_type } = &*real_self.read_link().await? {
-                result.symlinks.push(real_self);
-                result.path = if link_type.contains(LinkType::ABSOLUTE) {
-                    real_self.root().to_resolved().await?
+                .rsplit_once('/')
+                .map_or(current.path.as_str(), |(_, name)| name);
+            if parent_result.path != parent {
+                current_vc = parent_result
+                    .path
+                    .join(basename.into())
+                    .to_resolved()
+                    .await?;
+            }
+            symlinks.extend(parent_result.symlinks);
+
+            // use `get_type` before trying `read_link`, as there's a good chance of a cache hit on
+            // `get_type`, and `read_link` isn't the common codepath.
+            if !matches!(*current_vc.get_type().await?, FileSystemEntryType::Symlink) {
+                return Ok(RealPathResult {
+                    path: current_vc,
+                    symlinks: symlinks.into_iter().collect(), // convert set to vec
+                }
+                .cell());
+            }
+
+            if let LinkContent::Link { target, link_type } = &*current_vc.read_link().await? {
+                symlinks.insert(current_vc);
+                current_vc = if link_type.contains(LinkType::ABSOLUTE) {
+                    current_vc.root()
                 } else {
-                    result.path
+                    *parent_result.path
                 }
                 .join(target.clone())
                 .to_resolved()
                 .await?;
-                return Ok(result.cell());
+            } else {
+                // get_type() and read_link() might disagree temporarily due to turbo-tasks
+                // eventual consistency or if the file gets invalidated before the directory does
+                return Ok(RealPathResult {
+                    path: current_vc,
+                    symlinks: symlinks.into_iter().collect(), // convert set to vec
+                }
+                .cell());
             }
         }
-        result.path = real_self;
-        Ok(result.cell())
+
+        // Too many attempts or detected a cycle, we bailed out!
+        //
+        // TODO: There's no proper way to indicate an non-turbo-tasks error here, so just return the
+        // original path and all the symlinks we followed.
+        //
+        // Returning the followed symlinks is still important, even if there is an error! Otherwise
+        // we may never notice if the symlink loop is fixed.
+        Ok(RealPathResult {
+            path: self,
+            symlinks: symlinks.into_iter().collect(),
+        }
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -150,6 +150,8 @@ impl DiskWatcher {
         // Create a watcher object, delivering debounced events.
         // The notification back-end is selected based on the platform.
         let config = Config::default();
+        // we should track and invalidate each part of a symlink chain ourselves in turbo-tasks-fs
+        config.with_follow_symlinks(false);
 
         let mut watcher = if let Some(poll_interval) = poll_interval {
             let config = config.with_poll_interval(poll_interval);


### PR DESCRIPTION
While working on filesystem watching stuff, I saw that `notify-rs` had a new `with_follow_symlinks` flag, which seems very relevant to us and how we handle symlinks.

When looking to enable this, I noticed that we lacked e2e tests for symlinks. I added a few tests, but found lots of other bugs...

- I ran into https://github.com/vercel/next.js/discussions/77463#discussioncomment-12847522, which I documented, but am not fixing, because it's too far out of scope.
- I ran into a bug with realpath, which is fixed here.

Closes PACK-4374