### PR TITLE
Turbopack: ignore PermissionDenied in raw_read_dir

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -565,6 +565,7 @@ impl FileSystem for DiskFileSystem {
             Err(e)
                 if e.kind() == ErrorKind::NotFound
                     || e.kind() == ErrorKind::NotADirectory
+                    || e.kind() == ErrorKind::PermissionDenied
                     || e.kind() == ErrorKind::InvalidFilename =>
             {
                 return Ok(RawDirectoryContent::not_found());

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -385,6 +385,12 @@ impl DiskWatcher {
                             ) => {
                                 batched_invalidate_path.extend(paths);
                             }
+                            // Watch MetadataKind::Permissions as this could change the result of
+                            // raw_read_dir which skips entries with PermissionDenied.
+                            EventKind::Modify(ModifyKind::Metadata(MetadataKind::Permissions)) => {
+                                batched_invalidate_path_and_children.extend(paths.clone());
+                                batched_invalidate_path_and_children_dir.extend(paths);
+                            }
                             EventKind::Create(_) => {
                                 batched_invalidate_path_and_children.extend(paths.clone());
                                 batched_invalidate_path_and_children_dir.extend(paths.clone());


### PR DESCRIPTION
Related to https://github.com/vercel/next.js/issues/78509

Prevent a single `Permission denied` from bringing down everything, in this case, it was some internal Docker directory

```
[WebServer] - Execution of primary_chunkable_referenced_modules failed
[WebServer] - Execution of resolve_reference_from_dir failed
[WebServer] - Execution of read_matches failed
[WebServer] - Execution of read_matches failed
[WebServer] - Execution of read_matches failed
[WebServer] - Execution of read_matches failed
[WebServer] - Execution of <DiskFileSystem as FileSystem>::raw_read_dir failed
[WebServer] - reading dir /home/runner/work/sentry-gh-error/sentry-gh-error/docker-data/postgres
[WebServer] - Permission denied (os error 13)]
```