### PR TITLE
Turbopack: flush key spaces when done with them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9334,6 +9334,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thread_local",
+ "tracing",
  "twox-hash 2.1.0",
  "zstd",
 ]

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -25,6 +25,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true}
 thread_local = { workspace = true }
+tracing = { workspace = true }
 twox-hash = { version = "2.0.1", features = ["xxhash64"] }
 zstd = { version = "0.13.2", features = ["zdict_builder"] }
 

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(once_cell_try)]
 #![feature(new_zeroed_alloc)]
 #![feature(get_mut_unchecked)]
+#![feature(sync_unsafe_cell)]
 
 mod arc_slice;
 mod collector;

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -50,6 +50,28 @@ fn full_cycle() -> Result<()> {
 
     test_case(
         &mut test_cases,
+        "Many SST files",
+        |batch| {
+            for i in 10..100u8 {
+                batch.put(0, vec![i], vec![i].into())?;
+                unsafe { batch.flush(0)? };
+            }
+            Ok(())
+        },
+        |db| {
+            let Some(value) = db.get(0, &[42u8])? else {
+                panic!("Value not found");
+            };
+            assert_eq!(&*value, &[42]);
+            assert_eq!(db.get(0, &[42u8, 42])?, None);
+            assert_eq!(db.get(0, &[1u8])?, None);
+            assert_eq!(db.get(0, &[255u8])?, None);
+            Ok(())
+        },
+    );
+
+    test_case(
+        &mut test_cases,
         "Families",
         |batch| {
             for i in 0..16u8 {

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -231,8 +231,10 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
     /// Flushes a family of the write batch, reducing the amount of buffered memory used.
     /// Does not commit any data persistently.
     ///
-    /// Safety: Caller must ensure that no concurrent put or delete operation is happening on the
-    /// flushed family.
+    /// # Safety
+    ///
+    /// Caller must ensure that no concurrent put or delete operation is happening on the flushed
+    /// family.
     pub unsafe fn flush(&self, family: u32) -> Result<()> {
         // Flush the thread local collectors to the global collector.
         let mut collectors = Vec::new();

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -17,6 +17,7 @@ use rayon::{
 };
 use smallvec::SmallVec;
 use thread_local::ThreadLocal;
+use tracing::Span;
 
 use crate::{
     collector::Collector,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -232,7 +232,6 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
     ///
     /// Safety: Caller must ensure that no concurrent put or delete operation is happening on the
     /// flushed family.
-    #[tracing::instrument(level = "trace", skip(self))]
     pub unsafe fn flush(&self, family: u32) -> Result<()> {
         // Flush the thread local collectors to the global collector.
         let mut collectors = Vec::new();

--- a/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
@@ -90,6 +90,10 @@ impl SerialWriteBatch<'_> for NoopWriteBatch {
     fn delete(&mut self, _key_space: KeySpace, _key: WriteBuffer<'_>) -> Result<()> {
         Ok(())
     }
+
+    fn flush(&mut self, _key_space: KeySpace) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl ConcurrentWriteBatch<'_> for NoopWriteBatch {
@@ -103,6 +107,10 @@ impl ConcurrentWriteBatch<'_> for NoopWriteBatch {
     }
 
     fn delete(&self, _key_space: KeySpace, _key: WriteBuffer<'_>) -> Result<()> {
+        Ok(())
+    }
+
+    unsafe fn flush(&self, _key_space: KeySpace) -> Result<()> {
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -160,6 +160,10 @@ impl<'a> ConcurrentWriteBatch<'a> for TurboWriteBatch<'a> {
     fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.batch.delete(key_space as u32, key.into_static())
     }
+
+    unsafe fn flush(&self, key_space: KeySpace) -> Result<()> {
+        self.batch.flush(key_space as u32)
+    }
 }
 
 impl KeyBase for WriteBuffer<'_> {


### PR DESCRIPTION
### What?

Add a flushing feature that allows to flush the in memory buffered data to disk when done with a key space. This reduces the memory usage.

Closes PACK-4530