### PR TITLE
Support *.md for Turbopack

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -49,6 +49,10 @@ module.exports =
     if (process.env.TURBOPACK) {
       nextConfig.turbopack = Object.assign({}, nextConfig?.turbopack, {
         rules: Object.assign({}, nextConfig?.turbopack?.rules, {
+          '*.md': {
+            loaders: [loader],
+            as: '*.tsx',
+          },
           '*.mdx': {
             loaders: [loader],
             as: '*.tsx',


### PR DESCRIPTION
This is maybe not the right way to do it but I've wasted half an hour on this. 

The docs [here](https://nextjs.org/docs/pages/building-your-application/configuring/mdx#using-plugins-with-turbopack) imply that `.md` extension will work with Turbopack but it **absolutely does not** without something like this.

Alternatively, the misleading docs need to change to not list `.md` extension at all.

I have not actually tested the PR, this is just a guess