### PR TITLE
[errors] fix edge server initial error is not sent via hmr

### DIFF
--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -158,24 +158,10 @@ export class WebpackHotMiddleware {
     if (this.clientLatestStats?.stats) {
       this.publishStats(this.clientLatestStats.stats)
     }
-    // if (this.serverLatestStats?.stats) {
-    //   this.publishStats(this.serverLatestStats.stats)
-    // }
-
-    // this.publish({
-    //   action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING,
-    // })
   }
 
   onEdgeServerDone = (statsResult: webpack.Stats) => {
     if (this.closed) return
-    // if (!isMiddlewareStats(statsResult)) {
-    //   console.log('is not middleware stats')
-    //   this.onServerInvalid()
-    //   this.onServerDone(statsResult)
-    //   return
-    // }
-
     if (statsResult.hasErrors()) {
       this.middlewareLatestStats = { ts: Date.now(), stats: statsResult }
       this.publishStats(statsResult)

--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -177,6 +177,7 @@ export class WebpackHotMiddleware {
       this.onServerInvalid()
       this.onServerDone(statsResult)
     }
+
     if (statsResult.hasErrors()) {
       this.middlewareLatestStats = { ts: Date.now(), stats: statsResult }
       this.publishStats(statsResult)

--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -23,21 +23,10 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type ws from 'next/dist/compiled/ws'
-import { isMiddlewareFilename } from '../../build/utils'
 import type { VersionInfo } from './parse-version-info'
 import type { HMR_ACTION_TYPES } from './hot-reloader-types'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
 import { devIndicatorServerState } from './dev-indicator-server-state'
-
-function isMiddlewareStats(stats: webpack.Stats) {
-  for (const key of stats.compilation.entrypoints.keys()) {
-    if (isMiddlewareFilename(key)) {
-      return true
-    }
-  }
-
-  return false
-}
 
 function statsToJson(stats?: webpack.Stats | null) {
   if (!stats) return {}
@@ -169,14 +158,23 @@ export class WebpackHotMiddleware {
     if (this.clientLatestStats?.stats) {
       this.publishStats(this.clientLatestStats.stats)
     }
+    // if (this.serverLatestStats?.stats) {
+    //   this.publishStats(this.serverLatestStats.stats)
+    // }
+
+    // this.publish({
+    //   action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING,
+    // })
   }
 
   onEdgeServerDone = (statsResult: webpack.Stats) => {
-    if (!isMiddlewareStats(statsResult)) {
-      this.onServerInvalid()
-      this.onServerDone(statsResult)
-      return
-    }
+    if (this.closed) return
+    // if (!isMiddlewareStats(statsResult)) {
+    //   console.log('is not middleware stats')
+    //   this.onServerInvalid()
+    //   this.onServerDone(statsResult)
+    //   return
+    // }
 
     if (statsResult.hasErrors()) {
       this.middlewareLatestStats = { ts: Date.now(), stats: statsResult }

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -265,17 +265,7 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/app-code/react-dom-server-edge-implicit'
     )
 
-    if (isTurbopack) {
-      await assertHasRedbox(browser)
-    } else {
-      // FIXME: why no redbox when there is an error?
-      await assertNoRedbox(browser)
-      // error happens too early it seems to be caught by browser.log()
-      // but the layout not being rendered indicates that it actually crashed
-      expect(await browser.elementByCss('body').text()).toMatchInlineSnapshot(
-        `""`
-      )
-    }
+    await assertHasRedbox(browser)
     const redbox = {
       description: await getRedboxDescription(browser),
       source: await getRedboxSource(browser),
@@ -300,10 +290,28 @@ describe('react-dom/server in React Server environment', () => {
       `)
     } else {
       expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": null,
-          "source": null,
-        }
+       {
+         "description": "Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
+         "source": "./node_modules/.pnpm/next@file+..+next-repo-548b9ffc88a1a85326dd460c2cea2354fe70867cfcf20dfd398fe124a0d0f1ab+packa_u25kve6m4knr3ugkwxfb4f6gc4/node_modules/next/dist/build/webpack/loaders/next-app-loader/index.js?name=app%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage&page=%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage&appPaths=%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage&pagePath=private-next-app-dir%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage.js&appDir=%2Fprivate%2Fvar%2Ffolders%2Fwv%2Fxyy9xyz10sl4twdx_hp25mjc0000gn%2FT%2Fnext-install-4d23475f6a03f4cc836b1fa585a37f45b3b7bcc86d5dc80cc51909a53a0f766b%2Fapp&pageExtensions=tsx&pageExtensions=ts&pageExtensions=jsx&pageExtensions=js&rootDir=%2Fprivate%2Fvar%2Ffolders%2Fwv%2Fxyy9xyz10sl4twdx_hp25mjc0000gn%2FT%2Fnext-install-4d23475f6a03f4cc836b1fa585a37f45b3b7bcc86d5dc80cc51909a53a0f766b&isDev=true&tsconfigPath=tsconfig.json&basePath=&assetPrefix=&nextConfigOutput=&preferredRegion=&middlewareConfig=e30%3D!./app/exports/app-code/react-dom-server-edge-implicit/page.js?__next_edge_ssr_entry__
+       Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+         | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
+          ,-[1:1]
+        1 | import * as ReactDOMServerEdge from 'react-dom/server'
+          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        2 | // Fine to drop once React is on ESM
+        3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
+          \`----
+         x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+         | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
+          ,-[3:1]
+        1 | import * as ReactDOMServerEdge from 'react-dom/server'
+        2 | // Fine to drop once React is on ESM
+        3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
+          : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        4 | 
+        5 | export const runtime = 'edge'
+          \`----",
+       }
       `)
     }
   })

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -265,44 +265,29 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/app-code/react-dom-server-edge-implicit'
     )
 
-    await assertHasRedbox(browser)
-    const redbox = {
-      description: await getRedboxDescription(browser),
-      source: await getRedboxSource(browser),
-    }
     if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
+      expect(browser).toDisplayRedbox(`
        {
          "description": "Ecmascript file had an error",
+         "environmentLabel": null,
+         "label": "Build Error",
          "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
        Ecmascript file had an error
-         1 | import * as ReactDOMServerEdge from 'react-dom/server'
-         2 | // Fine to drop once React is on ESM
        > 3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
-           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         4 |
-         5 | export const runtime = 'edge'
-         6 |
-
-       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-       Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+         "stack": [],
        }
       `)
     } else {
       // FIXME: the source map of source file path is not correct
       // Expected: `./app/exports/app-code/react-dom-server-edge-implicit/page.js`
       // Observed: `./node_modules/.pnpm/next@file+..+next-repo.../page.js?__next_edge_ssr_entry__
-      const sourceLines = redbox.source.split('\n')
-      const filepath = sourceLines[0]
-      // Override the 1st line of source to a placeholder
-      if (filepath.includes('node_modules')) {
-        redbox.source =
-          `<FIXME-edge-source-path>\n` + sourceLines.slice(1).join('\n')
-      }
-      expect(redbox).toMatchInlineSnapshot(`
+      expect(browser).toDisplayRedbox(`
        {
          "description": "Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
-         "source": "<FIXME-edge-source-path>
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "<FIXME-nextjs-internal-source>
        Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
           ,-[1:1]
@@ -318,9 +303,10 @@ describe('react-dom/server in React Server environment', () => {
         2 | // Fine to drop once React is on ESM
         3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
           : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        4 | 
+        4 |
         5 | export const runtime = 'edge'
           \`----",
+         "stack": [],
        }
       `)
     }

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -289,10 +289,20 @@ describe('react-dom/server in React Server environment', () => {
        }
       `)
     } else {
+      // FIXME: the source map of source file path is not correct
+      // Expected: `./app/exports/app-code/react-dom-server-edge-implicit/page.js`
+      // Observed: `./node_modules/.pnpm/next@file+..+next-repo.../page.js?__next_edge_ssr_entry__
+      const sourceLines = redbox.source.split('\n')
+      const filepath = sourceLines[0]
+      if (filepath.includes('node_modules')) {
+        redbox.source =
+          `./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)\n` +
+          sourceLines.slice(1).join('\n')
+      }
       expect(redbox).toMatchInlineSnapshot(`
        {
          "description": "Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
-         "source": "./node_modules/.pnpm/next@file+..+next-repo-548b9ffc88a1a85326dd460c2cea2354fe70867cfcf20dfd398fe124a0d0f1ab+packa_u25kve6m4knr3ugkwxfb4f6gc4/node_modules/next/dist/build/webpack/loaders/next-app-loader/index.js?name=app%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage&page=%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage&appPaths=%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage&pagePath=private-next-app-dir%2Fexports%2Fapp-code%2Freact-dom-server-edge-implicit%2Fpage.js&appDir=%2Fprivate%2Fvar%2Ffolders%2Fwv%2Fxyy9xyz10sl4twdx_hp25mjc0000gn%2FT%2Fnext-install-4d23475f6a03f4cc836b1fa585a37f45b3b7bcc86d5dc80cc51909a53a0f766b%2Fapp&pageExtensions=tsx&pageExtensions=ts&pageExtensions=jsx&pageExtensions=js&rootDir=%2Fprivate%2Fvar%2Ffolders%2Fwv%2Fxyy9xyz10sl4twdx_hp25mjc0000gn%2FT%2Fnext-install-4d23475f6a03f4cc836b1fa585a37f45b3b7bcc86d5dc80cc51909a53a0f766b&isDev=true&tsconfigPath=tsconfig.json&basePath=&assetPrefix=&nextConfigOutput=&preferredRegion=&middlewareConfig=e30%3D!./app/exports/app-code/react-dom-server-edge-implicit/page.js?__next_edge_ssr_entry__
+         "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
        Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
           ,-[1:1]

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -294,15 +294,15 @@ describe('react-dom/server in React Server environment', () => {
       // Observed: `./node_modules/.pnpm/next@file+..+next-repo.../page.js?__next_edge_ssr_entry__
       const sourceLines = redbox.source.split('\n')
       const filepath = sourceLines[0]
+      // Override the 1st line of source to a placeholder
       if (filepath.includes('node_modules')) {
         redbox.source =
-          `./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)\n` +
-          sourceLines.slice(1).join('\n')
+          `<FIXME-edge-source-path>\n` + sourceLines.slice(1).join('\n')
       }
       expect(redbox).toMatchInlineSnapshot(`
        {
          "description": "Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
-         "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
+         "source": "<FIXME-edge-source-path>
        Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
           ,-[1:1]

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -1,10 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import {
-  assertHasRedbox,
-  assertNoRedbox,
-  getRedboxDescription,
-  getRedboxSource,
-} from 'next-test-utils'
+import { assertHasRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 describe('use-cache-segment-configs', () => {
@@ -22,31 +17,40 @@ describe('use-cache-segment-configs', () => {
     if (isNextDev) {
       const browser = await next.browser('/runtime')
 
+      await assertHasRedbox(browser)
+
       if (isTurbopack) {
-        await assertHasRedbox(browser)
-
-        const description = await getRedboxDescription(browser)
-        expect(description).toMatchInlineSnapshot(
-          `"Ecmascript file had an error"`
-        )
-        const source = await getRedboxSource(browser)
-
-        expect(source).toMatchInlineSnapshot(`
-         "./app/runtime/page.tsx (1:14)
+        expect(browser).toDisplayRedbox(`
+         {
+           "description": "Ecmascript file had an error",
+           "environmentLabel": null,
+           "label": "Build Error",
+           "source": "./app/runtime/page.tsx (1:14)
          Ecmascript file had an error
          > 1 | export const runtime = 'edge'
-             |              ^^^^^^^
-           2 |
-           3 | export default function Page() {
-           4 |   return <div>This page uses \`export const runtime\`.</div>
-
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it."
+             |              ^^^^^^^",
+           "stack": [],
+         }
         `)
       } else {
-        // TODO(veil): Figure out why dev overlay is not shown with Webpack when
-        // the runtime is 'edge'. It's possibly related to the import trace
-        // being wrong (pointing at the Webpack loader resource).
-        await assertNoRedbox(browser)
+        // FIXME: Fix broken import trace for Webpack loader resource.
+        expect(browser).toDisplayRedbox(`
+         {
+           "description": "Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
+           "environmentLabel": null,
+           "label": "Build Error",
+           "source": "<FIXME-nextjs-internal-source>
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+            ,-[1:1]
+          1 | export const runtime = 'edge'
+            :              ^^^^^^^
+          2 |
+          3 | export default function Page() {
+          4 |   return <div>This page uses \`export const runtime\`.</div>
+            \`----",
+           "stack": [],
+         }
+        `)
       }
     } else {
       const { cliOutput } = await next.build()

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -134,6 +134,18 @@ async function createErrorSnapshot(
         '<FIXME-project-root>'
       )
     }
+
+    // This is the processed path the nextjs file from node_modules,
+    // likely not being processed properly and it's not deterministic among tests.
+    // e.g. it could be a encoded url of loader path:
+    // ../packages/next/dist/build/webpack/loaders/next-app-loader/index.js...
+    const sourceLines = focusedSource.split('\n')
+    if (sourceLines[0].startsWith('./node_modules/.pnpm/next@file+')) {
+      focusedSource =
+        `<FIXME-nextjs-internal-source>` +
+        '\n' +
+        sourceLines.slice(1).join('\n')
+    }
   }
 
   const snapshot: ErrorSnapshot = {

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -140,7 +140,10 @@ async function createErrorSnapshot(
     // e.g. it could be a encoded url of loader path:
     // ../packages/next/dist/build/webpack/loaders/next-app-loader/index.js...
     const sourceLines = focusedSource.split('\n')
-    if (sourceLines[0].startsWith('./node_modules/.pnpm/next@file+')) {
+    if (
+      sourceLines[0].startsWith('./node_modules/.pnpm/next@file+') ||
+      sourceLines[0].startsWith('./node_modules/.pnpm/file+')
+    ) {
       focusedSource =
         `<FIXME-nextjs-internal-source>` +
         '\n' +


### PR DESCRIPTION
### Issue

When there's a webpack build error in edge runtime occurred, the error is not sent through hmr to client, until you trigger the hmr again then it would show up. This is because the error is not sent through the hmr "sync" event, but when you trigger a hmr then the "building" event is triggered again which carries the error.

### Fix

It's mostly because we have a guard for middleware file in edge compiler hmr handling, since previously we only check if it contains the middleware file then it's a legit edge compiler hmr. For other edge routes it's not from the middleware routes.