### PR TITLE
fix(turbo-tasks): Add a few more transient-from-persistent task assertions

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
@@ -1,0 +1,52 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput};
+use turbo_tasks_testing::{register, run_without_cache_check, Registration};
+
+static REGISTRATION: Registration = register!();
+
+const EXPECTED_MSG: &str =
+    "Collectible is transient, transient collectibles cannot be emitted from persistent tasks";
+
+#[tokio::test]
+async fn test_transient_emit_from_persistent() {
+    let result = run_without_cache_check(&REGISTRATION, async {
+        emit_incorrect_task_input_operation(IncorrectTaskInput(U32Wrapper(123).resolved_cell()))
+            .read_strongly_consistent()
+            .await?;
+        anyhow::Ok(())
+    })
+    .await;
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains(&EXPECTED_MSG.escape_debug().to_string()));
+}
+
+#[turbo_tasks::function(operation)]
+async fn emit_incorrect_task_input_operation(value: IncorrectTaskInput) {
+    turbo_tasks::emit(ResolvedVc::upcast::<Box<dyn Number>>(value.0));
+}
+
+/// Has an intentionally incorrect `TaskInput` implementation
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+)]
+struct IncorrectTaskInput(ResolvedVc<U32Wrapper>);
+
+impl TaskInput for IncorrectTaskInput {
+    fn is_transient(&self) -> bool {
+        false
+    }
+}
+
+#[turbo_tasks::value_trait]
+trait Number {}
+
+#[turbo_tasks::value]
+struct U32Wrapper(u32);
+
+#[turbo_tasks::value_impl]
+impl Number for U32Wrapper {}


### PR DESCRIPTION
Transient tasks are tasks that depend on a value that cannot be serialized. Transient tasks and anything that depend on them therefore cannot be serialized. Because of this, it's not valid for persistent (serialized) tasks to depend on transient tasks.

We're seeing issues from transient collectibles being read from persistent tasks.

This should only be possible if a persistent task emits a transient collectible. That shouldn't be possible either (where would it get the transient collectible from?), but asserting doesn't seem like a bad idea, and might get us a stack trace closer to the root-cause.

Closes PACK-4428