### PR TITLE
Add a new `fs` method to track a glob.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9549,6 +9549,7 @@ dependencies = [
  "triomphe 0.1.12",
  "turbo-rcstr",
  "turbo-tasks",
+ "turbo-tasks-backend",
  "turbo-tasks-build",
  "turbo-tasks-hash",
  "turbo-tasks-memory",

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -63,6 +63,7 @@ sha2 = "0.10.2"
 tempfile = { workspace = true }
 turbo-tasks-memory = { workspace = true }
 turbo-tasks-testing = { workspace = true }
+turbo-tasks-backend = { workspace = true }
 
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 
 use crate::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent};
 
@@ -131,11 +131,6 @@ impl FileSystem for AttachedFileSystem {
     #[turbo_tasks::function(fs)]
     fn raw_read_dir(self: Vc<Self>, path: Vc<FileSystemPath>) -> Vc<RawDirectoryContent> {
         self.get_inner_fs_path(path).raw_read_dir()
-    }
-
-    #[turbo_tasks::function(fs)]
-    fn track(self: Vc<Self>, path: Vc<FileSystemPath>) -> Vc<Completion> {
-        self.get_inner_fs_path(path).track()
     }
 
     #[turbo_tasks::function(fs)]

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use auto_hash_map::AutoMap;
 use include_dir::{Dir, DirEntry};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ValueToString, Vc};
+use turbo_tasks::{ValueToString, Vc};
 
 use crate::{
     File, FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
@@ -67,11 +67,6 @@ impl FileSystem for EmbeddedFileSystem {
         }
 
         Ok(RawDirectoryContent::new(converted_entries))
-    }
-
-    #[turbo_tasks::function]
-    fn track(&self, _path: Vc<FileSystemPath>) -> Vc<Completion> {
-        Completion::immutable()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -55,6 +55,13 @@ impl Glob {
             .any(|result| matches!(result, ("", _)))
     }
 
+    // Returns true if the glob could match a filename underneath this path prefix
+    // Typically this prefix would represent a directory.
+    pub fn match_prefix(&self, path: &str) -> bool {
+        self.iter_matches(path, true, true)
+            .any(|result| matches!(result, ("", _)))
+    }
+
     fn iter_matches<'a>(
         &'a self,
         path: &'a str,

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -46,8 +46,8 @@ use invalidator_map::InvalidatorMap;
 use jsonc_parser::{parse_to_serde_value, ParseOptions};
 use mime::Mime;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use read_glob::read_glob;
 pub use read_glob::ReadGlobResult;
+use read_glob::{read_glob, track_glob};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{
@@ -1328,6 +1328,12 @@ impl FileSystemPath {
         read_glob(self, glob, include_dot_files)
     }
 
+    // Tracks all files and directories matching the glob
+    #[turbo_tasks::function]
+    pub fn track_glob(self: Vc<Self>, glob: Vc<Glob>, include_dot_files: bool) -> Vc<Completion> {
+        track_glob(self, glob, include_dot_files)
+    }
+
     #[turbo_tasks::function]
     pub fn root(self: Vc<Self>) -> Vc<Self> {
         self.fs().root()
@@ -1466,6 +1472,7 @@ impl FileSystemPath {
         self.fs().raw_read_dir(self)
     }
 
+    /// Tracks this path without reading the contents
     pub fn track(self: Vc<Self>) -> Vc<Completion> {
         self.fs().track(self)
     }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
+use futures::try_join;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{Completion, ResolvedVc, TryJoinIterExt, Vc};
 
 use crate::{glob::Glob, DirectoryContent, DirectoryEntry, FileSystemPath};
 
@@ -23,6 +24,16 @@ pub async fn read_glob(
     include_dot_files: bool,
 ) -> Result<Vc<ReadGlobResult>> {
     Ok(*read_glob_internal("", directory, glob, include_dot_files).await?)
+}
+
+/// Tracks all files and directories that match of a glob pattern.
+#[turbo_tasks::function(fs)]
+pub async fn track_glob(
+    directory: Vc<FileSystemPath>,
+    glob: Vc<Glob>,
+    include_dot_files: bool,
+) -> Result<Vc<Completion>> {
+    track_glob_internal("", directory, glob, include_dot_files).await
 }
 
 #[turbo_tasks::function(fs)]
@@ -81,4 +92,70 @@ async fn read_glob_internal(
         DirectoryContent::NotFound => {}
     }
     Ok(ReadGlobResult::resolved_cell(result))
+}
+
+/// Traverses all directories that match the given `glob`.
+///
+/// This ensures that the calling task will be invalidated
+/// whenever the directories change, but unlike
+#[turbo_tasks::function(fs)]
+async fn track_glob_inner(
+    prefix: RcStr,
+    directory: Vc<FileSystemPath>,
+    glob: Vc<Glob>,
+    include_dot_files: bool,
+) -> Result<Vc<Completion>> {
+    track_glob_internal(&prefix, directory, glob, include_dot_files).await
+}
+
+async fn track_glob_internal(
+    prefix: &str,
+    directory: Vc<FileSystemPath>,
+    glob: Vc<Glob>,
+    include_dot_files: bool,
+) -> Result<Vc<Completion>> {
+    let dir = directory.read_dir().await?;
+    let glob_value = glob.await?;
+    let mut reads = Vec::new();
+    let mut completions = Vec::new();
+    let mut links = Vec::new();
+    let mut types = Vec::new();
+    match &*dir {
+        DirectoryContent::Entries(entries) => {
+            for (segment, entry) in entries.iter() {
+                if !include_dot_files && segment.starts_with('.') {
+                    continue;
+                }
+                let entry = entry.resolve_symlink().await?;
+                match entry {
+                    DirectoryEntry::Directory(path) => {
+                        let full_path_prefix: RcStr = format!("{prefix}{segment}/").into();
+                        if glob_value.execute(&full_path_prefix) {
+                            completions.push(track_glob_inner(
+                                full_path_prefix,
+                                *path,
+                                glob,
+                                include_dot_files,
+                            ));
+                        }
+                    }
+                    DirectoryEntry::File(path) => reads.push(path.read()),
+                    DirectoryEntry::Symlink(path) => {
+                        links.push(path.read_link());
+                    }
+                    DirectoryEntry::Other(path) => {
+                        types.push(path.get_type());
+                    }
+                    DirectoryEntry::Error => {}
+                }
+            }
+        }
+        DirectoryContent::NotFound => {}
+    }
+    let reads = reads.iter().try_join();
+    let links = links.iter().try_join();
+    let types = types.iter().try_join();
+    let completions = completions.iter().try_join();
+    try_join!(reads, links, types, completions)?;
+    Ok(Completion::new())
 }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -99,7 +99,7 @@ async fn resolve_symlink_safely(entry: &DirectoryEntry) -> Result<DirectoryEntry
         {
             bail!(
                 "'{}' is a symlink causes that causes an infinite loop!",
-                source_path.await?.path.to_string()
+                source_path.to_string().await?
             )
         }
     }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -99,7 +99,7 @@ async fn resolve_symlink_safely(entry: &DirectoryEntry) -> Result<DirectoryEntry
         {
             bail!(
                 "'{}' is a symlink causes that causes an infinite loop!",
-                source_path.to_string().await?
+                source_path.await?.path.to_string()
             )
         }
     }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -439,7 +439,7 @@ pub mod tests {
             let foo = sub.join("foo.js");
             File::create_new(&foo).unwrap().write_all(b"foo").unwrap();
             // put a link in sub that points back at its parent director
-            symlink(&sub, sub.join("link")).unwrap();
+            symlink(sub, sub.join("link")).unwrap();
         }
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -455,6 +455,18 @@ pub mod tests {
             let err = fs
                 .root()
                 .read_glob(Glob::new("**".into()), false)
+                .await
+                .expect_err("Should have detected an infinite loop");
+
+            assert_eq!(
+                "'sub/link' is a symlink causes that causes an infinite loop!",
+                format!("{}", err.root_cause())
+            );
+
+            // Same when calling track glob
+            let err = fs
+                .root()
+                .track_glob(Glob::new("**".into()), false)
                 .await
                 .expect_err("Should have detected an infinite loop");
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use futures::try_join;
 use rustc_hash::FxHashMap;
+use turbo_rcstr::RcStr;
 use turbo_tasks::{Completion, ResolvedVc, TryJoinIterExt, Vc};
 
 use crate::{glob::Glob, DirectoryContent, DirectoryEntry, FileSystem, FileSystemPath};
@@ -22,10 +23,22 @@ pub async fn read_glob(
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<ReadGlobResult>> {
-    Ok(*read_glob_internal(directory, glob, include_dot_files).await?)
+    Ok(*read_glob_internal("", directory, glob, include_dot_files).await?)
 }
 
+#[turbo_tasks::function(fs)]
+async fn read_glob_inner(
+    prefix: RcStr,
+    directory: Vc<FileSystemPath>,
+    glob: Vc<Glob>,
+    include_dot_files: bool,
+) -> Result<Vc<ReadGlobResult>> {
+    Ok(*read_glob_internal(&prefix, directory, glob, include_dot_files).await?)
+}
+
+// The `prefix` represents the relative directory path where symlinks are not resolve.
 async fn read_glob_internal(
+    prefix: &str,
     directory: Vc<FileSystemPath>,
     glob: Vc<Glob>,
     include_dot_files: bool,
@@ -39,35 +52,26 @@ async fn read_glob_internal(
                 if !include_dot_files && segment.starts_with('.') {
                     continue;
                 }
-                let entry = entry.resolve_symlink().await?;
-                match entry {
-                    DirectoryEntry::Directory(path) => {
-                        let full_path = &path.await?.path;
-                        let full_path_str = full_path.as_str();
-                        if glob_value.execute(full_path_str) {
-                            result
-                                .results
-                                .insert(full_path.to_string(), DirectoryEntry::Directory(path));
-                        }
-                        if glob_value.match_prefix(full_path_str) {
-                            result.inner.insert(
-                                full_path.to_string(),
-                                read_glob(*path, glob, include_dot_files)
-                                    .to_resolved()
-                                    .await?,
-                            );
-                        }
+                // This is redundant with logic inside of `read_dir` but here we track it separately
+                // so we don't follow symlinks.
+                let entry_path: RcStr = if prefix.is_empty() {
+                    segment.clone()
+                } else {
+                    format!("{prefix}/{segment}").into()
+                };
+                let entry = resolve_symlink_safely(entry).await?;
+                if glob_value.execute(&entry_path) {
+                    result.results.insert(entry_path.to_string(), entry);
+                }
+                if let DirectoryEntry::Directory(path) = entry {
+                    if glob_value.match_in_directory(&entry_path) {
+                        result.inner.insert(
+                            entry_path.to_string(),
+                            read_glob_inner(entry_path, *path, glob, include_dot_files)
+                                .to_resolved()
+                                .await?,
+                        );
                     }
-                    DirectoryEntry::File(path)
-                    | DirectoryEntry::Other(path)
-                    | DirectoryEntry::Symlink(path) => {
-                        let full_path = &path.await?.path;
-                        let full_path_str = full_path.as_str();
-                        if glob_value.execute(full_path_str) {
-                            result.results.insert(full_path.to_string(), entry);
-                        }
-                    }
-                    DirectoryEntry::Error => {}
                 }
             }
         }
@@ -76,20 +80,58 @@ async fn read_glob_internal(
     Ok(ReadGlobResult::resolved_cell(result))
 }
 
+// Resolve a symlink checking for recursion.
+async fn resolve_symlink_safely(entry: &DirectoryEntry) -> Result<DirectoryEntry> {
+    let resolved_entry = entry.resolve_symlink().await?;
+    if resolved_entry != *entry && matches!(&resolved_entry, DirectoryEntry::Directory(_)) {
+        // We followed a symlink to a directory
+        // To prevent an infinite loop, which in the case of turbo-tasks would simply
+        // exhaust RAM or go into an infinite loop with the GC we need to check for a
+        // recursive symlink, we need to check for recursion.
+
+        // Recursion can only occur if the symlink is a directory and points to an
+        // ancestor of the current path, which can be detected via a simple prefix
+        // match.
+        let source_path = entry.path().unwrap();
+        if *source_path
+            .is_inside_or_equal(*resolved_entry.path().unwrap())
+            .await?
+        {
+            bail!(
+                "'{}' is a symlink causes that causes an infinite loop!",
+                source_path.await?.path.to_string()
+            )
+        }
+    }
+    Ok(resolved_entry)
+}
+
 /// Traverses all directories that match the given `glob`.
 ///
 /// This ensures that the calling task will be invalidated
-/// whenever the directories change, but unlike read_glob doesn't accumulate data.
+/// whenever the directories or contents of the directories change,
+///  but unlike read_glob doesn't accumulate data.
 #[turbo_tasks::function(fs)]
 pub async fn track_glob(
     directory: Vc<FileSystemPath>,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {
-    track_glob_internal(directory, glob, include_dot_files).await
+    track_glob_internal("", directory, glob, include_dot_files).await
+}
+
+#[turbo_tasks::function(fs)]
+async fn track_glob_inner(
+    prefix: RcStr,
+    directory: Vc<FileSystemPath>,
+    glob: Vc<Glob>,
+    include_dot_files: bool,
+) -> Result<Vc<Completion>> {
+    track_glob_internal(&prefix, directory, glob, include_dot_files).await
 }
 
 async fn track_glob_internal(
+    prefix: &str,
     directory: Vc<FileSystemPath>,
     glob: Vc<Glob>,
     include_dot_files: bool,
@@ -106,20 +148,33 @@ async fn track_glob_internal(
                 if !include_dot_files && segment.starts_with('.') {
                     continue;
                 }
-                match entry.resolve_symlink().await? {
+                // This is redundant with logic inside of `read_dir` but here we track it separately
+                // so we don't follow symlinks.
+                let entry_path = if prefix.is_empty() {
+                    segment.clone()
+                } else {
+                    format!("{prefix}/{segment}").into()
+                };
+
+                match resolve_symlink_safely(entry).await? {
                     DirectoryEntry::Directory(path) => {
-                        if glob_value.match_prefix(&path.await?.path) {
-                            completions.push(track_glob(*path, glob, include_dot_files));
+                        if glob_value.match_in_directory(&entry_path) {
+                            completions.push(track_glob_inner(
+                                entry_path,
+                                *path,
+                                glob,
+                                include_dot_files,
+                            ));
                         }
                     }
                     DirectoryEntry::File(path) => {
-                        if glob_value.execute(&path.await?.path) {
+                        if glob_value.execute(&entry_path) {
                             reads.push(fs.read(*path))
                         }
                     }
                     DirectoryEntry::Symlink(_) => panic!("we already resolved symlinks"),
                     DirectoryEntry::Other(path) => {
-                        if glob_value.execute(&path.await?.path) {
+                        if glob_value.execute(&entry_path) {
                             types.push(path.get_type())
                         }
                     }
@@ -135,4 +190,282 @@ async fn track_glob_internal(
         completions.iter().try_join()
     )?;
     Ok(Completion::new())
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use std::{
+        fs::{create_dir, File},
+        io::prelude::*,
+    };
+
+    use turbo_rcstr::RcStr;
+    use turbo_tasks::{apply_effects, Completion, ReadRef, ResolvedVc, Vc};
+    use turbo_tasks_backend::{noop_backing_storage, BackendOptions, TurboTasksBackend};
+
+    use crate::{
+        glob::Glob, DirectoryEntry, DiskFileSystem, FileContent, FileSystem, FileSystemPath,
+    };
+
+    #[tokio::test]
+    async fn read_glob_basic() {
+        crate::register();
+        let scratch = tempfile::tempdir().unwrap();
+        {
+            // Create a simple directory with 2 files, a subdirectory and a dotfile
+            let path = scratch.path();
+            File::create_new(path.join("foo"))
+                .unwrap()
+                .write_all(b"foo")
+                .unwrap();
+            create_dir(path.join("sub")).unwrap();
+            File::create_new(path.join("sub/bar"))
+                .unwrap()
+                .write_all(b"bar")
+                .unwrap();
+            // Add a dotfile
+            File::create_new(path.join("sub/.gitignore"))
+                .unwrap()
+                .write_all(b"ignore")
+                .unwrap();
+        }
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        let path: RcStr = scratch.path().to_str().unwrap().into();
+        tt.run_once(async {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
+                "temp".into(),
+                path,
+                Vec::new(),
+            ));
+            let read_dir = fs
+                .root()
+                .read_glob(Glob::new("**".into()), false)
+                .await
+                .unwrap();
+            assert_eq!(read_dir.results.len(), 2);
+            assert_eq!(
+                read_dir.results.get("foo"),
+                Some(&DirectoryEntry::File(
+                    fs.root().join("foo".into()).to_resolved().await?
+                ))
+            );
+            assert_eq!(
+                read_dir.results.get("sub"),
+                Some(&DirectoryEntry::Directory(
+                    fs.root().join("sub".into()).to_resolved().await?
+                ))
+            );
+            assert_eq!(read_dir.inner.len(), 1);
+            let inner = &*read_dir.inner.get("sub").unwrap().await?;
+            assert_eq!(inner.results.len(), 1);
+            assert_eq!(
+                inner.results.get("sub/bar"),
+                Some(&DirectoryEntry::File(
+                    fs.root().join("sub/bar".into()).to_resolved().await?
+                ))
+            );
+            assert_eq!(inner.inner.len(), 0);
+
+            // Now with a more specific pattern
+            let read_dir = fs
+                .root()
+                .read_glob(Glob::new("**/bar".into()), false)
+                .await
+                .unwrap();
+            assert_eq!(read_dir.results.len(), 0);
+            assert_eq!(read_dir.inner.len(), 1);
+            let inner = &*read_dir.inner.get("sub").unwrap().await?;
+            assert_eq!(inner.results.len(), 1);
+            assert_eq!(
+                inner.results.get("sub/bar"),
+                Some(&DirectoryEntry::File(
+                    fs.root().join("sub/bar".into()).to_resolved().await?
+                ))
+            );
+            assert_eq!(inner.inner.len(), 0);
+
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_glob_symlinks() {
+        crate::register();
+        let scratch = tempfile::tempdir().unwrap();
+        {
+            use std::os::unix::fs::symlink;
+
+            // Create a simple directory with 1 file and a symlink pointing at at a file in a
+            // subdirectory
+            let path = scratch.path();
+            create_dir(path.join("sub")).unwrap();
+            let foo = path.join("sub/foo.js");
+            File::create_new(&foo).unwrap().write_all(b"foo").unwrap();
+            symlink(&foo, path.join("link.js")).unwrap();
+        }
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        let path: RcStr = scratch.path().to_str().unwrap().into();
+        tt.run_once(async {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
+                "temp".into(),
+                path,
+                Vec::new(),
+            ));
+            let read_dir = fs
+                .root()
+                .read_glob(Glob::new("*.js".into()), false)
+                .await
+                .unwrap();
+            assert_eq!(read_dir.results.len(), 1);
+            assert_eq!(
+                read_dir.results.get("link.js"),
+                Some(&DirectoryEntry::File(
+                    fs.root().join("sub/foo.js".into()).to_resolved().await?
+                ))
+            );
+            assert_eq!(read_dir.inner.len(), 0);
+
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[turbo_tasks::function(operation)]
+    pub async fn delete(path: ResolvedVc<FileSystemPath>) -> anyhow::Result<()> {
+        path.write(FileContent::NotFound.cell()).await?;
+        Ok(())
+    }
+
+    #[turbo_tasks::function(operation)]
+    pub async fn track_star_star_glob(path: ResolvedVc<FileSystemPath>) -> Vc<Completion> {
+        path.track_glob(Glob::new("**".into()), false)
+    }
+
+    #[tokio::test]
+    async fn track_glob_invalidations() {
+        crate::register();
+        let scratch = tempfile::tempdir().unwrap();
+
+        // Create a simple directory with 2 files, a subdirectory and a dotfile
+        let path = scratch.path();
+        File::create_new(path.join("foo"))
+            .unwrap()
+            .write_all(b"foo")
+            .unwrap();
+        create_dir(path.join("sub")).unwrap();
+        File::create_new(path.join("sub/bar"))
+            .unwrap()
+            .write_all(b"bar")
+            .unwrap();
+        // Add a dotfile
+        create_dir(path.join("sub/.vim")).unwrap();
+        let gitignore = path.join("sub/.vim/.gitignore");
+        File::create_new(&gitignore)
+            .unwrap()
+            .write_all(b"ignore")
+            .unwrap();
+
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        let path: RcStr = scratch.path().to_str().unwrap().into();
+        tt.run_once(async {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
+                "temp".into(),
+                path,
+                Vec::new(),
+            ));
+            // TODO: why does this get executed multiple times
+            let read_dir = track_star_star_glob(fs.root().to_resolved().await?)
+                .read_strongly_consistent()
+                .await?;
+
+            // Delete a file that we shouldn't be tracking
+            let delete_result = delete(
+                fs.root()
+                    .join("sub/.vim/.gitignore".into())
+                    .to_resolved()
+                    .await?,
+            );
+            delete_result.read_strongly_consistent().await?;
+            apply_effects(delete_result).await?;
+
+            let read_dir2 = track_star_star_glob(fs.root().to_resolved().await?)
+                .read_strongly_consistent()
+                .await?;
+            assert!(ReadRef::ptr_eq(&read_dir, &read_dir2));
+
+            // Delete a file that we should be tracking
+            let delete_result = delete(fs.root().join("foo".into()).to_resolved().await?);
+            delete_result.read_strongly_consistent().await?;
+            apply_effects(delete_result).await?;
+
+            let read_dir2 = track_star_star_glob(fs.root().to_resolved().await?)
+                .read_strongly_consistent()
+                .await?;
+
+            assert!(!ReadRef::ptr_eq(&read_dir, &read_dir2));
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_glob_symlinks_loop() {
+        crate::register();
+        let scratch = tempfile::tempdir().unwrap();
+        {
+            use std::os::unix::fs::symlink;
+
+            // Create a simple directory with 1 file and a symlink pointing at at a file in a
+            // subdirectory
+            let path = scratch.path();
+            let sub = &path.join("sub");
+            create_dir(sub).unwrap();
+            let foo = sub.join("foo.js");
+            File::create_new(&foo).unwrap().write_all(b"foo").unwrap();
+            // put a link in sub that points back at its parent director
+            symlink(&sub, sub.join("link")).unwrap();
+        }
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        let path: RcStr = scratch.path().to_str().unwrap().into();
+        tt.run_once(async {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
+                "temp".into(),
+                path,
+                Vec::new(),
+            ));
+            let err = fs
+                .root()
+                .read_glob(Glob::new("**".into()), false)
+                .await
+                .expect_err("Should have detected an infinite loop");
+
+            assert_eq!(
+                "'sub/link' is a symlink causes that causes an infinite loop!",
+                format!("{}", err.root_cause())
+            );
+
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -139,23 +139,20 @@ async fn track_glob_internal(
                             ));
                         }
                     }
-                    DirectoryEntry::File(path) => reads.push(path.read()),
-                    DirectoryEntry::Symlink(path) => {
-                        links.push(path.read_link());
-                    }
-                    DirectoryEntry::Other(path) => {
-                        types.push(path.get_type());
-                    }
+                    DirectoryEntry::File(path) => reads.push(path.track()),
+                    DirectoryEntry::Symlink(path) => links.push(path.read_link()),
+                    DirectoryEntry::Other(path) => types.push(path.get_type()),
                     DirectoryEntry::Error => {}
                 }
             }
         }
         DirectoryContent::NotFound => {}
     }
-    let reads = reads.iter().try_join();
-    let links = links.iter().try_join();
-    let types = types.iter().try_join();
-    let completions = completions.iter().try_join();
-    try_join!(reads, links, types, completions)?;
+    try_join!(
+        reads.iter().try_join(),
+        links.iter().try_join(),
+        types.iter().try_join(),
+        completions.iter().try_join()
+    )?;
     Ok(Completion::new())
 }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -387,7 +387,6 @@ pub mod tests {
                 path,
                 Vec::new(),
             ));
-            // TODO: why does this get executed multiple times
             let read_dir = track_star_star_glob(fs.root().to_resolved().await?)
                 .read_strongly_consistent()
                 .await?;

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ValueDefault, ValueToString, Vc};
+use turbo_tasks::{ValueDefault, ValueToString, Vc};
 
 use super::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent};
 use crate::RawDirectoryContent;
@@ -59,11 +59,6 @@ impl FileSystem for VirtualFileSystem {
     #[turbo_tasks::function]
     fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible on the virtual file system")
-    }
-
-    #[turbo_tasks::function]
-    fn track(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
-        bail!("Tracking is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -157,7 +157,7 @@ async fn read_path(
 ) -> anyhow::Result<()> {
     let path_str = path.await?.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
-    let _ = path.track().await?;
+    let _ = path.read().await?;
     Ok(())
 }
 

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ValueToString, Vc};
+use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{
     FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
 };
@@ -31,11 +31,6 @@ impl FileSystem for ServerFileSystem {
     #[turbo_tasks::function]
     fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
-    }
-
-    #[turbo_tasks::function]
-    fn track(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
-        bail!("Tracking is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -16,8 +16,7 @@ use turbo_tasks::{
 use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{
-    glob::Glob, json::parse_json_with_source_context, rope::Rope, DirectoryEntry, File,
-    FileContent, FileSystemPath, ReadGlobResult,
+    glob::Glob, json::parse_json_with_source_context, rope::Rope, File, FileContent, FileSystemPath,
 };
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -510,15 +509,9 @@ impl EvaluateContext for WebpackLoaderContext {
                 let directory_subscriptions = directories
                     .iter()
                     .map(|(dir, glob)| {
-                        // TODO: there is some redundancy between `dir_dependency` and what
-                        // `read_glob` does, Introduce a new read_glob
-                        // option that will track all files the way
-                        // `dir_dependency` does but in a single traversal.
-                        dir_dependency(
-                            self.cwd
-                                .join(dir.clone())
-                                .read_glob(Glob::new(glob.clone()), false),
-                        )
+                        self.cwd
+                            .join(dir.clone())
+                            .track_glob(Glob::new(glob.clone()), false)
                     })
                     .try_join();
                 let build_paths = build_file_paths
@@ -776,45 +769,6 @@ impl Issue for BuildDependencyIssue {
             .resolved_cell(),
         )))
     }
-}
-
-/// A hack to invalidate when any file in a directory changes. Need to be
-/// awaited before files are accessed.
-#[turbo_tasks::function]
-async fn dir_dependency(glob: Vc<ReadGlobResult>) -> Result<Vc<Completion>> {
-    let shallow = dir_dependency_shallow(glob);
-    let glob = glob.await?;
-    glob.inner
-        .values()
-        .map(|&inner| dir_dependency(*inner))
-        .try_join()
-        .await?;
-    shallow.await?;
-    Ok(Completion::new())
-}
-
-#[turbo_tasks::function]
-async fn dir_dependency_shallow(glob: Vc<ReadGlobResult>) -> Result<Vc<Completion>> {
-    let glob = glob.await?;
-    for item in glob.results.values() {
-        // Reading all files to add itself as dependency
-        match *item {
-            DirectoryEntry::File(file) => {
-                file.read().await?;
-            }
-            DirectoryEntry::Directory(dir) => {
-                dir_dependency(dir.read_glob(Glob::new("**".into()), false)).await?;
-            }
-            DirectoryEntry::Symlink(symlink) => {
-                symlink.read_link().await?;
-            }
-            DirectoryEntry::Other(other) => {
-                other.get_type().await?;
-            }
-            DirectoryEntry::Error => {}
-        }
-    }
-    Ok(Completion::new())
 }
 
 #[turbo_tasks::value(shared)]


### PR DESCRIPTION
This will ensure that the caller is invalidated whenever any directory or file matching the glob changes.

Happy for feedback on the name!

In addition to creating this fast path for the webpack.rs loader, also optimize the way paths are constructed in `read_dir` to use `new_normalized` instead of `join`.  This allows us to skip some cpu intensive string manipulation that is unneeded when composing paths returned from a `readdir` operation.

Before:

![before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/AwJ29EfoPcPdLSwCZxAz/6e0ce683-da94-40ad-aeec-99e381d8dc26.png)

We can see the `read_glob` and `dir_dependency` calls which happened sequentially.

After:

![after.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/AwJ29EfoPcPdLSwCZxAz/988ed4ca-78a4-4849-b070-445981f018de.png)

We can see the same time spent in `read file` but we have saved a lot of time in `FileSystemPath::join` (eliminated!) and we eliminated the redundant traversal of `dir_dependency`.



Closes PACK-4527