### PR TITLE
test: try to fix flakiness in amphtml util

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "@vercel/og": "0.6.8",
     "abort-controller": "3.0.0",
     "alex": "9.1.0",
-    "amphtml-validator": "1.0.38",
     "async-sema": "3.0.1",
     "babel-plugin-react-compiler": "19.0.0-beta-e552027-20250112",
     "browserslist": "4.22.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
       alex:
         specifier: 9.1.0
         version: 9.1.0
-      amphtml-validator:
-        specifier: 1.0.38
-        version: 1.0.38
       async-sema:
         specifier: 3.0.1
         version: 3.0.1

--- a/test/lib/amp-test-utils.js
+++ b/test/lib/amp-test-utils.js
@@ -1,8 +1,14 @@
 /* eslint-env jest */
-import amphtmlValidator from 'amphtml-validator'
+import amphtmlValidator from 'next/dist/compiled/amphtml-validator'
 
-export async function validateAMP(html) {
-  const validator = await amphtmlValidator.getInstance()
+// Use the same validator that we use for builds.
+// This avoids trying to load one from the network, which can cause random test flakiness.
+// (duplicated from 'packages/next/src/export/routes/pages.ts')
+const validatorPath = require.resolve(
+  'next/dist/compiled/amphtml-validator/validator_wasm.js'
+)
+export async function validateAMP(/** @type {string} */ html) {
+  const validator = await amphtmlValidator.getInstance(validatorPath)
   const result = validator.validateString(html)
   if (result.status !== 'PASS') {
     for (let ii = 0; ii < result.errors.length; ii++) {


### PR DESCRIPTION
This PR modifies the AMP HTML testing util to avoid loading the validator from the network, which causes random test flakiness. I've also made it use the validator from `next/dist/compiled` to match what we do during builds. This means we can drop `amphtml-validator` from the root package.json.