### PR TITLE
perf(turbopack): Make `FileSystemPath` not `Vc<T>`

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -438,7 +438,7 @@ pub async fn project_new(
 
     let tasks_ref = turbo_tasks.clone();
     turbo_tasks.spawn_once_task(async move {
-        benchmark_file_io(tasks_ref, container.project().node_root())
+        benchmark_file_io(tasks_ref, (*container.project().node_root().await?).clone())
             .await
             .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
     });
@@ -491,7 +491,7 @@ impl CompilationEvent for SlowFilesystemEvent {
 #[tracing::instrument(skip(turbo_tasks))]
 async fn benchmark_file_io(
     turbo_tasks: NextTurboTasks,
-    directory: Vc<FileSystemPath>,
+    directory: FileSystemPath,
 ) -> Result<Vc<Completion>> {
     // try to get the real file path on disk so that we can use it with tokio
     let fs = Vc::try_resolve_downcast_type::<DiskFileSystem>(directory.fs())
@@ -1377,12 +1377,13 @@ pub async fn get_source_map_rope(
         return Ok(OptionStringifiedSourceMap::none());
     };
 
-    let server_path = container.project().node_root().join(chunk_base.into());
+    let server_path = container.project().node_root().await?.join(chunk_base)?;
 
     let client_path = container
         .project()
         .client_relative_path()
-        .join(chunk_base.into());
+        .await?
+        .join(chunk_base)?;
 
     let mut map = container.get_source_map(server_path, module.clone());
 
@@ -1461,8 +1462,12 @@ pub async fn project_trace_source(
                 }
             };
 
-            let project_root_uri =
-                uri_from_file(project.container.project().project_root_path(), None).await? + "/";
+            let project_root_uri = uri_from_file(
+                (*project.container.project().project_root_path().await?).clone(),
+                None,
+            )
+            .await?
+                + "/";
             let (file, original_file, is_internal) = if let Some(source_file) =
                 original_file.strip_prefix(&project_root_uri)
             {
@@ -1530,9 +1535,11 @@ pub async fn project_get_source_for_asset(
                 .container
                 .project()
                 .project_path()
+                .await?
                 .fs()
                 .root()
-                .join(file_path.clone().into())
+                .await?
+                .join(&file_path)?
                 .read()
                 .await?;
 

--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use next_core::{all_assets_from_entries, next_manifests::NextFontManifest};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -12,9 +12,9 @@ use turbopack_core::{
 use crate::paths::get_font_paths_from_root;
 
 pub(crate) async fn create_font_manifest(
-    client_root: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
-    dir: Vc<FileSystemPath>,
+    client_root: FileSystemPath,
+    node_root: FileSystemPath,
+    dir: FileSystemPath,
     original_name: &str,
     manifest_path_prefix: &str,
     pathname: &str,
@@ -25,17 +25,20 @@ pub(crate) async fn create_font_manifest(
 
     // `_next` gets added again later, so we "strip" it here via
     // `get_font_paths_from_root`.
-    let font_paths: Vec<String> =
-        get_font_paths_from_root(&*client_root.await?, &all_client_output_assets)
-            .await?
-            .iter()
-            .filter_map(|p| p.split("_next/").last().map(|f| f.to_string()))
-            .collect();
+    let font_paths: Vec<String> = get_font_paths_from_root(&client_root, &all_client_output_assets)
+        .await?
+        .iter()
+        .filter_map(|p| p.split("_next/").last().map(|f| f.to_string()))
+        .collect();
 
     let path = if app_dir {
-        node_root.join(format!("server/app{manifest_path_prefix}/next-font-manifest.json",).into())
+        node_root.join(&format!(
+            "server/app{manifest_path_prefix}/next-font-manifest.json"
+        ))?
     } else {
-        node_root.join(format!("server/pages{manifest_path_prefix}/next-font-manifest.json").into())
+        node_root.join(&format!(
+            "server/pages{manifest_path_prefix}/next-font-manifest.json"
+        ))?
     };
 
     let has_fonts = !font_paths.is_empty();
@@ -50,7 +53,7 @@ pub(crate) async fn create_font_manifest(
     let next_font_manifest = if !has_fonts {
         Default::default()
     } else if app_dir {
-        let dir_str = dir.to_string().await?;
+        let dir_str = dir.value_to_string().await?;
         let page_path = format!("{dir_str}{original_name}").into();
 
         NextFontManifest {

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -15,8 +15,8 @@ use crate::dynamic_imports::DynamicImportedChunks;
 #[turbo_tasks::function]
 pub async fn create_react_loadable_manifest(
     dynamic_import_entries: Vc<DynamicImportedChunks>,
-    client_relative_path: Vc<FileSystemPath>,
-    output_path: Vc<FileSystemPath>,
+    client_relative_path: FileSystemPath,
+    output_path: FileSystemPath,
     runtime: NextRuntime,
 ) -> Result<Vc<OutputAssets>> {
     let dynamic_import_entries = &*dynamic_import_entries.await?;
@@ -28,7 +28,7 @@ pub async fn create_react_loadable_manifest(
 
         let id = &*module_id.await?;
 
-        let client_relative_path_value = client_relative_path.await?;
+        let client_relative_path_value = client_relative_path.clone();
         let files = chunk_output
             .iter()
             .map(move |&file| {
@@ -55,7 +55,7 @@ pub async fn create_react_loadable_manifest(
     Ok(Vc::cell(match runtime {
         NextRuntime::NodeJs => vec![ResolvedVc::upcast(
             VirtualOutputAsset::new(
-                output_path.with_extension("json".into()),
+                output_path.with_extension("json"),
                 AssetContent::file(FileContent::Content(File::from(manifest_json)).cell()),
             )
             .to_resolved()
@@ -64,7 +64,7 @@ pub async fn create_react_loadable_manifest(
         NextRuntime::Edge => vec![
             ResolvedVc::upcast(
                 VirtualOutputAsset::new(
-                    output_path.with_extension("js".into()),
+                    output_path.with_extension("js"),
                     AssetContent::file(
                         FileContent::Content(File::from(format!(
                             "self.__REACT_LOADABLE_MANIFEST={};",
@@ -78,7 +78,7 @@ pub async fn create_react_loadable_manifest(
             ),
             ResolvedVc::upcast(
                 VirtualOutputAsset::new(
-                    output_path.with_extension("json".into()),
+                    output_path.with_extension("json"),
                     AssetContent::file(FileContent::Content(File::from(manifest_json)).cell()),
                 )
                 .to_resolved()

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -64,7 +64,9 @@ impl OutputAsset for NftJsonAsset {
         Ok(path
             .fs
             .root()
-            .join(format!("{}.nft.json", path.path).into()))
+            .await?
+            .join(&format!("{}.nft.json", path.path))?
+            .cell())
     }
 }
 
@@ -114,12 +116,12 @@ impl Asset for NftJsonAsset {
         let client_root = this.project.client_fs().root();
         let client_root_ref = client_root.await?;
 
-        let ident_folder = self.path().parent().await?;
+        let ident_folder = self.path().await?.parent();
         let ident_folder_in_project_fs = this
             .project
             .project_path()
-            .join(ident_folder.path.clone())
-            .await?;
+            .await?
+            .join(&ident_folder.path)?;
 
         let chunk = this.chunk;
         let entries = this

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -59,8 +59,8 @@ pub(crate) struct ServerActionsManifest {
 #[turbo_tasks::function]
 pub(crate) async fn create_server_actions_manifest(
     actions: Vc<AllActions>,
-    project_path: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
+    node_root: FileSystemPath,
     page_name: RcStr,
     runtime: NextRuntime,
     rsc_asset_context: Vc<Box<dyn AssetContext>>,
@@ -105,7 +105,7 @@ fn server_actions_loader_modifier() -> Vc<RcStr> {
 /// client and present inside the paired manifest.
 #[turbo_tasks::function]
 pub(crate) async fn build_server_actions_loader(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     page_name: RcStr,
     actions: Vc<AllActions>,
     asset_context: Vc<Box<dyn AssetContext>>,
@@ -129,7 +129,7 @@ pub(crate) async fn build_server_actions_loader(
         )?;
     }
 
-    let path = project_path.join(format!(".next-internal/server/app{page_name}/actions.js").into());
+    let path = project_path.join(&format!(".next-internal/server/app{page_name}/actions.js"))?;
     let file = File::from(contents.build());
     let source = VirtualSource::new_with_ident(
         AssetIdent::from_path(path).with_modifier(server_actions_loader_modifier()),
@@ -155,7 +155,7 @@ pub(crate) async fn build_server_actions_loader(
 /// Builds a manifest containing every action's hashed id, with an internal
 /// module id which exports a function using that hashed name.
 async fn build_manifest(
-    node_root: Vc<FileSystemPath>,
+    node_root: FileSystemPath,
     page_name: RcStr,
     runtime: NextRuntime,
     actions: Vc<AllActions>,
@@ -163,8 +163,9 @@ async fn build_manifest(
     async_module_info: Vc<AsyncModulesInfo>,
 ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
     let manifest_path_prefix = &page_name;
-    let manifest_path = node_root
-        .join(format!("server/app{manifest_path_prefix}/server-reference-manifest.json",).into());
+    let manifest_path = node_root.join(&format!(
+        "server/app{manifest_path_prefix}/server-reference-manifest.json"
+    ))?;
     let mut manifest = ServerReferenceManifest {
         ..Default::default()
     };
@@ -212,7 +213,13 @@ pub async fn to_rsc_context(
     // opposed to the following hack to construct the RSC module corresponding to this client
     // module.
     let source = FileSource::new_with_query(
-        client_module.ident().path().root().join(entry_path.into()),
+        client_module
+            .ident()
+            .path()
+            .await?
+            .root()
+            .await?
+            .join(entry_path)?,
         Vc::cell(entry_query.into()),
     );
     let module = asset_context

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -55,7 +55,13 @@ where
     }
 
     for (chunk_item, chunks) in chunk_items {
-        let size = *chunk_item.content_ident().path().read().len().await?;
+        let size = *chunk_item
+            .content_ident()
+            .path()
+            .await?
+            .read()
+            .len()
+            .await?;
         let path = chunk_item.asset_ident().path().await?.path.clone();
         modules.push(WebpackStatsModule {
             name: path.clone(),

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -583,11 +583,15 @@ pub async fn parse_segment_config_from_loader_tree_internal(
     }
 
     let modules = &loader_tree.modules;
-    for path in [modules.page, modules.default, modules.layout]
-        .into_iter()
-        .flatten()
+    for path in [
+        modules.page.clone(),
+        modules.default.clone(),
+        modules.layout.clone(),
+    ]
+    .into_iter()
+    .flatten()
     {
-        let source = Vc::upcast(FileSource::new(*path));
+        let source = Vc::upcast(FileSource::new(path));
         config.apply_parent_config(&*parse_segment_config_from_source(source).await?);
     }
 

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -91,7 +91,7 @@ impl BaseLoaderTreeBuilder {
     pub async fn create_module_tuple_code(
         &mut self,
         module_type: AppDirModuleType,
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
     ) -> Result<String> {
         let name = module_type.name();
         let i = self.unique_number();
@@ -109,7 +109,7 @@ impl BaseLoaderTreeBuilder {
         );
 
         let module = self
-            .process_source(Vc::upcast(FileSource::new(*path)))
+            .process_source(Vc::upcast(FileSource::new(path.clone())))
             .to_resolved()
             .await?;
 

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -16,7 +16,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 pub fn route_bootstrap(
     asset: Vc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
-    base_path: Vc<FileSystemPath>,
+    base_path: FileSystemPath,
     bootstrap_asset: Vc<Box<dyn Source>>,
     config: Vc<BootstrapConfig>,
 ) -> Vc<Box<dyn EvaluatableAsset>> {
@@ -45,17 +45,17 @@ impl BootstrapConfig {
 pub async fn bootstrap(
     asset: ResolvedVc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
-    base_path: Vc<FileSystemPath>,
+    base_path: FileSystemPath,
     bootstrap_asset: Vc<Box<dyn Source>>,
     inner_assets: Vc<InnerAssets>,
     config: Vc<BootstrapConfig>,
 ) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
     let path = asset.ident().path().await?;
-    let Some(path) = base_path.await?.get_path_to(&path) else {
+    let Some(path) = base_path.get_path_to(&path) else {
         bail!(
             "asset {} is not in base path {}",
             asset.ident().to_string().await?,
-            base_path.to_string().await?
+            base_path.value_to_string().await?
         );
     };
     let path = if let Some((name, ext)) = path.rsplit_once('.') {
@@ -73,7 +73,12 @@ pub async fn bootstrap(
     let config_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                asset.ident().path().join("bootstrap-config.ts".into()),
+                asset
+                    .ident()
+                    .path()
+                    .await?
+                    .join("bootstrap-config.ts")?
+                    .cell(),
                 AssetContent::file(
                     File::from(
                         config

--- a/crates/next-core/src/embed_js.rs
+++ b/crates/next-core/src/embed_js.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath};
@@ -12,16 +13,18 @@ pub(crate) fn next_js_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_js_file(path: RcStr) -> Vc<FileContent> {
-    next_js_fs().root().join(path).read()
+pub(crate) async fn next_js_file(path: RcStr) -> Result<Vc<FileContent>> {
+    Ok(next_js_fs().root().await?.join(&path)?.read())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_js_file_path(path: RcStr) -> Vc<FileSystemPath> {
-    next_js_fs().root().join(path)
+pub(crate) async fn next_js_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(next_js_fs().root().await?.join(&path)?.cell())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_asset(path: RcStr) -> Vc<Box<dyn Source>> {
-    Vc::upcast(FileSource::new(next_js_file_path(path)))
+pub(crate) async fn next_asset(path: RcStr) -> Result<Vc<Box<dyn Source>>> {
+    Ok(Vc::upcast(FileSource::new(
+        (*next_js_file_path(path).await?).clone(),
+    )))
 }

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -24,7 +24,7 @@ pub async fn middleware_files(page_extensions: Vc<Vec<RcStr>>) -> Result<Vc<Vec<
 #[turbo_tasks::function]
 pub async fn get_middleware_module(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     userland_module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_MIDDLEWARE_MODULE";

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -1,9 +1,7 @@
 use anyhow::Result;
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{
-    FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc,
-};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, Vc};
 use turbopack_core::{
     chunk::{ChunkingContext, availability_info::AvailabilityInfo},
     module::Module,
@@ -191,9 +189,9 @@ pub async fn get_app_client_references_chunks(
 
                 let base_ident = server_component.ident();
 
-                let server_path = server_component.server_path();
-                let is_layout = server_path.file_stem().await?.as_deref() == Some("layout");
-                let server_component_path = server_path.to_string().await?;
+                let server_path = server_component.server_path().await?;
+                let is_layout = server_path.file_stem() == Some("layout");
+                let server_component_path = server_path.value_to_string().await?;
 
                 let ssr_modules = client_reference_types
                     .iter()

--- a/crates/next-core/src/next_app/app_favicon_entry.rs
+++ b/crates/next-core/src/next_app/app_favicon_entry.rs
@@ -28,7 +28,7 @@ pub async fn get_app_route_favicon_entry(
     nodejs_context: Vc<ModuleAssetContext>,
     edge_context: Vc<ModuleAssetContext>,
     favicon: MetadataItem,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
 ) -> Result<Vc<AppEntry>> {
     let path = match favicon {
         // TODO(alexkirsz) Is there a difference here?

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::next_app::{AppPage, PageSegment, PageType};
@@ -83,12 +82,12 @@ fn match_metadata_file<'a>(
     })
 }
 
-pub(crate) async fn get_content_type(path: Vc<FileSystemPath>) -> Result<String> {
-    let stem = &*path.file_stem().await?;
-    let ext = &*path.extension().await?;
+pub(crate) async fn get_content_type(path: FileSystemPath) -> Result<String> {
+    let stem = path.file_stem();
+    let ext = path.extension();
 
-    let name = stem.as_deref().unwrap_or_default();
-    let mut ext = ext.as_str();
+    let name = stem.unwrap_or_default();
+    let mut ext = &*ext;
     if ext == "jpg" {
         ext = "jpeg"
     }

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::resolve::{ExternalTraced, ExternalType, options::ImportMapping};
 
@@ -8,14 +8,15 @@ use crate::next_import_map::get_next_package;
 
 #[turbo_tasks::function]
 pub async fn get_postcss_package_mapping(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Vc<ImportMapping>> {
     Ok(ImportMapping::Alternatives(vec![
         // Prefer the local installed version over the next.js version
-        ImportMapping::PrimaryAlternative("postcss".into(), Some(project_path)).resolved_cell(),
+        ImportMapping::PrimaryAlternative("postcss".into(), Some(project_path.clone()))
+            .resolved_cell(),
         ImportMapping::PrimaryAlternative(
             "postcss".into(),
-            Some(get_next_package(*project_path).to_resolved().await?),
+            Some((*get_next_package(project_path).await?).clone()),
         )
         .resolved_cell(),
     ])

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -12,7 +12,7 @@ use turbopack_ecmascript::resolve::cjs_resolve;
 
 #[turbo_tasks::value(shared)]
 pub enum RuntimeEntry {
-    Request(ResolvedVc<Request>, ResolvedVc<FileSystemPath>),
+    Request(ResolvedVc<Request>, FileSystemPath),
     Evaluatable(ResolvedVc<Box<dyn EvaluatableAsset>>),
     Source(ResolvedVc<Box<dyn Source>>),
 }
@@ -24,8 +24,9 @@ impl RuntimeEntry {
         self: Vc<Self>,
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
-        let (request, path) = match *self.await? {
-            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(*e)),
+        let this = self.await?;
+        let (request, path) = match &*this {
+            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(**e)),
             RuntimeEntry::Source(source) => {
                 return Ok(EvaluatableAssets::one(source.to_evaluatable(asset_context)));
             }
@@ -33,8 +34,8 @@ impl RuntimeEntry {
         };
 
         let modules = cjs_resolve(
-            Vc::upcast(PlainResolveOrigin::new(asset_context, *path)),
-            *request,
+            Vc::upcast(PlainResolveOrigin::new(asset_context, path.clone())),
+            **request,
             None,
             false,
         )

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -53,12 +53,12 @@ pub async fn get_next_client_transforms_rules(
     let cache_kinds = next_config.cache_kinds().to_resolved().await?;
     let mut is_app_dir = false;
 
-    match context_ty {
+    match &context_ty {
         ClientContextType::Pages { pages_dir } => {
             if !foreign_code {
                 rules.push(
                     get_next_pages_transforms_rule(
-                        *pages_dir,
+                        pages_dir.clone(),
                         ExportFilter::StripDataExports,
                         enable_mdx_rs,
                     )
@@ -66,9 +66,9 @@ pub async fn get_next_client_transforms_rules(
                 );
                 rules.push(get_next_disallow_export_all_in_page_rule(
                     enable_mdx_rs,
-                    pages_dir.await?,
+                    pages_dir.clone(),
                 ));
-                rules.push(get_next_page_config_rule(enable_mdx_rs, pages_dir.await?));
+                rules.push(get_next_page_config_rule(enable_mdx_rs, pages_dir.clone()));
             }
         }
         ClientContextType::App { .. } => {

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -149,13 +149,18 @@ impl EcmascriptClientReferenceModule {
             AssetContent::file(File::from(code.source_code().clone()).into());
 
         let proxy_source = VirtualSource::new(
-            self.server_ident.path().join(
-                // Depending on the original format, we call the file `proxy.mjs` or `proxy.cjs`.
-                // This is because we're placing the virtual module next to the original code, so
-                // its parsing will be affected by `type` fields in package.json --
-                // a bare `proxy.js` may end up being unexpectedly parsed as the wrong format.
-                format!("proxy.{}", if is_esm { "mjs" } else { "cjs" }).into(),
-            ),
+            self.server_ident
+                .path()
+                .await?
+                .join(
+                    // Depending on the original format, we call the file `proxy.mjs` or
+                    // `proxy.cjs`. This is because we're placing the virtual
+                    // module next to the original code, so its parsing will be
+                    // affected by `type` fields in package.json --
+                    // a bare `proxy.js` may end up being unexpectedly parsed as the wrong format.
+                    &format!("proxy.{}", if is_esm { "mjs" } else { "cjs" }),
+                )?
+                .cell(),
             proxy_module_content,
         );
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -63,14 +63,13 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             None => source.ident(),
         };
         let ident_ref = ident.await?;
-        let ident_path = ident_ref.path.await?;
+        let ident_path = ident_ref.path.clone();
         let client_source = if ident_path.path.contains("next/dist/esm/") {
-            let path = ident_ref.path.root().join(
-                ident_path
-                    .path
-                    .replace("next/dist/esm/", "next/dist/")
-                    .into(),
-            );
+            let path = ident_ref
+                .path
+                .root()
+                .await?
+                .join(&ident_path.path.replace("next/dist/esm/", "next/dist/"))?;
             Vc::upcast(FileSource::new_with_query(path, *ident_ref.query))
         } else {
             source

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1630,7 +1630,7 @@ impl JsConfig {
 
 #[turbo_tasks::value]
 struct OutdatedConfigIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     old_name: RcStr,
     new_name: RcStr,
     description: RcStr,
@@ -1650,7 +1650,7 @@ impl Issue for OutdatedConfigIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -44,7 +44,7 @@ struct Fallback {
 
 #[turbo_tasks::function]
 pub(super) async fn get_font_fallback(
-    lookup_path: ResolvedVc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     options_vc: Vc<NextFontGoogleOptions>,
 ) -> Result<Vc<FontFallback>> {
     let options = options_vc.await?;
@@ -52,8 +52,8 @@ pub(super) async fn get_font_fallback(
         Some(fallback) => FontFallback::Manual(fallback.clone()).cell(),
         None => {
             let metrics_json = load_next_js_templateon(
-                lookup_path,
-                "dist/server/capsize-font-metrics.json".into(),
+                lookup_path.clone(),
+                "dist/server/capsize-font-metrics.json",
             )
             .await?;
             let fallback = lookup_fallback(
@@ -76,7 +76,7 @@ pub(super) async fn get_font_fallback(
                 .cell(),
                 Err(_) => {
                     NextFontIssue {
-                        path: lookup_path,
+                        path: lookup_path.clone(),
                         title: StyledString::Text(
                             format!(
                                 "Failed to find font override values for font `{}`",

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -74,13 +74,13 @@ struct FontData(FxIndexMap<RcStr, FontDataEntry>);
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontGoogleReplacer {
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontGoogleReplacer {
     #[turbo_tasks::function]
-    pub fn new(project_path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project_path: FileSystemPath) -> Vc<Self> {
         Self::cell(NextFontGoogleReplacer { project_path })
     }
 
@@ -91,14 +91,14 @@ impl NextFontGoogleReplacer {
 
         let query_vc = Vc::cell(query);
 
-        let font_data = load_font_data(*self.project_path);
+        let font_data = load_font_data(self.project_path.clone());
         let options = font_options_from_query_map(query_vc, font_data);
 
-        let fallback = get_font_fallback(*self.project_path, options);
+        let fallback = get_font_fallback(self.project_path.clone(), options);
         let properties = get_font_css_properties(options, fallback).await?;
         let js_asset = VirtualSource::new(
-            next_js_file_path("internal/font/google".into())
-                .join(format!("{}.js", get_request_id(options.font_family(), request_hash).await?).into()),
+            next_js_file_path("internal/font/google".into()).await?
+                .join(&format!("{}.js", get_request_id(options.font_family(), request_hash).await?))?.cell(),
             AssetContent::file(FileContent::Content(
                 formatdoc!(
                     r#"
@@ -154,7 +154,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
     #[turbo_tasks::function]
     async fn result(
         self: Vc<Self>,
-        _context: Vc<FileSystemPath>,
+        _context: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -169,7 +169,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
         };
 
         let this = &*self.await?;
-        if can_use_next_font(*this.project_path, **query).await? {
+        if can_use_next_font(this.project_path.clone(), **query).await? {
             Ok(self.import_map_result(query.await?.as_str().into()))
         } else {
             Ok(ImportMapResult::NoEntry.into())
@@ -179,7 +179,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
 
 #[turbo_tasks::value(shared)]
 pub struct NextFontGoogleCssModuleReplacer {
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: ResolvedVc<ExecutionContext>,
 }
 
@@ -187,7 +187,7 @@ pub struct NextFontGoogleCssModuleReplacer {
 impl NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: ResolvedVc<FileSystemPath>,
+        project_path: FileSystemPath,
         execution_context: ResolvedVc<ExecutionContext>,
     ) -> Vc<Self> {
         Self::cell(NextFontGoogleCssModuleReplacer {
@@ -200,18 +200,17 @@ impl NextFontGoogleCssModuleReplacer {
     async fn import_map_result(&self, query: RcStr) -> Result<Vc<ImportMapResult>> {
         let request_hash = get_request_hash(&query).await?;
         let query_vc = Vc::cell(query);
-        let font_data = load_font_data(*self.project_path);
+        let font_data = load_font_data(self.project_path.clone());
         let options = font_options_from_query_map(query_vc, font_data);
         let stylesheet_url = get_stylesheet_url_from_options(options, font_data);
         let scoped_font_family =
             get_scoped_font_family(FontFamilyType::WebFont.cell(), options.font_family());
-        let css_virtual_path = next_js_file_path("internal/font/google".into()).join(
-            format!(
+        let css_virtual_path = next_js_file_path("internal/font/google".into())
+            .await?
+            .join(&format!(
                 "/{}.module.css",
                 get_request_id(options.font_family(), request_hash).await?
-            )
-            .into(),
-        );
+            ))?;
 
         // When running Next.js integration tests, use the mock data available in
         // process.env.NEXT_FONT_GOOGLE_MOCKED_RESPONSES instead of making real
@@ -221,12 +220,12 @@ impl NextFontGoogleCssModuleReplacer {
         let stylesheet_str = mocked_responses_path
             .as_ref()
             .map_or_else(
-                || fetch_real_stylesheet(stylesheet_url, css_virtual_path).boxed(),
+                || fetch_real_stylesheet(stylesheet_url, css_virtual_path.clone()).boxed(),
                 |p| get_mock_stylesheet(stylesheet_url, p, *self.execution_context).boxed(),
             )
             .await?;
 
-        let font_fallback = get_font_fallback(*self.project_path, options);
+        let font_fallback = get_font_fallback(self.project_path.clone(), options);
 
         let stylesheet = match stylesheet_str {
             Some(s) => Some(
@@ -249,7 +248,7 @@ impl NextFontGoogleCssModuleReplacer {
         };
 
         let css_asset = VirtualSource::new(
-            css_virtual_path,
+            css_virtual_path.cell(),
             AssetContent::file(
                 FileContent::Content(
                     build_stylesheet(
@@ -284,7 +283,7 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
     async fn result(
         self: Vc<Self>,
-        _context: Vc<FileSystemPath>,
+        _context: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -311,13 +310,13 @@ struct NextFontGoogleFontFileOptions {
 
 #[turbo_tasks::value(shared)]
 pub struct NextFontGoogleFontFileReplacer {
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontGoogleFontFileReplacer {
     #[turbo_tasks::function]
-    pub fn new(project_path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project_path: FileSystemPath) -> Vc<Self> {
         Self::cell(NextFontGoogleFontFileReplacer { project_path })
     }
 }
@@ -335,7 +334,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
     #[turbo_tasks::function]
     async fn result(
         &self,
-        _context: Vc<FileSystemPath>,
+        _context: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -367,18 +366,20 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
             name.push_str(".p")
         }
 
-        let font_virtual_path =
-            next_js_file_path("internal/font/google".into()).join(format!("/{name}.{ext}").into());
+        let font_virtual_path = next_js_file_path("internal/font/google".into())
+            .await?
+            .join(&format!("/{name}.{ext}"))?;
 
         // doesn't seem ideal to download the font into a string, but probably doesn't
         // really matter either.
-        let Some(font) = fetch_from_google_fonts(Vc::cell(url.into()), font_virtual_path).await?
+        let Some(font) =
+            fetch_from_google_fonts(Vc::cell(url.into()), font_virtual_path.clone()).await?
         else {
             return Ok(ImportMapResult::Result(ResolveResult::unresolvable()).cell());
         };
 
         let font_source = VirtualSource::new(
-            font_virtual_path,
+            font_virtual_path.cell(),
             AssetContent::file(FileContent::Content(font.await?.0.as_slice().into()).cell()),
         )
         .to_resolved()
@@ -389,10 +390,10 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
 }
 
 #[turbo_tasks::function]
-async fn load_font_data(project_root: ResolvedVc<FileSystemPath>) -> Result<Vc<FontData>> {
+async fn load_font_data(project_root: FileSystemPath) -> Result<Vc<FontData>> {
     let data: FontData = load_next_js_templateon(
         project_root,
-        "dist/compiled/@next/font/dist/google/font-data.json".into(),
+        "dist/compiled/@next/font/dist/google/font-data.json",
     )
     .await?;
 
@@ -598,7 +599,7 @@ async fn font_file_options_from_query_map(
 
 async fn fetch_real_stylesheet(
     stylesheet_url: Vc<RcStr>,
-    css_virtual_path: Vc<FileSystemPath>,
+    css_virtual_path: FileSystemPath,
 ) -> Result<Option<Vc<RcStr>>> {
     let body = fetch_from_google_fonts(stylesheet_url, css_virtual_path).await?;
 
@@ -607,7 +608,7 @@ async fn fetch_real_stylesheet(
 
 async fn fetch_from_google_fonts(
     url: Vc<RcStr>,
-    virtual_path: Vc<FileSystemPath>,
+    virtual_path: FileSystemPath,
 ) -> Result<Option<Vc<HttpResponseBody>>> {
     let result = fetch(
         url,
@@ -626,7 +627,7 @@ async fn fetch_from_google_fonts(
             //
             // TODO(WEB-283): Use fallback in dev in this case
             // TODO(WEB-293): Fail production builds (not dev) in this case
-            err.to_issue(IssueSeverity::Warning.into(), virtual_path)
+            err.to_issue(IssueSeverity::Warning.into(), virtual_path.cell())
                 .to_resolved()
                 .await?
                 .emit();
@@ -660,11 +661,11 @@ async fn get_mock_stylesheet(
     } = *execution_context.await?;
     let asset_context =
         node_evaluate_asset_context(execution_context, None, None, "next_font".into(), false);
-    let loader_path = mock_fs.root().join("loader.js".into());
+    let loader_path = mock_fs.root().await?.join("loader.js")?;
     let mocked_response_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                loader_path,
+                loader_path.clone().cell(),
                 AssetContent::file(
                     File::from(format!(
                         "import data from './{}'; export default function load() {{ return data; \
@@ -683,10 +684,10 @@ async fn get_mock_stylesheet(
         )
         .module();
 
-    let root = mock_fs.root();
+    let root = (*mock_fs.root().await?).clone();
     let val = evaluate(
         mocked_response_asset,
-        root,
+        root.clone(),
         *env,
         AssetIdent::from_path(loader_path),
         asset_context,

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -4,7 +4,7 @@ use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontIssue {
-    pub(crate) path: ResolvedVc<FileSystemPath>,
+    pub(crate) path: FileSystemPath,
     pub(crate) title: ResolvedVc<StyledString>,
     pub(crate) description: ResolvedVc<StyledString>,
     pub(crate) severity: ResolvedVc<IssueSeverity>,
@@ -24,7 +24,7 @@ impl Issue for NextFontIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -33,7 +33,7 @@ static BOLD_WEIGHT: f64 = 700.0;
 
 #[turbo_tasks::function]
 pub(super) async fn get_font_fallbacks(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     options_vc: Vc<NextFontLocalOptions>,
 ) -> Result<Vc<FontFallbackResult>> {
     let options = &*options_vc.await?;
@@ -89,16 +89,13 @@ pub(super) async fn get_font_fallbacks(
 }
 
 async fn get_font_adjustment(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     options: Vc<NextFontLocalOptions>,
     fallback_font: &DefaultFallbackFont,
 ) -> Result<FontResult<FontAdjustment>> {
     let options = &*options.await?;
     let main_descriptor = pick_font_for_fallback_generation(&options.fonts)?;
-    let font_file = &*lookup_path
-        .join(main_descriptor.path.clone())
-        .read()
-        .await?;
+    let font_file = &*lookup_path.join(&main_descriptor.path)?.read().await?;
     let font_file_rope = match font_file {
         FileContent::NotFound => {
             return Ok(FontResult::FontFileNotFound(FontFileNotFound(

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -53,13 +53,13 @@ struct NextFontLocalFontFileOptions {
 
 #[turbo_tasks::value]
 pub(crate) struct NextFontLocalResolvePlugin {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: FileSystemPath) -> Vc<Self> {
         NextFontLocalResolvePlugin { root }.cell()
     }
 }
@@ -76,7 +76,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
     async fn before_resolve(
         self: Vc<Self>,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         _reference_type: Value<ReferenceType>,
         request_vc: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
@@ -99,7 +99,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
         match request_key.as_str() {
             "next/font/local/target.css" => {
-                if !can_use_next_font(*this.root, **query_vc).await? {
+                if !can_use_next_font(this.root.clone(), **query_vc).await? {
                     return Ok(ResolveResultOption::none());
                 }
 
@@ -108,8 +108,8 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let qstr = qstring::QString::from(query.as_str());
                 let options_vc = font_options_from_query_map(**query_vc);
 
-                let font_fallbacks = &*get_font_fallbacks(lookup_path, options_vc).await?;
-                let lookup_path = lookup_path.to_resolved().await?;
+                let font_fallbacks = &*get_font_fallbacks(lookup_path.clone(), options_vc).await?;
+                let lookup_path = lookup_path.clone();
                 let font_fallbacks = match font_fallbacks {
                     FontFallbackResult::FontFileNotFound(err) => {
                         FontResolvingIssue {
@@ -161,13 +161,12 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                         .unwrap_or_else(|| "".to_owned()),
                 );
                 let js_asset = VirtualSource::new(
-                    lookup_path.join(
-                        format!(
+                    lookup_path
+                        .join(&format!(
                             "{}.js",
                             get_request_id(options_vc.font_family(), request_hash).await?
-                        )
-                        .into(),
-                    ),
+                        ))?
+                        .cell(),
                     AssetContent::file(FileContent::Content(file_content.into()).into()),
                 )
                 .to_resolved()
@@ -181,18 +180,15 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let query = query_vc.await?.to_string();
                 let request_hash = get_request_hash(&query).await?;
                 let options = font_options_from_query_map(**query_vc);
-                let css_virtual_path = lookup_path.join(
-                    format!(
-                        "/{}.module.css",
-                        get_request_id(options.font_family(), request_hash).await?
-                    )
-                    .into(),
-                );
-                let fallback = &*get_font_fallbacks(lookup_path, options).await?;
+                let css_virtual_path = lookup_path.join(&format!(
+                    "/{}.module.css",
+                    get_request_id(options.font_family(), request_hash).await?
+                ))?;
+                let fallback = &*get_font_fallbacks(lookup_path.clone(), options).await?;
                 let fallback = match fallback {
                     FontFallbackResult::FontFileNotFound(err) => {
                         FontResolvingIssue {
-                            origin_path: lookup_path.to_resolved().await?,
+                            origin_path: lookup_path.clone(),
                             font_path: ResolvedVc::cell(err.0.clone()),
                         }
                         .resolved_cell()
@@ -213,7 +209,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 .await?;
 
                 let css_asset = VirtualSource::new(
-                    css_virtual_path,
+                    css_virtual_path.cell(),
                     AssetContent::file(FileContent::Content(stylesheet.into()).cell()),
                 )
                 .to_resolved()
@@ -242,12 +238,12 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                     name.push_str(".p")
                 }
 
-                let font_virtual_path = lookup_path.join(format!("/{name}.{ext}").into());
+                let font_virtual_path = lookup_path.join(&format!("/{name}.{ext}"))?;
 
-                let font_file = lookup_path.join(path.clone()).read();
+                let font_file = lookup_path.join(&path)?.read();
 
                 let font_source =
-                    VirtualSource::new(font_virtual_path, AssetContent::file(font_file))
+                    VirtualSource::new(font_virtual_path.cell(), AssetContent::file(font_file))
                         .to_resolved()
                         .await?;
 
@@ -328,7 +324,7 @@ async fn font_file_options_from_query_map(
 #[turbo_tasks::value(shared)]
 struct FontResolvingIssue {
     font_path: ResolvedVc<RcStr>,
-    origin_path: ResolvedVc<FileSystemPath>,
+    origin_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -340,7 +336,7 @@ impl Issue for FontResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.origin_path
+        self.origin_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -81,7 +81,7 @@ struct HasPath {
 }
 
 pub(crate) async fn can_use_next_font(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     query: Vc<RcStr>,
 ) -> Result<bool> {
     let query_map = qstring::QString::from(&**query.await?);
@@ -94,11 +94,11 @@ pub(crate) async fn can_use_next_font(
     )?;
 
     let document_re = lazy_regex::regex!("^(src/)?_document\\.[^/]+$");
-    let path = project_path.join(request.path.clone());
+    let path = project_path.join(&request.path)?;
     let can_use = !document_re.is_match(&request.path);
     if !can_use {
         NextFontIssue {
-            path: path.to_resolved().await?,
+            path,
             title: StyledString::Line(vec![
                 StyledString::Code("next/font:".into()),
                 StyledString::Text(" error:".into()),

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -90,7 +90,7 @@ const EDGE_UNSUPPORTED_NODE_INTERNALS: [&str; 44] = [
 /// Computes the Next-specific client import map.
 #[turbo_tasks::function]
 pub async fn get_next_client_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: Value<ClientContextType>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -99,24 +99,24 @@ pub async fn get_next_client_import_map(
 
     insert_next_shared_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         execution_context,
         next_config,
         false,
     )
     .await?;
 
-    insert_optimized_module_aliases(&mut import_map, project_path).await?;
+    insert_optimized_module_aliases(&mut import_map, project_path.clone()).await?;
 
     insert_alias_option(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         next_config.resolve_alias_options(),
         ["browser"],
     )
     .await?;
 
-    match ty.into_value() {
+    match ty.clone().into_value() {
         ClientContextType::Pages { .. } => {}
         ClientContextType::App { app_dir } => {
             let react_flavor = if *next_config.enable_ppr().await?
@@ -132,42 +132,42 @@ pub async fn get_next_client_import_map(
             import_map.insert_exact_alias(
                 "react",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react{react_flavor}"),
                 ),
             );
             import_map.insert_wildcard_alias(
                 "react/",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react{react_flavor}/*"),
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-dom{react_flavor}"),
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom/static",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     "next/dist/compiled/react-dom-experimental/static",
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom/static.edge",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     "next/dist/compiled/react-dom-experimental/static.edge",
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom/static.browser",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     "next/dist/compiled/react-dom-experimental/static.browser",
                 ),
             );
@@ -175,47 +175,50 @@ pub async fn get_next_client_import_map(
             import_map.insert_exact_alias(
                 "react-dom/client",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-dom{react_flavor}/{react_client_package}"),
                 ),
             );
             import_map.insert_wildcard_alias(
                 "react-dom/",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-dom{react_flavor}/*"),
                 ),
             );
             import_map.insert_wildcard_alias(
                 "react-server-dom-webpack/",
-                request_to_import_mapping(app_dir, "react-server-dom-turbopack/*"),
+                request_to_import_mapping(app_dir.clone(), "react-server-dom-turbopack/*"),
             );
             import_map.insert_wildcard_alias(
                 "react-server-dom-turbopack/",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-server-dom-turbopack{react_flavor}/*"),
                 ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/head",
-                request_to_import_mapping(project_path, "next/dist/client/components/noop-head"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    "next/dist/client/components/noop-head",
+                ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/dynamic",
-                request_to_import_mapping(project_path, "next/dist/shared/lib/app-dynamic"),
+                request_to_import_mapping(project_path.clone(), "next/dist/shared/lib/app-dynamic"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/link",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/link"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/link"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/form",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/form"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/form"),
             );
         }
         ClientContextType::Fallback => {}
@@ -225,7 +228,7 @@ pub async fn get_next_client_import_map(
     // see https://github.com/vercel/next.js/blob/8013ef7372fc545d49dbd060461224ceb563b454/packages/next/src/build/webpack-config.ts#L1449-L1531
     insert_exact_alias_map(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         fxindexmap! {
             "server-only" => "next/dist/compiled/server-only/index".to_string(),
             "client-only" => "next/dist/compiled/client-only/index".to_string(),
@@ -241,7 +244,7 @@ pub async fn get_next_client_import_map(
             for (original, alias) in NEXT_ALIASES {
                 import_map.insert_exact_alias(
                     format!("node:{original}"),
-                    request_to_import_mapping(project_path, alias),
+                    request_to_import_mapping(project_path.clone(), alias),
                 );
             }
         }
@@ -270,8 +273,10 @@ pub async fn get_next_client_fallback_import_map(
             app_dir: context_dir,
         } => {
             for (original, alias) in NEXT_ALIASES {
-                import_map
-                    .insert_exact_alias(original, request_to_import_mapping(context_dir, alias));
+                import_map.insert_exact_alias(
+                    original,
+                    request_to_import_mapping(context_dir.clone(), alias),
+                );
             }
         }
         ClientContextType::Fallback => {}
@@ -286,7 +291,7 @@ pub async fn get_next_client_fallback_import_map(
 /// Computes the Next-specific server-side import map.
 #[turbo_tasks::function]
 pub async fn get_next_server_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: Value<ServerContextType>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -295,7 +300,7 @@ pub async fn get_next_server_import_map(
 
     insert_next_shared_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         execution_context,
         next_config,
         false,
@@ -304,7 +309,7 @@ pub async fn get_next_server_import_map(
 
     insert_alias_option(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         next_config.resolve_alias_options(),
         [],
     )
@@ -345,22 +350,25 @@ pub async fn get_next_server_import_map(
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/head",
-                request_to_import_mapping(project_path, "next/dist/client/components/noop-head"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    "next/dist/client/components/noop-head",
+                ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/dynamic",
-                request_to_import_mapping(project_path, "next/dist/shared/lib/app-dynamic"),
+                request_to_import_mapping(project_path.clone(), "next/dist/shared/lib/app-dynamic"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/link",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/link"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/link"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/form",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/form"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/form"),
             );
         }
         ServerContextType::Middleware { .. } | ServerContextType::Instrumentation { .. } => {}
@@ -381,7 +389,7 @@ pub async fn get_next_server_import_map(
 /// Computes the Next-specific edge-side import map.
 #[turbo_tasks::function]
 pub async fn get_next_edge_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: Value<ServerContextType>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -393,7 +401,7 @@ pub async fn get_next_edge_import_map(
     // Alias next/dist imports to next/dist/esm assets
     insert_wildcard_alias_map(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         fxindexmap! {
             "next/dist/build/" => "next/dist/esm/build/*".to_string(),
             "next/dist/client/" => "next/dist/esm/client/*".to_string(),
@@ -408,7 +416,7 @@ pub async fn get_next_edge_import_map(
     // Alias the usage of next public APIs
     insert_exact_alias_map(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         fxindexmap! {
             "next/app" => "next/dist/api/app".to_string(),
             "next/document" => "next/dist/api/document".to_string(),
@@ -432,18 +440,18 @@ pub async fn get_next_edge_import_map(
 
     insert_next_shared_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         execution_context,
         next_config,
         true,
     )
     .await?;
 
-    insert_optimized_module_aliases(&mut import_map, project_path).await?;
+    insert_optimized_module_aliases(&mut import_map, project_path.clone()).await?;
 
     insert_alias_option(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         next_config.resolve_alias_options(),
         [],
     )
@@ -462,17 +470,20 @@ pub async fn get_next_edge_import_map(
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/head",
-                request_to_import_mapping(project_path, "next/dist/client/components/noop-head"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    "next/dist/client/components/noop-head",
+                ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/dynamic",
-                request_to_import_mapping(project_path, "next/dist/shared/lib/app-dynamic"),
+                request_to_import_mapping(project_path.clone(), "next/dist/shared/lib/app-dynamic"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/link",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/link"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/link"),
             );
         }
     }
@@ -480,7 +491,7 @@ pub async fn get_next_edge_import_map(
     insert_next_server_special_aliases(
         &mut import_map,
         project_path,
-        ty,
+        ty.clone(),
         NextRuntime::Edge,
         next_config,
     )
@@ -522,8 +533,8 @@ async fn insert_unsupported_node_internal_aliases(import_map: &mut ImportMap) ->
 }
 
 pub fn get_next_client_resolved_map(
-    _context: Vc<FileSystemPath>,
-    _root: ResolvedVc<FileSystemPath>,
+    _context: FileSystemPath,
+    _root: FileSystemPath,
     _mode: NextMode,
 ) -> Vc<ResolvedMap> {
     let glob_mappings = vec![];
@@ -561,32 +572,33 @@ static NEXT_ALIASES: [(&str, &str); 23] = [
 
 async fn insert_next_server_special_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
 ) -> Result<()> {
-    let external_cjs_if_node =
-        move |context_dir: ResolvedVc<FileSystemPath>, request: &str| match runtime {
-            NextRuntime::Edge => request_to_import_mapping(context_dir, request),
-            NextRuntime::NodeJs => external_request_to_cjs_import_mapping(context_dir, request),
-        };
-    let external_esm_if_node =
-        move |context_dir: ResolvedVc<FileSystemPath>, request: &str| match runtime {
-            NextRuntime::Edge => request_to_import_mapping(context_dir, request),
-            NextRuntime::NodeJs => external_request_to_esm_import_mapping(context_dir, request),
-        };
+    let external_cjs_if_node = move |context_dir: FileSystemPath, request: &str| match runtime {
+        NextRuntime::Edge => request_to_import_mapping(context_dir, request),
+        NextRuntime::NodeJs => external_request_to_cjs_import_mapping(context_dir, request),
+    };
+    let external_esm_if_node = move |context_dir: FileSystemPath, request: &str| match runtime {
+        NextRuntime::Edge => request_to_import_mapping(context_dir, request),
+        NextRuntime::NodeJs => external_request_to_esm_import_mapping(context_dir, request),
+    };
 
     import_map.insert_exact_alias(
         "next/dist/compiled/@vercel/og/index.node.js",
-        external_esm_if_node(project_path, "next/dist/compiled/@vercel/og/index.node.js"),
+        external_esm_if_node(
+            project_path.clone(),
+            "next/dist/compiled/@vercel/og/index.node.js",
+        ),
     );
 
     import_map.insert_exact_alias(
         "next/dist/server/ReactDOMServerPages",
         ImportMapping::Alternatives(vec![
-            request_to_import_mapping(project_path, "react-dom/server.edge"),
-            request_to_import_mapping(project_path, "react-dom/server.browser"),
+            request_to_import_mapping(project_path.clone(), "react-dom/server.edge"),
+            request_to_import_mapping(project_path.clone(), "react-dom/server.browser"),
         ])
         .resolved_cell(),
     );
@@ -595,33 +607,50 @@ async fn insert_next_server_special_aliases(
         "@opentelemetry/api",
         // It needs to prefer the local version of @opentelemetry/api
         ImportMapping::Alternatives(vec![
-            external_cjs_if_node(project_path, "@opentelemetry/api"),
-            external_cjs_if_node(project_path, "next/dist/compiled/@opentelemetry/api"),
+            external_cjs_if_node(project_path.clone(), "@opentelemetry/api"),
+            external_cjs_if_node(
+                project_path.clone(),
+                "next/dist/compiled/@opentelemetry/api",
+            ),
         ])
         .resolved_cell(),
     );
 
-    match ty {
+    match &ty {
         ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {}
         ServerContextType::PagesData { .. } => {}
         // the logic closely follows the one in createRSCAliases in webpack-config.ts
         ServerContextType::AppSSR { app_dir }
         | ServerContextType::AppRSC { app_dir, .. }
         | ServerContextType::AppRoute { app_dir, .. } => {
-            let next_package = get_next_package(*app_dir).to_resolved().await?;
+            let next_package = (*get_next_package(app_dir.clone()).await?).clone();
             import_map.insert_exact_alias(
                 "styled-jsx",
-                request_to_import_mapping(next_package, "styled-jsx"),
+                request_to_import_mapping(next_package.clone(), "styled-jsx"),
             );
             import_map.insert_wildcard_alias(
                 "styled-jsx/",
                 request_to_import_mapping(next_package, "styled-jsx/*"),
             );
 
-            rsc_aliases(import_map, project_path, ty, runtime, next_config).await?;
+            rsc_aliases(
+                import_map,
+                project_path.clone(),
+                ty.clone(),
+                runtime,
+                next_config,
+            )
+            .await?;
         }
         ServerContextType::Middleware { .. } | ServerContextType::Instrumentation { .. } => {
-            rsc_aliases(import_map, project_path, ty, runtime, next_config).await?;
+            rsc_aliases(
+                import_map,
+                project_path.clone(),
+                ty.clone(),
+                runtime,
+                next_config,
+            )
+            .await?;
         }
     }
 
@@ -634,7 +663,7 @@ async fn insert_next_server_special_aliases(
         ServerContextType::Pages { .. } => {
             insert_exact_alias_map(
                 import_map,
-                project_path,
+                project_path.clone(),
                 fxindexmap! {
                     "server-only" => "next/dist/compiled/server-only/empty".to_string(),
                     "client-only" => "next/dist/compiled/client-only/index".to_string(),
@@ -651,7 +680,7 @@ async fn insert_next_server_special_aliases(
         | ServerContextType::Instrumentation { .. } => {
             insert_exact_alias_map(
                 import_map,
-                project_path,
+                project_path.clone(),
                 fxindexmap! {
                     "server-only" => "next/dist/compiled/server-only/empty".to_string(),
                     "client-only" => "next/dist/compiled/client-only/error".to_string(),
@@ -663,7 +692,7 @@ async fn insert_next_server_special_aliases(
         ServerContextType::AppSSR { .. } => {
             insert_exact_alias_map(
                 import_map,
-                project_path,
+                project_path.clone(),
                 fxindexmap! {
                     "server-only" => "next/dist/compiled/server-only/index".to_string(),
                     "client-only" => "next/dist/compiled/client-only/index".to_string(),
@@ -676,7 +705,7 @@ async fn insert_next_server_special_aliases(
 
     import_map.insert_exact_alias(
         "@vercel/og",
-        external_cjs_if_node(project_path, "next/dist/server/og/image-response"),
+        external_cjs_if_node(project_path.clone(), "next/dist/server/og/image-response"),
     );
 
     Ok(())
@@ -695,7 +724,7 @@ async fn get_react_client_package(next_config: Vc<NextConfig>) -> Result<&'stati
 
 async fn rsc_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
@@ -818,7 +847,7 @@ pub fn mdx_import_source_file() -> RcStr {
 // Keep in sync with getOptimizedModuleAliases in webpack-config.ts
 async fn insert_optimized_module_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<()> {
     insert_exact_alias_map(
         import_map,
@@ -842,20 +871,20 @@ async fn insert_optimized_module_aliases(
 // Make sure to not add any external requests here.
 async fn insert_next_shared_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: Vc<ExecutionContext>,
     next_config: Vc<NextConfig>,
     is_runtime_edge: bool,
 ) -> Result<()> {
-    let package_root = next_js_fs().root().to_resolved().await?;
+    let package_root = (*next_js_fs().root().await?).clone();
 
     insert_alias_to_alternatives(
         import_map,
         mdx_import_source_file(),
         vec![
-            request_to_import_mapping(project_path, "./mdx-components"),
-            request_to_import_mapping(project_path, "./src/mdx-components"),
-            request_to_import_mapping(project_path, "@mdx-js/react"),
+            request_to_import_mapping(project_path.clone(), "./mdx-components"),
+            request_to_import_mapping(project_path.clone(), "./src/mdx-components"),
+            request_to_import_mapping(project_path.clone(), "@mdx-js/react"),
         ],
     );
 
@@ -871,7 +900,7 @@ async fn insert_next_shared_aliases(
     // TODO: Add BeforeResolve plugins for `@next/font/google`
 
     let next_font_google_replacer_mapping = ImportMapping::Dynamic(ResolvedVc::upcast(
-        NextFontGoogleReplacer::new(*project_path)
+        NextFontGoogleReplacer::new(project_path.clone())
             .to_resolved()
             .await?,
     ))
@@ -892,7 +921,7 @@ async fn insert_next_shared_aliases(
     import_map.insert_alias(
         AliasPattern::exact("@vercel/turbopack-next/internal/font/google/cssmodule.module.css"),
         ImportMapping::Dynamic(ResolvedVc::upcast(
-            NextFontGoogleCssModuleReplacer::new(*project_path, execution_context)
+            NextFontGoogleCssModuleReplacer::new(project_path.clone(), execution_context)
                 .to_resolved()
                 .await?,
         ))
@@ -902,23 +931,26 @@ async fn insert_next_shared_aliases(
     import_map.insert_alias(
         AliasPattern::exact(GOOGLE_FONTS_INTERNAL_PREFIX),
         ImportMapping::Dynamic(ResolvedVc::upcast(
-            NextFontGoogleFontFileReplacer::new(*project_path)
+            NextFontGoogleFontFileReplacer::new(project_path.clone())
                 .to_resolved()
                 .await?,
         ))
         .resolved_cell(),
     );
 
-    let next_package = get_next_package(*project_path).to_resolved().await?;
-    import_map.insert_singleton_alias("@swc/helpers", next_package);
-    import_map.insert_singleton_alias("styled-jsx", next_package);
-    import_map.insert_singleton_alias("next", project_path);
-    import_map.insert_singleton_alias("react", project_path);
-    import_map.insert_singleton_alias("react-dom", project_path);
+    let next_package = (*get_next_package(project_path.clone()).await?).clone();
+    import_map.insert_singleton_alias("@swc/helpers", next_package.clone());
+    import_map.insert_singleton_alias("styled-jsx", next_package.clone());
+    import_map.insert_singleton_alias("next", project_path.clone());
+    import_map.insert_singleton_alias("react", project_path.clone());
+    import_map.insert_singleton_alias("react-dom", project_path.clone());
     let react_client_package = get_react_client_package(next_config).await?;
     import_map.insert_exact_alias(
         "react-dom/client",
-        request_to_import_mapping(project_path, &format!("react-dom/{react_client_package}")),
+        request_to_import_mapping(
+            project_path.clone(),
+            &format!("react-dom/{react_client_package}"),
+        ),
     );
 
     import_map.insert_alias(
@@ -931,45 +963,48 @@ async fn insert_next_shared_aliases(
     //https://github.com/vercel/next.js/blob/f94d4f93e4802f951063cfa3351dd5a2325724b3/packages/next/src/build/webpack-config.ts#L1196
     import_map.insert_exact_alias(
         "setimmediate",
-        request_to_import_mapping(project_path, "next/dist/compiled/setimmediate"),
+        request_to_import_mapping(project_path.clone(), "next/dist/compiled/setimmediate"),
     );
 
     import_map.insert_exact_alias(
         "private-next-rsc-server-reference",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/server-reference",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-action-client-wrapper",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/action-client-wrapper",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-action-validate",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/action-validate",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-action-encryption",
-        request_to_import_mapping(project_path, "next/dist/server/app-render/encryption"),
+        request_to_import_mapping(
+            project_path.clone(),
+            "next/dist/server/app-render/encryption",
+        ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-cache-wrapper",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/cache-wrapper",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-track-dynamic-import",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/track-dynamic-import",
         ),
     );
@@ -978,23 +1013,20 @@ async fn insert_next_shared_aliases(
     insert_package_alias(
         import_map,
         "@vercel/turbopack-node/",
-        turbopack_node::embed_js::embed_fs()
-            .root()
-            .to_resolved()
-            .await?,
+        (*turbopack_node::embed_js::embed_fs().root().await?).clone(),
     );
 
     let image_config = next_config.image_config().await?;
     if let Some(loader_file) = image_config.loader_file.as_deref() {
         import_map.insert_exact_alias(
             "next/dist/shared/lib/image-loader",
-            request_to_import_mapping(project_path, loader_file),
+            request_to_import_mapping(project_path.clone(), loader_file),
         );
 
         if is_runtime_edge {
             import_map.insert_exact_alias(
                 "next/dist/esm/shared/lib/image-loader",
-                request_to_import_mapping(project_path, loader_file),
+                request_to_import_mapping(project_path.clone(), loader_file),
             );
         }
     }
@@ -1003,29 +1035,31 @@ async fn insert_next_shared_aliases(
 }
 
 #[turbo_tasks::function]
-pub async fn get_next_package(context_directory: Vc<FileSystemPath>) -> Result<Vc<FileSystemPath>> {
+pub async fn get_next_package(context_directory: FileSystemPath) -> Result<Vc<FileSystemPath>> {
     let result = resolve(
-        context_directory,
+        context_directory.clone(),
         Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
         Request::parse(Value::new(Pattern::Constant("next/package.json".into()))),
-        node_cjs_resolve_options(context_directory.root()),
+        node_cjs_resolve_options((*context_directory.root().await?).clone()),
     );
     let source = result
         .first_source()
         .await?
         .context("Next.js package not found")?;
-    Ok(source.ident().path().parent())
+    Ok(source.ident().path().await?.parent().cell())
 }
 
 pub async fn insert_alias_option<const N: usize>(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     alias_options: Vc<ResolveAliasMap>,
     conditions: [&'static str; N],
 ) -> Result<()> {
     let conditions = BTreeMap::from(conditions.map(|c| (c.into(), ConditionValue::Set)));
     for (alias, value) in &alias_options.await? {
-        if let Some(mapping) = export_value_to_import_mapping(value, &conditions, project_path) {
+        if let Some(mapping) =
+            export_value_to_import_mapping(value, &conditions, project_path.clone())
+        {
             import_map.insert_alias(alias, mapping);
         }
     }
@@ -1035,7 +1069,7 @@ pub async fn insert_alias_option<const N: usize>(
 fn export_value_to_import_mapping(
     value: &SubpathValue,
     conditions: &BTreeMap<RcStr, ConditionValue>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Option<ResolvedVc<ImportMapping>> {
     let mut result = Vec::new();
     value.add_results(
@@ -1048,14 +1082,14 @@ fn export_value_to_import_mapping(
         None
     } else {
         Some(if result.len() == 1 {
-            ImportMapping::PrimaryAlternative(result[0].0.into(), Some(project_path))
+            ImportMapping::PrimaryAlternative(result[0].0.into(), Some(project_path.clone()))
                 .resolved_cell()
         } else {
             ImportMapping::Alternatives(
                 result
                     .iter()
                     .map(|(m, _)| {
-                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path))
+                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path.clone()))
                             .resolved_cell()
                     })
                     .collect(),
@@ -1067,22 +1101,27 @@ fn export_value_to_import_mapping(
 
 fn insert_exact_alias_map(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
-        import_map.insert_exact_alias(pattern, request_to_import_mapping(project_path, &request));
+        import_map.insert_exact_alias(
+            pattern,
+            request_to_import_mapping(project_path.clone(), &request),
+        );
     }
 }
 
 fn insert_wildcard_alias_map(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
-        import_map
-            .insert_wildcard_alias(pattern, request_to_import_mapping(project_path, &request));
+        import_map.insert_wildcard_alias(
+            pattern,
+            request_to_import_mapping(project_path.clone(), &request),
+        );
     }
 }
 
@@ -1099,11 +1138,7 @@ fn insert_alias_to_alternatives<'a>(
 }
 
 /// Inserts an alias to an import mapping into an import map.
-fn insert_package_alias(
-    import_map: &mut ImportMap,
-    prefix: &str,
-    package_root: ResolvedVc<FileSystemPath>,
-) {
+fn insert_package_alias(import_map: &mut ImportMap, prefix: &str, package_root: FileSystemPath) {
     import_map.insert_wildcard_alias(
         prefix,
         ImportMapping::PrimaryAlternative("./*".into(), Some(package_root)).resolved_cell(),
@@ -1115,10 +1150,7 @@ async fn insert_turbopack_dev_alias(import_map: &mut ImportMap) -> Result<()> {
     insert_package_alias(
         import_map,
         "@vercel/turbopack-ecmascript-runtime/",
-        turbopack_ecmascript_runtime::embed_fs()
-            .root()
-            .to_resolved()
-            .await?,
+        (*turbopack_ecmascript_runtime::embed_fs().root().await?).clone(),
     );
     Ok(())
 }
@@ -1126,16 +1158,16 @@ async fn insert_turbopack_dev_alias(import_map: &mut ImportMap) -> Result<()> {
 /// Handles instrumentation-client.ts bundling logic
 async fn insert_instrumentation_client_alias(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<()> {
     insert_alias_to_alternatives(
         import_map,
         "private-next-instrumentation-client",
         vec![
-            request_to_import_mapping(project_path, "./src/instrumentation-client"),
-            request_to_import_mapping(project_path, "./src/instrumentation-client.ts"),
-            request_to_import_mapping(project_path, "./instrumentation-client"),
-            request_to_import_mapping(project_path, "./instrumentation-client.ts"),
+            request_to_import_mapping(project_path.clone(), "./src/instrumentation-client"),
+            request_to_import_mapping(project_path.clone(), "./src/instrumentation-client.ts"),
+            request_to_import_mapping(project_path.clone(), "./instrumentation-client"),
+            request_to_import_mapping(project_path.clone(), "./instrumentation-client.ts"),
             ImportMapping::Ignore.resolved_cell(),
         ],
     );
@@ -1156,7 +1188,7 @@ fn insert_exact_alias_or_js(
 /// Creates a direct import mapping to the result of resolving a request
 /// in a context.
 fn request_to_import_mapping(
-    context_path: ResolvedVc<FileSystemPath>,
+    context_path: FileSystemPath,
     request: &str,
 ) -> ResolvedVc<ImportMapping> {
     ImportMapping::PrimaryAlternative(request.into(), Some(context_path)).resolved_cell()
@@ -1165,7 +1197,7 @@ fn request_to_import_mapping(
 /// Creates a direct import mapping to the result of resolving an external
 /// request.
 fn external_request_to_cjs_import_mapping(
-    context_dir: ResolvedVc<FileSystemPath>,
+    context_dir: FileSystemPath,
     request: &str,
 ) -> ResolvedVc<ImportMapping> {
     ImportMapping::PrimaryAlternativeExternal {
@@ -1180,7 +1212,7 @@ fn external_request_to_cjs_import_mapping(
 /// Creates a direct import mapping to the result of resolving an external
 /// request.
 fn external_request_to_esm_import_mapping(
-    context_dir: ResolvedVc<FileSystemPath>,
+    context_dir: FileSystemPath,
     request: &str,
 ) -> ResolvedVc<ImportMapping> {
     ImportMapping::PrimaryAlternativeExternal {

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -35,10 +35,10 @@ pub struct BuildManifest {
 impl BuildManifest {
     pub async fn build_output(
         self,
-        output_path: Vc<FileSystemPath>,
-        client_relative_path: Vc<FileSystemPath>,
+        output_path: FileSystemPath,
+        client_relative_path: FileSystemPath,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let client_relative_path_ref = &*client_relative_path.await?;
+        let client_relative_path_ref = client_relative_path.clone();
 
         #[derive(Serialize, Default, Debug)]
         #[serde(rename_all = "camelCase")]
@@ -55,23 +55,34 @@ impl BuildManifest {
         let pages: Vec<(RcStr, Vec<RcStr>)> = self
             .pages
             .iter()
-            .map(|(k, chunks)| async move {
-                Ok((
-                    k.clone(),
-                    chunks
-                        .await?
-                        .iter()
-                        .copied()
-                        .map(|chunk| async move {
-                            let chunk_path = chunk.path().await?;
-                            Ok(client_relative_path_ref
-                                .get_path_to(&chunk_path)
-                                .context("client chunk entry path must be inside the client root")?
-                                .into())
-                        })
-                        .try_join()
-                        .await?,
-                ))
+            .map(|(k, chunks)| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    Ok((
+                        k.clone(),
+                        chunks
+                            .await?
+                            .iter()
+                            .copied()
+                            .map(|chunk| {
+                                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                                async move {
+                                    let chunk_path = chunk.path().await?;
+                                    Ok(client_relative_path_ref
+                                        .get_path_to(&chunk_path)
+                                        .context(
+                                            "client chunk entry path must be inside the client \
+                                             root",
+                                        )?
+                                        .into())
+                                }
+                            })
+                            .try_join()
+                            .await?,
+                    ))
+                }
             })
             .try_join()
             .await?;
@@ -80,12 +91,16 @@ impl BuildManifest {
             .polyfill_files
             .iter()
             .copied()
-            .map(|chunk| async move {
-                let chunk_path = chunk.path().await?;
-                Ok(client_relative_path_ref
-                    .get_path_to(&chunk_path)
-                    .context("failed to resolve client-relative path to polyfill")?
-                    .into())
+            .map(|chunk| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    let chunk_path = chunk.path().await?;
+                    Ok(client_relative_path_ref
+                        .get_path_to(&chunk_path)
+                        .context("failed to resolve client-relative path to polyfill")?
+                        .into())
+                }
             })
             .try_join()
             .await?;
@@ -94,12 +109,16 @@ impl BuildManifest {
             .root_main_files
             .iter()
             .copied()
-            .map(|chunk| async move {
-                let chunk_path = chunk.path().await?;
-                Ok(client_relative_path_ref
-                    .get_path_to(&chunk_path)
-                    .context("failed to resolve client-relative path to root_main_file")?
-                    .into())
+            .map(|chunk| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    let chunk_path = chunk.path().await?;
+                    Ok(client_relative_path_ref
+                        .get_path_to(&chunk_path)
+                        .context("failed to resolve client-relative path to root_main_file")?
+                        .into())
+                }
             })
             .try_join()
             .await?;
@@ -421,10 +440,10 @@ pub struct AppBuildManifest {
 impl AppBuildManifest {
     pub async fn build_output(
         self,
-        output_path: Vc<FileSystemPath>,
-        client_relative_path: Vc<FileSystemPath>,
+        output_path: FileSystemPath,
+        client_relative_path: FileSystemPath,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let client_relative_path_ref = &*client_relative_path.await?;
+        let client_relative_path_ref = client_relative_path.clone();
 
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -435,23 +454,34 @@ impl AppBuildManifest {
         let pages: Vec<(RcStr, Vec<RcStr>)> = self
             .pages
             .iter()
-            .map(|(k, chunks)| async move {
-                Ok((
-                    k.clone(),
-                    chunks
-                        .await?
-                        .iter()
-                        .copied()
-                        .map(|chunk| async move {
-                            let chunk_path = chunk.path().await?;
-                            Ok(client_relative_path_ref
-                                .get_path_to(&chunk_path)
-                                .context("client chunk entry path must be inside the client root")?
-                                .into())
-                        })
-                        .try_join()
-                        .await?,
-                ))
+            .map(|(k, chunks)| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    Ok((
+                        k.clone(),
+                        chunks
+                            .await?
+                            .iter()
+                            .copied()
+                            .map(|chunk| {
+                                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                                async move {
+                                    let chunk_path = chunk.path().await?;
+                                    Ok(client_relative_path_ref
+                                        .get_path_to(&chunk_path)
+                                        .context(
+                                            "client chunk entry path must be inside the client \
+                                             root",
+                                        )?
+                                        .into())
+                                }
+                            })
+                            .try_join()
+                            .await?,
+                    ))
+                }
             })
             .try_join()
             .await?;

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -34,7 +34,7 @@ pub struct PageSsrEntryModule {
 pub async fn create_page_ssr_entry_module(
     pathname: Vc<RcStr>,
     reference_type: Value<ReferenceType>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     ssr_module_context: Vc<Box<dyn AssetContext>>,
     source: Vc<Box<dyn Source>>,
     next_original_name: Vc<RcStr>,
@@ -88,7 +88,7 @@ pub async fn create_page_ssr_entry_module(
     // Load the file from the next.js codebase.
     let mut source = load_next_js_template(
         template_file,
-        project_root,
+        project_root.clone(),
         replacements,
         FxIndexMap::default(),
         FxIndexMap::default(),
@@ -159,7 +159,7 @@ pub async fn create_page_ssr_entry_module(
         if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page) {
             ssr_module = wrap_edge_page(
                 ssr_module_context,
-                project_root,
+                project_root.clone(),
                 ssr_module,
                 definition_page.clone(),
                 definition_pathname.clone(),
@@ -170,7 +170,7 @@ pub async fn create_page_ssr_entry_module(
         } else {
             ssr_module = wrap_edge_entry(
                 ssr_module_context,
-                project_root,
+                project_root.clone(),
                 ssr_module,
                 definition_pathname.clone(),
             );
@@ -186,19 +186,19 @@ pub async fn create_page_ssr_entry_module(
 }
 
 #[turbo_tasks::function]
-fn process_global_item(
+async fn process_global_item(
     item: Vc<PagesStructureItem>,
     reference_type: Value<ReferenceType>,
     module_context: Vc<Box<dyn AssetContext>>,
-) -> Vc<Box<dyn Module>> {
-    let source = Vc::upcast(FileSource::new(item.file_path()));
-    module_context.process(source, reference_type).module()
+) -> Result<Vc<Box<dyn Module>>> {
+    let source = Vc::upcast(FileSource::new((*item.file_path().await?).clone()));
+    Ok(module_context.process(source, reference_type).module())
 }
 
 #[turbo_tasks::function]
 async fn wrap_edge_page(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     page: RcStr,
     pathname: RcStr,
@@ -228,7 +228,7 @@ async fn wrap_edge_page(
 
     let source = load_next_js_template(
         "edge-ssr.js",
-        project_root,
+        project_root.clone(),
         fxindexmap! {
             "VAR_USERLAND" => INNER.into(),
             "VAR_PAGE" => pathname.clone(),

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -86,7 +86,7 @@ pub async fn get_next_server_transforms_rules(
     if !foreign_code {
         rules.push(get_next_page_static_info_assert_rule(
             mdx_rs,
-            Some(context_ty),
+            Some(context_ty.clone()),
             None,
         ));
     }
@@ -95,12 +95,12 @@ pub async fn get_next_server_transforms_rules(
     let cache_kinds = next_config.cache_kinds().to_resolved().await?;
     let mut is_app_dir = false;
 
-    let is_server_components = match context_ty {
+    let is_server_components = match &context_ty {
         ServerContextType::Pages { pages_dir } | ServerContextType::PagesApi { pages_dir } => {
             if !foreign_code {
                 rules.push(get_next_disallow_export_all_in_page_rule(
                     mdx_rs,
-                    pages_dir.await?,
+                    pages_dir.clone(),
                 ));
             }
             false
@@ -109,7 +109,7 @@ pub async fn get_next_server_transforms_rules(
             if !foreign_code {
                 rules.push(
                     get_next_pages_transforms_rule(
-                        *pages_dir,
+                        pages_dir.clone(),
                         ExportFilter::StripDefaultExport,
                         mdx_rs,
                     )
@@ -117,7 +117,7 @@ pub async fn get_next_server_transforms_rules(
                 );
                 rules.push(get_next_disallow_export_all_in_page_rule(
                     mdx_rs,
-                    pages_dir.await?,
+                    pages_dir.clone(),
                 ));
             }
             false

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -33,7 +33,7 @@ pub use next_lint::get_next_lint_transform_rule;
 pub use next_strip_page_exports::get_next_pages_transforms_rule;
 pub use next_track_dynamic_imports::get_next_track_dynamic_imports_transform_rule;
 pub use server_actions::get_server_actions_transform_rule;
-use turbo_tasks::{ReadRef, ResolvedVc, Value};
+use turbo_tasks::{ResolvedVc, Value};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
 use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};
@@ -121,7 +121,7 @@ pub(crate) fn module_rule_match_js_no_url(enable_mdx_rs: bool) -> RuleCondition 
 
 pub(crate) fn module_rule_match_pages_page_file(
     enable_mdx_rs: bool,
-    pages_directory: ReadRef<FileSystemPath>,
+    pages_directory: FileSystemPath,
 ) -> RuleCondition {
     let conditions = match_js_extension(enable_mdx_rs);
 

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::disallow_re_export_all_in_page::disallow_re_export_all_in_page;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, ResolvedVc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -11,7 +11,7 @@ use super::module_rule_match_pages_page_file;
 
 pub fn get_next_disallow_export_all_in_page_rule(
     enable_mdx_rs: bool,
-    pages_dir: ReadRef<FileSystemPath>,
+    pages_dir: FileSystemPath,
 ) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
         NextDisallowReExportAllInPage,

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -2,17 +2,14 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::page_config::page_config;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, ResolvedVc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
 
 use super::module_rule_match_pages_page_file;
 
-pub fn get_next_page_config_rule(
-    enable_mdx_rs: bool,
-    pages_dir: ReadRef<FileSystemPath>,
-) -> ModuleRule {
+pub fn get_next_page_config_rule(enable_mdx_rs: bool, pages_dir: FileSystemPath) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextPageConfig {
         // [TODO]: update once turbopack build works
         is_development: true,

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -81,7 +81,7 @@ impl CustomTransformer for NextPageStaticInfo {
             if is_server_layer_page {
                 for warning in collected_exports.warnings.iter() {
                     PageStaticInfoIssue {
-                        file_path: ctx.file_path,
+                        file_path: ctx.file_path.clone(),
                         messages: vec![
                             format!(
                                 "Next.js can't recognize the exported `{}` field in \"{}\" as {}.",
@@ -116,7 +116,7 @@ impl CustomTransformer for NextPageStaticInfo {
                     messages.push("Visit https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config for more information.".to_string());
 
                     PageStaticInfoIssue {
-                        file_path: ctx.file_path,
+                        file_path: ctx.file_path.clone(),
                         messages,
                         severity: IssueSeverity::Warning,
                     }
@@ -130,7 +130,7 @@ impl CustomTransformer for NextPageStaticInfo {
                 && is_app_page
             {
                 PageStaticInfoIssue {
-                    file_path: ctx.file_path,
+                    file_path: ctx.file_path.clone(),
                     messages: vec![format!(r#"Page "{}" cannot use both "use client" and export function "generateStaticParams()"."#, ctx.file_path_str)],
                     severity: IssueSeverity::Error,
                 }
@@ -145,7 +145,7 @@ impl CustomTransformer for NextPageStaticInfo {
 
 #[turbo_tasks::value(shared)]
 pub struct PageStaticInfoIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub messages: Vec<String>,
     pub severity: IssueSeverity,
 }
@@ -169,7 +169,7 @@ impl Issue for PageStaticInfoIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -5,7 +5,7 @@ use swc_core::{
     common::FileName,
     ecma::{ast::Program, visit::VisitWith},
 };
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -31,7 +31,7 @@ use crate::next_config::NextConfig;
 pub async fn get_next_react_server_components_transform_rule(
     next_config: Vc<NextConfig>,
     is_react_server_layer: bool,
-    app_dir: Option<ResolvedVc<FileSystemPath>>,
+    app_dir: Option<FileSystemPath>,
 ) -> Result<ModuleRule> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
@@ -53,7 +53,7 @@ struct NextJsReactServerComponents {
     is_react_server_layer: bool,
     dynamic_io_enabled: bool,
     use_cache_enabled: bool,
-    app_dir: Option<ResolvedVc<FileSystemPath>>,
+    app_dir: Option<FileSystemPath>,
 }
 
 impl NextJsReactServerComponents {
@@ -61,7 +61,7 @@ impl NextJsReactServerComponents {
         is_react_server_layer: bool,
         dynamic_io_enabled: bool,
         use_cache_enabled: bool,
-        app_dir: Option<ResolvedVc<FileSystemPath>>,
+        app_dir: Option<FileSystemPath>,
     ) -> Self {
         Self {
             is_react_server_layer,
@@ -89,10 +89,7 @@ impl CustomTransformer for NextJsReactServerComponents {
                 dynamic_io_enabled: self.dynamic_io_enabled,
                 use_cache_enabled: self.use_cache_enabled,
             }),
-            match self.app_dir {
-                None => None,
-                Some(path) => Some(path.await?.path.clone().into()),
-            },
+            self.app_dir.as_ref().map(|path| path.path.clone().into()),
         );
 
         program.visit_with(&mut visitor);

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -4,7 +4,7 @@ use next_custom_transforms::transforms::strip_page_exports::{
     ExportFilter, next_transform_strip_page_exports,
 };
 use swc_core::ecma::ast::Program;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -13,7 +13,7 @@ use super::module_rule_match_js_no_url;
 
 /// Returns a rule which applies the Next.js page export stripping transform.
 pub async fn get_next_pages_transforms_rule(
-    pages_dir: Vc<FileSystemPath>,
+    pages_dir: FileSystemPath,
     export_filter: ExportFilter,
     enable_mdx_rs: bool,
 ) -> Result<ModuleRule> {
@@ -25,20 +25,16 @@ pub async fn get_next_pages_transforms_rule(
     Ok(ModuleRule::new(
         RuleCondition::all(vec![
             RuleCondition::all(vec![
-                RuleCondition::ResourcePathInExactDirectory(pages_dir.await?),
+                RuleCondition::ResourcePathInExactDirectory(pages_dir.clone()),
                 RuleCondition::not(RuleCondition::ResourcePathInExactDirectory(
-                    pages_dir.join("api".into()).await?,
+                    pages_dir.join("api")?,
                 )),
                 RuleCondition::not(RuleCondition::any(vec![
                     // TODO(alexkirsz): Possibly ignore _app as well?
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.js".into()).await?),
-                    RuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.jsx".into()).await?,
-                    ),
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.ts".into()).await?),
-                    RuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.tsx".into()).await?,
-                    ),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.js")?),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.jsx")?),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.ts")?),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.tsx")?),
                 ])),
             ]),
             module_rule_match_js_no_url(enable_mdx_rs),

--- a/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/crates/next-core/src/next_shared/transforms/relay.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript_plugins::transform::relay::RelayTransformer;
@@ -10,13 +10,12 @@ use crate::next_config::NextConfig;
 /// Returns a transform rule for the relay graphql transform.
 pub async fn get_relay_transform_rule(
     next_config: Vc<NextConfig>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Option<ModuleRule>> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
-    let project_path = &*project_path.await?;
     let module_rule = next_config.compiler().await?.relay.as_ref().map(|config| {
         get_ecma_transform_rule(
-            Box::new(RelayTransformer::new(config, project_path)),
+            Box::new(RelayTransformer::new(config, &project_path)),
             enable_mdx_rs,
             true,
         )

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 #[allow(unused_imports)]
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 
@@ -9,7 +9,7 @@ use crate::next_config::NextConfig;
 
 pub async fn get_swc_ecma_transform_plugin_rule(
     next_config: Vc<NextConfig>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Option<ModuleRule>> {
     let plugin_configs = next_config.experimental_swc_plugins().await?;
     if !plugin_configs.is_empty() {
@@ -31,7 +31,7 @@ pub async fn get_swc_ecma_transform_plugin_rule(
 
 #[cfg(feature = "plugin")]
 pub async fn get_swc_ecma_transform_rule_impl(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     plugin_configs: &[(RcStr, serde_json::Value)],
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {
@@ -52,58 +52,63 @@ pub async fn get_swc_ecma_transform_rule_impl(
 
     let plugins = plugin_configs
         .iter()
-        .map(|(name, config)| async move {
-            // [TODO]: SWC's current experimental config supports
-            // two forms of plugin path,
-            // one for implicit package name resolves to node_modules,
-            // and one for explicit path to a .wasm binary.
-            // Current resolve will fail with latter.
-            let request = Request::parse(Value::new(Pattern::Constant(name.as_str().into())));
-            let resolve_options = resolve_options(
-                *project_path,
-                ResolveOptionsContext {
-                    enable_node_modules: Some(project_path.root().to_resolved().await?),
-                    enable_node_native_modules: true,
-                    ..Default::default()
-                }
-                .cell(),
-            );
+        .map(|(name, config)| {
+            let project_path = project_path.clone();
 
-            let plugin_wasm_module_resolve_result = handle_resolve_error(
-                resolve(
-                    *project_path,
+            async move {
+                // [TODO]: SWC's current experimental config supports
+                // two forms of plugin path,
+                // one for implicit package name resolves to node_modules,
+                // and one for explicit path to a .wasm binary.
+                // Current resolve will fail with latter.
+                let request = Request::parse(Value::new(Pattern::Constant(name.as_str().into())));
+                let resolve_options = resolve_options(
+                    project_path.clone(),
+                    ResolveOptionsContext {
+                        enable_node_modules: Some((*project_path.root().await?).clone()),
+                        enable_node_native_modules: true,
+                        ..Default::default()
+                    }
+                    .cell(),
+                );
+
+                let plugin_wasm_module_resolve_result = handle_resolve_error(
+                    resolve(
+                        project_path.clone(),
+                        Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                        request,
+                        resolve_options,
+                    )
+                    .as_raw_module_result(),
                     Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                    // TODO proper error location
+                    project_path.clone(),
                     request,
                     resolve_options,
+                    false,
+                    // TODO proper error location
+                    None,
                 )
-                .as_raw_module_result(),
-                Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-                // TODO proper error location
-                *project_path,
-                request,
-                resolve_options,
-                false,
-                // TODO proper error location
-                None,
-            )
-            .await?;
+                .await?;
 
-            let Some(plugin_module) = &*plugin_wasm_module_resolve_result.first_module().await?
-            else {
-                // Ignore unresolveable plugin modules, handle_resolve_error has already emitted an
-                // issue.
-                return Ok(None);
-            };
+                let Some(plugin_module) =
+                    &*plugin_wasm_module_resolve_result.first_module().await?
+                else {
+                    // Ignore unresolveable plugin modules, handle_resolve_error has already emitted
+                    // an issue.
+                    return Ok(None);
+                };
 
-            let content = &*plugin_module.content().file_content().await?;
-            let FileContent::Content(file) = content else {
-                bail!("Expected file content for plugin module");
-            };
+                let content = &*plugin_module.content().file_content().await?;
+                let FileContent::Content(file) = content else {
+                    bail!("Expected file content for plugin module");
+                };
 
-            Ok(Some((
-                SwcPluginModule::new(name, file.content().to_bytes()?.to_vec()).resolved_cell(),
-                config.clone(),
-            )))
+                Ok(Some((
+                    SwcPluginModule::new(name, file.content().to_bytes()?.to_vec()).resolved_cell(),
+                    config.clone(),
+                )))
+            }
         })
         .try_flat_join()
         .await?;

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod babel;
 pub(crate) mod sass;
 
 pub async fn webpack_loader_options(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     next_config: Vc<NextConfig>,
     foreign: bool,
     condition_strs: Vec<RcStr>,
@@ -22,7 +22,7 @@ pub async fn webpack_loader_options(
     let rules = if foreign {
         rules
     } else {
-        *maybe_add_babel_loader(*project_path, rules.map(|v| *v)).await?
+        *maybe_add_babel_loader(project_path.clone(), rules.map(|v| *v)).await?
     };
 
     let conditions = next_config.webpack_conditions().to_resolved().await?;

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -2,7 +2,7 @@ use std::{env, sync::MutexGuard};
 
 use anyhow::{Context, Result, anyhow};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
 use crate::{EnvMap, GLOBAL_ENV_LOCK, ProcessEnv, sorted_env_vars};
@@ -13,16 +13,13 @@ use crate::{EnvMap, GLOBAL_ENV_LOCK, ProcessEnv, sorted_env_vars};
 #[turbo_tasks::value]
 pub struct DotenvProcessEnv {
     prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl DotenvProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(
-        prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>,
-        path: ResolvedVc<FileSystemPath>,
-    ) -> Vc<Self> {
+    pub fn new(prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>, path: FileSystemPath) -> Vc<Self> {
         DotenvProcessEnv { prior, path }.cell()
     }
 
@@ -65,7 +62,7 @@ impl DotenvProcessEnv {
             if let Err(e) = res {
                 return Err(e).context(anyhow!(
                     "unable to read {} for env vars",
-                    this.path.to_string().await?
+                    this.path.value_to_string().await?
                 ));
             }
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -26,7 +26,7 @@ pub async fn content_from_relative_path(
     );
     disk_fs.await?.start_watching(None).await?;
 
-    let fs_path = disk_fs.root().join(path.into());
+    let fs_path = disk_fs.root().await?.join(path)?;
     Ok(fs_path.read())
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -25,8 +25,8 @@ impl EmbeddedFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for EmbeddedFileSystem {
     #[turbo_tasks::function]
-    async fn read(&self, path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
-        let file = match self.dir.get_file(&path.await?.path) {
+    fn read(&self, path: FileSystemPath) -> Result<Vc<FileContent>> {
+        let file = match self.dir.get_file(&path.path) {
             Some(file) => file,
             None => return Ok(FileContent::NotFound.cell()),
         };
@@ -35,13 +35,13 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _path: Vc<FileSystemPath>) -> Vc<LinkContent> {
+    fn read_link(&self, _path: FileSystemPath) -> Vc<LinkContent> {
         LinkContent::NotFound.cell()
     }
 
     #[turbo_tasks::function]
-    async fn raw_read_dir(&self, path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
-        let path_str = &path.await?.path;
+    async fn raw_read_dir(&self, path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
+        let path_str = &path.path;
         let dir = match (path_str.as_str(), self.dir.get_dir(path_str)) {
             ("", _) => self.dir,
             (_, Some(dir)) => dir,
@@ -70,18 +70,18 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 
     #[turbo_tasks::function]
-    async fn metadata(&self, path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
-        if self.dir.get_entry(&path.await?.path).is_none() {
+    async fn metadata(&self, path: FileSystemPath) -> Result<Vc<FileMeta>> {
+        if self.dir.get_entry(&path.path).is_none() {
             bail!("path not found, can't read metadata");
         }
 

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use turbo_tasks::Vc;
 
 use crate::{DiskFileSystem, FileSystemPath};
 
@@ -138,10 +137,11 @@ pub fn extract_disk_access<T>(value: io::Result<T>, path: &Path) -> Result<Optio
 }
 
 #[cfg(not(target_os = "windows"))]
-pub async fn uri_from_file(root: Vc<FileSystemPath>, path: Option<&str>) -> Result<String> {
-    let root_fs = root.fs();
-    let root_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(root_fs)
-        .await?
+pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
+    use turbo_tasks::ResolvedVc;
+
+    let root_fs = root.fs;
+    let root_fs = ResolvedVc::try_downcast_type::<DiskFileSystem>(root_fs)
         .context("Expected root to have a DiskFileSystem")?
         .await?;
 
@@ -150,7 +150,7 @@ pub async fn uri_from_file(root: Vc<FileSystemPath>, path: Option<&str>) -> Resu
         &sys_to_unix(
             &root_fs
                 .to_sys_path(match path {
-                    Some(path) => root.join(path.into()),
+                    Some(path) => root.join(path)?,
                     None => root,
                 })
                 .await?
@@ -164,7 +164,7 @@ pub async fn uri_from_file(root: Vc<FileSystemPath>, path: Option<&str>) -> Resu
 }
 
 #[cfg(target_os = "windows")]
-pub async fn uri_from_file(root: Vc<FileSystemPath>, path: Option<&str>) -> Result<String> {
+pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
     let root_fs = root.fs();
     let root_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(root_fs)
         .await?

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -15,9 +15,9 @@ impl VirtualFileSystem {
     ///
     /// NOTE: This function is not a `turbo_tasks::function` to avoid instances
     /// being equivalent identity-wise. This ensures that a
-    /// [`Vc<FileSystemPath>`] created from this [`Vc<VirtualFileSystem>`]
+    /// [`FileSystemPath`] created from this [`Vc<VirtualFileSystem>`]
     /// will never be equivalent, nor be interoperable, with a
-    /// [`Vc<FileSystemPath>`] created from another
+    /// [`FileSystemPath`] created from another
     /// [`Vc<VirtualFileSystem>`].
     pub fn new() -> Vc<Self> {
         Self::cell(VirtualFileSystem {
@@ -29,9 +29,9 @@ impl VirtualFileSystem {
     ///
     /// NOTE: This function is not a `turbo_tasks::function` to avoid instances
     /// being equivalent identity-wise. This ensures that a
-    /// [`Vc<FileSystemPath>`] created from this [`Vc<VirtualFileSystem>`]
+    /// [`FileSystemPath`] created from this [`Vc<VirtualFileSystem>`]
     /// will never be equivalent, nor be interoperable, with a
-    /// [`Vc<FileSystemPath>`] created from another
+    /// [`FileSystemPath`] created from another
     /// [`Vc<VirtualFileSystem>`].
     pub fn new_with_name(name: RcStr) -> Vc<Self> {
         Self::cell(VirtualFileSystem { name })
@@ -47,32 +47,32 @@ impl ValueDefault for VirtualFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for VirtualFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
+    fn read(&self, _fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<LinkContent>> {
+    fn read_link(&self, _fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
+    fn metadata(&self, _fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
         bail!("Reading is not possible on the virtual file system")
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -60,12 +60,12 @@ impl EcmascriptBrowserChunkContent {
 #[turbo_tasks::value_impl]
 impl EcmascriptBrowserChunkContent {
     #[turbo_tasks::function]
-    pub(crate) fn own_version(&self) -> Vc<EcmascriptBrowserChunkVersion> {
-        EcmascriptBrowserChunkVersion::new(
-            self.chunking_context.output_root(),
-            self.chunk.path(),
+    pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBrowserChunkVersion>> {
+        Ok(EcmascriptBrowserChunkVersion::new(
+            (*self.chunking_context.output_root().await?).clone(),
+            (*self.chunk.path().await?).clone(),
             *self.content,
-        )
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -68,8 +68,11 @@ impl EcmascriptBrowserEvaluateChunk {
     }
 
     #[turbo_tasks::function]
-    fn chunks_data(&self) -> Vc<ChunksData> {
-        ChunkData::from_assets(self.chunking_context.output_root(), *self.other_chunks)
+    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        Ok(ChunkData::from_assets(
+            (*self.chunking_context.output_root().await?).clone(),
+            *self.other_chunks,
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -18,12 +18,10 @@ pub(super) struct EcmascriptBrowserChunkVersion {
 impl EcmascriptBrowserChunkVersion {
     #[turbo_tasks::function]
     pub async fn new(
-        output_root: Vc<FileSystemPath>,
-        chunk_path: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
+        chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {
-        let output_root = output_root.await?;
-        let chunk_path = chunk_path.await?;
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -45,16 +45,16 @@ impl ResolveReactRefreshResult {
 /// given path. Emits an issue if we can't.
 #[turbo_tasks::function]
 pub async fn assert_can_resolve_react_refresh(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     resolve_options_context: Vc<ResolveOptionsContext>,
 ) -> Result<Vc<ResolveReactRefreshResult>> {
     let resolve_options = apply_cjs_specific_options(turbopack_resolve::resolve::resolve_options(
-        *path,
+        path.clone(),
         resolve_options_context,
     ));
     for request in [react_refresh_request_in_next(), react_refresh_request()] {
         let result = turbopack_core::resolve::resolve(
-            *path,
+            path.clone(),
             Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
             request,
             resolve_options,
@@ -72,7 +72,7 @@ pub async fn assert_can_resolve_react_refresh(
 /// An issue that occurred while resolving the React Refresh runtime module.
 #[turbo_tasks::value(shared)]
 pub struct ReactRefreshResolvingIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -94,7 +94,7 @@ impl Issue for ReactRefreshResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -48,26 +48,19 @@ async fn foreign_code_context_condition() -> Result<ContextCondition> {
 }
 
 #[turbo_tasks::function]
-pub async fn get_client_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
-) -> Result<Vc<ImportMap>> {
+pub async fn get_client_import_map(project_path: FileSystemPath) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
-    import_map.insert_singleton_alias("@swc/helpers", project_path);
-    import_map.insert_singleton_alias("styled-jsx", project_path);
-    import_map.insert_singleton_alias("react", project_path);
-    import_map.insert_singleton_alias("react-dom", project_path);
+    import_map.insert_singleton_alias("@swc/helpers", project_path.clone());
+    import_map.insert_singleton_alias("styled-jsx", project_path.clone());
+    import_map.insert_singleton_alias("react", project_path.clone());
+    import_map.insert_singleton_alias("react-dom", project_path.clone());
 
     import_map.insert_wildcard_alias(
         "@vercel/turbopack-ecmascript-runtime/",
         ImportMapping::PrimaryAlternative(
             "./*".into(),
-            Some(
-                turbopack_ecmascript_runtime::embed_fs()
-                    .root()
-                    .to_resolved()
-                    .await?,
-            ),
+            Some((*turbopack_ecmascript_runtime::embed_fs().root().await?).clone()),
         )
         .resolved_cell(),
     );
@@ -77,12 +70,14 @@ pub async fn get_client_import_map(
 
 #[turbo_tasks::function]
 pub async fn get_client_resolve_options_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<ResolveOptionsContext>> {
-    let next_client_import_map = get_client_import_map(project_path).to_resolved().await?;
+    let next_client_import_map = get_client_import_map(project_path.clone())
+        .to_resolved()
+        .await?;
     let module_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().to_resolved().await?),
+        enable_node_modules: Some((*project_path.root().await?).clone()),
         custom_conditions: vec![node_env.await?.to_string().into(), "browser".into()],
         import_map: Some(next_client_import_map),
         browser: true,
@@ -103,7 +98,7 @@ pub async fn get_client_resolve_options_context(
 
 #[turbo_tasks::function]
 async fn get_client_module_options_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: ResolvedVc<ExecutionContext>,
     env: ResolvedVc<Environment>,
     node_env: Vc<NodeEnv>,
@@ -118,10 +113,11 @@ async fn get_client_module_options_context(
         ..Default::default()
     };
 
-    let resolve_options_context = get_client_resolve_options_context(project_path, node_env);
+    let resolve_options_context =
+        get_client_resolve_options_context(project_path.clone(), node_env);
 
     let enable_react_refresh = is_dev
-        && assert_can_resolve_react_refresh(project_path, resolve_options_context)
+        && assert_can_resolve_react_refresh(project_path.clone(), resolve_options_context)
             .await?
             .is_found();
 
@@ -172,15 +168,16 @@ async fn get_client_module_options_context(
 
 #[turbo_tasks::function]
 pub fn get_client_asset_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: Vc<ExecutionContext>,
     compile_time_info: Vc<CompileTimeInfo>,
     node_env: Vc<NodeEnv>,
     source_maps_type: SourceMapsType,
 ) -> Vc<Box<dyn AssetContext>> {
-    let resolve_options_context = get_client_resolve_options_context(project_path, node_env);
+    let resolve_options_context =
+        get_client_resolve_options_context(project_path.clone(), node_env);
     let module_options_context = get_client_module_options_context(
-        project_path,
+        project_path.clone(),
         execution_context,
         compile_time_info.environment(),
         node_env,

--- a/turbopack/crates/turbopack-cli/src/embed_js.rs
+++ b/turbopack/crates/turbopack-cli/src/embed_js.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath, embed_directory};
@@ -8,11 +9,11 @@ fn embed_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file(path: RcStr) -> Vc<FileContent> {
-    embed_fs().root().join(path).read()
+pub(crate) async fn embed_file(path: RcStr) -> Result<Vc<FileContent>> {
+    Ok(embed_fs().root().await?.join(&path)?.read())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file_path(path: RcStr) -> Vc<FileSystemPath> {
-    embed_fs().root().join(path)
+pub(crate) async fn embed_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(embed_fs().root().await?.join(&path)?.cell())
 }

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -86,7 +86,7 @@ impl AssetContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn write(self: Vc<Self>, path: Vc<FileSystemPath>) -> Result<()> {
+    pub async fn write(self: Vc<Self>, path: FileSystemPath) -> Result<()> {
         let this = self.await?;
         match &*this {
             AssetContent::File(file) => {

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -171,7 +171,7 @@ pub trait ChunkingContext {
 
     /// Returns a URL (relative or absolute, depending on the asset prefix) to
     /// the static asset based on its `ident`.
-    fn asset_url(self: Vc<Self>, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>>;
+    fn asset_url(self: Vc<Self>, ident: FileSystemPath) -> Result<Vc<RcStr>>;
 
     fn asset_path(
         self: Vc<Self>,
@@ -231,7 +231,7 @@ pub trait ChunkingContext {
     /// * exports the result of evaluating the last module as a CommonJS default export.
     fn entry_chunk_group(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -282,7 +282,7 @@ pub trait ChunkingContextExt {
 
     fn entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -293,7 +293,7 @@ pub trait ChunkingContextExt {
 
     fn root_entry_chunk_group(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -303,7 +303,7 @@ pub trait ChunkingContextExt {
 
     fn root_entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -364,7 +364,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
 
     fn entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -382,7 +382,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
 
     fn root_entry_chunk_group(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -398,7 +398,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
 
     fn root_entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -460,7 +460,7 @@ async fn evaluated_chunk_group_assets(
 #[turbo_tasks::function]
 async fn entry_chunk_group_asset(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    path: Vc<FileSystemPath>,
+    path: FileSystemPath,
     evaluatable_assets: Vc<EvaluatableAssets>,
     module_graph: Vc<ModuleGraph>,
     extra_chunks: Vc<OutputAssets>,

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -69,10 +69,9 @@ impl ChunkData {
 
     #[turbo_tasks::function]
     pub async fn from_asset(
-        output_root: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
         chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<ChunkDataOption>> {
-        let output_root = output_root.await?;
         let path = chunk.path().await?;
         // The "path" in this case is the chunk's path, not the chunk item's path.
         // The difference is a chunk is a file served by the dev server, and an
@@ -153,14 +152,14 @@ impl ChunkData {
 
     #[turbo_tasks::function]
     pub async fn from_assets(
-        output_root: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
         chunks: Vc<OutputAssets>,
     ) -> Result<Vc<ChunksData>> {
         Ok(Vc::cell(
             chunks
                 .await?
                 .iter()
-                .map(|&chunk| ChunkData::from_asset(output_root, *chunk))
+                .map(|&chunk| ChunkData::from_asset(output_root.clone(), *chunk))
                 .try_join()
                 .await?
                 .into_iter()

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -125,7 +125,7 @@ impl Chunks {
 pub trait Chunk {
     fn ident(self: Vc<Self>) -> Vc<AssetIdent>;
     fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>>;
-    // fn path(self: Vc<Self>) -> Vc<FileSystemPath> {
+    // fn path(self: Vc<Self>) -> FileSystemPath {
     //     self.ident().path()
     // }
 

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -214,7 +214,7 @@ pub enum InputRelativeConstant {
 pub enum FreeVarReference {
     EcmaScriptModule {
         request: RcStr,
-        lookup_path: Option<ResolvedVc<FileSystemPath>>,
+        lookup_path: Option<FileSystemPath>,
         export: Option<RcStr>,
     },
     Ident(RcStr),

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -68,14 +68,14 @@ pub trait AssetContext {
     /// Gets the resolve options for a given path.
     fn resolve_options(
         self: Vc<Self>,
-        origin_path: Vc<FileSystemPath>,
+        origin_path: FileSystemPath,
         reference_type: Value<ReferenceType>,
     ) -> Vc<ResolveOptions>;
 
     /// Resolves an request to an [ModuleResolveResult].
     fn resolve_asset(
         self: Vc<Self>,
-        origin_path: Vc<FileSystemPath>,
+        origin_path: FileSystemPath,
         request: Vc<Request>,
         resolve_options: Vc<ResolveOptions>,
         reference_type: Value<ReferenceType>,

--- a/turbopack/crates/turbopack-core/src/data_uri_source.rs
+++ b/turbopack/crates/turbopack-core/src/data_uri_source.rs
@@ -17,7 +17,7 @@ pub struct DataUriSource {
     media_type: RcStr,
     encoding: RcStr,
     data: ResolvedVc<RcStr>,
-    lookup_path: ResolvedVc<FileSystemPath>,
+    lookup_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -27,7 +27,7 @@ impl DataUriSource {
         media_type: RcStr,
         encoding: RcStr,
         data: ResolvedVc<RcStr>,
-        lookup_path: ResolvedVc<FileSystemPath>,
+        lookup_path: FileSystemPath,
     ) -> Vc<Self> {
         Self::cell(DataUriSource {
             media_type,
@@ -52,7 +52,7 @@ impl Source for DataUriSource {
             )))[0..6]
         );
         Ok(
-            AssetIdent::from_path(self.lookup_path.join(filename.into()))
+            AssetIdent::from_path(self.lookup_path.join(&filename)?)
                 .with_content_type(content_type),
         )
     }

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -13,14 +13,14 @@ use crate::{
 /// references to other [Source]s.
 #[turbo_tasks::value]
 pub struct FileSource {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub query: ResolvedVc<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
 impl FileSource {
     #[turbo_tasks::function]
-    pub fn new(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(path: FileSystemPath) -> Vc<Self> {
         Self::cell(FileSource {
             path,
             query: ResolvedVc::cell(RcStr::default()),
@@ -29,11 +29,11 @@ impl FileSource {
 
     #[turbo_tasks::function]
     pub async fn new_with_query(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         query: ResolvedVc<RcStr>,
     ) -> Result<Vc<Self>> {
         if query.await?.is_empty() {
-            Ok(Self::new(*path))
+            Ok(Self::new(path))
         } else {
             Ok(Self::cell(FileSource { path, query }))
         }
@@ -44,7 +44,7 @@ impl FileSource {
 impl Source for FileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.path).with_query(*self.query)
+        AssetIdent::from_path(self.path.clone()).with_query(*self.query)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -14,7 +14,7 @@ use crate::resolve::ModulePart;
 #[derive(Clone, Debug, Hash)]
 pub struct AssetIdent {
     /// The primary path of the asset
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     /// The query string of the asset (e.g. `?foo=bar`)
     pub query: ResolvedVc<RcStr>,
     /// The fragment of the asset (e.g. `#foo`)
@@ -42,11 +42,8 @@ impl AssetIdent {
 
     pub async fn rename_as_ref(&mut self, pattern: &str) -> Result<()> {
         let root = self.path.root();
-        let path = self.path.await?;
-        self.path = root
-            .join(pattern.replace('*', &path.path).into())
-            .to_resolved()
-            .await?;
+        let path = &self.path;
+        self.path = root.await?.join(&pattern.replace('*', &path.path))?;
         Ok(())
     }
 }
@@ -55,7 +52,7 @@ impl AssetIdent {
 impl ValueToString for AssetIdent {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let mut s = self.path.to_string().owned().await?.into_owned();
+        let mut s = self.path.to_string();
 
         let query = self.query.await?;
         if !query.is_empty() {
@@ -125,9 +122,9 @@ impl AssetIdent {
         ident.into_value().cell()
     }
 
-    /// Creates an [AssetIdent] from a [Vc<FileSystemPath>]
+    /// Creates an [AssetIdent] from a [FileSystemPath]
     #[turbo_tasks::function]
-    pub fn from_path(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn from_path(path: FileSystemPath) -> Vc<Self> {
         Self::new(Value::new(AssetIdent {
             path,
             query: ResolvedVc::cell(RcStr::default()),
@@ -162,7 +159,7 @@ impl AssetIdent {
     }
 
     #[turbo_tasks::function]
-    pub fn with_path(&self, path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn with_path(&self, path: FileSystemPath) -> Vc<Self> {
         let mut this = self.clone();
         this.path = path;
         Self::new(Value::new(this))
@@ -191,7 +188,7 @@ impl AssetIdent {
 
     #[turbo_tasks::function]
     pub fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -206,18 +203,18 @@ impl AssetIdent {
     #[turbo_tasks::function]
     pub async fn output_name(
         &self,
-        context_path: Vc<FileSystemPath>,
+        context_path: FileSystemPath,
         expected_extension: RcStr,
     ) -> Result<Vc<RcStr>> {
         // TODO(PACK-2140): restrict character set to A–Za–z0–9-_.~'()
         // to be compatible with all operating systems + URLs.
 
         // For clippy -- This explicit deref is necessary
-        let path = &*self.path.await?;
-        let mut name = if let Some(inner) = context_path.await?.get_path_to(path) {
+        let path = &self.path;
+        let mut name = if let Some(inner) = context_path.get_path_to(path) {
             clean_separators(inner)
         } else {
-            clean_separators(&self.path.to_string().await?)
+            clean_separators(&self.path.to_string())
         };
         let removed_extension = name.ends_with(&*expected_extension);
         if removed_extension {

--- a/turbopack/crates/turbopack-core/src/issue/code_gen.rs
+++ b/turbopack/crates/turbopack-core/src/issue/code_gen.rs
@@ -6,7 +6,7 @@ use super::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 #[turbo_tasks::value(shared)]
 pub struct CodeGenerationIssue {
     pub severity: ResolvedVc<IssueSeverity>,
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub title: ResolvedVc<StyledString>,
     pub message: ResolvedVc<StyledString>,
 }
@@ -30,7 +30,7 @@ impl Issue for CodeGenerationIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -20,7 +20,7 @@ pub struct ResolvingIssue {
     pub severity: ResolvedVc<IssueSeverity>,
     pub request_type: String,
     pub request: ResolvedVc<Request>,
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub resolve_options: ResolvedVc<ResolveOptions>,
     pub error_message: Option<String>,
     pub source: Option<IssueSource>,
@@ -51,7 +51,7 @@ impl Issue for ResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -68,7 +68,7 @@ impl Issue for ResolvingIssue {
 
         if let Some(import_map) = &self.resolve_options.await?.import_map {
             for request in request_parts {
-                match lookup_import_map(**import_map, *self.file_path, **request).await {
+                match lookup_import_map(**import_map, self.file_path.clone(), **request).await {
                     Ok(None) => {}
                     Ok(Some(str)) => writeln!(description, "Import map: {str}")?,
                     Err(err) => {
@@ -103,7 +103,7 @@ impl Issue for ResolvingIssue {
         writeln!(
             detail,
             "Path where resolving has started: {context}",
-            context = self.file_path.to_string().await?
+            context = self.file_path
         )?;
         writeln!(
             detail,
@@ -129,7 +129,7 @@ impl Issue for ResolvingIssue {
 
 async fn lookup_import_map(
     import_map: Vc<ImportMap>,
-    file_path: Vc<FileSystemPath>,
+    file_path: FileSystemPath,
     request: Vc<Request>,
 ) -> Result<Option<ReadRef<RcStr>>> {
     let result = import_map.await?.lookup(file_path, request).await?;

--- a/turbopack/crates/turbopack-core/src/proxied_asset.rs
+++ b/turbopack/crates/turbopack-core/src/proxied_asset.rs
@@ -15,17 +15,14 @@ use crate::{
 #[turbo_tasks::value]
 pub struct ProxiedAsset {
     asset: ResolvedVc<Box<dyn OutputAsset>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl ProxiedAsset {
     /// Creates a new [`ProxiedAsset`] from an [`Asset`] and a path.
     #[turbo_tasks::function]
-    pub fn new(
-        asset: ResolvedVc<Box<dyn OutputAsset>>,
-        path: ResolvedVc<FileSystemPath>,
-    ) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn OutputAsset>>, path: FileSystemPath) -> Vc<Self> {
         ProxiedAsset { asset, path }.cell()
     }
 }
@@ -34,7 +31,7 @@ impl ProxiedAsset {
 impl OutputAsset for ProxiedAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/raw_output.rs
+++ b/turbopack/crates/turbopack-core/src/raw_output.rs
@@ -11,7 +11,7 @@ use crate::{
 /// This module has no references to other modules.
 #[turbo_tasks::value]
 pub struct RawOutput {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     source: ResolvedVc<Box<dyn Source>>,
 }
 
@@ -19,7 +19,7 @@ pub struct RawOutput {
 impl OutputAsset for RawOutput {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 }
 
@@ -34,10 +34,7 @@ impl Asset for RawOutput {
 #[turbo_tasks::value_impl]
 impl RawOutput {
     #[turbo_tasks::function]
-    pub fn new(
-        path: ResolvedVc<FileSystemPath>,
-        source: ResolvedVc<Box<dyn Source>>,
-    ) -> Vc<RawOutput> {
+    pub fn new(path: FileSystemPath, source: ResolvedVc<Box<dyn Source>>) -> Vc<RawOutput> {
         RawOutput { path, source }.cell()
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/node.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/node.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
 use super::options::{
@@ -7,7 +7,7 @@ use super::options::{
 };
 
 #[turbo_tasks::function]
-pub fn node_cjs_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveOptions> {
+pub fn node_cjs_resolve_options(root: FileSystemPath) -> Vc<ResolveOptions> {
     let conditions: ResolutionConditions = [
         ("node".into(), ConditionValue::Set),
         ("require".into(), ConditionValue::Set),
@@ -37,7 +37,7 @@ pub fn node_cjs_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveO
 }
 
 #[turbo_tasks::function]
-pub fn node_esm_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveOptions> {
+pub fn node_esm_resolve_options(root: FileSystemPath) -> Vc<ResolveOptions> {
     let conditions: ResolutionConditions = [
         ("node".into(), ConditionValue::Set),
         ("import".into(), ConditionValue::Set),

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -12,23 +12,21 @@ use crate::{
 /// A condition which determines if the hooks of a resolve plugin gets called.
 #[turbo_tasks::value]
 pub struct AfterResolvePluginCondition {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
     glob: ResolvedVc<Glob>,
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
-    pub fn new(root: ResolvedVc<FileSystemPath>, glob: ResolvedVc<Glob>) -> Vc<Self> {
+    pub fn new(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Vc<Self> {
         AfterResolvePluginCondition { root, glob }.cell()
     }
 
     #[turbo_tasks::function]
-    pub async fn matches(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
-        let root = self.root.await?;
+    pub async fn matches(&self, path: FileSystemPath) -> Result<Vc<bool>> {
+        let root = self.root.clone();
         let glob = self.glob.await?;
-
-        let path = fs_path.await?;
 
         if let Some(path) = root.get_path_to(&path) {
             if glob.matches(path) {
@@ -86,7 +84,7 @@ pub trait BeforeResolvePlugin {
 
     fn before_resolve(
         self: Vc<Self>,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         reference_type: Value<ReferenceType>,
         request: Vc<Request>,
     ) -> Vc<ResolveResultOption>;
@@ -102,8 +100,8 @@ pub trait AfterResolvePlugin {
     /// result.
     fn after_resolve(
         self: Vc<Self>,
-        fs_path: Vc<FileSystemPath>,
-        lookup_path: Vc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        lookup_path: FileSystemPath,
         reference_type: Value<ReferenceType>,
         request: Vc<Request>,
     ) -> Vc<ResolveResultOption>;

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -19,32 +19,32 @@ impl ServerFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for ServerFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
+    fn read(&self, _fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<LinkContent>> {
+    fn read_link(&self, _fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
+    fn metadata(&self, _fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 }

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -10,7 +10,7 @@ use crate::{
 /// to other assets.
 #[turbo_tasks::value]
 pub struct VirtualOutputAsset {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub content: ResolvedVc<AssetContent>,
     pub references: ResolvedVc<OutputAssets>,
 }
@@ -18,7 +18,7 @@ pub struct VirtualOutputAsset {
 #[turbo_tasks::value_impl]
 impl VirtualOutputAsset {
     #[turbo_tasks::function]
-    pub fn new(path: ResolvedVc<FileSystemPath>, content: ResolvedVc<AssetContent>) -> Vc<Self> {
+    pub fn new(path: FileSystemPath, content: ResolvedVc<AssetContent>) -> Vc<Self> {
         VirtualOutputAsset {
             path,
             content,
@@ -29,7 +29,7 @@ impl VirtualOutputAsset {
 
     #[turbo_tasks::function]
     pub fn new_with_references(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         content: ResolvedVc<AssetContent>,
         references: ResolvedVc<OutputAssets>,
     ) -> Vc<Self> {
@@ -46,7 +46,7 @@ impl VirtualOutputAsset {
 impl OutputAsset for VirtualOutputAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/virtual_source.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_source.rs
@@ -19,11 +19,13 @@ pub struct VirtualSource {
 impl VirtualSource {
     #[turbo_tasks::function]
     pub async fn new(
-        path: Vc<FileSystemPath>,
+        path: ResolvedVc<FileSystemPath>,
         content: ResolvedVc<AssetContent>,
     ) -> Result<Vc<Self>> {
         Ok(Self::cell(VirtualSource {
-            ident: AssetIdent::from_path(path).to_resolved().await?,
+            ident: AssetIdent::from_path((*path.await?).clone())
+                .to_resolved()
+                .await?,
             content,
         }))
     }

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -82,9 +82,11 @@ impl SingleItemCssChunk {
 #[turbo_tasks::value_impl]
 impl Chunk for SingleItemCssChunk {
     #[turbo_tasks::function]
-    fn ident(self: Vc<Self>) -> Vc<AssetIdent> {
+    async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
         let self_as_output_asset: Vc<Box<dyn OutputAsset>> = Vc::upcast(self);
-        AssetIdent::from_path(self_as_output_asset.path())
+        Ok(AssetIdent::from_path(
+            (*self_as_output_asset.path().await?).clone(),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -38,7 +38,9 @@ impl OutputAsset for SingleItemCssChunkSourceMapAsset {
                 this.chunk.ident_for_path(),
                 ".single.css".into(),
             )
-            .append(".map".into()))
+            .await?
+            .append(".map")?
+            .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -35,7 +35,9 @@ impl OutputAsset for CssChunkSourceMapAsset {
             .await?
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, ".css".into())
-            .append(".map".into()))
+            .await?
+            .append(".map")?
+            .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -35,7 +35,7 @@ pub struct DevHtmlEntry {
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct DevHtmlAsset {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     entries: Vec<DevHtmlEntry>,
     body: Option<RcStr>,
 }
@@ -49,7 +49,7 @@ fn dev_html_chunk_reference_description() -> Vc<RcStr> {
 impl OutputAsset for DevHtmlAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -73,7 +73,7 @@ impl Asset for DevHtmlAsset {
 
 impl DevHtmlAsset {
     /// Create a new dev HTML asset.
-    pub fn new(path: ResolvedVc<FileSystemPath>, entries: Vec<DevHtmlEntry>) -> Vc<Self> {
+    pub fn new(path: FileSystemPath, entries: Vec<DevHtmlEntry>) -> Vc<Self> {
         DevHtmlAsset {
             path,
             entries,
@@ -84,7 +84,7 @@ impl DevHtmlAsset {
 
     /// Create a new dev HTML asset.
     pub fn new_with_body(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         entries: Vec<DevHtmlEntry>,
         body: RcStr,
     ) -> Vc<Self> {
@@ -100,7 +100,7 @@ impl DevHtmlAsset {
 #[turbo_tasks::value_impl]
 impl DevHtmlAsset {
     #[turbo_tasks::function]
-    pub async fn with_path(self: Vc<Self>, path: ResolvedVc<FileSystemPath>) -> Result<Vc<Self>> {
+    pub async fn with_path(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<Self>> {
         let mut html: DevHtmlAsset = self.owned().await?;
         html.path = path;
         Ok(html.cell())
@@ -119,7 +119,7 @@ impl DevHtmlAsset {
     #[turbo_tasks::function]
     async fn html_content(self: Vc<Self>) -> Result<Vc<DevHtmlAssetContent>> {
         let this = self.await?;
-        let context_path = this.path.parent().await?;
+        let context_path = this.path.parent();
         let mut chunk_paths = vec![];
         for chunk in &*self.chunks().await? {
             let chunk_path = &*chunk.path().await?;

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -4,8 +4,7 @@ use anyhow::Result;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    Completion, FxIndexMap, FxIndexSet, ResolvedVc, State, TryJoinIterExt, Value, ValueToString,
-    Vc, fxindexset,
+    Completion, FxIndexMap, FxIndexSet, ResolvedVc, State, TryJoinIterExt, Value, Vc, fxindexset,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -27,7 +26,7 @@ type ExpandedState = State<FxHashSet<RcStr>>;
 
 #[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 pub struct AssetGraphContentSource {
-    root_path: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
     root_assets: ResolvedVc<OutputAssetsSet>,
     expanded: Option<ExpandedState>,
 }
@@ -37,7 +36,7 @@ impl AssetGraphContentSource {
     /// Serves all assets references by root_asset.
     #[turbo_tasks::function]
     pub fn new_eager(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -51,7 +50,7 @@ impl AssetGraphContentSource {
     /// asset when it has served its content before.
     #[turbo_tasks::function]
     pub fn new_lazy(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -64,7 +63,7 @@ impl AssetGraphContentSource {
     /// Serves all assets references by all root_assets.
     #[turbo_tasks::function]
     pub fn new_eager_multiple(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_assets: ResolvedVc<OutputAssetsSet>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -78,7 +77,7 @@ impl AssetGraphContentSource {
     /// of an asset when it has served its content before.
     #[turbo_tasks::function]
     pub fn new_lazy_multiple(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_assets: ResolvedVc<OutputAssetsSet>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -93,7 +92,7 @@ impl AssetGraphContentSource {
         Ok(Vc::cell(
             expand(
                 &*self.root_assets.await?,
-                &*self.root_path.await?,
+                &self.root_path,
                 self.expanded.as_ref(),
             )
             .await?,
@@ -307,7 +306,7 @@ impl Introspectable for AssetGraphContentSource {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<RcStr> {
-        self.root_path.to_string()
+        Vc::cell(self.root_path.path.clone())
     }
 
     #[turbo_tasks::function]
@@ -385,7 +384,7 @@ impl Introspectable for FullyExpanded {
 
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<RcStr>> {
-        Ok(self.0.await?.root_path.to_string())
+        Ok(Vc::cell(self.0.await?.root_path.path.clone()))
     }
 
     #[turbo_tasks::function]
@@ -393,8 +392,7 @@ impl Introspectable for FullyExpanded {
         let source = self.0.await?;
         let key = ResolvedVc::cell("asset".into());
 
-        let expanded_assets =
-            expand(&*source.root_assets.await?, &*source.root_path.await?, None).await?;
+        let expanded_assets = expand(&*source.root_assets.await?, &source.root_path, None).await?;
         let children = expanded_assets
             .iter()
             .map(|(_k, &v)| async move {

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -15,7 +15,7 @@ use super::{
 
 #[turbo_tasks::value]
 pub struct IssueFilePathContentSource {
-    file_path: Option<ResolvedVc<FileSystemPath>>,
+    file_path: Option<FileSystemPath>,
     description: RcStr,
     source: ResolvedVc<Box<dyn ContentSource>>,
 }
@@ -24,7 +24,7 @@ pub struct IssueFilePathContentSource {
 impl IssueFilePathContentSource {
     #[turbo_tasks::function]
     pub fn new_file_path(
-        file_path: ResolvedVc<FileSystemPath>,
+        file_path: FileSystemPath,
         description: RcStr,
         source: ResolvedVc<Box<dyn ContentSource>>,
     ) -> Vc<Self> {
@@ -56,7 +56,7 @@ impl ContentSource for IssueFilePathContentSource {
     async fn get_routes(self: ResolvedVc<Self>) -> Result<Vc<RouteTree>> {
         let this = self.await?;
         let routes = content_source_get_routes_operation(this.source)
-            .issue_file_path(this.file_path.map(|v| *v), &*this.description)
+            .issue_file_path(this.file_path.clone(), &*this.description)
             .await?
             .connect();
         Ok(routes.map_routes(Vc::upcast(
@@ -111,7 +111,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
     async fn vary(&self) -> Result<Vc<ContentSourceDataVary>> {
         let source = self.source.await?;
         Ok(get_content_source_vary_operation(self.get_content)
-            .issue_file_path(source.file_path.map(|v| *v), &*source.description)
+            .issue_file_path(source.file_path.clone(), &*source.description)
             .await?
             .connect())
     }
@@ -125,7 +125,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
         let source = self.source.await?;
         Ok(
             get_content_source_get_operation(self.get_content, path, data)
-                .issue_file_path(source.file_path.map(|v| *v), &*source.description)
+                .issue_file_path(source.file_path.clone(), &*source.description)
                 .await?
                 .connect(),
         )

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -422,7 +422,7 @@ pub trait ContentSource {
 pub trait ContentSourceExt {
     fn issue_file_path(
         self: Vc<Self>,
-        file_path: Vc<FileSystemPath>,
+        file_path: FileSystemPath,
         description: RcStr,
     ) -> Vc<Box<dyn ContentSource>>;
 }
@@ -433,7 +433,7 @@ where
 {
     fn issue_file_path(
         self: Vc<Self>,
-        file_path: Vc<FileSystemPath>,
+        file_path: FileSystemPath,
         description: RcStr,
     ) -> Vc<Box<dyn ContentSource>> {
         Vc::upcast(IssueFilePathContentSource::new_file_path(

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -383,8 +383,12 @@ impl Issue for FatalStreamIssue {
     }
 
     #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        ServerFileSystem::new().root().join(self.resource.clone())
+    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(ServerFileSystem::new()
+            .root()
+            .await?
+            .join(&self.resource)?
+            .cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/server.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/server.rs
@@ -41,7 +41,7 @@ impl CustomTransformer for ServerDirectiveTransformer {
                 Program::Script(s) => s.body = vec![stmt],
             }
             UnsupportedServerActionIssue {
-                file_path: ctx.file_path,
+                file_path: ctx.file_path.clone(),
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
@@ -66,7 +66,6 @@ impl CustomTransformer for RelayTransformer {
         let path_to_proj = PathBuf::from(
             ctx.file_path
                 .parent()
-                .await?
                 .get_relative_path_to(&self.project_path)
                 .context("Expected relative path to relay artifact")?,
         );

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::ecma::ast::Program;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -49,7 +49,7 @@ impl SwcPluginModule {
 
 #[turbo_tasks::value(shared)]
 struct UnsupportedSwcEcmaTransformPluginsIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -72,7 +72,7 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -227,7 +227,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
             use turbopack_core::issue::IssueExt;
 
             UnsupportedSwcEcmaTransformPluginsIssue {
-                file_path: ctx.file_path,
+                file_path: ctx.file_path.clone(),
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -64,7 +64,7 @@ impl AsyncLoaderChunkItem {
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root(),
+            (*this.chunking_context.output_root().await?).clone(),
             self.chunks(),
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -82,24 +82,23 @@ impl Chunk for EcmascriptChunk {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let chunk_items = &*self.content.included_chunk_items().await?;
         let mut common_path = if let Some(chunk_item) = chunk_items.first() {
-            let path = chunk_item.asset_ident().path().to_resolved().await?;
-            Some((path, path.await?))
+            let path = chunk_item.asset_ident().path().await?;
+            Some((*path).clone())
         } else {
             None
         };
 
         // The included chunk items describe the chunk uniquely
         for &chunk_item in chunk_items.iter() {
-            if let Some((common_path_vc, common_path_ref)) = common_path.as_mut() {
+            if let Some(common_path_ref) = common_path.as_mut() {
                 let path = chunk_item.asset_ident().path().await?;
                 while !path.is_inside_or_equal_ref(common_path_ref) {
-                    let parent = common_path_vc.parent().to_resolved().await?;
-                    if parent == *common_path_vc {
+                    let parent = common_path_ref.parent();
+                    if parent == *common_path_ref {
                         common_path = None;
                         break;
                     }
-                    *common_path_vc = parent;
-                    *common_path_ref = (*common_path_vc).await?;
+                    *common_path_ref = parent;
                 }
             }
         }
@@ -117,10 +116,10 @@ impl Chunk for EcmascriptChunk {
             .await?;
 
         let ident = AssetIdent {
-            path: if let Some((common_path, _)) = common_path {
+            path: if let Some(common_path) = common_path {
                 common_path
             } else {
-                ServerFileSystem::new().root().to_resolved().await?
+                (*ServerFileSystem::new().root().await?).clone()
             },
             query: ResolvedVc::cell(RcStr::default()),
             fragment: None,

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -30,8 +30,11 @@ pub(super) struct ManifestChunkItem {
 #[turbo_tasks::value_impl]
 impl ManifestChunkItem {
     #[turbo_tasks::function]
-    fn chunks_data(&self) -> Vc<ChunksData> {
-        ChunkData::from_assets(self.chunking_context.output_root(), self.manifest.chunks())
+    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        Ok(ChunkData::from_assets(
+            (*self.chunking_context.output_root().await?).clone(),
+            self.manifest.chunks(),
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -67,9 +67,12 @@ impl ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    pub fn chunks_data(&self) -> Vc<ChunksData> {
+    pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         let chunks = self.manifest.manifest_chunks();
-        ChunkData::from_assets(self.chunking_context.output_root(), chunks)
+        Ok(ChunkData::from_assets(
+            (*self.chunking_context.output_root().await?).clone(),
+            chunks,
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -193,8 +193,8 @@ async fn parse_internal(
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
     let content = source.content();
-    let fs_path_vc = source.ident().path();
-    let fs_path = &*fs_path_vc.await?;
+    let fs_path_vc = (*source.ident().path().await?).clone();
+    let fs_path = fs_path_vc.clone();
     let ident = &*source.ident().to_string().await?;
     let file_path_hash = hash_xxh3_hash64(&*source.ident().to_string().await?) as u128;
     let ty = ty.into_value();
@@ -223,8 +223,7 @@ async fn parse_internal(
                     let transforms = &*transforms.await?;
                     match parse_file_content(
                         string.into_owned(),
-                        fs_path_vc,
-                        fs_path,
+                        &fs_path,
                         ident,
                         source.ident().query().owned().await?,
                         file_path_hash,
@@ -264,7 +263,6 @@ async fn parse_internal(
 
 async fn parse_file_content(
     string: String,
-    fs_path_vc: Vc<FileSystemPath>,
     fs_path: &FileSystemPath,
     ident: &str,
     query: RcStr,
@@ -418,7 +416,7 @@ async fn parse_file_content(
                 file_name_str: fs_path.file_name(),
                 file_name_hash: file_path_hash,
                 query_str: query,
-                file_path: fs_path_vc.to_resolved().await?,
+                file_path: fs_path.clone(),
             };
             let span = tracing::trace_span!("transforms");
             async {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -7,7 +7,7 @@ use swc_core::{
     ecma::ast::{Expr, Ident},
     quote,
 };
-use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
@@ -27,11 +27,11 @@ use crate::{
 /// This singleton behavior must be enforced by the caller!
 #[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
 pub struct ImportMetaBinding {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 impl ImportMetaBinding {
-    pub fn new(path: ResolvedVc<FileSystemPath>) -> Self {
+    pub fn new(path: FileSystemPath) -> Self {
         ImportMetaBinding { path }
     }
 
@@ -43,7 +43,7 @@ impl ImportMetaBinding {
         let rel_path = chunking_context
             .root_path()
             .await?
-            .get_relative_path_to(&*self.path.await?);
+            .get_relative_path_to(&self.path);
         let path = rel_path.map_or_else(
             || {
                 quote!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -122,13 +122,13 @@ impl CachedExternalModule {
 #[turbo_tasks::value_impl]
 impl Module for CachedExternalModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let fs = VirtualFileSystem::new_with_name("externals".into());
 
-        AssetIdent::from_path(fs.root().join(self.request.clone()))
+        Ok(AssetIdent::from_path(fs.root().await?.join(&self.request)?)
             .with_layer(layer())
             .with_modifier(Vc::cell(self.request.clone()))
-            .with_modifier(Vc::cell(self.external_type.to_string().into()))
+            .with_modifier(Vc::cell(self.external_type.to_string().into())))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -354,7 +354,7 @@ async fn to_single_pattern_mapping(
                     .into(),
                 )
                 .resolved_cell(),
-                path: origin.origin_path().to_resolved().await?,
+                path: (*origin.origin_path().await?).clone(),
             }
             .resolved_cell()
             .emit();
@@ -380,7 +380,7 @@ async fn to_single_pattern_mapping(
             "asset is not placeable in ESM chunks, so it doesn't have a module id".into(),
         )
         .resolved_cell(),
-        path: origin.origin_path().to_resolved().await?,
+        path: (*origin.origin_path().await?).clone(),
     }
     .resolved_cell()
     .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -25,10 +25,10 @@ impl FileSourceReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for FileSourceReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        let context_dir = self.source.ident().path().parent();
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        let context_dir = self.source.ident().path().await?.parent();
 
-        resolve_raw(context_dir, *self.path, false).as_raw_module_result()
+        Ok(resolve_raw(context_dir, *self.path, false).as_raw_module_result())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 
@@ -6,7 +6,7 @@ use crate::SpecifiedModuleType;
 
 #[turbo_tasks::value(shared)]
 pub struct SpecifiedModuleTypeIssue {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub specified_type: SpecifiedModuleType,
 }
 
@@ -14,7 +14,7 @@ pub struct SpecifiedModuleTypeIssue {
 impl Issue for SpecifiedModuleTypeIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use swc_core::{ecma::ast::Expr, quote};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
     resolve::parse::Request,
@@ -47,7 +47,7 @@ pub async fn request_to_string(request: Vc<Request>) -> Result<Vc<RcStr>> {
 #[derive(Debug, Clone)]
 pub struct InlineSourceMap {
     /// The file path of the module containing the sourcemap data URL
-    pub origin_path: ResolvedVc<FileSystemPath>,
+    pub origin_path: FileSystemPath,
     /// The Base64 encoded JSON sourcemap string
     pub source_map: RcStr,
 }
@@ -57,7 +57,8 @@ impl GenerateSourceMap for InlineSourceMap {
     #[turbo_tasks::function]
     pub async fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {
         let source_map = maybe_decode_data_url(&self.source_map);
-        let source_map = resolve_source_map_sources(source_map.as_ref(), *self.origin_path).await?;
+        let source_map =
+            resolve_source_map_sources(source_map.as_ref(), self.origin_path.clone()).await?;
         Ok(Vc::cell(source_map))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -75,7 +75,7 @@ impl WorkerAssetReference {
                 title: StyledString::Text("non-ecmascript placeable asset".into()).resolved_cell(),
                 message: StyledString::Text("asset is not placeable in ESM chunks".into())
                     .resolved_cell(),
-                path: self.origin.origin_path().to_resolved().await?,
+                path: (*self.origin.origin_path().await?).clone(),
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -105,7 +105,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleLocalsModule {
         let analyze = original_module.analyze();
         let analyze_result = analyze.await?;
 
-        let module_type_result = *original_module.determine_module_type().await?;
+        let module_type_result = &*original_module.determine_module_type().await?;
         let generate_source_map = *chunking_context
             .reference_module_source_maps(Vc::upcast(self))
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -27,12 +27,12 @@ impl StaticEcmascriptCode {
     #[turbo_tasks::function]
     pub async fn new(
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
-        asset_path: ResolvedVc<FileSystemPath>,
+        asset_path: FileSystemPath,
         generate_source_map: bool,
     ) -> Result<Vc<Self>> {
         let module = asset_context
             .process(
-                Vc::upcast(FileSource::new(*asset_path)),
+                Vc::upcast(FileSource::new(asset_path.clone())),
                 Value::new(ReferenceType::Runtime),
             )
             .module()

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -116,7 +116,7 @@ pub struct TransformContext<'a> {
     pub file_name_str: &'a str,
     pub file_name_hash: u128,
     pub query_str: RcStr,
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
 }
 
 impl EcmascriptInputTransform {
@@ -293,7 +293,7 @@ pub fn remove_shebang(program: &mut Program) {
 
 #[turbo_tasks::value(shared)]
 pub struct UnsupportedServerActionIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -313,7 +313,7 @@ impl Issue for UnsupportedServerActionIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -91,7 +91,7 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
         let analyze = self.analyze();
         let analyze_ref = analyze.await?;
 
-        let module_type_result = *module.full_module.determine_module_type().await?;
+        let module_type_result = module.full_module.determine_module_type().await?;
         let generate_source_map = *chunking_context
             .reference_module_source_maps(Vc::upcast(self))
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -98,8 +98,8 @@ impl ModuleReference for WebpackChunkAssetReference {
                     Lit::Num(num) => format!("{num}"),
                     _ => todo!(),
                 };
-                let filename = format!("./chunks/{chunk_id}.js").into();
-                let source = Vc::upcast(FileSource::new(context_path.join(filename)));
+                let filename = format!("./chunks/{chunk_id}.js");
+                let source = Vc::upcast(FileSource::new(context_path.join(&filename)?));
 
                 *ModuleResolveResult::module(ResolvedVc::upcast(
                     WebpackModuleAsset::new(source, *self.runtime, *self.transforms)
@@ -165,12 +165,12 @@ impl ModuleReference for WebpackRuntimeAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
-        let options = self.origin.resolve_options(ty.clone());
+        let options = self.origin.resolve_options(ty.clone()).await?;
 
         let options = apply_cjs_specific_options(options);
 
         let resolved = resolve(
-            self.origin.origin_path().parent().resolve().await?,
+            self.origin.origin_path().await?.parent(),
             Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
             *self.request,
             options,

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -12,7 +12,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::source::Source;
 
@@ -31,7 +31,7 @@ pub enum WebpackRuntime {
         /// before converting to string
         #[turbo_tasks(trace_ignore)]
         chunk_request_expr: JsValue,
-        context_path: ResolvedVc<FileSystemPath>,
+        context_path: FileSystemPath,
     },
     None,
 }
@@ -232,7 +232,7 @@ pub async fn webpack_runtime(
 
                         return Ok(WebpackRuntime::Webpack5 {
                             chunk_request_expr: value,
-                            context_path: source.ident().path().parent().to_resolved().await?,
+                            context_path: source.ident().path().await?.parent(),
                         }
                         .into());
                     }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -53,7 +53,7 @@ impl WorkerLoaderChunkItem {
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root(),
+            (*this.chunking_context.output_root().await?).clone(),
             self.chunks(),
         ))
     }

--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -16,7 +16,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 #[turbo_tasks::value]
 pub struct ProcessEnvAsset {
     /// The root path which we can construct our env asset path.
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 
     /// A HashMap filled with the env key/values.
     env: ResolvedVc<Box<dyn ProcessEnv>>,
@@ -26,7 +26,7 @@ pub struct ProcessEnvAsset {
 impl ProcessEnvAsset {
     #[turbo_tasks::function]
     pub async fn new(
-        root: ResolvedVc<FileSystemPath>,
+        root: FileSystemPath,
         env: ResolvedVc<Box<dyn ProcessEnv>>,
     ) -> Result<Vc<Self>> {
         Ok(ProcessEnvAsset { root, env }.cell())
@@ -36,8 +36,8 @@ impl ProcessEnvAsset {
 #[turbo_tasks::value_impl]
 impl Source for ProcessEnvAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.root.join(".env.js".into()))
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(AssetIdent::from_path(self.root.join(".env.js")?))
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/dotenv.rs
+++ b/turbopack/crates/turbopack-env/src/dotenv.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_env::{CommandLineProcessEnv, CustomProcessEnv, ProcessEnv};
 use turbo_tasks_fs::FileSystemPath;
 
@@ -8,7 +8,7 @@ use crate::TryDotenvProcessEnv;
 /// Loads a series of dotenv files according to the precedence rules set by
 /// https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order
 #[turbo_tasks::function]
-pub async fn load_env(project_path: Vc<FileSystemPath>) -> Result<Vc<Box<dyn ProcessEnv>>> {
+pub async fn load_env(project_path: ResolvedVc<FileSystemPath>) -> Result<Vc<Box<dyn ProcessEnv>>> {
     let env: Vc<Box<dyn ProcessEnv>> = Vc::upcast(CommandLineProcessEnv::new());
 
     let node_env = env.read("NODE_ENV".into()).await?;
@@ -35,7 +35,7 @@ pub async fn load_env(project_path: Vc<FileSystemPath>) -> Result<Vc<Box<dyn Pro
     .flatten();
 
     let env = files.fold(env, |prior, f| {
-        let path = project_path.join(f.into());
+        let path = project_path.join_vc(f.into());
         Vc::upcast(TryDotenvProcessEnv::new(prior, path))
     });
 

--- a/turbopack/crates/turbopack-env/src/try_env.rs
+++ b/turbopack/crates/turbopack-env/src/try_env.rs
@@ -20,7 +20,8 @@ impl TryDotenvProcessEnv {
         prior: ResolvedVc<Box<dyn ProcessEnv>>,
         path: ResolvedVc<FileSystemPath>,
     ) -> Result<Vc<Self>> {
-        let dotenv = DotenvProcessEnv::new(Some(*prior), *path)
+        let path_value = (*path.await?).clone();
+        let dotenv = DotenvProcessEnv::new(Some(*prior), path_value)
             .to_resolved()
             .await?;
         Ok(TryDotenvProcessEnv {

--- a/turbopack/crates/turbopack-node/src/embed_js.rs
+++ b/turbopack/crates/turbopack-node/src/embed_js.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath, embed_directory};
@@ -8,11 +9,11 @@ pub fn embed_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file(path: RcStr) -> Vc<FileContent> {
-    embed_fs().root().join(path).read()
+pub(crate) async fn embed_file(path: RcStr) -> Result<Vc<FileContent>> {
+    Ok(embed_fs().root().await?.join(&path)?.read())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file_path(path: RcStr) -> Vc<FileSystemPath> {
-    embed_fs().root().join(path)
+pub(crate) async fn embed_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(embed_fs().root().await?.join(&path)?.cell())
 }

--- a/turbopack/crates/turbopack-node/src/execution_context.rs
+++ b/turbopack/crates/turbopack-node/src/execution_context.rs
@@ -5,7 +5,7 @@ use turbopack_core::chunk::ChunkingContext;
 
 #[turbo_tasks::value]
 pub struct ExecutionContext {
-    pub project_path: ResolvedVc<FileSystemPath>,
+    pub project_path: FileSystemPath,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     pub env: ResolvedVc<Box<dyn ProcessEnv>>,
 }
@@ -14,7 +14,7 @@ pub struct ExecutionContext {
 impl ExecutionContext {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: ResolvedVc<FileSystemPath>,
+        project_path: FileSystemPath,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         env: ResolvedVc<Box<dyn ProcessEnv>>,
     ) -> Vc<Self> {
@@ -28,7 +28,7 @@ impl ExecutionContext {
 
     #[turbo_tasks::function]
     pub fn project_path(&self) -> Vc<FileSystemPath> {
-        *self.project_path
+        self.project_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/node_entry.rs
+++ b/turbopack/crates/turbopack-node/src/node_entry.rs
@@ -9,9 +9,9 @@ pub struct NodeRenderingEntry {
     pub runtime_entries: ResolvedVc<EvaluatableAssets>,
     pub module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    pub intermediate_output_path: ResolvedVc<FileSystemPath>,
-    pub output_root: ResolvedVc<FileSystemPath>,
-    pub project_dir: ResolvedVc<FileSystemPath>,
+    pub intermediate_output_path: FileSystemPath,
+    pub output_root: FileSystemPath,
+    pub project_dir: FileSystemPath,
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-node/src/render/issue.rs
+++ b/turbopack/crates/turbopack-node/src/render/issue.rs
@@ -3,9 +3,9 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString};
 
 #[turbo_tasks::value(shared)]
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct RenderingIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub message: ResolvedVc<StyledString>,
     pub status: Option<i32>,
 }
@@ -24,7 +24,7 @@ impl Issue for RenderingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -20,11 +20,11 @@ use crate::{get_intermediate_asset, node_entry::NodeEntry, route_matcher::RouteM
 /// Creates a [NodeApiContentSource].
 #[turbo_tasks::function]
 pub fn create_node_api_source(
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     base_segments: Vec<BaseSegment>,
     route_type: RouteType,
-    server_root: ResolvedVc<FileSystemPath>,
+    server_root: FileSystemPath,
     route_match: ResolvedVc<Box<dyn RouteMatcher>>,
     pathname: ResolvedVc<RcStr>,
     entry: ResolvedVc<Box<dyn NodeEntry>>,
@@ -56,11 +56,11 @@ pub fn create_node_api_source(
 /// to this directory.
 #[turbo_tasks::value]
 pub struct NodeApiContentSource {
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     base_segments: Vec<BaseSegment>,
     route_type: RouteType,
-    server_root: ResolvedVc<FileSystemPath>,
+    server_root: FileSystemPath,
     pathname: ResolvedVc<RcStr>,
     route_match: ResolvedVc<Box<dyn RouteMatcher>>,
     entry: ResolvedVc<Box<dyn NodeEntry>>,
@@ -129,15 +129,15 @@ impl GetContentSourceContent for NodeApiContentSource {
         };
         let entry = (*self.entry).entry(data.clone()).await?;
         Ok(ContentSourceContent::HttpProxy(render_proxy_operation(
-            self.cwd,
+            self.cwd.clone(),
             self.env,
-            self.server_root.join(path.clone()).to_resolved().await?,
+            self.server_root.join(&path)?,
             ResolvedVc::upcast(entry.module),
             entry.runtime_entries,
             entry.chunking_context,
-            entry.intermediate_output_path,
-            entry.output_root,
-            entry.project_dir,
+            entry.intermediate_output_path.clone(),
+            entry.output_root.clone(),
+            entry.project_dir.clone(),
             RenderData {
                 params: params.clone(),
                 method: method.clone(),

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -75,16 +75,16 @@ impl StaticResult {
 /// Renders a module as static HTML in a node.js process.
 #[turbo_tasks::function(operation)]
 pub async fn render_static_operation(
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     runtime_entries: ResolvedVc<EvaluatableAssets>,
     fallback_page: ResolvedVc<DevHtmlAsset>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
-    output_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
+    output_root: FileSystemPath,
+    project_dir: FileSystemPath,
     data: ResolvedVc<RenderData>,
     debug: bool,
 ) -> Result<Vc<StaticResult>> {
@@ -137,7 +137,7 @@ pub async fn render_static_operation(
 }
 
 async fn static_error(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     error: anyhow::Error,
     operation: Option<NodeJsOperation>,
     fallback_page: Vc<DevHtmlAsset>,
@@ -202,16 +202,16 @@ struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
 
 #[derive(Clone, Debug, TaskInput, PartialEq, Eq, Hash, Deserialize, Serialize, TraceRawVcs)]
 struct RenderStreamOptions {
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     runtime_entries: ResolvedVc<EvaluatableAssets>,
     fallback_page: ResolvedVc<DevHtmlAsset>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
-    output_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
+    output_root: FileSystemPath,
+    project_dir: FileSystemPath,
     data: ResolvedVc<RenderData>,
     debug: bool,
 }
@@ -291,12 +291,12 @@ async fn render_stream_internal(
             *runtime_entries,
         ).to_resolved().await?;
         let renderer_pool_op = get_renderer_pool_operation(
-            cwd,
+            cwd.clone(),
             env,
             intermediate_asset,
-            intermediate_output_path,
-            output_root,
-            project_dir,
+            intermediate_output_path.clone(),
+            output_root.clone(),
+            project_dir.clone(),
             debug,
         );
 
@@ -345,8 +345,8 @@ async fn render_stream_internal(
                 let trace = trace_stack(
                     error,
                     *intermediate_asset,
-                    *intermediate_output_path,
-                    *project_dir,
+                    intermediate_output_path.clone(),
+                    project_dir.clone(),
                 )
                 .await?;
                 yield RenderItem::Response(
@@ -377,9 +377,14 @@ async fn render_stream_internal(
                     // We have already started to send a result, so we can't change the
                     // headers/body to a proxy error.
                     operation.disallow_reuse();
-                    let trace =
-                        trace_stack(error, *intermediate_asset, *intermediate_output_path, *project_dir).await?;
-                        drop(guard);
+                    let trace = trace_stack(
+                        error,
+                        *intermediate_asset,
+                        intermediate_output_path.clone(),
+                        project_dir.clone(),
+                    )
+                    .await?;
+                    drop(guard);
                     Err(anyhow!("error during streaming render: {}", trace))?;
                     return;
                 }

--- a/turbopack/crates/turbopack-node/src/transforms/util.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/util.rs
@@ -37,7 +37,7 @@ pub async fn emitted_assets_to_virtual_sources(
         .map(|(file, (content, _source_map))| {
             // TODO handle SourceMap
             VirtualSource::new(
-                ServerFileSystem::new().root().join(file),
+                ServerFileSystem::new().root().join_vc(file),
                 AssetContent::File(FileContent::Content(File::from(content)).resolved_cell())
                     .cell(),
             )

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -87,8 +87,8 @@ impl EcmascriptBuildNodeChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
         Ok(EcmascriptBuildNodeChunkVersion::new(
-            self.chunking_context.output_root(),
-            self.chunk.path(),
+            (*self.chunking_context.output_root().await?).clone(),
+            (*self.chunk.path().await?).clone(),
             *self.content,
             self.chunking_context.await?.minify_type(),
         ))

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -95,12 +95,13 @@ impl EcmascriptBuildNodeRuntimeChunk {
     }
 
     #[turbo_tasks::function]
-    fn ident_for_path(self: Vc<Self>) -> Vc<AssetIdent> {
-        AssetIdent::from_path(
+    async fn ident_for_path(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
+        Ok(AssetIdent::from_path(
             turbopack_ecmascript_runtime::embed_fs()
                 .root()
-                .join("runtime.js".into()),
-        )
+                .await?
+                .join("runtime.js")?,
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -17,13 +17,11 @@ pub(super) struct EcmascriptBuildNodeChunkVersion {
 impl EcmascriptBuildNodeChunkVersion {
     #[turbo_tasks::function]
     pub async fn new(
-        output_root: Vc<FileSystemPath>,
-        chunk_path: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
+        chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
         minify_type: MinifyType,
     ) -> Result<Vc<Self>> {
-        let output_root = output_root.await?;
-        let chunk_path = chunk_path.await?;
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -94,7 +94,7 @@ pub async fn esm_resolve(
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = Value::new(ReferenceType::EcmaScriptModules(ty.into_value()));
-    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), ty.clone())
+    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()).await?, ty.clone())
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -109,7 +109,7 @@ pub async fn cjs_resolve(
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO pass CommonJsReferenceSubType
     let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
+    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()).await?)
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -124,11 +124,11 @@ pub async fn cjs_resolve_source(
 ) -> Result<Vc<ResolveResult>> {
     // TODO pass CommonJsReferenceSubType
     let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
+    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()).await?)
         .resolve()
         .await?;
     let result = resolve(
-        origin.origin_path().parent().resolve().await?,
+        origin.origin_path().await?.parent(),
         ty.clone(),
         *request,
         options,
@@ -137,7 +137,7 @@ pub async fn cjs_resolve_source(
     handle_resolve_source_error(
         result,
         ty,
-        origin.origin_path(),
+        (*origin.origin_path().await?).clone(),
         *request,
         options,
         is_optional,
@@ -161,7 +161,7 @@ async fn specific_resolve(
     handle_resolve_error(
         result,
         reference_type,
-        origin.origin_path(),
+        (*origin.origin_path().await?).clone(),
         request,
         options,
         is_optional,

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -33,7 +33,7 @@ struct NodePreGypConfig {
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct NodePreGypConfigReference {
-    pub context_dir: ResolvedVc<FileSystemPath>,
+    pub context_dir: FileSystemPath,
     pub config_file_pattern: ResolvedVc<Pattern>,
     pub compile_target: ResolvedVc<CompileTarget>,
 }
@@ -42,7 +42,7 @@ pub struct NodePreGypConfigReference {
 impl NodePreGypConfigReference {
     #[turbo_tasks::function]
     pub fn new(
-        context_dir: ResolvedVc<FileSystemPath>,
+        context_dir: FileSystemPath,
         config_file_pattern: ResolvedVc<Pattern>,
         compile_target: ResolvedVc<CompileTarget>,
     ) -> Vc<Self> {
@@ -59,7 +59,7 @@ impl ModuleReference for NodePreGypConfigReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         resolve_node_pre_gyp_files(
-            *self.context_dir,
+            self.context_dir.clone(),
             *self.config_file_pattern,
             *self.compile_target,
         )
@@ -70,7 +70,7 @@ impl ModuleReference for NodePreGypConfigReference {
 impl ValueToString for NodePreGypConfigReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let context_dir = self.context_dir.to_string().await?;
+        let context_dir = self.context_dir.value_to_string().await?;
         let config_file_pattern = self.config_file_pattern.to_string().await?;
         let compile_target = self.compile_target.await?;
         Ok(Vc::cell(
@@ -82,7 +82,7 @@ impl ValueToString for NodePreGypConfigReference {
 
 #[turbo_tasks::function]
 pub async fn resolve_node_pre_gyp_files(
-    context_dir: Vc<FileSystemPath>,
+    context_dir: FileSystemPath,
     config_file_pattern: Vc<Pattern>,
     compile_target: Vc<CompileTarget>,
 ) -> Result<Vc<ModuleResolveResult>> {
@@ -104,8 +104,8 @@ pub async fn resolve_node_pre_gyp_files(
     if let Some(config_asset) = *config {
         if let AssetContent::File(file) = &*config_asset.content().await? {
             if let FileContent::Content(config_file) = &*file.await? {
-                let config_file_path = config_asset.ident().path();
-                let mut affecting_paths = vec![config_file_path];
+                let config_file_path = (*config_asset.ident().path().await?).clone();
+                let mut affecting_paths = vec![config_file_path.clone()];
                 let config_file_dir = config_file_path.parent();
                 let node_pre_gyp_config: NodePreGypConfigJson =
                     parse_json_rope_with_source_context(config_file.content())?;
@@ -120,32 +120,30 @@ pub async fn resolve_node_pre_gyp_files(
                         PLATFORM_TEMPLATE.replace(&native_binding_path, platform.as_str());
                     let native_binding_path =
                         ARCH_TEMPLATE.replace(&native_binding_path, compile_target.arch.as_str());
-                    let native_binding_path: RcStr = LIBC_TEMPLATE
-                        .replace(
-                            &native_binding_path,
-                            // node-pre-gyp only cares about libc on linux
-                            if platform == Platform::Linux {
-                                compile_target.libc.as_str()
-                            } else {
-                                "unknown"
-                            },
-                        )
-                        .into();
+                    let native_binding_path = LIBC_TEMPLATE.replace(
+                        &native_binding_path,
+                        // node-pre-gyp only cares about libc on linux
+                        if platform == Platform::Linux {
+                            compile_target.libc.as_str()
+                        } else {
+                            "unknown"
+                        },
+                    );
 
                     // Find all dynamic libraries in the given directory.
                     if let DirectoryContent::Entries(entries) = &*config_file_dir
-                        .join(native_binding_path.clone())
+                        .join(&native_binding_path)?
                         .read_dir()
                         .await?
                     {
                         let extension = compile_target.dylib_ext();
                         for (key, entry) in entries.iter().filter(|(k, _)| k.ends_with(extension)) {
                             if let &DirectoryEntry::File(dylib) | &DirectoryEntry::Symlink(dylib) =
-                                entry
+                                &entry
                             {
                                 sources.insert(
                                     format!("{native_binding_path}/{key}").into(),
-                                    Vc::upcast(FileSource::new(*dylib)),
+                                    Vc::upcast(FileSource::new(dylib.clone())),
                                 );
                             }
                         }
@@ -156,7 +154,7 @@ pub async fn resolve_node_pre_gyp_files(
                         native_binding_path, node_pre_gyp_config.binary.module_name
                     )
                     .into();
-                    let resolved_file_vc = config_file_dir.join(node_file_path.clone());
+                    let resolved_file_vc = config_file_dir.join(&node_file_path)?;
                     if *resolved_file_vc.get_type().await? == FileSystemEntryType::File {
                         sources.insert(
                             node_file_path,
@@ -167,26 +165,26 @@ pub async fn resolve_node_pre_gyp_files(
                 if let DirectoryContent::Entries(entries) = &*config_file_dir
                     // TODO
                     // read the dependencies path from `bindings.gyp`
-                    .join("deps/lib".into())
+                    .join("deps/lib")?
                     .read_dir()
                     .await?
                 {
                     for (key, entry) in entries.iter() {
-                        match *entry {
+                        match entry {
                             DirectoryEntry::File(dylib) => {
                                 sources.insert(
                                     format!("deps/lib/{key}").into(),
-                                    Vc::upcast(FileSource::new(*dylib)),
+                                    Vc::upcast(FileSource::new(dylib.clone())),
                                 );
                             }
                             DirectoryEntry::Symlink(dylib) => {
                                 let realpath_with_links = dylib.realpath_with_links().await?;
-                                for &symlink in realpath_with_links.symlinks.iter() {
-                                    affecting_paths.push(*symlink);
+                                for symlink in realpath_with_links.symlinks.iter() {
+                                    affecting_paths.push(symlink.clone());
                                 }
                                 sources.insert(
                                     format!("deps/lib/{key}").into(),
-                                    Vc::upcast(FileSource::new(*realpath_with_links.path)),
+                                    Vc::upcast(FileSource::new(realpath_with_links.path.clone())),
                                 );
                             }
                             _ => {}
@@ -221,17 +219,14 @@ pub async fn resolve_node_pre_gyp_files(
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct NodeGypBuildReference {
-    pub context_dir: ResolvedVc<FileSystemPath>,
+    pub context_dir: FileSystemPath,
     pub compile_target: ResolvedVc<CompileTarget>,
 }
 
 #[turbo_tasks::value_impl]
 impl NodeGypBuildReference {
     #[turbo_tasks::function]
-    pub fn new(
-        context_dir: ResolvedVc<FileSystemPath>,
-        compile_target: ResolvedVc<CompileTarget>,
-    ) -> Vc<Self> {
+    pub fn new(context_dir: FileSystemPath, compile_target: ResolvedVc<CompileTarget>) -> Vc<Self> {
         Self::cell(NodeGypBuildReference {
             context_dir,
             compile_target,
@@ -243,7 +238,7 @@ impl NodeGypBuildReference {
 impl ModuleReference for NodeGypBuildReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        resolve_node_gyp_build_files(*self.context_dir, *self.compile_target)
+        resolve_node_gyp_build_files(self.context_dir.clone(), *self.compile_target)
     }
 }
 
@@ -251,7 +246,7 @@ impl ModuleReference for NodeGypBuildReference {
 impl ValueToString for NodeGypBuildReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let context_dir = self.context_dir.to_string().await?;
+        let context_dir = self.context_dir.value_to_string().await?;
         let compile_target = self.compile_target.await?;
         Ok(Vc::cell(
             format!("node-gyp in {context_dir} for {compile_target}").into(),
@@ -261,7 +256,7 @@ impl ValueToString for NodeGypBuildReference {
 
 #[turbo_tasks::function]
 pub async fn resolve_node_gyp_build_files(
-    context_dir: Vc<FileSystemPath>,
+    context_dir: FileSystemPath,
     compile_target: Vc<CompileTarget>,
 ) -> Result<Vc<ModuleResolveResult>> {
     lazy_static! {
@@ -271,7 +266,7 @@ pub async fn resolve_node_gyp_build_files(
                 .expect("create napi_build_version regex failed");
     }
     let binding_gyp_pat = Pattern::new(Pattern::Constant("binding.gyp".into()));
-    let gyp_file = resolve_raw(context_dir, binding_gyp_pat, true);
+    let gyp_file = resolve_raw(context_dir.clone(), binding_gyp_pat, true);
     if let [binding_gyp] = &gyp_file.primary_sources().await?[..] {
         let mut merged_affecting_sources =
             gyp_file.await?.get_affecting_sources().collect::<Vec<_>>();
@@ -284,7 +279,7 @@ pub async fn resolve_node_gyp_build_files(
                         FxIndexMap::with_capacity_and_hasher(captured.len(), Default::default());
                     for found in captured.iter().skip(1).flatten() {
                         let name = found.as_str();
-                        let target_path = context_dir.join("build/Release".into());
+                        let target_path = context_dir.join("build/Release")?;
                         let resolved_prebuilt_file = resolve_raw(
                             target_path,
                             Pattern::new(Pattern::Constant(format!("{name}.node").into())),
@@ -340,14 +335,14 @@ pub async fn resolve_node_gyp_build_files(
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct NodeBindingsReference {
-    pub context_dir: ResolvedVc<FileSystemPath>,
+    pub context_dir: FileSystemPath,
     pub file_name: RcStr,
 }
 
 #[turbo_tasks::value_impl]
 impl NodeBindingsReference {
     #[turbo_tasks::function]
-    pub fn new(context_dir: ResolvedVc<FileSystemPath>, file_name: RcStr) -> Vc<Self> {
+    pub fn new(context_dir: FileSystemPath, file_name: RcStr) -> Vc<Self> {
         Self::cell(NodeBindingsReference {
             context_dir,
             file_name,
@@ -359,7 +354,7 @@ impl NodeBindingsReference {
 impl ModuleReference for NodeBindingsReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        resolve_node_bindings_files(*self.context_dir, self.file_name.clone())
+        resolve_node_bindings_files(self.context_dir.clone(), self.file_name.clone())
     }
 }
 
@@ -368,14 +363,14 @@ impl ValueToString for NodeBindingsReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(
-            format!("bindings in {}", self.context_dir.to_string().await?,).into(),
+            format!("bindings in {}", self.context_dir.value_to_string().await?).into(),
         ))
     }
 }
 
 #[turbo_tasks::function]
 pub async fn resolve_node_bindings_files(
-    context_dir: Vc<FileSystemPath>,
+    context_dir: FileSystemPath,
     file_name: RcStr,
 ) -> Result<Vc<ModuleResolveResult>> {
     lazy_static! {
@@ -390,7 +385,7 @@ pub async fn resolve_node_bindings_files(
     let mut root_context_dir = context_dir;
     loop {
         let resolved = resolve_raw(
-            root_context_dir,
+            root_context_dir.clone(),
             Pattern::new(Pattern::Constant("package.json".into())),
             true,
         )
@@ -403,31 +398,34 @@ pub async fn resolve_node_bindings_files(
                 }
             }
         };
-        let current_context = root_context_dir.await?;
+        let current_context = root_context_dir.clone();
         let parent = root_context_dir.parent();
-        let parent_context = parent.await?;
+        let parent_context = parent.clone();
         if parent_context.path == current_context.path {
             break;
         }
         root_context_dir = parent;
     }
 
-    let try_path = |sub_path: RcStr| async move {
-        let path = root_context_dir.join(sub_path.clone());
-        Ok(
-            if matches!(*path.get_type().await?, FileSystemEntryType::File) {
-                Some((
-                    RequestKey::new(sub_path),
-                    ResolvedVc::upcast(
-                        RawModule::new(Vc::upcast(FileSource::new(path)))
-                            .to_resolved()
-                            .await?,
-                    ),
-                ))
-            } else {
-                None
-            },
-        )
+    let try_path = |sub_path: RcStr| {
+        let root_context_dir = root_context_dir.clone();
+        async move {
+            let path = root_context_dir.join(&sub_path)?;
+            Ok(
+                if matches!(*path.get_type().await?, FileSystemEntryType::File) {
+                    Some((
+                        RequestKey::new(sub_path),
+                        ResolvedVc::upcast(
+                            RawModule::new(Vc::upcast(FileSource::new(path.clone())))
+                                .to_resolved()
+                                .await?,
+                        ),
+                    ))
+                } else {
+                    None
+                },
+            )
+        }
     };
 
     let modules = BINDINGS_TRY

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -30,11 +30,11 @@ pub struct ResolveOptionsContext {
     #[serde(default)]
     /// Enable resolving of the node_modules folder when within the provided
     /// directory
-    pub enable_node_modules: Option<ResolvedVc<FileSystemPath>>,
+    pub enable_node_modules: Option<FileSystemPath>,
     #[serde(default)]
     /// A specific path to a tsconfig.json file to use for resolving modules. If `None`, one will
     /// be looked up through the filesystem
-    pub tsconfig_path: Option<ResolvedVc<FileSystemPath>>,
+    pub tsconfig_path: Option<FileSystemPath>,
     #[serde(default)]
     /// Mark well-known Node.js modules as external imports and load them using
     /// native `require`. e.g. url, querystring, os

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -140,8 +140,7 @@ impl EcmascriptChunkItem for StaticUrlJsChunkItem {
                 path = StringifyJs(
                     &self
                         .chunking_context
-                        .asset_url(self.static_asset.path())
-                        .await?
+                        .asset_url((*self.static_asset.path().await?).clone())
                 )
             )
             .into(),

--- a/turbopack/crates/turbopack-static/src/fixed.rs
+++ b/turbopack/crates/turbopack-static/src/fixed.rs
@@ -10,17 +10,14 @@ use turbopack_core::{
 /// content hashing to generate a long term cacheable URL.
 #[turbo_tasks::value]
 pub struct FixedStaticAsset {
-    output_path: ResolvedVc<FileSystemPath>,
+    output_path: FileSystemPath,
     source: ResolvedVc<Box<dyn Source>>,
 }
 
 #[turbo_tasks::value_impl]
 impl FixedStaticAsset {
     #[turbo_tasks::function]
-    pub fn new(
-        output_path: ResolvedVc<FileSystemPath>,
-        source: ResolvedVc<Box<dyn Source>>,
-    ) -> Vc<Self> {
+    pub fn new(output_path: FileSystemPath, source: ResolvedVc<Box<dyn Source>>) -> Vc<Self> {
         FixedStaticAsset {
             output_path,
             source,
@@ -33,7 +30,7 @@ impl FixedStaticAsset {
 impl OutputAsset for FixedStaticAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.output_path
+        self.output_path.clone().cell()
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -56,7 +56,7 @@ pub(crate) async fn instantiating_loader_source(
     let code: RcStr = code.into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().append("_.loader.mjs".into()),
+        source.ident().path().await?.append("_.loader.mjs")?.cell(),
         AssetContent::file(File::from(code).into()),
     )))
 }
@@ -80,7 +80,7 @@ pub(crate) async fn compiling_loader_source(
     .into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().append("_.loader.mjs".into()),
+        source.ident().path().await?.append("_.loader.mjs")?.cell(),
         AssetContent::file(File::from(code).into()),
     )))
 }

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -50,14 +50,14 @@ impl WebAssemblySource {
 #[turbo_tasks::value_impl]
 impl Source for WebAssemblySource {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        match self.source_ty {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(match self.source_ty {
             WebAssemblySourceType::Binary => self.source.ident(),
             WebAssemblySourceType::Text => self
                 .source
                 .ident()
-                .with_path(self.source.ident().path().append("_.wasm".into())),
-        }
+                .with_path(self.source.ident().path().await?.append("_.wasm")?),
+        })
     }
 }
 

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -76,11 +76,11 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
         async move {
             let task = tt.spawn_once_task(async move {
                 let input_fs = DiskFileSystem::new("tests".into(), tests_root.clone(), vec![]);
-                let input = input_fs.root().join(input.clone());
+                let input = input_fs.root().await?.join(&input)?;
 
                 let input_dir = input.parent().parent();
                 let output_fs: Vc<NullFileSystem> = NullFileSystem.into();
-                let output_dir = output_fs.root().to_resolved().await?;
+                let output_dir = (*output_fs.root().to_resolved().await?.await?).clone();
 
                 let source = FileSource::new(input);
                 let compile_time_info = CompileTimeInfo::builder(
@@ -115,12 +115,12 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let module = module_asset_context
                     .process(Vc::upcast(source), Value::new(ReferenceType::Undefined))
                     .module();
-                let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, *output_dir)
+                let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, output_dir.clone())
                     .to_resolved()
                     .await?;
 
                 let emit_op =
-                    emit_with_completion_operation(ResolvedVc::upcast(rebased), output_dir);
+                    emit_with_completion_operation(ResolvedVc::upcast(rebased), output_dir.clone());
                 emit_op.read_strongly_consistent().await?;
                 apply_effects(emit_op).await?;
 

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -38,9 +38,9 @@ async fn main() -> Result<()> {
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);
-            let input = fs.root().join("demo".into());
-            let output = fs.root().join("out".into());
-            let entry = fs.root().join("demo/index.js".into());
+            let input = fs.root().await?.join("demo")?;
+            let output = fs.root().await?.join("out")?;
+            let entry = fs.root().await?.join("demo/index.js")?;
 
             let source = FileSource::new(entry);
             let module_asset_context = turbopack::ModuleAssetContext::new(
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
                 ResolveOptionsContext {
                     enable_typescript: true,
                     enable_react: true,
-                    enable_node_modules: Some(fs.root().to_resolved().await?),
+                    enable_node_modules: Some((*fs.root().await?).clone()),
                     custom_conditions: vec!["development".into()],
                     ..Default::default()
                 }
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
                     Value::new(turbopack_core::reference_type::ReferenceType::Undefined),
                 )
                 .module();
-            let rebased = RebasedAsset::new(module, input, output);
+            let rebased = RebasedAsset::new(module, input, output.clone());
             emit_with_completion(Vc::upcast(rebased), output).await?;
 
             anyhow::Ok::<Vc<()>>(Default::default())

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -45,12 +45,7 @@ pub async fn node_evaluate_asset_context(
         "@vercel/turbopack-node/",
         ImportMapping::PrimaryAlternative(
             "./*".into(),
-            Some(
-                turbopack_node::embed_js::embed_fs()
-                    .root()
-                    .to_resolved()
-                    .await?,
-            ),
+            Some((*turbopack_node::embed_js::embed_fs().root().await?).clone()),
         )
         .resolved_cell(),
     );
@@ -65,13 +60,7 @@ pub async fn node_evaluate_asset_context(
     // base context used for node_modules (and context for app code will be derived
     // from this)
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(
-            execution_context
-                .project_path()
-                .root()
-                .to_resolved()
-                .await?,
-        ),
+        enable_node_modules: Some((*execution_context.project_path().await?.root().await?).clone()),
         enable_node_externals: true,
         enable_node_native_modules: true,
         custom_conditions: vec![node_env.clone(), "node".into()],

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -157,7 +157,7 @@ pub struct ModuleOptionsContext {
     ///
     /// The filepath is the directory from which the bundled files will require the externals at
     /// runtime.
-    pub enable_externals_tracing: Option<ResolvedVc<FileSystemPath>>,
+    pub enable_externals_tracing: Option<FileSystemPath>,
 
     /// If true, it stores the last successful parse result in state and keeps using it when
     /// parsing fails. This is useful to keep the module graph structure intact when syntax errors


### PR DESCRIPTION
### What?

Make `FileSystemPath` usable without `Vc<T>`.

### Why?

String concattation does not require caching.

### How?



Closes PACK-4858