### PR TITLE
chore(test/e2e): Remove stale TODO comment from webpack persistent caching test

### DIFF
--- a/test/e2e/persistent-caching/persistent-caching.test.ts
+++ b/test/e2e/persistent-caching/persistent-caching.test.ts
@@ -55,19 +55,16 @@ describe('persistent-caching', () => {
 
     {
       const browser = await next.browser('/')
-      // TODO Persistent Caching for webpack dev server is broken
       expect(await browser.elementByCss('main').text()).toBe(appTimestamp)
       await browser.close()
     }
     {
       const browser = await next.browser('/client')
-      // TODO Persistent Caching for webpack dev server is broken
       expect(await browser.elementByCss('main').text()).toBe(appClientTimestamp)
       await browser.close()
     }
     {
       const browser = await next.browser('/pages')
-      // TODO Persistent Caching for webpack dev server is broken
       expect(await browser.elementByCss('main').text()).toBe(pagesTimestamp)
       await browser.close()
     }


### PR DESCRIPTION
It looks like this is a stale comment from https://github.com/vercel/next.js/pull/78944 where this was fixed.

Closes PACK-4551