### PR TITLE
[playwright] do not swallow errors in browser.eval

### DIFF
--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -486,16 +486,12 @@ export class Playwright<TCurrent = undefined> {
     ...args: any[]
   ): Playwright<any> & Promise<any> {
     return this.startChain(async () =>
-      page
-        .evaluate(fn, ...args)
-        .catch((err) => {
-          // TODO: gross, why are we doing this
-          console.error('eval error:', err)
-          return null!
-        })
-        .finally(async () => {
-          await page.waitForLoadState()
-        })
+      page.evaluate(fn, ...args).catch((err) => {
+        throw new Error(
+          `Error while evaluating \`${typeof fn === 'string' ? fn : fn.toString()}\``,
+          { cause: err }
+        )
+      })
     )
   }
 


### PR DESCRIPTION
split out from #78308, because it seems like swallowing errors in `browser.eval()` was load bearing, which i really dislike tbh. need to investigate what role it was serving and how we can do that better.