### PR TITLE
[dev-overlay] solidate the line number parsing

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/code-frame.tsx
@@ -14,18 +14,16 @@ import {
 export type CodeFrameProps = { stackFrame: StackFrame; codeFrame: string }
 
 export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
-  const decodedLines = useMemo(
-    () => groupCodeFrameLines(formatCodeFrame(codeFrame)),
-    [codeFrame]
-  )
   const parsedLineStates = useMemo(() => {
+    const decodedLines = groupCodeFrameLines(formatCodeFrame(codeFrame))
+
     return decodedLines.map((line) => {
       return {
         line,
         parsedLine: parseLineNumberFromCodeFrameLine(line, stackFrame),
       }
     })
-  }, [decodedLines, stackFrame])
+  }, [codeFrame, stackFrame])
 
   const open = useOpenInEditor({
     file: stackFrame.file,

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.test.ts
@@ -49,4 +49,45 @@ describe('parse line numbers', () => {
       isErroredLine: false,
     })
   })
+
+  it('parse line numbers when a token contains both break and spaces', () => {
+    //   4 |   return (
+    //   5 |     <p>
+    // > 6 |       <p>nest</p>
+    //     |       ^
+    //   7 |     </p>
+    //   8 |   )
+    //   9 | }
+    const input = {
+      stackFrame: {
+        file: 'app/page.tsx',
+        lineNumber: 6,
+        column: 7,
+        methodName: 'Page',
+        arguments: [],
+      },
+      codeFrame: `"\u001b[0m \u001b[90m 4 |\u001b[39m   \u001b[36mreturn\u001b[39m (\n \u001b[90m 5 |\u001b[39m     \u001b[33m<\u001b[39m\u001b[33mp\u001b[39m\u001b[33m>\u001b[39m\n\u001b[31m\u001b[1m>\u001b[22m\u001b[39m\u001b[90m 6 |\u001b[39m       \u001b[33m<\u001b[39m\u001b[33mp\u001b[39m\u001b[33m>\u001b[39mnest\u001b[33m<\u001b[39m\u001b[33m/\u001b[39m\u001b[33mp\u001b[39m\u001b[33m>\u001b[39m\n \u001b[90m   |\u001b[39m       \u001b[31m\u001b[1m^\u001b[22m\u001b[39m\n \u001b[90m 7 |\u001b[39m     \u001b[33m<\u001b[39m\u001b[33m/\u001b[39m\u001b[33mp\u001b[39m\u001b[33m>\u001b[39m\n \u001b[90m 8 |\u001b[39m   )\n \u001b[90m 9 |\u001b[39m }\u001b[0m"`,
+    }
+    const formattedFrame = formatCodeFrame(input.codeFrame)
+    const decodedLines = groupCodeFrameLines(formattedFrame)
+
+    expect(
+      parseLineNumberFromCodeFrameLine(decodedLines[1], input.stackFrame)
+    ).toEqual({
+      lineNumber: '5',
+      isErroredLine: false,
+    })
+    expect(
+      parseLineNumberFromCodeFrameLine(decodedLines[2], input.stackFrame)
+    ).toEqual({
+      lineNumber: '6',
+      isErroredLine: true,
+    })
+    expect(
+      parseLineNumberFromCodeFrameLine(decodedLines[4], input.stackFrame)
+    ).toEqual({
+      lineNumber: '7',
+      isErroredLine: false,
+    })
+  })
 })

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
@@ -43,9 +43,23 @@ export function groupCodeFrameLines(formattedFrame: string) {
 
   let line: typeof decoded = []
   for (const token of decoded) {
-    if (token.content === '\n') {
+    // If the token is a new line with only line break "\n",
+    // break here into a new line.
+    // The line could also contain spaces, it's still considered line break if "\n" line has spaces.
+    if (token.content.includes('\n')) {
+      const [left, right] = token.content.split('\n')
+      line.push({
+        ...token,
+        content: left,
+      })
       lines.push(line)
       line = []
+      if (right) {
+        line.push({
+          ...token,
+          content: right,
+        })
+      }
     } else {
       line.push(token)
     }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
@@ -47,17 +47,19 @@ export function groupCodeFrameLines(formattedFrame: string) {
     // break here into a new line.
     // The line could also contain spaces, it's still considered line break if "\n" line has spaces.
     if (token.content.includes('\n')) {
-      const [left, right] = token.content.split('\n')
-      line.push({
-        ...token,
-        content: left,
-      })
-      lines.push(line)
-      line = []
-      if (right) {
+      const [beforeBreak, afterBreak] = token.content.split('\n')
+      if (beforeBreak) {
         line.push({
           ...token,
-          content: right,
+          content: beforeBreak,
+        })
+      }
+      lines.push(line)
+      line = []
+      if (afterBreak) {
+        line.push({
+          ...token,
+          content: afterBreak,
         })
       }
     } else {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
@@ -46,22 +46,24 @@ export function groupCodeFrameLines(formattedFrame: string) {
     // If the token is a new line with only line break "\n",
     // break here into a new line.
     // The line could also contain spaces, it's still considered line break if "\n" line has spaces.
-    if (token.content.includes('\n')) {
-      const [beforeBreak, afterBreak] = token.content.split('\n')
-      if (beforeBreak) {
-        line.push({
-          ...token,
-          content: beforeBreak,
-        })
+    if (
+      token &&
+      typeof token.content === 'string' &&
+      token.content.includes('\n')
+    ) {
+      const segments = token.content.split('\n')
+      for (const segment of segments) {
+        lines.push(line)
+        line = []
+        if (segment) {
+          line.push({
+            ...token,
+            content: segment,
+          })
+        }
       }
       lines.push(line)
       line = []
-      if (afterBreak) {
-        line.push({
-          ...token,
-          content: afterBreak,
-        })
-      }
     } else {
       line.push(token)
     }
@@ -82,7 +84,6 @@ export function parseLineNumberFromCodeFrameLine(
   // parse line number from line first 2 tokens
   // e.g. ` > 1 | const foo = 'bar'` => `1`, first token is `1 |`
   // e.g. `  2 | const foo = 'bar'` => `2`. first 2 tokens are ' ' and ' 2 |'
-  // console.log('line', line)
   if (line[0]?.content === '>' || line[0]?.content === ' ') {
     lineNumberToken = line[1]
     lineNumber = lineNumberToken?.content?.replace('|', '')?.trim()

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/code-frame/parse-code-frame.ts
@@ -46,24 +46,21 @@ export function groupCodeFrameLines(formattedFrame: string) {
     // If the token is a new line with only line break "\n",
     // break here into a new line.
     // The line could also contain spaces, it's still considered line break if "\n" line has spaces.
-    if (
-      token &&
-      typeof token.content === 'string' &&
-      token.content.includes('\n')
-    ) {
+    if (typeof token.content === 'string' && token.content.includes('\n')) {
       const segments = token.content.split('\n')
-      for (const segment of segments) {
-        lines.push(line)
-        line = []
+      for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i]
         if (segment) {
           line.push({
             ...token,
             content: segment,
           })
         }
+        if (i < segments.length - 1) {
+          lines.push(line)
+          line = []
+        }
       }
-      lines.push(line)
-      line = []
     } else {
       line.push(token)
     }


### PR DESCRIPTION
### What

Enhance the line break solution of dev overlay code frame from #77078

We parse the tokens and group them into lines by detect the line break token. There's a missing case we didn't notice before where the line break token could contain spaces look like below:

![image](https://github.com/user-attachments/assets/20760ca4-46d9-40bf-9a0f-1cb9a8014fd2)

* The content before `\n` should belong to previous line
* The content after `\n` should belong to the next line

Also improved the memoization situation in the code frame to avoid re-parsing the lines and tokens.

Closes NDX-1042