### PR TITLE
Draft: use global-error file for static routes

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -52,7 +52,10 @@ interface ErrorBoundaryHandlerState {
 // instead of caching the error page
 function HandleISRError({ error }: { error: any }) {
   const store = staticGenerationAsyncStorage.getStore()
-  if (store?.isRevalidate || store?.isStaticGeneration) {
+  if (
+    (store?.isRevalidate || store?.isStaticGeneration) &&
+    !store?.forceStatic
+  ) {
     console.error(error)
     throw error
   }

--- a/test/e2e/app-dir/global-error/basic/app/force-static-with-error/page.js
+++ b/test/e2e/app-dir/global-error/basic/app/force-static-with-error/page.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-static'
+
+export default function Page() {
+  throw new Error('Forced error in force-static page')
+}

--- a/test/e2e/app-dir/global-error/basic/index.test.ts
+++ b/test/e2e/app-dir/global-error/basic/index.test.ts
@@ -90,4 +90,9 @@ describe('app dir - global error', () => {
       )
     }
   })
+
+  test('force-static page with error should render user defined global error boundary', async () => {
+    const browser = await next.browser('/force-static-with-error')
+    expect(await browser.elementByCss('h1').text()).toBe('Global Error')
+  })
 })


### PR DESCRIPTION
### What?
I fixed usage of `app/global-error.tsx` for routes, which have `export const dynamic = 'force-static'; export const revalidate = 1 // or some number`

### Why?

### How?