### PR TITLE
fix: make webpack handle "use cache" in node_modules 

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -75,7 +75,7 @@ export interface SWCLoaderOptions {
 // these are exact code conditions checked
 // for to force transpiling a `node_module`
 const FORCE_TRANSPILE_CONDITIONS =
-  /(next\/font|next\/dynamic|use server|use client)/
+  /next\/font|next\/dynamic|use server|use client|use cache/
 
 async function loaderTransform(
   this: LoaderContext<SWCLoaderOptions> & TelemetryLoaderContext,

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -449,7 +449,7 @@ export function makeErroringExoticSearchParamsForUseCache(
   const promise = Promise.resolve({})
 
   const proxiedPromise = new Proxy(promise, {
-    get(target, prop, receiver) {
+    get: function get(target, prop, receiver) {
       if (Object.hasOwn(promise, prop)) {
         // The promise has this property directly. we must return it. We know it
         // isn't a dynamic access because it can only be something that was
@@ -462,12 +462,12 @@ export function makeErroringExoticSearchParamsForUseCache(
         typeof prop === 'string' &&
         (prop === 'then' || !wellKnownProperties.has(prop))
       ) {
-        throwForSearchParamsAccessInUseCache(workStore)
+        throwForSearchParamsAccessInUseCache(workStore, get)
       }
 
       return ReflectAdapter.get(target, prop, receiver)
     },
-    has(target, prop) {
+    has: function has(target, prop) {
       // We don't expect key checking to be used except for testing the existence of
       // searchParams so we make all has tests throw an error. this means that `promise.then`
       // can resolve to the then function on the Promise prototype but 'then' in promise will assume
@@ -476,13 +476,13 @@ export function makeErroringExoticSearchParamsForUseCache(
         typeof prop === 'string' &&
         (prop === 'then' || !wellKnownProperties.has(prop))
       ) {
-        throwForSearchParamsAccessInUseCache(workStore)
+        throwForSearchParamsAccessInUseCache(workStore, has)
       }
 
       return ReflectAdapter.has(target, prop)
     },
-    ownKeys() {
-      throwForSearchParamsAccessInUseCache(workStore)
+    ownKeys: function ownKeys() {
+      throwForSearchParamsAccessInUseCache(workStore, ownKeys)
     },
   })
 

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -21,12 +21,14 @@ export function throwWithStaticGenerationBailoutErrorWithDynamicError(
 }
 
 export function throwForSearchParamsAccessInUseCache(
-  workStore: WorkStore
+  workStore: WorkStore,
+  constructorOpt?: Function
 ): never {
   const error = new Error(
     `Route ${workStore.route} used "searchParams" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "searchParams" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
   )
 
+  Error.captureStackTrace(error, constructorOpt)
   workStore.invalidUsageError ??= error
 
   throw error

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -22,7 +22,7 @@ export function throwWithStaticGenerationBailoutErrorWithDynamicError(
 
 export function throwForSearchParamsAccessInUseCache(
   workStore: WorkStore,
-  constructorOpt?: Function
+  constructorOpt: Function
 ): never {
   const error = new Error(
     `Route ${workStore.route} used "searchParams" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "searchParams" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`

--- a/test/e2e/app-dir/use-cache/app/directive-in-node-modules/with-handler/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/directive-in-node-modules/with-handler/page.tsx
@@ -1,0 +1,17 @@
+import { getCachedRandomWithHandler } from 'my-pkg'
+
+export default async function Page() {
+  const one = await getCachedRandomWithHandler()
+  const two = await getCachedRandomWithHandler()
+  return (
+    <main>
+      <div>
+        One: <span id="one">{one}</span>
+      </div>
+      <div>
+        Two: <span id="two">{two}</span>
+      </div>
+      {one === two ? '✅ Cached' : '❌ Not cached'}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/directive-in-node-modules/without-handler/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/directive-in-node-modules/without-handler/page.tsx
@@ -1,0 +1,17 @@
+import { getCachedRandom } from 'my-pkg'
+
+export default async function Page() {
+  const one = await getCachedRandom()
+  const two = await getCachedRandom()
+  return (
+    <main>
+      <div>
+        One: <span id="one">{one}</span>
+      </div>
+      <div>
+        Two: <span id="two">{two}</span>
+      </div>
+      {one === two ? '✅ Cached' : '❌ Not cached'}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/use-cache/node_modules/my-pkg/index.js
+++ b/test/e2e/app-dir/use-cache/node_modules/my-pkg/index.js
@@ -1,0 +1,9 @@
+export async function getCachedRandom() {
+  'use cache'
+  return Math.random()
+}
+
+export async function getCachedRandomWithHandler() {
+  'use cache: default'
+  return Math.random()
+}

--- a/test/e2e/app-dir/use-cache/node_modules/my-pkg/package.json
+++ b/test/e2e/app-dir/use-cache/node_modules/my-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "my-pkg",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -503,6 +503,8 @@ describe('use-cache', () => {
         '/cache-fetch-no-store',
         '/cache-life',
         '/cache-tag',
+        '/directive-in-node-modules/with-handler',
+        '/directive-in-node-modules/without-handler',
         '/draft-mode',
         '/form',
         '/imported-from-client',
@@ -913,6 +915,25 @@ describe('use-cache', () => {
       ])
     })
   }
+
+  describe('usage in node_modules', () => {
+    it('should cache results when using a directive without a handler', async () => {
+      const browser = await next.browser(
+        '/directive-in-node-modules/without-handler'
+      )
+      const randomOne = await browser.elementByCss('#one').text()
+      const randomTwo = await browser.elementByCss('#two').text()
+      expect(randomOne).toBe(randomTwo)
+    })
+    it('should cache results when using a directive with a handler', async () => {
+      const browser = await next.browser(
+        '/directive-in-node-modules/with-handler'
+      )
+      const randomOne = await browser.elementByCss('#one').text()
+      const randomTwo = await browser.elementByCss('#two').text()
+      expect(randomOne).toBe(randomTwo)
+    })
+  })
 })
 
 async function getSanitizedLogs(browser: Playwright): Promise<string[]> {


### PR DESCRIPTION
Turbopack applies the "use cache" transform in node_modules, but Webpack wasn't doing that. This is due to a sneaky little regex that controls whether files in node_modules are passed to SWC for transforming or not -- `use client` and `use server` were included there, but `use cache` wasn't. This PR fixes that.

(I don't really expect NPM packages to use `"use cache"` because it's pretty application-specific, but it might be relevant in a monorepo situation where shared utils that use the directive can live in a separate package)
