### PR TITLE
[dev-overlay] Consider scrollbar width for drag positioning

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/draggable.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/draggable.tsx
@@ -73,13 +73,17 @@ export function Draggable({
     const offset = padding * 2
     const triggerWidth = ref.current?.offsetWidth || 0
     const triggerHeight = ref.current?.offsetHeight || 0
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth
 
     function getAbsolutePosition(corner: Corners) {
       const isRight = corner.includes('right')
       const isBottom = corner.includes('bottom')
 
       return {
-        x: isRight ? window.innerWidth - offset - triggerWidth : 0,
+        x: isRight
+          ? window.innerWidth - scrollbarWidth - offset - triggerWidth
+          : 0,
         y: isBottom ? window.innerHeight - offset - triggerHeight : 0,
       }
     }
@@ -93,7 +97,12 @@ export function Draggable({
         y: 0 - basePosition.y,
       },
       'top-right': {
-        x: window.innerWidth - offset - triggerWidth - basePosition.x,
+        x:
+          window.innerWidth -
+          scrollbarWidth -
+          offset -
+          triggerWidth -
+          basePosition.x,
         y: 0 - basePosition.y,
       },
       'bottom-left': {
@@ -101,7 +110,12 @@ export function Draggable({
         y: window.innerHeight - offset - triggerHeight - basePosition.y,
       },
       'bottom-right': {
-        x: window.innerWidth - offset - triggerWidth - basePosition.x,
+        x:
+          window.innerWidth -
+          scrollbarWidth -
+          offset -
+          triggerWidth -
+          basePosition.x,
         y: window.innerHeight - offset - triggerHeight - basePosition.y,
       },
     }


### PR DESCRIPTION
This PR fixes a small bug with the dragging logic established in #78716

Namely, I didn't take into account the scrollbar width when calculating `translate` for each corner. So if the page was scrollable the drag end would be a bit janky:


https://github.com/user-attachments/assets/17e227e9-7af1-4ab8-91b2-b7cc4d363793

After this PR, the snapping is much smoother with no jank:


https://github.com/user-attachments/assets/06021fae-da61-46b3-b224-11f319835fa3

