### PR TITLE
docs: Add missing deprecation notice for legacyBehavior in Link component

### DIFF
--- a/docs/01-app/05-api-reference/02-components/link.mdx
+++ b/docs/01-app/05-api-reference/02-components/link.mdx
@@ -364,7 +364,9 @@ export default function Home() {
 
 ### `legacyBehavior`
 
-An `<a>` element is no longer required as a child of `<Link>`. Add the `legacyBehavior` prop to use the legacy behavior or remove the `<a>` to upgrade. A [codemod is available](/docs/app/guides/upgrading/codemods#new-link) to automatically upgrade your code.
+> **Deprecated**: The `legacyBehavior` prop will be removed in Next.js v16. To adopt the new `<Link>` behavior, simply remove any `<a>` tags used as children of `<Link>`. A [codemod is available](/docs/app/guides/upgrading/codemods#new-link) to help you automatically upgrade your codebase.
+
+In the latest versions of Next.js, an `<a>` element is no longer required as a child of the `<Link>` component. If you still need the old behavior for compatibility reasons, you can add the `legacyBehavior` prop. However, it is strongly recommended to migrate to the modern approach for future compatibility.
 
 > **Good to know**: when `legacyBehavior` is not set to `true`, all [`anchor`](https://developer.mozilla.org/docs/Web/HTML/Element/a) tag properties can be passed to `next/link` as well such as, `className`, `onClick`, etc.
 

--- a/docs/01-app/05-api-reference/02-components/link.mdx
+++ b/docs/01-app/05-api-reference/02-components/link.mdx
@@ -364,7 +364,7 @@ export default function Home() {
 
 ### `legacyBehavior`
 
-> **Deprecated**: The `legacyBehavior` prop will be removed in Next.js v16. To adopt the new `<Link>` behavior, simply remove any `<a>` tags used as children of `<Link>`. A [codemod is available](/docs/app/guides/upgrading/codemods#new-link) to help you automatically upgrade your codebase.
+> **Warning**: The `legacyBehavior` prop will be removed in Next.js v16. To adopt the new `<Link>` behavior, remove any `<a>` tags used as children of `<Link>`. A [codemod is available](/docs/app/guides/upgrading/codemods#new-link) to help you automatically upgrade your codebase.
 
 In the latest versions of Next.js, an `<a>` element is no longer required as a child of the `<Link>` component. If you still need the old behavior for compatibility reasons, you can add the `legacyBehavior` prop. However, it is strongly recommended to migrate to the modern approach for future compatibility.
 

--- a/docs/01-app/05-api-reference/02-components/link.mdx
+++ b/docs/01-app/05-api-reference/02-components/link.mdx
@@ -366,7 +366,7 @@ export default function Home() {
 
 > **Warning**: The `legacyBehavior` prop will be removed in Next.js v16. To adopt the new `<Link>` behavior, remove any `<a>` tags used as children of `<Link>`. A [codemod is available](/docs/app/guides/upgrading/codemods#new-link) to help you automatically upgrade your codebase.
 
-In the latest versions of Next.js, an `<a>` element is no longer required as a child of the `<Link>` component. If you still need the old behavior for compatibility reasons, you can add the `legacyBehavior` prop. However, it is strongly recommended to migrate to the modern approach for future compatibility.
+Since version 13, an `<a>` element is no longer required as a child of the `<Link>` component. If you still need the old behavior for compatibility reasons, you can add the `legacyBehavior` prop.
 
 > **Good to know**: when `legacyBehavior` is not set to `true`, all [`anchor`](https://developer.mozilla.org/docs/Web/HTML/Element/a) tag properties can be passed to `next/link` as well such as, `className`, `onClick`, etc.
 


### PR DESCRIPTION
## What?

The Pages Router section of the Link component documentation now clearly states the deprecation notice for the `legacyBehavior` prop.

## Why?

The Pages Router documentation was missing the deprecation notice that appears in the App Router docs, which could lead developers to continue using a feature that is scheduled for removal in Next.js v16.

## How?

Added the deprecation notice to the `legacyBehavior` section in the Pages Router part of the documentation, making it consistent with the notice already present in the App Router section. The notice clearly states that the prop will be removed in Next.js v16 and provides information about migrating to the new behavior.

Fixes #78381


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
