### PR TITLE
chore(CI): Re-run `pnpm install` after `pnpm build` in `build_reusable.yml`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -214,7 +214,6 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
-        pnpm install
         ./node_modules/.bin/devlow-bench ./scripts/devlow-bench.mjs \
           --datadog=ubuntu-latest-16-core \
           ${{ matrix.mode }} \
@@ -230,7 +229,6 @@ jobs:
     with:
       stepName: 'test-devlow'
       afterBuild: |
-        pnpm install
         pnpm run --filter=devlow-bench test
     secrets: inherit
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -220,6 +220,16 @@ jobs:
       - run: ANALYZE=1 pnpm build
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
+      # Some packages e.g. `devlow-bench` depend on `pnpm build` to generate
+      # their `dist` directory. The first run of `pnpm install` will generate
+      # warnings because these don't exist yet.
+      #
+      # We need to run `pnpm install` a _second_ time to fix this. Fortunately,
+      # this second run is very fast and cheap.
+      - name: Re-run pnpm install to link built packages into node_modules/.bin
+        run: pnpm install
+        if: ${{ inputs.skipInstallBuild != 'yes' }}
+
       - run: pnpm playwright install-deps
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 


### PR DESCRIPTION
Apparently there's a chicken-and-egg problem between `pnpm install` and `pnpm build` where some packages depend on `pnpm build` being run first, but `pnpm build` can't run until after `pnpm install`.

Remove this one-off hack in `afterBuild` for `devlow-bench` and document it in `build_reusable.yml`.

Closes PACK-4504