### PR TITLE
build: Fix minifier options for webpack builds

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1207,7 +1207,10 @@ export default async function getBaseWebpackConfig(
               // @ts-ignore No typings yet
               const { MinifyPlugin } =
                 require('./webpack/plugins/minify-webpack-plugin/src/index.js') as typeof import('./webpack/plugins/minify-webpack-plugin/src')
-              new MinifyPlugin({ noMangling }).apply(compiler)
+              new MinifyPlugin({
+                noMangling,
+                disableCharFreq: !isClient,
+              }).apply(compiler)
             },
             // Minify CSS
             (compiler: webpack.Compiler) => {

--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -32,7 +32,9 @@ function buildError(error: any, file: string) {
 const debugMinify = process.env.NEXT_DEBUG_MINIFY
 
 export class MinifyPlugin {
-  constructor(private options: { noMangling?: boolean }) {}
+  constructor(
+    private options: { noMangling?: boolean; disableCharFreq?: boolean }
+  ) {}
 
   async optimize(
     compiler: any,
@@ -47,7 +49,11 @@ export class MinifyPlugin {
       RawSource: typeof sources.RawSource
     }
   ) {
-    const mangle = !this.options.noMangling
+    const mangle = this.options.noMangling
+      ? false
+      : {
+          disableCharFreq: !!this.options.disableCharFreq,
+        }
     const compilationSpan =
       getCompilationSpan(compilation)! || getCompilationSpan(compiler)
 


### PR DESCRIPTION
### What?

Adjust the options for the SWC minifier to disable character frequency analysis for webpack builds correctly.

### Why?

https://github.com/vercel/next.js/pull/77887 only adjusted the option for rspack.

### How?

Follow-up of https://github.com/vercel/next.js/pull/77887


Closes PACK-4498