### PR TITLE
[next-server] ensure prepare is done before preloading entry

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1720,9 +1720,11 @@ export default abstract class Server<
   public async prepare(): Promise<void> {
     if (this.prepared) return
 
-    if (this.preparedPromise === null) {
-      // Get instrumentation module
+    // Get instrumentation module
+    if (!this.instrumentation) {
       this.instrumentation = await this.loadInstrumentationModule()
+    }
+    if (this.preparedPromise === null) {
       this.preparedPromise = this.prepareImpl().then(() => {
         this.prepared = true
         this.preparedPromise = null

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -376,6 +376,9 @@ export default class NextNodeServer extends BaseServer<
   }
 
   public async unstable_preloadEntries(): Promise<void> {
+    // Ensure prepare process will be finished before preloading entries.
+    await this.prepare()
+
     const appPathsManifest = this.getAppPathsManifest()
     const pagesManifest = this.getPagesManifest()
 

--- a/test/e2e/app-dir/instrumentation-order/app/layout.tsx
+++ b/test/e2e/app-dir/instrumentation-order/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instrumentation-order/app/page.tsx
+++ b/test/e2e/app-dir/instrumentation-order/app/page.tsx
@@ -1,0 +1,8 @@
+import { connection } from 'next/server'
+
+console.log('global-side-effect:app-router-page')
+
+export default async function Page() {
+  await connection()
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
+++ b/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+import { waitFor } from 'next-test-utils'
+
+const ORDERED_LOGS = [
+  'instrumentation:side-effect',
+  'instrumentation:register:begin',
+  'instrumentation:register:timeout',
+  'instrumentation:register:end',
+  'global-side-effect:app-router-page',
+]
+
+describe('instrumentation-order', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  it('should work using cheerio', async () => {
+    // Wait for the timeout in the instrumentation to complete
+    await waitFor(500)
+
+    // Dev mode requires to render the page to trigger the build of the page
+    if (isNextDev) {
+      await next.render$('/')
+    }
+
+    const serverLog = next.cliOutput.split('Starting...')[1]
+    const cliOutputLines = serverLog.split('\n')
+    const searchedLines = cliOutputLines.filter((line) =>
+      ORDERED_LOGS.includes(line.trim())
+    )
+
+    expect(searchedLines).toEqual(ORDERED_LOGS)
+  })
+})

--- a/test/e2e/app-dir/instrumentation-order/instrumentation.ts
+++ b/test/e2e/app-dir/instrumentation-order/instrumentation.ts
@@ -1,0 +1,12 @@
+console.log('instrumentation:side-effect')
+
+export async function register() {
+  console.log('instrumentation:register:begin')
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      console.log('instrumentation:register:timeout')
+      resolve(true)
+    }, 300)
+  })
+  console.log('instrumentation:register:end')
+}

--- a/test/e2e/app-dir/instrumentation-order/next.config.js
+++ b/test/e2e/app-dir/instrumentation-order/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What

The global side effect in App Router pages are executed earlier while instrumentation is still running.
It's related to `unstable_preloadEntries`, that causing page being preloaded before instrumentation `register()` call is finished, which is introduced earlier as experimental feature but flagged as default behavior since #65289 (v14.3.0-canary). This explains why 14.2 stable doesn't have it.

Since `register()` is a convention that users are relying on it to be executed at the very beginning, we need to ensure they're finished before preloading entries.

Fixes #78044
Closes NDX-1021