### PR TITLE
Turbopack: don't resolve traced references in dev

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -850,6 +850,7 @@ impl AppProject {
             .map(|m| ResolvedVc::upcast(*m))
             .collect();
 
+        let should_trace = self.project.next_mode().await?.is_production();
         if *self.project.per_page_module_graph().await? {
             // Implements layout segment optimization to compute a graph "chain" for each layout
             // segment
@@ -878,6 +879,7 @@ impl AppProject {
                             ChunkGroupEntry::Entry(client_shared_entries),
                         ],
                         VisitedModules::empty(),
+                        should_trace,
                     );
                     graphs.push(graph);
                     let mut visited_modules = VisitedModules::from_graph(graph);
@@ -894,6 +896,7 @@ impl AppProject {
                             // but that breaks everything for some reason.
                             vec![ChunkGroupEntry::Entry(vec![ResolvedVc::upcast(*module)])],
                             visited_modules,
+                            should_trace,
                         );
                         graphs.push(graph);
                         let is_layout =
@@ -915,6 +918,7 @@ impl AppProject {
                     let graph = SingleModuleGraph::new_with_entries_visited_intern(
                         vec![ChunkGroupEntry::Entry(client_shared_entries)],
                         VisitedModules::empty(),
+                        should_trace,
                     );
                     graphs.push(graph);
                     VisitedModules::from_graph(graph)
@@ -923,6 +927,7 @@ impl AppProject {
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
                     vec![rsc_entry_chunk_group],
                     visited_modules,
+                    should_trace,
                 );
                 graphs.push(graph);
                 visited_modules = visited_modules.concatenate(graph);
@@ -932,6 +937,7 @@ impl AppProject {
                 let additional_module_graph = SingleModuleGraph::new_with_entries_visited_intern(
                     additional_entries.owned().await?,
                     visited_modules,
+                    should_trace,
                 );
                 graphs.push(additional_module_graph);
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -863,7 +863,7 @@ impl AppProject {
                     let ServerEntries {
                         server_utils,
                         server_component_entries,
-                    } = &*find_server_entries(*rsc_entry).await?;
+                    } = &*find_server_entries(*rsc_entry, should_trace).await?;
 
                     let graph = SingleModuleGraph::new_with_entries_visited_intern(
                         vec![
@@ -1255,6 +1255,7 @@ impl AppEndpoint {
             .get_client_references_for_endpoint(
                 *rsc_entry,
                 matches!(this.ty, AppEndpointType::Page { .. }),
+                project.next_mode().await?.is_production(),
             )
             .to_resolved()
             .await?;

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -532,6 +532,7 @@ impl ReducedGraphs {
         &self,
         entry: Vc<Box<dyn Module>>,
         has_layout_segments: bool,
+        include_traced: bool,
     ) -> Result<Vc<ClientReferenceGraphResult>> {
         let span = tracing::info_span!("collect all client references for endpoint");
         async move {
@@ -567,7 +568,7 @@ impl ReducedGraphs {
                 let ServerEntries {
                     server_utils,
                     server_component_entries,
-                } = &*find_server_entries(entry).await?;
+                } = &*find_server_entries(entry, include_traced).await?;
                 result.server_utils = server_utils.clone();
                 result.server_component_entries = server_component_entries.clone();
             }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -795,6 +795,7 @@ impl PageEndpoint {
         let this = self.await?;
         let project = this.pages_project.project();
 
+        let should_trace = project.next_mode().await?.is_production();
         if *project.per_page_module_graph().await? {
             let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
             // Implements layout segment optimization to compute a graph "chain" for document, app,
@@ -811,6 +812,7 @@ impl PageEndpoint {
                 let graph = SingleModuleGraph::new_with_entries_visited_intern(
                     vec![ChunkGroupEntry::Shared(module)],
                     visited_modules,
+                    should_trace,
                 );
                 graphs.push(graph);
                 visited_modules = visited_modules.concatenate(graph);
@@ -819,6 +821,7 @@ impl PageEndpoint {
             let graph = SingleModuleGraph::new_with_entries_visited_intern(
                 vec![ChunkGroupEntry::Entry(vec![ssr_chunk_module.ssr_module])],
                 visited_modules,
+                should_trace,
             );
             graphs.push(graph);
 

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -314,7 +314,8 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                 }
             };
 
-            let referenced_modules = primary_chunkable_referenced_modules(*parent_module).await?;
+            let referenced_modules =
+                primary_chunkable_referenced_modules(*parent_module, true).await?;
 
             let referenced_modules = referenced_modules
                 .iter()

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -151,7 +151,10 @@ pub struct ServerEntries {
 }
 
 #[turbo_tasks::function]
-pub async fn find_server_entries(entry: ResolvedVc<Box<dyn Module>>) -> Result<Vc<ServerEntries>> {
+pub async fn find_server_entries(
+    entry: ResolvedVc<Box<dyn Module>>,
+    include_traced: bool,
+) -> Result<Vc<ServerEntries>> {
     async move {
         let entry_path = entry.ident().path().to_resolved().await?;
         let graph = AdjacencyMap::new()
@@ -166,6 +169,7 @@ pub async fn find_server_entries(entry: ResolvedVc<Box<dyn Module>>) -> Result<V
                 }],
                 VisitClientReference {
                     stop_at_server_entries: true,
+                    include_traced,
                 },
             )
             .await
@@ -198,6 +202,8 @@ pub async fn find_server_entries(entry: ResolvedVc<Box<dyn Module>>) -> Result<V
 }
 
 struct VisitClientReference {
+    /// Whether to walk ChunkingType::Traced references
+    include_traced: bool,
     /// Used to discover ServerComponents and ServerUtils
     stop_at_server_entries: bool,
 }
@@ -300,6 +306,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
 
     fn edges(&mut self, node: &VisitClientReferenceNode) -> Self::EdgesFuture {
         let node = node.clone();
+        let include_traced = self.include_traced;
         async move {
             let parent_module = match node.ty {
                 // This should never occur since we always skip visiting these
@@ -315,7 +322,7 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
             };
 
             let referenced_modules =
-                primary_chunkable_referenced_modules(*parent_module, true).await?;
+                primary_chunkable_referenced_modules(*parent_module, include_traced).await?;
 
             let referenced_modules = referenced_modules
                 .iter()

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -303,8 +303,10 @@ async fn build_internal(
     .instrument(tracing::info_span!("resolve entries"))
     .await?;
 
-    let module_graph =
-        ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(entries.clone())]));
+    let module_graph = ModuleGraph::from_modules(
+        Vc::cell(vec![ChunkGroupEntry::Entry(entries.clone())]),
+        false,
+    );
     let module_id_strategy = ResolvedVc::upcast(
         get_global_module_id_strategy(module_graph)
             .to_resolved()

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -156,7 +156,7 @@ pub async fn create_web_entry_source(
         )
         .collect::<Vec<ResolvedVc<Box<dyn Module>>>>();
     let module_graph =
-        ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(all_modules)]))
+        ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(all_modules)]), false)
             .to_resolved()
             .await?;
 

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1321,6 +1321,7 @@ const COMMON_CHUNKING_TYPE: ChunkingType = ChunkingType::ParallelInheritAsync;
 
 struct SingleModuleGraphBuilder<'a> {
     visited_modules: &'a FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
+    /// Whether to walk ChunkingType::Traced references
     include_traced: bool,
 }
 impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -187,6 +187,7 @@ impl SingleModuleGraph {
     async fn new_inner(
         entries: &GraphEntriesT,
         visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
+        include_traced: bool,
     ) -> Result<Vc<Self>> {
         let root_edges = entries
             .iter()
@@ -201,7 +202,13 @@ impl SingleModuleGraph {
 
         let (children_nodes_iter, visited_nodes) = AdjacencyMap::new()
             .skip_duplicates()
-            .visit(root_edges, SingleModuleGraphBuilder { visited_modules })
+            .visit(
+                root_edges,
+                SingleModuleGraphBuilder {
+                    visited_modules,
+                    include_traced,
+                },
+            )
             .await
             .completed()?
             .into_inner_with_visited();
@@ -726,15 +733,19 @@ impl ModuleGraph {
     }
 
     #[turbo_tasks::function]
-    pub fn from_entry_module(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
-        Self::from_single_graph(SingleModuleGraph::new_with_entries(Vc::cell(vec![
-            ChunkGroupEntry::Entry(vec![module]),
-        ])))
+    pub fn from_entry_module(
+        module: ResolvedVc<Box<dyn Module>>,
+        include_traced: bool,
+    ) -> Vc<Self> {
+        Self::from_single_graph(SingleModuleGraph::new_with_entries(
+            Vc::cell(vec![ChunkGroupEntry::Entry(vec![module])]),
+            include_traced,
+        ))
     }
 
     #[turbo_tasks::function]
-    pub fn from_modules(modules: Vc<GraphEntries>) -> Vc<Self> {
-        Self::from_single_graph(SingleModuleGraph::new_with_entries(modules))
+    pub fn from_modules(modules: Vc<GraphEntries>, include_traced: bool) -> Vc<Self> {
+        Self::from_single_graph(SingleModuleGraph::new_with_entries(modules, include_traced))
     }
 
     #[turbo_tasks::function]
@@ -1159,16 +1170,25 @@ impl ModuleGraph {
 #[turbo_tasks::value_impl]
 impl SingleModuleGraph {
     #[turbo_tasks::function]
-    pub async fn new_with_entries(entries: Vc<GraphEntries>) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(&*entries.await?, &Default::default()).await
+    pub async fn new_with_entries(
+        entries: Vc<GraphEntries>,
+        include_traced: bool,
+    ) -> Result<Vc<Self>> {
+        SingleModuleGraph::new_inner(&*entries.await?, &Default::default(), include_traced).await
     }
 
     #[turbo_tasks::function]
     pub async fn new_with_entries_visited(
         entries: Vc<GraphEntries>,
         visited_modules: Vc<VisitedModules>,
+        include_traced: bool,
     ) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(&*entries.await?, &visited_modules.await?.modules).await
+        SingleModuleGraph::new_inner(
+            &*entries.await?,
+            &visited_modules.await?.modules,
+            include_traced,
+        )
+        .await
     }
 
     #[turbo_tasks::function]
@@ -1176,8 +1196,10 @@ impl SingleModuleGraph {
         // This must not be a Vc<Vec<_>> to ensure layout segment optimization hits the cache
         entries: GraphEntriesT,
         visited_modules: Vc<VisitedModules>,
+        include_traced: bool,
     ) -> Result<Vc<Self>> {
-        SingleModuleGraph::new_inner(&entries, &visited_modules.await?.modules).await
+        SingleModuleGraph::new_inner(&entries, &visited_modules.await?.modules, include_traced)
+            .await
     }
 }
 
@@ -1299,6 +1321,7 @@ const COMMON_CHUNKING_TYPE: ChunkingType = ChunkingType::ParallelInheritAsync;
 
 struct SingleModuleGraphBuilder<'a> {
     visited_modules: &'a FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
+    include_traced: bool,
 }
 impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
     type Edge = SingleModuleGraphBuilderEdge;
@@ -1333,10 +1356,11 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
             | SingleModuleGraphBuilderNode::Issues(_) => unreachable!(),
         };
         let visited_modules = self.visited_modules;
+        let include_traced = self.include_traced;
         async move {
             Ok(match (module, chunkable_ref_target) {
                 (Some(module), None) => {
-                    let refs_cell = primary_chunkable_referenced_modules(*module);
+                    let refs_cell = primary_chunkable_referenced_modules(*module, include_traced);
                     let refs = match refs_cell.await {
                         Ok(refs) => refs,
                         Err(e) => {

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -282,6 +282,7 @@ pub struct ModulesWithChunkingType(Vec<(ChunkingType, ModulesVec)>);
 #[turbo_tasks::function]
 pub async fn primary_chunkable_referenced_modules(
     module: Vc<Box<dyn Module>>,
+    include_traced: bool,
 ) -> Result<Vc<ModulesWithChunkingType>> {
     let modules = module
         .references()
@@ -292,6 +293,10 @@ pub async fn primary_chunkable_referenced_modules(
                 ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(*reference)
             {
                 if let Some(chunking_type) = &*reference.chunking_type().await? {
+                    if !include_traced && matches!(chunking_type, ChunkingType::Traced) {
+                        return Ok(None);
+                    }
+
                     let resolved = reference
                         .resolve_reference()
                         .resolve()

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -156,11 +156,14 @@ async fn emit_evaluate_pool_assets_operation(
         entries
     };
 
-    let module_graph = ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(
-        iter::once(entry_module)
-            .chain(runtime_entries.iter().copied().map(ResolvedVc::upcast))
-            .collect(),
-    )]));
+    let module_graph = ModuleGraph::from_modules(
+        Vc::cell(vec![ChunkGroupEntry::Entry(
+            iter::once(entry_module)
+                .chain(runtime_entries.iter().copied().map(ResolvedVc::upcast))
+                .collect(),
+        )]),
+        false,
+    );
 
     let bootstrap = chunking_context.root_entry_chunk_group_asset(
         entrypoint,

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -257,7 +257,8 @@ pub async fn get_intermediate_asset(
     Ok(Vc::upcast(chunking_context.root_entry_chunk_group_asset(
         chunking_context.chunk_path(None, main_entry.ident(), ".js".into()),
         other_entries.with_entry(*main_entry),
-        ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(
+        ModuleGraph::from_modules(
+            Vc::cell(vec![ChunkGroupEntry::Entry(
                 other_entries
                     .await?
                     .into_iter()
@@ -265,7 +266,9 @@ pub async fn get_intermediate_asset(
                     .chain(std::iter::once(main_entry))
                     .map(ResolvedVc::upcast)
                     .collect(),
-            )])),
+            )]),
+            false,
+        ),
         OutputAssets::empty(),
     )))
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -400,8 +400,10 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .copied()
             .map(ResolvedVc::upcast)
             .collect::<Vec<_>>();
-        let module_graph =
-            ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(all_modules.clone())]));
+        let module_graph = ModuleGraph::from_modules(
+            Vc::cell(vec![ChunkGroupEntry::Entry(all_modules.clone())]),
+            false,
+        );
         // TODO: Load runtime entries from snapshots
         match options.runtime {
             Runtime::Browser => chunking_context.evaluated_chunk_group_assets(


### PR DESCRIPTION
Related to https://github.com/vercel/next.js/issues/78509

We still call `ref.resolve_reference()` in dev on `ChunkingType::Traced` but never look at the result (and unnecessarily call `read_matches` potentially).

Closes PACK-4461