### PR TITLE
Add code and documentation for new option, --experimental-https-passp…

### DIFF
--- a/docs/01-app/05-api-reference/06-cli/next.mdx
+++ b/docs/01-app/05-api-reference/06-cli/next.mdx
@@ -52,6 +52,7 @@ The following commands are available:
 | `--experimental-https-key <path>`        | Path to a HTTPS key file.                                                                                                                            |
 | `--experimental-https-cert <path>`       | Path to a HTTPS certificate file.                                                                                                                    |
 | `--experimental-https-ca <path>`         | Path to a HTTPS certificate authority file.                                                                                                          |
+| `--experimental-https-passphrase <path>` | Passphrase for HTTPS certificate file.                                                                                                               |
 | `--experimental-upload-trace <traceUrl>` | Reports a subset of the debugging trace to a remote HTTP URL.                                                                                        |
 
 ### `next build` options
@@ -209,7 +210,7 @@ next dev --experimental-https
 
 With the generated certificate, the Next.js development server will exist at `https://localhost:3000`. The default port `3000` is used unless a port is specified with `-p`, `--port`, or `PORT`.
 
-You can also provide a custom certificate and key with `--experimental-https-key` and `--experimental-https-cert`. Optionally, you can provide a custom CA certificate with `--experimental-https-ca` as well.
+You can also provide a custom certificate and key with `--experimental-https-key` and `--experimental-https-cert`. Optionally, you can provide a custom CA certificate with `--experimental-https-ca` as well, and a --experimental-https-passphrase for the certificate.
 
 ```bash filename="Terminal"
 next dev --experimental-https --experimental-https-key ./certificates/localhost-key.pem --experimental-https-cert ./certificates/localhost.pem

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -201,6 +201,10 @@ program
     'Path to a HTTPS certificate authority file.'
   )
   .option(
+    '--experimental-https-passphrase, <path>',
+    'Passphrase for certificate file.'
+  )
+  .option(
     '--experimental-upload-trace, <traceUrl>',
     'Reports a subset of the debugging trace to a remote HTTP URL. Includes sensitive data.'
   )

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -49,6 +49,7 @@ export type NextDevOptions = {
   experimentalHttpsKey?: string
   experimentalHttpsCert?: string
   experimentalHttpsCa?: string
+  experimentalHttpsPassphrase?: string
   experimentalUploadTrace?: string
 }
 
@@ -359,12 +360,14 @@ const nextDev = async (
         const key = options.experimentalHttpsKey
         const cert = options.experimentalHttpsCert
         const rootCA = options.experimentalHttpsCa
+        const certPassphrase = options.experimentalHttpsPassphrase
 
         if (key && cert) {
           certificate = {
             key: path.resolve(key),
             cert: path.resolve(cert),
             rootCA: rootCA ? path.resolve(rootCA) : undefined,
+            passphrase: certPassphrase,
           }
         } else {
           certificate = await createSelfSignedCertificate(host)

--- a/packages/next/src/lib/mkcert.ts
+++ b/packages/next/src/lib/mkcert.ts
@@ -14,6 +14,7 @@ export interface SelfSignedCertificate {
   key: string
   cert: string
   rootCA?: string
+  passphrase?: string
 }
 
 function getBinaryName() {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -183,6 +183,9 @@ export async function startServer(
         {
           key: fs.readFileSync(selfSignedCertificate.key),
           cert: fs.readFileSync(selfSignedCertificate.cert),
+          ...(selfSignedCertificate.passphrase
+            ? { passphrase: selfSignedCertificate.passphrase }
+            : {}),
         },
         requestListener
       )


### PR DESCRIPTION
…hrase that allows a passphrase to be provided with locked certificates

## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding a feature

- [x] Implements an existing feature request or RFC. (https://github.com/vercel/next.js/discussions/35533)