### PR TITLE
Docs IA 2.0: Move Production Checklist under `Guides`

### DIFF
--- a/docs/01-app/02-guides/production-checklist.mdx
+++ b/docs/01-app/02-guides/production-checklist.mdx
@@ -1,5 +1,6 @@
 ---
-title: Production Checklist
+title: How to optimize your Next.js application for production
+nav_title: Production
 description: Recommendations to ensure the best performance and user experience before taking your Next.js application to production.
 ---
 

--- a/docs/01-app/03-building-your-application/06-optimizing/06-package-bundling.mdx
+++ b/docs/01-app/03-building-your-application/06-optimizing/06-package-bundling.mdx
@@ -5,7 +5,7 @@ description: Learn how to optimize your application's server and client bundles.
 related:
   description: Learn more about optimizing your application for production.
   links:
-    - app/building-your-application/deploying/production-checklist
+    - app/guides/production-checklist
 ---
 
 Bundling external packages can significantly improve the performance of your application. <AppOnly>By default, packages imported inside Server Components and Route Handlers are automatically bundled by Next.js. This page will guide you through how to analyze and further optimize package bundling.</AppOnly> <PagesOnly>By default, packages imported into your application are not bundled. This can impact performance or might not work if external packages are not pre-bundled, for example, if imported from a monorepo or `node_modules`. This page will guide you through how to analyze and configure package bundling.</PagesOnly>

--- a/docs/02-pages/02-guides/production-checklist.mdx
+++ b/docs/02-pages/02-guides/production-checklist.mdx
@@ -1,7 +1,8 @@
 ---
-title: Production Checklist
+title: How to optimize your Next.js application for production
+nav_title: Production
 description: Recommendations to ensure the best performance and user experience before taking your Next.js application to production.
-source: app/building-your-application/deploying/production-checklist
+source: app/guides/production-checklist
 ---
 
 {/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/02-pages/03-building-your-application/05-optimizing/06-package-bundling.mdx
+++ b/docs/02-pages/03-building-your-application/05-optimizing/06-package-bundling.mdx
@@ -6,7 +6,7 @@ source: app/building-your-application/optimizing/package-bundling
 related:
   description: Learn more about optimizing your application for production.
   links:
-    - pages/building-your-application/deploying/production-checklist
+    - pages/guides/production-checklist
 ---
 
 {/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4549/production-checklist
Redirects: https://github.com/vercel/front/pull/44234