### PR TITLE
Turbopack: make_task_dirty only needs meta data

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -176,7 +176,7 @@ pub fn make_task_dirty(
         return;
     }
 
-    let mut task = ctx.task(task_id, TaskDataCategory::All);
+    let mut task = ctx.task(task_id, TaskDataCategory::Meta);
 
     make_task_dirty_internal(
         &mut task,


### PR DESCRIPTION
### What?

Avoid loading data for marking a task as dirty

Closes PACK-4501