### PR TITLE
[test] Repro for dropped `ignoreList` by Turbopack in browser sourcemaps

### DIFF
--- a/test/e2e/app-dir/server-source-maps/fixtures/default/package.json
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "internal-pkg": "file:./internal-pkg",
+    "internal-pkg": "link:./internal-pkg",
     "external-pkg": "file:./external-pkg"
   }
 }


### PR DESCRIPTION
Turbopack can handle this case on the server (with incorrect sources) but fails for browser sourcemaps. The middleware fails to sourcemap on-demand because it thinks the files are not part of the project. The generated sourcemap does include `ignoreList` in this test but that's not what we're seeing internally where the `ignoreList` entry is absent entirely.