### PR TITLE
Track environment variables accessed by the `postcss` transform

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -24,8 +24,10 @@ type Dependencies = {
 };
 
 export type IpcInfoMessage =
-  | {type: 'dependencies', 
-    envVariables?: string[]} & Dependencies
+  | {
+    type: 'dependencies', 
+    envVariables?: string[],
+  } & Dependencies
   | {
     type: "emittedError";
     severity: "warning" | "error";


### PR DESCRIPTION
Right now we track environment variables accessed during webpack loaders and report them as part of their dependencies, but we don't do this for `postcss`.

Resolve that by sharing more code between the two paths.


Closes PACK-4451