### PR TITLE
chore(CI): Line-wrap afterBuild blocks in build_and_test.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,7 +100,10 @@ jobs:
     needs: ['build-next']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: pnpm lint-no-typescript && pnpm check-examples && pnpm validate-externals-doc
+      afterBuild: |
+        pnpm lint-no-typescript
+        pnpm check-examples
+        pnpm validate-externals-doc
       stepName: 'lint'
     secrets: inherit
 
@@ -210,7 +213,12 @@ jobs:
           - '--scenario=heavy-npm-deps-build-turbo-cache-enabled --page=homepage'
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: pnpm install && ./node_modules/.bin/devlow-bench ./scripts/devlow-bench.mjs --datadog=ubuntu-latest-16-core ${{ matrix.mode }} ${{ matrix.selector }}
+      afterBuild: |
+        pnpm install
+        ./node_modules/.bin/devlow-bench ./scripts/devlow-bench.mjs \
+          --datadog=ubuntu-latest-16-core \
+          ${{ matrix.mode }} \
+          ${{ matrix.selector }}
       stepName: 'devlow-bench-${{ matrix.mode }}-${{ matrix.selector }}'
     secrets: inherit
 
@@ -221,7 +229,9 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       stepName: 'test-devlow'
-      afterBuild: pnpm install && pnpm run --filter=devlow-bench test
+      afterBuild: |
+        pnpm install
+        pnpm run --filter=devlow-bench test
     secrets: inherit
 
   test-turbopack-dev:
@@ -240,7 +250,19 @@ jobs:
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json" IS_TURBOPACK_TEST=1 TURBOPACK_DEV=1  NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=dev NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --test-pattern '^(test\/(development|e2e))/.*\.test\.(js|jsx|ts|tsx)$' --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY}
+      afterBuild: |
+        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json"
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_DEV=1
+        export NEXT_E2E_TEST_TIMEOUT=240000
+        export NEXT_TEST_MODE=dev
+        export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+
+        node run-tests.js \
+          --test-pattern '^(test\/(development|e2e))/.*\.test\.(js|jsx|ts|tsx)$' \
+          --timings \
+          -g ${{ matrix.group }} \
+          -c $TEST_CONCURRENCY
       stepName: 'test-turbopack-dev-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
@@ -262,7 +284,17 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json" IS_TURBOPACK_TEST=1 TURBOPACK_DEV=1 NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
+      afterBuild: |
+        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json"
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_DEV=1
+        export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          -c $TEST_CONCURRENCY \
+          --type integration
       stepName: 'test-turbopack-integration-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
@@ -287,7 +319,14 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json" IS_TURBOPACK_TEST=1 TURBOPACK_BUILD=1 NEXT_TEST_MODE=start NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+      afterBuild: |
+        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json"
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_BUILD=1
+        export NEXT_TEST_MODE=start
+        export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+
+        node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
       stepName: 'test-turbopack-production-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
@@ -303,7 +342,16 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json" IS_TURBOPACK_TEST=1 TURBOPACK_BUILD=1 node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
+      afterBuild: |
+        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json"
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_BUILD=1
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          -c ${TEST_CONCURRENCY} \
+          --type integration
       stepName: 'test-turbopack-production-integration-${{ matrix.group }}'
     secrets: inherit
 
@@ -314,7 +362,20 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: rustup target add wasm32-unknown-unknown && curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh && node ./scripts/normalize-version-bump.js && pnpm dlx turbo@${TURBO_VERSION} run build-wasm -- --target nodejs && git checkout . && mv crates/wasm/pkg crates/wasm/pkg-nodejs && node ./scripts/setup-wasm.mjs && NEXT_TEST_MODE=start TEST_WASM=true node run-tests.js test/production/pages-dir/production/test/index.test.ts test/e2e/streaming-ssr/index.test.ts
+      afterBuild: |
+        rustup target add wasm32-unknown-unknown
+        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        node ./scripts/normalize-version-bump.js
+        pnpm dlx turbo@${TURBO_VERSION} run build-wasm -- --target nodejs
+        git checkout .
+        mv crates/wasm/pkg crates/wasm/pkg-nodejs
+        node ./scripts/setup-wasm.mjs
+
+        export NEXT_TEST_MODE=start
+        export TEST_WASM=true
+        node run-tests.js \
+          test/production/pages-dir/production/test/index.test.ts \
+          test/e2e/streaming-ssr/index.test.ts
       stepName: 'test-next-swc-wasm'
     secrets: inherit
 
@@ -330,7 +391,9 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: rustup target add wasm32-wasip1-threads && pnpm dlx turbo@${TURBO_VERSION} run build-native-wasi
+      afterBuild: |
+        rustup target add wasm32-wasip1-threads
+        pnpm dlx turbo@${TURBO_VERSION} run build-native-wasi
       stepName: 'test-next-swc-napi-wasi'
     secrets: inherit
 
@@ -384,7 +447,11 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: node scripts/test-new-tests.mjs --flake-detection --mode dev --group ${{ matrix.group }}
+      afterBuild: |
+        node scripts/test-new-tests.mjs \
+          --flake-detection \
+          --mode dev \
+          --group ${{ matrix.group }}
       stepName: 'test-new-tests-dev-${{matrix.group}}'
       timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
 
@@ -402,7 +469,11 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: node scripts/test-new-tests.mjs --flake-detection --mode start --group ${{ matrix.group }}
+      afterBuild: |
+        node scripts/test-new-tests.mjs \
+          --flake-detection \
+          --mode start \
+          --group ${{ matrix.group }}
       stepName: 'test-new-tests-start-${{matrix.group}}'
       timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
 
@@ -421,7 +492,12 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: NEXT_E2E_TEST_TIMEOUT=240000 node scripts/test-new-tests.mjs --mode deploy --group ${{ matrix.group }}
+      afterBuild: |
+        export NEXT_E2E_TEST_TIMEOUT=240000
+
+        node scripts/test-new-tests.mjs \
+          --mode deploy \
+          --group ${{ matrix.group }}
       stepName: 'test-new-tests-deploy-${{matrix.group}}'
 
     secrets: inherit
@@ -442,7 +518,15 @@ jobs:
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: NEXT_TEST_MODE=dev NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
+      afterBuild: |
+        export NEXT_TEST_MODE=dev
+        export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          -c ${TEST_CONCURRENCY} \
+          --type development
       stepName: 'test-dev-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
@@ -460,7 +544,13 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: NEXT_TEST_MODE=dev node run-tests.js -c ${TEST_CONCURRENCY} test/e2e/app-dir/app/index.test.ts test/e2e/app-dir/app-edge/app-edge.test.ts
+      afterBuild: |
+        export NEXT_TEST_MODE=dev
+
+        node run-tests.js \
+          -c ${TEST_CONCURRENCY} \
+          test/e2e/app-dir/app/index.test.ts \
+          test/e2e/app-dir/app-edge/app-edge.test.ts
       stepName: 'test-dev-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
@@ -481,7 +571,14 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: node run-tests.js -c 4 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts
+      afterBuild: |
+        node run-tests.js \
+          -c 4 \
+          test/production/pages-dir/production/test/index.test.ts \
+          test/integration/css-client-nav/test/index.test.js \
+          test/integration/rewrites-has-condition/test/index.test.js \
+          test/integration/create-next-app/index.test.ts \
+          test/integration/create-next-app/package-manager/pnpm.test.ts
       stepName: 'test-integration-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
@@ -501,7 +598,13 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: NEXT_TEST_MODE=start node run-tests.js test/e2e/app-dir/app/index.test.ts test/e2e/app-dir/app-edge/app-edge.test.ts test/e2e/app-dir/metadata-edge/index.test.ts
+      afterBuild: |
+        export NEXT_TEST_MODE=start
+
+        node run-tests.js \
+          test/e2e/app-dir/app/index.test.ts \
+          test/e2e/app-dir/app-edge/app-edge.test.ts \
+          test/e2e/app-dir/metadata-edge/index.test.ts
       stepName: 'test-prod-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
@@ -558,7 +661,14 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
+      afterBuild: |
+        export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          -c ${TEST_CONCURRENCY} \
+          --type integration
       stepName: 'test-integration-${{ matrix.group }}-react-${{ matrix.react }}'
     secrets: inherit
 
@@ -569,11 +679,19 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: pnpm playwright install &&
-        BROWSER_NAME=firefox node run-tests.js test/production/pages-dir/production/test/index.test.ts &&
-        NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/e2e/basepath/basepath.test.ts &&
-        BROWSER_NAME=safari DEVICE_NAME='iPhone XR' node run-tests.js -c 1 test/production/prerender-prefetch/index.test.ts
+      afterBuild: |
+        pnpm playwright install
 
+        # these all run without concurrency (`-c 1`) because they're heavier
+        BROWSER_NAME=firefox node run-tests.js -c 1 \
+          test/production/pages-dir/production/test/index.test.ts
+
+        NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js -c 1 \
+          test/production/pages-dir/production/test/index.test.ts \
+          test/e2e/basepath/basepath.test.ts
+
+        BROWSER_NAME=safari DEVICE_NAME='iPhone XR' node run-tests.js -c 1 \
+          test/production/prerender-prefetch/index.test.ts
       stepName: 'test-firefox-safari'
     secrets: inherit
 
@@ -587,7 +705,14 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" node run-tests.js --timings -c ${TEST_CONCURRENCY} --type integration
+      afterBuild: |
+        export __NEXT_EXPERIMENTAL_PPR=true
+        export NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json"
+
+        node run-tests.js \
+          --timings \
+          -c ${TEST_CONCURRENCY} \
+          --type integration
       stepName: 'test-ppr-integration'
     secrets: inherit
 
@@ -602,7 +727,16 @@ jobs:
         group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=dev node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
+      afterBuild: |
+        export __NEXT_EXPERIMENTAL_PPR=true
+        export NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json"
+        export NEXT_TEST_MODE=dev
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          -c ${TEST_CONCURRENCY} \
+          --type development
       stepName: 'test-ppr-dev-${{ matrix.group }}'
     secrets: inherit
 
@@ -617,7 +751,16 @@ jobs:
         group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+      afterBuild: |
+        export __NEXT_EXPERIMENTAL_PPR=true
+        export NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json"
+        export NEXT_TEST_MODE=start
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          -c ${TEST_CONCURRENCY} \
+          --type production
       stepName: 'test-ppr-prod-${{ matrix.group }}'
     secrets: inherit
 


### PR DESCRIPTION
As part of #76251 I rewrote the `afterBuild` job from:

```yaml
- run: /bin/bash -c "${{ inputs.afterBuild }}"
```

to

```yaml
- run: ${{ inputs.afterBuild }}
  # defaults.run.shell sets a stronger options (`-leo pipefail`)
  # Set this back to github action's weaker defaults:
  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
  #
  # We must use a login shell: fnm installation may modify the `.profile`
  shell: bash -le {0}
```

So it should handle escaping and line wrapping without problems now. Because we run `bash` with `-e`, failed commands should abort the entire script, so `&&` shouldn't be needed everywhere.

Closes PACK-4502