### PR TITLE
Turbopack: cache directory creation

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -60,7 +60,7 @@ use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     debug::ValueDebugFormat, effect, mark_session_dependent, mark_stateful, trace::TraceRawVcs,
-    ApplyEffectContext, Completion, InvalidationReason, Invalidator, NonLocalValue, ReadRef,
+    ApplyEffectsContext, Completion, InvalidationReason, Invalidator, NonLocalValue, ReadRef,
     ResolvedVc, ValueToString, Vc,
 };
 use turbo_tasks_hash::{
@@ -402,7 +402,7 @@ impl DiskFileSystemInner {
     }
 
     async fn create_directory(self: &Arc<Self>, directory: &Path) -> Result<()> {
-        let already_created = ApplyEffectContext::with_or_insert_with(
+        let already_created = ApplyEffectsContext::with_or_insert_with(
             DiskFileSystemApplyContext::default,
             |fs_context| fs_context.created_directories.contains(directory),
         );
@@ -415,7 +415,7 @@ impl DiskFileSystemInner {
                     path = display(directory.display())
                 ))
                 .await?;
-            ApplyEffectContext::with(|fs_context: &mut DiskFileSystemApplyContext| {
+            ApplyEffectsContext::with(|fs_context: &mut DiskFileSystemApplyContext| {
                 fs_context
                     .created_directories
                     .insert(directory.to_path_buf())

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -90,7 +90,7 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
-pub use effect::{apply_effects, effect, get_effects, ApplyEffectContext, Effects};
+pub use effect::{apply_effects, effect, get_effects, ApplyEffectsContext, Effects};
 pub use id::{
     ExecutionId, FunctionId, LocalTaskId, SessionId, TaskId, TraitTypeId, ValueTypeId,
     TRANSIENT_TASK_BIT,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -89,7 +89,7 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
-pub use effect::{apply_effects, effect, get_effects, Effects};
+pub use effect::{apply_effects, effect, get_effects, ApplyEffectContext, Effects};
 pub use id::{
     ExecutionId, FunctionId, LocalTaskId, SessionId, TaskId, TraitTypeId, ValueTypeId,
     TRANSIENT_TASK_BIT,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -36,6 +36,7 @@
 #![feature(arbitrary_self_types_pointers)]
 #![feature(new_zeroed_alloc)]
 #![feature(never_type)]
+#![feature(downcast_unchecked)]
 
 pub mod backend;
 mod capture_future;


### PR DESCRIPTION
### What?

Calling create directory for every written file is very expensive.

Instead keep a memory cache of already created directories.

Closes PACK-4556