### PR TITLE
fix bad next.browser() arguments in socket.io test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -53,7 +53,7 @@
       "test/e2e/app-dir/rsc-basic/rsc-basic.test.ts",
       "test/e2e/basepath/basepath.test.ts",
       "test/e2e/postcss-config-cjs/index.test.ts",
-      "test/e2e/socket-io/index.test.js",
+      "test/e2e/socket-io/index.test.ts",
       "test/e2e/middleware-matcher/index.test.ts",
       "test/e2e/next-script/index.test.ts",
       "test/production/standalone-mode/**/*"

--- a/test/e2e/socket-io/index.test.ts
+++ b/test/e2e/socket-io/index.test.ts
@@ -10,13 +10,16 @@ describe('socket-io', () => {
       'utf-8-validate': '6.0.3',
       bufferutil: '4.0.8',
     },
+    // the socket.io setup relies on patching next's `http.Server` instance,
+    // which we can't do when deployed
+    skipDeployment: true,
   })
 
   it('should support socket.io without falling back to polling', async () => {
     let requestsCount = 0
 
-    const browser1 = await next.browser(next.url, '/')
-    const browser2 = await next.browser(next.url, '/', {
+    const browser1 = await next.browser('/')
+    const browser2 = await next.browser('/', {
       beforePageLoad(page) {
         page.on('request', () => {
           requestsCount++
@@ -30,6 +33,7 @@ describe('socket-io', () => {
     await input1.fill('hello world')
     await check(() => input2.inputValue(), /hello world/)
 
+    expect(requestsCount).toBeGreaterThan(0)
     const currentRequestsCount = requestsCount
 
     await input1.fill('123456')


### PR DESCRIPTION
i guess we forgot to remove the `next.url` when this was converted from `webdriver()` to `next.browser()`