### PR TITLE
Turbopack: refactor codegen of module fragments

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -153,6 +153,14 @@ impl CodeGen {
 #[turbo_tasks::value(transparent)]
 pub struct CodeGens(Vec<CodeGen>);
 
+#[turbo_tasks::value_impl]
+impl CodeGens {
+    #[turbo_tasks::function]
+    pub fn empty() -> Vc<Self> {
+        Vc::cell(Vec::new())
+    }
+}
+
 pub trait IntoCodeGenReference {
     fn into_code_gen_reference(
         self,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -109,6 +109,14 @@ impl ReferencedAsset {
 #[turbo_tasks::value(transparent)]
 pub struct EsmAssetReferences(Vec<ResolvedVc<EsmAssetReference>>);
 
+#[turbo_tasks::value_impl]
+impl EsmAssetReferences {
+    #[turbo_tasks::function]
+    pub fn empty() -> Vc<Self> {
+        Vc::cell(Vec::new())
+    }
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Hash, Debug)]
 pub struct EsmAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -1,16 +1,5 @@
-use std::sync::Arc;
-
-use anyhow::{bail, Result};
-use either::Either;
-use swc_core::{
-    common::{util::take::Take, Globals},
-    ecma::{
-        ast::Program,
-        codegen::{text_writer::JsWriter, Emitter},
-    },
-};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
-use turbo_tasks_fs::rope::RopeBuilder;
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext},
     ident::AssetIdent,
@@ -21,10 +10,10 @@ use turbopack_core::{
 use super::module::EcmascriptModuleFacadeModule;
 use crate::{
     chunk::{
-        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
-        EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType,
     },
-    process_content_with_code_gens,
+    EcmascriptAnalyzable, EcmascriptOptions,
 };
 
 /// The chunk item for [EcmascriptModuleFacadeModule].
@@ -48,82 +37,23 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let chunking_context = self.chunking_context;
-        let exports = self.module.get_exports();
-        let EcmascriptExports::EsmExports(exports) = *exports.await? else {
-            bail!("Expected EsmExports");
-        };
+        let module_graph = self.module_graph;
 
-        let externals = *chunking_context
-            .environment()
-            .supports_commonjs_externals()
-            .await?;
+        let content =
+            self.module
+                .module_content(*module_graph, *chunking_context, async_module_info);
 
         let async_module_options = self
             .module
             .get_async_module()
             .module_options(async_module_info);
 
-        let async_module = async_module_options.owned().await?;
-
-        let mut code = RopeBuilder::default();
-
-        let (esm_references, part_references) = self.module.await?.specific_references().await?;
-        let esm_code_gens = esm_references
-            .await?
-            .iter()
-            .map(|r| Either::Left(r.code_generation(*chunking_context)))
-            .chain(
-                part_references
-                    .iter()
-                    .map(|r| Either::Right(r.code_generation(*chunking_context))),
-            )
-            .try_join()
-            .await?;
-        let additional_code_gens = [
-            self.module
-                .async_module()
-                .code_generation(
-                    async_module_info,
-                    self.module.references(),
-                    *chunking_context,
-                )
-                .await?,
-            exports
-                .code_generation(*self.module_graph, *chunking_context, None)
-                .await?,
-        ];
-        let code_gens = esm_code_gens.iter().chain(additional_code_gens.iter());
-
-        let mut program = Program::Module(swc_core::ecma::ast::Module::dummy());
-        process_content_with_code_gens(&mut program, &Globals::new(), None, code_gens);
-
-        let mut bytes: Vec<u8> = vec![];
-
-        let source_map: Arc<swc_core::common::SourceMap> = Default::default();
-
-        let mut emitter = Emitter {
-            cfg: swc_core::ecma::codegen::Config::default(),
-            cm: source_map.clone(),
-            comments: None,
-            wr: JsWriter::new(source_map.clone(), "\n", &mut bytes, None),
-        };
-
-        emitter.emit_program(&program)?;
-
-        code.push_bytes(&bytes);
-
-        Ok(EcmascriptChunkItemContent {
-            inner_code: code.build(),
-            source_map: None,
-            options: EcmascriptChunkItemOptions {
-                strict: true,
-                externals,
-                async_module,
-                ..Default::default()
-            },
-            ..Default::default()
-        }
-        .cell())
+        Ok(EcmascriptChunkItemContent::new(
+            content,
+            *chunking_context,
+            EcmascriptOptions::default().cell(),
+            async_module_options,
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -210,14 +210,12 @@ impl EcmascriptAnalyzable for EcmascriptModuleFacadeModule {
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptModuleContent>> {
-        let this = self.await?;
-
-        let (esm_references, part_references) = this.specific_references().await?;
+        let (esm_references, part_references) = self.await?.specific_references().await?;
 
         Ok(EcmascriptModuleContent::new(
             EcmascriptModuleContentOptions {
                 parsed: ParseResult::empty().to_resolved().await?,
-                ident: this.module.ident().to_resolved().await?,
+                ident: self.ident().to_resolved().await?,
                 specified_module_type: SpecifiedModuleType::EcmaScript,
                 module_graph,
                 chunking_context,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -9,11 +9,8 @@ use turbopack_core::{
 
 use super::module::EcmascriptModuleLocalsModule;
 use crate::{
-    chunk::{
-        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
-        EcmascriptChunkType,
-    },
-    EcmascriptModuleContent, EcmascriptModuleContentOptions,
+    chunk::{EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkType},
+    EcmascriptAnalyzable,
 };
 
 /// The chunk item for [EcmascriptModuleLocalsModule].
@@ -34,41 +31,22 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
     #[turbo_tasks::function]
     async fn content_with_async_module_info(
         &self,
-        async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let module = self.module.await?;
         let chunking_context = self.chunking_context;
         let module_graph = self.module_graph;
-        let exports = self.module.get_exports().to_resolved().await?;
         let original_module = module.module;
-        let parsed = original_module.parse().to_resolved().await?;
 
         let analyze = original_module.analyze();
         let analyze_result = analyze.await?;
         let async_module_options = analyze_result
             .async_module
-            .module_options(async_module_info.map(|info| *info));
+            .module_options(async_module_info);
 
-        let module_type_result = *original_module.determine_module_type().await?;
-        let generate_source_map = *chunking_context
-            .reference_module_source_maps(*ResolvedVc::upcast(self.module))
-            .await?;
-
-        let content = EcmascriptModuleContent::new(EcmascriptModuleContentOptions {
-            parsed,
-            ident: self.module.ident().to_resolved().await?,
-            specified_module_type: module_type_result.module_type,
-            module_graph,
-            chunking_context,
-            references: analyze.local_references().to_resolved().await?,
-            esm_references: analyze_result.esm_local_references,
-            code_generation: analyze_result.code_generation,
-            async_module: analyze_result.async_module,
-            generate_source_map,
-            original_source_map: analyze_result.source_map,
-            exports,
-            async_module_info,
-        });
+        let content =
+            self.module
+                .module_content(*module_graph, *chunking_context, async_module_info);
 
         Ok(EcmascriptChunkItemContent::new(
             content,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -118,6 +118,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleLocalsModule {
                 chunking_context,
                 references: analyze.local_references().to_resolved().await?,
                 esm_references: analyze_result.esm_local_references,
+                part_references: vec![],
                 code_generation: analyze_result.code_generation,
                 async_module: analyze_result.async_module,
                 generate_source_map,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -5,7 +5,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkableModule, ChunkingContext},
+    chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
     module_graph::ModuleGraph,
@@ -20,7 +20,8 @@ use crate::{
         async_module::OptionAsyncModule,
         esm::{EsmExport, EsmExports},
     },
-    EcmascriptModuleAsset,
+    AnalyzeEcmascriptModuleResult, EcmascriptAnalyzable, EcmascriptModuleAsset,
+    EcmascriptModuleContent, EcmascriptModuleContentOptions,
 };
 
 /// A module derived from an original ecmascript module that only contains the
@@ -71,6 +72,60 @@ impl Asset for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.module.content()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptAnalyzable for EcmascriptModuleLocalsModule {
+    #[turbo_tasks::function]
+    fn analyze(&self) -> Vc<AnalyzeEcmascriptModuleResult> {
+        self.module.analyze()
+    }
+
+    #[turbo_tasks::function]
+    fn module_content_without_analysis(
+        &self,
+        generate_source_map: bool,
+    ) -> Vc<EcmascriptModuleContent> {
+        self.module
+            .module_content_without_analysis(generate_source_map)
+    }
+
+    #[turbo_tasks::function]
+    async fn module_content(
+        &self,
+        module_graph: ResolvedVc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+        async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
+    ) -> Result<Vc<EcmascriptModuleContent>> {
+        let exports = self.module.get_exports().to_resolved().await?;
+        let parsed = self.module.parse().to_resolved().await?;
+
+        let analyze = self.module.analyze();
+        let analyze_result = analyze.await?;
+
+        let module_type_result = *self.module.determine_module_type().await?;
+        let generate_source_map = *chunking_context
+            .reference_module_source_maps(*ResolvedVc::upcast(self.module))
+            .await?;
+
+        Ok(EcmascriptModuleContent::new(
+            EcmascriptModuleContentOptions {
+                parsed,
+                ident: self.module.ident().to_resolved().await?,
+                specified_module_type: module_type_result.module_type,
+                module_graph,
+                chunking_context,
+                references: analyze.local_references().to_resolved().await?,
+                esm_references: analyze_result.esm_local_references,
+                code_generation: analyze_result.code_generation,
+                async_module: analyze_result.async_module,
+                generate_source_map,
+                original_source_map: analyze_result.source_map,
+                exports,
+                async_module_info,
+            },
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -8,7 +8,6 @@ use turbopack_core::{
         ModuleChunkItemIdExt,
     },
     module::Module,
-    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::{ModulePart, ModuleResolveResult},
 };
@@ -110,7 +109,6 @@ impl ChunkableModuleReference for EcmascriptModulePartReference {
 impl EcmascriptModulePartReference {
     pub async fn code_generation(
         self: Vc<Self>,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let referenced_asset = ReferencedAsset::from_resolve_result(self.resolve_reference());

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -26,7 +26,8 @@ use crate::{
     side_effect_optimization::facade::module::EcmascriptModuleFacadeModule,
     tree_shake::{side_effect_module::SideEffectsModule, Key},
     AnalyzeEcmascriptModuleResult, EcmascriptAnalyzable, EcmascriptModuleAsset,
-    EcmascriptModuleAssetType, EcmascriptModuleContent, EcmascriptParsable,
+    EcmascriptModuleAssetType, EcmascriptModuleContent, EcmascriptModuleContentOptions,
+    EcmascriptParsable,
 };
 
 /// A reference to part of an ES module.
@@ -74,14 +75,44 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
-    fn module_content(
-        &self,
-        module_graph: Vc<ModuleGraph>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        async_module_info: Option<Vc<AsyncModuleInfo>>,
-    ) -> Vc<EcmascriptModuleContent> {
-        self.full_module
-            .module_content(module_graph, chunking_context, async_module_info)
+    async fn module_content(
+        self: Vc<Self>,
+        module_graph: ResolvedVc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+        async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
+    ) -> Result<Vc<EcmascriptModuleContent>> {
+        let module = self.await?;
+
+        let split_data = split_module(*module.full_module);
+        let parsed = part_of_module(split_data, module.part.clone())
+            .to_resolved()
+            .await?;
+
+        let analyze = self.analyze();
+        let analyze_ref = analyze.await?;
+
+        let module_type_result = *module.full_module.determine_module_type().await?;
+        let generate_source_map = *chunking_context
+            .reference_module_source_maps(Vc::upcast(self))
+            .await?;
+
+        Ok(EcmascriptModuleContent::new(
+            EcmascriptModuleContentOptions {
+                parsed,
+                ident: self.ident().to_resolved().await?,
+                specified_module_type: module_type_result.module_type,
+                module_graph,
+                chunking_context,
+                references: analyze.references().to_resolved().await?,
+                esm_references: analyze_ref.esm_references,
+                code_generation: analyze_ref.code_generation,
+                async_module: analyze_ref.async_module,
+                generate_source_map,
+                original_source_map: analyze_ref.source_map,
+                exports: analyze_ref.exports,
+                async_module_info,
+            },
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -105,6 +105,7 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
                 chunking_context,
                 references: analyze.references().to_resolved().await?,
                 esm_references: analyze_ref.esm_references,
+                part_references: vec![],
                 code_generation: analyze_ref.code_generation,
                 async_module: analyze_ref.async_module,
                 generate_source_map,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     module_graph::ModuleGraph,
 };
 
-use super::{asset::EcmascriptModulePartAsset, part_of_module, split_module};
+use super::asset::EcmascriptModulePartAsset;
 use crate::{
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
@@ -18,7 +18,7 @@ use crate::{
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     tree_shake::side_effect_module::SideEffectsModule,
     utils::StringifyModuleId,
-    EcmascriptModuleContent, EcmascriptModuleContentOptions,
+    EcmascriptAnalyzable,
 };
 
 /// This is an implementation of [ChunkItem] for
@@ -42,47 +42,22 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
     #[turbo_tasks::function]
     async fn content_with_async_module_info(
         &self,
-        async_module_info: Option<ResolvedVc<AsyncModuleInfo>>,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let module = self.module.await?;
-
-        let split_data = split_module(*module.full_module);
-        let parsed = part_of_module(split_data, module.part.clone())
-            .to_resolved()
-            .await?;
-
         let analyze = self.module.analyze();
         let analyze_ref = analyze.await?;
-        let async_module_options = analyze_ref
-            .async_module
-            .module_options(async_module_info.map(|info| *info));
+        let async_module_options = analyze_ref.async_module.module_options(async_module_info);
 
-        let module_type_result = *module.full_module.determine_module_type().await?;
-        let generate_source_map = *self
-            .chunking_context
-            .reference_module_source_maps(*ResolvedVc::upcast(self.module))
-            .await?;
-
-        let content = EcmascriptModuleContent::new(EcmascriptModuleContentOptions {
-            parsed,
-            ident: self.module.ident().to_resolved().await?,
-            specified_module_type: module_type_result.module_type,
-            module_graph: self.module_graph,
-            chunking_context: self.chunking_context,
-            references: analyze.references().to_resolved().await?,
-            esm_references: analyze_ref.esm_references,
-            code_generation: analyze_ref.code_generation,
-            async_module: analyze_ref.async_module,
-            generate_source_map,
-            original_source_map: analyze_ref.source_map,
-            exports: analyze_ref.exports,
+        let content = self.module.module_content(
+            *self.module_graph,
+            *self.chunking_context,
             async_module_info,
-        });
+        );
 
         Ok(EcmascriptChunkItemContent::new(
             content,
             *self.chunking_context,
-            *module.full_module.await?.options,
+            *self.module.await?.full_module.await?.options,
             async_module_options,
         ))
     }


### PR DESCRIPTION
So that every type of ecmascript chunk item uses `EcmascriptModuleContent::new`

Part of PACK-2960

Closes PACK-4487