### PR TITLE
fix: Dealing with regular expression parsing issues caused by terser configuration after webpack packaging

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -200,7 +200,7 @@ module.exports = ({ dev, turbo, bundleType, experimental, ...rest }) => {
             compress: {
               dead_code: true,
               // Zero means no limit.
-              passes: 0,
+              // passes: 0,
             },
             format: {
               preamble: '',


### PR DESCRIPTION
## Problem description

When I was using this plugin [md-editor-rt](https://github.com/imzbf/md-editor-rt), the development environment was fine, but after packaging, I found an error message as follows:

![image](https://github.com/user-attachments/assets/8f662961-5910-443f-8849-443ce24c8bc7)

## How to trigger

\`\`\`
something
\`\`\`

Note that there is no language specified after ```

## How to solve it

Suggest changing the default value of passes to 1 to balance compression and speed.

Reference Documents [terser](https://www.npmjs.com/package/terser).

```js
{
  // ...
  optimization: {
    // ...
    minimizer: [
      new TerserPlugin({
        // ...
        terserOptions: {
          compress: {
            // ...
            // Zero means no limit.
            // passes: 0,
            // The advantage of 0 is that it can bring the ultimate code compression effect, but the problem is that excessive optimization may lead to some unsafe issues, such as code structure destruction, regular expressions, etc
            // Suggest changing to default 1 to balance compression effect and construction speed
          },
          // ...
        },
      }),
    ],
  }
}
```

