### PR TITLE
make sure eslint-plugin-next is built when running 'pnpm dev'

### DIFF
--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -19,6 +19,7 @@
     "eslint": "8.56.0"
   },
   "scripts": {
+    "dev": "pnpm build",
     "build": "swc -d dist src && pnpm types",
     "types": "tsc src/index.ts --skipLibCheck --declaration --emitDeclarationOnly --declarationDir dist",
     "prepublishOnly": "cd ../../ && turbo run build"


### PR DESCRIPTION
this fixes an annoying issue where `eslint-plugin-next` causes a bunch of typescript errors after a `pnpm clean`. the reason for this was that it didn't have a `"dev"` script, so `pnpm dev` ignored it, and so it never got built at all.