### PR TITLE
perf(turbopack): Remove needless clone of sourcemap

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -114,11 +114,16 @@ pub fn generate_js_source_map(
         None
     };
 
-    let mut map = files_map.build_source_map_with_config(
-        &mappings,
-        input_map.as_ref(),
-        InlineSourcesContentConfig {},
-    );
+    let map =
+        files_map.build_source_map_with_config(&mappings, None, InlineSourcesContentConfig {});
+
+    let mut map = match input_map {
+        Some(mut input_map) => {
+            input_map.adjust_mappings(&map);
+            input_map
+        }
+        None => map,
+    };
     add_default_ignore_list(&mut map);
 
     let mut result = vec![];


### PR DESCRIPTION
### What?

Use `sourcemap::SourceMap::adjust_mapping` directly instead of relying on `swc_common`.

### Why?

https://github.com/swc-project/swc/blob/6750459d9180048a39c11e14b02c9bfed251a12e/crates/swc_common/src/source_map.rs#L1385-L1388


```rust
    if let Some(mut orig) = orig.cloned() {
        orig.adjust_mappings(&map);
        return orig;
    }
```

If we pass `orig,` the original source map is cloned. I'll fix this API issue from the SWC side in the future. 

x-ref, numbers: https://vercel.slack.com/archives/C03EWR7LGEN/p1746729015204369?thread_ts=1746727709.014039&cid=C03EWR7LGEN

### How?


Closes PACK-4555