### PR TITLE
docs(css): Clarify CSS modules support SCSS extensions

### DIFF
--- a/docs/01-app/03-building-your-application/05-styling/01-css.mdx
+++ b/docs/01-app/03-building-your-application/05-styling/01-css.mdx
@@ -100,7 +100,7 @@ export function Button() {
 
 </PagesOnly>
 
-CSS Modules are **only enabled for files with the `.module.css` and `.module.sass` extensions**.
+CSS Modules are **only enabled for files with the `.module.css`, `.module.scss`, and `.module.sass` extensions**.
 
 In production, all CSS Module files will be automatically concatenated into **many minified and code-split** `.css` files.
 These `.css` files represent hot execution paths in your application, ensuring the minimal amount of CSS is loaded for your application to paint.


### PR DESCRIPTION
### What?

This change explicitly notes that `module.scss` files are also explicitly supported.

### Why?

According to [the SASS documentation](https://nextjs.org/docs/app/guides/sass), Next.js natively supports both `.sass` and `.scss` extensions. However, these CSS module docs only suggest they can be used with `.css` and `.sass` (but not explicitly also `.scss`). 