### PR TITLE
fix(next): address CVE-2025-27789 vulnerability risk

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -151,7 +151,7 @@
     "@babel/preset-env": "7.22.5",
     "@babel/preset-react": "7.22.5",
     "@babel/preset-typescript": "7.22.5",
-    "@babel/runtime": "7.22.5",
+    "@babel/runtime": "7.26.10",
     "@babel/traverse": "7.22.5",
     "@babel/types": "7.22.5",
     "@capsizecss/metrics": "3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -973,8 +973,8 @@ importers:
         specifier: 7.22.5
         version: 7.22.5(@babel/core@7.22.5)
       '@babel/runtime':
-        specifier: 7.22.5
-        version: 7.22.5
+        specifier: 7.26.10
+        version: 7.26.10
       '@babel/traverse':
         specifier: 7.22.5
         version: 7.22.5
@@ -3332,8 +3332,8 @@ packages:
   '@babel/regjsgen@0.8.0':
     resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
 
-  '@babel/runtime@7.22.5':
-    resolution: {integrity: sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==}
+  '@babel/runtime@7.26.10':
+    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.22.15':
@@ -14786,11 +14786,11 @@ packages:
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
 
-  regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-
   regenerator-runtime@0.13.4:
     resolution: {integrity: sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regenerator-transform@0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
@@ -19371,9 +19371,9 @@ snapshots:
 
   '@babel/regjsgen@0.8.0': {}
 
-  '@babel/runtime@7.22.5':
+  '@babel/runtime@7.26.10':
     dependencies:
-      regenerator-runtime: 0.13.11
+      regenerator-runtime: 0.14.1
 
   '@babel/template@7.22.15':
     dependencies:
@@ -19552,7 +19552,7 @@ snapshots:
   '@emotion/babel-plugin@11.11.0':
     dependencies:
       '@babel/helper-module-imports': 7.24.7
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.2
@@ -19579,7 +19579,7 @@ snapshots:
 
   '@emotion/react@11.11.1(@types/react@19.1.1)(react@19.2.0-canary-197d6a04-20250424)':
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.2
@@ -22454,7 +22454,7 @@ snapshots:
   '@testing-library/dom@10.1.0':
     dependencies:
       '@babel/code-frame': 7.22.5
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       '@types/aria-query': 5.0.1
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -22465,7 +22465,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.22.5
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       '@types/aria-query': 5.0.1
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -22476,7 +22476,7 @@ snapshots:
   '@testing-library/jest-dom@6.1.2(@jest/globals@29.7.0)(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(vitest@3.0.4(@types/node@20.17.6)(sass@1.54.0)(tsx@4.19.2))':
     dependencies:
       '@adobe/css-tools': 4.3.1
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       aria-query: 5.3.0
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -22501,7 +22501,7 @@ snapshots:
 
   '@testing-library/react@15.0.7(@types/react@19.1.1)(react-dom@19.2.0-canary-197d6a04-20250424(react@19.2.0-canary-197d6a04-20250424))(react@19.2.0-canary-197d6a04-20250424)':
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       '@testing-library/dom': 10.1.0
       '@types/react-dom': 19.1.2(@types/react@19.1.1)
       react: 19.2.0-canary-197d6a04-20250424
@@ -24009,13 +24009,13 @@ snapshots:
 
   babel-plugin-macros@3.0.1:
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       cosmiconfig: 7.0.0
       resolve: 1.22.8
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
@@ -26001,7 +26001,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       csstype: 3.1.2
 
   dom-serializer@0.1.1:
@@ -32388,7 +32388,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
 
   possible-typed-array-names@1.0.0: {}
 
@@ -33548,7 +33548,7 @@ snapshots:
 
   react-textarea-autosize@8.5.3(@types/react@19.1.1)(react@19.2.0-canary-c44e4a25-20250409):
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       react: 19.2.0-canary-c44e4a25-20250409
       use-composed-ref: 1.3.0(react@19.2.0-canary-c44e4a25-20250409)
       use-latest: 1.2.1(@types/react@19.1.1)(react@19.2.0-canary-c44e4a25-20250409)
@@ -33557,7 +33557,7 @@ snapshots:
 
   react-virtualized@9.22.3(react-dom@19.2.0-canary-197d6a04-20250424(react@19.2.0-canary-197d6a04-20250424))(react@19.2.0-canary-197d6a04-20250424):
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       clsx: 1.1.1
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
@@ -33760,17 +33760,17 @@ snapshots:
 
   regenerate@1.4.2: {}
 
-  regenerator-runtime@0.13.11: {}
-
   regenerator-runtime@0.13.4: {}
+
+  regenerator-runtime@0.14.1: {}
 
   regenerator-transform@0.15.0:
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
 
   regexp.prototype.flags@1.5.3:
     dependencies:
@@ -33844,7 +33844,7 @@ snapshots:
 
   relay-runtime@13.0.2:
     dependencies:
-      '@babel/runtime': 7.22.5
+      '@babel/runtime': 7.26.10
       fbjs: 3.0.2
       invariant: 2.2.4
 


### PR DESCRIPTION
# Babel Security Update Summary

- Updated `@babel/runtime` from `7.22.5` to `7.26.10` in `packages/next/package.json`
- Updated corresponding dependency in `pnpm-lock.yaml` 
- Changed underlying `regenerator-runtime` dependency from version `0.13.11` to `0.14.1`
- Updated all related package references to use the new `@babel/runtime` version
- These changes address the security vulnerability CVE-2025-27789

Fixes NEXT-77879