### PR TITLE
refactor(turbo-tasks): Use an execution id instead of the parent task id to prevent local Vc escapes

### DIFF
--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -125,6 +125,13 @@ define_id!(
     serde(transparent),
     doc = "Represents the nth `local` function call inside a task.",
 );
+define_id!(
+    ExecutionId: u16,
+    derive(Debug, Serialize, Deserialize),
+    serde(transparent),
+    doc = "An identifier for a specific task execution. Used to assert that local `Vc`s don't \
+        leak. This value may overflow and re-use old values.",
+);
 
 impl Debug for TaskId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -91,7 +91,8 @@ pub use completion::{Completion, Completions};
 pub use display::ValueToString;
 pub use effect::{apply_effects, effect, get_effects, Effects};
 pub use id::{
-    FunctionId, LocalTaskId, SessionId, TaskId, TraitTypeId, ValueTypeId, TRANSIENT_TASK_BIT,
+    ExecutionId, FunctionId, LocalTaskId, SessionId, TaskId, TraitTypeId, ValueTypeId,
+    TRANSIENT_TASK_BIT,
 };
 pub use invalidation::{
     get_invalidator, DynamicEqHash, InvalidationReason, InvalidationReasonKind,

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -20,7 +20,8 @@ pub enum LocalTask {
 pub fn get_local_task_execution_spec<'a>(
     turbo_tasks: &'_ dyn TurboTasksBackendApi<impl Backend + 'static>,
     ty: &'a LocalTaskType,
-    // if this is a `LocalTaskType::Resolve*`, we'll spawn another task with this persistence
+    // if this is a `LocalTaskType::Resolve*`, we'll spawn another task with this persistence, if
+    // this is a `LocalTaskType::Native`, this refers to the parent non-local task.
     persistence: TaskPersistence,
 ) -> TaskExecutionSpec<'a> {
     match ty {
@@ -29,7 +30,6 @@ pub fn get_local_task_execution_spec<'a>(
             this,
             arg,
         } => {
-            debug_assert_eq!(persistence, TaskPersistence::Local);
             let func = registry::get_function(*native_fn_id);
             let span = func.span(TaskPersistence::Local);
             let entered = span.enter();


### PR DESCRIPTION
Re-using the task id just for the `Vc` scope escape check isn't ideal:

- A task can execute multiple times. Just using task ids doesn't guarantee that the `Vc` hasn't leaked across multiple executions of the same task.
- This is just a fallback check to help with debugging, so allocating 32 bits to this id seems wasteful. We can do a good job with 16 bits. Nothing else really needs the task id, so we can get rid of it later in this PR stack.

A version of this idea was part of the original local tasks idea: https://www.notion.so/vercel/Resolved-Vcs-Vc-Lifetimes-Local-Vcs-and-Vc-Refcounts-49d666d3f9594017b5b312b87ddc5bff?pvs=4#da95dbdc390144a9bb1b3d2fb73867b7

Even with this extra 4 bits, the overall enum size is still 16 bits due to alignment and the size of the other enum variants, so this shouldn't regress memory consumption.

The next PR (https://github.com/vercel/next.js/pull/78561) removes `TaskId` entirely...

Closes PACK-4469