### PR TITLE
Turbopack: prevent hanging due to content hashing

### DIFF
--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -21,7 +21,7 @@ use turbopack::{
     css::chunk::CssChunkType, ecmascript::chunk::EcmascriptChunkType,
     global_module_ids::get_global_module_id_strategy,
 };
-use turbopack_browser::{BrowserChunkingContext, ContentHashing};
+use turbopack_browser::{BrowserChunkingContext, ContentHashing, CurrentChunkMethod};
 use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
@@ -335,6 +335,7 @@ async fn build_internal(
             )
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
+            .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
             .minify_type(minify_type);
 
             match *node_env.await? {


### PR DESCRIPTION
If you enable content hashing, you need to use `CurrentChunkMethod::DocumentCurrentScript`, otherwise there's an infinite loop of `getting the current chunk's name for including it in the content <--> building the content of the chunk`

This was already being done here for next-client: https://github.com/vercel/next.js/blob/fb0abb44bf21ca98848d0b9c7ff45a291cc05e46/crates/next-core/src/next_client/context.rs#L465

Closes PACK-4446