### PR TITLE
Batch ipc info messages to improve performance.

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -95,6 +95,8 @@ function createIpc<TIncoming, TOutgoing>(
     process.exit(0);
   });
 
+  // TODO(lukesandberg): some of the messages being sent are very large and contain lots
+  //  of redundant information.  Consider adding gzip compression to our stream.
   function send(message: any): Promise<void> {
     // Reserve 4 bytes for our length prefix, we will over-write after encoding.
     const packet = Buffer.from("0000" + JSON.stringify(message), "utf8");

--- a/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -125,7 +125,7 @@ export default async function transform(
     }
   }
   ipc.sendInfo({
-    type:"dependencies",
+    type: "dependencies",
     filePaths,
     directories,
     build,

--- a/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -87,6 +87,10 @@ export default async function transform(
   });
 
   const assets = [];
+  const filePaths: string[] =[];
+  const build: string[] = [];
+  const directories: Array<[string, string]> = [];
+
   for (const msg of messages) {
     switch (msg.type) {
       case "asset":
@@ -104,36 +108,28 @@ export default async function transform(
         break;
       case "dependency":
       case "missing-dependency":
-        ipc.sendInfo({
-          type: "fileDependency",
-          path: toPath(msg.file),
-        });
+        filePaths.push(toPath(msg.file));
         break;
       case "build-dependency":
-        ipc.sendInfo({
-          type: "buildDependency",
-          path: toPath(msg.file),
-        });
+        build.push(toPath(msg.file));
         break;
       case "dir-dependency":
-        ipc.sendInfo({
-          type: "dirDependency",
-          path: toPath(msg.dir),
-          glob: msg.glob,
-        });
+        directories.push([toPath(msg.dir), msg.glob]);
         break;
       case "context-dependency":
-        ipc.sendInfo({
-          type: "dirDependency",
-          path: toPath(msg.file),
-          glob: "**",
-        });
+        directories.push([toPath(msg.dir), "**"]);
         break;
       default:
         // TODO: do we need to do anything here?
         break;
     }
   }
+  ipc.sendInfo({
+    type:"dependencies",
+    filePaths,
+    directories,
+    build,
+  });
   return {
     css,
     map: sourceMap ? JSON.stringify(map) : undefined,

--- a/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -88,7 +88,7 @@ export default async function transform(
 
   const assets = [];
   const filePaths: string[] =[];
-  const build: string[] = [];
+  const buildFilePaths: string[] = [];
   const directories: Array<[string, string]> = [];
 
   for (const msg of messages) {
@@ -111,7 +111,7 @@ export default async function transform(
         filePaths.push(toPath(msg.file));
         break;
       case "build-dependency":
-        build.push(toPath(msg.file));
+        buildFilePaths.push(toPath(msg.file));
         break;
       case "dir-dependency":
         directories.push([toPath(msg.dir), msg.glob]);
@@ -128,7 +128,7 @@ export default async function transform(
     type: "dependencies",
     filePaths,
     directories,
-    build,
+    buildFilePaths,
   });
   return {
     css,

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -23,7 +23,7 @@ export type IpcInfoMessage =
       envVariables?: string[]
       directories?: Array<[string, string]>
       filePaths?: string[],
-      build?: string[],
+      buildFilePaths?: string[],
     }
   | {
     type: "emittedError";

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -155,6 +155,7 @@ type ResolveOptions = {
 
 // Patch process.env to track which env vars are read
 const originalEnv = process.env;
+// TODO: when should this be cleared?
 const readEnvVars = new Set<string>();
 process.env = new Proxy(originalEnv, {
   get(target, prop) {
@@ -355,7 +356,7 @@ const transform = (
                   break
               }
               // TODO(lukesandberg): should we batch these and flush lazily?
-              // turbopack just collects these and reports them later.
+              // turbopack just collects these and reports them when finishing the task.
               ipc.sendInfo({
                 type: "log",
                 time: Date.now(),

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -155,7 +155,6 @@ type ResolveOptions = {
 
 // Patch process.env to track which env vars are read
 const originalEnv = process.env;
-// TODO: when should this be cleared?
 const readEnvVars = new Set<string>();
 process.env = new Proxy(originalEnv, {
   get(target, prop) {

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -19,27 +19,17 @@ import { type StructuredError } from "src/ipc";
 
 export type IpcInfoMessage =
   | {
-    type: "fileDependency";
-    path: string;
-  }
-  | {
-    type: "buildDependency";
-    path: string;
-  }
-  | {
-    type: "dirDependency";
-    path: string;
-    glob: string;
-  }
-  | {
-    type: "envDependency";
-    name: string;
-  }
+      type: 'dependencies'
+      envVariables?: string[]
+      directories?: Array<[string, string]>
+      filePaths?: string[],
+      build?: string[],
+    }
   | {
     type: "emittedError";
     severity: "warning" | "error";
     error: StructuredError;
-  }
+    }
   | {
     type: "log";
     time: number;
@@ -364,7 +354,8 @@ const transform = (
                   // TODO: do we need to handle this?
                   break
               }
-
+              // TODO(lukesandberg): should we batch these and flush lazily?
+              // turbopack just collects these and reports them later.
               ipc.sendInfo({
                 type: "log",
                 time: Date.now(),
@@ -469,25 +460,15 @@ const transform = (
         },
       },
       (err, result) => {
-        for (const envVar of readEnvVars) {
-          ipc.sendInfo({
-            type: "envDependency",
-            name: envVar,
-          });
-        }
-        for (const dep of result.contextDependencies) {
-          ipc.sendInfo({
-            type: "dirDependency",
-            path: toPath(dep),
-            glob: "**",
-          });
-        }
-        for (const dep of result.fileDependencies) {
-          ipc.sendInfo({
-            type: "fileDependency",
-            path: toPath(dep),
-          });
-        }
+        ipc.sendInfo({
+          type: 'dependencies',
+          envVariables: Array.from(readEnvVars),
+          filePaths: result.fileDependencies.map(toPath),
+          directories: result.contextDependencies.map((dep) => [
+            toPath(dep),
+            '**',
+          ]),
+        });
         if (err) return reject(err);
         if (!result.result) return reject(new Error("No result from loaders"));
         const [source, map] = result.result;
@@ -518,17 +499,17 @@ function makeErrorEmitter(
       error:
         error instanceof Error
           ? {
-            name: error.name,
-            message: error.message,
-            stack: error.stack ? parseStackTrace(error.stack) : [],
-            cause: undefined,
-          }
+              name: error.name,
+              message: error.message,
+              stack: error.stack ? parseStackTrace(error.stack) : [],
+              cause: undefined,
+            }
           : {
             name: "Error",
-            message: error,
-            stack: [],
-            cause: undefined,
-          },
+              message: error,
+              stack: [],
+              cause: undefined,
+            },
     });
   };
 }

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -535,7 +535,7 @@ async fn pull_operation<T: EvaluateContext>(
             }
             EvalJavaScriptIncomingMessage::End { data } => break ControlFlow::Break(Ok(data)),
             EvalJavaScriptIncomingMessage::Info { data } => {
-                let guard = duration_span!("info");
+                let guard = duration_span!("info message");
                 evaluate_context
                     .info(state, serde_json::from_value(data)?, pool)
                     .await?;

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -525,19 +525,24 @@ async fn pull_operation<T: EvaluateContext>(
     let output = loop {
         match operation.recv().await? {
             EvalJavaScriptIncomingMessage::Error(error) => {
+                let guard = duration_span!("error");
                 evaluate_context.emit_error(error, pool).await?;
                 // Do not reuse the process in case of error
                 operation.disallow_reuse();
                 // Issue emitted, we want to break but don't want to return an error
+                drop(guard);
                 break ControlFlow::Break(Ok(None));
             }
             EvalJavaScriptIncomingMessage::End { data } => break ControlFlow::Break(Ok(data)),
             EvalJavaScriptIncomingMessage::Info { data } => {
+                let guard = duration_span!("info");
                 evaluate_context
                     .info(state, serde_json::from_value(data)?, pool)
                     .await?;
+                drop(guard);
             }
             EvalJavaScriptIncomingMessage::Request { id, data } => {
+                let guard = duration_span!("request");
                 match evaluate_context
                     .request(state, serde_json::from_value(data)?, pool)
                     .await
@@ -561,6 +566,7 @@ async fn pull_operation<T: EvaluateContext>(
                             .await?;
                     }
                 }
+                drop(guard);
             }
         }
     };

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -348,10 +348,17 @@ pub struct LogInfo {
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum InfoMessage {
+    // Sent to inform turbopack about the dependencies of the task.
+    // All fields are `default` since it is ok for the client to
+    // simply omit instead of sending empty arrays.
     Dependencies {
+        #[serde(default)]
         env_variables: Vec<RcStr>,
+        #[serde(default)]
         file_paths: Vec<RcStr>,
+        #[serde(default)]
         directories: Vec<(RcStr, RcStr)>,
+        #[serde(default)]
         build: Vec<RcStr>,
     },
     EmittedError {

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -360,7 +360,7 @@ pub enum InfoMessage {
         #[serde(default)]
         directories: Vec<(RcStr, RcStr)>,
         #[serde(default)]
-        build: Vec<RcStr>,
+        build_file_paths: Vec<RcStr>,
     },
     EmittedError {
         severity: IssueSeverity,
@@ -477,7 +477,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 env_variables,
                 file_paths,
                 directories,
-                build,
+                build_file_paths,
             } => {
                 // Track dependencies of the loader task
                 // TODO:Because these are reporter _after_ the loader actually read the dependency
@@ -508,7 +508,7 @@ impl EvaluateContext for WebpackLoaderContext {
                         )
                     })
                     .try_join();
-                let build_paths = build
+                let build_paths = build_file_paths
                     .iter()
                     .map(|path| self.cwd.join(path.clone()).to_resolved())
                     .try_join();

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -349,7 +349,7 @@ pub struct LogInfo {
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum InfoMessage {
-    // Sent to inform turbopack about the dependencies of the task.
+    // Sent to inform Turbopack about the dependencies of the task.
     // All fields are `default` since it is ok for the client to
     // simply omit instead of sending empty arrays.
     Dependencies {
@@ -480,7 +480,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 build_file_paths,
             } => {
                 // Track dependencies of the loader task
-                // TODO:Because these are reporter _after_ the loader actually read the dependency
+                // TODO: Because these are reported _after_ the loader actually read the dependency
                 // there is a race condition where we may miss updates that race
                 // with the loader execution.
 


### PR DESCRIPTION
Batch the dependency messages sent from our nodejs worker process.

Some large projects using tailwind may report thousands of dependencies which can cause the node process to hang due to memory pressure.  We are addressing the memory pressure issue independently in #78462, but by reducing the number of small packets we can also improve performance.



Closes PACK-4447