### PR TITLE
Turbopack: Add failing test for #78592

### DIFF
--- a/test/e2e/app-dir/file-loader-wasm/app/layout.tsx
+++ b/test/e2e/app-dir/file-loader-wasm/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/file-loader-wasm/app/page.tsx
+++ b/test/e2e/app-dir/file-loader-wasm/app/page.tsx
@@ -1,0 +1,6 @@
+import duckdbWasm from '@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm'
+console.log(duckdbWasm)
+
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/file-loader-wasm/file-loader-wasm.test.ts
+++ b/test/e2e/app-dir/file-loader-wasm/file-loader-wasm.test.ts
@@ -1,0 +1,16 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('file-loader-wasm', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      '@duckdb/duckdb-wasm': '1.29.1-dev132.0',
+      'file-loader': '^6.2.0',
+    },
+  })
+
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})

--- a/test/e2e/app-dir/file-loader-wasm/next.config.js
+++ b/test/e2e/app-dir/file-loader-wasm/next.config.js
@@ -1,0 +1,32 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  turbopack: {
+    rules: {
+      '*.wasm': {
+        loaders: [
+          {
+            loader: 'file-loader',
+            options: {
+              esModule: true,
+            },
+          },
+        ],
+        as: '*.js',
+      },
+    },
+  },
+
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.wasm/,
+      loader: 'file-loader',
+      options: {},
+    })
+
+    return config
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
I've added a test for the issue in #78592.

This shows a different error than the one reported in the issue because in that reproduction `as: '*.js'` is missing. That's a separate issue where the error is not clear enough and it shouldn't crash but report an error for the module in my opinion.

For the underlying error: It seems we try to read the file as utf8 before passing it to the webpack loader. In webpack a buffer is passed instead of a string.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
