### PR TITLE
test: log html output for a flaky test to debug it

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -94,7 +94,19 @@ describe('app dir - rsc basics', () => {
   it('should correctly render page returning undefined', async () => {
     const homeHTML = await next.render('/return-undefined/page')
     const $ = cheerio.load(homeHTML)
-    expect(stripHTMLComments($('#return-undefined-layout').html())).toBeEmpty()
+    try {
+      expect(
+        stripHTMLComments($('#return-undefined-layout').html())
+      ).toBeEmpty()
+    } catch (err) {
+      const sep = '='.repeat(40) + ' PAGE HTML ' + '='.repeat(40)
+      console.log()
+      console.log(sep)
+      console.log($('html').html())
+      console.log(sep)
+      console.log()
+      throw err
+    }
   })
 
   it('should correctly render component returning undefined', async () => {


### PR DESCRIPTION
this test has been flaky recently but we don't know why and can't repro locally. this PR adds a log to inspect the full HTML when it fails

x-ref: https://vercel.slack.com/archives/C05KYT5S9FF/p1745259844464719