### PR TITLE
Docs IA 2.0: Move CI build caching page under guides, and create equivalent `/app` guide

### DIFF
--- a/docs/01-app/02-guides/ci-build-caching.mdx
+++ b/docs/01-app/02-guides/ci-build-caching.mdx
@@ -1,5 +1,6 @@
 ---
-title: Continuous Integration (CI) Build Caching
+title: How to configure Continuous Integration (CI) build caching
+nav_title: CI Build Caching
 description: Learn how to configure CI to cache Next.js builds
 ---
 

--- a/docs/02-pages/02-guides/ci-build-caching.mdx
+++ b/docs/02-pages/02-guides/ci-build-caching.mdx
@@ -1,0 +1,8 @@
+---
+title: How to configure Continuous Integration (CI) build caching
+nav_title: CI Build Caching
+description: Learn how to configure CI to cache Next.js builds
+source: app/guides/ci-build-caching
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/errors/no-cache.mdx
+++ b/errors/no-cache.mdx
@@ -13,4 +13,4 @@ This results in slower builds and can hurt Next.js' persistent caching of client
 > **Note**: If this is a new project, or being built for the first time in your CI, you can ignore this error.
 > However, you'll want to make sure it doesn't continue to happen and fix it if it does!
 
-Follow the instructions in [CI Build Caching](/docs/pages/building-your-application/deploying/ci-build-caching) to ensure your Next.js cache is persisted between builds.
+Follow the instructions in [CI Build Caching](/docs/pages/guides/ci-build-caching) to ensure your Next.js cache is persisted between builds.


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4577/ci-build-caching
Redirects: https://github.com/vercel/next.js/pull/78416