### PR TITLE
fix(turbopack): Fix sourcemap path on windows

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1288,6 +1288,8 @@ impl FileSystemPath {
     /// None when the joined path would leave the filesystem root.
     #[turbo_tasks::function]
     pub async fn try_join(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
+        let path = path.replace('\\', "/");
+
         if let Some(path) = join_path(&self.path, &path) {
             Ok(Vc::cell(Some(
                 Self::new_normalized(*self.fs, path.into())

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1288,6 +1288,7 @@ impl FileSystemPath {
     /// None when the joined path would leave the filesystem root.
     #[turbo_tasks::function]
     pub async fn try_join(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
+        // TODO(PACK-3279): Remove this once we do not produce invalid paths at the first place.
         #[cfg(target_os = "windows")]
         let path = path.replace('\\', "/");
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1288,6 +1288,7 @@ impl FileSystemPath {
     /// None when the joined path would leave the filesystem root.
     #[turbo_tasks::function]
     pub async fn try_join(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
+        #[cfg(target_os = "windows")]
         let path = path.replace('\\', "/");
 
         if let Some(path) = join_path(&self.path, &path) {

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -178,9 +178,7 @@ pub async fn fileify_source_map(
     let transform_source = async |src: &mut Option<String>| {
         if let Some(src) = src {
             if let Some(src_rest) = src.strip_prefix(&prefix) {
-                dbg!(&src_rest);
                 *src = uri_from_file(context_path, Some(src_rest)).await?;
-                dbg!(&*src);
             }
         }
         anyhow::Ok(())

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -178,7 +178,9 @@ pub async fn fileify_source_map(
     let transform_source = async |src: &mut Option<String>| {
         if let Some(src) = src {
             if let Some(src_rest) = src.strip_prefix(&prefix) {
+                dbg!(&src_rest);
                 *src = uri_from_file(context_path, Some(src_rest)).await?;
+                dbg!(&*src);
             }
         }
         anyhow::Ok(())


### PR DESCRIPTION
### What?

Fix source map path on windows, by fixing `url_to_file` function

Note: This PR is based on https://github.com/vercel/next.js/pull/78430 by @JustSuperHuman

### Why?

### How?

 - Closes PACK-4217
 - Closes PACK-3924
 - Closes https://github.com/vercel/next.js/issues/72789