### PR TITLE
Update anyhow to 1.0.98

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,9 +232,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 dependencies = [
  "backtrace",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,7 +325,7 @@ tungstenite = "0.20.1"
 allsorts = { version = "0.14.0", default-features = false, features = [
   "flate2_rust",
 ] }
-anyhow = "1.0.69"
+anyhow = "1.0.98"
 assert_cmd = "2.0.8"
 async-compression = { version = "0.3.13", default-features = false, features = [
   "gzip",


### PR DESCRIPTION
This includes nice utilities like `.into_boxed_dyn_error()`.


Closes PACK-4515