### PR TITLE
Turbopack: fix cell not found bug

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1212,7 +1212,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         {
             let mut ctx = self.execute_context(turbo_tasks);
-            let mut task = ctx.task(task_id, TaskDataCategory::Data);
+            let mut task = ctx.task(task_id, TaskDataCategory::All);
             let in_progress = remove!(task, InProgress)?;
             let InProgressState::Scheduled { done_event } = in_progress else {
                 task.add_new(CachedDataItem::InProgress { value: in_progress });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1003,7 +1003,12 @@ impl AggregationUpdateQueue {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("process balance edge").entered();
 
-        let (mut upper, mut task) = ctx.task_pair(upper_id, task_id, TaskDataCategory::Meta);
+        let (mut upper, mut task) = ctx.task_pair(
+            upper_id,
+            task_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         let upper_aggregation_number = get_aggregation_number(&upper);
         let task_aggregation_number = get_aggregation_number(&task);
 
@@ -1187,7 +1192,11 @@ impl AggregationUpdateQueue {
             name = ctx.get_task_description(task_id)
         )
         .entered();
-        let task = ctx.task(task_id, TaskDataCategory::Meta);
+        let task = ctx.task(
+            task_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         self.find_and_schedule_dirty_internal(task_id, task, ctx);
     }
 
@@ -1234,7 +1243,11 @@ impl AggregationUpdateQueue {
         update: AggregatedDataUpdate,
     ) {
         for upper_id in upper_ids {
-            let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+            let mut upper = ctx.task(
+                upper_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             let diff = update.apply(
                 &mut upper,
                 ctx.session_id(),
@@ -1265,7 +1278,11 @@ impl AggregationUpdateQueue {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("lost follower (n uppers)", uppers = upper_ids.len()).entered();
 
-        let mut follower = ctx.task(lost_follower_id, TaskDataCategory::Meta);
+        let mut follower = ctx.task(
+            lost_follower_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         let mut follower_in_upper_ids = Vec::new();
         let mut persistent_uppers = 0;
         upper_ids.retain(|&mut upper_id| {
@@ -1298,7 +1315,11 @@ impl AggregationUpdateQueue {
             if !data.is_empty() {
                 for upper_id in upper_ids.iter() {
                     // remove data from upper
-                    let mut upper = ctx.task(*upper_id, TaskDataCategory::Meta);
+                    let mut upper = ctx.task(
+                        *upper_id,
+                        // For performance reasons this should stay `Meta` and not `All`
+                        TaskDataCategory::Meta,
+                    );
                     let diff = data.apply(
                         &mut upper,
                         ctx.session_id(),
@@ -1331,7 +1352,11 @@ impl AggregationUpdateQueue {
         }
 
         for upper_id in follower_in_upper_ids {
-            let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+            let mut upper = ctx.task(
+                upper_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             if update_count!(
                 upper,
                 Follower {
@@ -1379,7 +1404,11 @@ impl AggregationUpdateQueue {
         .entered();
 
         lost_follower_ids.retain(|lost_follower_id| {
-            let mut follower = ctx.task(*lost_follower_id, TaskDataCategory::Meta);
+            let mut follower = ctx.task(
+                *lost_follower_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             let mut remove_upper = false;
             let mut follower_in_upper = false;
             update!(follower, Upper { task: upper_id }, |old| {
@@ -1404,7 +1433,11 @@ impl AggregationUpdateQueue {
 
                 if !data.is_empty() {
                     // remove data from upper
-                    let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+                    let mut upper = ctx.task(
+                        upper_id,
+                        // For performance reasons this should stay `Meta` and not `All`
+                        TaskDataCategory::Meta,
+                    );
                     let diff = data.apply(
                         &mut upper,
                         ctx.session_id(),
@@ -1434,7 +1467,11 @@ impl AggregationUpdateQueue {
             follower_in_upper
         });
         for lost_follower_id in lost_follower_ids {
-            let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+            let mut upper = ctx.task(
+                upper_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             if update_count!(
                 upper,
                 Follower {
@@ -1479,14 +1516,22 @@ impl AggregationUpdateQueue {
             trace_span!("process new follower (n uppers)", uppers = upper_ids.len()).entered();
 
         let follower_aggregation_number = {
-            let follower = ctx.task(new_follower_id, TaskDataCategory::Meta);
+            let follower = ctx.task(
+                new_follower_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             get_aggregation_number(&follower)
         };
         let mut upper_upper_ids_with_new_follower = SmallVec::new();
         let mut tasks_for_which_increment_active_count = SmallVec::new();
         let mut is_active = false;
         swap_retain(&mut upper_ids, |&mut upper_id| {
-            let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+            let mut upper = ctx.task(
+                upper_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             // decide if it should be an inner or follower
             let upper_aggregation_number = get_aggregation_number(&upper);
 
@@ -1539,7 +1584,11 @@ impl AggregationUpdateQueue {
         });
 
         if !upper_ids.is_empty() {
-            let mut follower = ctx.task(new_follower_id, TaskDataCategory::Meta);
+            let mut follower = ctx.task(
+                new_follower_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             let mut uppers_count: Option<usize> = None;
             let mut persistent_uppers = 0;
             swap_retain(&mut upper_ids, |&mut upper_id| {
@@ -1579,7 +1628,11 @@ impl AggregationUpdateQueue {
                 if has_data || !is_active {
                     for upper_id in upper_ids.iter() {
                         // add data to upper
-                        let mut upper = ctx.task(*upper_id, TaskDataCategory::Meta);
+                        let mut upper = ctx.task(
+                            *upper_id,
+                            // For performance reasons this should stay `Meta` and not `All`
+                            TaskDataCategory::Meta,
+                        );
                         if has_data {
                             let diff = data.apply(
                                 &mut upper,
@@ -1654,7 +1707,11 @@ impl AggregationUpdateQueue {
         let mut followers_with_aggregation_number = new_follower_ids
             .into_iter()
             .map(|new_follower_id| {
-                let follower = ctx.task(new_follower_id, TaskDataCategory::Meta);
+                let follower = ctx.task(
+                    new_follower_id,
+                    // For performance reasons this should stay `Meta` and not `All`
+                    TaskDataCategory::Meta,
+                );
                 (new_follower_id, get_aggregation_number(&follower))
             })
             .collect::<SmallVec<[_; 4]>>();
@@ -1665,7 +1722,11 @@ impl AggregationUpdateQueue {
         let mut upper_upper_ids_for_new_followers = SmallVec::new();
         let upper_aggregation_number;
         {
-            let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+            let mut upper = ctx.task(
+                upper_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             if ctx.should_track_activeness() {
                 let activeness_state = get!(upper, Activeness);
                 is_active = activeness_state.is_some();
@@ -1719,7 +1780,11 @@ impl AggregationUpdateQueue {
             swap_retain(
                 &mut inner_tasks_with_aggregation_number,
                 |&mut (inner_id, _)| {
-                    let mut inner = ctx.task(inner_id, TaskDataCategory::Meta);
+                    let mut inner = ctx.task(
+                        inner_id,
+                        // For performance reasons this should stay `Meta` and not `All`
+                        TaskDataCategory::Meta,
+                    );
                     if update_count!(inner, Upper { task: upper_id }, 1) {
                         if count!(inner, Upper).is_power_of_two() {
                             self.push_optimize_task(inner_id);
@@ -1763,7 +1828,11 @@ impl AggregationUpdateQueue {
             }
             if !upper_data_updates.is_empty() {
                 // add data to upper
-                let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+                let mut upper = ctx.task(
+                    upper_id,
+                    // For performance reasons this should stay `Meta` and not `All`
+                    TaskDataCategory::Meta,
+                );
                 let diffs = upper_data_updates
                     .into_iter()
                     .filter_map(|data| {
@@ -1804,7 +1873,11 @@ impl AggregationUpdateQueue {
                 if !is_active {
                     // We need to check this again, since this might have changed in the
                     // meantime due to race conditions
-                    let upper = ctx.task(upper_id, TaskDataCategory::Meta);
+                    let upper = ctx.task(
+                        upper_id,
+                        // For performance reasons this should stay `Meta` and not `All`
+                        TaskDataCategory::Meta,
+                    );
                     is_active = upper.has_key(&CachedDataItemKey::Activeness {});
                 }
                 if is_active {
@@ -1849,11 +1922,19 @@ impl AggregationUpdateQueue {
         let _span = trace_span!("process new follower").entered();
 
         let follower_aggregation_number = {
-            let follower = ctx.task(new_follower_id, TaskDataCategory::Meta);
+            let follower = ctx.task(
+                new_follower_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             get_aggregation_number(&follower)
         };
 
-        let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+        let mut upper = ctx.task(
+            upper_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         // decide if it should be an inner or follower
         let upper_aggregation_number = get_aggregation_number(&upper);
 
@@ -1912,7 +1993,11 @@ impl AggregationUpdateQueue {
             let mut is_active = upper.has_key(&CachedDataItemKey::Activeness {});
             drop(upper);
 
-            let mut inner = ctx.task(new_follower_id, TaskDataCategory::Meta);
+            let mut inner = ctx.task(
+                new_follower_id,
+                // For performance reasons this should stay `Meta` and not `All`
+                TaskDataCategory::Meta,
+            );
             if update_count!(inner, Upper { task: upper_id }, 1) {
                 if count!(inner, Upper).is_power_of_two() {
                     self.push_optimize_task(new_follower_id);
@@ -1924,7 +2009,11 @@ impl AggregationUpdateQueue {
 
                 if !data.is_empty() {
                     // add data to upper
-                    let mut upper = ctx.task(upper_id, TaskDataCategory::Meta);
+                    let mut upper = ctx.task(
+                        upper_id,
+                        // For performance reasons this should stay `Meta` and not `All`
+                        TaskDataCategory::Meta,
+                    );
                     let diff = data.apply(
                         &mut upper,
                         ctx.session_id(),
@@ -1949,7 +2038,11 @@ impl AggregationUpdateQueue {
                     });
                 }
                 if !is_active {
-                    let upper = ctx.task(upper_id, TaskDataCategory::Meta);
+                    let upper = ctx.task(
+                        upper_id,
+                        // For performance reasons this should stay `Meta` and not `All`
+                        TaskDataCategory::Meta,
+                    );
                     is_active = upper.has_key(&CachedDataItemKey::Activeness {});
                 }
                 if is_active {
@@ -1966,7 +2059,11 @@ impl AggregationUpdateQueue {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("decrease active count").entered();
 
-        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+        let mut task = ctx.task(
+            task_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         let state = get_mut_or_insert_with!(task, Activeness, || ActivenessState::new(task_id));
         let is_zero = state.decrement_active_counter();
         let is_empty = state.is_empty();
@@ -1991,7 +2088,11 @@ impl AggregationUpdateQueue {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("increase active count").entered();
 
-        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+        let mut task = ctx.task(
+            task_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         let state = get_mut_or_insert_with!(task, Activeness, || ActivenessState::new(task_id));
         let is_positive_now = state.increment_active_counter();
         let is_empty = state.is_empty();
@@ -2023,7 +2124,11 @@ impl AggregationUpdateQueue {
         let _span =
             trace_span!("check update aggregation number", base_aggregation_number).entered();
 
-        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+        let mut task = ctx.task(
+            task_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         let current = get!(task, AggregationNumber).copied().unwrap_or_default();
         let old = current.effective;
         // The base aggregation number can only increase
@@ -2116,7 +2221,11 @@ impl AggregationUpdateQueue {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("check optimize").entered();
 
-        let task = ctx.task(task_id, TaskDataCategory::All);
+        let task = ctx.task(
+            task_id,
+            // For performance reasons this should stay `Meta` and not `All`
+            TaskDataCategory::Meta,
+        );
         let aggregation_number = get!(task, AggregationNumber).copied().unwrap_or_default();
         if is_root_node(aggregation_number.effective) {
             return;
@@ -2164,7 +2273,11 @@ impl AggregationUpdateQueue {
                 if task_id.is_transient() {
                     return None;
                 }
-                let task = ctx.task(task_id, TaskDataCategory::Meta);
+                let task = ctx.task(
+                    task_id,
+                    // For performance reasons this should stay `Meta` and not `All`
+                    TaskDataCategory::Meta,
+                );
                 let n = get_aggregation_number(&task);
                 if is_root_node(n) {
                     root_uppers += 1;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -422,14 +422,22 @@ impl<B: BackingStorage> TaskGuardImpl<'_, B> {
                     #[cfg(debug_assertions)]
                     debug_assert!(
                         self.category == TaskDataCategory::Data
-                            || self.category == TaskDataCategory::All
+                            || self.category == TaskDataCategory::All,
+                        "To read data of {:?} the task need to be accessed with this category \
+                         (It's accessed with {:?})",
+                        category,
+                        self.category
                     );
                 }
                 TaskDataCategory::Meta => {
                     #[cfg(debug_assertions)]
                     debug_assert!(
                         self.category == TaskDataCategory::Meta
-                            || self.category == TaskDataCategory::All
+                            || self.category == TaskDataCategory::All,
+                        "To read data of {:?} the task need to be accessed with this category \
+                         (It's accessed with {:?})",
+                        category,
+                        self.category
                     );
                 }
             }
@@ -631,6 +639,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         &self,
         ty: CachedDataItemType,
     ) -> impl Iterator<Item = (CachedDataItemKey, CachedDataItemValueRef<'_>)> {
+        self.check_access(ty.category());
         self.task.iter(ty)
     }
 
@@ -646,6 +655,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
     where
         F: for<'a> FnMut(CachedDataItemKey, CachedDataItemValueRef<'a>) -> bool + 'l,
     {
+        self.check_access(ty.category());
         if !self.backend.should_persist() || self.task_id.is_transient() {
             return Either::Left(self.task.extract_if(ty, f));
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -47,7 +47,7 @@ impl UpdateOutputOperation {
         output: Result<Result<RawVc>, Option<Cow<'static, str>>>,
         mut ctx: impl ExecuteContext,
     ) {
-        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
         let Some(InProgressState::InProgress(box InProgressStateInner {
             stale,
             new_children,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -557,26 +557,26 @@ impl CachedDataItem {
 
     pub fn category(&self) -> TaskDataCategory {
         match self {
-            Self::Collectible { .. }
-            | Self::Child { .. }
-            | Self::CellData { .. }
+            Self::CellData { .. }
             | Self::CellTypeMaxIndex { .. }
             | Self::OutputDependency { .. }
             | Self::CellDependency { .. }
             | Self::CollectiblesDependency { .. }
             | Self::OutputDependent { .. }
-            | Self::CellDependent { .. }
-            | Self::CollectiblesDependent { .. } => TaskDataCategory::Data,
+            | Self::CellDependent { .. } => TaskDataCategory::Data,
 
-            Self::Output { .. }
+            Self::Collectible { .. }
+            | Self::Output { .. }
             | Self::AggregationNumber { .. }
             | Self::Dirty { .. }
             | Self::Follower { .. }
+            | Self::Child { .. }
             | Self::Upper { .. }
             | Self::AggregatedDirtyContainer { .. }
             | Self::AggregatedCollectible { .. }
             | Self::AggregatedDirtyContainerCount { .. }
-            | Self::Stateful { .. } => TaskDataCategory::Meta,
+            | Self::Stateful { .. }
+            | Self::CollectiblesDependent { .. } => TaskDataCategory::Meta,
 
             Self::OutdatedCollectible { .. }
             | Self::OutdatedOutputDependency { .. }
@@ -639,26 +639,26 @@ impl CachedDataItemKey {
 impl CachedDataItemType {
     pub fn category(&self) -> TaskDataCategory {
         match self {
-            Self::Collectible { .. }
-            | Self::Child { .. }
-            | Self::CellData { .. }
+            Self::CellData { .. }
             | Self::CellTypeMaxIndex { .. }
             | Self::OutputDependency { .. }
             | Self::CellDependency { .. }
             | Self::CollectiblesDependency { .. }
             | Self::OutputDependent { .. }
-            | Self::CellDependent { .. }
-            | Self::CollectiblesDependent { .. } => TaskDataCategory::Data,
+            | Self::CellDependent { .. } => TaskDataCategory::Data,
 
-            Self::Output { .. }
+            Self::Collectible { .. }
+            | Self::Output { .. }
             | Self::AggregationNumber { .. }
             | Self::Dirty { .. }
             | Self::Follower { .. }
+            | Self::Child { .. }
             | Self::Upper { .. }
             | Self::AggregatedDirtyContainer { .. }
             | Self::AggregatedCollectible { .. }
             | Self::AggregatedDirtyContainerCount { .. }
-            | Self::Stateful { .. } => TaskDataCategory::Meta,
+            | Self::Stateful { .. }
+            | Self::CollectiblesDependent { .. } => TaskDataCategory::Meta,
 
             Self::OutdatedCollectible { .. }
             | Self::OutdatedOutputDependency { .. }

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -33,7 +33,7 @@ async fn dirty_in_progress() {
             output.await?;
             println!("update to {}", b);
             input_val.state.set(b);
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(50)).await;
             println!("update to {}", c);
             input_val.state.set(c);
             let read = output.strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
@@ -12,12 +12,12 @@ static REGISTRATION: Registration = register!();
 #[tokio::test]
 async fn recompute() {
     run(&REGISTRATION, || async {
-        let input = ChangingInput {
-            state: State::new(1),
-        }
-        .cell();
-        let output = compute(input, 100);
-        let read = output.await?;
+        let input = ChangingInput::new(1).resolve().await?;
+        let input2 = ChangingInput::new(2).resolve().await?;
+        input.await?.state.set(1);
+        input2.await?.state.set(1000);
+        let output = compute(input, input2, 1);
+        let read = output.strongly_consistent().await?;
         assert_eq!(read.value, 42);
         assert_eq!(read.collectible, "1");
 
@@ -26,6 +26,13 @@ async fn recompute() {
             let read = output.strongly_consistent().await?;
             assert_eq!(read.value, 42);
             assert_eq!(read.collectible, i.to_string());
+        }
+
+        for i in 0..100 {
+            input2.await?.state.set(i);
+            let read = output.strongly_consistent().await?;
+            assert_eq!(read.value, 42);
+            assert_eq!(read.collectible, "99");
         }
         anyhow::Ok(())
     })
@@ -36,6 +43,18 @@ async fn recompute() {
 #[turbo_tasks::value]
 struct ChangingInput {
     state: State<u32>,
+}
+
+#[turbo_tasks::value_impl]
+impl ChangingInput {
+    #[turbo_tasks::function]
+    fn new(key: u32) -> Vc<Self> {
+        let _ = key;
+        Self {
+            state: State::new(1),
+        }
+        .cell()
+    }
 }
 
 #[turbo_tasks::value]
@@ -58,32 +77,39 @@ impl ValueToString for Collectible {
 }
 
 #[turbo_tasks::function(operation)]
-fn inner_compute(input: ResolvedVc<ChangingInput>) -> Vc<u32> {
-    inner_compute2(*input, 1000)
+async fn inner_compute(
+    input: ResolvedVc<ChangingInput>,
+    input2: ResolvedVc<ChangingInput>,
+) -> Result<Vc<u32>> {
+    println!("inner_compute()");
+    Ok(inner_compute2(*input, *input2.await?.state.get()))
 }
 
 #[turbo_tasks::function]
 async fn inner_compute2(input: Vc<ChangingInput>, innerness: u32) -> Result<Vc<u32>> {
+    println!("inner_compute2({innerness})");
     if innerness > 0 {
         return Ok(inner_compute2(input, innerness - 1));
     }
-    let collectible: ResolvedVc<Box<dyn ValueToString>> = ResolvedVc::upcast(
-        Collectible {
-            value: *input.await?.state.get(),
-        }
-        .resolved_cell(),
-    );
+    let value = *input.await?.state.get();
+    let collectible: ResolvedVc<Box<dyn ValueToString>> =
+        ResolvedVc::upcast(Collectible { value }.resolved_cell());
     emit(collectible);
 
     Ok(Vc::cell(42))
 }
 
 #[turbo_tasks::function]
-async fn compute(input: ResolvedVc<ChangingInput>, innerness: u32) -> Result<Vc<Output>> {
+async fn compute(
+    input: ResolvedVc<ChangingInput>,
+    input2: ResolvedVc<ChangingInput>,
+    innerness: u32,
+) -> Result<Vc<Output>> {
+    println!("compute({innerness})");
     if innerness > 0 {
-        return Ok(compute(*input, innerness - 1));
+        return Ok(compute(*input, *input2, innerness - 1));
     }
-    let operation = inner_compute(input);
+    let operation = inner_compute(input, input2);
     let value = *operation.connect().await?;
     let collectibles = operation.peek_collectibles::<Box<dyn ValueToString>>();
     if collectibles.len() != 1 {


### PR DESCRIPTION
### What?

* Some debug asserts were missing to validate the correct category on read access via `iter()` or `extract_if()`. Added these.
* incorrect accessed category led to empty list of dependencies after restoring from persistent caching, which led to weird bugs like Cell not found errors

So optimized the category assignment to make sure aggregation updates can operate on Meta only. Children, Collectibles and CollectiblesDependent were moved to Meta category since they are accessed during aggregation updates. `Children` are used as follower for non-aggregating nodes. `Collectibles` are read when computing the aggregated information and `CollectiblesDependent` are read when aggregated collectibles are modified.

* Added a unit test reproducting this bug and the next PR in the stack also added a e2e test reproducting it.

Closes PACK-4379