### PR TITLE
Skip empty prefetch request for dynamic routes

### DIFF
--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,13 +1,14 @@
 import type { LoaderTree } from '../lib/app-dir-module'
-import type { FlightRouterState } from './types'
+import { HasLoadingBoundary, type FlightRouterState } from './types'
 import type { GetDynamicParamFromSegment } from './app-render'
 import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 
-export function createFlightRouterStateFromLoaderTree(
-  [segment, parallelRoutes, { layout }]: LoaderTree,
+function createFlightRouterStateFromLoaderTreeImpl(
+  [segment, parallelRoutes, { layout, loading }]: LoaderTree,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   searchParams: any,
-  rootLayoutIncluded = false
+  includeHasLoadingBoundary: boolean,
+  didFindRootLayout: boolean
 ): FlightRouterState {
   const dynamicParam = getDynamicParamFromSegment(segment)
   const treeSegment = dynamicParam ? dynamicParam.treeSegment : segment
@@ -17,23 +18,83 @@ export function createFlightRouterStateFromLoaderTree(
     {},
   ]
 
-  if (!rootLayoutIncluded && typeof layout !== 'undefined') {
-    rootLayoutIncluded = true
+  // Mark the first segment that has a layout as the "root" layout
+  if (!didFindRootLayout && typeof layout !== 'undefined') {
+    didFindRootLayout = true
     segmentTree[4] = true
   }
 
-  segmentTree[1] = Object.keys(parallelRoutes).reduce(
-    (existingValue, currentValue) => {
-      existingValue[currentValue] = createFlightRouterStateFromLoaderTree(
-        parallelRoutes[currentValue],
-        getDynamicParamFromSegment,
-        searchParams,
-        rootLayoutIncluded
-      )
-      return existingValue
-    },
-    {} as FlightRouterState[1]
-  )
+  let childHasLoadingBoundary = false
+  const children: FlightRouterState[1] = {}
+  Object.keys(parallelRoutes).forEach((parallelRouteKey) => {
+    const child = createFlightRouterStateFromLoaderTreeImpl(
+      parallelRoutes[parallelRouteKey],
+      getDynamicParamFromSegment,
+      searchParams,
+      includeHasLoadingBoundary,
+      didFindRootLayout
+    )
+    if (
+      includeHasLoadingBoundary &&
+      child[5] !== HasLoadingBoundary.SubtreeHasNoLoadingBoundary
+    ) {
+      childHasLoadingBoundary = true
+    }
+    children[parallelRouteKey] = child
+  })
+  segmentTree[1] = children
+
+  if (includeHasLoadingBoundary) {
+    // During a route tree prefetch, the FlightRouterState includes whether a
+    // tree has a loading boundary. The client uses this to determine if it can
+    // skip the data prefetch request — if `hasLoadingBoundary` is `false`, the
+    // data prefetch response will be empty, so there's no reason to request it.
+    // NOTE: It would be better to accumulate this while building the loader
+    // tree so we don't have to keep re-deriving it, but since this won't be
+    // once PPR is enabled everywhere, it's not that important.
+    segmentTree[5] = loading
+      ? HasLoadingBoundary.SegmentHasLoadingBoundary
+      : childHasLoadingBoundary
+        ? HasLoadingBoundary.SubtreeHasLoadingBoundary
+        : HasLoadingBoundary.SubtreeHasNoLoadingBoundary
+  }
 
   return segmentTree
+}
+
+export function createFlightRouterStateFromLoaderTree(
+  loaderTree: LoaderTree,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  searchParams: any
+) {
+  const includeHasLoadingBoundary = false
+  const didFindRootLayout = false
+  return createFlightRouterStateFromLoaderTreeImpl(
+    loaderTree,
+    getDynamicParamFromSegment,
+    searchParams,
+    includeHasLoadingBoundary,
+    didFindRootLayout
+  )
+}
+
+export function createRouteTreePrefetch(
+  loaderTree: LoaderTree,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment
+): FlightRouterState {
+  // Search params should not be added to page segment's cache key during a
+  // route tree prefetch request, because they do not affect the structure of
+  // the route. The client cache has its own logic to handle search params.
+  const searchParams = {}
+  // During a route tree prefetch, we include `hasLoadingBoundary` in
+  // the response.
+  const includeHasLoadingBoundary = true
+  const didFindRootLayout = false
+  return createFlightRouterStateFromLoaderTreeImpl(
+    loaderTree,
+    getDynamicParamFromSegment,
+    searchParams,
+    includeHasLoadingBoundary,
+    didFindRootLayout
+  )
 }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -94,7 +94,23 @@ export type FlightRouterState = [
    */
   refresh?: 'refetch' | 'refresh' | 'inside-shared-layout' | null,
   isRootLayout?: boolean,
+  /**
+   * Only present when responding to a tree prefetch request. Indicates whether
+   * there is a loading boundary somewhere in the tree. The client cache uses
+   * this to determine if it can skip the data prefetch request.
+   */
+  hasLoadingBoundary?: HasLoadingBoundary,
 ]
+
+export const enum HasLoadingBoundary {
+  // There is a loading boundary in this particular segment
+  SegmentHasLoadingBoundary = 1,
+  // There is a loading boundary somewhere in the subtree (but not in
+  // this segment)
+  SubtreeHasLoadingBoundary = 2,
+  // There is no loading boundary in this segment or any of its descendants
+  SubtreeHasNoLoadingBoundary = 3,
+}
 
 /**
  * Individual Flight response path

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -9,7 +9,10 @@ import { matchSegment } from '../../client/components/match-segments'
 import type { LoaderTree } from '../lib/app-dir-module'
 import { getLinkAndScriptTags } from './get-css-inlined-link-tags'
 import { getPreloadableFonts } from './get-preloadable-fonts'
-import { createFlightRouterStateFromLoaderTree } from './create-flight-router-state-from-loader-tree'
+import {
+  createFlightRouterStateFromLoaderTree,
+  createRouteTreePrefetch,
+} from './create-flight-router-state-from-loader-tree'
 import type { AppRenderContext } from './app-render'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 import {
@@ -153,12 +156,15 @@ export async function walkTreeWithFlightRouterState({
         ? flightRouterState[0]
         : actualSegment
 
-    const routerState = createFlightRouterStateFromLoaderTree(
-      // Create router state using the slice of the loaderTree
-      loaderTreeToFilter,
-      getDynamicParamFromSegment,
-      query
-    )
+    const routerState = parsedRequestHeaders.isRouteTreePrefetchRequest
+      ? // Route tree prefetch requests contain some extra information
+        createRouteTreePrefetch(loaderTreeToFilter, getDynamicParamFromSegment)
+      : createFlightRouterStateFromLoaderTree(
+          loaderTreeToFilter,
+          getDynamicParamFromSegment,
+          query
+        )
+
     return [
       [
         overriddenSegment,

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
@@ -35,6 +35,13 @@ export default function Page() {
           <LinkAccordion href="/ppr-disabled-with-loading-boundary">
             Page with PPR disabled, but has a loading boundary
           </LinkAccordion>
+          <ul>
+            <li>
+              <LinkAccordion href="/ppr-disabled-with-loading-boundary/child">
+                Another dynamic page that shares the same loading boundary
+              </LinkAccordion>
+            </li>
+          </ul>
         </li>
       </ul>
     </>

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/child/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/child/page.tsx
@@ -1,0 +1,6 @@
+import { connection } from 'next/server'
+
+export default async function PPRDisabledWithLoadingBoundaryChildPage() {
+  await connection()
+  return <div id="child-page-content">Child page content</div>
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-with-loading-boundary/loading.tsx
@@ -1,15 +1,3 @@
-import { Suspense } from 'react'
-import { connection } from 'next/server'
-
-async function Content() {
-  await connection()
-  return 'Dynamic Content'
-}
-
-export default function PPRDisabled() {
-  return (
-    <Suspense fallback="Loading...">
-      <Content />
-    </Suspense>
-  )
+export default function Loading() {
+  return <div id="loading-boundary">Loading...</div>
 }

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -92,6 +92,140 @@ describe('segment cache (incremental opt in)', () => {
       testPrefetchDeduping('/ppr-disabled-with-loading-boundary'))
   })
 
+  it('prefetches a dynamic route when PPR is disabled if it has a loading.tsx boundary', async () => {
+    let act
+    const browser = await next.browser('/', {
+      beforePageLoad(p) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Initiate a prefetch for a dynamic page with no PPR, but with a
+    // loading.tsx boundary. We should be able to prefetch up to the
+    // loading boundary.
+    await act(async () => {
+      const checkbox = await browser.elementByCss(
+        `input[data-link-accordion="/ppr-disabled-with-loading-boundary"]`
+      )
+      await checkbox.click()
+    }, [
+      // Response includes the loading boundary
+      { includes: 'Loading...' },
+      // but it does not include the dynamic page content
+      { includes: 'Page content', block: 'reject' },
+    ])
+
+    // Navigate to the page
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`a[href="/ppr-disabled-with-loading-boundary"]`)
+          .click()
+        // We can immediately render the loading boundary before the network
+        // responds, because it was prefetched
+        const loadingBoundary = await browser.elementById('loading-boundary')
+        expect(await loadingBoundary.text()).toBe('Loading...')
+      },
+      // The page content is fetched on navigation
+      { includes: 'Page content' }
+    )
+    const pageContent = await browser.elementById('page-content')
+    expect(await pageContent.text()).toBe('Page content')
+  })
+
+  it(
+    'skips prefetching a dynamic route when PPR is disabled if everything up ' +
+      'to its loading.tsx boundary is already cached',
+    async () => {
+      let act
+      const browser = await next.browser('/', {
+        beforePageLoad(p) {
+          act = createRouterAct(p)
+        },
+      })
+
+      // Initiate a prefetch for a dynamic page with no PPR, but with a
+      // loading.tsx boundary. We should be able to prefetch up to the
+      // loading boundary.
+      await act(async () => {
+        const checkbox = await browser.elementByCss(
+          `input[data-link-accordion="/ppr-disabled-with-loading-boundary"]`
+        )
+        await checkbox.click()
+      }, [
+        // Response includes the loading boundary
+        { includes: 'Loading...' },
+        // but it does not include the dynamic page content
+        { includes: 'Page content', block: 'reject' },
+      ])
+
+      await act(async () => {
+        const checkbox = await browser.elementByCss(
+          `input[data-link-accordion="/ppr-disabled-with-loading-boundary/child"]`
+        )
+        await checkbox.click()
+      }, 'no-requests')
+
+      // Navigate to the page
+      await act(async () => {
+        await browser
+          .elementByCss(`a[href="/ppr-disabled-with-loading-boundary/child"]`)
+          .click()
+        // We can immediately render the loading boundary before the network
+        // responds, because it was prefetched
+        const loadingBoundary = await browser.elementById('loading-boundary')
+        expect(await loadingBoundary.text()).toBe('Loading...')
+      }, [
+        // The page content is fetched on navigation
+        { includes: 'Child page content' },
+        // The loading boundary is not fetched on navigation, because it
+        // was already loaded into the cache during the prefetch for the
+        // other page.
+        { includes: 'Loading...', block: 'reject' },
+      ])
+      const pageContent = await browser.elementById('child-page-content')
+      expect(await pageContent.text()).toBe('Child page content')
+    }
+  )
+
+  it('skips prefetching a dynamic route when PPR is disabled if it has no loading.tsx boundary', async () => {
+    let act
+    const browser = await next.browser('/', {
+      beforePageLoad(p) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Initiate a prefetch for a dynamic page with no loading.tsx and no PPR.
+    // The route tree prefetch will tell the client that there is no loading
+    // boundary, and therefore the client can skip prefetching the data, since
+    // it would be an empty response, anyway.
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          `input[data-link-accordion="/ppr-disabled"]`
+        )
+        await checkbox.click()
+      },
+      // This assertion will fail if more than one request includes the given
+      // string. Because the string appears in the FlightRouterState for the
+      // page, it effectively asserts that only one prefetch request is issued
+      // — the one for the route tree.
+      { includes: 'ppr-disabled' }
+    )
+
+    // Navigate to the page
+    await act(
+      async () => {
+        await browser.elementByCss(`a[href="/ppr-disabled"]`).click()
+      },
+      // The page content is fetched on navigation
+      { includes: 'Page content' }
+    )
+    const pageContent = await browser.elementById('page-content')
+    expect(await pageContent.text()).toBe('Page content')
+  })
+
   it(
     'prefetches a shared layout on a PPR-enabled route that was previously ' +
       'omitted from a non-PPR-enabled route',


### PR DESCRIPTION
In the Segment Cache implementation of prefetching, a prefetch happens in two phases: first we fetch the route tree, then we fetch the data itself.

The route tree prefetch tells us important metadata about the structure of the target route, like whether it shares any layouts with the current page. We can use this information to omit parts of the tree from subsequent data request.

In this PR, I've added a new piece of metadata to the route tree prefetch response: `hasLoadingBoundary`. For each segment in the tree, this represents whether there is a `loading.tsx` boundary somewhere within it. This is useful because we know that during a prefetch, the server will only render up to the nearest loading boundary (unless prefetch={true} is set); if there are no loading boundaries, then the server will return an empty response.

In the latter case, we can use this information to skip the data prefetch entirely, freeing up bandwidth for other requests in the queue.