### PR TITLE
Update test new tests for deploy mode

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -481,7 +481,7 @@ jobs:
     name: Test new tests when deployed
     needs:
       ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This updates our workflow for testing new tests against deploy mode to allow running against forks as we don't want to introduce flakey tests in this mode even if opened from forks.