### PR TITLE
[dynamicIO] Do not skip dynamic validation when metadata is dynamic

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -42,7 +42,6 @@ import {
   OUTLET_BOUNDARY_NAME,
 } from '../../lib/metadata/metadata-constants'
 import { scheduleOnNextTick } from '../../lib/scheduler'
-import { InvariantError } from '../../shared/lib/invariant-error'
 
 const hasPostpone = typeof React.unstable_postpone === 'function'
 
@@ -653,15 +652,6 @@ export function throwIfDisallowedEmptyStaticShell(
   serverDynamic: DynamicTrackingState,
   clientDynamic: DynamicTrackingState
 ): void {
-  // TODO: Now that metadata is streaming we don't really need to check if it is blocking
-  // the root. We leave this here for now to ensure we've actually covered all our bases here
-  // but we can actually remove this in a future update
-  if (dynamicValidation.hasDynamicMetadata) {
-    throw new InvariantError(
-      'Expected `generateMetadata` not to block the application shell but it did.'
-    )
-  }
-
   if (dynamicValidation.hasSuspenseAboveBody) {
     // This route has opted into allowing fully dynamic rendering
     // by including a Suspense boundary above the body. In this case

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/app/page.tsx
@@ -1,0 +1,23 @@
+export async function generateMetadata() {
+  await new Promise((r) => setTimeout(r, 0))
+  return { title: 'Dynamic Metadata' }
+}
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page has dynamic metadata and is also dynamic in the page without a
+        Suspense boundary. This is violation of dynamic IO rules. This test
+        exists however because there was previously a bug that would incorrectly
+        report this as an invariant error.
+      </p>
+      <Dynamic />
+    </>
+  )
+}
+
+async function Dynamic() {
+  await new Promise((r) => setTimeout(r))
+  return <p id="dynamic">Dynamic</p>
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
+    dynamicIO: true,
+    serverMinification: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Metadata can be dynamic without that being an error. A bug was introduced in a recent refactor where the presence of dynamic metadata was incorrectly interpreted as a sign that the metadata did not have a Suspense boundary around it. This would be a problem because metadata is now streaming however it was actually a misuse of the tracking flag and would incorrectly error if you had dynamic metadata at all. This fix addresses the incorrect invariant by removing it.

there is arguably a second bug here in that InvariantError causes the validation of the page to be skipped but it doesn't error the build. That is concerning but not the focus of this change. regardless by removing the incorrect invariant error code the validation begins to work again as expected.