### PR TITLE
Fix dynamic route param encoding

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1249,14 +1249,9 @@ export default abstract class Server<
           if (pageIsDynamic) {
             let params: ParsedUrlQuery | false = {}
 
-            // If we don't already have valid params, try to parse them from
-            // the query params.
-            if (!paramsResult.hasValidParams) {
-              paramsResult = utils.normalizeDynamicRouteParams(
-                queryParams,
-                false
-              )
-            }
+            // ensure we normalize the dynamic route params for encoding/
+            // default values
+            paramsResult = utils.normalizeDynamicRouteParams(queryParams, false)
 
             // for prerendered ISR paths we attempt parsing the route
             // params from the URL directly as route-matches may not


### PR DESCRIPTION
Our encoding test in `vercel/vercel` started failing from https://github.com/vercel/next.js/pull/77994 this reverts part of the change there to ensure we always normalize our dynamic route params. Validated in https://github.com/vercel/vercel/pull/13259

<details>

<summary>test failure</summary>

![CleanShot 2025-04-12 at 11 10 48@2x](https://github.com/user-attachments/assets/9696ae4a-8db1-420b-8bc6-ba3e43efb1b1)

</details>

x-ref: [slack thread](https://vercel.slack.com/archives/C02CDC2ALJH/p1744481510502349)

