### PR TITLE
feat(turbopack): Add simple tree shaker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9619,6 +9619,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "auto-hash-map",
  "bitvec",
  "bytes-str",
  "codspeed-criterion-compat",

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -348,6 +348,9 @@ pub async fn get_client_module_options_context(
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         keep_last_successful_parse: next_mode.is_development(),
+        remove_unused_exports: *next_config
+            .turbopack_remove_unused_exports(next_mode.is_development())
+            .await?,
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -76,7 +76,7 @@ impl EcmascriptClientReferenceModule {
         // Adapted from https://github.com/facebook/react/blob/c5b9375767e2c4102d7e5559d383523736f1c902/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js#L323-L354
         if let EcmascriptExports::EsmExports(exports) = &*self.client_module.get_exports().await? {
             is_esm = true;
-            let exports = exports.expand_exports().await?;
+            let exports = exports.expand_exports(None).await?;
 
             if !exports.dynamic_exports.is_empty() {
                 // TODO: throw? warn?

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -326,7 +326,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
 
             let referenced_modules = referenced_modules
                 .iter()
-                .flat_map(|(chunking_type, modules)| match chunking_type {
+                .flat_map(|(chunking_type, _, modules)| match chunking_type {
                     ChunkingType::Traced => None,
                     _ => Some(modules.iter()),
                 })

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -797,6 +797,8 @@ pub struct ExperimentalConfig {
     turbopack_tree_shaking: Option<bool>,
     // Whether to enable the global-not-found convention
     global_not_found: Option<bool>,
+    /// Defaults to false in development mode, true in production mode.
+    turbopack_remove_unused_exports: Option<bool>,
 }
 
 #[derive(
@@ -1556,6 +1558,15 @@ impl NextConfig {
             None => Some(TreeShakingMode::ReexportsOnly),
         })
         .cell()
+    }
+
+    #[turbo_tasks::function]
+    pub fn turbopack_remove_unused_exports(&self, is_development: bool) -> Vc<bool> {
+        Vc::cell(
+            self.experimental
+                .turbopack_remove_unused_exports
+                .unwrap_or(!is_development),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -11,6 +11,7 @@ use turbopack_core::{
     module::Module,
     module_graph::ModuleGraph,
     reference::{ModuleReferences, SingleChunkableModuleReference},
+    resolve::ExportUsage,
 };
 use turbopack_ecmascript::{
     chunk::{
@@ -56,6 +57,7 @@ impl Module for NextDynamicEntryModule {
             SingleChunkableModuleReference::new(
                 Vc::upcast(*self.module),
                 dynamic_ref_description(),
+                ExportUsage::all(),
             )
             .to_resolved()
             .await?,
@@ -98,6 +100,7 @@ impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
             SingleChunkableModuleReference::new(
                 Vc::upcast(*self.module),
                 dynamic_ref_description(),
+                ExportUsage::all(),
             )
             .to_resolved()
             .await?,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -565,6 +565,9 @@ pub async fn get_server_module_options_context(
             None
         },
         keep_last_successful_parse: next_mode.is_development(),
+        remove_unused_exports: *next_config
+            .turbopack_remove_unused_exports(next_mode.is_development())
+            .await?,
         ..Default::default()
     };
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -461,6 +461,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         turbopackPersistentCaching: z.boolean().optional(),
         turbopackSourceMaps: z.boolean().optional(),
         turbopackTreeShaking: z.boolean().optional(),
+        turbopackRemoveUnusedExports: z.boolean().optional(),
         optimizePackageImports: z.array(z.string()).optional(),
         optimizeServerReact: z.boolean().optional(),
         clientTraceMetadata: z.array(z.string()).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -433,6 +433,11 @@ export interface ExperimentalConfig {
   turbopackTreeShaking?: boolean
 
   /**
+   * Enable removing unused exports for turbopack dev server and build.
+   */
+  turbopackRemoveUnusedExports?: boolean
+
+  /**
    * For use with `@next/mdx`. Compile MDX files using the new Rust compiler.
    * @see https://nextjs.org/docs/app/api-reference/next-config-js/mdxRs
    */

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -44,6 +44,7 @@ use crate::{
     },
     output::OutputAssets,
     reference::ModuleReference,
+    resolve::ExportUsage,
 };
 
 /// A module id, which can be a number or string
@@ -280,6 +281,11 @@ pub trait ChunkableModuleReference: ModuleReference + ValueToString {
             inherit_async: false,
             hoisted: false,
         }))
+    }
+
+    #[turbo_tasks::function]
+    fn export_usage(self: Vc<Self>) -> Vc<ExportUsage> {
+        ExportUsage::all()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -78,21 +78,21 @@ async fn compute_async_module_info_single(
         &mut (),
         |_, _, _| Ok(GraphTraversalAction::Continue),
         |parent_info, module, _| {
-            let Some((parent_module, chunking_type)) = parent_info else {
+            let Some((parent_module, ref_data)) = parent_info else {
                 // An entry module
                 return;
             };
             let module = module.module();
             let parent_module = parent_module.module;
 
-            if chunking_type.is_inherit_async() && async_modules.contains(&module) {
+            if ref_data.chunking_type.is_inherit_async() && async_modules.contains(&module) {
                 async_modules.insert(parent_module);
             }
         },
     )?;
 
     graph.traverse_cycles(
-        |ty| ty.is_inherit_async(),
+        |ref_data| ref_data.chunking_type.is_inherit_async(),
         |cycle| {
             if cycle
                 .iter()

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -19,7 +19,7 @@ use turbo_tasks::{
 use crate::{
     chunk::ChunkingType,
     module::Module,
-    module_graph::{GraphTraversalAction, ModuleGraph, SingleModuleGraphModuleNode},
+    module_graph::{GraphTraversalAction, ModuleGraph, RefData, SingleModuleGraphModuleNode},
 };
 
 #[derive(
@@ -462,7 +462,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                     })
                     .collect::<Result<Vec<_>>>()?,
                 &mut module_chunk_groups,
-                |parent_info: Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+                |parent_info: Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
                  node: &'_ SingleModuleGraphModuleNode,
                  module_chunk_groups: &mut FxHashMap<
                     ResolvedVc<Box<dyn Module>>,
@@ -473,8 +473,8 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                         Inherit(ResolvedVc<Box<dyn Module>>),
                         ChunkGroup(It),
                     }
-                    let chunk_groups = if let Some((parent, chunking_type)) = parent_info {
-                        match chunking_type {
+                    let chunk_groups = if let Some((parent, ref_data)) = parent_info {
+                        match &ref_data.chunking_type {
                             ChunkingType::Parallel { .. } => {
                                 ChunkGroupInheritance::Inherit(parent.module)
                             }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -6,7 +6,6 @@ use std::{
 use anyhow::{Context, Result, bail};
 use auto_hash_map::AutoSet;
 use petgraph::{
-    Directed,
     graph::{DiGraph, EdgeIndex, NodeIndex},
     visit::{
         Dfs, EdgeRef, IntoNeighbors, IntoNodeReferences, NodeIndexable, Reversed, VisitMap,
@@ -20,6 +19,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{
     CollectiblesSource, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt,
     ValueToString, Vc,
+    debug::ValueDebugFormat,
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
     trace::TraceRawVcs,
 };
@@ -37,6 +37,7 @@ use crate::{
         traced_di_graph::{TracedDiGraph, iter_neighbors_rev},
     },
     reference::primary_chunkable_referenced_modules,
+    resolve::ExportUsage,
 };
 
 pub mod async_module_info;
@@ -175,7 +176,7 @@ impl GraphEntries {
 #[turbo_tasks::value(cell = "new", eq = "manual", into = "new")]
 #[derive(Clone, Default)]
 pub struct SingleModuleGraph {
-    graph: TracedDiGraph<SingleModuleGraphNode, ChunkingType>,
+    graph: TracedDiGraph<SingleModuleGraphNode, RefData>,
 
     /// The number of modules in the graph (excluding VisitedModule nodes)
     pub number_of_modules: usize,
@@ -193,6 +194,23 @@ pub struct SingleModuleGraph {
     pub entries: GraphEntriesT,
 }
 
+#[derive(
+    Debug,
+    Clone,
+    Hash,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    ValueDebugFormat,
+    NonLocalValue,
+)]
+pub struct RefData {
+    pub chunking_type: ChunkingType,
+    pub export: ExportUsage,
+}
+
 impl SingleModuleGraph {
     /// Walks the graph starting from the given entries and collects all reachable nodes, skipping
     /// nodes listed in `visited_modules`
@@ -208,6 +226,7 @@ impl SingleModuleGraph {
             .map(|e| async move {
                 Ok(SingleModuleGraphBuilderEdge {
                     to: SingleModuleGraphBuilderNode::new_module(e).await?,
+                    export: ExportUsage::All,
                 })
             })
             .try_join()
@@ -228,24 +247,27 @@ impl SingleModuleGraph {
         let node_count = visited_nodes.0.len();
         drop(visited_nodes);
 
-        let mut graph: petgraph::Graph<SingleModuleGraphNode, ChunkingType, Directed> =
-            DiGraph::with_capacity(
-                node_count,
-                // From real world measurements each module has about 3-4 children
-                // If it has more this would cause an additional allocation, but that's fine
-                node_count * 4,
-            );
+        let mut graph: DiGraph<SingleModuleGraphNode, RefData> = DiGraph::with_capacity(
+            node_count,
+            // From real world measurements each module has about 3-4 children
+            // If it has more this would cause an additional allocation, but that's fine
+            node_count * 4,
+        );
 
         let mut number_of_modules = 0;
         let mut modules: FxHashMap<ResolvedVc<Box<dyn Module>>, NodeIndex> =
             FxHashMap::with_capacity_and_hasher(node_count, Default::default());
         {
             let _span = tracing::info_span!("build module graph").entered();
-            for (parent, current) in children_nodes_iter.into_breadth_first_edges() {
-                let parent_edge = match parent {
-                    Some(SingleModuleGraphBuilderNode::Module { module, .. }) => {
-                        Some((*modules.get(&module).unwrap(), COMMON_CHUNKING_TYPE))
-                    }
+            for (parent, (current, export)) in children_nodes_iter.into_breadth_first_edges() {
+                let parent_edge = match parent.map(|v| v.0) {
+                    Some(SingleModuleGraphBuilderNode::Module { module, .. }) => Some((
+                        *modules.get(&module).unwrap(),
+                        RefData {
+                            chunking_type: COMMON_CHUNKING_TYPE,
+                            export,
+                        },
+                    )),
                     Some(SingleModuleGraphBuilderNode::ChunkableReference { .. }) => {
                         // Handled when visiting ChunkableReference below
                         continue;
@@ -268,8 +290,8 @@ impl SingleModuleGraph {
                             idx
                         };
                         // Add the edge
-                        if let Some((parent_idx, chunking_type)) = parent_edge {
-                            graph.add_edge(parent_idx, current_idx, chunking_type);
+                        if let Some((parent_idx, ref_data)) = parent_edge {
+                            graph.add_edge(parent_idx, current_idx, ref_data);
                         }
                     }
                     SingleModuleGraphBuilderNode::VisitedModule { module, idx } => {
@@ -283,14 +305,14 @@ impl SingleModuleGraph {
                             idx
                         };
                         // Add the edge
-                        if let Some((parent_idx, chunking_type)) = parent_edge {
-                            graph.add_edge(parent_idx, current_idx, chunking_type);
+                        if let Some((parent_idx, data)) = parent_edge {
+                            graph.add_edge(parent_idx, current_idx, data);
                         }
                     }
                     SingleModuleGraphBuilderNode::ChunkableReference {
                         source,
                         target,
-                        chunking_type,
+                        ref_data,
                         ..
                     } => {
                         // Find the current node, if it was already added
@@ -312,7 +334,7 @@ impl SingleModuleGraph {
                             modules.insert(target, idx);
                             idx
                         };
-                        graph.add_edge(*modules.get(&source).unwrap(), target_idx, chunking_type);
+                        graph.add_edge(*modules.get(&source).unwrap(), target_idx, ref_data);
                     }
                 }
             }
@@ -409,7 +431,7 @@ impl SingleModuleGraph {
         &'a self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
-            Option<(&'a SingleModuleGraphModuleNode, &'a ChunkingType)>,
+            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
             &'a SingleModuleGraphModuleNode,
         ) -> GraphTraversalAction,
     ) -> Result<()> {
@@ -469,7 +491,7 @@ impl SingleModuleGraph {
         &'a self,
         mut visitor: impl FnMut(
             (
-                Option<(&'a SingleModuleGraphModuleNode, &'a ChunkingType)>,
+                Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
                 &'a SingleModuleGraphModuleNode,
             ),
         ) -> GraphTraversalAction,
@@ -537,12 +559,12 @@ impl SingleModuleGraph {
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
         mut visit_preorder: impl FnMut(
-            Option<(&'a SingleModuleGraphModuleNode, &'a ChunkingType)>,
+            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
             &'a SingleModuleGraphNode,
             &mut S,
         ) -> Result<GraphTraversalAction>,
         mut visit_postorder: impl FnMut(
-            Option<(&'a SingleModuleGraphModuleNode, &'a ChunkingType)>,
+            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
             &'a SingleModuleGraphNode,
             &mut S,
         ),
@@ -608,7 +630,7 @@ impl SingleModuleGraph {
 
     pub fn traverse_cycles<'l>(
         &'l self,
-        edge_filter: impl Fn(&'l ChunkingType) -> bool,
+        edge_filter: impl Fn(&'l RefData) -> bool,
         mut visit_cycle: impl FnMut(&[&'l SingleModuleGraphModuleNode]),
     ) {
         // see https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
@@ -745,7 +767,7 @@ impl SingleModuleGraph {
                         module_idx,
                         |n| reversed_graph.neighbors(n).next().is_none(),
                         // Edge weights
-                        |e| match e.weight() {
+                        |e| match e.weight().chunking_type {
                             // Prefer following normal imports/requires when we can
                             ChunkingType::Parallel { .. } => 0,
                             _ => 1,
@@ -870,7 +892,7 @@ impl ImportTracer for ModuleGraphImportTracer {
                         module_idx,
                         |n| reversed_graph.neighbors(n).next().is_none(),
                         // Edge weights
-                        |e| match e.weight() {
+                        |e| match e.weight().chunking_type {
                             // Prefer following normal imports/requires when we can
                             ChunkingType::Parallel { .. } => 0,
                             _ => 1,
@@ -1007,7 +1029,7 @@ impl ModuleGraph {
                         .graph
                         .edge_weight(*edge_idx)
                         .unwrap();
-                    ty.is_inherit_async()
+                    ty.chunking_type.is_inherit_async()
                 })
                 .map(|(_, child_idx)| {
                     anyhow::Ok(
@@ -1125,7 +1147,7 @@ impl ModuleGraph {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
             &'_ SingleModuleGraphModuleNode,
         ) -> Result<GraphTraversalAction>,
     ) -> Result<()> {
@@ -1180,7 +1202,7 @@ impl ModuleGraph {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
             &'_ SingleModuleGraphModuleNode,
         ) -> GraphTraversalAction,
     ) -> Result<()> {
@@ -1230,7 +1252,7 @@ impl ModuleGraph {
     pub async fn traverse_all_edges_unordered(
         &self,
         mut visitor: impl FnMut(
-            (&'_ SingleModuleGraphModuleNode, &'_ ChunkingType),
+            (&'_ SingleModuleGraphModuleNode, &'_ RefData),
             &'_ SingleModuleGraphModuleNode,
         ) -> Result<()>,
     ) -> Result<()> {
@@ -1277,12 +1299,12 @@ impl ModuleGraph {
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
         mut visit_preorder: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
             &'_ SingleModuleGraphModuleNode,
             &mut S,
         ) -> Result<GraphTraversalAction>,
         mut visit_postorder: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
             &'_ SingleModuleGraphModuleNode,
             &mut S,
         ),
@@ -1368,7 +1390,7 @@ impl ModuleGraph {
     /// and call the visitor with the nodes in the cycle.
     pub async fn traverse_cycles(
         &self,
-        edge_filter: impl Fn(&ChunkingType) -> bool,
+        edge_filter: impl Fn(&RefData) -> bool,
         mut visit_cycle: impl FnMut(&[&SingleModuleGraphModuleNode]),
     ) -> Result<()> {
         for graph in &self.graphs {
@@ -1403,7 +1425,7 @@ impl ModuleGraph {
         entries: impl IntoIterator<Item = (ResolvedVc<Box<dyn Module>>, P)>,
         state: &mut S,
         mut visit: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
             &'_ SingleModuleGraphModuleNode,
             &mut S,
         ) -> Result<GraphTraversalAction>,
@@ -1556,7 +1578,7 @@ pub enum GraphTraversalAction {
 enum SingleModuleGraphBuilderNode {
     /// This edge is represented as a node: source Module -> ChunkableReference ->  target Module
     ChunkableReference {
-        chunking_type: ChunkingType,
+        ref_data: RefData,
         source: ResolvedVc<Box<dyn Module>>,
         target: ResolvedVc<Box<dyn Module>>,
         // These two fields are only used for tracing. Derived from `source.ident()` and
@@ -1588,10 +1610,10 @@ impl SingleModuleGraphBuilderNode {
     async fn new_chunkable_ref(
         source: ResolvedVc<Box<dyn Module>>,
         target: ResolvedVc<Box<dyn Module>>,
-        chunking_type: ChunkingType,
+        ref_data: RefData,
     ) -> Result<Self> {
         Ok(Self::ChunkableReference {
-            chunking_type,
+            ref_data,
             source,
             source_ident: source.ident().to_string().await?,
             target,
@@ -1604,6 +1626,7 @@ impl SingleModuleGraphBuilderNode {
 }
 struct SingleModuleGraphBuilderEdge {
     to: SingleModuleGraphBuilderNode,
+    export: ExportUsage,
 }
 
 /// The chunking type that occurs most often, is handled more efficiently by not creating
@@ -1618,32 +1641,42 @@ struct SingleModuleGraphBuilder<'a> {
     /// Whether to walk ChunkingType::Traced references
     include_traced: bool,
 }
-impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
+impl Visit<(SingleModuleGraphBuilderNode, ExportUsage)> for SingleModuleGraphBuilder<'_> {
     type Edge = SingleModuleGraphBuilderEdge;
     type EdgesIntoIter = Vec<Self::Edge>;
     type EdgesFuture = impl Future<Output = Result<Self::EdgesIntoIter>>;
 
-    fn visit(&mut self, edge: Self::Edge) -> VisitControlFlow<SingleModuleGraphBuilderNode> {
+    fn visit(
+        &mut self,
+        edge: Self::Edge,
+    ) -> VisitControlFlow<(SingleModuleGraphBuilderNode, ExportUsage)> {
         match edge.to {
-            SingleModuleGraphBuilderNode::Module { .. } => VisitControlFlow::Continue(edge.to),
-            SingleModuleGraphBuilderNode::ChunkableReference {
-                ref chunking_type, ..
-            } => match chunking_type {
-                ChunkingType::Traced => VisitControlFlow::Skip(edge.to),
-                _ => VisitControlFlow::Continue(edge.to),
-            },
+            SingleModuleGraphBuilderNode::Module { .. } => {
+                VisitControlFlow::Continue((edge.to, edge.export))
+            }
+            SingleModuleGraphBuilderNode::ChunkableReference { ref ref_data, .. } => {
+                match &ref_data.chunking_type {
+                    ChunkingType::Traced => VisitControlFlow::Skip((edge.to, edge.export)),
+                    _ => VisitControlFlow::Continue((edge.to, edge.export)),
+                }
+            }
             // Module was already visited previously
-            SingleModuleGraphBuilderNode::VisitedModule { .. } => VisitControlFlow::Skip(edge.to),
+            SingleModuleGraphBuilderNode::VisitedModule { .. } => {
+                VisitControlFlow::Skip((edge.to, edge.export))
+            }
         }
     }
 
-    fn edges(&mut self, node: &SingleModuleGraphBuilderNode) -> Self::EdgesFuture {
+    fn edges(
+        &mut self,
+        (node, _): &(SingleModuleGraphBuilderNode, ExportUsage),
+    ) -> Self::EdgesFuture {
         // Destructure beforehand to not have to clone the whole node when entering the async block
         let (module, chunkable_ref_target) = match node {
             SingleModuleGraphBuilderNode::Module { module, .. } => (Some(*module), None),
-            SingleModuleGraphBuilderNode::ChunkableReference { target, .. } => {
-                (None, Some(*target))
-            }
+            SingleModuleGraphBuilderNode::ChunkableReference {
+                target, ref_data, ..
+            } => (None, Some((*target, ref_data.export.clone()))),
             // These are always skipped in `visit()`
             SingleModuleGraphBuilderNode::VisitedModule { .. } => unreachable!(),
         };
@@ -1661,8 +1694,10 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
                     };
 
                     refs.iter()
-                        .flat_map(|(ty, modules)| modules.iter().map(|m| (ty.clone(), *m)))
-                        .map(async |(ty, target)| {
+                        .flat_map(|(ty, export, modules)| {
+                            modules.iter().map(|m| (ty.clone(), export.clone(), *m))
+                        })
+                        .map(async |(ty, export, target)| {
                             let to = if ty == COMMON_CHUNKING_TYPE {
                                 if let Some(idx) = visited_modules.get(&target) {
                                     SingleModuleGraphBuilderNode::new_visited_module(target, *idx)
@@ -1670,15 +1705,22 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
                                     SingleModuleGraphBuilderNode::new_module(target).await?
                                 }
                             } else {
-                                SingleModuleGraphBuilderNode::new_chunkable_ref(module, target, ty)
-                                    .await?
+                                SingleModuleGraphBuilderNode::new_chunkable_ref(
+                                    module,
+                                    target,
+                                    RefData {
+                                        chunking_type: ty,
+                                        export: export.clone(),
+                                    },
+                                )
+                                .await?
                             };
-                            Ok(SingleModuleGraphBuilderEdge { to })
+                            Ok(SingleModuleGraphBuilderEdge { to, export })
                         })
                         .try_join()
                         .await?
                 }
-                (None, Some(chunkable_ref_target)) => {
+                (None, Some((chunkable_ref_target, export))) => {
                     vec![SingleModuleGraphBuilderEdge {
                         to: if let Some(idx) = visited_modules.get(&chunkable_ref_target) {
                             SingleModuleGraphBuilderNode::new_visited_module(
@@ -1688,6 +1730,7 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
                         } else {
                             SingleModuleGraphBuilderNode::new_module(chunkable_ref_target).await?
                         },
+                        export,
                     }]
                 }
                 _ => unreachable!(),
@@ -1695,18 +1738,18 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
         }
     }
 
-    fn span(&mut self, node: &SingleModuleGraphBuilderNode) -> tracing::Span {
+    fn span(&mut self, (node, _): &(SingleModuleGraphBuilderNode, ExportUsage)) -> tracing::Span {
         match node {
             SingleModuleGraphBuilderNode::Module { ident, .. } => {
                 tracing::info_span!("module", name = display(ident))
             }
 
             SingleModuleGraphBuilderNode::ChunkableReference {
-                chunking_type,
+                ref_data,
                 source_ident,
                 target_ident,
                 ..
-            } => match chunking_type {
+            } => match &ref_data.chunking_type {
                 ChunkingType::Parallel {
                     inherit_async: false,
                     ..
@@ -1714,7 +1757,7 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
                 _ => {
                     tracing::info_span!(
                         "chunkable reference",
-                        ty = debug(chunking_type),
+                        ty = debug(&ref_data.chunking_type),
                         source = display(source_ident),
                         target = display(target_ident)
                     )

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -302,7 +302,7 @@ impl PreBatches {
                             inherit_async: false,
                             hoisted: false,
                         },
-                        |(_, ty)| ty,
+                        |(_, ty)| &ty.chunking_type,
                     );
                     let module = node.module;
                     if !ty.is_parallel() {
@@ -367,7 +367,7 @@ pub async fn compute_module_batches(
                     // Already a boundary module, can skip check
                     return Ok(());
                 };
-                if ty.is_parallel() {
+                if ty.chunking_type.is_parallel() {
                     let parent_chunk_groups = chunk_group_info
                         .module_chunk_groups
                         .get(&parent.module)
@@ -398,7 +398,7 @@ pub async fn compute_module_batches(
         // cycles that include boundary modules
         module_graph
             .traverse_cycles(
-                |ty| ty.is_parallel(),
+                |ref_data| ref_data.chunking_type.is_parallel(),
                 |cycle| {
                     if cycle
                         .iter()

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     module::{Module, Modules},
     output::{OutputAsset, OutputAssets},
     raw_module::RawModule,
-    resolve::{ModuleResolveResult, RequestKey},
+    resolve::{ExportUsage, ModuleResolveResult, RequestKey},
 };
 pub mod source_map;
 
@@ -89,13 +89,22 @@ impl SingleModuleReference {
 pub struct SingleChunkableModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
     description: RcStr,
+    export: ResolvedVc<ExportUsage>,
 }
 
 #[turbo_tasks::value_impl]
 impl SingleChunkableModuleReference {
     #[turbo_tasks::function]
-    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: RcStr) -> Vc<Self> {
-        Self::cell(SingleChunkableModuleReference { asset, description })
+    pub fn new(
+        asset: ResolvedVc<Box<dyn Module>>,
+        description: RcStr,
+        export: ResolvedVc<ExportUsage>,
+    ) -> Vc<Self> {
+        Self::cell(SingleChunkableModuleReference {
+            asset,
+            description,
+            export,
+        })
     }
 }
 
@@ -107,6 +116,11 @@ impl ChunkableModuleReference for SingleChunkableModuleReference {
             inherit_async: true,
             hoisted: false,
         }))
+    }
+
+    #[turbo_tasks::function]
+    fn export_usage(&self) -> Vc<ExportUsage> {
+        *self.export
     }
 }
 
@@ -273,7 +287,7 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
 
 type ModulesVec = Vec<ResolvedVc<Box<dyn Module>>>;
 #[turbo_tasks::value(transparent)]
-pub struct ModulesWithChunkingType(Vec<(ChunkingType, ModulesVec)>);
+pub struct ModulesWithRefData(Vec<(ChunkingType, ExportUsage, ModulesVec)>);
 
 /// Aggregates all primary [Module]s referenced by an [Module] via [ChunkableModuleReference]s.
 /// This does not include transitively references [Module]s, only includes
@@ -284,7 +298,7 @@ pub struct ModulesWithChunkingType(Vec<(ChunkingType, ModulesVec)>);
 pub async fn primary_chunkable_referenced_modules(
     module: Vc<Box<dyn Module>>,
     include_traced: bool,
-) -> Result<Vc<ModulesWithChunkingType>> {
+) -> Result<Vc<ModulesWithRefData>> {
     let modules = module
         .references()
         .await?
@@ -305,7 +319,9 @@ pub async fn primary_chunkable_referenced_modules(
                     .primary_modules()
                     .owned()
                     .await?;
-                return Ok(Some((chunking_type.clone(), resolved)));
+                let export = (*reference.export_usage().await?).clone();
+
+                return Ok(Some((chunking_type.clone(), export, resolved)));
             }
             Ok(None)
         })

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -103,6 +103,35 @@ impl ModuleResolveResultItem {
     }
 }
 
+#[turbo_tasks::value]
+#[derive(Debug, Clone, Default, Hash)]
+pub enum ExportUsage {
+    Named(RcStr),
+    /// This means the whole content of the module is used.
+    #[default]
+    All,
+    /// Only side effects are used.
+    Evaluation,
+}
+
+#[turbo_tasks::value_impl]
+impl ExportUsage {
+    #[turbo_tasks::function]
+    pub fn all() -> Vc<Self> {
+        Self::All.cell()
+    }
+
+    #[turbo_tasks::function]
+    pub fn evaluation() -> Vc<Self> {
+        Self::Evaluation.cell()
+    }
+
+    #[turbo_tasks::function]
+    pub fn named(name: RcStr) -> Vc<Self> {
+        Self::Named(name).cell()
+    }
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct ModuleResolveResult {
@@ -1773,6 +1802,7 @@ async fn resolve_internal_inline(
     };
     async move {
         let options_value: &ResolveOptions = &*options.await?;
+
         let request_value = request.await?;
 
         // Apply import mappings if provided

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+auto-hash-map = { workspace = true }
 bytes-str = { workspace = true }
 data-encoding = { workspace = true }
 either = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -22,7 +22,8 @@ use turbopack_core::{
     reference::ModuleReference,
     reference_type::{EcmaScriptModulesReferenceSubType, ImportWithType},
     resolve::{
-        ExternalType, ModulePart, ModuleResolveResult, ModuleResolveResultItem, RequestKey,
+        ExportUsage, ExternalType, ModulePart, ModuleResolveResult, ModuleResolveResultItem,
+        RequestKey,
         origin::{ResolveOrigin, ResolveOriginExt},
         parse::Request,
     },
@@ -287,6 +288,15 @@ impl ChunkableModuleReference for EsmAssetReference {
                 })
             },
         ))
+    }
+
+    #[turbo_tasks::function]
+    fn export_usage(&self) -> Vc<ExportUsage> {
+        match &self.export_name {
+            Some(ModulePart::Export(export_name)) => ExportUsage::named(export_name.clone()),
+            Some(ModulePart::Evaluation) => ExportUsage::evaluation(),
+            _ => ExportUsage::all(),
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2585,10 +2585,9 @@ async fn handle_free_var_reference(
                         ),
                         Default::default(),
                         match state.tree_shaking_mode {
-                            Some(TreeShakingMode::ModuleFragments)
-                            | Some(TreeShakingMode::ReexportsOnly) => {
-                                export.clone().map(ModulePart::export)
-                            }
+                            Some(
+                                TreeShakingMode::ModuleFragments | TreeShakingMode::ReexportsOnly,
+                            ) => export.clone().map(ModulePart::export),
                             None => None,
                         },
                         state.import_externals,

--- a/turbopack/crates/turbopack-ecmascript/src/simple_tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/simple_tree_shake/mod.rs
@@ -1,0 +1,100 @@
+//! Intermediate tree shaking that uses global information but not good as the full tree shaking.
+
+use anyhow::{Context, Result};
+use auto_hash_map::AutoSet;
+use rustc_hash::FxHashMap;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbopack_core::{module_graph::ModuleGraph, resolve::ExportUsage};
+
+use crate::chunk::EcmascriptChunkPlaceable;
+
+#[turbo_tasks::function]
+pub async fn get_module_export_usages(
+    graph: ResolvedVc<ModuleGraph>,
+    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+) -> Result<Vc<ModuleExportUsageInfo>> {
+    let export_usage_info = compute_export_usage_info(graph)
+        .resolve_strongly_consistent()
+        .await?;
+
+    let export_usage_info = export_usage_info.await?;
+
+    let Some(exports) = export_usage_info.used_exports.get(&module) else {
+        // We exclude template files from tree shaking because they are entrypoints to the module
+        // graph.
+        return Ok(ModuleExportUsageInfo::All.cell());
+    };
+
+    Ok(exports.clone().cell())
+}
+
+#[turbo_tasks::function(operation)]
+async fn compute_export_usage_info(graph: ResolvedVc<ModuleGraph>) -> Result<Vc<ExportUsageInfo>> {
+    let mut used_exports = FxHashMap::<_, ModuleExportUsageInfo>::default();
+
+    graph
+        .await?
+        .traverse_all_edges_unordered(|(_, ref_data), target| {
+            if let Some(target_module) =
+                ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(target.module)
+            {
+                let e = used_exports.entry(target_module).or_default();
+
+                e.add(&ref_data.export);
+            }
+
+            Ok(())
+        })
+        .await
+        .context("failed to traverse module graph")?;
+
+    Ok(ExportUsageInfo { used_exports }.cell())
+}
+
+#[turbo_tasks::value]
+#[derive(Default)]
+pub struct ExportUsageInfo {
+    used_exports: FxHashMap<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>, ModuleExportUsageInfo>,
+}
+
+#[turbo_tasks::value]
+#[derive(Default, Clone)]
+pub enum ModuleExportUsageInfo {
+    All,
+    #[default]
+    Evaluation,
+    Exports(AutoSet<RcStr>),
+}
+
+impl ModuleExportUsageInfo {
+    fn add(&mut self, usage: &ExportUsage) {
+        match (&mut *self, usage) {
+            (Self::All, _) => {}
+            (_, ExportUsage::All) => {
+                *self = Self::All;
+            }
+            (Self::Evaluation, ExportUsage::Named(name)) => {
+                // Promote evaluation to something more specific
+                *self = Self::Exports(AutoSet::from_iter([name.clone()]));
+            }
+
+            (Self::Exports(l), ExportUsage::Named(r)) => {
+                // Merge exports
+                l.insert(r.clone());
+            }
+
+            (_, ExportUsage::Evaluation) => {
+                // Ignore evaluation
+            }
+        }
+    }
+
+    pub fn is_export_used(&self, export: &RcStr) -> bool {
+        match self {
+            Self::All => true,
+            Self::Evaluation => false,
+            Self::Exports(exports) => exports.contains(export),
+        }
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -215,7 +215,7 @@ impl EcmascriptModulePartAsset {
                             EcmascriptModuleFacadeModule::new(
                                 **final_module,
                                 ModulePart::renamed_export(new_export.clone(), export.clone()),
-                                module.options(),
+                                module.options().await?.remove_unused_exports,
                             )
                             .to_resolved()
                             .await?,
@@ -226,7 +226,7 @@ impl EcmascriptModulePartAsset {
                         EcmascriptModuleFacadeModule::new(
                             **final_module,
                             ModulePart::renamed_namespace(export.clone()),
-                            module.options(),
+                            module.options().await?.remove_unused_exports,
                         )
                         .to_resolved()
                         .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
     module::Module,
     module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences, SingleChunkableModuleReference},
-    resolve::{ModulePart, origin::ResolveOrigin},
+    resolve::{ExportUsage, ModulePart, origin::ResolveOrigin},
 };
 
 use super::{
@@ -27,6 +27,7 @@ use crate::{
         FollowExportsResult, analyse_ecmascript_module, esm::FoundExportType, follow_reexports,
     },
     side_effect_optimization::facade::module::EcmascriptModuleFacadeModule,
+    simple_tree_shake::get_module_export_usages,
     tree_shake::{Key, side_effect_module::SideEffectsModule},
 };
 
@@ -96,6 +97,16 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
             .reference_module_source_maps(Vc::upcast(self))
             .await?;
 
+        let export_usage_info = if module.full_module.options().await?.remove_unused_exports {
+            Some(
+                get_module_export_usages(*module_graph, Vc::upcast(*module.full_module))
+                    .to_resolved()
+                    .await?,
+            )
+        } else {
+            None
+        };
+
         Ok(EcmascriptModuleContentOptions {
             parsed,
             ident: self.ident().to_resolved().await?,
@@ -111,6 +122,7 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
             original_source_map: analyze_ref.source_map,
             exports: analyze_ref.exports,
             async_module_info,
+            export_usage_info,
         }
         .cell())
     }
@@ -203,6 +215,7 @@ impl EcmascriptModulePartAsset {
                             EcmascriptModuleFacadeModule::new(
                                 **final_module,
                                 ModulePart::renamed_export(new_export.clone(), export.clone()),
+                                module.options(),
                             )
                             .to_resolved()
                             .await?,
@@ -213,6 +226,7 @@ impl EcmascriptModulePartAsset {
                         EcmascriptModuleFacadeModule::new(
                             **final_module,
                             ModulePart::renamed_namespace(export.clone()),
+                            module.options(),
                         )
                         .to_resolved()
                         .await?,
@@ -322,12 +336,19 @@ impl Module for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let part_dep = |part: ModulePart| -> Vc<Box<dyn ModuleReference>> {
+            let export = match &part {
+                ModulePart::Export(export) => ExportUsage::named(export.clone()),
+                ModulePart::Evaluation => ExportUsage::evaluation(),
+                _ => ExportUsage::all(),
+            };
+
             Vc::upcast(SingleChunkableModuleReference::new(
                 Vc::upcast(EcmascriptModulePartAsset::new_with_resolved_part(
                     *self.full_module,
                     part,
                 )),
                 rcstr!("part reference"),
+                export,
             ))
         };
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     module::Module,
     module_graph::ModuleGraph,
     reference::{ModuleReferences, SingleChunkableModuleReference},
-    resolve::ModulePart,
+    resolve::{ExportUsage, ModulePart},
 };
 
 use crate::{
@@ -85,6 +85,7 @@ impl Module for SideEffectsModule {
                         SingleChunkableModuleReference::new(
                             *ResolvedVc::upcast(*side_effect),
                             rcstr!("side effect"),
+                            ExportUsage::evaluation(),
                         )
                         .to_resolved()
                         .await?,
@@ -98,6 +99,7 @@ impl Module for SideEffectsModule {
             SingleChunkableModuleReference::new(
                 *ResolvedVc::upcast(self.resolved_as),
                 rcstr!("resolved as"),
+                ExportUsage::all(),
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -46,13 +46,12 @@ pub fn apply_esm_specific_options(
     options: Vc<ResolveOptions>,
     reference_type: ReferenceType,
 ) -> Vc<ResolveOptions> {
-    apply_esm_specific_options_internal(
-        options,
-        matches!(
-            reference_type,
-            ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportWithType(_))
-        ),
-    )
+    let clear_extensions = matches!(
+        reference_type,
+        ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportWithType(_))
+    );
+
+    apply_esm_specific_options_internal(options, clear_extensions)
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -241,6 +241,8 @@ async fn run_inner_operation(
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct TestOptions {
     tree_shaking_mode: Option<TreeShakingMode>,
+    #[serde(default)]
+    remove_unused_exports: bool,
 }
 
 #[turbo_tasks::value]
@@ -376,10 +378,12 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
                 ContextCondition::InDirectory("node_modules".into()),
                 ModuleOptionsContext {
                     tree_shaking_mode: options.tree_shaking_mode,
+                    remove_unused_exports: options.remove_unused_exports,
                     ..Default::default()
                 }
                 .resolved_cell(),
             )],
+            remove_unused_exports: options.remove_unused_exports,
             ..Default::default()
         }
         .into(),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -96,6 +96,8 @@ struct SnapshotOptions {
     environment: SnapshotEnvironment,
     #[serde(default)]
     tree_shaking_mode: Option<TreeShakingMode>,
+    #[serde(default)]
+    remove_unused_exports: bool,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -122,6 +124,7 @@ impl Default for SnapshotOptions {
             runtime_type: default_runtime_type(),
             environment: Default::default(),
             tree_shaking_mode: Default::default(),
+            remove_unused_exports: false,
         }
     }
 }
@@ -305,6 +308,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),
                 ModuleOptionsContext {
+                    remove_unused_exports: options.remove_unused_exports,
                     css: CssOptionsContext {
                         ..Default::default()
                     },
@@ -314,6 +318,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             )],
             module_rules: vec![module_rules],
             tree_shaking_mode: options.tree_shaking_mode,
+            remove_unused_exports: options.remove_unused_exports,
             ..Default::default()
         }
         .into(),

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js
@@ -1,0 +1,3 @@
+import { getCat } from 'lib'
+
+console.log(`I like ${getCat()}`)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js
@@ -1,0 +1,16 @@
+
+let cat = "cat";
+let dog = "dog";
+
+export function getChimera() {
+  return cat + dog;
+}
+
+export function getCat() {
+  return cat;
+}
+
+export function getDog() {
+  return dog;
+}
+

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/package.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/options.json
@@ -1,0 +1,4 @@
+{
+  "treeShakingMode": "reexports-only",
+  "removeUnusedExports": true
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js
@@ -1,0 +1,31 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js", {
+
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({});
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$intermediate$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$node_modules$2f$lib$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js [test] (ecmascript)");
+;
+console.log(`I like ${(0, __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$intermediate$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$node_modules$2f$lib$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__["getCat"])()}`);
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js [test] (ecmascript)": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({
+    "getCat": (()=>getCat)
+});
+let cat = "cat";
+let dog = "dog";
+function getChimera() {
+    return cat + dog;
+}
+function getCat() {
+    return cat;
+}
+function getDog() {
+    return dog;
+}
+}),
+}]);
+
+//# sourceMappingURL=4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js"],"sourcesContent":["import { getCat } from 'lib'\n\nconsole.log(`I like ${getCat()}`)\n"],"names":[],"mappings":";AAAA;;AAEA,QAAQ,GAAG,CAAC,CAAC,OAAO,EAAE,CAAA,GAAA,gQAAA,CAAA,SAAM,AAAD,KAAK"}},
+    {"offset": {"line": 13, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js"],"sourcesContent":["\nlet cat = \"cat\";\nlet dog = \"dog\";\n\nexport function getChimera() {\n  return cat + dog;\n}\n\nexport function getCat() {\n  return cat;\n}\n\nexport function getDog() {\n  return dog;\n}\n\n"],"names":[],"mappings":";;;AACA,IAAI,MAAM;AACV,IAAI,MAAM;AAEH,SAAS;IACd,OAAO,MAAM;AACf;AAEO,SAAS;IACd,OAAO;AACT;AAEO,SAAS;IACd,OAAO;AACT","ignoreList":[0]}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_index_1ae89033.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_index_1ae89033.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_index_1ae89033.js",
+    {},
+    {"otherChunks":["output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_index_1ae89033.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_index_1ae89033.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
     output::OutputAssets,
     reference::{ModuleReferences, SingleChunkableModuleReference},
     reference_type::ReferenceType,
-    resolve::{origin::ResolveOrigin, parse::Request},
+    resolve::{ExportUsage, origin::ResolveOrigin, parse::Request},
     source::Source,
 };
 use turbopack_ecmascript::{
@@ -108,9 +108,13 @@ impl WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
         Ok(Vc::cell(vec![ResolvedVc::upcast(
-            SingleChunkableModuleReference::new(Vc::upcast(self.loader()), rcstr!("wasm loader"))
-                .to_resolved()
-                .await?,
+            SingleChunkableModuleReference::new(
+                Vc::upcast(self.loader()),
+                rcstr!("wasm loader"),
+                ExportUsage::all(),
+            )
+            .to_resolved()
+            .await?,
         )]))
     }
 }

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     chunk::{ChunkableModule, ChunkingType, module_id_strategies::GlobalModuleIdStrategy},
     ident::AssetIdent,
     module::Module,
-    module_graph::ModuleGraph,
+    module_graph::{ModuleGraph, RefData},
 };
 use turbopack_ecmascript::async_chunk::module::AsyncLoaderModule;
 
@@ -32,7 +32,14 @@ pub async fn get_global_module_id_strategy(
         let mut async_idents = vec![];
         module_graph
             .traverse_all_edges_unordered(|parent, current| {
-                if let (_, &ChunkingType::Async) = parent {
+                if let (
+                    _,
+                    &RefData {
+                        chunking_type: ChunkingType::Async,
+                        ..
+                    },
+                ) = parent
+                {
                     let module =
                         ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(current.module)
                             .context("expected chunkable module for async reference")?;

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -54,7 +54,6 @@ use turbopack_core::{
 pub use turbopack_css as css;
 pub use turbopack_ecmascript as ecmascript;
 use turbopack_ecmascript::{
-    EcmascriptOptions,
     references::external_module::{CachedExternalModule, CachedExternalType},
     tree_shake::asset::EcmascriptModulePartAsset,
 };
@@ -171,7 +170,7 @@ async fn apply_module_type(
                                         Vc::upcast(EcmascriptModuleFacadeModule::new(
                                             Vc::upcast(*module),
                                             part,
-                                            **options,
+                                            options.await?.remove_unused_exports,
                                         ))
                                     } else {
                                         Vc::upcast(*module)
@@ -189,21 +188,21 @@ async fn apply_module_type(
                                                 EcmascriptModuleFacadeModule::new(
                                                     Vc::upcast(*module),
                                                     ModulePart::exports(),
-                                                    **options,
+                                                    options.await?.remove_unused_exports,
                                                 )
                                                 .resolve()
                                                 .await?,
                                             ),
                                             part,
                                             side_effect_free_packages,
-                                            **options,
+                                            options.await?.remove_unused_exports,
                                         )
                                     } else {
                                         apply_reexport_tree_shaking(
                                             Vc::upcast(*module),
                                             part,
                                             side_effect_free_packages,
-                                            **options,
+                                            options.await?.remove_unused_exports,
                                         )
                                     }
                                 }
@@ -217,7 +216,7 @@ async fn apply_module_type(
                             Vc::upcast(EcmascriptModuleFacadeModule::new(
                                 Vc::upcast(*module),
                                 ModulePart::facade(),
-                                **options,
+                                options.await?.remove_unused_exports,
                             ))
                         } else {
                             Vc::upcast(*module)
@@ -281,7 +280,7 @@ async fn apply_reexport_tree_shaking(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     part: ModulePart,
     side_effect_free_packages: Vc<Glob>,
-    options: ResolvedVc<EcmascriptOptions>,
+    remove_unused_exports: bool,
 ) -> Result<Vc<Box<dyn Module>>> {
     if let ModulePart::Export(export) = &part {
         let FollowExportsResult {
@@ -296,14 +295,14 @@ async fn apply_reexport_tree_shaking(
                 Vc::upcast(EcmascriptModuleFacadeModule::new(
                     **final_module,
                     ModulePart::renamed_export(new_export.clone(), export.clone()),
-                    *options,
+                    remove_unused_exports,
                 ))
             }
         } else {
             Vc::upcast(EcmascriptModuleFacadeModule::new(
                 **final_module,
                 ModulePart::renamed_namespace(export.clone()),
-                *options,
+                remove_unused_exports,
             ))
         };
         return Ok(module);

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -144,6 +144,7 @@ impl ModuleOptions {
             execution_context,
             tree_shaking_mode,
             keep_last_successful_parse,
+            remove_unused_exports,
             ..
         } = *module_options_context.await?;
 
@@ -174,6 +175,7 @@ impl ModuleOptions {
             refresh,
             extract_source_map: matches!(ecmascript_source_maps, SourceMapsType::Full),
             keep_last_successful_parse,
+            remove_unused_exports,
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.resolved_cell();

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -169,6 +169,11 @@ pub struct ModuleOptionsContext {
     /// A list of rules to use a different module option context for certain
     /// context paths. The first matching is used.
     pub rules: Vec<(ContextCondition, ResolvedVc<ModuleOptionsContext>)>,
+
+    /// `matches!(tree_shaking_mode, Some(TreeShakingMode::Intermediate))` is not enough because we
+    /// use different tree shaking modes for user code and foreign code while intermediate tree
+    /// shaking is a global option.
+    pub remove_unused_exports: bool,
     pub placeholder_for_future_extensions: (),
 }
 


### PR DESCRIPTION
### What?

Implement a simple tree-shaking. Simple tree shaking is a tree-shaking implementation that only has two options for each export: used/unused. This information is shared among the whole application, so there's no fine-grained control for each export. 

### Why?

Because advanced tree shaking requires some more time to implement.

Closes PACK-4819