### PR TITLE
Remove useMemo from useSearchParams

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -47,6 +47,7 @@ import { getRedirectTypeFromError, getURLFromRedirectError } from './redirect'
 import { isRedirectError, RedirectType } from './redirect-error'
 import { pingVisibleLinks } from './links'
 import GracefulDegradeBoundary from './errors/graceful-degrade-boundary'
+import { ReadonlyURLSearchParams } from './navigation'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -536,7 +537,9 @@ function Router({
       <RuntimeStyles />
       <PathParamsContext.Provider value={pathParams}>
         <PathnameContext.Provider value={pathname}>
-          <SearchParamsContext.Provider value={searchParams}>
+          <SearchParamsContext.Provider
+            value={new ReadonlyURLSearchParams(searchParams)}
+          >
             <GlobalLayoutRouterContext.Provider
               value={globalLayoutRouterContext}
             >

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,7 +1,7 @@
 import type { FlightRouterState } from '../../server/app-render/types'
 import type { Params } from '../../server/request/params'
 
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 import {
   AppRouterContext,
   LayoutRouterContext,
@@ -14,7 +14,7 @@ import {
 } from '../../shared/lib/hooks-client-context.shared-runtime'
 import { getSegmentValue } from './router-reducer/reducers/get-segment-value'
 import { PAGE_SEGMENT_KEY, DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
-import { ReadonlyURLSearchParams } from './navigation.react-server'
+import type { ReadonlyURLSearchParams } from './navigation.react-server'
 
 const useDynamicRouteParams =
   typeof window === 'undefined'
@@ -45,20 +45,15 @@ const useDynamicRouteParams =
  */
 // Client components API
 export function useSearchParams(): ReadonlyURLSearchParams {
-  const searchParams = useContext(SearchParamsContext)
+  const maybeSearchParams = useContext(SearchParamsContext)
 
+  // When the router is not ready in Pages, we won't have the search params
+  // available.
+  //
   // In the case where this is `null`, the compat types added in
   // `next-env.d.ts` will add a new overload that changes the return type to
   // include `null`.
-  const readonlySearchParams = useMemo(() => {
-    if (!searchParams) {
-      // When the router is not ready in pages, we won't have the search params
-      // available.
-      return null
-    }
-
-    return new ReadonlyURLSearchParams(searchParams)
-  }, [searchParams]) as ReadonlyURLSearchParams
+  const searchParams = maybeSearchParams as ReadonlyURLSearchParams
 
   if (typeof window === 'undefined') {
     // AsyncLocalStorage should not be included in the client bundle.
@@ -68,7 +63,7 @@ export function useSearchParams(): ReadonlyURLSearchParams {
     bailoutToClientRendering('useSearchParams()')
   }
 
-  return readonlySearchParams
+  return searchParams
 }
 
 /**

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -48,6 +48,7 @@ import {
 import { onRecoverableError } from './react-client-callbacks/on-recoverable-error'
 import tracer from './tracing/tracer'
 import { isNextRouterError } from './components/is-next-router-error'
+import { ReadonlyURLSearchParams } from './components/navigation'
 
 /// <reference types="react-dom/experimental" />
 
@@ -316,7 +317,9 @@ function AppContainer({
       }
     >
       <AppRouterContext.Provider value={adaptedForAppRouter}>
-        <SearchParamsContext.Provider value={adaptForSearchParams(router)}>
+        <SearchParamsContext.Provider
+          value={new ReadonlyURLSearchParams(adaptForSearchParams(router))}
+        >
           <PathnameContextProviderAdapter
             router={router}
             isAutoExport={self.__NEXT_DATA__.autoExport ?? false}

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -104,6 +104,7 @@ import { getCacheControlHeader } from './lib/cache-control'
 import { getErrorSource } from '../shared/lib/error-source'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import type { PagesDevOverlayType } from '../client/components/react-dev-overlay/pages/pages-dev-overlay'
+import { ReadonlyURLSearchParams } from '../api/navigation'
 
 let tryGetPreviewData: typeof import('./api-utils/node/try-get-preview-data').tryGetPreviewData
 let warn: typeof import('../build/output/log').warn
@@ -742,7 +743,9 @@ export async function renderToHTMLImpl(
 
   const AppContainer = ({ children }: { children: JSX.Element }) => (
     <AppRouterContext.Provider value={appRouter}>
-      <SearchParamsContext.Provider value={adaptForSearchParams(router)}>
+      <SearchParamsContext.Provider
+        value={new ReadonlyURLSearchParams(adaptForSearchParams(router))}
+      >
         <PathnameContextProviderAdapter
           router={router}
           isAutoExport={isAutoExport}

--- a/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
@@ -2,8 +2,10 @@
 
 import { createContext } from 'react'
 import type { Params } from '../../server/request/params'
+import type { ReadonlyURLSearchParams } from '../../api/navigation'
 
-export const SearchParamsContext = createContext<URLSearchParams | null>(null)
+export const SearchParamsContext =
+  createContext<ReadonlyURLSearchParams | null>(null)
 export const PathnameContext = createContext<string | null>(null)
 export const PathParamsContext = createContext<Params | null>(null)
 


### PR DESCRIPTION
I was looking at this hook because we're seeing a lot of unusual errors in production that originate from here. Not sure what the cause is yet, so I was trying to look for anything that look fishy.

Some of the stack traces originated from an internal React invariant inside the useMemo hook. I'm not sure how this is possible, but to reduce the surface area of things that might go wrong, I refactored this hook to no longer include a `useMemo`, by hoisting the ReadonlyURLSearchParams call into the top-level context provider.