### PR TITLE
Change stylistic ESLint TypeScript defaults

### DIFF
--- a/packages/eslint-config-next/typescript.js
+++ b/packages/eslint-config-next/typescript.js
@@ -1,3 +1,7 @@
 module.exports = {
   extends: ['plugin:@typescript-eslint/recommended'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': 1,
+    '@typescript-eslint/no-unused-expressions': 1,
+  },
 }

--- a/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
+++ b/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
@@ -509,10 +509,10 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v8
       "error",
     ],
     "@typescript-eslint/no-unused-expressions": [
-      "error",
+      1,
     ],
     "@typescript-eslint/no-unused-vars": [
-      "error",
+      1,
     ],
     "@typescript-eslint/no-wrapper-object-types": [
       "error",
@@ -767,10 +767,10 @@ exports[`Next Build production mode first time setup with TypeScript - ESLint v9
       "error",
     ],
     "@typescript-eslint/no-unused-expressions": [
-      "error",
+      1,
     ],
     "@typescript-eslint/no-unused-vars": [
-      "error",
+      1,
     ],
     "@typescript-eslint/no-wrapper-object-types": [
       "error",


### PR DESCRIPTION
As discussed stylistic ESLint defaults should not be errors they should be warnings instead as errors from ESLint should be serious as they cause builds to fail. If users want to be more strict they can make them errors themselves.

x-ref: [slack thread](https://vercel.slack.com/archives/C088NDH88AY/p1745893026311189?thread_ts=1745871583.511739&cid=C088NDH88AY)