### PR TITLE
Revert "De-dupe build_and_deploy run for PRs"

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,7 +18,6 @@ env:
 
 jobs:
   deploy-target:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     outputs:
       value: ${{ steps.deploy-target.outputs.value }}


### PR DESCRIPTION
Reverting to figure out why we aren't finding the artifacts https://github.com/vercel/next.js/actions/runs/14805980982/job/41575122432?pr=78797

Reverts vercel/next.js#78792