### PR TITLE
refactor: skip the prospective render when there's a more specific route to be rendered

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1981,10 +1981,23 @@ export default async function build(
                           // check that dynamic pages won't error when they
                           // enable PPR.
                           else if (config.experimental.dynamicIO && isDynamic) {
-                            prospectiveRenders.set(originalAppPath, {
-                              page,
-                              originalAppPath,
-                            })
+                            // If there's a page with a more specific render
+                            // available, then we should skip the prospective
+                            // render because it'll be done as a part of the
+                            // that render to validate the dynamic state.
+                            if (
+                              // The existence of any prerendered routes when
+                              // PPR is disabled means that the route has more
+                              // specific prerendered routes that should be
+                              // used for the diagnostic render anyways.
+                              !workerResult.prerenderedRoutes ||
+                              workerResult.prerenderedRoutes.length === 0
+                            ) {
+                              prospectiveRenders.set(originalAppPath, {
+                                page,
+                                originalAppPath,
+                              })
+                            }
                           }
 
                           if (workerResult.prerenderedRoutes) {


### PR DESCRIPTION
When there's a more specific route available to render, when PPR is disabled but Dynamic IO is enabled, we should skip the prospective diagnostic render because it would have been skipped as a part of the PPR render anyways.