### PR TITLE
Turbopack: Use separate meta and data modified flags

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -18,8 +18,8 @@ use turbo_tasks::{SessionId, TaskId, TurboTasksBackendApi};
 
 use crate::{
     backend::{
-        storage::StorageWriteGuard, OperationGuard, TaskDataCategory, TransientTask,
-        TurboTasksBackend, TurboTasksBackendInner,
+        storage::{SpecificTaskDataCategory, StorageWriteGuard},
+        OperationGuard, TaskDataCategory, TransientTask, TurboTasksBackend, TurboTasksBackendInner,
     },
     backing_storage::BackingStorage,
     data::{
@@ -463,9 +463,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
     }
 
     fn add(&mut self, item: CachedDataItem) -> bool {
-        self.check_access(item.category());
+        let category = item.category();
+        self.check_access(category);
         if !self.task_id.is_transient() && item.is_persistent() {
-            self.task.track_modification();
+            self.task.track_modification(category.into_specific());
         }
         self.task.add(item)
     }
@@ -477,9 +478,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
     }
 
     fn insert(&mut self, item: CachedDataItem) -> Option<CachedDataItemValue> {
-        self.check_access(item.category());
+        let category = item.category();
+        self.check_access(category);
         if !self.task_id.is_transient() && item.is_persistent() {
-            self.task.track_modification();
+            self.task.track_modification(category.into_specific());
         }
         self.task.insert(item)
     }
@@ -489,17 +491,19 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         key: CachedDataItemKey,
         update: impl FnOnce(Option<CachedDataItemValue>) -> Option<CachedDataItemValue>,
     ) {
-        self.check_access(key.category());
+        let category = key.category();
+        self.check_access(category);
         if !self.task_id.is_transient() && key.is_persistent() {
-            self.task.track_modification();
+            self.task.track_modification(category.into_specific());
         }
         self.task.update(key, update);
     }
 
     fn remove(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValue> {
-        self.check_access(key.category());
+        let category = key.category();
+        self.check_access(category);
         if !self.task_id.is_transient() && key.is_persistent() {
-            self.task.track_modification();
+            self.task.track_modification(category.into_specific());
         }
         self.task.remove(key)
     }
@@ -510,9 +514,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
     }
 
     fn get_mut(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRefMut<'_>> {
-        self.check_access(key.category());
+        let category = key.category();
+        self.check_access(category);
         if !self.task_id.is_transient() && key.is_persistent() {
-            self.task.track_modification();
+            self.task.track_modification(category.into_specific());
         }
         self.task.get_mut(key)
     }
@@ -522,9 +527,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         key: CachedDataItemKey,
         insert: impl FnOnce() -> CachedDataItemValue,
     ) -> CachedDataItemValueRefMut<'_> {
-        self.check_access(key.category());
+        let category = key.category();
+        self.check_access(category);
         if !self.task_id.is_transient() && key.is_persistent() {
-            self.task.track_modification();
+            self.task.track_modification(category.into_specific());
         }
         self.task.get_mut_or_insert_with(key, insert)
     }
@@ -561,14 +567,17 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
     {
         self.check_access(ty.category());
         if !self.task_id.is_transient() && ty.is_persistent() {
-            self.task.track_modification();
+            self.task.track_modification(ty.category().into_specific());
         }
         self.task.extract_if(ty, f)
     }
 
     fn invalidate_serialization(&mut self) {
+        // TODO this causes race conditions, since we never know when a value is changed. We can't
+        // "snapshot" the value correctly.
         if !self.task_id.is_transient() {
-            self.task.track_modification();
+            self.task.track_modification(SpecificTaskDataCategory::Data);
+            self.task.track_modification(SpecificTaskDataCategory::Meta);
         }
     }
 }


### PR DESCRIPTION
### What?

We store "meta" and "data" separately, so we also need separate modified flags for them. This way we avoid e. g. storing unmodified "data" when only "meta" was actually modified.

Closes PACK-4509