### PR TITLE
[Fix] Inverse prefetch segment for Pages routes

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3566,8 +3566,7 @@ export default async function build(
               // We don't need to add the prefetch segment data routes if it was
               // added due to a page that was already generated. This would have
               // happened if the page was static or partially static.
-              const originalAppPath = pageInfos.get(route.page)?.originalAppPath
-              if (originalAppPath && route.prefetchSegmentDataRoutes) {
+              if (route.prefetchSegmentDataRoutes) {
                 continue
               }
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3557,31 +3557,20 @@ export default async function build(
               ...routesManifest.staticRoutes,
               ...routesManifest.dynamicRoutes,
             ]) {
-              // We only want to handle pages that are using the app router. We
-              // need this path in order to determine if it's an app route or an
-              // app page.
-              const originalAppPath = pageInfos.get(route.page)?.originalAppPath
-              if (!originalAppPath) {
-                continue
-              }
-
-              // We only want to handle app pages, not app routes.
-              if (isAppRouteRoute(originalAppPath)) {
-                continue
-              }
+              // If the segment paths aren't defined, we need to insert a
+              // reverse routing rule so that there isn't any conflicts
+              // with other dynamic routes for the prefetch segment
+              // routes. This is true for any route that is not PPR-enabled,
+              // including all routes defined by Pages Router.
 
               // We don't need to add the prefetch segment data routes if it was
               // added due to a page that was already generated. This would have
               // happened if the page was static or partially static.
-              if (route.prefetchSegmentDataRoutes) {
+              const originalAppPath = pageInfos.get(route.page)?.originalAppPath
+              if (originalAppPath && route.prefetchSegmentDataRoutes) {
                 continue
               }
 
-              // If the segment paths aren't defined, we need to insert a
-              // reverse routing rule so that there isn't any conflicts
-              // with other dynamic routes for the prefetch segment
-              // routes. This is only an issue for pages that do not have
-              // partial prerendering enabled.
               route.prefetchSegmentDataRoutes = [
                 buildInversePrefetchSegmentDataRoute(
                   route.page,

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/new/[teamSlug]/layout.jsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/new/[teamSlug]/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/app/new/[teamSlug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/app/new/[teamSlug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return '/new/[teamSlug]/page.tsx'
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/pages/_app.js
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/pages/_app.js
@@ -1,0 +1,3 @@
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/pages/_document.js
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/pages/_document.js
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/pages/new/templates/[[...slug]].js
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/pages/new/templates/[[...slug]].js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return '/new/templates/[[...slug]].js'
+}


### PR DESCRIPTION
Another follow-up to https://github.com/vercel/next.js/pull/78387 and https://github.com/vercel/next.js/pull/78568. Refer to those PRs for full details.

Fixes a routing conflict related to per-segment prefetches in sites that use both App Router and Pages Router.

The fix is to expand the behavior added in the previous PRs — we output an "inverse" tree prefetch route for every route in the route manifest that is not PPR-enabled, including ones defined by Pages Router.