### PR TITLE
fix(CI): Avoid rebuilding native code in jobs that don't depend on native code

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -388,7 +388,7 @@ jobs:
 
   test-unit:
     name: test unit
-    needs: ['changes', 'build-next']
+    needs: ['changes', 'build-next', 'build-native']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
@@ -398,8 +398,6 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      skipNativeBuild: 'yes'
-      skipNativeInstall: 'yes'
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-${{ matrix.node }}'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -130,7 +130,6 @@ jobs:
     with:
       needsRust: 'yes'
       needsNextest: 'yes'
-      skipInstallBuild: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: pnpm dlx turbo@${TURBO_VERSION} run test-cargo-unit
       mold: 'yes'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,6 +86,8 @@ jobs:
     needs: ['build-next']
     uses: ./.github/workflows/build_reusable.yml
     with:
+      skipNativeBuild: 'yes'
+      skipNativeInstall: 'yes'
       afterBuild: |
         pnpm lint-no-typescript
         pnpm check-examples
@@ -128,6 +130,7 @@ jobs:
     with:
       needsRust: 'yes'
       needsNextest: 'yes'
+      skipInstallBuild: 'yes'
       skipNativeBuild: 'yes'
       afterBuild: pnpm dlx turbo@${TURBO_VERSION} run test-cargo-unit
       mold: 'yes'
@@ -213,6 +216,7 @@ jobs:
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
     uses: ./.github/workflows/build_reusable.yml
     with:
+      skipNativeBuild: 'yes'
       stepName: 'test-devlow'
       afterBuild: |
         pnpm run --filter=devlow-bench test
@@ -343,6 +347,8 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
+      skipNativeBuild: 'yes'
+      skipNativeInstall: 'yes'
       afterBuild: |
         rustup target add wasm32-unknown-unknown
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -372,6 +378,8 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
+      skipNativeBuild: 'yes'
+      skipNativeInstall: 'yes'
       afterBuild: |
         rustup target add wasm32-wasip1-threads
         pnpm dlx turbo@${TURBO_VERSION} run build-native-wasi
@@ -380,7 +388,7 @@ jobs:
 
   test-unit:
     name: test unit
-    needs: ['changes']
+    needs: ['changes', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
@@ -390,6 +398,8 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
+      skipNativeBuild: 'yes'
+      skipNativeInstall: 'yes'
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-${{ matrix.node }}'


### PR DESCRIPTION
The following jobs do not depend on `build-native`, but don't specify `skipNativeBuild`:

- `lint`
- `test-devlow`
- `test-next-swc-wasm`
- `test-next-swc-napi-wasi` *(currently disabled)*
- `test-unit` *(does actually appear to depend on native binaries)*

That means that they still build the native binary, but they don't wait for `build-native` to finish first, so they don't use the cached version (they run before the cache is populated), and instead each spend 5 minutes of CPU time rebuilding the native binary.

Closes PACK-4549