### PR TITLE
Update test new tests for deploy mode

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -517,7 +517,7 @@ jobs:
           path: crates/wasm
 
       - name: Create tarballs
-        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ runner.temp }}/preview-tarballs"
+        run: GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }} node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ runner.temp }}/preview-tarballs"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,8 +3,9 @@ name: build-and-deploy
 
 on:
   push:
-    # TODO: Run only on canary pushes but PR syncs.
-    # Requires checking if CI is approved
+  # we need the preview tarball for deploy tests
+  pull_request:
+    types: [opened, synchronize]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -479,8 +479,7 @@ jobs:
 
   test-new-tests-deploy:
     name: Test new tests when deployed
-    needs:
-      ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
+    needs: ['optimize-ci']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
 
     strategy:
@@ -492,7 +491,7 @@ jobs:
     with:
       afterBuild: |
         export NEXT_E2E_TEST_TIMEOUT=240000
-
+        export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || "" }}
         node scripts/test-new-tests.mjs \
           --mode deploy \
           --group ${{ matrix.group }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -479,7 +479,8 @@ jobs:
 
   test-new-tests-deploy:
     name: Test new tests when deployed
-    needs: ['optimize-ci']
+    needs:
+      ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
 
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -491,7 +491,7 @@ jobs:
     with:
       afterBuild: |
         export NEXT_E2E_TEST_TIMEOUT=240000
-        export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || "" }}
+        export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }}
         node scripts/test-new-tests.mjs \
           --mode deploy \
           --group ${{ matrix.group }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -481,7 +481,7 @@ jobs:
     name: Test new tests when deployed
     needs:
       ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
 
     strategy:
       fail-fast: false

--- a/scripts/create-preview-tarballs.js
+++ b/scripts/create-preview-tarballs.js
@@ -82,7 +82,7 @@ async function main() {
         }
       )
       // tarball name is printed as the last line of npm-pack
-      const tarballName = stdout.trim().split('\n').pop()
+      const tarballName = stdout.trim().split('\n').pop() || ''
       console.info(`Created tarball ${path.join(packDestination, tarballName)}`)
 
       nextSwcPackageNames.add(manifest.name)
@@ -97,16 +97,21 @@ async function main() {
   ])
   const packages = JSON.parse(lernaListJson.stdout)
   const packagesByVersion = new Map()
+  const PR_NUMBER = process.env.GH_PR_NUMBER
+  const basePackageUrl = PR_NUMBER
+    ? `https://vercel-packages.vercel.app/next/prs/${PR_NUMBER}/`
+    : `https://vercel-packages.vercel.app/next/commits/${commitSha}/`
+
   for (const packageInfo of packages) {
     packagesByVersion.set(
       packageInfo.name,
-      `https://vercel-packages.vercel.app/next/commits/${commitSha}/${packageInfo.name}`
+      `${basePackageUrl}${packageInfo.name}`
     )
   }
   for (const nextSwcPackageName of nextSwcPackageNames) {
     packagesByVersion.set(
       nextSwcPackageName,
-      `https://vercel-packages.vercel.app/next/commits/${commitSha}/${nextSwcPackageName}`
+      `${basePackageUrl}${nextSwcPackageName}`
     )
   }
 
@@ -164,7 +169,7 @@ async function main() {
       }
     )
     // tarball name is printed as the last line of npm-pack
-    const tarballName = stdout.trim().split('\n').pop()
+    const tarballName = stdout.trim().split('\n').pop() || ''
     console.info(`Created tarball ${path.join(packDestination, tarballName)}`)
   }
 

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -79,13 +79,15 @@ async function main() {
   }
 
   const RUN_TESTS_ARGS = ['run-tests.js', '-c', '1', '--retries', '0']
-
+  const PR_NUMBER = process.env.GH_PR_NUMBER
   // Only override the test version for deploy tests, as they need to run against
   // the artifacts for the pull request. Otherwise, we don't need to specify this property,
   // as tests will run against the local version of Next.js
   const nextTestVersion =
     testMode === 'deploy'
-      ? `https://vercel-packages.vercel.app/next/commits/${commitSha}/next`
+      ? PR_NUMBER
+        ? `https://vercel-packages.vercel.app/next/prs/${PR_NUMBER}/next`
+        : `https://vercel-packages.vercel.app/next/commits/${commitSha}/next`
       : undefined
 
   if (nextTestVersion) {

--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// test 3
+// test 4
 
 describe('back/forward cache', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// test
+
 describe('back/forward cache', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// test
+// test 2
 
 describe('back/forward cache', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -1,7 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// test 4
-
 describe('back/forward cache', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// test 2
+// test 3
 
 describe('back/forward cache', () => {
   const { next } = nextTestSetup({


### PR DESCRIPTION
This updates our workflow for testing new tests against deploy mode to allow running against forks as we don't want to introduce flakey tests in this mode even if opened from forks.