### PR TITLE
Share logic across our two transforms

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -69,8 +69,8 @@ macro_rules! embed_directory_internal {
         // make sure the types the `include_dir!` proc macro refers to are in scope
         use turbo_tasks_fs::embed::include_dir;
 
-        static dir: include_dir::Dir<'static> = turbo_tasks_fs::embed::include_dir!($path);
+        static DIR: include_dir::Dir<'static> = turbo_tasks_fs::embed::include_dir!($path);
 
-        turbo_tasks_fs::embed::directory_from_include_dir($name.into(), &dir)
+        turbo_tasks_fs::embed::directory_from_include_dir($name.into(), &DIR)
     }};
 }

--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -11,13 +11,13 @@ export type StructuredError = {
   cause: StructuredError | undefined
 }
 
-export function structuredError(e: Error): StructuredError {
+export function structuredError(e: Error | string): StructuredError {
   e = getProperError(e)
 
   return {
     name: e.name,
     message: e.message,
-    stack: typeof e.stack === 'string' ? parseStackTrace(e.stack!) : [],
+    stack: typeof e.stack === 'string' ? parseStackTrace(e.stack) : [],
     cause: e.cause ? structuredError(getProperError(e.cause)) : undefined,
   }
 }
@@ -34,7 +34,7 @@ type State =
 export type Ipc<TIncoming, TOutgoing> = {
   recv(): Promise<TIncoming>
   send(message: TOutgoing): Promise<void>
-  sendError(error: Error): Promise<never>
+  sendError(error: Error | string): Promise<never>
   sendReady(): Promise<void>
 }
 
@@ -121,7 +121,7 @@ function createIpc<TIncoming, TOutgoing>(
 
   // TODO(lukesandberg): some of the messages being sent are very large and contain lots
   //  of redundant information.  Consider adding gzip compression to our stream.
-  function doSend(message: any): Promise<void> {
+  function doSend(message: string): Promise<void> {
     return new Promise((resolve, reject) => {
       // Reserve 4 bytes for our length prefix, we will over-write after encoding.
       const packet = Buffer.from('0000' + message, 'utf8')

--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -11,7 +11,7 @@ export type StructuredError = {
   cause: StructuredError | undefined
 }
 
-export function structuredError(e: Error | string): StructuredError {
+export function structuredError(e: unknown): StructuredError {
   e = getProperError(e)
 
   return {

--- a/turbopack/crates/turbopack-node/js/src/transforms/transforms.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/transforms.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared utilities for our 2 transform implementations.
+ */
+
+import type { Ipc } from '../ipc/evaluate'
+import { relative, isAbsolute, join, sep } from 'path'
+import { type StructuredError } from '../ipc'
+import { type StackFrame } from '../compiled/stacktrace-parser'
+
+export type IpcInfoMessage =
+  | {
+      type: 'dependencies'
+      envVariables?: string[]
+      directories?: Array<[string, string]>
+      filePaths?: string[]
+      buildFilePaths?: string[]
+    }
+  | {
+      type: 'emittedError'
+      severity: 'warning' | 'error'
+      error: StructuredError
+    }
+  | {
+      type: 'log'
+      logs: Array<{
+        time: number
+        logType: string
+        args: any[]
+        trace?: StackFrame[]
+      }>
+    }
+
+export type IpcRequestMessage = {
+  type: 'resolve'
+  options: any
+  lookupPath: string
+  request: string
+}
+
+export type TransformIpc = Ipc<IpcInfoMessage, IpcRequestMessage>
+
+const contextDir = process.cwd()
+export const toPath = (file: string) => {
+  const relPath = relative(contextDir, file)
+  if (isAbsolute(relPath)) {
+    throw new Error(
+      `Cannot depend on path (${file}) outside of root directory (${contextDir})`
+    )
+  }
+  return sep !== '/' ? relPath.replaceAll(sep, '/') : relPath
+}
+export const fromPath = (path: string) => {
+  return join(contextDir, sep !== '/' ? path.replaceAll('/', sep) : path)
+}
+
+// Patch process.env to track which env vars are read
+const originalEnv = process.env
+const readEnvVars = new Set<string>()
+process.env = new Proxy(originalEnv, {
+  get(target, prop) {
+    if (typeof prop === 'string') {
+      // We register the env var as dependency on the
+      // current transform and all future transforms
+      // since the env var might be cached in module scope
+      // and influence them all
+      readEnvVars.add(prop)
+    }
+    return Reflect.get(target, prop)
+  },
+})
+
+export function getReadEnvVariables(): string[] {
+  return Array.from(readEnvVars)
+}

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -33,7 +33,7 @@ use super::{
     webpack::WebpackLoaderContext,
 };
 use crate::{
-    embed_js::embed_file, execution_context::ExecutionContext,
+    embed_js::embed_file_path, execution_context::ExecutionContext,
     transforms::webpack::evaluate_webpack_loader,
 };
 
@@ -410,15 +410,9 @@ async fn postcss_executor(
         .await?;
 
     Ok(asset_context.process(
-        Vc::upcast(VirtualSource::new(
-            postcss_config_path.join("transform.ts".into()),
-            AssetContent::File(
-                embed_file("transforms/postcss.ts".into())
-                    .to_resolved()
-                    .await?,
-            )
-            .cell(),
-        )),
+        Vc::upcast(FileSource::new(embed_file_path(
+            "transforms/postcss.ts".into(),
+        ))),
         Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
             "CONFIG".into() => config_asset
         }))),

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -379,7 +379,9 @@ pub enum InfoMessage {
         severity: IssueSeverity,
         error: StructuredError,
     },
-    Log(LogInfo),
+    Log {
+        logs: Vec<LogInfo>,
+    },
 }
 
 #[derive(Debug, Clone, TaskInput, Hash, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
@@ -553,8 +555,8 @@ impl EvaluateContext for WebpackLoaderContext {
                 .resolved_cell()
                 .emit();
             }
-            InfoMessage::Log(log) => {
-                state.push(log);
+            InfoMessage::Log { logs } => {
+                state.extend(logs);
             }
         }
         Ok(())


### PR DESCRIPTION
This reduces a small bit of duplication between our two transforms (`toPath` and `fromPath`) and fixes a small bug in `postcss` where we didn't register the environment variables it read as dependencies which could cause persistence issues.

Finally, batch `log` messages sent by webpack transforms, the turbopack side doesn't read them until the end anyway and we can reduce overhead a touch by sending them in a single batch.


Closes PACK-4532