### PR TITLE
test: increase timeouts for some flaky tests

### DIFF
--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { createSandbox } from 'development-sandbox'
+import { timeouts } from '../../lib/browsers/playwright'
 
 describe('Undefined default export', () => {
   const { next } = nextTestSetup({
@@ -90,7 +91,7 @@ describe('Undefined default export', () => {
 
     // The page will fail build and navigate to /_error route of pages router.
     // Wait for the DOM node #__next to be present
-    await browser.waitForElementByCss('#__next')
+    await browser.waitForElementByCss('#__next', timeouts.VERY_LONG)
 
     await expect(browser).toDisplayRedbox(`
      {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -12,6 +12,7 @@ import fs from 'fs-extra'
 import nodeFs from 'fs'
 import { join } from 'path'
 import { outdent } from 'outdent'
+import { timeouts } from '../../../lib/browsers/playwright'
 
 const GENERIC_RSC_ERROR =
   'Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
@@ -892,7 +893,7 @@ describe('app-dir action handling', () => {
       await browser
         .elementByCss(`[href='/delayed-action/${runtime}/other']`)
         .click()
-        .waitForElementByCss('#other-page')
+        .waitForElementByCss('#other-page', timeouts.VERY_LONG)
 
       await retry(async () => {
         expect(

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 import type { Request, Response } from 'playwright'
+import { timeouts } from '../../../lib/browsers/playwright'
 
 describe('app dir - basepath', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -13,7 +14,7 @@ describe('app dir - basepath', () => {
   it('should successfully hard navigate from pages -> app', async () => {
     const browser = await next.browser('/base/pages-path')
     await browser.elementByCss('#to-another').click()
-    await browser.waitForElementByCss('#page-2')
+    await browser.waitForElementByCss('#page-2', timeouts.VERY_LONG)
   })
 
   it('should support `basePath`', async () => {

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -14,6 +14,12 @@ import {
 } from 'playwright'
 import path from 'path'
 
+export const timeouts = {
+  MEDIUM: 5_000,
+  LONG: 10_000,
+  VERY_LONG: 30_000,
+}
+
 type EventType = 'request' | 'response'
 
 type PageLog = { source: string; message: string; args: unknown[] }
@@ -372,7 +378,7 @@ export class Playwright<TCurrent = undefined> {
   }
 
   elementByCss(selector: string) {
-    return this.waitForElementByCss(selector, 5_000)
+    return this.waitForElementByCss(selector, timeouts.MEDIUM)
   }
 
   elementById(id: string) {
@@ -451,7 +457,7 @@ export class Playwright<TCurrent = undefined> {
     )
   }
 
-  waitForElementByCss(selector: string, timeout = 10_000) {
+  waitForElementByCss(selector: string, timeout = timeouts.LONG) {
     return this.startChain(async () => {
       const el = await page.waitForSelector(selector, {
         timeout,


### PR DESCRIPTION
these have been occasionally failing since we decreased the default timeouts in #78026. can't do much about that, presumably this is just slow compilation in dev or something, so i've increased the timeouts for the failing assertions.