### PR TITLE
Update self-hosting.mdx to add missing /

### DIFF
--- a/docs/01-app/02-guides/self-hosting.mdx
+++ b/docs/01-app/02-guides/self-hosting.mdx
@@ -6,7 +6,7 @@ description: Learn how to self-host your Next.js application on a Node.js server
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
-When [deploying](docs/app/getting-started/deploying) your Next.js app, you may want to configure how different features are handled based on your infrastructure.
+When [deploying](/docs/app/getting-started/deploying) your Next.js app, you may want to configure how different features are handled based on your infrastructure.
 
 > **🎥 Watch:** Learn more about self-hosting Next.js → [YouTube (45 minutes)](https://www.youtube.com/watch?v=sIVL4JMqRfc).
 


### PR DESCRIPTION
### What?
Link to [Getting Started > Deploying page](https://nextjs.org/docs/pages/getting-started/deploying) inside the [Guides > Self-hosting page](https://nextjs.org/docs/pages/guides/self-hosting) leads to 404 not found.
### Why?
This error happens because of a missing / in self-hosting.mdx
