### PR TITLE
chore(CI): Use `TEST_CONCURRENCY` by default in `run-tests.js`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,6 @@ env:
   TURBO_VERSION: 2.3.3
   NODE_MAINTENANCE_VERSION: 18
   NODE_LTS_VERSION: 20
-  TEST_CONCURRENCY: 8
   # disable backtrace for test snapshots
   RUST_BACKTRACE: 0
 
@@ -259,8 +258,7 @@ jobs:
         node run-tests.js \
           --test-pattern '^(test\/(development|e2e))/.*\.test\.(js|jsx|ts|tsx)$' \
           --timings \
-          -g ${{ matrix.group }} \
-          -c $TEST_CONCURRENCY
+          -g ${{ matrix.group }}
       stepName: 'test-turbopack-dev-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
@@ -291,7 +289,6 @@ jobs:
         node run-tests.js \
           --timings \
           -g ${{ matrix.group }} \
-          -c $TEST_CONCURRENCY \
           --type integration
       stepName: 'test-turbopack-integration-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
@@ -324,7 +321,7 @@ jobs:
         export NEXT_TEST_MODE=start
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
 
-        node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+        node run-tests.js --timings -g ${{ matrix.group }} --type production
       stepName: 'test-turbopack-production-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
@@ -348,7 +345,6 @@ jobs:
         node run-tests.js \
           --timings \
           -g ${{ matrix.group }} \
-          -c ${TEST_CONCURRENCY} \
           --type integration
       stepName: 'test-turbopack-production-integration-${{ matrix.group }}'
     secrets: inherit
@@ -408,7 +404,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
-      afterBuild: node run-tests.js -c ${TEST_CONCURRENCY} --type unit
+      afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-${{ matrix.node }}'
 
     secrets: inherit
@@ -426,7 +422,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
-      afterBuild: node run-tests.js -c ${TEST_CONCURRENCY} --type unit
+      afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
       runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
@@ -523,7 +519,6 @@ jobs:
         node run-tests.js \
           --timings \
           -g ${{ matrix.group }} \
-          -c ${TEST_CONCURRENCY} \
           --type development
       stepName: 'test-dev-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
@@ -546,7 +541,6 @@ jobs:
         export NEXT_TEST_MODE=dev
 
         node run-tests.js \
-          -c ${TEST_CONCURRENCY} \
           test/e2e/app-dir/app/index.test.ts \
           test/e2e/app-dir/app-edge/app-edge.test.ts
       stepName: 'test-dev-windows'
@@ -571,7 +565,7 @@ jobs:
       nodeVersion: 18.18.2
       afterBuild: |
         node run-tests.js \
-          -c 4 \
+          --concurrency 4 \
           test/production/pages-dir/production/test/index.test.ts \
           test/integration/css-client-nav/test/index.test.js \
           test/integration/rewrites-has-condition/test/index.test.js \
@@ -624,7 +618,11 @@ jobs:
         react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: NEXT_TEST_MODE=start NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+      afterBuild: |
+        export NEXT_TEST_MODE=start
+        export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+
+        node run-tests.js --timings -g ${{ matrix.group }} --type production
       stepName: 'test-prod-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
@@ -665,7 +663,6 @@ jobs:
         node run-tests.js \
           --timings \
           -g ${{ matrix.group }} \
-          -c ${TEST_CONCURRENCY} \
           --type integration
       stepName: 'test-integration-${{ matrix.group }}-react-${{ matrix.react }}'
     secrets: inherit
@@ -680,15 +677,17 @@ jobs:
       afterBuild: |
         pnpm playwright install
 
-        # these all run without concurrency (`-c 1`) because they're heavier
-        BROWSER_NAME=firefox node run-tests.js -c 1 \
+        # these all run without concurrency because they're heavier
+        export TEST_CONCURRENCY=1
+
+        BROWSER_NAME=firefox node run-tests.js \
           test/production/pages-dir/production/test/index.test.ts
 
-        NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js -c 1 \
+        NEXT_TEST_MODE=start BROWSER_NAME=safari node run-tests.js \
           test/production/pages-dir/production/test/index.test.ts \
           test/e2e/basepath/basepath.test.ts
 
-        BROWSER_NAME=safari DEVICE_NAME='iPhone XR' node run-tests.js -c 1 \
+        BROWSER_NAME=safari DEVICE_NAME='iPhone XR' node run-tests.js \
           test/production/prerender-prefetch/index.test.ts
       stepName: 'test-firefox-safari'
     secrets: inherit
@@ -709,7 +708,6 @@ jobs:
 
         node run-tests.js \
           --timings \
-          -c ${TEST_CONCURRENCY} \
           --type integration
       stepName: 'test-ppr-integration'
     secrets: inherit
@@ -733,7 +731,6 @@ jobs:
         node run-tests.js \
           --timings \
           -g ${{ matrix.group }} \
-          -c ${TEST_CONCURRENCY} \
           --type development
       stepName: 'test-ppr-dev-${{ matrix.group }}'
     secrets: inherit
@@ -757,7 +754,6 @@ jobs:
         node run-tests.js \
           --timings \
           -g ${{ matrix.group }} \
-          -c ${TEST_CONCURRENCY} \
           --type production
       stepName: 'test-ppr-prod-${{ matrix.group }}'
     secrets: inherit

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -74,6 +74,8 @@ env:
   NAPI_CLI_VERSION: 2.14.7
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20.9.0
+  # run-tests.js reads `TEST_CONCURRENCY` if no explicit `--concurrency` or `-c`
+  # argument is provided
   TEST_CONCURRENCY: 8
   # disable backtrace for test snapshots
   RUST_BACKTRACE: 0

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -101,7 +101,6 @@ jobs:
 
         node run-tests.js \
           --group ${{ matrix.group }}/${{ inputs.e2e_groups }} \
-          --concurrency $TEST_CONCURRENCY \
           --retries ${{ inputs.num_retries }} \
           --type ${{ inputs.test_type }}
       stepName: test-${{ inputs.name }}-${{ matrix.group }}
@@ -140,7 +139,6 @@ jobs:
 
         node run-tests.js \
           --group ${{ matrix.group }}/${{ inputs.integration_groups }} \
-          --concurrency $TEST_CONCURRENCY \
           --retries ${{ inputs.num_retries }} \
           --type integration
       stepName: test-${{ inputs.name }}-integration-${{ matrix.group }}

--- a/run-tests.js
+++ b/run-tests.js
@@ -200,8 +200,13 @@ async function main() {
   // Ensure we have the arguments awaited from yargs.
   argv = await argv
 
+  // `.github/workflows/build_reusable.yml` sets this, we should use it unless
+  // it's overridden by an explicit `--concurrency` argument.
+  const envConcurrency =
+    process.env.TEST_CONCURRENCY && parseInt(process.env.TEST_CONCURRENCY, 10)
+
   const options = {
-    concurrency: argv.concurrency || DEFAULT_CONCURRENCY,
+    concurrency: argv.concurrency ?? envConcurrency ?? DEFAULT_CONCURRENCY,
     debug: argv.debug ?? false,
     timings: argv.timings ?? false,
     writeTimings: argv.writeTimings ?? false,


### PR DESCRIPTION
It seems too easy to accidentally not pass through `TEST_CONCURRENCY` in `build_and_test.yml`, so IMO `run-tests.js` should use it by default, still allowing overriding with `-c` or `--concurrency`.

I tested by spot-checking CI jobs for log lines like this:

```
Running tests with concurrency: 4 in test mode undefined
```

or

```
Running tests with concurrency: 1 in test mode undefined
```

Closes PACK-4506