### PR TITLE
Reserve bandwidth for most recently hovered link 

### DIFF
--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -118,9 +118,10 @@ export const enum NavigationResultTag {
  */
 export const enum PrefetchPriority {
   /**
-   * Assigned to any visible link that was hovered/touched at some point. This
-   * is not removed on mouse exit, because a link that was momentarily
-   * hovered is more likely to to be interacted with than one that was not.
+   * Assigned to the most recently hovered/touched link. Special network
+   * bandwidth is reserved for this task only. There's only ever one Intent-
+   * priority task at a time; when a new Intent task is scheduled, the previous
+   * one is bumped down to Default.
    */
   Intent = 2,
   /**


### PR DESCRIPTION
Based on:

- #77880 

---

The prefetch scheduler limits the number of concurrent prefetch requests, to avoid saturating browser's internal network queue. As a starting point, I had previously hardcoded this to 3 — intentionally stingy, to leave room for additional optimizations.

In this PR, I allow the most recently hovered link to exceed the default limit. This increased limit only applies to the *most recently* hovered link; if a different link is hovered, the previous one is bumped back down to the default.

The principle is that when hovering over a new link, we should have enough bandwidth to start prefetching its data. (In practice, because we don't cancel in-progress requests, it's still possible that we'll fill up the queue, but this makes it less likely.)

As part of this change, I changed the implementation of the internal Intent priority level. Intent used to assigned to any link that was ever hovered over; it would never get bumped back down to Default, even on mouseexit. This was intentional at the time, but given this new optimizaiton, it makes more sense to downgrade previously hovered links to free up the bandwidth.