### PR TITLE
fix(turbo-tasks): Store persistence of wrapped task on RawVc::LocalOutput

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -91,8 +91,8 @@ impl UpdateOutputOperation {
                     cell,
                 })
             }
-            Ok(Ok(RawVc::LocalOutput(_, _))) => {
-                panic!("LocalOutput must not be output of a task");
+            Ok(Ok(RawVc::LocalOutput(..))) => {
+                panic!("Non-local tasks must not return a local Vc");
             }
             Ok(Err(err)) => {
                 task.insert(CachedDataItem::Error {

--- a/turbopack/crates/turbo-tasks-backend/tests/transient_vc.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/transient_vc.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/transient_vc.rs

--- a/turbopack/crates/turbo-tasks-memory/tests/transient_vc.rs
+++ b/turbopack/crates/turbo-tasks-memory/tests/transient_vc.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/transient_vc.rs

--- a/turbopack/crates/turbo-tasks-testing/tests/transient_vc.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/transient_vc.rs
@@ -1,0 +1,55 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+
+use anyhow::Result;
+use turbo_tasks::{TaskInput, TransientValue, Vc};
+use turbo_tasks_testing::{register, run_without_cache_check, Registration};
+
+static REGISTRATION: Registration = register!();
+
+#[tokio::test]
+async fn test_transient_vc() -> Result<()> {
+    run_without_cache_check(&REGISTRATION, async {
+        test_transient_operation(TransientValue::new(123))
+            .read_strongly_consistent()
+            .await?;
+        Ok(())
+    })
+    .await
+}
+
+#[turbo_tasks::function(operation)]
+async fn test_transient_operation(transient_arg: TransientValue<i32>) -> Result<()> {
+    let called_with_transient = has_transient_arg(transient_arg);
+    let called_with_persistent = has_persistent_arg(123);
+
+    assert!(called_with_transient.is_transient());
+    assert!(!called_with_persistent.is_transient());
+    assert!(has_vc_arg(called_with_transient).is_transient());
+    assert!(!has_vc_arg(called_with_persistent).is_transient());
+
+    let called_with_transient_resolved = called_with_transient.to_resolved().await?;
+    let called_with_persistent_resolved = called_with_persistent.to_resolved().await?;
+
+    assert!(called_with_transient_resolved.is_transient());
+    assert!(!called_with_persistent_resolved.is_transient());
+    assert!(has_vc_arg(*called_with_transient_resolved).is_transient());
+    assert!(!has_vc_arg(*called_with_persistent_resolved).is_transient());
+
+    Ok(())
+}
+
+#[turbo_tasks::function]
+fn has_transient_arg(arg: TransientValue<i32>) -> Vc<i32> {
+    Vc::cell(*arg)
+}
+
+#[turbo_tasks::function]
+fn has_persistent_arg(arg: i32) -> Vc<i32> {
+    Vc::cell(arg)
+}
+
+#[turbo_tasks::function]
+async fn has_vc_arg(arg: Vc<i32>) -> Result<Vc<i32>> {
+    Ok(Vc::cell(*arg.await?))
+}

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -306,7 +306,7 @@ pub struct UpdateInfo {
     placeholder_for_future_fields: (),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum TaskPersistence {
     /// Tasks that may be persisted across sessions using serialization.
     Persistent,
@@ -796,7 +796,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         #[cfg(not(feature = "tokio_tracing"))]
         tokio::task::spawn(future);
 
-        RawVc::LocalOutput(parent_task_id, local_task_id)
+        RawVc::LocalOutput(parent_task_id, persistence, local_task_id)
     }
 
     fn begin_primary_job(&self) {

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -139,7 +139,7 @@ where
     }
 
     fn is_transient(&self) -> bool {
-        self.node.get_task_id().is_transient()
+        self.node.is_transient()
     }
 
     async fn resolve_input(&self) -> Result<Self> {


### PR DESCRIPTION
Using the parent task id for determining the persistence of a `RawVc::LocalOutput` is (sometimes) wrong.

If we have a transient task calling a persistent task, the wrapped `LocalOutput` should be persistent.

We just store the persistence here, and not the task id of the wrapped `LocalOutput`, because when this is constructed, no non-local task id has been reserved yet. We don't really need the full task id though: just the persistence/transient bit is sufficient.

After this PR stack, the parent task id isn't really used for anything anymore, so we can get rid of it (TODO).

Tested using the repro here: https://vercel.slack.com/archives/C046HAU4H7F/p1744792143917369?thread_ts=1744792143.917369

Closes PACK-4443