### PR TITLE
Postpone on `useSearchParams` access for segment prefetch requests

### DIFF
--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -1,10 +1,26 @@
 import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { workAsyncStorage } from '../../server/app-render/work-async-storage.external'
+import { postponeWithTracking } from '../../server/app-render/dynamic-rendering'
+import { workUnitAsyncStorage } from '../../server/app-render/work-unit-async-storage.external'
 
 export function bailoutToClientRendering(reason: string): void | never {
   const workStore = workAsyncStorage.getStore()
 
-  if (workStore?.forceStatic) return
+  if (workStore?.forceStatic || !workStore?.isStaticGeneration) {
+    return
+  }
 
-  if (workStore?.isStaticGeneration) throw new BailoutToCSRError(reason)
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (workUnitStore) {
+    if (workStore.isPrefetchRequest && workUnitStore.type === 'prerender-ppr') {
+      postponeWithTracking(
+        workStore.route,
+        reason,
+        workUnitStore.dynamicTracking
+      )
+    }
+  } else {
+    throw new BailoutToCSRError(reason)
+  }
 }

--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -12,14 +12,8 @@ export function bailoutToClientRendering(reason: string): void | never {
 
   const workUnitStore = workUnitAsyncStorage.getStore()
 
-  if (workUnitStore) {
-    if (workStore.isPrefetchRequest && workUnitStore.type === 'prerender-ppr') {
-      postponeWithTracking(
-        workStore.route,
-        reason,
-        workUnitStore.dynamicTracking
-      )
-    }
+  if (workStore.isPrefetchRequest && workUnitStore?.type === 'prerender-ppr') {
+    postponeWithTracking(workStore.route, reason, workUnitStore.dynamicTracking)
   } else {
     throw new BailoutToCSRError(reason)
   }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2353,6 +2353,10 @@ export default abstract class Server<
       isSSG &&
       isRSCRequest &&
       !isDynamicRSCRequest &&
+      // TODO: Find a more suitable condition to omit stripping the flight
+      // headers in this case, so that we can read `workStore.isPrefetchRequest`
+      // in `bailoutToClientRendering`.
+      !req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()] &&
       (!isEdgeRuntime(opts.runtime) ||
         (this.serverOptions as any).webServerConfig)
     ) {

--- a/test/e2e/app-dir/use-search-params-client-segment-cache/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-search-params-client-segment-cache/app/[slug]/page.tsx
@@ -1,0 +1,19 @@
+import { SearchParamsAccess } from './search-params-access'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return slug === 'prerendered' ? (
+    <div>Prerendered</div>
+  ) : (
+    <SearchParamsAccess />
+  )
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'prerendered' }]
+}

--- a/test/e2e/app-dir/use-search-params-client-segment-cache/app/[slug]/search-params-access.tsx
+++ b/test/e2e/app-dir/use-search-params-client-segment-cache/app/[slug]/search-params-access.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+export function SearchParamsAccess() {
+  const searchParams = useSearchParams()
+  return <p>{searchParams.get('foo')}</p>
+}

--- a/test/e2e/app-dir/use-search-params-client-segment-cache/app/layout.tsx
+++ b/test/e2e/app-dir/use-search-params-client-segment-cache/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-search-params-client-segment-cache/app/page.tsx
+++ b/test/e2e/app-dir/use-search-params-client-segment-cache/app/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import React from 'react'
+import { Suspense } from 'react'
+import { SearchParamsAccess } from './[slug]/search-params-access'
+
+export default function Home() {
+  return (
+    <>
+      <Suspense>
+        <p>
+          This search params access should not make the page partially static.
+        </p>
+        <SearchParamsAccess />
+      </Suspense>
+      <p>
+        <Link href="/prerendered?foo=1">Go to /prerendered</Link>
+      </p>
+      <p>
+        <Link href="/not-prerendered?foo=2">Go to /not-prerendered</Link>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-search-params-client-segment-cache/next.config.ts
+++ b/test/e2e/app-dir/use-search-params-client-segment-cache/next.config.ts
@@ -1,0 +1,13 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    ppr: true,
+    // FIXME: Should also work when DIO is enabled.
+    // dynamicIO: true,
+    clientSegmentCache: true,
+    removeUncaughtErrorAndRejectionListeners: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/use-search-params-client-segment-cache/use-search-params-client-segment-cache.test.ts
+++ b/test/e2e/app-dir/use-search-params-client-segment-cache/use-search-params-client-segment-cache.test.ts
@@ -1,0 +1,38 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from '../../../lib/next-test-utils'
+
+describe('use-search-params-client-segment-cache', () => {
+  const { next, isNextStart, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not have a failed prefetch request', async () => {
+    let requestCount = 0
+
+    await next.browser('/', {
+      beforePageLoad(page) {
+        page.on('request', () => {
+          requestCount++
+        })
+
+        page.on('response', async (res) => {
+          requestCount--
+          if (res.status() === 500) {
+            throw new Error('Unexpected error response for ' + res.url())
+          }
+        })
+      },
+    })
+
+    await retry(async () => {
+      expect(requestCount).toBe(0)
+    })
+  })
+
+  if (isNextStart && !isNextDeploy) {
+    it('should render a page with useSearchParams wrapped in Suspense fully static', async () => {
+      const meta = await next.readJSON('.next/server/app/index.meta')
+      expect(meta.postponed).toBeUndefined()
+    })
+  }
+})


### PR DESCRIPTION
Normally, when using `useSearchParams` without a suspense boundary we throw a build error to inform a user about this mistake as early as possible. However, when `ppr` and `clientSegmentCache` are enabled, it can occur that a postponed page is built successfully due to accessing fallback params, and then only the segment prefetch request (using the actual params) fails. This results in a 500 error response, which we'd like to avoid.

As an immediate fix to unblock further dogfooding, we can postpone when `useSearchParams` is accessed during those on-demand static prefetch generations.

This fix does not work when `dynamicIO` is enabled, though. For that to work, we need to come up with a better approach.