### PR TITLE
nit(turbo-tasks): Reorder the fields in RawVc::LocalOutput, add more documentation

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -843,7 +843,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         #[cfg(not(feature = "tokio_tracing"))]
         tokio::task::spawn(future);
 
-        RawVc::LocalOutput(persistence, execution_id, local_task_id)
+        RawVc::LocalOutput(execution_id, local_task_id, persistence)
     }
 
     fn begin_primary_job(&self) {


### PR DESCRIPTION
It seems like `persistence` is the least-read and least-important field of this enum variant, so move it to the end...

Also added documentation to the `RawVc` enum variants. This stuff is already documented elsewhere, but it's useful to have something here as well.

Closes PACK-4474