### PR TITLE
Fix import in useSearchParams to shared module

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -14,7 +14,7 @@ import {
 } from '../../shared/lib/hooks-client-context.shared-runtime'
 import { getSegmentValue } from './router-reducer/reducers/get-segment-value'
 import { PAGE_SEGMENT_KEY, DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
-import { ReadonlyURLSearchParams } from './navigation.react-server'
+import { ReadonlyURLSearchParams } from '../../api/navigation'
 
 const useDynamicRouteParams =
   typeof window === 'undefined'


### PR DESCRIPTION
I was looking at this hook because we're seeing a lot of unusual errors in production that originate from here. Not sure what the cause is yet, so I was trying to look for anything that look fishy.

One thing I noticed is that ReadonlyURLSearchParams was being imported from navigation.react-server.ts, rather than navigation.ts. Not sure what kind of issue this might result in but figured I'd update just in case.

I also removed a useMemo hook that only existed to make the searchParams object readonly, by hoisting the constructor to the context provider. Not that important of an optimization, but I wanted to remove one extra complexity from this hook to reduce the surface area of things that might be screwy.

The remaining one that I see is the inline require but not tackling that one yet.