### PR TITLE
fix(next/image): detect `.gif` and automatically set `unoptimized=true`

### DIFF
--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -421,6 +421,78 @@ describe('getImageProps()', () => {
       ['src', 'https://example.com/test.svg?v=1'],
     ])
   })
+  it('should auto unoptimized for relative gif', async () => {
+    const { props } = getImageProps({
+      alt: 'a nice desc',
+      src: '/test.gif',
+      width: 100,
+      height: 200,
+    })
+    expect(warningMessages).toStrictEqual([])
+    expect(Object.entries(props)).toStrictEqual([
+      ['alt', 'a nice desc'],
+      ['loading', 'lazy'],
+      ['width', 100],
+      ['height', 200],
+      ['decoding', 'async'],
+      ['style', { color: 'transparent' }],
+      ['src', '/test.gif'],
+    ])
+  })
+  it('should auto unoptimized for relative gif with query', async () => {
+    const { props } = getImageProps({
+      alt: 'a nice desc',
+      src: '/test.gif?v=1',
+      width: 100,
+      height: 200,
+    })
+    expect(warningMessages).toStrictEqual([])
+    expect(Object.entries(props)).toStrictEqual([
+      ['alt', 'a nice desc'],
+      ['loading', 'lazy'],
+      ['width', 100],
+      ['height', 200],
+      ['decoding', 'async'],
+      ['style', { color: 'transparent' }],
+      ['src', '/test.gif?v=1'],
+    ])
+  })
+  it('should auto unoptimized for absolute gif', async () => {
+    const { props } = getImageProps({
+      alt: 'a nice desc',
+      src: 'https://example.com/test.gif',
+      width: 100,
+      height: 200,
+    })
+    expect(warningMessages).toStrictEqual([])
+    expect(Object.entries(props)).toStrictEqual([
+      ['alt', 'a nice desc'],
+      ['loading', 'lazy'],
+      ['width', 100],
+      ['height', 200],
+      ['decoding', 'async'],
+      ['style', { color: 'transparent' }],
+      ['src', 'https://example.com/test.gif'],
+    ])
+  })
+  it('should auto unoptimized for absolute gif with query', async () => {
+    const { props } = getImageProps({
+      alt: 'a nice desc',
+      src: 'https://example.com/test.gif?v=1',
+      width: 100,
+      height: 200,
+    })
+    expect(warningMessages).toStrictEqual([])
+    expect(Object.entries(props)).toStrictEqual([
+      ['alt', 'a nice desc'],
+      ['loading', 'lazy'],
+      ['width', 100],
+      ['height', 200],
+      ['decoding', 'async'],
+      ['style', { color: 'transparent' }],
+      ['src', 'https://example.com/test.gif?v=1'],
+    ])
+  })
   it('should add query string for imported local image when NEXT_DEPLOYMENT_ID defined', async () => {
     try {
       process.env.NEXT_DEPLOYMENT_ID = 'dpl_123'

--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -493,6 +493,29 @@ describe('getImageProps()', () => {
       ['src', 'https://example.com/test.gif?v=1'],
     ])
   })
+  it('should optimize for gif with unoptimized=false', async () => {
+    const { props } = getImageProps({
+      alt: 'a nice desc',
+      src: '/test.gif',
+      width: 100,
+      height: 200,
+      unoptimized: false,
+    })
+    expect(warningMessages).toStrictEqual([])
+    expect(Object.entries(props)).toStrictEqual([
+      ['alt', 'a nice desc'],
+      ['loading', 'lazy'],
+      ['width', 100],
+      ['height', 200],
+      ['decoding', 'async'],
+      ['style', { color: 'transparent' }],
+      [
+        'srcSet',
+        '/_next/image?url=%2Ftest.gif&w=128&q=75 1x, /_next/image?url=%2Ftest.gif&w=256&q=75 2x',
+      ],
+      ['src', '/_next/image?url=%2Ftest.gif&w=256&q=75'],
+    ])
+  })
   it('should add query string for imported local image when NEXT_DEPLOYMENT_ID defined', async () => {
     try {
       process.env.NEXT_DEPLOYMENT_ID = 'dpl_123'


### PR DESCRIPTION
We have a client-side bypass rule for `.svg` already that automatically sets `unoptimized=true`.

This PR extends the behavior to `.gif` as well since most are animated and therefore the Image Optimization API will just pass-through instead of optimizing it. However, even the existing bypass behavior will waste cpu, memory, and even disk space for these often large images. 

While this PR will change `.gif` default to `unoptimized=true`, you can get the old behavior by setting `unoptimized=false` on the gif in the rare cases you need it.
