### PR TITLE
fix(turbopack): Provide full path to SWC Wasm plugins

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -186,7 +186,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                         PluginSerializedBytes::try_serialize(&module_program)?;
 
                     let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
-                        Some(ctx.file_name_str.to_string()),
+                        Some(ctx.file_path_str.to_string()),
                         //[TODO]: Support env-related variable injection, i.e process.env.NODE_ENV
                         "development".to_string(),
                         None,


### PR DESCRIPTION
### What?

Provide full path to the SWC Wasm plugins

### Why?

To align with other SWC Wasm plugin runtimes

### How?

 - Closes PACK-4363
 - Closes #78181