### PR TITLE
fix(CI): Remove e2e test timeout overrides from rspack & turbopack suites

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -238,7 +238,6 @@ jobs:
         export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json"
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_DEV=1
-        export NEXT_E2E_TEST_TIMEOUT=240000
         export NEXT_TEST_MODE=dev
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
 

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -92,7 +92,6 @@ jobs:
         # e2e and ${{ inputs.test_type }} tests with `node run-tests.js`
 
         export NEXT_TEST_CONTINUE_ON_ERROR=TRUE
-        export NEXT_E2E_TEST_TIMEOUT=240000
         export NEXT_TEST_MODE=${{
           inputs.test_type == 'development' && 'dev' || 'start'
         }}
@@ -125,7 +124,6 @@ jobs:
         # legacy integration tests with `node run-tests.js`
 
         export NEXT_TEST_CONTINUE_ON_ERROR=TRUE
-        export NEXT_E2E_TEST_TIMEOUT=240000
 
         # HACK: Despite the name, these environment variables are just used to
         # gate tests, so they're applicable to both turbopack and rspack tests


### PR DESCRIPTION
**The default timeout is 1 minute.** This PR reduces the timeouts for these tests from 4 minutes to 1 minute.

Maybe these overrides made sense at some point, but turbopack shouldn't ever be significantly slower than webpack in any test (if it is, that's a bug), so we shouldn't need larger timeouts for these.

This long 4 minute timeout has contributed to github action job timeouts we've previously experienced for the arewerspack/areweturboyet nightly jobs, so IMO it's hurting more than it's helping.

areweturboyet development tests: https://github.com/vercel/next.js/actions/runs/14893493964
areweturboyet production tests: https://github.com/vercel/next.js/actions/runs/14893499248

Closes PACK-4547