### PR TITLE
Turbopack: handle webpack loader event backpressure

### DIFF
--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -432,7 +432,7 @@ impl NodeJsPoolProcess {
                 bail!("timed out waiting for the Node.js process to connect ({timeout:?} timeout)\nProcess output:\n{stdout}\nProcess error output:\n{stderr}");
             },
         };
-        connection.set_nodelay(true);
+        let _ = connection.set_nodelay(true);
 
         let child_stdout = BufReader::new(child.stdout.take().unwrap());
         let child_stderr = BufReader::new(child.stderr.take().unwrap());

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -432,6 +432,7 @@ impl NodeJsPoolProcess {
                 bail!("timed out waiting for the Node.js process to connect ({timeout:?} timeout)\nProcess output:\n{stdout}\nProcess error output:\n{stderr}");
             },
         };
+        connection.set_nodelay(true);
 
         let child_stdout = BufReader::new(child.stdout.take().unwrap());
         let child_stderr = BufReader::new(child.stderr.take().unwrap());

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -432,7 +432,6 @@ impl NodeJsPoolProcess {
                 bail!("timed out waiting for the Node.js process to connect ({timeout:?} timeout)\nProcess output:\n{stdout}\nProcess error output:\n{stderr}");
             },
         };
-        let _ = connection.set_nodelay(true);
 
         let child_stdout = BufReader::new(child.stdout.take().unwrap());
         let child_stderr = BufReader::new(child.stderr.take().unwrap());


### PR DESCRIPTION
## Improve IPC socket handling in Turbopack Node.js communication

### What?
Enhances the IPC communication between Turbopack and Node.js processes by implementing proper socket backpressure handling.

### Why?
The current implementation doesn't properly handle backpressure when writing to sockets, which can lead to hanging where Node.js doesn't write the rest of the data.

### How?
- Added a `Writable` stream wrapper around the socket to properly handle backpressure
- Implemented drain event handling to ensure data is written correctly
- Enabled noDelay on both the Node.js client and Rust server sides
- Moved stringify into the promise to make the stringify + write happen in the same tick.

Part of PACK-4409

Fixes #78407

Closes PACK-4452