### PR TITLE
Optimize glob matching in turbo-tasks-fs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,9 +2673,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3014,7 +3014,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -9569,6 +9569,7 @@ dependencies = [
  "fast-glob",
  "futures",
  "futures-retry",
+ "globset",
  "include_dir",
  "indexmap 2.7.1",
  "jsonc-parser 0.21.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii"
@@ -604,7 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f6ca6f0c18c02c2fbfc119df551b8aeb8a385f6d5980f1475ba0255f1e97f1e"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "itertools 0.10.5",
  "log",
  "nom",
@@ -618,7 +618,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
 ]
 
 [[package]]
@@ -835,7 +835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -2320,6 +2320,15 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fast-glob"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ea3f6bbcf4dbe2076b372186fc7aeecd5f6f84754582e56ee7db262b15a6f0"
+dependencies = [
+ "arrayvec 0.7.6",
+]
 
 [[package]]
 name = "fastrand"
@@ -4825,7 +4834,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "itoa",
 ]
 
@@ -5841,7 +5850,7 @@ checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
 dependencies = [
  "arbitrary",
  "arg_enum_proc_macro",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "av1-grain",
  "bitstream-io",
  "built",
@@ -7009,7 +7018,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f352d5d14be5a1f956d76ae0c8060c3487aaa2a080f10a4b4ff023c7c05a9047"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "static-map-macro",
 ]
 
@@ -7658,7 +7667,7 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2a2cf0263f34234cfcebde0545e4ed017e1b2b5667792c6902319d75df03110"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "indexmap 2.7.1",
  "is-macro",
  "rustc-hash 2.1.1",
@@ -7945,7 +7954,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250786944fbc05f6484eda9213df129ccfe17226ae9ad51b62fce2f72135dbee"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitflags 2.9.0",
  "either",
  "new_debug_unreachable",
@@ -8087,7 +8096,7 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "012cd84fcc6c6fab718a177a3ffc360332d6bad29dbe19699be2ccbaba91e712"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "indexmap 2.7.1",
  "is-macro",
  "num-bigint",
@@ -9557,6 +9566,7 @@ dependencies = [
  "criterion",
  "dashmap 6.1.0",
  "dunce",
+ "fast-glob",
  "futures",
  "futures-retry",
  "include_dir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7847,7 +7847,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d11c8e71901401b9aae2ece4946eeb7674b14b8301a53768afbbeeb0e48b599"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitflags 2.9.0",
  "either",
  "new_debug_unreachable",
@@ -7916,7 +7916,7 @@ version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca0ad5b72d8b440e701d47f544a728543414f6f165c6c61a899a76d3c7fdf9d"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitflags 2.9.0",
  "indexmap 2.7.1",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,12 @@ opt-level = 3
 [profile.release.package.serde]
 opt-level = 3
 
+
+[profile.profiling]
+inherits = "release"
+debug = true
+
+
 [workspace.dependencies]
 # Workspace crates
 next-api = { path = "crates/next-api" }

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -64,6 +64,7 @@ tempfile = { workspace = true }
 turbo-tasks-memory = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbo-tasks-backend = { workspace = true }
+fast-glob = "0.4.5"
 
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -65,6 +65,7 @@ turbo-tasks-memory = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 fast-glob = "0.4.5"
+globset = "0.4.16"
 
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/benches/mod.rs
@@ -102,13 +102,13 @@ fn bench_rope_iteration(c: &mut Criterion) {
 }
 
 fn bench_glob_match_simple(c: &mut Criterion) {
-    const GLOB: &str = "some/**/n*de?txt";
+    const GLOB: &str = "some/**/n*d[k-m]e?txt";
     const PATH: &str = "some/a/bigger/path/to/the/crazy/needle.txt";
     glob_bench(c, "simple", GLOB, PATH);
 }
 
 fn bench_glob_match_alternations(c: &mut Criterion) {
-    const GLOB: &str = "some/**/{tob,crazy}/*.{png,txt}";
+    const GLOB: &str = "some/**/{tob,crazy}/?*.{png,txt}";
     const PATH: &str = "some/a/bigger/path/to/the/crazy/needle.txt";
 
     glob_bench(c, "alternations", GLOB, PATH);

--- a/turbopack/crates/turbo-tasks-fs/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/benches/mod.rs
@@ -128,6 +128,15 @@ fn glob_bench(c: &mut Criterion, name: &'static str, glob: &str, path: &str) {
     let g = turbo_tasks_fs::glob::Glob::parse(glob).unwrap();
     group.bench_function("turbo-glob-cached", |b| b.iter(|| g.execute(path)));
 
+    group.bench_function("globset", |b| {
+        b.iter(|| {
+            let g = globset::Glob::new(glob).unwrap().compile_matcher();
+            g.is_match(path)
+        })
+    });
+    let g = globset::Glob::new(glob).unwrap().compile_matcher();
+    group.bench_function("globset-cached", |b| b.iter(|| g.is_match(path)));
+
     group.finish();
 }
 

--- a/turbopack/crates/turbo-tasks-fs/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/benches/mod.rs
@@ -128,14 +128,6 @@ fn glob_bench(c: &mut Criterion, name: &'static str, glob: &str, path: &str) {
     let g = turbo_tasks_fs::glob::Glob::parse(glob).unwrap();
     group.bench_function("turbo-glob-cached", |b| b.iter(|| g.execute(path)));
 
-    group.bench_function("turbo-glob-2", |b| {
-        b.iter(|| {
-            let g = turbo_tasks_fs::glob::GlobProgram::compile(glob).unwrap();
-            g.matches(path, false)
-        })
-    });
-    let g = turbo_tasks_fs::glob::GlobProgram::compile(glob).unwrap();
-    group.bench_function("turbo-glob-2-cached", |b| b.iter(|| g.matches(path, false)));
     group.finish();
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -231,6 +231,8 @@ impl GlobPart {
                 let mut is_escaped = false;
                 let mut literal = String::new();
 
+                // TODO(lukes): there shouldn't be a need to traverse graphemes here, just literal
+                // matches since all of our delimiters are ascii characters
                 let mut cursor = GraphemeCursor::new(0, input.len(), true);
 
                 let mut start = cursor.cur_cursor();

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -1,10 +1,9 @@
-use std::{fmt::Display, mem::take};
+use std::fmt::Display;
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, TryJoinIterExt, Vc};
-use unicode_segmentation::GraphemeCursor;
 
 #[derive(PartialEq, Eq, Debug, Clone, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
 enum GlobPart {
@@ -45,118 +44,36 @@ enum GlobPart {
 #[turbo_tasks::value]
 #[derive(Debug, Clone)]
 pub struct Glob {
-    expression: Vec<GlobPart>,
+    #[turbo_tasks(trace_ignore)]
+    program: GlobProgram,
 }
 
 impl Glob {
     pub fn execute(&self, path: &str) -> bool {
         // TODO(lukesandberg): deprecate this implicit behavior
         let match_partial = path.ends_with('/');
-        self.iter_matches(path, true, match_partial)
-            .any(|result| matches!(result, ("", _)))
+        let path = if match_partial {
+            &path[0..path.len() - 1]
+        } else {
+            path
+        };
+        self.program.matches(path, match_partial)
     }
 
     // Returns true if the glob could match a filename underneath this `path` where the path
     // represents a directory.
     pub fn match_in_directory(&self, path: &str) -> bool {
-        debug_assert!(!path.ends_with('/'));
-        // TODO(lukesandberg): see if we can avoid this allocation by changing the matching
-        // algorithm
-        let path = format!("{path}/");
-        self.iter_matches(&path, true, true)
-            .any(|result| matches!(result, ("", _)))
+        self.program.matches(path, true)
     }
 
-    fn iter_matches<'a>(
-        &'a self,
-        path: &'a str,
-        previous_part_is_path_separator_equivalent: bool,
-        match_in_directory: bool,
-    ) -> GlobMatchesIterator<'a> {
-        GlobMatchesIterator {
-            current: path,
-            glob: self,
-            match_in_directory,
-            is_path_separator_equivalent: previous_part_is_path_separator_equivalent,
-            stack: Vec::new(),
-            index: 0,
-        }
-    }
-
-    pub fn parse(input: &str) -> Result<Glob> {
-        let mut current = input;
-        let mut expression = Vec::new();
-
-        while !current.is_empty() {
-            let (part, remainder) = GlobPart::parse(current, false)
-                .with_context(|| anyhow!("Failed to parse glob {input}"))?;
-            expression.push(part);
-            current = remainder;
-        }
-
-        Ok(Glob { expression })
+    pub fn parse(input: &str) -> Result<Self> {
+        Ok(Self {
+            program: GlobProgram::compile(input)?,
+        })
     }
 }
 
-struct GlobMatchesIterator<'a> {
-    current: &'a str,
-    glob: &'a Glob,
-    // In this mode we are checking if the glob might match something in the directory represented
-    // by this path.
-    match_in_directory: bool,
-    is_path_separator_equivalent: bool,
-    stack: Vec<GlobPartMatchesIterator<'a>>,
-    index: usize,
-}
-
-impl<'a> Iterator for GlobMatchesIterator<'a> {
-    type Item = (&'a str, bool);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(part) = self.glob.expression.get(self.index) {
-                let iter = if let Some(iter) = self.stack.get_mut(self.index) {
-                    iter
-                } else {
-                    let iter = part.iter_matches(
-                        self.current,
-                        self.is_path_separator_equivalent,
-                        self.match_in_directory,
-                    );
-                    self.stack.push(iter);
-                    self.stack.last_mut().unwrap()
-                };
-                if let Some((new_path, new_is_path_separator_equivalent)) = iter.next() {
-                    self.current = new_path;
-                    self.is_path_separator_equivalent = new_is_path_separator_equivalent;
-
-                    self.index += 1;
-
-                    if self.match_in_directory && self.current.is_empty() {
-                        return Some(("", self.is_path_separator_equivalent));
-                    }
-                } else {
-                    if self.index == 0 {
-                        // failed to match
-                        return None;
-                    }
-                    // backtrack
-                    self.stack.pop();
-                    self.index -= 1;
-                }
-            } else {
-                // end of expression, matched successfully
-
-                // backtrack for the next iteration
-                self.index -= 1;
-
-                return Some((self.current, self.is_path_separator_equivalent));
-            }
-        }
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Hash)]
 struct ByteRange {
     low: u8,
     high: u8,
@@ -186,7 +103,7 @@ impl Ord for ByteRange {
     }
 }
 
-#[derive(Debug, Eq, Clone, PartialEq)]
+#[derive(Debug, Eq, Clone, PartialEq, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
 struct RangeSet {
     ranges: Vec<ByteRange>,
@@ -280,10 +197,39 @@ impl<'a> SparseSet<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct BitSet {
+    bits: Box<[u64]>, // use a boxed slice instead of a vec since this is not extendable
+}
+impl BitSet {
+    const BITS: usize = { u64::BITS as usize };
+    fn new(len: usize) -> Self {
+        let words = len.div_ceil(Self::BITS);
+        Self {
+            bits: vec![0u64; words].into_boxed_slice(),
+        }
+    }
+    fn set(&mut self, bit: usize) {
+        let word_index = bit / Self::BITS;
+        let bit_index = bit % Self::BITS;
+
+        self.bits[word_index] |= 1 << bit_index;
+    }
+    fn has(&self, bit: usize) -> bool {
+        let word_index = bit / Self::BITS;
+        let bit_index = bit % Self::BITS;
+        self.bits[word_index] & 1 << bit_index != 0
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct GlobProgram {
-    instructions: Vec<GlobInstruction>,
-    range_sets: Vec<RangeSet>,
+    instructions: Box<[GlobInstruction]>,
+    // Instructions we can end on that are a valid match
+    match_instructions: BitSet,
+    // Instructions we can end on that are a valid prefix match
+    prefix_match_instructions: BitSet,
+    range_sets: Box<[RangeSet]>,
 }
 
 impl GlobProgram {
@@ -305,39 +251,23 @@ impl GlobProgram {
             let t = tok.next_token();
             match t {
                 GlobToken::Literal(lit) => {
-                    // If the previous token is a literal mark it as having a successor.
-                    if let Some(GlobInstruction::MatchLiteral((_, has_next))) =
-                        instructions.last_mut()
-                    {
-                        *has_next = true;
-                    }
-                    instructions.push(GlobInstruction::MatchLiteral((lit, false)));
+                    instructions.push(GlobInstruction::MatchLiteral(lit));
                 }
                 GlobToken::Star => {
+                    instructions.push(GlobInstruction::Fork(3)); // allowed to match nothing
                     instructions.push(GlobInstruction::MatchAnyNonDelim);
                     // After a star match we either loop back to try again, or proceed.
                     instructions.push(GlobInstruction::Fork(-1));
                 }
                 GlobToken::GlobStar => {
-                    if instructions.len() >= 2
-                        && matches!(
-                            instructions.last().unwrap(),
-                            GlobInstruction::MatchGlobStar { .. }
-                        )
-                    {
-                        // This is a redundant globstar
-                        // e.g. /**/**/
-                        // just skip this one.
-                    } else {
-                        // allow globstars to match nothing by skipping it
-                        instructions.push(GlobInstruction::Fork(2));
-                        // We don't actually know if it is terminal or not yet.  We will determing
-                        // this after code generation.
-                        instructions.push(GlobInstruction::MatchGlobStar { terminal: false });
-                    }
+                    // allow globstars to match nothing by skipping it
+                    instructions.push(GlobInstruction::Fork(2));
+                    // We don't actually know if it is terminal or not yet.  We will determine
+                    // this after code generation.
+                    instructions.push(GlobInstruction::MatchGlobStar { terminal: false });
                 }
                 GlobToken::QuestionMark => {
-                    // A question match, optionally matches a non- delimiter character, so we either
+                    // A question match, optionally matches a non-delimiter character, so we either
                     // skip forward or not.
                     instructions.push(GlobInstruction::Fork(2));
                     instructions.push(GlobInstruction::MatchAnyNonDelim);
@@ -354,11 +284,9 @@ impl GlobProgram {
                             GlobToken::Literal(lit) => {
                                 if lit > 127 {
                                     // TODO(lukesandberg): These are supportable by expanding into
-                                    // several RanngeSets for
-                                    // each byte in the multibyte characters
+                                    // several RanngeSets for each byte in the multibyte characters
                                     // However, this is very unlikely to be required by a user so
-                                    // for now the feature is
-                                    // omitted.
+                                    // for now the feature is omitted.
                                     bail!("Unsupported non-ascii character in set");
                                 }
                                 debug_assert!(
@@ -390,7 +318,7 @@ impl GlobProgram {
                                     set.add_singleton(lit);
                                 }
                                 if partial_range.is_some() {
-                                    bail!("unexpectedm hyphen at the end of a character class")
+                                    bail!("unexpectedmhyphen at the end of a character class")
                                 }
                                 set.finalize();
                                 let index = range_sets.len();
@@ -423,33 +351,40 @@ impl GlobProgram {
                 GlobToken::Comma | GlobToken::RBracket => {
                     // We don't need to check this, the tokenizer enforces that these tokens can
                     // only occur inside of an alternation so there must be something on our stack.
-                    let pending = left_bracket_starts.last_mut().unwrap();
-                    // for an alternation we either 'jump' past it to the next one, or we process it
-                    // directly
+                    {
+                        let pending = left_bracket_starts.last_mut().unwrap();
+                        // for an alternation we either 'jump' past it to the next one, or we
+                        // process it directly
 
-                    let mut branch = Vec::new();
-                    std::mem::swap(&mut instructions, &mut branch);
-                    pending.branches.push(branch);
+                        let mut branch = Vec::new();
+                        std::mem::swap(&mut instructions, &mut branch);
+                        pending.branches.push(branch);
+                    }
 
                     // If we hit a `}` then we are done so compute the jumps and pop the prefix.
                     if t == GlobToken::RBracket {
-                        let num_branches = pending.branches.len();
-                        if num_branches == 1 {
-                            bail!("Cannot have an alternation with only one member");
+                        let mut branches = left_bracket_starts.pop().unwrap();
+                        let mut prefix = &mut branches.prefix;
+                        let branches = &mut branches.branches;
+                        let num_branches = branches.len();
+                        if num_branches <= 1 {
+                            bail!(
+                                "Cannot have an alternation with less than 2 members, remove the \
+                                 brackets?"
+                            );
                         }
-                        // TODO(lukesandberg): consider looking for common suffixes or prefixes,
-                        // shouldn't be common
+                        // TODO(lukesandberg): we could eliminate common suffixes and prefixes
 
-                        // The length of each branch plus one for the jump to the end
+                        // The length of each branch plus one for the jump to the end.
                         // For each alternative we have a `Fork` instruction so account for those
                         let mut next_branch_offset = num_branches - 1;
-                        for branch in &pending.branches[0..num_branches - 1] {
+                        for branch in &branches[0..num_branches - 1] {
                             // to jump past the branch we need to jump past all its instructions +1
                             // to account for the JUMP instruction at the end
                             next_branch_offset += branch.len() + 1;
-                            pending.prefix.push(GlobInstruction::Fork(
+                            prefix.push(GlobInstruction::Fork(
                                 next_branch_offset.try_into().context(
-                                    "program too large, cannot have more than 64K instructions",
+                                    "glob too large, cannot have more than 32K instructions",
                                 )?,
                             ));
                             next_branch_offset -= 1; // subtract one since we added a fork
@@ -460,25 +395,23 @@ impl GlobProgram {
                         // however we aren't starting at the beginning, we already added
                         // `num_branches-1` `FORK` instructions`
                         let mut end_of_alternation =
-                            next_branch_offset + pending.branches.last().unwrap().len();
-                        for branch in &mut pending.branches[0..num_branches - 1] {
+                            next_branch_offset + branches.last().unwrap().len();
+                        for branch in &mut branches[0..num_branches - 1] {
                             end_of_alternation -= branch.len(); // from the end of this branch, this is how far it is to the end of the
                                                                 // alternation
-                            pending.prefix.extend(branch.drain(..));
-                            pending.prefix.push(GlobInstruction::Jump(
+                            prefix.extend(branch.drain(..));
+                            prefix.push(GlobInstruction::Jump(
                                 end_of_alternation.try_into().context(
-                                    "program too large, cannot have more than 64K instructions",
+                                    "glob too large, cannot have more than 64K instructions",
                                 )?,
                             ));
                             end_of_alternation -= 1; // account for the jump instruction
                         }
-                        end_of_alternation -= pending.branches.last().unwrap().len();
-                        pending
-                            .prefix
-                            .extend(pending.branches.last_mut().unwrap().drain(..));
+                        end_of_alternation -= branches.last().unwrap().len();
+
+                        prefix.extend(branches.last_mut().unwrap().drain(..));
                         debug_assert!(end_of_alternation == 0);
-                        std::mem::swap(&mut instructions, &mut pending.prefix);
-                        left_bracket_starts.pop();
+                        std::mem::swap(&mut instructions, &mut prefix);
                     }
                 }
                 GlobToken::End => {
@@ -492,63 +425,110 @@ impl GlobProgram {
         }
 
         // Now we need to annotate 'terminal' globstars in order to speed up validating program
-        // matches The issue is that if we are executing a globstar when the program
-        // completes then pass or fail is dependant upon whether there are unconditioal require
-        // subsequent matches e.g. `foo/**` matches `foo/bar/baz.js` but foo/**/a` does not,
-        // because we have to match that 'a' similarly `foo/{**,bar}` matches
-        // `foo/bar/baz.js` Do determin this we need to chase pointers from globstars to the
+        // matches. The issue is that if we are executing a globstar when the program
+        // completes then pass or fail is dependant upon whether there are any unconditional
+        // required subsequent matches e.g. `foo/**` matches `foo/bar/baz.js` but foo/**/a`
+        // does not, because we have to match that 'a' similarly `foo/{**,bar}` matches
+        // `foo/bar/baz.js`. To determine this we need to chase pointers from globstars to the
         // end of the program, and if there is a path to match then it is a terminal globstar.
+        // Similarly for other matches (branches, stars) we might end a match on some control flow
+        // rather than following it to the end we can just precompute properties of each
+        // instructions
 
         if instructions.len() > u16::MAX as usize {
             bail!("program too large");
         }
-        let mut storage = vec![0; instructions.len() * 2];
-        let mut visited = SparseSet::from_storage(storage.as_mut_slice());
-        for start in 0..(instructions.len() as u16) {
-            if matches!(
-                instructions[start as usize],
-                GlobInstruction::MatchGlobStar { .. }
-            ) {
-                visited.add(start + 1);
-                let mut thread_index = 0;
-                while thread_index < visited.n {
-                    let ip = visited.get(thread_index);
-                    match &instructions[ip as usize] {
-                        GlobInstruction::Fork(offset) => {
-                            visited.add(ip + 1);
-                            visited.add(((*offset as i16) + (ip as i16)) as u16);
-                        }
-                        GlobInstruction::Jump(offset) => {
-                            visited.add(ip + *offset);
-                        }
-                        GlobInstruction::Match => {
-                            // There is a path to the end, update to `terminal`
-                            instructions[start as usize] =
-                                GlobInstruction::MatchGlobStar { terminal: true };
-                            break;
-                        }
-                        _ => {
-                            break;
-                        }
+
+        let mut visited = BitSet::new(instructions.len());
+        let mut has_path_to_match = BitSet::new(instructions.len());
+        let mut has_path_to_prefix_match = BitSet::new(instructions.len());
+
+        for start in (0..instructions.len()).rev() {
+            visited.set(start as usize);
+            let (valid_prefix_end, valid_match) = match instructions[start as usize] {
+                GlobInstruction::MatchLiteral(byte) => (byte == b'/', false),
+                GlobInstruction::MatchAnyNonDelim => (false, false),
+                GlobInstruction::MatchGlobStar { terminal } => {
+                    debug_assert!(!terminal); // shouldn't have been set
+                                              // a globstar is always a valid prefix end but is only a valid match if the
+                                              // subsequent instruction is.
+                    let next = start + 1;
+                    debug_assert!(visited.has(next), "should have already visited the target");
+                    let has_path_to_end = has_path_to_match.has(next);
+                    if has_path_to_end {
+                        instructions[start] = GlobInstruction::MatchGlobStar { terminal: true };
                     }
-                    thread_index += 1;
+                    (true, has_path_to_match.has(next))
                 }
+                GlobInstruction::MatchClass(index) => {
+                    (range_sets[index as usize].contains(b'/'), false)
+                }
+                GlobInstruction::Jump(offset) => {
+                    let target = start + offset as usize;
+                    debug_assert!(
+                        visited.has(target),
+                        "should have already visited the target"
+                    );
+                    // copy from the target
+                    (
+                        has_path_to_prefix_match.has(target),
+                        has_path_to_match.has(target),
+                    )
+                }
+                GlobInstruction::Fork(offset) => {
+                    let next_instruction = (start + 1) as usize;
+                    debug_assert!(
+                        visited.has(next_instruction),
+                        "should have already visited the target"
+                    );
+                    let next = (
+                        has_path_to_prefix_match.has(next_instruction),
+                        has_path_to_match.has(next_instruction),
+                    );
 
-                // Check if this has an unconditional path to Match
-
-                visited.clear();
+                    if offset < 0 {
+                        // Forks that point backwards are implementing loops.
+                        // So we need to follow them now.
+                        next
+                    } else {
+                        let fork_target = start as usize + offset as usize;
+                        debug_assert!(
+                            visited.has(fork_target),
+                            "should have already visited the target"
+                        );
+                        let fork = (
+                            has_path_to_prefix_match.has(fork_target),
+                            has_path_to_match.has(fork_target),
+                        );
+                        (next.0 || fork.0, next.1 || fork.1)
+                    }
+                }
+                GlobInstruction::Match => {
+                    // For prefix matches, we only want to say it matches if a a file within the
+                    // directory could match, so if we see a Maatch instruction then we cannot match
+                    // it with this glob
+                    (false, true)
+                }
+            };
+            if valid_prefix_end {
+                has_path_to_prefix_match.set(start as usize)
+            }
+            if valid_match {
+                has_path_to_match.set(start as usize)
             }
         }
 
         Ok(GlobProgram {
-            instructions,
-            range_sets,
+            instructions: instructions.into_boxed_slice(),
+            match_instructions: has_path_to_match,
+            prefix_match_instructions: has_path_to_prefix_match,
+            range_sets: range_sets.into_boxed_slice(),
         })
     }
 
     pub fn matches(&self, v: &str, prefix: bool) -> bool {
         let len = self.instructions.len();
-        // Use a single uninitialize allocation for our storage.
+        // Use a single uninitialized allocation for our storage.
         let mut storage: Vec<u16> =
             unsafe { std::mem::transmute(vec![std::mem::MaybeUninit::<u16>::uninit(); len * 4]) };
         let (set1, set2) = storage.split_at_mut(len * 2);
@@ -557,13 +537,15 @@ impl GlobProgram {
         // Access via references to make the swap operations cheaper.
         let mut cur = &mut set1;
         let mut next = &mut set2;
+        // start at the first instruction!
         cur.add(0);
-        // Process all characters in order
-        // It would be faster to process `bytes` but this adds complexity in a number of places
-
-        let bytes = v.as_bytes();
-        for i in 0..bytes.len() {
-            let byte = bytes[i];
+        // Process all bytes in order
+        // Each iteration of the outer loop advances one byte through the input
+        // Each iteration of the inner loop iterates at most once for every instruction in the
+        // program but typically far less
+        // This bounds execution at O(N*M) where N is the size of the path and M is the size of the
+        // program
+        for &byte in v.as_bytes() {
             let mut thread_index = 0;
             // We need to use this looping construct since we may add elements to `cur` as we go.
             // `cur.n` will never be > `len` so this loop is bounded to N iterations.
@@ -571,7 +553,7 @@ impl GlobProgram {
             while thread_index < n_threads {
                 let ip = cur.get(thread_index);
                 match self.instructions[ip as usize] {
-                    GlobInstruction::MatchLiteral((m, has_next)) => {
+                    GlobInstruction::MatchLiteral(m) => {
                         if byte == m {
                             // We matched, proceed to the next character
                             next.add(ip + 1);
@@ -584,19 +566,19 @@ impl GlobProgram {
                     }
                     GlobInstruction::MatchGlobStar { terminal } => {
                         if terminal {
-                            // If we find a terminal globstar, we are done! this must match
+                            // If we find a terminal globstar, we are done! this must match whatever
+                            // remains
                             return true;
                         }
                         // If we see a `/` then we need to consider ending the globstar.
                         if byte == b'/' {
                             next.add(ip + 1);
-                        } else if n_threads == 1 {
                         }
                         // but even so we should keep trying to match, just like a fork.
                         next.add(ip);
                     }
-                    GlobInstruction::MatchClass(set_index) => {
-                        if self.range_sets[set_index as usize].contains(byte) {
+                    GlobInstruction::MatchClass(index) => {
+                        if self.range_sets[index as usize].contains(byte) {
                             next.add(ip + 1);
                         }
                     }
@@ -631,44 +613,38 @@ impl GlobProgram {
             std::mem::swap(&mut cur, &mut next);
         }
         // If we get here we have matched a prefix of the instructions and run out of text.
-        // So in prefix mode we are done, otherwise we need to check if we hit the end of the
-        // isntructions
+        // We need to ensure that whatever instructions we landed on are valid for a prefix match
         if prefix {
-            return true;
+            for i in 0..cur.n {
+                let insn = cur.get(i);
+                if self.prefix_match_instructions.has(insn as usize) {
+                    return true;
+                }
+            }
         }
 
         // We matched if there is some path from any current thread to the end, so we need to
         // process all jumps and forks
-        let mut i = 0;
-        while i < cur.n {
-            let ip = cur.get(i);
-            match self.instructions[ip as usize] {
-                GlobInstruction::Jump(offset) => {
-                    // Push another thread onto the current list
-                    cur.add(offset + ip);
-                }
-                GlobInstruction::Fork(offset) => {
-                    cur.add(ip + 1);
-                    cur.add((offset + (ip as i16)) as u16);
-                }
-                GlobInstruction::Match => {
-                    return true;
-                }
-                _ => {
-                    //ignore
-                }
+        // Consider a pattern like `a{b,c}` matching `ab`
+        // The program would be `Lit(a)Fork(2)Lit(b)Jump(2)Lit(c)Match`
+        // So when matching 'b' we need to execute a jump to find the match.`
+        for i in 0..cur.n {
+            let insn = cur.get(i);
+            if self.match_instructions.has(insn as usize) {
+                return true;
             }
-            i += 1;
         }
         false
     }
 }
 
 // Consider a more compact encoding.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+// The jump offsets force this to 4 bytes
+// A variable length instruction encoding would help a lot
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 enum GlobInstruction {
-    // Matches a single literal byte, stores if there is a following literal
-    MatchLiteral((u8, bool)),
+    // Matches a single literal byte
+    MatchLiteral(u8),
     // Matches any non-`/` character
     MatchAnyNonDelim,
     // Matches **, which is any character but can only 'end' on a `/` or end of string
@@ -836,251 +812,6 @@ impl<'a> Tokenizer<'a> {
     }
 }
 
-impl GlobPart {
-    /// Iterates over all possible matches of this part with the provided path.
-    /// The least greedy match is returned first. This is usually used for
-    /// backtracking. The string slice returned is the remaining part or the
-    /// path. The boolean flag returned specifies if the matched part should
-    /// be considered as path-separator equivalent.
-    fn iter_matches<'a>(
-        &'a self,
-        path: &'a str,
-        previous_part_is_path_separator_equivalent: bool,
-        match_in_directory: bool,
-    ) -> GlobPartMatchesIterator<'a> {
-        GlobPartMatchesIterator {
-            path,
-            part: self,
-            match_in_directory,
-            previous_part_is_path_separator_equivalent,
-            cursor: GraphemeCursor::new(0, path.len(), true),
-            index: 0,
-            glob_iterator: None,
-        }
-    }
-
-    fn parse(input: &str, inside_of_braces: bool) -> Result<(GlobPart, &str)> {
-        debug_assert!(!input.is_empty());
-        let two_chars = {
-            let mut chars = input.chars();
-            (chars.next().unwrap(), chars.next())
-        };
-        match two_chars {
-            ('/', _) => Ok((GlobPart::PathSeparator, &input[1..])),
-            ('*', Some('*')) => Ok((GlobPart::AnyDirectories, &input[2..])),
-            ('*', _) => Ok((GlobPart::AnyFile, &input[1..])),
-            ('?', _) => Ok((GlobPart::AnyFileChar, &input[1..])),
-            ('[', Some('[')) => todo!("glob char classes are not implemented yet"),
-            ('[', _) => todo!("glob char sequences are not implemented yet"),
-            ('{', Some(_)) => {
-                let mut current = &input[1..];
-                let mut alternatives = Vec::new();
-                let mut expression = Vec::new();
-
-                loop {
-                    let (part, remainder) = GlobPart::parse(current, true)?;
-                    expression.push(part);
-                    current = remainder;
-                    match current.chars().next() {
-                        Some(',') => {
-                            alternatives.push(Glob {
-                                expression: take(&mut expression),
-                            });
-                            current = &current[1..];
-                        }
-                        Some('}') => {
-                            alternatives.push(Glob {
-                                expression: take(&mut expression),
-                            });
-                            current = &current[1..];
-                            break;
-                        }
-                        None => bail!("Unterminated glob braces"),
-                        _ => {
-                            // next part of the glob
-                        }
-                    }
-                }
-
-                Ok((GlobPart::Alternatives(alternatives), current))
-            }
-            ('{', None) => {
-                bail!("Unterminated glob braces")
-            }
-            _ => {
-                let mut is_escaped = false;
-                let mut literal = String::new();
-
-                // TODO(lukes): there shouldn't be a need to traverse graphemes here, just literal
-                // matches since all of our delimiters are ascii characters
-                let mut cursor = GraphemeCursor::new(0, input.len(), true);
-
-                let mut start = cursor.cur_cursor();
-                let mut end_cursor = cursor
-                    .next_boundary(input, 0)
-                    .map_err(|e| anyhow!("{:?}", e))?;
-
-                while let Some(end) = end_cursor {
-                    let c = &input[start..end];
-                    if is_escaped {
-                        is_escaped = false;
-                    } else if c == "\\" {
-                        is_escaped = true;
-                    } else if c == "/"
-                        || c == "*"
-                        || c == "?"
-                        || c == "["
-                        || c == "{"
-                        || (inside_of_braces && (c == "," || c == "}"))
-                    {
-                        break;
-                    }
-                    literal.push_str(c);
-
-                    start = cursor.cur_cursor();
-                    end_cursor = cursor
-                        .next_boundary(input, end)
-                        .map_err(|e| anyhow!("{:?}", e))?;
-                }
-
-                Ok((GlobPart::File(literal), &input[start..]))
-            }
-        }
-    }
-}
-
-struct GlobPartMatchesIterator<'a> {
-    path: &'a str,
-    part: &'a GlobPart,
-    match_in_directory: bool,
-    previous_part_is_path_separator_equivalent: bool,
-    cursor: GraphemeCursor,
-    index: usize,
-    glob_iterator: Option<Box<GlobMatchesIterator<'a>>>,
-}
-
-impl<'a> Iterator for GlobPartMatchesIterator<'a> {
-    type Item = (&'a str, bool);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.part {
-            GlobPart::AnyDirectories => {
-                if self.cursor.cur_cursor() == 0 {
-                    let Ok(Some(_)) = self.cursor.next_boundary(self.path, 0) else {
-                        return None;
-                    };
-                    return Some((self.path, true));
-                }
-
-                if self.cursor.cur_cursor() == self.path.len() {
-                    return None;
-                }
-
-                loop {
-                    let start = self.cursor.cur_cursor();
-                    // next_boundary does not set cursor offset to the end of the string
-                    // if there is no next boundary - manually set cursor to the end
-                    let end = match self.cursor.next_boundary(self.path, 0) {
-                        Ok(end) => {
-                            if let Some(end) = end {
-                                end
-                            } else {
-                                self.cursor.set_cursor(self.path.len());
-                                self.cursor.cur_cursor()
-                            }
-                        }
-                        _ => return None,
-                    };
-
-                    if &self.path[start..end] == "/" {
-                        return Some((&self.path[end..], true));
-                    } else if start == end {
-                        return Some((&self.path[start..], false));
-                    }
-                }
-            }
-            GlobPart::AnyFile => {
-                let Ok(Some(c)) = self.cursor.next_boundary(self.path, 0) else {
-                    return None;
-                };
-
-                let idx = self.path[0..c].len();
-
-                // TODO verify if `*` does match zero chars?
-                if let Some(slice) = self.path.get(0..c) {
-                    if slice.ends_with('/') {
-                        None
-                    } else {
-                        Some((
-                            &self.path[c..],
-                            self.previous_part_is_path_separator_equivalent && idx == 1,
-                        ))
-                    }
-                } else {
-                    None
-                }
-            }
-            GlobPart::AnyFileChar => todo!(),
-            GlobPart::PathSeparator => {
-                if self.cursor.cur_cursor() == 0 {
-                    let Ok(Some(b)) = self.cursor.next_boundary(self.path, 0) else {
-                        return None;
-                    };
-                    if self.path.starts_with('/') {
-                        Some((&self.path[b..], true))
-                    } else if self.previous_part_is_path_separator_equivalent {
-                        Some((self.path, true))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            }
-            GlobPart::FileChar(chars) => {
-                let start = self.cursor.cur_cursor();
-                let Ok(Some(end)) = self.cursor.next_boundary(self.path, 0) else {
-                    return None;
-                };
-                let mut chars_in_path = self.path[start..end].chars();
-                let c = chars_in_path.next()?;
-                if chars_in_path.next().is_some() {
-                    return None;
-                }
-                chars.contains(&c).then(|| (&self.path[end..], false))
-            }
-            GlobPart::File(name) => {
-                if self.cursor.cur_cursor() == 0 && self.path.starts_with(name) {
-                    let Ok(Some(_)) = self.cursor.next_boundary(self.path, 0) else {
-                        return None;
-                    };
-                    Some((&self.path[name.len()..], false))
-                } else {
-                    None
-                }
-            }
-            GlobPart::Alternatives(alternatives) => loop {
-                if let Some(glob_iterator) = &mut self.glob_iterator {
-                    if let Some((path, is_path_separator_equivalent)) = glob_iterator.next() {
-                        return Some((path, is_path_separator_equivalent));
-                    } else {
-                        self.index += 1;
-                        self.glob_iterator = None;
-                    }
-                } else if let Some(alternative) = alternatives.get(self.index) {
-                    self.glob_iterator = Some(Box::new(alternative.iter_matches(
-                        self.path,
-                        self.previous_part_is_path_separator_equivalent,
-                        self.match_in_directory,
-                    )));
-                } else {
-                    return None;
-                }
-            },
-        }
-    }
-}
-
 impl TryFrom<&str> for Glob {
     type Error = anyhow::Error;
 
@@ -1098,14 +829,20 @@ impl Glob {
 
     #[turbo_tasks::function]
     pub async fn alternatives(globs: Vec<Vc<Glob>>) -> Result<Vc<Self>> {
-        if globs.len() == 1 {
-            return Ok(globs.into_iter().next().unwrap());
+        match globs.len() {
+            0 => Ok(Self::cell(Glob::parse("")?)),
+            1 => Ok(globs.into_iter().next().unwrap()),
+            _ => {
+                todo!()
+            }
         }
-        Ok(Self::cell(Glob {
-            expression: vec![GlobPart::Alternatives(
-                globs.into_iter().map(|g| g.owned()).try_join().await?,
-            )],
-        }))
+        // if globs.len() == 1 {
+        // }
+        // Ok(Self::cell(Glob {
+        //     expression: vec![GlobPart::Alternatives(
+        //         globs.into_iter().map(|g| g.owned()).try_join().await?,
+        //     )],
+        // }))
     }
 }
 
@@ -1113,8 +850,8 @@ impl Glob {
 mod tests {
     use rstest::*;
 
-    use super::{Glob, GlobToken, Tokenizer};
-    use crate::glob::GlobProgram;
+    use super::{Glob, GlobToken};
+    use crate::glob::Tokenizer;
 
     #[rstest]
     #[case::file("file.js", "file.js")]
@@ -1193,12 +930,6 @@ mod tests {
         println!("{glob:?} compiled to {parsed:?} matching {path}");
 
         assert!(parsed.execute(path));
-
-        let parsed2 = GlobProgram::compile(glob).unwrap();
-        println!("{glob:?} compiled to\n{parsed2:#?}\nmatching {path}");
-        let prefix = path.ends_with('/');
-
-        assert!(parsed2.matches(path, prefix));
     }
 
     #[rstest]
@@ -1213,12 +944,6 @@ mod tests {
         println!("{glob:?} compiled to {parsed:?} matching {path}");
 
         assert!(!parsed.execute(path));
-
-        let parsed2 = GlobProgram::compile(glob).unwrap();
-        println!("{glob:?} compiled to {parsed2:?} matching {path}");
-        let prefix = path.ends_with('/');
-
-        assert!(!parsed2.matches(path, prefix));
     }
 
     #[test]

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -180,12 +180,6 @@ impl<'a> SparseSet<'a> {
     fn clear(&mut self) {
         self.n = 0
     }
-    fn clear_and_add(&mut self, v: u16) {
-        debug_assert!((v as usize) < self.mem.len() / 2);
-        self.n = 1;
-        *self.get_sparse_mut(v) = 0;
-        *self.get_dense_mut(0) = v;
-    }
 
     fn add(&mut self, v: u16) -> bool {
         debug_assert!((v as usize) < self.mem.len() / 2);
@@ -421,7 +415,7 @@ impl GlobProgram {
         let mut instruction = self.instructions[0];
         let mut vi = 0;
         let vlen = v.len();
-        'outer: while vi < vlen {
+        while vi < vlen {
             let mut byte = v[vi];
             vi += 1;
             let mut thread_index = 0;
@@ -433,25 +427,12 @@ impl GlobProgram {
                 match instruction {
                     GlobInstruction::MatchLiteral(m) => {
                         if byte == m {
-                            // if n_threads == 1 {
-                            //     ip += 1;
-                            //     cur.clear_and_add(ip);
-                            //     instruction = self.instructions[ip as usize];
-                            //     continue 'outer;
-                            // }
                             // We matched, proceed to the next character
                             next.add(ip + 1);
                         }
                     }
-
                     GlobInstruction::MatchAnyNonDelim => {
                         if byte != b'/' {
-                            // if n_threads == 1 {
-                            //     ip += 1;
-                            //     cur.clear_and_add(ip);
-                            //     instruction = self.instructions[ip as usize];
-                            //     continue 'outer;
-                            // }
                             next.add(ip + 1);
                         }
                     }
@@ -512,23 +493,11 @@ impl GlobProgram {
                     }
                     GlobInstruction::MatchClass(index) => {
                         if self.range_sets[index as usize].contains(byte) {
-                            // if n_threads == 1 {
-                            //     ip += 1;
-                            //     cur.clear_and_add(ip);
-                            //     instruction = self.instructions[ip as usize];
-                            //     continue 'outer;
-                            // }
                             next.add(ip + 1);
                         }
                     }
                     GlobInstruction::NegativeMatchClass(index) => {
                         if !self.range_sets[index as usize].contains(byte) {
-                            // if n_threads == 1 {
-                            //     ip += 1;
-                            //     cur.clear_and_add(ip);
-                            //     instruction = self.instructions[ip as usize];
-                            //     continue 'outer;
-                            // }
                             next.add(ip + 1);
                         }
                     }

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -844,9 +844,8 @@ fn generate_code(
     Ok((starts_with_globstar, ends_with_globstar))
 }
 
-// Consider a more compact encoding.
-// The jump offsets force this to 4 bytes
-// A variable length instruction encoding would help a lot
+// A more compact encoding would be nice but experimentally it does not save much
+// Instead we should explore ways to encode more hints into the instructions to speed up matchers.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 enum GlobInstruction {
     // Matches a single literal byte

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -370,18 +370,20 @@ impl GlobProgram {
         // program
         let mut n_threads = 1;
         let mut ip = 0;
+        let mut instruction = self.instructions[0];
         'outer: for &byte in v.as_bytes() {
             let mut thread_index = 0;
             // We manage the loop manually at the bottom to make it easier to skip it when hitting
             // some fast paths
             loop {
-                match self.instructions[ip as usize] {
+                match instruction {
                     GlobInstruction::MatchLiteral(m) => {
                         if byte == m {
                             if n_threads == 1 {
                                 cur.clear();
                                 ip += 1;
                                 cur.add(ip);
+                                instruction = self.instructions[ip as usize + 1];
                                 continue 'outer;
                             }
                             // We matched, proceed to the next character
@@ -395,6 +397,7 @@ impl GlobProgram {
                                 cur.clear();
                                 ip += 1;
                                 cur.add(ip);
+                                instruction = self.instructions[ip as usize + 1];
                                 continue 'outer;
                             }
                             next.add(ip + 1);
@@ -449,6 +452,7 @@ impl GlobProgram {
                                 cur.clear();
                                 ip += 1;
                                 cur.add(ip);
+                                instruction = self.instructions[ip as usize + 1];
                                 continue 'outer;
                             }
                             next.add(ip + 1);
@@ -460,6 +464,7 @@ impl GlobProgram {
                                 cur.clear();
                                 ip += 1;
                                 cur.add(ip);
+                                instruction = self.instructions[ip as usize + 1];
                                 continue 'outer;
                             }
                             next.add(ip + 1);
@@ -488,6 +493,7 @@ impl GlobProgram {
                 thread_index += 1;
                 if thread_index < n_threads {
                     ip = cur.get(thread_index);
+                    instruction = self.instructions[ip as usize];
                 } else {
                     break;
                 }

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -22,7 +22,6 @@ use turbo_tasks::Vc;
 pub struct Glob {
     #[turbo_tasks(trace_ignore)]
     program: GlobProgram,
-    src: String,
 }
 
 impl Glob {
@@ -34,12 +33,7 @@ impl Glob {
         } else {
             path
         };
-        let result = self.program.matches(path, match_partial);
-        let src = &self.src;
-
-        let dbg = format!("matching: '{src}' against '{path}' = {result}");
-        dbg!(dbg);
-        result
+        self.program.matches(path, match_partial)
     }
 
     // Returns true if the glob could match a filename underneath this `path` where the path
@@ -50,7 +44,6 @@ impl Glob {
 
     pub fn parse(input: &str) -> Result<Self> {
         Ok(Self {
-            src: input.to_string(),
             program: GlobProgram::compile(input)?,
         })
     }
@@ -249,7 +242,6 @@ pub struct GlobProgram {
 
 impl GlobProgram {
     fn compile(pattern: &str) -> Result<GlobProgram> {
-        dbg!(format!("Compiling: {pattern}"));
         GlobProgram::do_compile(pattern).with_context(|| format!("Failed to parse glob: {pattern}"))
     }
     fn do_compile(pattern: &str) -> Result<GlobProgram> {

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -321,7 +321,7 @@ pub mod tests {
                 path,
                 Vec::new(),
             ));
-            let read_dir = fs
+            let read_dir = &*fs
                 .root()
                 .read_glob(Glob::new("*.js".into()), false)
                 .await

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{glob::Glob, FileJsonContent, FileSystemPath};
 use turbopack_core::{
     asset::Asset,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -933,7 +933,6 @@ impl AssetContext for ModuleAssetContext {
             glob.push_str(pkgs.join(",").as_str());
             glob.push_str("}/**");
         }
-
         Ok(Glob::new(glob.into()))
     }
 }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -928,9 +928,11 @@ impl AssetContext for ModuleAssetContext {
         let pkgs = &*self.module_options_context.await?.side_effect_free_packages;
 
         let mut glob = String::new();
-        glob.push_str("**/node_modules/{");
-        glob.push_str(pkgs.join(",").as_str());
-        glob.push_str("}/**");
+        if !pkgs.is_empty() {
+            glob.push_str("**/node_modules/{");
+            glob.push_str(pkgs.join(",").as_str());
+            glob.push_str("}/**");
+        }
 
         Ok(Glob::new(glob.into()))
     }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -927,13 +927,12 @@ impl AssetContext for ModuleAssetContext {
     async fn side_effect_free_packages(&self) -> Result<Vc<Glob>> {
         let pkgs = &*self.module_options_context.await?.side_effect_free_packages;
 
-        let mut globs = Vec::with_capacity(pkgs.len());
+        let mut glob = String::new();
+        glob.push_str("**/node_modules/{");
+        glob.push_str(pkgs.join(",").as_str());
+        glob.push_str("}/**");
 
-        for pkg in pkgs {
-            globs.push(Glob::new(format!("**/node_modules/{{{}}}/**", pkg).into()));
-        }
-
-        Ok(Glob::alternatives(globs))
+        Ok(Glob::new(glob.into()))
     }
 }
 


### PR DESCRIPTION
Reimplement our glob matching as a NFA as described in the classic [rsc article](https://swtch.com/~rsc/regexp/regexp2.html) about implementing regular expressions.

The idea is to avoid backtracking by looking at each input character exactly once.  To do this we build a simple bytecode VM where we can execute multiple 'threads' concurrently.

'*.js' compiles to a program like
```
0: Fork 3
1: MatchNonDelim
2: Fork -1
3: MatchLiteral '.'
4: MatchLiteral 'j'
5: MatchLiteral 's'
6: Match
```

Fork means to split our execution into two paths, the next instruction and the current instruction plus the provided offset.  Because all threads are always looking at the same input byte we can track there state with a single integer (their instruction pointer). So for each input character we attempt to advance all threads. 

### Why?

To improve performance and add features.  This improves matching performance over the previous implementation by approximately 5x.  This doesn't quite allow us to meet the performance of `fast-glob` but we are quite close.

The only feature being added here are 'character sets' e.g. `[a-zA-z0-9]` is now supported.

### Why not something else?

The `globset` crate is a compelling alternative that I investigated, however it does not support the `match_in_directory` functionality we use when navigating directories.  It is also not particilarly feasible to add that functionality to their crate as they delegate matching to `regex::automata` so the only solution would be to buiild a lot of globs for all possible directory split points.  This is feasible but also complex.

This solution is more memory efficient than `globset` and is competitive with the `fast-glob` crate while supporting our additional feature requirements.

I do think we could consider dropping that feature requirement and accept navigating excess directories in exchange for slightly faster matches maintained by someone else.  On the other hand `glob` is _stable_ so perhaps maintaining this will not be a long term concern.

Closes PACK-4401
Fixes #72196
