### PR TITLE
Turbopack: fix data-url CSS Module client references

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -115,6 +115,12 @@ fn styles_rule_condition() -> RuleCondition {
             RuleCondition::ResourcePathEndsWith(".sass".into()),
             RuleCondition::not(RuleCondition::ResourcePathEndsWith(".module.sass".into())),
         ]),
+        RuleCondition::all(vec![
+            RuleCondition::ContentTypeStartsWith("text/css".into()),
+            RuleCondition::not(RuleCondition::ContentTypeStartsWith(
+                "text/css+module".into(),
+            )),
+        ]),
     ])
 }
 fn module_styles_rule_condition() -> RuleCondition {
@@ -122,6 +128,7 @@ fn module_styles_rule_condition() -> RuleCondition {
         RuleCondition::ResourcePathEndsWith(".module.css".into()),
         RuleCondition::ResourcePathEndsWith(".module.scss".into()),
         RuleCondition::ResourcePathEndsWith(".module.sass".into()),
+        RuleCondition::ContentTypeStartsWith("text/css+module".into()),
     ])
 }
 

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -54,16 +54,29 @@ pub async fn get_next_server_transforms_rules(
             // Ignore the internal ModuleCssAsset -> CssModuleAsset references
             // The CSS Module module itself is still needed for class names
             ModuleRule::new_internal(
-                RuleCondition::ResourcePathEndsWith(".module.css".into()),
+                RuleCondition::any(vec![
+                    RuleCondition::ResourcePathEndsWith(".module.css".into()),
+                    RuleCondition::ContentTypeStartsWith("text/css+module".into()),
+                ]),
                 vec![ModuleRuleEffect::Ignore],
             ),
         ]);
         rules.extend([
             // Ignore all non-module CSS references
             ModuleRule::new(
-                RuleCondition::all(vec![
-                    RuleCondition::ResourcePathEndsWith(".css".into()),
-                    RuleCondition::not(RuleCondition::ResourcePathEndsWith(".module.css".into())),
+                RuleCondition::any(vec![
+                    RuleCondition::all(vec![
+                        RuleCondition::ResourcePathEndsWith(".css".into()),
+                        RuleCondition::not(RuleCondition::ResourcePathEndsWith(
+                            ".module.css".into(),
+                        )),
+                    ]),
+                    RuleCondition::all(vec![
+                        RuleCondition::ContentTypeStartsWith("text/css".into()),
+                        RuleCondition::not(RuleCondition::ContentTypeStartsWith(
+                            "text/css+module".into(),
+                        )),
+                    ]),
                 ]),
                 vec![ModuleRuleEffect::Ignore],
             ),

--- a/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
@@ -1,6 +1,6 @@
 'use client'
 // @ts-expect-error
-import styles from 'data:text/css+module;.client{font-weight:700}'
+import styles from 'data:text/css+module,.client{font-weight:700}'
 
 export const ClientComponent = () => {
   return (

--- a/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
@@ -1,7 +1,6 @@
 'use client'
 // @ts-expect-error
-// .client{font-weight:700}
-import styles from 'data:text/css+module;base64,LmNsaWVudHtmb250LXdlaWdodDo3MDB9Cg=='
+import styles from 'data:text/css+module;.client{font-weight:700}'
 
 export const ClientComponent = () => {
   return (

--- a/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
@@ -1,0 +1,11 @@
+// @ts-expect-error
+// .client{font-weight:700}
+import styles from 'data:text/css+module;base64,LmNsaWVudHtmb250LXdlaWdodDo3MDB9Cg=='
+
+export const ClientComponent = () => {
+  return (
+    <div id="client" className={`${styles.client}`}>
+      This text should be bold
+    </div>
+  )
+}

--- a/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/client.tsx
@@ -1,3 +1,4 @@
+'use client'
 // @ts-expect-error
 // .client{font-weight:700}
 import styles from 'data:text/css+module;base64,LmNsaWVudHtmb250LXdlaWdodDo3MDB9Cg=='

--- a/test/e2e/app-dir/css-modules-data-urls/app/layout.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
@@ -1,0 +1,15 @@
+// @ts-expect-error
+// .home{font-weight:700}
+import styles from 'data:text/css+module;base64,LmhvbWV7Zm9udC13ZWlnaHQ6NzAwfQo='
+import { ClientComponent } from './client'
+
+export default function Home() {
+  return (
+    <>
+      <div id="rsc" className={`${styles.home}`}>
+        This text should be bold
+      </div>
+      <ClientComponent />
+    </>
+  )
+}

--- a/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
@@ -1,5 +1,5 @@
 // @ts-expect-error
-import styles from 'data:text/css+module;.home{font-weight:700}'
+import styles from 'data:text/css+module,.home{font-weight:700}'
 import { ClientComponent } from './client'
 
 export default function Home() {

--- a/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-data-urls/app/page.tsx
@@ -1,6 +1,5 @@
 // @ts-expect-error
-// .home{font-weight:700}
-import styles from 'data:text/css+module;base64,LmhvbWV7Zm9udC13ZWlnaHQ6NzAwfQo='
+import styles from 'data:text/css+module;.home{font-weight:700}'
 import { ClientComponent } from './client'
 
 export default function Home() {

--- a/test/e2e/app-dir/css-modules-data-urls/css-modules-data-urls.test.ts
+++ b/test/e2e/app-dir/css-modules-data-urls/css-modules-data-urls.test.ts
@@ -1,45 +1,49 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('css-modules-data-urls', () => {
-  const { next } = nextTestSetup({
-    files: __dirname,
-  })
+// CSS data urls are only support in Turbopack
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'css-modules-data-urls',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+    })
 
-  it('should apply rsc class name from data url correctly', async () => {
-    const browser = await next.browser('/')
+    it('should apply rsc class name from data url correctly', async () => {
+      const browser = await next.browser('/')
 
-    const clientElementClass =
-      (await browser.elementByCss('#client').getAttribute('class')) || ''
+      const clientElementClass =
+        (await browser.elementByCss('#client').getAttribute('class')) || ''
 
-    expect(clientElementClass).not.toBe('')
-  })
+      expect(clientElementClass).not.toBe('')
+    })
 
-  it('should apply rsc styles from data url correctly', async () => {
-    const browser = await next.browser('/')
+    it('should apply rsc styles from data url correctly', async () => {
+      const browser = await next.browser('/')
 
-    const rscElement = await browser
-      .elementByCss('#rsc')
-      .getComputedCss('font-weight')
+      const rscElement = await browser
+        .elementByCss('#rsc')
+        .getComputedCss('font-weight')
 
-    expect(rscElement).toBe('700')
-  })
+      expect(rscElement).toBe('700')
+    })
 
-  it('should apply client class name from data url correctly', async () => {
-    const browser = await next.browser('/')
+    it('should apply client class name from data url correctly', async () => {
+      const browser = await next.browser('/')
 
-    const clientElementClass =
-      (await browser.elementByCss('#client').getAttribute('class')) || ''
+      const clientElementClass =
+        (await browser.elementByCss('#client').getAttribute('class')) || ''
 
-    expect(clientElementClass).not.toBe('')
-  })
+      expect(clientElementClass).not.toBe('')
+    })
 
-  it('should apply client styles from data url correctly', async () => {
-    const browser = await next.browser('/')
+    it('should apply client styles from data url correctly', async () => {
+      const browser = await next.browser('/')
 
-    const clientElement = await browser
-      .elementByCss('#client')
-      .getComputedCss('font-weight')
+      const clientElement = await browser
+        .elementByCss('#client')
+        .getComputedCss('font-weight')
 
-    expect(clientElement).toBe('700')
-  })
-})
+      expect(clientElement).toBe('700')
+    })
+  }
+)

--- a/test/e2e/app-dir/css-modules-data-urls/css-modules-data-urls.test.ts
+++ b/test/e2e/app-dir/css-modules-data-urls/css-modules-data-urls.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('css-modules-data-urls', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should apply rsc class name from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const clientElementClass =
+      (await browser.elementByCss('#client').getAttribute('class')) || ''
+
+    expect(clientElementClass).not.toBe('')
+  })
+
+  it('should apply rsc styles from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const rscElement = await browser
+      .elementByCss('#rsc')
+      .getComputedCss('font-weight')
+
+    expect(rscElement).toBe('700')
+  })
+
+  it('should apply client class name from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const clientElementClass =
+      (await browser.elementByCss('#client').getAttribute('class')) || ''
+
+    expect(clientElementClass).not.toBe('')
+  })
+
+  it('should apply client styles from data url correctly', async () => {
+    const browser = await next.browser('/')
+
+    const clientElement = await browser
+      .elementByCss('#client')
+      .getComputedCss('font-weight')
+
+    expect(clientElement).toBe('700')
+  })
+})

--- a/test/e2e/app-dir/css-modules-data-urls/next.config.ts
+++ b/test/e2e/app-dir/css-modules-data-urls/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  /* config options here */
+}
+
+export default nextConfig

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -527,7 +527,10 @@ impl ModuleOptions {
                 ),
                 ModuleRule::new(
                     RuleCondition::all(vec![
-                        RuleCondition::ResourcePathEndsWith(".module.css".to_string()),
+                        RuleCondition::Any(vec![
+                            RuleCondition::ResourcePathEndsWith(".module.css".to_string()),
+                            RuleCondition::ContentTypeStartsWith("text/css+module".to_string()),
+                        ]),
                         // Create a normal CSS asset if `@import`ed from CSS already.
                         RuleCondition::ReferenceType(ReferenceType::Css(
                             CssReferenceSubType::AtImport(None),


### PR DESCRIPTION
Closes #78114
Closes #78096
Closes PACK-4337

cc @jantimon . Thank you for creating the tests, that made it much easier!

They are indeed not working with Webpack at the moment:
```
data:text/css+module,.client{font-weight:700}
Module parse failed: Unexpected token (1:0)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> .client{font-weight:700}
```