### PR TITLE
Turbopack: fix task data category

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -421,7 +421,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         let mut ctx = self.execute_context(turbo_tasks);
-        let mut task = ctx.task(task_id, TaskDataCategory::Meta);
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
 
         fn listen_to_done_event<B: BackingStorage>(
             this: &TurboTasksBackendInner<B>,
@@ -492,7 +492,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                         &mut ctx,
                     );
                 }
-                task = ctx.task(task_id, TaskDataCategory::Meta);
+                task = ctx.task(task_id, TaskDataCategory::All);
             }
 
             let is_dirty =


### PR DESCRIPTION
### What?

fix a debug assertion in the test suite due to a wrong task data category

this bug was introduced in https://github.com/vercel/next.js/pull/78728 (15.4.0-canary.23)

Closes PACK-4534