### PR TITLE
Turbopack: avoid tracking a modification when adding an already existing item

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1501,7 +1501,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         // handle stateful
         if stateful {
-            task.insert(CachedDataItem::Stateful { value: () });
+            let _ = task.add(CachedDataItem::Stateful { value: () });
         }
 
         // handle cell counters: update max index and remove cells that are no longer used
@@ -1938,7 +1938,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     .entry(RawVc::TaskCell(collectible.task, collectible.cell))
                     .or_insert(0) += count;
             }
-            task.insert(CachedDataItem::CollectiblesDependent {
+            let _ = task.add(CachedDataItem::CollectiblesDependent {
                 collectible_type,
                 task: reader_id,
                 value: (),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{SessionId, TaskId, TurboTasksBackendApi};
+use turbo_tasks::{KeyValuePair, SessionId, TaskId, TurboTasksBackendApi};
 
 use crate::{
     backend::{
@@ -466,6 +466,9 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         let category = item.category();
         self.check_access(category);
         if !self.task_id.is_transient() && item.is_persistent() {
+            if self.task.contains_key(&item.key()) {
+                return false;
+            }
             self.task.track_modification(category.into_specific());
         }
         self.task.add(item)


### PR DESCRIPTION
### What?

This makes sure that when trying to "add" and item that already exist, we don't flag the task as modified.

This commonly happens with `Dependent` edges. We just call "add" again, not knowing if they already exist.

Closes PACK-4519