### PR TITLE
fix(turbo-tasks): Make vc types use repr(transparent)

### DIFF
--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -163,6 +163,7 @@ type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
 #[must_use]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent, bound = "")]
+#[repr(transparent)]
 pub struct Vc<T>
 where
     T: ?Sized,

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -48,6 +48,7 @@ use crate::{
 /// [`State`]: crate::State
 /// [`ReadRef`]: crate::ReadRef
 #[must_use]
+#[repr(transparent)]
 pub struct OperationVc<T>
 where
     T: ?Sized,

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -66,6 +66,7 @@ use crate::{
 /// [`ReadRef`]: crate::ReadRef
 #[derive(Serialize, Deserialize)]
 #[serde(transparent, bound = "")]
+#[repr(transparent)]
 pub struct ResolvedVc<T>
 where
     T: ?Sized,


### PR DESCRIPTION
I thought this was already here, but @lukesandberg pointed out it wasn't. I'm pretty sure we're doing transmutes in a few places that assume this, so we should have it.

There's likely no change in behavior: The only sane memory layout for these types is the transparent one, but the annotation guarantees it for our unsafe code.

Closes PACK-4399