### PR TITLE
Scope `runInCleanSnapshot` to Work Store

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,7 +59,6 @@
     // singleton modules should always use "*.external" instead of "*-instance"
     "packages/next/src/server/app-render/action-async-storage-instance.ts",
     "packages/next/src/server/app-render/after-task-async-storage-instance.ts",
-    "packages/next/src/server/app-render/clean-async-snapshot-instance.ts",
     "packages/next/src/server/app-render/work-async-storage-instance.ts",
     "packages/next/src/server/app-render/work-unit-async-storage-instance.ts",
     "packages/next/src/client/components/segment-cache-impl/*"

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -178,7 +178,6 @@ import { CacheSignal } from './cache-signal'
 import { getTracedMetadata } from '../lib/trace/utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
-import './clean-async-snapshot.external'
 import { INFINITE_CACHE } from '../../lib/constants'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
 import { parseLoaderTree } from './parse-loader-tree'

--- a/packages/next/src/server/app-render/clean-async-snapshot-instance.ts
+++ b/packages/next/src/server/app-render/clean-async-snapshot-instance.ts
@@ -1,6 +1,0 @@
-import { createSnapshot } from '../app-render/async-local-storage'
-
-export const runInCleanSnapshot: <R, TArgs extends any[]>(
-  fn: (...args: TArgs) => R,
-  ...args: TArgs
-) => R = createSnapshot()

--- a/packages/next/src/server/app-render/clean-async-snapshot.external.ts
+++ b/packages/next/src/server/app-render/clean-async-snapshot.external.ts
@@ -1,4 +1,0 @@
-// Share the instance module in the next-shared layer
-import { runInCleanSnapshot } from './clean-async-snapshot-instance' with { 'turbopack-transition': 'next-shared' }
-
-export { runInCleanSnapshot }

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -98,6 +98,18 @@ export interface WorkStore {
 
   dynamicIOEnabled: boolean
   dev: boolean
+
+  /**
+   * Run the given function inside a clean AsyncLocalStorage snapshot. This is
+   * useful when generating cache entries, to ensure that the cache generation
+   * cannot read anything from the context we're currently executing in, which
+   * might include request-specific things like `cookies()` inside a
+   * `React.cache()`.
+   */
+  runInCleanSnapshot: <R, TArgs extends any[]>(
+    fn: (...args: TArgs) => R,
+    ...args: TArgs
+  ) => R
 }
 
 export type WorkAsyncStorage = AsyncLocalStorage<WorkStore>

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -12,6 +12,7 @@ import { AfterContext } from '../after/after-context'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { createLazyResult, type LazyResult } from '../lib/lazy-result'
 import { getCacheHandlerEntries } from '../use-cache/handlers'
+import { createSnapshot } from '../app-render/async-local-storage'
 
 export type WorkStoreContext = {
   /**
@@ -138,6 +139,7 @@ export function createWorkStore({
     dev: renderOpts.dev ?? false,
     previouslyRevalidatedTags,
     refreshTagsByCacheKind: createRefreshTagsByCacheKind(),
+    runInCleanSnapshot: createSnapshot(),
   }
 
   // TODO: remove this when we resolve accessing the store outside the execution context

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -27,7 +27,6 @@ import {
   workUnitAsyncStorage,
   getDraftModeProviderForCacheScope,
 } from '../app-render/work-unit-async-storage.external'
-import { runInCleanSnapshot } from '../app-render/clean-async-snapshot.external'
 
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 
@@ -83,7 +82,7 @@ function generateCacheEntry(
   // might include request specific things like cookies() inside a React.cache().
   // Note: It is important that we await at least once before this because it lets us
   // pop out of any stack specific contexts as well - aka "Sync" Local Storage.
-  return runInCleanSnapshot(
+  return workStore.runInCleanSnapshot(
     generateCacheEntryWithRestoredWorkStore,
     workStore,
     outerWorkUnitStore,

--- a/test/production/custom-server/als.js
+++ b/test/production/custom-server/als.js
@@ -1,0 +1,3 @@
+const { AsyncLocalStorage } = require('async_hooks')
+
+exports.requestIdStorage = new AsyncLocalStorage()

--- a/test/production/custom-server/app/use-cache/page.js
+++ b/test/production/custom-server/app/use-cache/page.js
@@ -1,0 +1,19 @@
+import { connection } from 'next/server'
+
+async function Inner({ id }) {
+  'use cache'
+
+  return <p>inner cache</p>
+}
+
+async function Outer({ id }) {
+  'use cache'
+
+  return <Inner id="inner" />
+}
+
+export default async function Page() {
+  await connection()
+
+  return <Outer id="outer" />
+}

--- a/test/production/custom-server/cache-handler.js
+++ b/test/production/custom-server/cache-handler.js
@@ -1,0 +1,35 @@
+// @ts-check
+
+const { requestIdStorage } = require('./als')
+
+const defaultCacheHandler =
+  require('next/dist/server/lib/cache-handlers/default').default
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandlerV2}
+ */
+const cacheHandler = {
+  async get(cacheKey) {
+    return defaultCacheHandler.get(cacheKey)
+  },
+
+  async set(cacheKey, pendingEntry) {
+    const requestId = requestIdStorage.getStore()
+    console.log('set cache', cacheKey, 'requestId:', requestId)
+    return defaultCacheHandler.set(cacheKey, pendingEntry)
+  },
+
+  async refreshTags() {
+    return defaultCacheHandler.refreshTags()
+  },
+
+  async getExpiration(...tags) {
+    return defaultCacheHandler.getExpiration(...tags)
+  },
+
+  async expireTags(...tags) {
+    return defaultCacheHandler.expireTags(...tags)
+  },
+}
+
+module.exports = cacheHandler

--- a/test/production/custom-server/custom-server.test.ts
+++ b/test/production/custom-server/custom-server.test.ts
@@ -36,6 +36,17 @@ describe('custom server', () => {
         expect($('body').text()).toMatch(/pages: 19\.\d+\.\d+/)
       }
     })
+
+    describe('when using "use cache" with a custom cache handler', () => {
+      it("should not unset the custom server's ALS context", async () => {
+        const cliOutputLength = next.cliOutput.length
+        const $ = await next.render$('/use-cache')
+        expect($('p').text()).toBe('inner cache')
+        const cliOutput = next.cliOutput.slice(cliOutputLength)
+        expect(cliOutput).toMatch(createCacheSetLogRegExp('outer'))
+        expect(cliOutput).toMatch(createCacheSetLogRegExp('inner'))
+      })
+    })
   })
 })
 
@@ -55,3 +66,11 @@ describe('custom server with quiet setting', () => {
     expect(next.cliOutput).not.toInclude('Server side error')
   })
 })
+
+function createCacheSetLogRegExp(id: string) {
+  // Expect a requestId, that's provided through ALS, to be present in the log
+  // message for the cache handler set call.
+  return new RegExp(
+    `set cache \\["[A-Za-z0-9_-]{21}","(?:[0-9a-f]{2})+",\\[{"id":"${id}"},"\\$undefined"\\]\\] requestId: \\d+`
+  )
+}

--- a/test/production/custom-server/next.config.js
+++ b/test/production/custom-server/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    useCache: true,
+    cacheHandlers: {
+      default: require.resolve('./cache-handler.js'),
+    },
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
This ensures that we capture a fresh `AsyncLocalStorage` snapshot per request, so that any ALS that the deployment runtime might use is not re-used across multiple requests.