### PR TITLE
Run export child process with runtime's default `max-old-space-size`

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -763,7 +763,9 @@ export function createStaticWorker(
       progress?.clear()
     },
     forkOptions: {
-      env: { ...process.env, NODE_OPTIONS: formatNodeOptions(nodeOptions) },
+      env: {
+        NODE_OPTIONS: formatNodeOptions(nodeOptions),
+      },
     },
     enableWorkerThreads: config.experimental.workerThreads,
     exposedMethods: staticWorkerExposedMethods,

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -16,7 +16,6 @@ async function turbopackBuildWithWorker() {
       maxRetries: 0,
       forkOptions: {
         env: {
-          ...process.env,
           NEXT_PRIVATE_BUILD_WORKER: '1',
           NODE_OPTIONS: formatNodeOptions(nodeOptions),
         },

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -57,7 +57,6 @@ async function webpackBuildWithWorker(
       maxRetries: 0,
       forkOptions: {
         env: {
-          ...process.env,
           NEXT_PRIVATE_BUILD_WORKER: '1',
           NODE_OPTIONS: formatNodeOptions(nodeOptions),
         },

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from 'child_process'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
 import { Transform } from 'stream'
 
-type FarmOptions = ConstructorParameters<typeof JestWorker>[1]
+type FarmOptions = NonNullable<ConstructorParameters<typeof JestWorker>[1]>
 
 const RESTARTED = Symbol('restarted')
 
@@ -19,7 +19,12 @@ export class Worker {
 
   constructor(
     workerPath: string,
-    options: FarmOptions & {
+    options: Omit<FarmOptions, 'forkOptions'> & {
+      forkOptions?:
+        | (Omit<NonNullable<FarmOptions['forkOptions']>, 'env'> & {
+            env?: Partial<NodeJS.ProcessEnv> | undefined
+          })
+        | undefined
       timeout?: number
       onActivity?: () => void
       onActivityAbort?: () => void
@@ -48,8 +53,8 @@ export class Worker {
         forkOptions: {
           ...farmOptions.forkOptions,
           env: {
-            ...((farmOptions.forkOptions?.env || {}) as any),
             ...process.env,
+            ...((farmOptions.forkOptions?.env || {}) as any),
             IS_NEXT_WORKER: 'true',
           } as any,
         },


### PR DESCRIPTION
We ended up always forwarding `NODE_OPTIONS` even if the callsites of `new Worker` removed `max-old-space-size` on purpose like https://github.com/vercel/next.js/blob/e3adfeb8160041f697840c94671cb141a0a40039/packages/next/src/build/index.ts#L753-L767 did.

This will also fix a bunch of "port is already in use" issues when you set `NODE_OPTIONS=--inspect`. 

## Test plan

`NODE_OPTIONS=--max-old-space-size=4096` and then `console.log('worker NODE_OPTIONS', process.env.NODE_OPTIONS)` in `packages/next/src/build/worker.ts`