### PR TITLE
fix: handle incremental PPR with client segment cache

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -338,6 +338,7 @@ const filterAndSortList = (
 }
 
 export interface PageInfo {
+  originalAppPath: string | undefined
   isHybridAmp?: boolean
   size: number
   totalSize: number

--- a/packages/next/src/server/lib/router-utils/build-prefetch-segment-data-route.test.ts
+++ b/packages/next/src/server/lib/router-utils/build-prefetch-segment-data-route.test.ts
@@ -1,4 +1,7 @@
-import { buildPrefetchSegmentDataRoute } from './build-prefetch-segment-data-route'
+import {
+  buildInversePrefetchSegmentDataRoute,
+  buildPrefetchSegmentDataRoute,
+} from './build-prefetch-segment-data-route'
 
 describe('buildPrefetchSegmentDataRoute', () => {
   it('should build a prefetch segment data route', () => {
@@ -10,7 +13,29 @@ describe('buildPrefetchSegmentDataRoute', () => {
     expect(route).toMatchInlineSnapshot(`
      {
        "destination": "/blog/[...slug].segments/$c$slug$[slug]/__PAGE__.segment.rsc",
+       "routeKeys": {
+         "nxtPslug": "nxtPslug",
+       },
        "source": "^/blog/(?<nxtPslug>.+?)\\.segments/\\$c\\$slug\\$\\k<nxtPslug>/__PAGE__\\.segment\\.rsc$",
+     }
+    `)
+  })
+})
+
+describe('buildInversePrefetchSegmentDataRoute', () => {
+  it('should build an inverted prefetch segment data route', () => {
+    const route = buildInversePrefetchSegmentDataRoute(
+      '/blog/[...slug]',
+      '/_tree'
+    )
+
+    expect(route).toMatchInlineSnapshot(`
+     {
+       "destination": "/blog/[...slug].prefetch.rsc",
+       "routeKeys": {
+         "nxtPslug": "nxtPslug",
+       },
+       "source": "^/blog/(?<nxtPslug>.+?)\\.segments/_tree\\.segment\\.rsc$",
      }
     `)
   })

--- a/packages/next/src/server/lib/router-utils/build-prefetch-segment-data-route.ts
+++ b/packages/next/src/server/lib/router-utils/build-prefetch-segment-data-route.ts
@@ -2,6 +2,7 @@ import path from '../../../shared/lib/isomorphic/path'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
 import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
 import {
+  RSC_PREFETCH_SUFFIX,
   RSC_SEGMENT_SUFFIX,
   RSC_SEGMENTS_DIR_SUFFIX,
 } from '../../../lib/constants'
@@ -11,6 +12,7 @@ export const SEGMENT_PATH_KEY = 'nextSegmentPath'
 export type PrefetchSegmentDataRoute = {
   source: string
   destination: string
+  routeKeys: { [key: string]: string }
 }
 
 export function buildPrefetchSegmentDataRoute(
@@ -24,7 +26,7 @@ export function buildPrefetchSegmentDataRoute(
     `${segmentPath}${RSC_SEGMENT_SUFFIX}`
   )
 
-  const { namedRegex } = getNamedRouteRegex(destination, {
+  const { namedRegex, routeKeys } = getNamedRouteRegex(destination, {
     prefixRouteKeys: true,
     includePrefix: true,
     includeSuffix: true,
@@ -35,5 +37,43 @@ export function buildPrefetchSegmentDataRoute(
   return {
     destination,
     source: namedRegex,
+    routeKeys,
+  }
+}
+
+/**
+ * Builds a prefetch segment data route that is inverted. This means that it's
+ * supposed to rewrite from the previous segment paths route back to the
+ * prefetch RSC route.
+ *
+ * @param page - The page to build the route for.
+ * @param segmentPath - The segment path to build the route for.
+ * @returns The prefetch segment data route.
+ */
+export function buildInversePrefetchSegmentDataRoute(
+  page: string,
+  segmentPath: string
+): PrefetchSegmentDataRoute {
+  const pagePath = normalizePagePath(page)
+
+  const source = path.posix.join(
+    `${pagePath}${RSC_SEGMENTS_DIR_SUFFIX}`,
+    `${segmentPath}${RSC_SEGMENT_SUFFIX}`
+  )
+
+  const { namedRegex, routeKeys } = getNamedRouteRegex(source, {
+    prefixRouteKeys: true,
+    includePrefix: true,
+    includeSuffix: true,
+    excludeOptionalTrailingSlash: true,
+    backreferenceDuplicateKeys: true,
+  })
+
+  const destination = path.posix.join(`${pagePath}${RSC_PREFETCH_SUFFIX}`)
+
+  return {
+    source: namedRegex,
+    destination,
+    routeKeys,
   }
 }

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/[teamSlug]/[projectSlug]/monitoring/page.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/[teamSlug]/[projectSlug]/monitoring/page.jsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+
+  return <div>/[lang]/[teamSlug]/[projectSlug]/monitoring</div>
+}
+
+export const experimental_ppr = true

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/[teamSlug]/~/monitoring/page.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/[teamSlug]/~/monitoring/page.jsx
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+
+  return <div>/[lang]/[teamSlug]/~/monitoring</div>
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/layout.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/layout.jsx
@@ -1,0 +1,11 @@
+export default function RootLayout({ children, params }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export function generateStaticParams() {
+  return ['en', 'fr'].map((lang) => ({ lang }))
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/loading.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/loading.jsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading...</div>
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/page.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/[lang]/page.jsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/es/~/monitoring">Monitoring</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
@@ -1,0 +1,33 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('conflicting routes', () => {
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    test('prefetching is disabled', () => {})
+    return
+  }
+
+  it.each([
+    '/en/vercel/~/monitoring',
+    '/fr/vercel/~/monitoring',
+    '/es/vercel/~/monitoring',
+  ])('%s matches the right route', async (path) => {
+    const res = await next.fetch(path, {
+      headers: {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': '/_tree',
+      },
+    })
+
+    expect(res.status).toBe(200)
+
+    if (isNextDeploy) {
+      expect(res.headers.get('x-matched-path')).toBe(
+        '/[lang]/[teamSlug]/~/monitoring.prefetch.rsc'
+      )
+    }
+  })
+})

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/next.config.js
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: 'incremental',
+    clientSegmentCache: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of prefetch segment data routes in the Next.js build process and adds new test cases to validate these updates. Key changes include the addition of a new `buildInversePrefetchSegmentDataRoute` utility, modifications to the route generation logic, and the introduction of experimental features like `clientSegmentCache`. This addresses a bug where conflicting routes while incremental PPR was enabled that matched routes incorrectly, for example:

```
/~/monitoring <- PPR disabled
/[teamSlug]/monitoring <- PPR enabled
```

Would previously cause client segment requests for `/~/monitoring` to match `/[teamSlug]/monitoring`. This addresses it by adding early rewrites to handle this case. This will be removed in future versions when incremental PPR is deprecated.

### Enhancements to prefetch segment data routes:

* Added a new utility, `buildInversePrefetchSegmentDataRoute`, to support inverted prefetch segment data routes, which rewrite from segment paths back to prefetch RSC routes. This is particularly useful for handling dynamic routes without conflicts when partial prerendering is disabled (`packages/next/src/server/lib/router-utils/build-prefetch-segment-data-route.ts`).
* Updated the `PrefetchSegmentDataRoute` type to include `routeKeys` for better route matching and added logic for generating these keys (`packages/next/src/server/lib/router-utils/build-prefetch-segment-data-route.ts`). [[1]](diffhunk://#diff-35b900720f7fd8bc8995f5dad9880b2ffafba0638ec6c949efc9ba34b0acc9cbR15) [[2]](diffhunk://#diff-35b900720f7fd8bc8995f5dad9880b2ffafba0638ec6c949efc9ba34b0acc9cbL27-R29)
* Modified the build process to utilize `buildInversePrefetchSegmentDataRoute` for dynamic routes with undefined segment paths when `clientSegmentCache` is enabled (`packages/next/src/build/index.ts`).

### Codebase improvements:

* Added `originalAppPath` to the `PageInfo` interface to track the original path of app pages and routes, improving route handling logic (`packages/next/src/build/utils.ts`).
* Simplified the logic for appending prefetch segment data routes by directly pushing the result of `buildPrefetchSegmentDataRoute` instead of using intermediate variables (`packages/next/src/build/index.ts`).

### Testing and experimental features:

* Added comprehensive unit tests for `buildInversePrefetchSegmentDataRoute` to ensure correct behavior and compatibility with existing route utilities (`packages/next/src/server/lib/router-utils/build-prefetch-segment-data-route.test.ts`).
* Introduced a new E2E test suite for validating conflicting routes and prefetching behavior under the experimental `clientSegmentCache` feature (`test/e2e/app-dir/segment-cache/conflicting-routes`).
* Enabled experimental features like `clientSegmentCache` and `ppr` (partial prerendering) in the test configuration to validate their integration (`test/e2e/app-dir/segment-cache/conflicting-routes/next.config.js`).

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as s
moothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
