### PR TITLE
Repeat fix in #78387 for routes without params

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3539,13 +3539,14 @@ export default async function build(
           await writeManifest(pagesManifestPath, pagesManifest)
 
           if (config.experimental.clientSegmentCache) {
-            for (const dynamicRoute of routesManifest.dynamicRoutes) {
+            for (const route of [
+              ...routesManifest.staticRoutes,
+              ...routesManifest.dynamicRoutes,
+            ]) {
               // We only want to handle pages that are using the app router. We
               // need this path in order to determine if it's an app route or an
               // app page.
-              const originalAppPath = pageInfos.get(
-                dynamicRoute.page
-              )?.originalAppPath
+              const originalAppPath = pageInfos.get(route.page)?.originalAppPath
               if (!originalAppPath) {
                 continue
               }
@@ -3558,7 +3559,7 @@ export default async function build(
               // We don't need to add the prefetch segment data routes if it was
               // added due to a page that was already generated. This would have
               // happened if the page was static or partially static.
-              if (dynamicRoute.prefetchSegmentDataRoutes) {
+              if (route.prefetchSegmentDataRoutes) {
                 continue
               }
 
@@ -3567,9 +3568,9 @@ export default async function build(
               // with other dynamic routes for the prefetch segment
               // routes. This is only an issue for pages that do not have
               // partial prerendering enabled.
-              dynamicRoute.prefetchSegmentDataRoutes = [
+              route.prefetchSegmentDataRoutes = [
                 buildInversePrefetchSegmentDataRoute(
-                  dynamicRoute.page,
+                  route.page,
                   // We use the special segment path of `/_tree` because it's
                   // the first one sent by the client router so it's the only
                   // one we need to rewrite to the regular prefetch RSC route.

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/[id]/page.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/[id]/page.jsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+
+  return <div>/prefetch-tests/[id]</div>
+}
+
+export const experimental_ppr = true

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/dynamic/page.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/dynamic/page.jsx
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+
+  return <div>/prefetch-tests/dynamic</div>
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/layout.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children, params }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/page.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/prefetch-tests/page.jsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/prefetch-tests/dynamic">Dynamic</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
@@ -30,4 +30,22 @@ describe('conflicting routes', () => {
       )
     }
   })
+
+  it('matches the right route when the original route has no dynamic params, is dynamic, and PPR is disabled', async () => {
+    const res = await next.fetch('/prefetch-tests/dynamic', {
+      headers: {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': '/_tree',
+      },
+    })
+
+    expect(res.status).toBe(200)
+
+    if (isNextDeploy) {
+      expect(res.headers.get('x-matched-path')).toBe(
+        '/prefetch-tests/dynamic.prefetch.rsc'
+      )
+    }
+  })
 })


### PR DESCRIPTION
Follow up to #78387. When incremental PPR mode is enabled, we need to create a special "inverse" route to handle tree requests for every route in the manifest that doesn't have PPR enabled. #78387 fixed this for "dynamic" routes — which in the context of the relevant module I believe means routes with params, and has nothing to do with dynamic data in the PPR sense — but it didn't handle for "static" routes — which here means routes without any params.

The fix is to apply the same logic in #78387 for all routes, both "static" and  "dynamic", in the routes manifest.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
