### PR TITLE
Turbopack: `ChunkingType::Parallel` with `hoisted` bool

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -264,9 +264,7 @@ pub async fn chunk_group_content(
             };
 
             Ok(match edge.ty {
-                ChunkingType::Parallel
-                | ChunkingType::ParallelInheritAsync
-                | ChunkingType::Shared { .. } => {
+                ChunkingType::Parallel { .. } | ChunkingType::Shared { .. } => {
                     if is_available {
                         GraphTraversalAction::Exclude
                     } else if state

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -178,8 +178,8 @@ pub enum ChunkingType {
     Parallel {
         /// Whether the parent module becomes an async module when the referenced module is async.
         inherit_async: bool,
-        /// Whether the referenced module is executed always immediately before the parent modules
-        /// (corresponding to ESM import semantics)
+        /// Whether the referenced module is executed always immediately before the parent module
+        /// (corresponding to ESM import semantics).
         hoisted: bool,
     },
     /// An async loader is placed into the referencing chunk and loads the

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -176,6 +176,7 @@ pub enum ChunkingType {
     /// The referenced module is placed in the same chunk group and is loaded in parallel.
     Parallel {
         /// Whether the parent module becomes an async module when the referenced module is async.
+        /// This should happen for e.g. ESM imports, but not for CommonJS requires.
         inherit_async: bool,
         /// Whether the referenced module is executed always immediately before the parent module
         /// (corresponding to ESM import semantics).

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -203,15 +203,6 @@ pub enum ChunkingType {
     Traced,
 }
 
-impl Default for ChunkingType {
-    fn default() -> Self {
-        ChunkingType::Parallel {
-            inherit_async: false,
-            hoisted: false,
-        }
-    }
-}
-
 impl ChunkingType {
     pub fn is_inherit_async(&self) -> bool {
         matches!(
@@ -278,7 +269,10 @@ pub struct ChunkingTypeOption(Option<ChunkingType>);
 #[turbo_tasks::value_trait]
 pub trait ChunkableModuleReference: ModuleReference + ValueToString {
     fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::default()))
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -173,8 +173,7 @@ pub trait OutputChunk: Asset {
     NonLocalValue,
 )]
 pub enum ChunkingType {
-    /// Module is placed in the same chunk group and is loaded in parallel. It
-    /// doesn't become an async module when the referenced module is async.
+    /// The referenced module is placed in the same chunk group and is loaded in parallel.
     Parallel {
         /// Whether the parent module becomes an async module when the referenced module is async.
         inherit_async: bool,

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -81,10 +81,7 @@ pub async fn children_from_module_references(
         {
             match &*chunkable.chunking_type().await? {
                 None => {}
-                Some(ChunkingType::Parallel) => key = parallel_reference_ty(),
-                Some(ChunkingType::ParallelInheritAsync) => {
-                    key = parallel_inherit_async_reference_ty()
-                }
+                Some(ChunkingType::Parallel { .. }) => key = parallel_reference_ty(),
                 Some(ChunkingType::Async) => key = async_reference_ty(),
                 Some(ChunkingType::Isolated { .. }) => key = isolated_reference_ty(),
                 Some(ChunkingType::Shared { .. }) => key = shared_reference_ty(),

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -88,7 +88,10 @@ async fn compute_async_module_info_single(
 
             // edges.push((parent_module, module, async_modules.contains(&module)));
             match chunking_type {
-                ChunkingType::ParallelInheritAsync
+                ChunkingType::Parallel {
+                    inherit_async: true,
+                    ..
+                }
                 | ChunkingType::Shared {
                     inherit_async: true,
                     ..
@@ -97,7 +100,11 @@ async fn compute_async_module_info_single(
                         async_modules.insert(parent_module);
                     }
                 }
-                ChunkingType::Parallel
+
+                ChunkingType::Parallel {
+                    inherit_async: false,
+                    ..
+                }
                 | ChunkingType::Async
                 | ChunkingType::Isolated { .. }
                 | ChunkingType::Traced

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -3,7 +3,6 @@ use rustc_hash::FxHashSet;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 
 use crate::{
-    chunk::ChunkingType,
     module::{Module, Modules},
     module_graph::{GraphTraversalAction, ModuleGraph, SingleModuleGraph},
 };
@@ -86,34 +85,8 @@ async fn compute_async_module_info_single(
             let module = module.module();
             let parent_module = parent_module.module;
 
-            // edges.push((parent_module, module, async_modules.contains(&module)));
-            match chunking_type {
-                ChunkingType::Parallel {
-                    inherit_async: true,
-                    ..
-                }
-                | ChunkingType::Shared {
-                    inherit_async: true,
-                    ..
-                } => {
-                    if async_modules.contains(&module) {
-                        async_modules.insert(parent_module);
-                    }
-                }
-
-                ChunkingType::Parallel {
-                    inherit_async: false,
-                    ..
-                }
-                | ChunkingType::Async
-                | ChunkingType::Isolated { .. }
-                | ChunkingType::Traced
-                | ChunkingType::Shared {
-                    inherit_async: false,
-                    ..
-                } => {
-                    // Nothing to propagate
-                }
+            if chunking_type.is_inherit_async() && async_modules.contains(&module) {
+                async_modules.insert(parent_module);
             }
         },
     )?;

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -460,7 +460,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
                 }
                 let chunk_groups = if let Some((parent, chunking_type)) = parent_info {
                     match chunking_type {
-                        ChunkingType::Parallel | ChunkingType::ParallelInheritAsync => {
+                        ChunkingType::Parallel { .. } => {
                             ChunkGroupInheritance::Inherit(parent.module)
                         }
                         ChunkingType::Async => ChunkGroupInheritance::ChunkGroup(Either::Left(

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1317,7 +1317,10 @@ struct SingleModuleGraphBuilderEdge {
 
 /// The chunking type that occurs most often, is handled more efficiently by not creating
 /// intermediate SingleModuleGraphBuilderNode::ChunkableReference nodes.
-const COMMON_CHUNKING_TYPE: ChunkingType = ChunkingType::ParallelInheritAsync;
+const COMMON_CHUNKING_TYPE: ChunkingType = ChunkingType::Parallel {
+    inherit_async: true,
+    hoisted: true,
+};
 
 struct SingleModuleGraphBuilder<'a> {
     visited_modules: &'a FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
@@ -1425,7 +1428,10 @@ impl Visit<SingleModuleGraphBuilderNode> for SingleModuleGraphBuilder<'_> {
                 target_ident,
                 ..
             } => match chunking_type {
-                ChunkingType::Parallel => Span::current(),
+                ChunkingType::Parallel {
+                    inherit_async: false,
+                    ..
+                } => Span::current(),
                 _ => {
                     tracing::info_span!(
                         "chunkable reference",

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -297,7 +297,13 @@ impl PreBatches {
                 std::iter::once(ResolvedVc::upcast(entry)),
                 &mut state,
                 |parent_info, node, state| {
-                    let ty = parent_info.map_or(&ChunkingType::Parallel, |(_, ty)| ty);
+                    let ty = parent_info.map_or(
+                        &ChunkingType::Parallel {
+                            inherit_async: false,
+                            hoisted: false,
+                        },
+                        |(_, ty)| ty,
+                    );
                     let module = node.module;
                     if !ty.is_parallel() {
                         state.items.push(PreBatchItem::NonParallelEdge(
@@ -688,7 +694,13 @@ pub async fn compute_module_batches(
                         PreBatchItem::ParallelModule(module)
                     } else {
                         pre_batches.single_module_entries.insert(module);
-                        PreBatchItem::NonParallelEdge(ChunkingType::Parallel, module)
+                        PreBatchItem::NonParallelEdge(
+                            ChunkingType::Parallel {
+                                inherit_async: false,
+                                hoisted: false,
+                            },
+                            module,
+                        )
                     }
                 } else {
                     item
@@ -846,7 +858,10 @@ pub async fn compute_module_batches(
                             index,
                             batch_indicies[idx],
                             ModuleBatchesGraphEdge {
-                                ty: ChunkingType::Parallel,
+                                ty: ChunkingType::Parallel {
+                                    inherit_async: false,
+                                    hoisted: false,
+                                },
                                 module: None,
                             },
                         );

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -14,7 +14,7 @@ use crate::{
     chunk::{
         chunk_item_batch::attach_async_info_to_chunkable_module, ChunkItem,
         ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
-        ChunkableModule, ChunkingContext, ChunkingType,
+        ChunkableModule, ChunkingContext,
     },
     module::{Module, StyleType},
     module_graph::{
@@ -99,10 +99,7 @@ pub async fn compute_style_groups(
             &mut (),
             |parent_info, module, _| {
                 if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
-                    if !matches!(
-                        ty,
-                        ChunkingType::Parallel | ChunkingType::ParallelInheritAsync
-                    ) {
+                    if ty.is_parallel() {
                         return Ok(GraphTraversalAction::Exclude);
                     }
                 }
@@ -114,10 +111,7 @@ pub async fn compute_style_groups(
             },
             |parent_info, item, _| {
                 if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
-                    if !matches!(
-                        ty,
-                        ChunkingType::Parallel | ChunkingType::ParallelInheritAsync
-                    ) {
+                    if ty.is_parallel() {
                         return;
                     }
                 }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -99,7 +99,7 @@ pub async fn compute_style_groups(
             &mut (),
             |parent_info, module, _| {
                 if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
-                    if ty.is_parallel() {
+                    if !ty.is_parallel() {
                         return Ok(GraphTraversalAction::Exclude);
                     }
                 }
@@ -111,7 +111,7 @@ pub async fn compute_style_groups(
             },
             |parent_info, item, _| {
                 if let Some((_, ModuleBatchesGraphEdge { ty, .. })) = parent_info {
-                    if ty.is_parallel() {
+                    if !ty.is_parallel() {
                         return;
                     }
                 }

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -102,7 +102,10 @@ impl SingleChunkableModuleReference {
 impl ChunkableModuleReference for SingleChunkableModuleReference {
     #[turbo_tasks::function]
     fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::ParallelInheritAsync))
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: true,
+            hoisted: false,
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -87,7 +87,13 @@ async fn get_inherit_async_referenced_asset(
     let Some(ty) = &*r.chunking_type().await? else {
         return Ok(None);
     };
-    if !matches!(ty, ChunkingType::ParallelInheritAsync) {
+    if !matches!(
+        ty,
+        ChunkingType::Parallel {
+            inherit_async: true,
+            ..
+        }
+    ) {
         return Ok(None);
     };
     let referenced_asset: turbo_tasks::ReadRef<ReferencedAsset> =

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -273,12 +273,18 @@ impl ChunkableModuleReference for EsmAssetReference {
         Ok(Vc::cell(
             if let Some(chunking_type) = self.annotations.chunking_type() {
                 match chunking_type {
-                    "parallel" => Some(ChunkingType::ParallelInheritAsync),
+                    "parallel" => Some(ChunkingType::Parallel {
+                        inherit_async: true,
+                        hoisted: true,
+                    }),
                     "none" => None,
                     _ => return Err(anyhow!("unknown chunking_type: {}", chunking_type)),
                 }
             } else {
-                Some(ChunkingType::ParallelInheritAsync)
+                Some(ChunkingType::Parallel {
+                    inherit_async: true,
+                    hoisted: true,
+                })
             },
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -127,7 +127,10 @@ impl ValueToString for UrlAssetReference {
 impl ChunkableModuleReference for UrlAssetReference {
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::Parallel))
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -102,7 +102,10 @@ impl ModuleReference for EcmascriptModulePartReference {
 impl ChunkableModuleReference for EcmascriptModulePartReference {
     #[turbo_tasks::function]
     fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::ParallelInheritAsync))
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: true,
+            hoisted: true,
+        }))
     }
 }
 


### PR DESCRIPTION
Add a `hoisted: bool` to `ChunkingType::Parallel` in preparation for scope hoisting (we can only merge modules if they are importing each other with ESM-import-style references (i.e. `hoisted: true`).

Part of PACK-2960

Closes PACK-4548