### PR TITLE
fix(react-compiler): Fix detection of interest

### DIFF
--- a/crates/next-custom-transforms/src/react_compiler.rs
+++ b/crates/next-custom-transforms/src/react_compiler.rs
@@ -75,6 +75,8 @@ impl Visit for Finder {
         if let Pat::Ident(ident) = &node.name {
             self.is_interested = ident.sym.starts_with("use")
                 || ident.sym.starts_with(|c: char| c.is_ascii_uppercase());
+        } else {
+            self.is_interested = false;
         }
 
         node.visit_children_with(self);

--- a/crates/next-custom-transforms/src/react_compiler.rs
+++ b/crates/next-custom-transforms/src/react_compiler.rs
@@ -1,5 +1,5 @@
 use swc_core::ecma::{
-    ast::{Callee, Expr, FnDecl, FnExpr, Program, ReturnStmt},
+    ast::{Callee, Expr, FnDecl, FnExpr, Pat, Program, ReturnStmt, VarDeclarator},
     visit::{Visit, VisitWith},
 };
 
@@ -67,5 +67,18 @@ impl Visit for Finder {
         }
 
         node.visit_children_with(self);
+    }
+
+    fn visit_var_declarator(&mut self, node: &VarDeclarator) {
+        let old = self.is_interested;
+
+        if let Pat::Ident(ident) = &node.name {
+            self.is_interested = ident.sym.starts_with("use")
+                || ident.sym.starts_with(|c: char| c.is_ascii_uppercase());
+        }
+
+        node.visit_children_with(self);
+
+        self.is_interested = old;
     }
 }


### PR DESCRIPTION
### What?

Mark function components declared as a variable interesting

### Why?

Because those are also React Components

### How?

 - Closes SWC-646
-  Closes https://github.com/vercel/next.js/issues/78867


Closes PACK-4536