### PR TITLE
[ppr] Route Cardinality Updates

### DIFF
--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -1,5 +1,9 @@
 import { FallbackMode } from '../../lib/fallback'
-import { assignErrorIfEmpty } from './app'
+import {
+  assignErrorIfEmpty,
+  filterUniqueRootParamsCombinations,
+  filterUniqueParams,
+} from './app'
 import type { PrerenderedRoute } from './types'
 
 describe('assignErrorIfEmpty', () => {
@@ -105,5 +109,49 @@ describe('assignErrorIfEmpty', () => {
     expect(prerenderedRoutes[2].throwOnEmptyStaticShell).toBe(true)
     expect(prerenderedRoutes[3].throwOnEmptyStaticShell).toBe(true)
     expect(prerenderedRoutes[4].throwOnEmptyStaticShell).toBe(false)
+  })
+})
+
+describe('filterUniqueParams', () => {
+  it('should filter out duplicate parameters', () => {
+    const params = [
+      { id: '1', name: 'test' },
+      { id: '1', name: 'test' },
+      { id: '2' },
+    ]
+
+    const unique = filterUniqueParams(['id', 'name'], params)
+
+    expect(unique).toEqual([{ id: '1', name: 'test' }, { id: '2' }])
+  })
+
+  it('should handle more complex routes', () => {
+    const params = [
+      { id: '1', name: 'test', age: '10' },
+      { id: '1', name: 'test', age: '20' },
+      { id: '2', name: 'test', age: '10' },
+    ]
+
+    const unique = filterUniqueParams(['id', 'name', 'age'], params)
+
+    expect(unique).toEqual([
+      { id: '1', name: 'test', age: '10' },
+      { id: '1', name: 'test', age: '20' },
+      { id: '2', name: 'test', age: '10' },
+    ])
+  })
+})
+
+describe('filterUniqueRootParamsCombinations', () => {
+  it('should return only the root parameters', () => {
+    const params = [
+      { id: '1', name: 'test' },
+      { id: '1', name: 'test' },
+      { id: '2', name: 'test' },
+    ]
+
+    const unique = filterUniqueRootParamsCombinations(['id'], params)
+
+    expect(unique).toEqual([{ id: '1' }, { id: '2' }])
   })
 })

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -1,0 +1,109 @@
+import { FallbackMode } from '../../lib/fallback'
+import { assignErrorIfEmpty } from './app'
+import type { PrerenderedRoute } from './types'
+
+describe('assignErrorIfEmpty', () => {
+  it('should assign throwOnEmptyStaticShell false for a static route', () => {
+    const prerenderedRoutes: PrerenderedRoute[] = [
+      {
+        params: {},
+        pathname: '/',
+        encodedPathname: '/',
+        fallbackRouteParams: [],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+    ]
+
+    assignErrorIfEmpty(prerenderedRoutes, [])
+
+    expect(prerenderedRoutes[0].throwOnEmptyStaticShell).toBe(true)
+  })
+
+  it('should assign throwOnEmptyStaticShell to the prerendered routes', () => {
+    const prerenderedRoutes: PrerenderedRoute[] = [
+      {
+        params: {},
+        pathname: '/[id]',
+        encodedPathname: '/[id]',
+        fallbackRouteParams: ['id'],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+      {
+        params: { id: '1' },
+        pathname: '/1',
+        encodedPathname: '/1',
+        fallbackRouteParams: [],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+    ]
+
+    assignErrorIfEmpty(prerenderedRoutes, ['id'])
+
+    expect(prerenderedRoutes[0].throwOnEmptyStaticShell).toBe(false)
+    expect(prerenderedRoutes[1].throwOnEmptyStaticShell).toBe(true)
+  })
+
+  it('should handle more complex routes', () => {
+    const prerenderedRoutes: PrerenderedRoute[] = [
+      {
+        params: {},
+        pathname: '/[id]/[name]',
+        encodedPathname: '/[id]/[name]',
+        fallbackRouteParams: ['id', 'name'],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+      {
+        params: { id: '1' },
+        pathname: '/1/[name]',
+        encodedPathname: '/1/[name]',
+        fallbackRouteParams: ['name'],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+      {
+        params: { id: '1', name: 'test' },
+        pathname: '/1/test',
+        encodedPathname: '/1/test',
+        fallbackRouteParams: [],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+      {
+        params: { id: '2', name: 'test' },
+        pathname: '/2/test',
+        encodedPathname: '/2/test',
+        fallbackRouteParams: [],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+      {
+        params: { id: '2' },
+        pathname: '/2/[name]',
+        encodedPathname: '/2/[name]',
+        fallbackRouteParams: ['name'],
+        fallbackMode: FallbackMode.NOT_FOUND,
+        fallbackRootParams: [],
+        throwOnEmptyStaticShell: true,
+      },
+    ]
+
+    assignErrorIfEmpty(prerenderedRoutes, ['id', 'name'])
+
+    expect(prerenderedRoutes[0].throwOnEmptyStaticShell).toBe(false)
+    expect(prerenderedRoutes[1].throwOnEmptyStaticShell).toBe(false)
+    expect(prerenderedRoutes[2].throwOnEmptyStaticShell).toBe(true)
+    expect(prerenderedRoutes[3].throwOnEmptyStaticShell).toBe(true)
+    expect(prerenderedRoutes[4].throwOnEmptyStaticShell).toBe(false)
+  })
+})

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -598,7 +598,7 @@ export async function buildAppStaticPaths({
   }
 
   // Now we have to set the throwOnEmptyStaticShell for each of the routes.
-  if (result.prerenderedRoutes && isRoutePPREnabled && dynamicIO) {
+  if (result.prerenderedRoutes && dynamicIO) {
     assignErrorIfEmpty(result.prerenderedRoutes, routeParamKeys)
   }
 

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -262,22 +262,18 @@ export function assignErrorIfEmpty(
     // route is a more specific route.
     const { fallbackRouteParams, params } = prerenderedRoutes[i]
     if (fallbackRouteParams && fallbackRouteParams.length > 0) {
-      for (let j = 0; j < prerenderedRoutes.length; j++) {
+      siblingLoop: for (let j = 0; j < prerenderedRoutes.length; j++) {
         // Skip the current route.
         if (i === j) continue
 
-        let k = 0
-        for (; k < routeParamKeys.length; k++) {
+        for (let k = 0; k < routeParamKeys.length; k++) {
           const key = routeParamKeys[k]
 
           // If the key is a fallback route param, then we can skip it, because
           // it always matches.
           if (fallbackRouteParams.includes(key)) {
-            // Rather than just continuing here, we set the index to the end of
-            // the array so that we can break out of the loop early while still
-            // satisfying the condition check later.
-            k = routeParamKeys.length
-            break
+            throwOnEmptyStaticShell = false
+            break siblingLoop
           }
 
           // If the param value is not equal, then we can break out of the loop
@@ -285,15 +281,8 @@ export function assignErrorIfEmpty(
           if (
             !areParamValuesEqual(params[key], prerenderedRoutes[j].params[key])
           ) {
-            break
+            continue siblingLoop
           }
-        }
-
-        // If we got to the end of the loop, then we know that the route is a
-        // more specific route.
-        if (k === routeParamKeys.length) {
-          throwOnEmptyStaticShell = false
-          break
         }
       }
     }

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -98,8 +98,8 @@ export async function buildPagesStaticPaths({
         entry = `/${defaultLocale}${entry}`
       }
 
-      const result = _routeMatcher(cleanedEntry)
-      if (!result) {
+      const params = _routeMatcher(cleanedEntry)
+      if (!params) {
         throw new Error(
           `The provided path \`${cleanedEntry}\` does not match the page: \`${page}\`.`
         )
@@ -109,6 +109,7 @@ export async function buildPagesStaticPaths({
       // encoded so we decode the segments ensuring we only escape path
       // delimiters
       prerenderedRoutes.push({
+        params,
         pathname: entry
           .split('/')
           .map((segment) =>
@@ -119,6 +120,7 @@ export async function buildPagesStaticPaths({
         fallbackRouteParams: undefined,
         fallbackMode: parseStaticPathsResult(staticPathsResult.fallback),
         fallbackRootParams: undefined,
+        throwOnEmptyStaticShell: undefined,
       })
     }
     // For the object-provided path, we must make sure it specifies all
@@ -196,6 +198,7 @@ export async function buildPagesStaticPaths({
       const curLocale = entry.locale || defaultLocale || ''
 
       prerenderedRoutes.push({
+        params,
         pathname: normalizePathname(
           `${curLocale ? `/${curLocale}` : ''}${
             curLocale && builtPage === '/' ? '' : builtPage
@@ -209,6 +212,7 @@ export async function buildPagesStaticPaths({
         fallbackRouteParams: undefined,
         fallbackMode: parseStaticPathsResult(staticPathsResult.fallback),
         fallbackRootParams: undefined,
+        throwOnEmptyStaticShell: undefined,
       })
     }
   })

--- a/packages/next/src/build/static-paths/types.ts
+++ b/packages/next/src/build/static-paths/types.ts
@@ -1,19 +1,34 @@
 import type { FallbackMode } from '../../lib/fallback'
+import type { Params } from '../../server/request/params'
 
 type StaticPrerenderedRoute = {
-  pathname: string
-  encodedPathname: string
-  fallbackRouteParams: undefined
-  fallbackMode: FallbackMode | undefined
-  fallbackRootParams: undefined
+  readonly params: Params
+  readonly pathname: string
+  readonly encodedPathname: string
+  readonly fallbackRouteParams: undefined
+  readonly fallbackMode: FallbackMode | undefined
+  readonly fallbackRootParams: undefined
+
+  /**
+   * When enabled, the route will be rendered with diagnostics enabled which
+   * will error the build if the route that is generated is empty.
+   */
+  throwOnEmptyStaticShell: undefined
 }
 
 type FallbackPrerenderedRoute = {
-  pathname: string
-  encodedPathname: string
-  fallbackRouteParams: readonly string[]
-  fallbackMode: FallbackMode | undefined
-  fallbackRootParams: readonly string[]
+  readonly params: Params
+  readonly pathname: string
+  readonly encodedPathname: string
+  readonly fallbackRouteParams: readonly string[]
+  readonly fallbackMode: FallbackMode | undefined
+  readonly fallbackRootParams: readonly string[]
+
+  /**
+   * When enabled, the route will be rendered with diagnostics enabled which
+   * will error the build if the route that is generated is empty.
+   */
+  throwOnEmptyStaticShell: boolean
 }
 
 export type PrerenderedRoute = StaticPrerenderedRoute | FallbackPrerenderedRoute

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -353,7 +353,7 @@ export interface PageInfo {
   pageDuration: number | undefined
   ssgPageDurations: number[] | undefined
   runtime: ServerRuntime
-  hasEmptyPrelude?: boolean
+  hasEmptyStaticShell?: boolean
   hasPostponed?: boolean
   isDynamicAppRoute?: boolean
 }
@@ -528,8 +528,9 @@ export async function printTreeView(
         symbol = 'ƒ'
       } else if (pageInfo?.isRoutePPREnabled) {
         if (
-          // If the page has an empty prelude, then it's equivalent to a dynamic page
-          pageInfo?.hasEmptyPrelude ||
+          // If the page has an empty static shell, then it's equivalent to a
+          // dynamic page
+          pageInfo?.hasEmptyStaticShell ||
           // ensure we don't mark dynamic paths that postponed as being dynamic
           // since in this case we're able to partially prerender it
           (pageInfo.isDynamicAppRoute && !pageInfo.hasPostponed)

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -652,8 +652,8 @@ async function exportAppImpl(
         info.metadata = result.metadata
       }
 
-      if (typeof result.hasEmptyPrelude !== 'undefined') {
-        info.hasEmptyPrelude = result.hasEmptyPrelude
+      if (typeof result.hasEmptyStaticShell !== 'undefined') {
+        info.hasEmptyStaticShell = result.hasEmptyStaticShell
       }
 
       if (typeof result.hasPostponed !== 'undefined') {

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -232,7 +232,7 @@ export async function exportAppPage(
     }
 
     // Writing static HTML to a file.
-    fileWriter.append(htmlFilepath, html ?? '')
+    fileWriter.append(htmlFilepath, html)
 
     const isParallelRoute = /\/@\w+/.test(page)
     const isNonSuccessfulStatusCode = res.statusCode > 300
@@ -268,7 +268,7 @@ export async function exportAppPage(
     return {
       // Only include the metadata if the environment has next support.
       metadata: hasNextSupport ? meta : undefined,
-      hasEmptyPrelude: Boolean(postponed) && html === '',
+      hasEmptyStaticShell: Boolean(postponed) && html === '',
       hasPostponed: Boolean(postponed),
       cacheControl,
       fetchMetrics,

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -70,7 +70,7 @@ export type ExportRouteResult =
       cacheControl: CacheControl
       metadata?: Partial<RouteMetadata>
       ssgNotFound?: boolean
-      hasEmptyPrelude?: boolean
+      hasEmptyStaticShell?: boolean
       hasPostponed?: boolean
       fetchMetrics?: FetchMetrics
     }
@@ -135,9 +135,9 @@ export type ExportAppResult = {
        */
       metadata?: Partial<RouteMetadata>
       /**
-       * If the page has an empty prelude when using PPR.
+       * If the page has an empty static shell when using PPR.
        */
-      hasEmptyPrelude?: boolean
+      hasEmptyStaticShell?: boolean
       /**
        * If the page has postponed when using PPR.
        */

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -109,6 +109,10 @@ async function exportPageImpl(
     // result, we just want to use it to error the build if there's a problem.
     _isProspectiveRender: isProspectiveRender = false,
 
+    // Configure the rendering of the page not to throw if an empty static shell
+    // is generated while rendering using PPR.
+    _doNotThrowOnEmptyStaticShell: doNotThrowOnEmptyStaticShell = false,
+
     // Pull the original query out.
     query: originalQuery = {},
   } = pathMap
@@ -267,6 +271,7 @@ async function exportPageImpl(
     // If it's static, then it won't affect anything.
     // If it's dynamic, then it can be handled when request hits the route.
     serveStreamingMetadata: true,
+    doNotThrowOnEmptyStaticShell,
     experimental: {
       ...input.renderOpts.experimental,
       isRoutePPREnabled,
@@ -590,7 +595,7 @@ async function exportPage(
     cacheControl: result.cacheControl,
     metadata: result.metadata,
     ssgNotFound: result.ssgNotFound,
-    hasEmptyPrelude: result.hasEmptyPrelude,
+    hasEmptyStaticShell: result.hasEmptyStaticShell,
     hasPostponed: result.hasPostponed,
     turborepoAccessTraceResult: turborepoAccessTraceResult.serialize(),
     fetchMetrics: result.fetchMetrics,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -132,7 +132,7 @@ import {
   createDynamicValidationState,
   getFirstDynamicReason,
   trackAllowedDynamicAccess,
-  throwIfDisallowedEmptyShell,
+  throwIfDisallowedEmptyStaticShell,
   consumeDynamicAccess,
   type DynamicAccess,
 } from './dynamic-rendering'
@@ -2411,7 +2411,7 @@ async function spawnDynamicValidationInDev(
 
   const finalClientController = new AbortController()
   const clientDynamicTracking = createDynamicTrackingState(false)
-  const dynamicValidation = createDynamicValidationState()
+  const dynamicValidation = createDynamicValidationState(false)
 
   const finalClientPrerenderStore: PrerenderStore = {
     type: 'prerender',
@@ -2551,7 +2551,7 @@ async function spawnDynamicValidationInDev(
   function LogDynamicValidation() {
     try {
       if (preludeIsEmpty) {
-        throwIfDisallowedEmptyShell(
+        throwIfDisallowedEmptyStaticShell(
           route,
           dynamicValidation,
           serverDynamicTracking,
@@ -3023,7 +3023,9 @@ async function prerenderToStream(
         }
 
         let clientIsDynamic = false
-        let dynamicValidation = createDynamicValidationState()
+        let dynamicValidation = createDynamicValidationState(
+          renderOpts.doNotThrowOnEmptyStaticShell
+        )
 
         const prerender = require('react-dom/static.edge')
           .prerender as (typeof import('react-dom/static.edge'))['prerender']
@@ -3086,7 +3088,7 @@ async function prerenderToStream(
           await processPrelude(unprocessedPrelude)
 
         if (preludeIsEmpty) {
-          throwIfDisallowedEmptyShell(
+          throwIfDisallowedEmptyStaticShell(
             workStore.route,
             dynamicValidation,
             serverDynamicTracking,
@@ -3443,7 +3445,9 @@ async function prerenderToStream(
         const clientDynamicTracking = createDynamicTrackingState(
           renderOpts.isDebugDynamicAccesses
         )
-        const dynamicValidation = createDynamicValidationState()
+        const dynamicValidation = createDynamicValidationState(
+          renderOpts.doNotThrowOnEmptyStaticShell
+        )
 
         const finalClientPrerenderStore: PrerenderStore = (prerenderStore = {
           type: 'prerender',
@@ -3570,7 +3574,7 @@ async function prerenderToStream(
 
         if (preludeIsEmpty) {
           // We don't have a shell because the root errored when we aborted.
-          throwIfDisallowedEmptyShell(
+          throwIfDisallowedEmptyStaticShell(
             workStore.route,
             dynamicValidation,
             serverDynamicTracking,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2411,7 +2411,7 @@ async function spawnDynamicValidationInDev(
 
   const finalClientController = new AbortController()
   const clientDynamicTracking = createDynamicTrackingState(false)
-  const dynamicValidation = createDynamicValidationState(false)
+  const dynamicValidation = createDynamicValidationState()
 
   const finalClientPrerenderStore: PrerenderStore = {
     type: 'prerender',
@@ -2550,7 +2550,10 @@ async function spawnDynamicValidationInDev(
 
   function LogDynamicValidation() {
     try {
-      if (preludeIsEmpty) {
+      // If we've disabled throwing on empty static shell, then we don't need to
+      // track any dynamic access that occurs above the suspense boundary because
+      // we'll do so in the route shell.
+      if (preludeIsEmpty && !ctx.renderOpts.doNotThrowOnEmptyStaticShell) {
         throwIfDisallowedEmptyStaticShell(
           route,
           dynamicValidation,
@@ -3023,9 +3026,7 @@ async function prerenderToStream(
         }
 
         let clientIsDynamic = false
-        let dynamicValidation = createDynamicValidationState(
-          renderOpts.doNotThrowOnEmptyStaticShell
-        )
+        let dynamicValidation = createDynamicValidationState()
 
         const prerender = require('react-dom/static.edge')
           .prerender as (typeof import('react-dom/static.edge'))['prerender']
@@ -3087,7 +3088,10 @@ async function prerenderToStream(
         const { prelude, preludeIsEmpty } =
           await processPrelude(unprocessedPrelude)
 
-        if (preludeIsEmpty) {
+        // If we've disabled throwing on empty static shell, then we don't need to
+        // track any dynamic access that occurs above the suspense boundary because
+        // we'll do so in the route shell.
+        if (preludeIsEmpty && !ctx.renderOpts.doNotThrowOnEmptyStaticShell) {
           throwIfDisallowedEmptyStaticShell(
             workStore.route,
             dynamicValidation,
@@ -3445,9 +3449,7 @@ async function prerenderToStream(
         const clientDynamicTracking = createDynamicTrackingState(
           renderOpts.isDebugDynamicAccesses
         )
-        const dynamicValidation = createDynamicValidationState(
-          renderOpts.doNotThrowOnEmptyStaticShell
-        )
+        const dynamicValidation = createDynamicValidationState()
 
         const finalClientPrerenderStore: PrerenderStore = (prerenderStore = {
           type: 'prerender',
@@ -3572,7 +3574,10 @@ async function prerenderToStream(
           }
         }
 
-        if (preludeIsEmpty) {
+        // If we've disabled throwing on empty static shell, then we don't need to
+        // track any dynamic access that occurs above the suspense boundary because
+        // we'll do so in the route shell.
+        if (preludeIsEmpty && !ctx.renderOpts.doNotThrowOnEmptyStaticShell) {
           // We don't have a shell because the root errored when we aborted.
           throwIfDisallowedEmptyStaticShell(
             workStore.route,

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -78,7 +78,6 @@ export type DynamicTrackingState = {
 
 // Stores dynamic reasons used during an SSR render.
 export type DynamicValidationState = {
-  readonly doNotThrowOnEmptyStaticShell: boolean | undefined
   hasSuspenseAboveBody: boolean
   hasDynamicMetadata: boolean
   hasDynamicViewport: boolean
@@ -96,11 +95,8 @@ export function createDynamicTrackingState(
   }
 }
 
-export function createDynamicValidationState(
-  doNotThrowOnEmptyStaticShell: boolean | undefined
-): DynamicValidationState {
+export function createDynamicValidationState(): DynamicValidationState {
   return {
-    doNotThrowOnEmptyStaticShell,
     hasSuspenseAboveBody: false,
     hasDynamicMetadata: false,
     hasDynamicViewport: false,
@@ -664,13 +660,6 @@ export function throwIfDisallowedEmptyStaticShell(
     throw new InvariantError(
       'Expected `generateMetadata` not to block the application shell but it did.'
     )
-  }
-
-  // If we've disabled throwing on empty static shell, then we don't need to
-  // track any dynamic access that occurs above the suspense boundary because
-  // we'll do so in the route shell.
-  if (dynamicValidation.doNotThrowOnEmptyStaticShell) {
-    return
   }
 
   if (dynamicValidation.hasSuspenseAboveBody) {

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -262,6 +262,13 @@ export interface RenderOptsPartial {
   reactMaxHeadersLength: number | undefined
 
   isStaticGeneration?: boolean
+
+  /**
+   * When true, the page will be rendered using the static rendering to detect
+   * any dynamic API's that would have stopped the page from being fully
+   * statically generated.
+   */
+  doNotThrowOnEmptyStaticShell?: boolean
 }
 
 export type RenderOpts = LoadComponentsReturnType<AppPageModule> &

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -41,6 +41,7 @@ const zExportMap: zod.ZodType<ExportPathMap> = z.record(
     _isDynamicError: z.boolean().optional(),
     _isRoutePPREnabled: z.boolean().optional(),
     _isProspectiveRender: z.boolean().optional(),
+    _doNotThrowOnEmptyStaticShell: z.boolean().optional(),
   })
 )
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -719,6 +719,15 @@ export type ExportPathMap = {
      * @internal
      */
     _isProspectiveRender?: boolean
+
+    /**
+     * When true, it indicates that the diagnostic render for this page is
+     * disabled. This is only used when the app has `experimental.ppr` and
+     * `experimental.dynamicIO` enabled.
+     *
+     * @internal
+     */
+    _doNotThrowOnEmptyStaticShell?: boolean
   }
 }
 

--- a/test/e2e/app-dir/empty-fallback-shells/app/[slug]/page.jsx
+++ b/test/e2e/app-dir/empty-fallback-shells/app/[slug]/page.jsx
@@ -1,0 +1,8 @@
+export default async function Page({ params }) {
+  const { slug } = await params
+  return <div data-testid={`hello-${slug}`}>Hello /{slug}</div>
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'foo' }]
+}

--- a/test/e2e/app-dir/empty-fallback-shells/app/layout.jsx
+++ b/test/e2e/app-dir/empty-fallback-shells/app/layout.jsx
@@ -1,0 +1,11 @@
+import { Suspense } from 'react'
+
+export default function Layout({ children }) {
+  return (
+    <html>
+      <Suspense>
+        <body>{children}</body>
+      </Suspense>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/empty-fallback-shells/empty-fallback-shells.test.ts
+++ b/test/e2e/app-dir/empty-fallback-shells/empty-fallback-shells.test.ts
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('empty-fallback-shells', () => {
+  const { next, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should start and not postpone the response', async () => {
+    const res = await next.fetch('/world')
+    const html = await res.text()
+    expect(html).toContain('hello-world')
+
+    if (isNextDeploy) {
+      expect(res.headers.get('x-matched-path')).toBe('/[slug]')
+    }
+
+    // If we didn't use the fallback shell, then we didn't postpone the response
+    // and therefore shouldn't have sent the postponed header.
+    expect(res.headers.get('x-nextjs-postponed')).not.toBe('1')
+  })
+})

--- a/test/e2e/app-dir/empty-fallback-shells/next.config.js
+++ b/test/e2e/app-dir/empty-fallback-shells/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+    ppr: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
This enables a new set of cardinality changes for pages with PPR and Dynamic IO enabled on it. When a set of more specific routes are generated, we no longer error when the static shell is empty and instead infer that as a sign that the user doesn't want to provide a route fallback. If the user does in fact place suspense boundaries above params access, the fallback shell will not be empty and will be used.

Given the following application structure:
```
/[lang]/layout.tsx
/[lang]/[teamSlug]/page.tsx
```

Where we have the following returned for `generateStaticProps`: `[{ lang: "en", teamSlug: "nextjs"}]`, we'd have the following rendered:

```
/[lang]/[teamSlug] <- empty shell won't cause error
/en/[teamSlug] <- empty shell won't cause error
/en/nextjs <- empty shell will cause error
```

If `/[lang]/[teamSlug]` generated an empty shell, then a request to `/fr/nextjs` wouldn't use the `/[lang]/[teamSlug]` fallback shell and would instead generate a new blocking route shell. Otherwise if it didn't generate an empty shell, it would use the fallback shell that's outputted.

If `/en/[teamSlug]` generated an empty shell, then a request to `/en/react` wouldn't use the `/en/[teamSlug]` fallback shell and would instead generate a new blocking route shell. Otherwise if it didn't generate an empty shell, it would use the fallback shell that's outputted.