### PR TITLE
Fix timings data for deploy tests

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -80,6 +80,8 @@ env:
 
   TURBO_TEAM: 'vercel'
   TURBO_CACHE: 'remote:rw'
+  TURBO_API: ${{ secrets.HOSTED_TURBO_API }}
+  TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
   NEXT_TELEMETRY_DISABLED: 1
   # allow not skipping install-native postinstall script if we don't have a binary available already
   NEXT_SKIP_NATIVE_POSTINSTALL: ${{ inputs.skipNativeInstall == 'yes' && '1' || '' }}

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -11,6 +11,10 @@ env:
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
   DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
+  TURBO_TEAM: 'vercel'
+  TURBO_CACHE: 'remote:rw'
+  TURBO_API: ${{ secrets.HOSTED_TURBO_API }}
+  TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
   DD_ENV: 'ci'
 
 jobs:


### PR DESCRIPTION
This fixes an issue where deploy tests were intermittently passing when they shouldn't have been due to jobs not being sorted consistently across retries.  