### PR TITLE
feat(next-swc): Add a fast path to RC detector

### DIFF
--- a/crates/next-custom-transforms/src/react_compiler.rs
+++ b/crates/next-custom-transforms/src/react_compiler.rs
@@ -1,5 +1,5 @@
 use swc_core::ecma::{
-    ast::{Callee, Expr, FnDecl, FnExpr, Pat, Program, ReturnStmt, VarDeclarator},
+    ast::{Callee, Expr, FnDecl, FnExpr, Pat, Program, ReturnStmt, Stmt, VarDeclarator},
     visit::{Visit, VisitWith},
 };
 
@@ -31,6 +31,13 @@ impl Visit for Finder {
             }
         }
 
+        node.visit_children_with(self);
+    }
+
+    fn visit_expr(&mut self, node: &Expr) {
+        if self.found {
+            return;
+        }
         node.visit_children_with(self);
     }
 
@@ -66,6 +73,13 @@ impl Visit for Finder {
             }
         }
 
+        node.visit_children_with(self);
+    }
+
+    fn visit_stmt(&mut self, node: &Stmt) {
+        if self.found {
+            return;
+        }
         node.visit_children_with(self);
     }
 


### PR DESCRIPTION
### What?

Add a fast path to the React compiler detector.

### Why?

https://github.com/vercel/next.js/pull/78874#issuecomment-2857798974

### How?


Closes PACK-4541