### PR TITLE
Turbopack: dedupe additional traced references

### DIFF
--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -26,7 +26,7 @@ use graph::{aggregate, AggregatedGraph, AggregatedGraphNodeContent};
 use module_options::{ModuleOptions, ModuleOptionsContext, ModuleRuleEffect, ModuleType};
 use tracing::{field::Empty, Instrument};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 pub use turbopack_core::condition;
 use turbopack_core::{
@@ -840,7 +840,8 @@ impl AssetContext for ModuleAssetContext {
                                             external_result
                                                 .primary_modules_raw_iter()
                                                 .map(|rvc| *rvc),
-                                        );
+                                        )
+                                        .collect::<FxIndexSet<_>>();
 
                                     modules
                                         .into_iter()


### PR DESCRIPTION
Fix a duplicated `[externals]/next/dist/server/app-render/work-unit-async-storage.external.js [external]`
This was due to the additional references containing duplicates in one case, but not in the other. So just always dedupe them.

But this whole test is very odd: 
https://github.com/vercel/next.js/blob/94ef480642bc44e46e9a286b191d6a3dc42a9fb4/test/e2e/app-dir/app-external/app/async-storage/page.js#L1-L6


Closes PACK-4385