### PR TITLE
Turbopack: reduce max coverage for compaction

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -13,7 +13,7 @@ use crate::database::{
     write_batch::{BaseWriteBatch, ConcurrentWriteBatch, WriteBatch, WriteBuffer},
 };
 
-const COMPACT_MAX_COVERAGE: f32 = 20.0;
+const COMPACT_MAX_COVERAGE: f32 = 10.0;
 const COMPACT_MAX_MERGE_SEQUENCE: usize = 8;
 
 pub struct TurboKeyValueDatabase {


### PR DESCRIPTION
### What?

Compact earlier to limit the number of accessed files.

Closes PACK-4499