### PR TITLE
test: flake debugging - avoid logs being eaten by jest

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -99,6 +99,7 @@ describe('app dir - rsc basics', () => {
         stripHTMLComments($('#return-undefined-layout').html())
       ).toBeEmpty()
     } catch (err) {
+      const console = require('console')
       const sep = '='.repeat(40) + ' PAGE HTML ' + '='.repeat(40)
       console.log()
       console.log(sep)


### PR DESCRIPTION
follow up to #78424. annoyingly, it appears that the console.log output gets swallowed by jest somehow, so i'm using `require('console')` instead which jest doesn't instrument.