### PR TITLE
ignore-list published sources if they have a sourcemap

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -166,11 +166,24 @@ if ((typeof exports.default === 'function' || (typeof exports.default === 'objec
 
         output.code += Buffer.from(`\n//# sourceMappingURL=${map}`)
 
+        const sourceMapPayload = JSON.parse(output.map)
+        if ('ignoreList' in sourceMapPayload) {
+          throw new Error(
+            'SWC already sets an ignoreList. We may no longer need to manually set ignoreList.'
+          )
+        }
+        // ignore-list everything
+        sourceMapPayload.ignoreList = sourceMapPayload.sources.map(
+          (source, sourceIndex) => {
+            return sourceIndex
+          }
+        )
+
         // add sourcemap to `files` array
         this._.files.push({
           base: map,
           dir: file.dir,
-          data: Buffer.from(output.map),
+          data: Buffer.from(JSON.stringify(sourceMapPayload)),
         })
       }
 

--- a/test/integration/edge-runtime-dynamic-code/test/index.test.js
+++ b/test/integration/edge-runtime-dynamic-code/test/index.test.js
@@ -109,11 +109,10 @@ describe.each([
             expect(output).toContain(
               isTurbopack
                 ? '' +
+                    // TODO(veil): Turbopack duplicates project path
                     '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/utils.js:11:16)' +
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/middleware.js:12:52)' +
-                    // Next.js internal frame. Feel free to adjust.
-                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-                    '\n    at'
+                    '\n   9 | export async function usingEval() {'
                 : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:18)' +
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:12:53)' +
                     // Next.js internal frame. Feel free to adjust.
@@ -124,9 +123,10 @@ describe.each([
             expect(output).toContain(
               isTurbopack
                 ? '' +
+                    // TODO(veil): Turbopack duplicates project path
                     '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/utils.js:11:16)' +
                     '\n    at handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:13:22)' +
-                    // Next.js internal frame. Feel free to adjust.
+                    // @opentelemetry/api internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
                     '\n    at'
                 : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:18)' +
@@ -175,9 +175,10 @@ describe.each([
                 ? '' +
                     '\n    at usingWebAssemblyCompile (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:17)' +
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/middleware.js:24:68)' +
-                    // Next.js internal frame. Feel free to adjust.
-                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-                    '\n    at'
+                    '\n  20 |' +
+                    '\n  21 | export async function usingWebAssemblyCompile(x) {' +
+                    '\n> 22 |   const module = await WebAssembly.compile(SQUARE_WASM_BUFFER)' +
+                    '\n     |                 ^'
                 : '\n    at usingWebAssemblyCompile (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:23)' +
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:24:68)' +
                     // Next.js internal frame. Feel free to adjust.
@@ -188,6 +189,7 @@ describe.each([
             expect(output).toContain(
               isTurbopack
                 ? '' +
+                    // TODO(veil): Turbopack duplicates project path
                     '\n    at usingWebAssemblyCompile (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:17)' +
                     '\n    at handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:17:42)' +
                     // Next.js internal frame. Feel free to adjust.
@@ -232,14 +234,12 @@ describe.each([
                 ? '' +
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:23)' +
                     '\n    at async middleware (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/middleware.js:37:29)' +
-                    // Next.js internal frame. Feel free to adjust.
-                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-                    '\n    at'
+                    '\n  26 |\n'
                 : '' +
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:23)' +
                     '\n    at async middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:37:29)' +
                     // Next.js internal frame. Feel free to adjust.
-                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
+                    // TODO(veil): https://linear.app/vercel/issue/NDX-464
                     '\n    at '
             )
             expect(stripAnsi(output)).toContain(
@@ -254,9 +254,7 @@ describe.each([
                     // TODO(veil): Turbopack duplicates project path
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:23)' +
                     '\n    at async handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:21:16)' +
-                    // Next.js internal frame. Feel free to adjust.
-                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-                    '\n    at'
+                    '\n  26 |'
                 : '' +
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:23)' +
                     '\n    at async handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:21:16)' +

--- a/test/integration/edge-runtime-with-node.js-apis/test/index.test.ts
+++ b/test/integration/edge-runtime-with-node.js-apis/test/index.test.ts
@@ -44,8 +44,6 @@ const unsupportedClasses = [
   'WritableStreamDefaultController',
 ]
 
-const isTurbopack = process.env.IS_TURBOPACK_TEST
-
 describe.each([
   {
     title: 'Middleware',
@@ -113,12 +111,7 @@ describe.each([
         expect(output)
           .toInclude(`A Node.js API is used (${api}) which is not supported in the Edge Runtime.
 Learn more: https://nextjs.org/docs/api-reference/edge-runtime`)
-        if (isTurbopack) {
-          expect(stripAnsi(output)).toInclude(errorHighlight)
-        } else {
-          // TODO(veil): Use codeframe froma stackframe that's not ignore-listed
-          expect(stripAnsi(output)).not.toInclude(errorHighlight)
-        }
+        expect(stripAnsi(output)).toInclude(errorHighlight)
       })
     }
   )

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -65,57 +65,29 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          ' ⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at <unknown>'
-        )
-      } else {
-        expect(stderrOutput).toStartWith(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at <unknown>'
-        )
-      }
-      expect(stderr).toContain(
-        '\n  5 | export async function getStaticProps() {' +
-          '\n> 6 |   missingVar;return {'
+
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at getStaticProps (../../test/integration/server-side-dev-errors/pages/gsp.js:6:2)' +
+          '\n  4 |' +
+          '\n  5 | export async function getStaticProps() {' +
+          '\n> 6 |   missingVar;return {' +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gsp.js (6:3) @ getStaticProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getStaticProps pages/gsp.js (6:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gsp.js (6:3) @ getStaticProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getStaticProps pages/gsp.js (6:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/gsp.js (6:3) @ getStaticProps
+        > 6 |   missingVar;return {
+            |   ^",
+          "stack": [
+            "getStaticProps pages/gsp.js (6:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(gspPage, content, { flush: true })
       await assertNoRedbox(browser)
@@ -142,57 +114,28 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          ' ⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at <unknown>'
-        )
-      } else {
-        expect(stderrOutput).toStartWith(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at <unknown>'
-        )
-      }
-      expect(stderrOutput).toContain(
-        '\n  5 | export async function getServerSideProps() {' +
-          '\n> 6 |   missingVar;return {'
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/gssp.js:6:2)' +
+          '\n  4 |' +
+          '\n  5 | export async function getServerSideProps() {' +
+          '\n> 6 |   missingVar;return {' +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gssp.js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/gssp.js (6:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/gssp.js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/gssp.js (6:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/gssp.js (6:3) @ getServerSideProps
+        > 6 |   missingVar;return {
+            |   ^",
+          "stack": [
+            "getServerSideProps pages/gssp.js (6:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(gsspPage, content)
       await assertNoRedbox(browser)
@@ -219,57 +162,28 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          ' ⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at <unknown>'
-        )
-      } else {
-        expect(stderrOutput).toStartWith(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at <unknown>'
-        )
-      }
-      expect(stderrOutput).toContain(
-        '\n  5 | export async function getServerSideProps() {' +
-          '\n> 6 |   missingVar;return {'
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at getServerSideProps (../../test/integration/server-side-dev-errors/pages/blog/[slug].js:6:2)' +
+          '\n  4 |' +
+          '\n  5 | export async function getServerSideProps() {' +
+          '\n> 6 |   missingVar;return {' +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/blog/[slug].js (6:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
-         > 6 |   missingVar;return {
-             |   ^",
-           "stack": [
-             "getServerSideProps pages/blog/[slug].js (6:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
+        > 6 |   missingVar;return {
+            |   ^",
+          "stack": [
+            "getServerSideProps pages/blog/[slug].js (6:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(dynamicGsspPage, content)
     } finally {
@@ -295,89 +209,44 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          ' ⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at async'
-        )
-      } else {
-        expect(stderrOutput).toStartWith(
-          '⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at async'
-        )
-      }
-      expect(stderrOutput).toContain(
-        '\n  1 | export default function handler(req, res) {' +
-          "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })"
+
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/hello.js:2:2)' +
+          '\n  1 | export default function handler(req, res) {' +
+          "\n> 2 |   missingVar;res.status(200).json({ hello: 'world' })" +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/hello.js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+            |   ^",
+          "stack": [
+            "handler pages/api/hello.js (2:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(apiPage, content)
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/hello.js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-             |   ^",
-           "stack": [
-             "handler pages/api/hello.js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/hello.js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+            |   ^",
+          "stack": [
+            "handler pages/api/hello.js (2:3)",
+          ],
+        }
+      `)
     } finally {
       await fs.writeFile(apiPage, content)
     }
@@ -401,91 +270,43 @@ describe('server-side dev errors', () => {
       })
 
       const stderrOutput = stripAnsi(stderr.slice(stderrIdx)).trim()
-      // FIXME(veil): error repeated
-      if (isTurbopack) {
-        expect(stderrOutput).toContain(
-          ' ⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at'
-        )
-      } else {
-        expect(stderrOutput).toContain(
-          ' ⨯ ReferenceError: missingVar is not defined' +
-            '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
-            // Next.js internal frame. Feel free to adjust.
-            // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-            '\n    at'
-        )
-      }
-
-      expect(stderrOutput).toContain(
-        '\n  1 | export default function handler(req, res) {' +
-          '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })'
+      expect(stderrOutput).toStartWith(
+        '⨯ ReferenceError: missingVar is not defined' +
+          '\n    at handler (../../test/integration/server-side-dev-errors/pages/api/blog/[slug].js:2:2)' +
+          '\n  1 | export default function handler(req, res) {' +
+          '\n> 2 |   missingVar;res.status(200).json({ slug: req.query.slug })' +
+          '\n    |  ^'
       )
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/blog/[slug].js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+            |   ^",
+          "stack": [
+            "handler pages/api/blog/[slug].js (2:3)",
+          ],
+        }
+      `)
 
       await fs.writeFile(dynamicApiPage, content)
 
-      if (isTurbopack) {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      } else {
-        await expect(browser).toDisplayRedbox(`
-         {
-           "description": "ReferenceError: missingVar is not defined",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "pages/api/blog/[slug].js (2:3) @ handler
-         > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-             |   ^",
-           "stack": [
-             "handler pages/api/blog/[slug].js (2:3)",
-           ],
-         }
-        `)
-      }
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "ReferenceError: missingVar is not defined",
+          "environmentLabel": null,
+          "label": "Runtime Error",
+          "source": "pages/api/blog/[slug].js (2:3) @ handler
+        > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+            |   ^",
+          "stack": [
+            "handler pages/api/blog/[slug].js (2:3)",
+          ],
+        }
+      `)
     } finally {
       await fs.writeFile(dynamicApiPage, content)
     }


### PR DESCRIPTION
This shouldn't affect most users since in those case these files would be inside node_modules/ and therefore ignore-listed by default.

The only exception I can think of is setups where modules are not inside node_modules/  inside another folder (Yarn Berry has such on option).

It's mostly targetted at our own testing where the Next.js installation may be symlinked and therefore not point into node_modules.

Webpack-bundled code may not be affected due to https://linear.app/vercel/issue/NDX-464.