### PR TITLE
`@next/mdx`: Use stable turbopack config options

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -23,6 +23,9 @@ module.exports =
           },
         }
 
+    /**
+     * @type {import('next').NextConfig}
+     */
     let nextConfig = Object.assign({}, inputConfig, {
       webpack(config, options) {
         config.resolve.alias['next-mdx-import-source-file'] = [
@@ -44,22 +47,16 @@ module.exports =
     })
 
     if (process.env.TURBOPACK) {
-      nextConfig.experimental = Object.assign({}, nextConfig?.experimental, {
-        turbo: Object.assign({}, nextConfig?.experimental?.turbo, {
-          rules: Object.assign({}, nextConfig?.experimental?.turbo?.rules, {
-            '*.mdx': {
-              loaders: [loader],
-              as: '*.tsx',
-            },
-          }),
-          resolveAlias: Object.assign(
-            {},
-            nextConfig?.experimental?.turbo?.resolveAlias,
-            {
-              'next-mdx-import-source-file':
-                '@vercel/turbopack-next/mdx-import-source',
-            }
-          ),
+      nextConfig.turbopack = Object.assign({}, nextConfig?.turbopack, {
+        rules: Object.assign({}, nextConfig?.turbopack?.rules, {
+          '*.mdx': {
+            loaders: [loader],
+            as: '*.tsx',
+          },
+        }),
+        resolveAlias: Object.assign({}, nextConfig?.turbopack?.resolveAlias, {
+          'next-mdx-import-source-file':
+            '@vercel/turbopack-next/mdx-import-source',
         }),
       })
     }


### PR DESCRIPTION
Now that Turbopack config has stabilized and moved out of `experimental`, use this field when automatically configuring it in `@next/mdx`.

This avoids the warning being shown about the config option having moved.

This requires `@next/mdx` be used with Next.js >= 15.3.0.

Test Plan: Ran `next dev --turbopack` in `examples/mdx`. Verified no warning about the deprecated experimental option was printed.

Closes PACK-4339
Resolves #78009
