### PR TITLE
chore(CI): Add a few more turbopack paths to labeler config

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -5,7 +5,7 @@
     "examples": ["examples/**"],
     "Font (next/font)": ["**/*font*"],
     "tests": ["test/**", "bench/**"],
-    "Turbopack": ["crates/next-*/**"],
+    "Turbopack": ["crates/next-*/**", "crates/napi/**", "turbopack/**"],
     "created-by: Chrome Aurora": [
       { "type": "user", "pattern": "atcastle" },
       { "type": "user", "pattern": "devknoll" },


### PR DESCRIPTION
Looks like we never added this after the turbopack repo migration.

Closes PACK-4564