### PR TITLE
fix(Link): ensure state updates in onNavigate handler get committed

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -283,16 +283,11 @@ function linkClicked(
 
       onNavigate(navigateEvent)
 
-      // Only proceed with navigation if preventDefault wasn't called
-      if (!isDefaultPrevented) {
-        dispatchNavigateAction(
-          as || href,
-          replace ? 'replace' : 'push',
-          scroll ?? true,
-          linkInstanceRef.current
-        )
+      // Skip navigation if preventDefault was called
+      if (isDefaultPrevented) {
+        return
       }
-    } else {
+
       dispatchNavigateAction(
         as || href,
         replace ? 'replace' : 'push',

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -271,30 +271,36 @@ function linkClicked(
 
   e.preventDefault()
 
-  const navigate = () => {
+  React.startTransition(() => {
     if (onNavigate) {
       let isDefaultPrevented = false
 
-      onNavigate({
+      const navigateEvent = {
         preventDefault: () => {
           isDefaultPrevented = true
         },
-      })
-
-      if (isDefaultPrevented) {
-        return
       }
+
+      onNavigate(navigateEvent)
+
+      // Only proceed with navigation if preventDefault wasn't called
+      if (!isDefaultPrevented) {
+        dispatchNavigateAction(
+          as || href,
+          replace ? 'replace' : 'push',
+          scroll ?? true,
+          linkInstanceRef.current
+        )
+      }
+    } else {
+      dispatchNavigateAction(
+        as || href,
+        replace ? 'replace' : 'push',
+        scroll ?? true,
+        linkInstanceRef.current
+      )
     }
-
-    dispatchNavigateAction(
-      as || href,
-      replace ? 'replace' : 'push',
-      scroll ?? true,
-      linkInstanceRef.current
-    )
-  }
-
-  React.startTransition(navigate)
+  })
 }
 
 function formatStringOrUrl(urlObjOrString: UrlObject | string): string {

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -246,36 +246,24 @@ function linkClicked(
 
       onNavigate(navigateEvent)
 
-      // Only proceed with navigation if preventDefault wasn't called
-      if (!isDefaultPrevented) {
-        // If the router is an NextRouter instance it will have `beforePopState`
-        const routerScroll = scroll ?? true
-        if ('beforePopState' in router) {
-          router[replace ? 'replace' : 'push'](href, as, {
-            shallow,
-            locale,
-            scroll: routerScroll,
-          })
-        } else {
-          router[replace ? 'replace' : 'push'](as || href, {
-            scroll: routerScroll,
-          })
-        }
+      // Skip navigation if preventDefault was called
+      if (isDefaultPrevented) {
+        return
       }
+    }
+
+    // Navigate if no onNavigate handler or preventDefault wasn't called
+    const routerScroll = scroll ?? true
+    if ('beforePopState' in router) {
+      router[replace ? 'replace' : 'push'](href, as, {
+        shallow,
+        locale,
+        scroll: routerScroll,
+      })
     } else {
-      // If the router is an NextRouter instance it will have `beforePopState`
-      const routerScroll = scroll ?? true
-      if ('beforePopState' in router) {
-        router[replace ? 'replace' : 'push'](href, as, {
-          shallow,
-          locale,
-          scroll: routerScroll,
-        })
-      } else {
-        router[replace ? 'replace' : 'push'](as || href, {
-          scroll: routerScroll,
-        })
-      }
+      router[replace ? 'replace' : 'push'](as || href, {
+        scroll: routerScroll,
+      })
     }
   })
 }

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -234,37 +234,50 @@ function linkClicked(
 
   e.preventDefault()
 
-  const navigate = () => {
+  React.startTransition(() => {
     if (onNavigate) {
       let isDefaultPrevented = false
 
-      onNavigate({
+      const navigateEvent = {
         preventDefault: () => {
           isDefaultPrevented = true
         },
-      })
+      }
 
-      if (isDefaultPrevented) {
-        return
+      onNavigate(navigateEvent)
+
+      // Only proceed with navigation if preventDefault wasn't called
+      if (!isDefaultPrevented) {
+        // If the router is an NextRouter instance it will have `beforePopState`
+        const routerScroll = scroll ?? true
+        if ('beforePopState' in router) {
+          router[replace ? 'replace' : 'push'](href, as, {
+            shallow,
+            locale,
+            scroll: routerScroll,
+          })
+        } else {
+          router[replace ? 'replace' : 'push'](as || href, {
+            scroll: routerScroll,
+          })
+        }
+      }
+    } else {
+      // If the router is an NextRouter instance it will have `beforePopState`
+      const routerScroll = scroll ?? true
+      if ('beforePopState' in router) {
+        router[replace ? 'replace' : 'push'](href, as, {
+          shallow,
+          locale,
+          scroll: routerScroll,
+        })
+      } else {
+        router[replace ? 'replace' : 'push'](as || href, {
+          scroll: routerScroll,
+        })
       }
     }
-
-    // If the router is an NextRouter instance it will have `beforePopState`
-    const routerScroll = scroll ?? true
-    if ('beforePopState' in router) {
-      router[replace ? 'replace' : 'push'](href, as, {
-        shallow,
-        locale,
-        scroll: routerScroll,
-      })
-    } else {
-      router[replace ? 'replace' : 'push'](as || href, {
-        scroll: routerScroll,
-      })
-    }
-  }
-
-  navigate()
+  })
 }
 
 type LinkPropsReal = React.PropsWithChildren<


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?
Fix a bug in Next.js's Link component where state updates inside the onNavigate event handler were not being committed to the UI during navigation.

### Why?
The onNavigate handler was intended to provide a way to create transition animations and pending states during navigation, but state updates within the handler weren't taking effect. This made it impossible to properly implement pending UI states using this API, forcing developers to fall back to the less appropriate onClick handler (which had its own issues like triggering when opening links in new tabs).

### How?
By wrapping both the onNavigate handler and the subsequent navigation action in a single React.startTransition() call, we ensure that:

1. State updates made inside the handler are treated with the same priority as the navigation itself
2. The transition properly manages both the state updates and navigation as a cohesive operation
3. Updates properly commit to the UI, allowing for pending states to be visible during navigation
4. The handler continues to respect `preventDefault()` calls when navigation should be canceled

This maintains the original API contract while fixing the underlying issue with state updates.

Fixes #78361 
