### PR TITLE
refactor(next-swc): Do not amend minifier options from Rust code

### DIFF
--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -140,9 +140,12 @@ export class MinifyPlugin {
                     },
                   }
                 : {}),
-              // Compress options are defined in crates/napi/src/minify.rs.
-              compress: false,
-              // Mangle options may be amended in crates/napi/src/minify.rs.
+              compress: {
+                inline: 2,
+                global_defs: {
+                  'process.env.__NEXT_PRIVATE_MINIMIZE_MACRO_FALSE': false,
+                },
+              },
               mangle,
               module: 'unknown',
               output: {

--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -52,6 +52,7 @@ export class MinifyPlugin {
     const mangle = this.options.noMangling
       ? false
       : {
+          reserved: ['AbortSignal'],
           disableCharFreq: !!this.options.disableCharFreq,
         }
     const compilationSpan =


### PR DESCRIPTION
### What?

Remove Rust-side amending logic for minifier options and move all configuration to JS side

### Why?

x-ref: https://vercel.slack.com/archives/C04KC8A53T7/p1746034154828369?thread_ts=1746024368.021439&cid=C04KC8A53T7

### How?


Closes PACK-4503