### PR TITLE
De-dupe build_and_deploy run for PRs

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   deploy-target:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     outputs:
       value: ${{ steps.deploy-target.outputs.value }}


### PR DESCRIPTION
This aims to avoid running the `build_and_deploy` workflow twice when pushed to the main Next.js repo and also opened as a PR. 

Follow-up to https://github.com/vercel/next.js/pull/78737

Validated against: https://github.com/vercel/next.js/actions/runs/14804173232/job/41569421246?pr=78795