### PR TITLE
Fix Content-Security-Policy middleware instructions that disables CSP handling when Chrome preloads the page

### DIFF
--- a/docs/01-app/03-building-your-application/07-configuring/15-content-security-policy.mdx
+++ b/docs/01-app/03-building-your-application/07-configuring/15-content-security-policy.mdx
@@ -139,10 +139,7 @@ export const config = {
      */
     {
       source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
-      missing: [
-        { type: 'header', key: 'next-router-prefetch' },
-        { type: 'header', key: 'purpose', value: 'prefetch' },
-      ],
+      missing: [{ type: 'header', key: 'next-router-prefetch' }],
     },
   ],
 }
@@ -160,10 +157,7 @@ export const config = {
      */
     {
       source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
-      missing: [
-        { type: 'header', key: 'next-router-prefetch' },
-        { type: 'header', key: 'purpose', value: 'prefetch' },
-      ],
+      missing: [{ type: 'header', key: 'next-router-prefetch' }],
     },
   ],
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

The current [Content Security Policy documentation page](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy) describes using middleware with matchers for "ignoring matching prefetches (from next/link) and static assets that don't need the CSP header".

However, that recommended configuration also disables the middleware for all requests with request header `Purpose: prefetch`.

The impact of this is that when a Chrome browser [decides to preload your Next.js pages](https://support.google.com/chrome/answer/12929150?visit_id=638803960561374049-2218356943&p=performance_preload_pages&rd=1#Preload_pages&zippy=%2Cturn-preload-pages-on-or-off), Chrome will send the request header `Purpose: prefetch`, the whole middleware will be skipped so the request/response headers are not set, and the Next.js response will be missing all the Content Security Policy nonces because the request header was not set for the server-side rendering.

When Next.js is deployed in an environment where Content Security Policy is enforced, e.g. via a default restrictive Content Security Policy response header being inserted when none is returned by Next.js, users of the Next.js app will intermittently encounter broken screens upon page load due to Next.js not returning a page with CSP nonces and CSP response header. Users have to do a browser reload to do a non-preload load to recover.

This applies even when Chrome in the default "standard" preloading mode, and not in the "extended" mode.

To fix this, adjust the middleware exclusion to not match on requests with request header `Purpose: prefetch`.

References:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Purpose - in the Browser compatibility section, expand the Chrome boxes to see the reference to https://crbug.com/40236973 
- https://issues.chromium.org/issues/40618796#comment24 - Chrome still sending it in 2023
- https://github.com/w3c/resource-hints/issues/74#issuecomment-1329189007 - Chrome still sending it in 2022
- https://chromestatus.com/feature/6247959677108224 - earlier introduction of `Sec-Purpose` header in parallel with `Purpose`
- https://issues.chromium.org/issues/40236973#comment5 - Chrome may stop sending legacy `Purpose` header in future, not yet confirmed as it's not been merged into Chromium yet
