### PR TITLE
feat(turbopack): Add basic compilation event support

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -31,6 +31,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{
     Completion, Effects, FxIndexSet, OperationVc, ReadRef, ResolvedVc, TransientInstance,
     TryJoinIterExt, UpdateInfo, Vc, get_effects,
+    message_queue::{CompilationEvent, DiagnosticEvent, Severity},
 };
 use turbo_tasks_fs::{
     DiskFileSystem, FileContent, FileSystem, FileSystemPath, get_relative_path_to,
@@ -402,6 +403,12 @@ pub async fn project_new(
         memory_limit,
         dependency_tracking,
     )?;
+
+    turbo_tasks.send_compilation_event(Arc::new(DiagnosticEvent::new(
+        "Starting the compilation events server...".to_owned(),
+        Severity::Trace,
+    )));
+
     let stats_path = std::env::var_os("NEXT_TURBOPACK_TASK_STATISTICS");
     if let Some(stats_path) = stats_path {
         let task_stats = turbo_tasks.task_statistics().enable().clone();
@@ -429,8 +436,9 @@ pub async fn project_new(
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
 
+    let tasks_ref = turbo_tasks.clone();
     turbo_tasks.spawn_once_task(async move {
-        benchmark_file_io(container.project().node_root())
+        benchmark_file_io(tasks_ref, container.project().node_root())
             .await
             .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
     });
@@ -444,6 +452,35 @@ pub async fn project_new(
     ))
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+struct SlowFilesystemEvent {
+    directory: String,
+    duration_ms: u128,
+}
+
+impl CompilationEvent for SlowFilesystemEvent {
+    fn type_name(&self) -> &'static str {
+        "SlowFilesystemEvent"
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "Slow filesystem detected. The benchmark took {}ms. If {} is a network drive, \
+             consider moving it to a local folder. If you have an antivirus enabled, consider \
+             excluding your project directory.",
+            self.duration_ms, self.directory
+        )
+    }
+
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}
+
 /// A very simple and low-overhead, but potentially noisy benchmark to detect
 /// very slow disk IO. Warns the user (via `println!`) if the benchmark takes
 /// more than `SLOW_FILESYSTEM_THRESHOLD`.
@@ -451,8 +488,11 @@ pub async fn project_new(
 /// This idea is copied from Bun:
 /// - https://x.com/jarredsumner/status/1637549427677364224
 /// - https://github.com/oven-sh/bun/blob/06a9aa80c38b08b3148bfeabe560/src/install/install.zig#L3038
-#[tracing::instrument]
-async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
+#[tracing::instrument(skip(turbo_tasks))]
+async fn benchmark_file_io(
+    turbo_tasks: NextTurboTasks,
+    directory: Vc<FileSystemPath>,
+) -> Result<Vc<Completion>> {
     // try to get the real file path on disk so that we can use it with tokio
     let fs = Vc::try_resolve_downcast_type::<DiskFileSystem>(directory.fs())
         .await?
@@ -490,12 +530,20 @@ async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completio
     .instrument(tracing::info_span!("benchmark file IO (measurement)"))
     .await?;
 
-    if Instant::now().duration_since(start) > SLOW_FILESYSTEM_THRESHOLD {
+    let duration = Instant::now().duration_since(start);
+    if duration > SLOW_FILESYSTEM_THRESHOLD {
         println!(
-            "Slow filesystem detected. If {} is a network drive, consider moving it to a local \
-             folder. If you have an antivirus enabled, consider excluding your project directory.",
+            "Slow filesystem detected. The benchmark took {}ms. If {} is a network drive, \
+             consider moving it to a local folder. If you have an antivirus enabled, consider \
+             excluding your project directory.",
+            duration.as_millis(),
             directory.to_string_lossy(),
         );
+
+        turbo_tasks.send_compilation_event(Arc::new(SlowFilesystemEvent {
+            directory: directory.to_string_lossy().into(),
+            duration_ms: duration.as_millis(),
+        }));
     }
 
     Ok(Completion::new())
@@ -1218,6 +1266,44 @@ pub fn project_update_info_subscribe(
             }
         }
     });
+    Ok(())
+}
+
+/// Subscribes to all compilation events that are not cached like timing and progress information.
+#[napi]
+pub fn project_compilation_events_subscribe(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    func: JsFunction,
+    event_types: Option<Vec<String>>,
+) -> napi::Result<()> {
+    let turbo_tasks = project.turbo_tasks.clone();
+    let tsfn: ThreadsafeFunction<Arc<dyn CompilationEvent>> =
+        func.create_threadsafe_function(0, |ctx| {
+            let event: Arc<dyn CompilationEvent> = ctx.value;
+
+            let env = ctx.env;
+            let mut obj = env.create_object()?;
+            obj.set_named_property("typeName", event.type_name())?;
+            obj.set_named_property("severity", event.severity().to_string())?;
+            obj.set_named_property("message", event.message())?;
+
+            let external = env.create_external(event, None);
+            obj.set_named_property("eventData", external)?;
+
+            Ok(vec![obj])
+        })?;
+
+    tokio::spawn(async move {
+        let mut receiver = turbo_tasks.get_compilation_events_stream(event_types);
+        while let Some(msg) = receiver.recv().await {
+            let status = tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
+
+            if status != Status::Ok {
+                break;
+            }
+        }
+    });
+
     Ok(())
 }
 

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -300,6 +300,12 @@ export declare function projectUpdateInfoSubscribe(
   aggregationMs: number,
   func: (...args: any[]) => any
 ): void
+/** Subscribes to all compilation events that are not cached like timing and progress information. */
+export declare function projectCompilationEventsSubscribe(
+  project: { __napiType: 'Project' },
+  func: (...args: any[]) => any,
+  eventTypes?: Array<string> | undefined | null
+): void
 export interface StackFrame {
   isServer: boolean
   isInternal?: boolean

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -27,6 +27,7 @@ import type {
 } from './generated-native'
 import type {
   Binding,
+  CompilationEvent,
   DefineEnv,
   Endpoint,
   HmrIdentifiers,
@@ -709,6 +710,18 @@ function bindingToApi(
           aggregationMs,
           callback
         )
+      )
+    }
+
+    compilationEventsSubscribe() {
+      return subscribe<TurbopackResult<CompilationEvent>>(
+        true,
+        async (callback) => {
+          binding.projectCompilationEventsSubscribe(
+            this._nativeProject,
+            callback
+          )
+        }
       )
     }
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -182,6 +182,13 @@ export type UpdateMessage =
       value: UpdateInfo
     }
 
+export type CompilationEvent = {
+  typeName: string
+  message: string
+  severity: string
+  eventData: any
+}
+
 export interface UpdateInfo {
   duration: number
   tasks: number
@@ -215,6 +222,10 @@ export interface Project {
   updateInfoSubscribe(
     aggregationMs: number
   ): AsyncIterableIterator<TurbopackResult<UpdateMessage>>
+
+  compilationEventsSubscribe(): AsyncIterableIterator<
+    TurbopackResult<CompilationEvent>
+  >
 
   shutdown(): Promise<void>
 

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -14,11 +14,13 @@ use std::{
 use anyhow::{Result, anyhow};
 use futures::FutureExt;
 use rustc_hash::FxHashMap;
+use tokio::sync::mpsc::Receiver;
 use turbo_tasks::{
     CellId, ExecutionId, InvalidationReason, LocalTaskId, MagicAny, RawVc, ReadCellOptions,
     ReadConsistency, TaskId, TaskPersistence, TraitTypeId, TurboTasksApi, TurboTasksCallApi,
     backend::{CellContent, TaskCollectiblesMap, TypedCellContent},
     event::{Event, EventListener},
+    message_queue::CompilationEvent,
     registry,
     test_helpers::with_turbo_tasks_for_testing,
     util::{SharedError, StaticOrArc},
@@ -313,6 +315,21 @@ impl TurboTasksApi for VcStorage {
 
     fn stop_and_wait(&self) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
         Box::pin(async {})
+    }
+
+    /// Should not be called on the testing VcStorage. These methods are only implemented for
+    /// structs with access to a `MessageQueue` like `TurboTasks`.
+    fn subscribe_to_compilation_events(
+        &self,
+        _event_types: Option<Vec<String>>,
+    ) -> Receiver<Arc<dyn CompilationEvent>> {
+        unimplemented!()
+    }
+
+    /// Should not be called on the testing VcStorage. These methods are only implemented for
+    /// structs with access to a `MessageQueue` like `TurboTasks`.
+    fn send_compilation_event(&self, _event: Arc<dyn CompilationEvent>) {
+        unimplemented!()
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -58,6 +58,7 @@ pub mod macro_helpers;
 mod magic_any;
 mod manager;
 mod marker_trait;
+pub mod message_queue;
 mod native_function;
 mod no_move_vec;
 mod once_map;

--- a/turbopack/crates/turbo-tasks/src/message_queue.rs
+++ b/turbopack/crates/turbo-tasks/src/message_queue.rs
@@ -1,0 +1,170 @@
+use std::{any::Any, collections::VecDeque, fmt::Display, sync::Arc};
+
+use dashmap::DashMap;
+use tokio::sync::{Mutex, mpsc};
+
+pub trait CompilationEvent: Sync + Send + Any {
+    fn type_name(&self) -> &'static str;
+    fn severity(&self) -> Severity;
+    fn message(&self) -> String;
+    fn to_json(&self) -> String;
+}
+
+const MAX_QUEUE_SIZE: usize = 256;
+
+type ArcMx<T> = Arc<Mutex<T>>;
+type CompilationEventChannel = mpsc::Sender<Arc<dyn CompilationEvent>>;
+
+pub struct CompilationEventQueue {
+    event_history: ArcMx<VecDeque<Arc<dyn CompilationEvent>>>,
+    subscribers: DashMap<String, Vec<CompilationEventChannel>>,
+}
+
+impl Default for CompilationEventQueue {
+    fn default() -> Self {
+        let subscribers = DashMap::new();
+        subscribers.insert("*".to_owned(), Vec::<CompilationEventChannel>::new());
+
+        Self {
+            event_history: Arc::new(Mutex::new(VecDeque::with_capacity(MAX_QUEUE_SIZE))),
+            subscribers,
+        }
+    }
+}
+
+impl CompilationEventQueue {
+    pub fn send(
+        &self,
+        message: Arc<dyn CompilationEvent>,
+    ) -> Result<(), mpsc::error::SendError<Arc<dyn CompilationEvent>>> {
+        let event_history = self.event_history.clone();
+        let subscribers = self.subscribers.clone();
+        let message_clone = message.clone();
+
+        // Spawn a task to handle the async operations
+        tokio::spawn(async move {
+            // Store the message in history
+            let mut history = event_history.lock().await;
+            if history.len() >= MAX_QUEUE_SIZE {
+                history.pop_front();
+            }
+            history.push_back(message_clone.clone());
+
+            // Send to all active receivers of the same message type
+            if let Some(mut type_subscribers) = subscribers.get_mut(message_clone.type_name()) {
+                let mut removal_indices = Vec::new();
+                for (ix, sender) in type_subscribers.iter().enumerate() {
+                    if sender.send(message_clone.clone()).await.is_err() {
+                        removal_indices.push(ix);
+                    }
+                }
+
+                for ix in removal_indices.iter().rev() {
+                    type_subscribers.remove(*ix);
+                }
+            }
+
+            // Send to all global message subscribers
+            let mut all_channel = subscribers.get_mut("*").unwrap();
+            let mut removal_indices = Vec::new();
+            for (ix, sender) in all_channel.iter_mut().enumerate() {
+                if sender.send(message_clone.clone()).await.is_err() {
+                    removal_indices.push(ix);
+                }
+            }
+
+            for ix in removal_indices.iter().rev() {
+                all_channel.remove(*ix);
+            }
+        });
+
+        Ok(())
+    }
+
+    pub fn subscribe(
+        &self,
+        event_types: Option<Vec<String>>,
+    ) -> mpsc::Receiver<Arc<dyn CompilationEvent>> {
+        let (tx, rx) = mpsc::channel(MAX_QUEUE_SIZE);
+        let subscribers = self.subscribers.clone();
+        let event_history = self.event_history.clone();
+        let tx_clone = tx.clone();
+
+        // Spawn a task to handle the async operations
+        tokio::spawn(async move {
+            // Store the sender
+            if let Some(event_types) = event_types {
+                for event_type in event_types.iter() {
+                    let mut type_subscribers = subscribers.entry(event_type.clone()).or_default();
+                    type_subscribers.push(tx_clone.clone());
+                }
+
+                for event in event_history.lock().await.iter() {
+                    if event_types.contains(&event.type_name().to_string()) {
+                        let _ = tx_clone.send(event.clone()).await;
+                    }
+                }
+            } else {
+                let mut global_subscribers = subscribers.entry("*".to_string()).or_default();
+                global_subscribers.push(tx_clone.clone());
+
+                for event in event_history.lock().await.iter() {
+                    let _ = tx_clone.send(event.clone()).await;
+                }
+            }
+        });
+
+        rx
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum Severity {
+    Info,
+    Trace,
+    Warning,
+    Error,
+    Fatal,
+}
+
+impl Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Severity::Info => write!(f, "INFO"),
+            Severity::Trace => write!(f, "TRACE"),
+            Severity::Warning => write!(f, "WARNING"),
+            Severity::Error => write!(f, "ERROR"),
+            Severity::Fatal => write!(f, "FATAL"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DiagnosticEvent {
+    pub message: String,
+    pub severity: Severity,
+}
+
+impl DiagnosticEvent {
+    pub fn new(message: String, severity: Severity) -> Self {
+        Self { message, severity }
+    }
+}
+
+impl CompilationEvent for DiagnosticEvent {
+    fn type_name(&self) -> &'static str {
+        "DiagnosticEvent"
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        self.message.clone()
+    }
+
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -174,6 +174,7 @@ pub async fn parse(
 ) -> Result<Vc<ParseResult>> {
     let name = source.ident().to_string().await?.to_string();
     let span = tracing::info_span!("parse ecmascript", name = name, ty = display(&*ty));
+
     match parse_internal(source, ty, transforms)
         .instrument(span)
         .await
@@ -428,8 +429,8 @@ async fn parse_file_content(
                 }
                 anyhow::Ok(())
             }
-            .instrument(span)
-            .await?;
+                .instrument(span)
+                .await?;
 
             if parser_handler.has_errors() {
                 let messages = if let Some(error) = collector_parse.last_emitted_issue() {
@@ -476,7 +477,7 @@ async fn parse_file_content(
             })
         },
     )
-    .await?;
+        .await?;
     if let ParseResult::Ok {
         globals: ref mut g, ..
     } = result


### PR DESCRIPTION
## Implement Compilation Events System for Turbopack

This PR adds a compilation events system to Turbopack that allows sending and subscribing to events during compilation. The system enables better communication of important information to users, such as filesystem performance warnings.

### What?

- Added a `CompilationEvent` trait in Turbo Tasks to standardize event messaging
- Implemented a broadcast-based event queue for distributing events to subscribers
- Created specific event types for diagnostics and slow filesystem detection
- Added JavaScript bindings to expose events to the Next.js frontend

### How?

- Created a new `message_queue.rs` module in turbo-tasks to handle event broadcasting
- Added methods to the TurboTasks manager to send and subscribe to compilation events
- Enhanced the filesystem benchmark to send detailed performance warnings through the new event system


Closes PACK-4612