### PR TITLE
perf(turbopack/rcstr): Precompute hash for equality bailout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9561,6 +9561,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "napi",
  "new_debug_unreachable",
+ "rustc-hash 2.1.1",
  "serde",
  "shrink-to-fit",
  "triomphe 0.1.12",

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 new_debug_unreachable = "1.0.6"
 shrink-to-fit = { workspace = true }
 napi = { workspace = true, optional = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -265,7 +265,7 @@ impl PartialEq for RcStr {
                 let r = unsafe { deref_from(other.unsafe_data) };
                 l.hash == r.hash && l.value == r.value
             }
-            (INLINE_TAG, INLINE_TAG) => self.as_str() == other.as_str(),
+            (INLINE_TAG, INLINE_TAG) => self.unsafe_data == other.unsafe_data,
             _ => false,
         }
     }


### PR DESCRIPTION
### What?

Precompute hash for `RcStr` and use it for equality bailout.

### Why?


We have lots of `RcStr` in key positions of the hashmap, so adding a fast bailout path to `==` improved the performance.

x-ref: https://vercel.slack.com/archives/C06PPGZ0FD3/p1746715835436899?thread_ts=1746658944.635819&cid=C06PPGZ0FD3

### How?



Closes PACK-4755