### PR TITLE
Treat _debugInfo as a wellknown property for sync request data access purposes

### DIFF
--- a/packages/next/src/shared/lib/utils/reflect-utils.ts
+++ b/packages/next/src/shared/lib/utils/reflect-utils.ts
@@ -40,6 +40,7 @@ export const wellKnownProperties = new Set([
 
   // React introspection
   'displayName',
+  '_debugInfo',
 
   // Common tested properties
   // fallthrough


### PR DESCRIPTION
When we converted our request access APIs to async we supported sync access to make the adoption easier. We do have a list of certain builtin properties that exist on promises or are tested for in the course of runtime operations that we say are not synchronously accessible however and you must await the request data promise to access those if necessary.

Recently it was discoverd that React will check the `_debugInfo` property of thenables and other async data types in dev. This was being reported as a warning when passing searchParams from RSC to client world. By adding `_debugInfo` to the wellKnownProperties set we can avoid this warning by also making it so you must await the promise to access a true request value such as `?_debugInfo=...` in a search string.

This change adds this property name to the well known set
