### PR TITLE
[ts-next-plugin] fix: validate metadata node before checking type

### DIFF
--- a/packages/next/src/server/typescript/rules/metadata.ts
+++ b/packages/next/src/server/typescript/rules/metadata.ts
@@ -206,7 +206,11 @@ const metadata = {
               }
             }
 
-            if (!hasCorrectType(declaration as tsModule.FunctionDeclaration)) {
+            if (
+              declaration &&
+              ts.isFunctionDeclaration(declaration) &&
+              !hasCorrectType(declaration)
+            ) {
               diagnostics.push({
                 file: source,
                 category: ts.DiagnosticCategory.Warning,
@@ -219,7 +223,11 @@ const metadata = {
           } else {
             // must be 'metadata' at this point
             const declaration = symbol.declarations?.[0]
-            if (!hasCorrectType(declaration as tsModule.VariableDeclaration)) {
+            if (
+              declaration &&
+              ts.isVariableDeclaration(declaration) &&
+              !hasCorrectType(declaration)
+            ) {
               diagnostics.push({
                 file: source,
                 category: ts.DiagnosticCategory.Warning,


### PR DESCRIPTION
### What?

Received error from TS Log:

```txt
Cannot read properties of undefined (reading 'type')

TypeError: Cannot read properties of undefined (reading 'type')
 at hasCorrectType (…/next@15.4.0-canary.3…/next/dist/server/typescript/rules/metadata.js:212:14)
 at Object.getSemanticDiagnosticsForExportDeclaration (…
```

### Why?

`declaration` can be undefined but was passed via `as` assertion.

### How?

Remove the `as` assertion and correctly validate the `declaration.`