### PR TITLE
docs: clarify Turbopack flag usage in CLI commands

### DIFF
--- a/docs/01-app/05-api-reference/08-turbopack.mdx
+++ b/docs/01-app/05-api-reference/08-turbopack.mdx
@@ -18,17 +18,18 @@ We built Turbopack to push the performance of Next.js, including:
 
 ## Getting started
 
-To enable Turbopack in your Next.js project, add the `--turbopack` flag to the `dev`, `build`, and `start` scripts in your `package.json` file:
+To enable Turbopack in your Next.js project, add the `--turbopack` flag to the `dev` or `build` script in your `package.json` file:
 
 ```json filename="package.json" highlight={3}
 {
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
-    "start": "next start --turbopack"
+    "build": "next build --turbopack"
   }
 }
 ```
+
+> **Note:** The `--turbopack` flag only affects `next dev` and `next build` commands. It has no effect on `next start` as this command simply serves the already built production output.
 
 Currently, Turbopack for `dev` is stable, while `build` is in alpha. We are actively working on production support as Turbopack moves closer to stability.
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

-->

### What?
This PR fixes inaccuracies in the Turbopack documentation. Fixes issue where the documentation incorrectly suggested using --turbopack with 'next start', which has no effect as confirmed in the source code.

### Why?
The documentation states that the flag is required for all three scripts (start, build, and dev), but in practice, you only need to add --turbopack to the dev or build script, depending on which command you want to use Turbopack.

Turboback does not affect the start script.

### How?
1. Corrects the statement implying that --turbopack flag is required for all three scripts (dev, build, and start)
2. Removes 'next start --turbopack' from examples as the flag has no effect in this context
3. Adds an explicit note explaining that the --turbopack flag only affects 'next dev' and 'next build' commands

Fixes #78339
