### PR TITLE
Prevent typescript errors in IDE for newly generated tests

### DIFF
--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -5,6 +5,7 @@ import * as helpers from './helpers'
 interface TestResponse {
   appDir: string
   type: 'e2e' | 'production' | 'development' | 'unit'
+  name: string
 }
 
 interface ErrorResponse {
@@ -61,24 +62,43 @@ export default function generator(plop: NodePlopAPI): void {
       },
     ],
     actions: function (answers) {
-      const { appDir, type } = answers as TestResponse
-      const testRoot = path.join(plop.getDestBasePath(), 'test')
-
+      const { appDir, type, name } = answers as TestResponse
+      const basePath = plop.getDestBasePath()
+      const testRoot = path.join(basePath, 'test')
       const appDirPath = appDir ? 'app-dir/' : ''
-      let templatePath = path.join(
+
+      const templatePath = path.join(
         testRoot,
         type === 'unit' ? 'unit' : 'e2e',
         appDirPath,
         'test-template'
       )
-      let targetPath = path.join(testRoot, type, appDirPath)
+
+      const targetPath = path.join(testRoot, type, appDirPath)
+
+      const cnaTemplatePath = path.join(
+        basePath,
+        'packages/create-next-app/templates',
+        appDir ? 'app-empty' : 'default-empty',
+        'ts'
+      )
 
       return [
         {
           type: 'addMany',
-          templateFiles: `${templatePath}/**/*`,
+          templateFiles: path.join(templatePath, '**/*'),
           base: templatePath,
           destination: targetPath,
+        },
+        {
+          type: 'add',
+          templateFile: path.join(cnaTemplatePath, 'tsconfig.json'),
+          path: path.join(targetPath, name, 'tsconfig.json'),
+        },
+        {
+          type: 'add',
+          templateFile: path.join(cnaTemplatePath, 'next-env.d.ts'),
+          path: path.join(targetPath, name, 'next-env.d.ts'),
         },
       ]
     },


### PR DESCRIPTION
When generating a new test with `pnpm new-test`, the IDE will show the following error when opening the generated `page.tsx` or `layout.tsx` files:

```sh
'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.ts (2686)
```

This is because by default, the generated test app is covered by the root `tsconfig.json`, containing `{"jsx": "react-jsx"}` which expects there to be a `React` import that the template files don't have.

When first running `pnpm next dev` or `pnpm next build`, a local `tsconfig.json` file is generated for the test app. This config contains `{"jsx": "preserve"}`, which fixes the initial errors.

To avoid this step, and prevent the initial compiler errors, we can just copy the `tsconfig.json` as well as the `next-env.d.ts` from the CNA template files into the new test app. (Those two files are git-ignored, by the way.)