### PR TITLE
[link] Avoid inlining of `LinkProps` in emitted declarations

### DIFF
--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -119,8 +119,11 @@ type InternalLinkProps = {
 
 // `RouteInferType` is a stub here to avoid breaking `typedRoutes` when the type
 // isn't generated yet. It will be replaced when the webpack plugin runs.
+// WARNING: This should be an interface to prevent TypeScript from inlining it
+// in declarations of libraries dependending on Next.js.
+// Not trivial to reproduce so only convert to an interface when needed.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type LinkProps<RouteInferType = any> = InternalLinkProps
+export interface LinkProps<RouteInferType = any> extends InternalLinkProps {}
 type LinkPropsRequired = RequiredKeys<LinkProps>
 type LinkPropsOptional = OptionalKeys<InternalLinkProps>
 


### PR DESCRIPTION
`tsc` might decide that `LinkProps` should be inlined which would break libraries depending on `next` since that effectively pins the dependency to a patch version.

Workaround is explained here: https://github.com/microsoft/TypeScript/issues/37151#issuecomment-756232934

I can't come up with a minimal repro but verified it manually in an internal package. This would've avoided https://github.com/vercel/microfrontends/pull/171

We should probably lint against types that could be interfaces. But really, https://github.com/microsoft/TypeScript/issues/57779 should be fixed. Inlining types from libraries should be configurable. Most dependencies are not pinned to patch versions but majors.