### PR TITLE
docs: improve userAgent device.type example in userAgent.mdx

### DIFF
--- a/docs/01-app/05-api-reference/04-functions/userAgent.mdx
+++ b/docs/01-app/05-api-reference/04-functions/userAgent.mdx
@@ -13,11 +13,11 @@ import { NextRequest, NextResponse, userAgent } from 'next/server'
 export function middleware(request: NextRequest) {
   const url = request.nextUrl
   const { device } = userAgent(request)
-  
-  // device.type can be: 'mobile', 'tablet', 'console', 'smarttv', 
+
+  // device.type can be: 'mobile', 'tablet', 'console', 'smarttv',
   // 'wearable', 'embedded', or undefined (for desktop browsers)
   const viewport = device.type || 'desktop'
-  
+
   url.searchParams.set('viewport', viewport)
   return NextResponse.rewrite(url)
 }
@@ -29,11 +29,11 @@ import { NextResponse, userAgent } from 'next/server'
 export function middleware(request) {
   const url = request.nextUrl
   const { device } = userAgent(request)
-  
-  // device.type can be: 'mobile', 'tablet', 'console', 'smarttv', 
+
+  // device.type can be: 'mobile', 'tablet', 'console', 'smarttv',
   // 'wearable', 'embedded', or undefined (for desktop browsers)
   const viewport = device.type || 'desktop'
-  
+
   url.searchParams.set('viewport', viewport)
   return NextResponse.rewrite(url)
 }

--- a/docs/01-app/05-api-reference/04-functions/userAgent.mdx
+++ b/docs/01-app/05-api-reference/04-functions/userAgent.mdx
@@ -13,7 +13,11 @@ import { NextRequest, NextResponse, userAgent } from 'next/server'
 export function middleware(request: NextRequest) {
   const url = request.nextUrl
   const { device } = userAgent(request)
-  const viewport = device.type === 'mobile' ? 'mobile' : 'desktop'
+  
+  // device.type can be: 'mobile', 'tablet', 'console', 'smarttv', 
+  // 'wearable', 'embedded', or undefined (for desktop browsers)
+  const viewport = device.type || 'desktop'
+  
   url.searchParams.set('viewport', viewport)
   return NextResponse.rewrite(url)
 }
@@ -25,7 +29,11 @@ import { NextResponse, userAgent } from 'next/server'
 export function middleware(request) {
   const url = request.nextUrl
   const { device } = userAgent(request)
-  const viewport = device.type === 'mobile' ? 'mobile' : 'desktop'
+  
+  // device.type can be: 'mobile', 'tablet', 'console', 'smarttv', 
+  // 'wearable', 'embedded', or undefined (for desktop browsers)
+  const viewport = device.type || 'desktop'
+  
   url.searchParams.set('viewport', viewport)
   return NextResponse.rewrite(url)
 }


### PR DESCRIPTION
### What?

Updates the `userAgent` middleware example in the documentation to accurately reflect all possible values of `device.type` and demonstrate proper handling of desktop browsers (undefined case).

### Why?

The current example shows a binary mobile/desktop check which doesn't accurately reflect the API's capabilities. The `device.type` property can actually return multiple values ('mobile', 'tablet', 'console', 'smarttv', 'wearable', 'embedded', or undefined), but the example only shows handling of 'mobile', which could mislead developers.

### How?

- Updated both TypeScript and JavaScript examples to:
  1. Add comprehensive comments documenting all possible `device.type` values
  2. Use proper undefined handling with the OR operator for desktop browsers
  3. Maintain consistency between TS and JS versions
  4. Better align with the documented behavior in the API reference
- Ran `pnpm prettier-fix` to ensure proper formatting
- Followed the [Docs Contribution Guide](https://nextjs.org/docs/community/contribution-guide)

The changes help developers better understand:
- The full range of device types they can detect
- How desktop browsers return undefined
- The proper way to handle device type detection
- Consistency with the rest of the API documentation

### Checklist

- [x] Read the [Docs Contribution Guide](https://nextjs.org/docs/community/contribution-guide)
- [x] Ran `pnpm prettier-fix` to fix formatting issues
- [x] Ensured examples are clear and follow documentation best practices
- [x] Maintained consistency with existing documentation style
- [x] Verified the accuracy of the technical information