### PR TITLE
fix(CI): Wait for lock when running apt-get

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,7 +19,9 @@ runs:
     - name: 'Install LLD (LLVM Linker) for Linux'
       if: runner.os == 'Linux'
       shell: bash
-      run: sudo apt-get -y update && sudo apt-get install -y lld
+      run: |
+        sudo apt-get -y -o DPkg::Lock::Timeout=60 update
+        sudo apt-get -o DPkg::Lock::Timeout=60 -y install lld
 
     - name: 'Add cargo problem matchers'
       shell: bash


### PR DESCRIPTION
Sometimes this step can fail because something else has the lock (I'm not sure what, as I thought these things run in isolated containers), but we can mitigate this by waiting for the lock up to 60 seconds.

![Screenshot 2025-05-08 at 9.33.10 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/f12de549-6cf0-48f0-959f-cf7595994e15.png)

We also call `apt` instead of `apt-get` in some of our CI scripts, but use of `apt` in scripts is discouraged as the CLI interface is unstable. `apt` does automatically wait for the lock, so those places don't have this problem.

More details here: https://blog.sinjakli.co.uk/2021/10/25/waiting-for-apt-locks-without-the-hacky-bash-scripts/

Closes PACK-4558