### PR TITLE
[errors] pass original error as cause

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -753,7 +753,6 @@
   "752": "Route %s used \"connection\" inside \"use cache\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
   "753": "Route %s used \"connection\" inside \"use cache: private\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
   "754": "%s cannot be used outside of a request context.",
-<<<<<<< HEAD
   "755": "Route must be a string",
   "756": "Route %s not found",
   "757": "Unknown styled string type: %s",
@@ -765,12 +764,9 @@
   "763": "\\`unstable_rootParams\\` must not be used within a client component. Next.js should be preventing it from being included in client components statically, but did not in this case.",
   "764": "Missing workStore in %s",
   "765": "Route %s used %s inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.",
-  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route."
-=======
-  "755": "Next.js navigation API is not allowed to be used in Middleware.",
-  "756": "Next.js navigation API is not allowed to be used in Pages Router.",
-  "757": "An error occurred while loading instrumentation hook",
-  "758": "Next.js failed to read file %s for getting static info",
-  "759": "Route %s not found"
->>>>>>> dbf9416218 ([errors] use error cause instead of overriding msg)
+  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route.",
+  "767": "Next.js navigation API is not allowed to be used in Middleware.",
+  "768": "Next.js navigation API is not allowed to be used in Pages Router.",
+  "769": "An error occurred while loading instrumentation hook",
+  "770": "Next.js failed to read file %s for getting static info"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -753,6 +753,7 @@
   "752": "Route %s used \"connection\" inside \"use cache\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
   "753": "Route %s used \"connection\" inside \"use cache: private\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
   "754": "%s cannot be used outside of a request context.",
+<<<<<<< HEAD
   "755": "Route must be a string",
   "756": "Route %s not found",
   "757": "Unknown styled string type: %s",
@@ -765,4 +766,11 @@
   "764": "Missing workStore in %s",
   "765": "Route %s used %s inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.",
   "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route."
+=======
+  "755": "Next.js navigation API is not allowed to be used in Middleware.",
+  "756": "Next.js navigation API is not allowed to be used in Pages Router.",
+  "757": "An error occurred while loading instrumentation hook",
+  "758": "Next.js failed to read file %s for getting static info",
+  "759": "Route %s not found"
+>>>>>>> dbf9416218 ([errors] use error cause instead of overriding msg)
 }

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -301,10 +301,12 @@ async function tryToReadFile(filePath: string, shouldThrow: boolean) {
     return await fs.readFile(filePath, {
       encoding: 'utf8',
     })
-  } catch (error: any) {
+  } catch (error) {
     if (shouldThrow) {
-      error.message = `Next.js ERROR: Failed to read file ${filePath}:\n${error.message}`
-      throw error
+      throw new Error(
+        `Next.js failed to read file ${filePath} for getting static info`,
+        { cause: error }
+      )
     }
   }
 }

--- a/packages/next/src/build/templates/middleware.ts
+++ b/packages/next/src/build/templates/middleware.ts
@@ -31,8 +31,10 @@ function errorHandledHandler(fn: AdapterOptions['handler']) {
       // since it's not allowed to be used in middleware as it's outside of react component tree.
       if (process.env.NODE_ENV !== 'production') {
         if (isNextRouterError(err)) {
-          err.message = `Next.js navigation API is not allowed to be used in Middleware.`
-          throw err
+          throw new Error(
+            `Next.js navigation API is not allowed to be used in Middleware.`,
+            { cause: err }
+          )
         }
       }
       const req = args[0]

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -942,8 +942,13 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
           // In development, error the navigation API usage in runtime,
           // since it's not allowed to be used in pages router as it doesn't contain error boundary like app router.
           if (isNextRouterError(initialErr)) {
-            error.message =
-              'Next.js navigation API is not allowed to be used in Pages Router.'
+            throw getServerError(
+              new Error(
+                'Next.js navigation API is not allowed to be used in Pages Router.',
+                { cause: error }
+              ),
+              errSource
+            )
           }
 
           throw getServerError(error, errSource)

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -712,9 +712,11 @@ export default class DevServer extends Server {
           this.dir,
           this.nextConfig.distDir
         )
-      } catch (err: any) {
-        err.message = `An error occurred while loading instrumentation hook: ${err.message}`
-        throw err
+      } catch (err) {
+        throw new Error(
+          `An error occurred while loading instrumentation hook`,
+          { cause: err }
+        )
       }
     }
     return instrumentationModule

--- a/packages/next/src/server/dev/node-stack-frames.ts
+++ b/packages/next/src/server/dev/node-stack-frames.ts
@@ -4,6 +4,7 @@ import {
   decorateServerError,
   type ErrorSourceType,
 } from '../../shared/lib/error-source'
+import isError from '../../lib/is-error'
 
 function getFilesystemFrame(frame: StackFrame): StackFrame {
   const f: StackFrame = { ...frame }
@@ -24,7 +25,35 @@ function getFilesystemFrame(frame: StackFrame): StackFrame {
   return f
 }
 
-export function getServerError(error: Error, type: ErrorSourceType): Error {
+// If there's a cause of the error, will keep the new error message
+// but with the original stack trace.
+function decorateErrorWithCause(error: Error): Error {
+  let message = error.message
+  let stack = error.stack
+  let curr: any = error
+  while (curr && isError(curr) && curr.cause) {
+    const cause = curr.cause
+    if (isError(cause)) {
+      if (cause.stack) {
+        // Append the stack trace of the cause to the current error
+        stack = `${stack}\nCaused by: ${cause.stack}`
+      }
+    }
+    curr = cause
+  }
+  // Override the error message if there's new information
+  if (error.message !== message) {
+    error.message = message
+  }
+  if (error.stack !== stack) {
+    error.stack = stack
+  }
+  return error
+}
+
+export function getServerError(err: Error, type: ErrorSourceType): Error {
+  const error = decorateErrorWithCause(err)
+
   if (error.name === 'TurbopackInternalError') {
     // If this is an internal Turbopack error we shouldn't show internal details
     // to the user. These are written to a log file instead.
@@ -44,7 +73,7 @@ export function getServerError(error: Error, type: ErrorSourceType): Error {
 
   n.name = error.name
   try {
-    n.stack = `${n.toString()}\n${parse(error.stack!)
+    n.stack = `${n.toString()}\n${parse(error.stack || '')
       .map(getFilesystemFrame)
       .map((f) => {
         let str = `    at ${f.methodName}`

--- a/packages/next/src/server/dev/node-stack-frames.ts
+++ b/packages/next/src/server/dev/node-stack-frames.ts
@@ -26,7 +26,9 @@ function getFilesystemFrame(frame: StackFrame): StackFrame {
 }
 
 export function getServerError(error: Error, type: ErrorSourceType): Error {
-  let message = error.message
+  const errMessage = error.message
+  const errorName = error.name
+
   // Retrieve the original error from the cause chain
   while (isError(error.cause)) {
     error = error.cause
@@ -43,12 +45,12 @@ export function getServerError(error: Error, type: ErrorSourceType): Error {
 
   let n: Error
   try {
-    throw new Error(message)
+    throw new Error(errMessage)
   } catch (e) {
     n = e as Error
   }
 
-  n.name = error.name
+  n.name = errorName
   try {
     n.stack = `${n.toString()}\n${parse(error.stack || '')
       .map(getFilesystemFrame)

--- a/packages/next/src/server/dev/node-stack-frames.ts
+++ b/packages/next/src/server/dev/node-stack-frames.ts
@@ -28,10 +28,12 @@ function getFilesystemFrame(frame: StackFrame): StackFrame {
 export function getServerError(error: Error, type: ErrorSourceType): Error {
   const errMessage = error.message
   const errorName = error.name
+  let errorStack = error.stack
 
   // Retrieve the original error from the cause chain
   while (isError(error.cause)) {
     error = error.cause
+    errorStack = error.stack
   }
   if (error.name === 'TurbopackInternalError') {
     // If this is an internal Turbopack error we shouldn't show internal details
@@ -52,7 +54,7 @@ export function getServerError(error: Error, type: ErrorSourceType): Error {
 
   n.name = errorName
   try {
-    n.stack = `${n.toString()}\n${parse(error.stack || '')
+    n.stack = `${n.toString()}\n${parse(errorStack || '')
       .map(getFilesystemFrame)
       .map((f) => {
         let str = `    at ${f.methodName}`
@@ -70,7 +72,7 @@ export function getServerError(error: Error, type: ErrorSourceType): Error {
       })
       .join('\n')}`
   } catch {
-    n.stack = error.stack
+    n.stack = errorStack
   }
 
   decorateServerError(n, type)

--- a/packages/next/src/server/dev/node-stack-frames.ts
+++ b/packages/next/src/server/dev/node-stack-frames.ts
@@ -25,35 +25,12 @@ function getFilesystemFrame(frame: StackFrame): StackFrame {
   return f
 }
 
-// If there's a cause of the error, will keep the new error message
-// but with the original stack trace.
-function decorateErrorWithCause(error: Error): Error {
+export function getServerError(error: Error, type: ErrorSourceType): Error {
   let message = error.message
-  let stack = error.stack
-  let curr: any = error
-  while (curr && isError(curr) && curr.cause) {
-    const cause = curr.cause
-    if (isError(cause)) {
-      if (cause.stack) {
-        // Append the stack trace of the cause to the current error
-        stack = `${stack}\nCaused by: ${cause.stack}`
-      }
-    }
-    curr = cause
+  // Retrieve the original error from the cause chain
+  while (isError(error.cause)) {
+    error = error.cause
   }
-  // Override the error message if there's new information
-  if (error.message !== message) {
-    error.message = message
-  }
-  if (error.stack !== stack) {
-    error.stack = stack
-  }
-  return error
-}
-
-export function getServerError(err: Error, type: ErrorSourceType): Error {
-  const error = decorateErrorWithCause(err)
-
   if (error.name === 'TurbopackInternalError') {
     // If this is an internal Turbopack error we shouldn't show internal details
     // to the user. These are written to a log file instead.
@@ -66,7 +43,7 @@ export function getServerError(err: Error, type: ErrorSourceType): Error {
 
   let n: Error
   try {
-    throw new Error(error.message)
+    throw new Error(message)
   } catch (e) {
     n = e as Error
   }

--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -55,9 +55,10 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
   if (instrumentation?.register) {
     try {
       await instrumentation.register()
-    } catch (err: any) {
-      err.message = `An error occurred while loading instrumentation hook: ${err.message}`
-      throw err
+    } catch (err: unknown) {
+      throw new Error(`An error occurred while loading instrumentation hook`, {
+        cause: err,
+      })
     }
   }
 }

--- a/packages/next/src/server/web/globals.ts
+++ b/packages/next/src/server/web/globals.ts
@@ -27,9 +27,10 @@ async function registerInstrumentation() {
   if (instrumentation?.register) {
     try {
       await instrumentation.register()
-    } catch (err: any) {
-      err.message = `An error occurred while loading instrumentation hook: ${err.message}`
-      throw err
+    } catch (err: unknown) {
+      throw new Error(`An error occurred while loading instrumentation hook`, {
+        cause: err,
+      })
     }
   }
 }

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -392,8 +392,7 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
             : __fetch(String(input), init)
 
         return await response.catch((err) => {
-          callingError.message = err.message
-          err.stack = callingError.stack
+          err.cause = callingError
           throw err
         })
       }

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -351,8 +351,9 @@ describe('Client Navigation rendering', () => {
             'no-store, must-revalidate'
           )
         } catch (err) {
-          err.message = res.url + ' ' + err.message
-          throw err
+          throw new Error(`header of request ${res.url} is not matched`, {
+            cause: err,
+          })
         }
       })
     })

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -642,8 +642,9 @@ describe('Production Usage', () => {
             'public, max-age=31536000, immutable'
           )
         } catch (err) {
-          err.message = res.url + ' ' + err.message
-          throw err
+          throw new Error(`header of request ${res.url} is not matched`, {
+            cause: err,
+          })
         }
       })
     })


### PR DESCRIPTION
### What

Passing original `error` as `cause` property when we need to throw it with a different message. For instance, when we need to disable the navigation API usage in certain place like middleware, we can determine if the thrown error is from navigation API. 

Always overriding the error message is annoying, why not just pass them as `error.cause` in the standard way and handle the error with `cause` differently. Since we still want to preserve the error stack of original error, so on the error handling side, we unpack the nested error with the cause, and append the error stack of cause like the standard stringified, and override the error message.

For example:

```js
const a = new Error('a')
const b = new Error('b', { cause: a })
console.log(b)
```
We will get

```
Error: b
    at <anonymous>:2:11
Caused by: Error: a
    at <anonymous>:1:11
```

To achieve the similar goal, we keep unpacking the error and append the stack of cause to the original stack.