### PR TITLE
Turbopack: defer sourcemaps processing to codegen

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -48,7 +48,7 @@ pub async fn request_to_string(request: Vc<Request>) -> Result<Vc<RcStr>> {
 pub struct InlineSourceMap {
     /// The file path of the module containing the sourcemap data URL
     pub origin_path: ResolvedVc<FileSystemPath>,
-    /// The decoded JSON sourcemap string
+    /// The Base64 encoded JSON sourcemap string
     pub source_map: RcStr,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -11,7 +11,6 @@ use turbopack_core::{
     module_graph::ModuleGraph,
     reference::ModuleReferences,
     resolve::ModulePart,
-    source_map::OptionStringifiedSourceMap,
 };
 
 use super::chunk_item::EcmascriptModuleFacadeChunkItem;
@@ -224,7 +223,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleFacadeModule {
             code_generation: CodeGens::empty().to_resolved().await?,
             async_module: ResolvedVc::cell(Some(self.async_module().to_resolved().await?)),
             generate_source_map: false,
-            original_source_map: OptionStringifiedSourceMap::none().to_resolved().await?,
+            original_source_map: None,
             exports: self.get_exports().to_resolved().await?,
             async_module_info,
         }


### PR DESCRIPTION
Closes PACK-3434

```
    // TODO This is too eagerly generating the source map. We should store a GenerateSourceMap
    // instead and only actually generate the SourceMap when it's needed. This would allow to avoid
    // generating the source map when a module is never included in the final bundle. It allows
    // analysis to finish earlier which makes references available earlier which benefits
    // parallelism. When SourceMaps are emitted it moves that generation work to the code generation
    // phase which is more parallelizable.
```