### PR TITLE
refactor(turbo-tasks): Use ResolvedVc for CollectiblesSource

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
@@ -9,7 +9,7 @@ use auto_hash_map::AutoSet;
 use rustc_hash::FxHashSet;
 use tokio::time::sleep;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{emit, CollectiblesSource, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{emit, CollectiblesSource, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_testing::{register, run, Registration};
 
 static REGISTRATION: Registration = register!();
@@ -206,14 +206,7 @@ async fn my_transitive_emitting_function_collectibles(
 ) -> Result<Vc<Collectibles>> {
     let result_op = my_transitive_emitting_function(key, key2);
     Ok(Vc::cell(
-        result_op
-            .peek_collectibles::<Box<dyn ValueToString>>()
-            .into_iter()
-            .map(|v| v.to_resolved())
-            .try_join()
-            .await?
-            .into_iter()
-            .collect(),
+        result_op.peek_collectibles::<Box<dyn ValueToString>>(),
     ))
 }
 

--- a/turbopack/crates/turbo-tasks/src/collectibles.rs
+++ b/turbopack/crates/turbo-tasks/src/collectibles.rs
@@ -1,8 +1,9 @@
 use auto_hash_map::AutoSet;
 
-use crate::{Vc, VcValueTrait};
+use crate::{ResolvedVc, VcValueTrait};
 
+/// Implemented on `OperationVc` and `RawVc`.
 pub trait CollectiblesSource {
-    fn take_collectibles<T: VcValueTrait>(self) -> AutoSet<Vc<T>>;
-    fn peek_collectibles<T: VcValueTrait>(self) -> AutoSet<Vc<T>>;
+    fn take_collectibles<T: VcValueTrait>(self) -> AutoSet<ResolvedVc<T>>;
+    fn peek_collectibles<T: VcValueTrait>(self) -> AutoSet<ResolvedVc<T>>;
 }

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -11,8 +11,8 @@ use crate::{
     id::LocalTaskId,
     manager::{read_local_output, read_task_cell, read_task_output, with_turbo_tasks},
     registry::{self, get_value_type},
-    turbo_tasks, CollectiblesSource, ReadCellOptions, ReadConsistency, TaskId, TraitTypeId,
-    ValueType, ValueTypeId, Vc, VcValueTrait,
+    turbo_tasks, CollectiblesSource, ReadCellOptions, ReadConsistency, ResolvedVc, TaskId,
+    TraitTypeId, ValueType, ValueTypeId, VcValueTrait,
 };
 
 #[derive(Error, Debug)]
@@ -44,10 +44,10 @@ impl Display for CellId {
     }
 }
 
-/// A type-erased representation of [`Vc`].
+/// A type-erased representation of [`Vc`][crate::Vc].
 ///
 /// Type erasure reduces the [monomorphization] (and therefore binary size and compilation time)
-/// required to support `Vc`.
+/// required to support [`Vc`][crate::Vc].
 ///
 /// This type is heavily used within the [`Backend`][crate::backend::Backend] trait, but should
 /// otherwise be treated as an internal implementation detail of `turbo-tasks`.
@@ -244,23 +244,26 @@ impl RawVc {
     }
 }
 
+/// This implementation of `CollectiblesSource` assumes that `self` is a `RawVc::TaskOutput`.
 impl CollectiblesSource for RawVc {
-    fn peek_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<Vc<T>> {
+    fn peek_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
+        debug_assert!(matches!(self, RawVc::TaskOutput(..)));
         let tt = turbo_tasks();
         tt.notify_scheduled_tasks();
         let map = tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
         map.into_iter()
-            .filter_map(|(raw, count)| (count > 0).then_some(raw.into()))
+            .filter_map(|(raw, count)| (count > 0).then_some(raw.try_into().unwrap()))
             .collect()
     }
 
-    fn take_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<Vc<T>> {
+    fn take_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
+        debug_assert!(matches!(self, RawVc::TaskOutput(..)));
         let tt = turbo_tasks();
         tt.notify_scheduled_tasks();
         let map = tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
         tt.unemit_collectibles(T::get_trait_type_id(), &map);
         map.into_iter()
-            .filter_map(|(raw, count)| (count > 0).then_some(raw.into()))
+            .filter_map(|(raw, count)| (count > 0).then_some(raw.try_into().unwrap()))
             .collect()
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -187,14 +187,19 @@ where
     }
 }
 
-impl<T> From<RawVc> for OperationVc<T>
+impl<T> TryFrom<RawVc> for OperationVc<T>
 where
     T: ?Sized,
 {
-    fn from(raw: RawVc) -> Self {
-        Self {
-            node: Vc::from(raw),
+    type Error = anyhow::Error;
+
+    fn try_from(raw: RawVc) -> Result<Self> {
+        if !matches!(raw, RawVc::TaskOutput(..)) {
+            anyhow::bail!("Given RawVc {raw:?} is not a TaskOutput");
         }
+        Ok(Self {
+            node: Vc::from(raw),
+        })
     }
 }
 
@@ -231,17 +236,17 @@ impl<T> CollectiblesSource for OperationVc<T>
 where
     T: ?Sized,
 {
-    fn take_collectibles<Vt: VcValueTrait>(self) -> AutoSet<Vc<Vt>> {
+    fn take_collectibles<Vt: VcValueTrait>(self) -> AutoSet<ResolvedVc<Vt>> {
         self.node.node.take_collectibles()
     }
 
-    fn peek_collectibles<Vt: VcValueTrait>(self) -> AutoSet<Vc<Vt>> {
+    fn peek_collectibles<Vt: VcValueTrait>(self) -> AutoSet<ResolvedVc<Vt>> {
         self.node.node.peek_collectibles()
     }
 }
 
-/// Indicates that a type does not contain any instances of [`Vc`] or
-/// [`ResolvedVc`][crate::ResolvedVc]. It may contain [`OperationVc`].
+/// Indicates that a type does not contain any instances of [`Vc`] or [`ResolvedVc`]. It may contain
+/// [`OperationVc`].
 ///
 /// # Safety
 ///

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -15,7 +15,7 @@ use crate::{
     debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
     trace::{TraceRawVcs, TraceRawVcsContext},
     vc::Vc,
-    Upcast, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
+    RawVc, Upcast, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
 };
 
 /// A "subtype" (via [`Deref`]) of [`Vc`] that represents a specific [`Vc::cell`]/`.cell()` or
@@ -316,5 +316,21 @@ where
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
         self.node.value_debug_format(depth)
+    }
+}
+
+impl<T> TryFrom<RawVc> for ResolvedVc<T>
+where
+    T: ?Sized,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(raw: RawVc) -> Result<Self> {
+        if !matches!(raw, RawVc::TaskCell(..)) {
+            anyhow::bail!("Given RawVc {raw:?} is not a TaskCell");
+        }
+        Ok(Self {
+            node: Vc::from(raw),
+        })
     }
 }

--- a/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
+++ b/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
@@ -2,8 +2,9 @@ use std::cmp::Ordering;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use auto_hash_map::AutoSet;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{emit, CollectiblesSource, FxIndexMap, ResolvedVc, TryJoinIterExt, Upcast, Vc};
+use turbo_tasks::{emit, CollectiblesSource, FxIndexMap, ResolvedVc, Upcast, Vc};
 
 #[turbo_tasks::value(serialization = "none")]
 #[derive(Clone, Debug)]
@@ -101,14 +102,7 @@ where
 {
     async fn peek_diagnostics(self) -> Result<CapturedDiagnostics> {
         Ok(CapturedDiagnostics {
-            diagnostics: self
-                .peek_collectibles()
-                .into_iter()
-                .map(|v: Vc<Box<dyn Diagnostic>>| v.to_resolved())
-                .try_join()
-                .await?
-                .into_iter()
-                .collect(),
+            diagnostics: self.peek_collectibles(),
         })
     }
 }
@@ -118,5 +112,5 @@ where
 #[derive(Debug)]
 #[turbo_tasks::value]
 pub struct CapturedDiagnostics {
-    pub diagnostics: auto_hash_map::AutoSet<ResolvedVc<Box<dyn Diagnostic>>>,
+    pub diagnostics: AutoSet<ResolvedVc<Box<dyn Diagnostic>>>,
 }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -904,13 +904,7 @@ where
                                 description: ResolvedVc::cell(RcStr::from(description.into())),
                             },
                         )),
-                        children
-                            .into_iter()
-                            .map(|v: Vc<Box<dyn IssueProcessingPath>>| v.to_resolved())
-                            .try_join()
-                            .await?
-                            .into_iter()
-                            .collect(),
+                        children,
                     )),
                 ));
             }
@@ -943,13 +937,7 @@ where
                                 description: ResolvedVc::cell(RcStr::from(description.into())),
                             },
                         )),
-                        children
-                            .into_iter()
-                            .map(|v: Vc<Box<dyn IssueProcessingPath>>| v.to_resolved())
-                            .try_join()
-                            .await?
-                            .into_iter()
-                            .collect(),
+                        children,
                     )),
                 ));
             }
@@ -967,48 +955,22 @@ where
 
     async fn peek_issues_with_path(self) -> Result<CapturedIssues> {
         Ok(CapturedIssues {
-            issues: self
-                .peek_collectibles()
-                .into_iter()
-                .map(|v: Vc<Box<dyn Issue>>| v.to_resolved())
-                .try_join()
-                .await?
-                .into_iter()
-                .collect(),
+            issues: self.peek_collectibles(),
             #[cfg(feature = "issue_path")]
             processing_path: ItemIssueProcessingPath::resolved_cell(ItemIssueProcessingPath(
                 None,
-                self.peek_collectibles()
-                    .into_iter()
-                    .map(|v: Vc<Box<dyn IssueProcessingPath>>| v.to_resolved())
-                    .try_join()
-                    .await?
-                    .into_iter()
-                    .collect(),
+                self.peek_collectibles(),
             )),
         })
     }
 
     async fn take_issues_with_path(self) -> Result<CapturedIssues> {
         Ok(CapturedIssues {
-            issues: self
-                .take_collectibles()
-                .into_iter()
-                .map(|v: Vc<Box<dyn Issue>>| v.to_resolved())
-                .try_join()
-                .await?
-                .into_iter()
-                .collect(),
+            issues: self.take_collectibles(),
             #[cfg(feature = "issue_path")]
             processing_path: ItemIssueProcessingPath::resolved_cell(ItemIssueProcessingPath(
                 None,
-                self.take_collectibles()
-                    .into_iter()
-                    .map(|v: Vc<Box<dyn IssueProcessingPath>>| v.to_resolved())
-                    .try_join()
-                    .await?
-                    .into_iter()
-                    .collect(),
+                self.take_collectibles(),
             )),
         })
     }


### PR DESCRIPTION
The `turbo_tasks::emit` function (https://turbopack-rust-docs.vercel.sh/rustdoc/turbo_tasks/fn.emit.html) already requires a `ResolvedVc`, so all of these values should be a `ResolvedVc`. That makes things easier for code consuming collectibles.

Collectibles need some documentation, but they're how we emit diagnostics or collect file writes that are accumulated at the top-level. They're effectively tracked side-effects for a function.

Collectibles are deduplicated. We need somewhat sane equality definitions, so we use `ResolvedVc` for that (we want to eventually remove the `Eq` definition on `Vc`, it doesn't behave as one might expect).

Closes PACK-4406