### PR TITLE
Turbopack: fix search_index merging in trace server

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -498,7 +498,9 @@ impl<'a> SpanRef<'a> {
                                 add_span_to_map(&mut map, span);
                             }
                             SpanOrMap::Map(other_map) => {
-                                map.extend(other_map);
+                                for (name, value) in other_map {
+                                    map.entry(name).or_default().extend(value);
+                                }
                             }
                         }
                         SpanOrMap::Map(map)


### PR DESCRIPTION
Fix a regression in https://github.com/vercel/next.js/pull/78357
Bug found by @sokra as well: https://github.com/vercel/next.js/pull/78357#discussion_r2063544480

Closes PACK-4588