### PR TITLE
docs: add Firebase App Hosting to deploying page

### DIFF
--- a/docs/01-app/01-getting-started/11-deploying.mdx
+++ b/docs/01-app/01-getting-started/11-deploying.mdx
@@ -48,6 +48,7 @@ Docker deployments support all Next.js features. Learn how to [configure them](/
 - [Docker](https://github.com/vercel/next.js/tree/canary/examples/with-docker)
 - [Docker Multi-Environment](https://github.com/vercel/next.js/tree/canary/examples/with-docker-multi-env)
 - [DigitalOcean](https://github.com/nextjs/deploy-digitalocean)
+- [Firebase App Hosting](https://firebase.google.com/docs/app-hosting/frameworks-tooling#runtimes-for-app-hosting)
 - [Fly.io](https://github.com/nextjs/deploy-fly)
 - [Google Cloud Run](https://github.com/nextjs/deploy-google-cloud-run)
 - [Render](https://github.com/nextjs/deploy-render)


### PR DESCRIPTION
Adding Firebase App Hosting to the adapters section the deploying getting started.