### PR TITLE
Turbopack: write tasks doesn't need to be session dependent, as effects will restore

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -717,7 +717,6 @@ impl FileSystem for DiskFileSystem {
 
     #[turbo_tasks::function(fs)]
     async fn write(&self, fs_path: FileSystemPath, content: Vc<FileContent>) -> Result<()> {
-        mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         let content = content.await?;
         let inner = self.inner.clone();
@@ -848,7 +847,6 @@ impl FileSystem for DiskFileSystem {
 
     #[turbo_tasks::function(fs)]
     async fn write_link(&self, fs_path: FileSystemPath, target: Vc<LinkContent>) -> Result<()> {
-        mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         let content = target.await?;
         let inner = self.inner.clone();

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -717,6 +717,10 @@ impl FileSystem for DiskFileSystem {
 
     #[turbo_tasks::function(fs)]
     async fn write(&self, fs_path: FileSystemPath, content: Vc<FileContent>) -> Result<()> {
+        // You might be tempted to use `mark_session_dependent` here, but
+        // `write` purely declares a side effect and does not need to be reexecuted in the next
+        // session. All side effects are reexecuted in general.
+
         let full_path = self.to_sys_path(fs_path).await?;
         let content = content.await?;
         let inner = self.inner.clone();
@@ -847,6 +851,10 @@ impl FileSystem for DiskFileSystem {
 
     #[turbo_tasks::function(fs)]
     async fn write_link(&self, fs_path: FileSystemPath, target: Vc<LinkContent>) -> Result<()> {
+        // You might be tempted to use `mark_session_dependent` here, but
+        // `write_link` purely declares a side effect and does not need to be reexecuted in the next
+        // session. All side effects are reexecuted in general.
+
         let full_path = self.to_sys_path(fs_path).await?;
         let content = target.await?;
         let inner = self.inner.clone();


### PR DESCRIPTION
### What?

Filesystem write task don't need to be session dependent. We don't need to reexecute them for that reason. We already emit an "effect" and that is still emitted after restoring from cache.

Not making them session dependent avoids dirty updates and also tracking the task as dirty in the aggregated graph. 

But the "effect" is not-serializeable, so the write task will be recomputed to recompute the value of the effect, when trying to apply the effect.

Closes PACK-5137