### PR TITLE
docs: updated installation guide to clarify create-next-app versioning

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -21,6 +21,13 @@ The quickest way to create a new Next.js app is using [`create-next-app`](/docs/
 npx create-next-app@latest
 ```
 
+- `@latest` installs the most recent stable version of Next.js.
+- To install a specific version (such as Next.js 14.2.24), replace `@latest` by that version name:
+
+```bash filename="Terminal"
+npx create-next-app@14.2.24
+```
+
 On installation, you'll see the following prompts:
 
 ```txt filename="Terminal"


### PR DESCRIPTION

### What?

Clarifies how `create-next-app@latest` works and explains how to install a specific Next.js version (like 14).

### Why?

To provide more information to user on how the versioning of `create-next-app` command works by describing what `@latest` is for and how they can use an older version of Next.js if they want to.

Fixes #76998
