### PR TITLE
Turbopack: Use single write to loader ipc socket

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -96,10 +96,8 @@ function createIpc<TIncoming, TOutgoing>(
   });
 
   function send(message: any): Promise<void> {
-    const packet = Buffer.from(JSON.stringify(message), "utf8");
-    const length = Buffer.alloc(4);
-    length.writeUInt32BE(packet.length);
-    socket.write(length);
+    const packet = Buffer.from("0000" + JSON.stringify(message), "utf8");
+    packet.writeUInt32BE(packet.length - 4, 0);
 
     return new Promise((resolve, reject) => {
       socket.write(packet, (err) => {

--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -96,6 +96,7 @@ function createIpc<TIncoming, TOutgoing>(
   });
 
   function send(message: any): Promise<void> {
+    // Reserve 4 bytes for our length prefix, we will over-write after encoding.
     const packet = Buffer.from("0000" + JSON.stringify(message), "utf8");
     packet.writeUInt32BE(packet.length - 4, 0);
 


### PR DESCRIPTION
## Optimize IPC message serialization in Turbopack

### What?
Optimizes the IPC message serialization by combining multiple buffer operations into a single buffer creation.

### Why?
The previous implementation created separate buffers for the message length and content, requiring two write operations. This change improves efficiency by creating a single buffer with space for the length prefix, then writing the length directly into that buffer.

As far as I can tell these writes were not guaranteed to be subsequent and the length did not have a write callback. 

### How?
- Creates a single buffer with "0000" placeholder prefix + the JSON message
- Writes the actual length (minus the 4-byte header) directly into the first 4 bytes
- Eliminates the need for a separate length buffer and reduces the number of write operations


Closes PACK-4424