### PR TITLE
Turbopack: Extract `EsRegex` into `turbo-esregex` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9244,6 +9244,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbo-esregex"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "regex",
+ "regress",
+ "serde",
+ "turbo-tasks",
+ "turbo-tasks-build",
+]
+
+[[package]]
 name = "turbo-persistence"
 version = "0.1.0"
 dependencies = [
@@ -9888,7 +9900,6 @@ dependencies = [
  "parking_lot",
  "petgraph 0.6.3",
  "regex",
- "regress",
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
@@ -9898,6 +9909,7 @@ dependencies = [
  "swc_core",
  "tokio",
  "tracing",
+ "turbo-esregex",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,7 @@ auto-hash-map = { path = "turbopack/crates/turbo-tasks-auto-hash-map" }
 swc-ast-explorer = { path = "turbopack/crates/turbopack-swc-ast-explorer" }
 turbo-prehash = { path = "turbopack/crates/turbo-prehash" }
 turbo-rcstr = { path = "turbopack/crates/turbo-rcstr" }
+turbo-esregex = { path = "turbopack/crates/turbo-esregex" }
 turbo-persistence = { path = "turbopack/crates/turbo-persistence" }
 turbo-tasks-malloc = { path = "turbopack/crates/turbo-tasks-malloc", default-features = false }
 turbo-tasks = { path = "turbopack/crates/turbo-tasks" }

--- a/turbopack/crates/turbo-esregex/Cargo.toml
+++ b/turbopack/crates/turbo-esregex/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "turbo-esregex"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+anyhow = { workspace = true }
+regex = { workspace = true }
+regress = { workspace = true }
+serde = { workspace = true }
+turbo-tasks = { workspace = true }
+
+[build-dependencies]
+turbo-tasks-build = { workspace = true }
+
+[lints]
+workspace = true

--- a/turbopack/crates/turbo-esregex/build.rs
+++ b/turbopack/crates/turbo-esregex/build.rs
@@ -1,0 +1,5 @@
+use turbo_tasks_build::generate_register;
+
+fn main() {
+    generate_register();
+}

--- a/turbopack/crates/turbo-esregex/src/lib.rs
+++ b/turbopack/crates/turbo-esregex/src/lib.rs
@@ -1,4 +1,11 @@
+#![feature(arbitrary_self_types_pointers)]
+
 use anyhow::{bail, Result};
+
+pub fn register() {
+    turbo_tasks::register();
+    include!(concat!(env!("OUT_DIR"), "/register.rs"));
+}
 
 /// A simple regular expression implementation following ecmascript semantics
 ///

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -26,7 +26,6 @@ once_cell = { workspace = true }
 parking_lot = { workspace = true }
 petgraph = { workspace = true }
 regex = { workspace = true }
-regress = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -35,6 +34,7 @@ smallvec = { workspace = true }
 strsim = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+turbo-esregex = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -24,6 +24,7 @@ use swc_core::{
         atoms::Atom,
     },
 };
+use turbo_esregex::EsRegex;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
 use turbopack_core::compile_time_info::{
@@ -32,12 +33,9 @@ use turbopack_core::compile_time_info::{
 
 use self::imports::ImportAnnotations;
 pub(crate) use self::imports::ImportMap;
-use crate::{
-    analyzer::es_regex::EsRegex, references::require_context::RequireContextMap, utils::StringifyJs,
-};
+use crate::{references::require_context::RequireContextMap, utils::StringifyJs};
 
 pub mod builtin;
-pub mod es_regex;
 pub mod graph;
 pub mod imports;
 pub mod linker;

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1116,5 +1116,6 @@ pub fn register() {
     turbo_tasks::register();
     turbo_tasks_fs::register();
     turbopack_core::register();
+    turbo_esregex::register();
     include!(concat!(env!("OUT_DIR"), "/register.rs"));
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -13,6 +13,7 @@ use swc_core::{
     },
     quote, quote_expr,
 };
+use turbo_esregex::EsRegex;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, NonLocalValue, ResolvedVc, Value,
@@ -36,7 +37,6 @@ use turbopack_core::{
 use turbopack_resolve::ecmascript::cjs_resolve;
 
 use crate::{
-    analyzer::es_regex::EsRegex,
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkType, EcmascriptExports,
     },


### PR DESCRIPTION
I’m exploring adding regex support for matching paths for webpack loaders in Turbopack. This seems generally useful.


Closes PACK-4473