### PR TITLE
feat: add editor docs about tab labels for app directory files

### DIFF
--- a/docs/01-app/02-guides/local-development.mdx
+++ b/docs/01-app/02-guides/local-development.mdx
@@ -173,6 +173,23 @@ It provides detailed information about the time taken for each module to compile
 1. Once the trace server is running you can view the trace at https://trace.nextjs.org/.
 1. By default the trace viewer will aggregate timings, in order to see each individual time you can switch from "Aggregated in order" to "Spans in order" at the top right of the viewer.
 
+## Editor configuration 
+### Custom editor tab labels for App directory key files 
+
+If you are using a [Code-OSS](https://github.com/microsoft/vscode)-based IDE (such as VSCode, Cursor, Windsurf, etc.), it is recommended to add the following to your `settings.json` file:
+```json
+ "workbench.editor.customLabels.patterns": {
+    "**/app/**/page.tsx": "${dirname} - page.tsx",
+    "**/app/**/layout.tsx": "${dirname} - layout.tsx",
+    "**/app/**/error.tsx": "${dirname} - error.tsx",
+    "**/app/**/not-found.tsx": "${dirname} - not-found.tsx",
+    "**/app/**/loading.tsx": "${dirname} - loading.tsx"
+  }
+```
+
+
+This configuration makes it easier to differentiate between pages by adding the folder name as a prefix to the tab title. It improves navigation and helps quickly locate the correct page.tsx for a specific route.
+
 ## Still having problems?
 
 Share the trace file generated in the [Turbopack Tracing](#turbopack-tracing) section and share it on [GitHub Discussions](https://github.com/vercel/next.js/discussions) or [Discord](https://nextjs.org/discord).


### PR DESCRIPTION

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Add custom label patterns for editor tabs in Code-OSS-based IDEs. This makes it easier to distinguish between different `page.tsx`, `layout.tsx`, etc., by prefixing the tab titles with their folder names. Improves navigation and speeds up development inside the app directory structure.

Preview of the labels with the setting applied:

<img width="906" alt="image" src="https://github.com/user-attachments/assets/faf59a6a-0e19-4cc6-b31e-8a958f3eaffb" />

Got the idea from: https://www.reddit.com/r/nextjs/comments/1k97ow4/better_tabs_in_your_ide_for_pagetsx_and_routets/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

