### PR TITLE
Docs IA 2.0: Improve landing page, add intro to Getting Started page

### DIFF
--- a/docs/01-app/01-getting-started/index.mdx
+++ b/docs/01-app/01-getting-started/index.mdx
@@ -2,3 +2,18 @@
 title: Getting Started
 description: Learn how to create full-stack web applications with the Next.js App Router.
 ---
+
+Welcome to the Next.js documentation!
+
+This **Getting Started** section will help you create your first Next.js app and learn the core features you'll use in every project.
+
+## Pre-requisite knowledge
+
+Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before diving in, it'll help if you're comfortable with:
+
+- HTML
+- CSS
+- JavaScript
+- React
+
+## Next Steps

--- a/docs/01-app/01-getting-started/index.mdx
+++ b/docs/01-app/01-getting-started/index.mdx
@@ -9,7 +9,7 @@ This **Getting Started** section will help you create your first Next.js app and
 
 ## Pre-requisite knowledge
 
-Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before getting started, it'll help if you're comfortable with:
+Our documentation assumes some familiarity with web development. Before getting started, it'll help if you're comfortable with:
 
 - HTML
 - CSS

--- a/docs/01-app/01-getting-started/index.mdx
+++ b/docs/01-app/01-getting-started/index.mdx
@@ -16,4 +16,6 @@ Our documentation assumes some familiarity with web development. Before getting 
 - JavaScript
 - React
 
+If you're new to React or need a refresher, we recommend starting with our [React Foundations course](/learn/react-foundations), and the [Next.js Foundations course](/learn/dashboard-app) that has you building an application as you learn.
+
 ## Next Steps

--- a/docs/01-app/01-getting-started/index.mdx
+++ b/docs/01-app/01-getting-started/index.mdx
@@ -9,7 +9,7 @@ This **Getting Started** section will help you create your first Next.js app and
 
 ## Pre-requisite knowledge
 
-Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before diving in, it'll help if you're comfortable with:
+Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before getting started, it'll help if you're comfortable with:
 
 - HTML
 - CSS

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,7 +12,7 @@ Welcome to the Next.js documentation!
 
 ## What is Next.js?
 
-Next.js is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations like routing, server rendering, and more.
+Next.js is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
 
 It also handles configuration for bundlers and compilers, so you can focus on building your application-not managing tooling.
 
@@ -33,14 +33,14 @@ Use the sidebar to navigate to navigate through the sections, or search (`Ctrl+K
 
 Next.js has two different routers:
 
-- **App Router**: The newer router that supports React's latest features, such as Server Components and Streaming.
-- **Pages Router**: The original router, still supported for older applications.
+- **App Router**: The newer router that supports new React features like Server Components.
+- **Pages Router**: The original router, still supported and being improved.
 
 At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the [App Router](/docs/app) and the [Pages Router](/docs/pages) docs.
 
 ## Pre-requisite knowledge
 
-Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before getting started, it'll help if you're comfortable with:
+Our documentation assumes some familiarity with web development. Before getting started, it'll help if you're comfortable with:
 
 - HTML
 - CSS

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: Welcome to the Next.js Documentation.
 related:
   title: Next Steps
-  description: Get started with Next.js by following the installation guide.
+  description: Create your first application and learn the core Next.js features.
   links:
     - app/getting-started
 ---
@@ -40,7 +40,7 @@ At the top of the sidebar, you'll notice a dropdown menu that allows you to swit
 
 ## Pre-requisite knowledge
 
-Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before diving in, it'll help if you're comfortable with:
+Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before getting started, it'll help if you're comfortable with:
 
 - HTML
 - CSS

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,7 +14,7 @@ Welcome to the Next.js documentation!
 
 Next.js is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
 
-It also handles configuration for bundlers and compilers, so you can focus on building your application-not managing tooling.
+It also automatically configures lower-level tools like bundlers and compilers. You can instead focus on building your product and shipping quickly.
 
 Whether you're an individual developer or part of a larger team, Next.js can help you build interactive, dynamic, and fast React applications.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -47,7 +47,7 @@ Our documentation assumes some familiarity with web development. Before getting 
 - JavaScript
 - React
 
-If you're new to React or need a refresher, we recommend starting with our [React Foundations course](/learn/react-foundations). We also recommend the [Next.js Foundations course](/learn/dashboard-app) that has you building an application as you learn.
+If you're new to React or need a refresher, we recommend starting with our [React Foundations course](/learn/react-foundations), and the [Next.js Foundations course](/learn/dashboard-app) that has you building an application as you learn.
 
 ## Accessibility
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -27,7 +27,7 @@ The docs are organized into 4 sections:
 - [Deep Dive](/docs/app/deep-dive): In-depth explanations on how Next.js works.
 - [API Reference](/docs/app/api-reference): Detailed technical reference for every feature.
 
-Use the sidebar to navigate to navigate through the sections, or search (`Ctrl+K` or `Cmd+K`) to quickly find a page.
+Use the sidebar to navigate through the sections, or search (`Ctrl+K` or `Cmd+K`) to quickly find a page.
 
 ## App Router and Pages Router
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,57 +5,53 @@ related:
   title: Next Steps
   description: Get started with Next.js by following the installation guide.
   links:
-    - app/getting-started/installation
+    - app/getting-started
 ---
 
 Welcome to the Next.js documentation!
 
 ## What is Next.js?
 
-Next.js is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
+Next.js is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations like routing, server rendering, and more.
 
-Under the hood, Next.js also abstracts and automatically configures tooling needed for React, like bundling, compiling, and more. This allows you to focus on building your application instead of spending time with configuration.
+It also handles configuration for bundlers and compilers, so you can focus on building your application-not managing tooling.
 
 Whether you're an individual developer or part of a larger team, Next.js can help you build interactive, dynamic, and fast React applications.
 
-## Main Features
+## How to use the docs
 
-Some of the main Next.js features include:
+The docs are organized into 4 sections:
 
-| Feature                                                            | Description                                                                                                                                                                                      |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Routing](/docs/app/building-your-application/routing)             | A file-system based router built on top of Server Components that supports layouts, nested routing, loading states, error handling, and more.                                                    |
-| [Rendering](/docs/app/building-your-application/rendering)         | Client-side and Server-side Rendering with Client and Server Components. Further optimized with Static and Dynamic Rendering on the server with Next.js. Streaming on Edge and Node.js runtimes. |
-| [Data Fetching](/docs/app/building-your-application/data-fetching) | Simplified data fetching with async/await in Server Components, and an extended `fetch` API for request memoization, data caching and revalidation.                                              |
-| [Styling](/docs/app/building-your-application/styling)             | Support for your preferred styling methods, including CSS Modules, Tailwind CSS, and CSS-in-JS                                                                                                   |
-| [Optimizations](/docs/app/building-your-application/optimizing)    | Image, Fonts, and Script Optimizations to improve your application's Core Web Vitals and User Experience.                                                                                        |
-| [TypeScript](/docs/app/api-reference/config/typescript)            | Improved support for TypeScript, with better type checking and more efficient compilation, as well as custom TypeScript Plugin and type checker.                                                 |
+- [Getting Started](/docs/app/getting-started): Step-by-step tutorials to help you create a new application and learn the core Next.js features.
+- [Guides](/docs/app/guides): Tutorials on specific use cases, choose what's relevant to you.
+- [Deep Dive](/docs/app/deep-dive): In-depth explanations on how Next.js works.
+- [API Reference](/docs/app/api-reference): Detailed technical reference for every feature.
 
-## How to Use These Docs
+Use the sidebar to navigate to navigate through the sections, or search (`Ctrl+K` or `Cmd+K`) to quickly find a page.
 
-On the left side of the screen, you'll find the docs navbar. The pages of the docs are organized sequentially, from basic to advanced, so you can follow them step-by-step when building your application. However, you can read them in any order or skip to the pages that apply to your use case.
+## App Router and Pages Router
 
-On the right side of the screen, you'll see a table of contents that makes it easier to navigate between sections of a page. If you need to quickly find a page, you can use the search bar at the top, or the search shortcut (`Ctrl+K` or `Cmd+K`).
+Next.js has two different routers:
 
-To get started, check out the [Installation](/docs/app/getting-started/installation) guide.
+- **App Router**: The newer router that supports React's latest features, such as Server Components and Streaming.
+- **Pages Router**: The original router, still supported for older applications.
 
-## App Router vs Pages Router
+At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the [App Router](/docs/app) and the [Pages Router](/docs/pages) docs.
 
-Next.js has two different routers: the App Router and the Pages Router. The App Router is a newer router that allows you to use React's latest features, such as Server Components and Streaming. The Pages Router is the original Next.js router, which allowed you to build server-rendered React applications and continues to be supported for older Next.js applications.
+## Pre-requisite knowledge
 
-At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the **App Router** and the **Pages Router** features. Since there are features that are unique to each directory, it's important to keep track of which tab is selected.
+Our documentation is designed to be beginner-friendly, but we assume some familiarity with web development. Before diving in, it'll help if you're comfortable with:
 
-The breadcrumbs at the top of the page will also indicate whether you're viewing App Router docs or Pages Router docs.
+- HTML
+- CSS
+- JavaScript
+- React
 
-## Pre-Requisite Knowledge
-
-Although our docs are designed to be beginner-friendly, we need to establish a baseline so that the docs can stay focused on Next.js functionality. We'll make sure to provide links to relevant documentation whenever we introduce a new concept.
-
-To get the most out of our docs, it's recommended that you have a basic understanding of HTML, CSS, and React. If you need to brush up on your React skills, check out our [React Foundations Course](/learn/react-foundations), which will introduce you to the fundamentals. Then, learn more about Next.js by [building a dashboard application](/learn/dashboard-app).
+If you're new to React or need a refresher, we recommend starting with our [React Foundations course](/learn/react-foundations). We also recommend the [Next.js Foundations course](/learn/dashboard-app) that has you building an application as you learn.
 
 ## Accessibility
 
-For optimal accessibility when using a screen reader while reading the docs, we recommend using Firefox and NVDA, or Safari and VoiceOver.
+For the best experience when using a screen reader, we recommend using Firefox and NVDA, or Safari and VoiceOver.
 
 ## Join our Community
 


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4621/add-introduction-and-pre-requesites-to-the-getting-started-page

Following up on @molebox's feedback that the Getting Started page should have an introduction and prerequisite knowledge. I also took a pass at the landing page, and tightened it. 