### PR TITLE
docs: getting started - Metadata and OG images / file extension

### DIFF
--- a/docs/01-app/01-getting-started/10-metadata-and-og-images.mdx
+++ b/docs/01-app/01-getting-started/10-metadata-and-og-images.mdx
@@ -235,9 +235,9 @@ The more specific image will take precedence over any OG images above it in the 
 
 The [`ImageResponse` constructor](/docs/app/api-reference/functions/image-response) allows you to generate dynamic images using JSX and CSS. This is useful for OG images that depend on data.
 
-For example, to generate a unique OG image for each blog post, add a `opengraph-image.ts` file inside the `blog` folder, and import the `ImageResponse` constructor from `next/og`:
+For example, to generate a unique OG image for each blog post, add a `opengraph-image.tsx` file inside the `blog` folder, and import the `ImageResponse` constructor from `next/og`:
 
-```tsx filename="app/blog/[slug]/opengraph-image.ts" switcher
+```tsx filename="app/blog/[slug]/opengraph-image.tsx" switcher
 import { ImageResponse } from 'next/og'
 import { getPost } from '@/app/lib/data'
 


### PR DESCRIPTION
Hi, Team.

The example code uses JSX but the file is named with a `.ts` extension, causing IDEs to throw errors, and compile fail.
This PR updates the file extension to .tsx to prevent confusion.