### PR TITLE
Turbopack: fix duplicate unsupported edge import modules

### DIFF
--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -4,6 +4,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
+    ident::AssetIdent,
     resolve::{
         options::{ImportMapResult, ImportMappingReplacement, ReplacedImportMapping},
         parse::Request,
@@ -63,7 +64,14 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
               "#
             };
             let content = AssetContent::file(File::from(code).into());
-            let source = VirtualSource::new(root_path, content).to_resolved().await?;
+            let source = VirtualSource::new_with_ident(
+                AssetIdent::from_path(root_path).with_modifier(Vc::cell(
+                    format!("unsupported edge import {}", module).into(),
+                )),
+                content,
+            )
+            .to_resolved()
+            .await?;
             return Ok(
                 ImportMapResult::Result(ResolveResult::source(ResolvedVc::upcast(source))).cell(),
             );

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -485,12 +485,7 @@ pub async fn get_next_edge_import_map(
         | ServerContextType::Pages { .. }
         | ServerContextType::PagesData { .. }
         | ServerContextType::PagesApi { .. } => {
-            insert_unsupported_node_internal_aliases(
-                &mut import_map,
-                *project_path,
-                execution_context,
-            )
-            .await?;
+            insert_unsupported_node_internal_aliases(&mut import_map).await?;
         }
     }
 
@@ -500,13 +495,9 @@ pub async fn get_next_edge_import_map(
 /// Insert default aliases for the node.js's internal to raise unsupported
 /// runtime errors. User may provide polyfills for their own by setting user
 /// config's alias.
-async fn insert_unsupported_node_internal_aliases(
-    import_map: &mut ImportMap,
-    project_path: Vc<FileSystemPath>,
-    execution_context: Vc<ExecutionContext>,
-) -> Result<()> {
+async fn insert_unsupported_node_internal_aliases(import_map: &mut ImportMap) -> Result<()> {
     let unsupported_replacer = ImportMapping::Dynamic(ResolvedVc::upcast(
-        NextEdgeUnsupportedModuleReplacer::new(project_path, execution_context)
+        NextEdgeUnsupportedModuleReplacer::new()
             .to_resolved()
             .await?,
     ))


### PR DESCRIPTION
1. Add the import in question to the module ident: `[project]/test/e2e/on-request-error/isr (unsupported edge import fs)`
2. Wrap the source creation into a separate turbotask, so that `fs` and `fs/promises` get the same Source cell (instead of two different Sources with the same ident)

Closes PACK-4386