### PR TITLE
Docs IA 2.0: Move authentication page under `guides`

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1,5 +1,6 @@
 ---
-title: Authentication
+title: How to implement authentication in Next.js
+nav_title: Authentication
 description: Learn how to implement authentication in your Next.js application.
 ---
 

--- a/docs/01-app/02-guides/index.mdx
+++ b/docs/01-app/02-guides/index.mdx
@@ -43,10 +43,10 @@ description: Learn how to implement common UI patterns and use cases using Next.
 
 ### Auth
 
-- [Creating a sign-up form](/docs/app/building-your-application/authentication#sign-up-and-login-functionality)
-- [Stateless, cookie-based session management](/docs/app/building-your-application/authentication#stateless-sessions)
-- [Stateful, database-backed session management](/docs/app/building-your-application/authentication#database-sessions)
-- [Managing authorization](/docs/app/building-your-application/authentication#authorization)
+- [Creating a sign-up form](/docs/app/guides/authentication#sign-up-and-login-functionality)
+- [Stateless, cookie-based session management](/docs/app/guides/authentication#stateless-sessions)
+- [Stateful, database-backed session management](/docs/app/guides/authentication#database-sessions)
+- [Managing authorization](/docs/app/guides/authentication#authorization)
 
 ### Testing
 

--- a/docs/02-pages/02-guides/authentication.mdx
+++ b/docs/02-pages/02-guides/authentication.mdx
@@ -2,7 +2,7 @@
 title: How to implement authentication in Next.js
 nav_title: Authentication
 description: Learn how to implement authentication in Next.js, covering best practices, securing routes, authorization techniques, and session management.
-source: app/building-your-application/authentication
+source: app/guides/authentication
 ---
 
 {/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/02-pages/02-guides/authentication.mdx
+++ b/docs/02-pages/02-guides/authentication.mdx
@@ -1,5 +1,6 @@
 ---
-title: Authentication
+title: How to implement authentication in Next.js
+nav_title: Authentication
 description: Learn how to implement authentication in Next.js, covering best practices, securing routes, authorization techniques, and session management.
 source: app/building-your-application/authentication
 ---

--- a/docs/02-pages/04-api-reference/03-functions/use-router.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/use-router.mdx
@@ -101,7 +101,7 @@ export default function Page() {
 }
 ```
 
-Redirecting the user to `pages/login.js`, useful for pages behind [authentication](/docs/pages/building-your-application/authentication):
+Redirecting the user to `pages/login.js`, useful for pages behind [authentication](/docs/pages/guides/authentication):
 
 ```jsx
 import { useEffect } from 'react'


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4574/authentication
Redirects: https://github.com/vercel/front/pull/44449