### PR TITLE
chore: Drop `@swc/counter`

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -101,7 +101,6 @@
   },
   "dependencies": {
     "@next/env": "15.4.0-canary.14",
-    "@swc/counter": "0.1.3",
     "@swc/helpers": "0.5.15",
     "caniuse-lite": "^1.0.30001579",
     "postcss": "8.4.31",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,9 +889,6 @@ importers:
       '@next/env':
         specifier: 15.4.0-canary.14
         version: link:../next-env
-      '@swc/counter':
-        specifier: 0.1.3
-        version: 0.1.3
       '@swc/helpers':
         specifier: 0.5.15
         version: 0.5.15


### PR DESCRIPTION
### What?

Drop dependency on `@swc/counter`

### Why?

x-ref: https://vercel.slack.com/archives/C06BR9ZH14H/p1745851763574729?thread_ts=1745851352.737009&cid=C06BR9ZH14H

### How?



Closes PACK-4479