### PR TITLE
docs: add warning about eslint-config-prettier

### DIFF
--- a/docs/01-app/05-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/05-api-reference/05-config/03-eslint.mdx
@@ -180,7 +180,16 @@ See [typescript-eslint > Configs](https://typescript-eslint.io/linting/configs) 
 
 ### With Prettier
 
-ESLint also contains code formatting rules, which can conflict with your existing [Prettier](https://prettier.io/) setup. We recommend including [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) in your ESLint config to make ESLint and Prettier work together.
+`eslint-config-prettier` is often unnecessary because modern ESLint best practices
+discourage enabling stylistic rules in shared configs, and recommended configs like
+`eslint:recommended` and `@typescript-eslint/recommended` now focus solely on
+logic-related checks.
+
+Unless you're using a legacy config that enables formatting rules,
+`eslint-config-prettier` provides no benefit and can cause confusion.
+If you _are_ using such a config, include
+[eslint-config-prettier](https://github.com/prettier/eslint-config-prettier)
+to prevent conflicts and ensure ESLint and Prettier work correctly together.
 
 First, install the dependency:
 


### PR DESCRIPTION
Adds a warning that `eslint-config-prettier` may be unnecessary for most users.  
For a more in-depth explanation, see:  [You Probably Don't Need eslint-config-prettier or eslint-plugin-prettier](https://www.joshuakgoldberg.com/blog/you-probably-dont-need-eslint-config-prettier-or-eslint-plugin-prettier/#)