### PR TITLE
doc: add build lifecycle hooks documentation

### DIFF
--- a/docs/03-architecture/nextjs-compiler.mdx
+++ b/docs/03-architecture/nextjs-compiler.mdx
@@ -278,6 +278,29 @@ module.exports = {
 }
 ```
 
+### Build Lifecycle Hooks
+
+The Next.js Compiler supports lifecycle hooks that allow you to run custom code at specific points during the build process. Currently, the following hook is supported:
+
+#### runAfterProductionCompile
+
+A hook function that executes after production build compilation finishes, but before running post-compilation tasks such as type checking and static page generation. This hook provides access to project metadata including the project directory and build output directory, making it useful for third-party tools to collect build outputs like sourcemaps.
+
+```js filename="next.config.js"
+module.exports = {
+  compiler: {
+    runAfterProductionCompile: async ({ distDir, projectDir }) => {
+      // Your custom code here
+    },
+  },
+}
+```
+
+The hook receives an object with the following properties:
+
+- `distDir`: The build output directory (defaults to `.next`)
+- `projectDir`: The root directory of the project
+
 ## Experimental Features
 
 ### SWC Trace profiling


### PR DESCRIPTION
Added documentation for the new Build Lifecycle Hooks feature in the Next.js Compiler, specifically the `runAfterProductionCompile` hook.

https://github.com/vercel/next.js/pull/77345