### PR TITLE
Docs IA 2.0: Create `public` folder API reference

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -202,7 +202,7 @@ export default function Document() {
 
 ### Create the `public` folder (optional)
 
-Create a [`public` folder](/docs/app/building-your-application/optimizing/static-assets) at the root of your project to store static assets such as images, fonts, etc. Files inside `public` can then be referenced by your code starting from the base URL (`/`).
+Create a [`public` folder](/docs/app/api-reference/file-conventions/public-folder) at the root of your project to store static assets such as images, fonts, etc. Files inside `public` can then be referenced by your code starting from the base URL (`/`).
 
 You can then reference these assets using the root path (`/`). For example, `public/profile.png` can be referenced as `/profile.png`:
 

--- a/docs/01-app/01-getting-started/02-project-structure.mdx
+++ b/docs/01-app/01-getting-started/02-project-structure.mdx
@@ -20,12 +20,12 @@ Top-level folders are used to organize your application's code and static assets
   height="525"
 />
 
-|                                                                          |                                    |
-| ------------------------------------------------------------------------ | ---------------------------------- |
-| [`app`](/docs/app/building-your-application/routing)                     | App Router                         |
-| [`pages`](/docs/pages/building-your-application/routing)                 | Pages Router                       |
-| [`public`](/docs/app/building-your-application/optimizing/static-assets) | Static assets to be served         |
-| [`src`](/docs/app/api-reference/file-conventions/src-folder)             | Optional application source folder |
+|                                                                    |                                    |
+| ------------------------------------------------------------------ | ---------------------------------- |
+| [`app`](/docs/app/building-your-application/routing)               | App Router                         |
+| [`pages`](/docs/pages/building-your-application/routing)           | Pages Router                       |
+| [`public`](/docs/app/api-reference/file-conventions/public-folder) | Static assets to be served         |
+| [`src`](/docs/app/api-reference/file-conventions/src-folder)       | Optional application source folder |
 
 ### Top-level files
 

--- a/docs/01-app/02-guides/production-checklist.mdx
+++ b/docs/01-app/02-guides/production-checklist.mdx
@@ -66,7 +66,7 @@ While building your application, we recommend using the following features to en
 - **[Streaming](/docs/app/building-your-application/routing/loading-ui-and-streaming):** Use Loading UI and React Suspense to progressively send UI from the server to the client, and prevent the whole route from blocking while data is being fetched.
 - **[Parallel Data Fetching](/docs/app/building-your-application/data-fetching/fetching#parallel-and-sequential-data-fetching):** Reduce network waterfalls by fetching data in parallel, where appropriate. Also, consider [preloading data](/docs/app/building-your-application/data-fetching/fetching#preloading-data) where appropriate.
 - **[Data Caching](/docs/app/building-your-application/caching#data-cache):** Verify whether your data requests are being cached or not, and opt into caching, where appropriate. Ensure requests that don't use `fetch` are [cached](/docs/app/api-reference/functions/unstable_cache).
-- **[Static Images](/docs/app/building-your-application/optimizing/static-assets):** Use the `public` directory to automatically cache your application's static assets, e.g. images.
+- **[Static Images](/docs/app/api-reference/file-conventions/public-folder):** Use the `public` directory to automatically cache your application's static assets, e.g. images.
 
 </AppOnly>
 
@@ -75,7 +75,7 @@ While building your application, we recommend using the following features to en
 - **[API Routes](/docs/pages/building-your-application/routing/api-routes):** Use Route Handlers to access your backend resources, and prevent sensitive secrets from being exposed to the client.
 - **[Data Caching](/docs/pages/building-your-application/data-fetching/get-static-props):** Verify whether your data requests are being cached or not, and opt into caching, where appropriate. Ensure requests that don't use `getStaticProps` are cached where appropriate.
 - **[Incremental Static Regeneration](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration):** Use Incremental Static Regeneration to update static pages after they've been built, without rebuilding your entire site.
-- **[Static Images](/docs/pages/building-your-application/optimizing/static-assets):** Use the `public` directory to automatically cache your application's static assets, e.g. images.
+- **[Static Images](/docs/pages/api-reference/file-conventions/public-folder):** Use the `public` directory to automatically cache your application's static assets, e.g. images.
 
 </PagesOnly>
 

--- a/docs/01-app/05-api-reference/03-file-conventions/public-folder.mdx
+++ b/docs/01-app/05-api-reference/03-file-conventions/public-folder.mdx
@@ -1,6 +1,6 @@
 ---
-title: Static Assets in `public`
-nav_title: Static Assets
+title: `public` folder
+nav_title: public
 description: Next.js allows you to serve static files, like images, in the public directory. You can learn how it works here.
 ---
 

--- a/docs/01-app/05-api-reference/03-file-conventions/public-folder.mdx
+++ b/docs/01-app/05-api-reference/03-file-conventions/public-folder.mdx
@@ -1,5 +1,5 @@
 ---
-title: `public` folder
+title: public Folder
 nav_title: public
 description: Next.js allows you to serve static files, like images, in the public directory. You can learn how it works here.
 ---

--- a/docs/01-app/05-api-reference/05-config/01-next-config-js/assetPrefix.mdx
+++ b/docs/01-app/05-api-reference/05-config/01-next-config-js/assetPrefix.mdx
@@ -63,13 +63,13 @@ While `assetPrefix` covers requests to `_next/static`, it does not influence the
 
 <AppOnly>
 
-- Files in the [public](/docs/app/building-your-application/optimizing/static-assets) folder; if you want to serve those assets over a CDN, you'll have to introduce the prefix yourself
+- Files in the [public](/docs/app/api-reference/file-conventions/public-folder) folder; if you want to serve those assets over a CDN, you'll have to introduce the prefix yourself
 
 </AppOnly>
 
 <PagesOnly>
 
-- Files in the [public](/docs/pages/building-your-application/optimizing/static-assets) folder; if you want to serve those assets over a CDN, you'll have to introduce the prefix yourself
+- Files in the [public](/docs/pages/api-reference/file-conventions/public-folder) folder; if you want to serve those assets over a CDN, you'll have to introduce the prefix yourself
 - `/_next/data/` requests for `getServerSideProps` pages. These requests will always be made against the main domain since they're not static.
 - `/_next/data/` requests for `getStaticProps` pages. These requests will always be made against the main domain to support [Incremental Static Generation](/docs/pages/building-your-application/data-fetching/incremental-static-regeneration), even if you're not using it (for consistency).
 

--- a/docs/01-app/05-api-reference/05-config/01-next-config-js/rewrites.mdx
+++ b/docs/01-app/05-api-reference/05-config/01-next-config-js/rewrites.mdx
@@ -91,7 +91,7 @@ The order Next.js routes are checked is:
 1. [headers](/docs/app/api-reference/config/next-config-js/headers) are checked/applied
 2. [redirects](/docs/app/api-reference/config/next-config-js/redirects) are checked/applied
 3. `beforeFiles` rewrites are checked/applied
-4. static files from the [public directory](/docs/app/building-your-application/optimizing/static-assets), `_next/static` files, and non-dynamic pages are checked/served
+4. static files from the [public directory](/docs/app/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
 5. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
 6. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
 
@@ -102,7 +102,7 @@ The order Next.js routes are checked is:
 1. [headers](/docs/pages/api-reference/config/next-config-js/headers) are checked/applied
 2. [redirects](/docs/pages/api-reference/config/next-config-js/redirects) are checked/applied
 3. `beforeFiles` rewrites are checked/applied
-4. static files from the [public directory](/docs/pages/building-your-application/optimizing/static-assets), `_next/static` files, and non-dynamic pages are checked/served
+4. static files from the [public directory](/docs/pages/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
 5. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
 6. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
 

--- a/docs/02-pages/03-building-your-application/01-routing/10-internationalization.mdx
+++ b/docs/02-pages/03-building-your-application/01-routing/10-internationalization.mdx
@@ -185,7 +185,7 @@ export async function middleware(req: NextRequest) {
 }
 ```
 
-This [Middleware](/docs/pages/building-your-application/routing/middleware) skips adding the default prefix to [API Routes](/docs/pages/building-your-application/routing/api-routes) and [public](/docs/pages/building-your-application/optimizing/static-assets) files like fonts or images. If a request is made to the default locale, we redirect to our prefix `/en`.
+This [Middleware](/docs/pages/building-your-application/routing/middleware) skips adding the default prefix to [API Routes](/docs/pages/building-your-application/routing/api-routes) and [public](/docs/pages/api-reference/file-conventions/public-folder) files like fonts or images. If a request is made to the default locale, we redirect to our prefix `/en`.
 
 ### Disabling Automatic Locale Detection
 

--- a/docs/02-pages/04-api-reference/02-file-conventions/public-folder.mdx
+++ b/docs/02-pages/04-api-reference/02-file-conventions/public-folder.mdx
@@ -2,7 +2,7 @@
 title: `public` folder
 nav_title: public
 description: Next.js allows you to serve static files, like images, in the public directory. You can learn how it works here.
-source: app/building-your-application/optimizing/static-assets
+source: app/api-reference/file-conventions/public-folder
 ---
 
 {/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/02-pages/04-api-reference/02-file-conventions/public-folder.mdx
+++ b/docs/02-pages/04-api-reference/02-file-conventions/public-folder.mdx
@@ -1,5 +1,6 @@
 ---
-title: Static Assets
+title: `public` folder
+nav_title: public
 description: Next.js allows you to serve static files, like images, in the public directory. You can learn how it works here.
 source: app/building-your-application/optimizing/static-assets
 ---

--- a/docs/02-pages/04-api-reference/02-file-conventions/public-folder.mdx
+++ b/docs/02-pages/04-api-reference/02-file-conventions/public-folder.mdx
@@ -1,5 +1,5 @@
 ---
-title: `public` folder
+title: public Folder
 nav_title: public
 description: Next.js allows you to serve static files, like images, in the public directory. You can learn how it works here.
 source: app/api-reference/file-conventions/public-folder

--- a/errors/can-not-output-to-public.mdx
+++ b/errors/can-not-output-to-public.mdx
@@ -14,4 +14,4 @@ Use a different `distDir` or export to a different folder.
 
 ## Useful Links
 
-- [Static file serving docs](/docs/pages/building-your-application/optimizing/static-assets)
+- [Static file serving docs](/docs/pages/api-reference/file-conventions/public-folder)

--- a/errors/can-not-output-to-static.mdx
+++ b/errors/can-not-output-to-static.mdx
@@ -14,4 +14,4 @@ Use a different `distDir` or export to a different folder.
 
 ## Useful Links
 
-- [Static file serving docs](/docs/pages/building-your-application/optimizing/static-assets)
+- [Static file serving docs](/docs/pages/api-reference/file-conventions/public-folder)

--- a/errors/conflicting-public-file-page.mdx
+++ b/errors/conflicting-public-file-page.mdx
@@ -30,4 +30,4 @@ pages/
 
 ## Useful Links
 
-- [Static file serving docs](/docs/pages/building-your-application/optimizing/static-assets)
+- [Static file serving docs](/docs/pages/api-reference/file-conventions/public-folder)

--- a/errors/custom-document-image-import.mdx
+++ b/errors/custom-document-image-import.mdx
@@ -44,5 +44,5 @@ module.exports = {
 
 - [Custom `Document`](/docs/pages/building-your-application/routing/custom-document)
 - [Custom `App`](/docs/pages/building-your-application/routing/custom-app)
-- [Static File Serving](/docs/pages/building-your-application/optimizing/static-assets)
+- [Static File Serving](/docs/pages/api-reference/file-conventions/public-folder)
 - [Disable Static Image Imports](/docs/pages/api-reference/components/image#disablestaticimages)

--- a/errors/static-dir-deprecated.mdx
+++ b/errors/static-dir-deprecated.mdx
@@ -35,4 +35,4 @@ You can move your `static` directory inside of the `public` directory and all UR
 
 ## Useful Links
 
-- [Static file serving docs](/docs/pages/building-your-application/optimizing/static-assets)
+- [Static file serving docs](/docs/pages/api-reference/file-conventions/public-folder)


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4604/public-folder

- Renames "Static Assets" page to "Public Folder" and moves it to the file-system conventions section. 

Redirects: https://github.com/vercel/front/pull/44623