### PR TITLE
Prevent `"use cache"` timeout errors from being caught in userland code

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -651,12 +651,17 @@ function createErrorWithComponentStack(
 }
 
 export function throwIfDisallowedDynamic(
-  route: string,
+  workStore: WorkStore,
   hasEmptyShell: boolean,
   dynamicValidation: DynamicValidationState,
   serverDynamic: DynamicTrackingState,
   clientDynamic: DynamicTrackingState
 ): void {
+  if (workStore.invalidDynamicUsageError) {
+    console.error(workStore.invalidDynamicUsageError)
+    throw new StaticGenBailoutError()
+  }
+
   if (hasEmptyShell) {
     if (dynamicValidation.hasSuspenseAboveBody) {
       // This route has opted into allowing fully dynamic rendering
@@ -698,7 +703,7 @@ export function throwIfDisallowedDynamic(
     // to indicate your are ok with fully dynamic rendering.
     if (dynamicValidation.hasDynamicViewport) {
       console.error(
-        `Route "${route}" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport`
+        `Route "${workStore.route}" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport`
       )
       throw new StaticGenBailoutError()
     }
@@ -708,7 +713,7 @@ export function throwIfDisallowedDynamic(
       dynamicValidation.hasDynamicMetadata
     ) {
       console.error(
-        `Route "${route}" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata`
+        `Route "${workStore.route}" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata`
       )
       throw new StaticGenBailoutError()
     }

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -51,12 +51,13 @@ export interface WorkStore {
   dynamicUsageStack?: string
 
   /**
-   * Invalid usage errors might be caught in userland. We attach them to the
-   * work store to ensure we can still fail the build or dev render.
+   * Invalid dynamic usage errors might be caught in userland. We attach them to
+   * the work store to ensure we can still fail the build, or show en error in
+   * dev mode.
    */
   // TODO: Collect an array of errors, and throw as AggregateError when
   // `serializeError` and the Dev Overlay support it.
-  invalidUsageError?: Error
+  invalidDynamicUsageError?: Error
 
   nextFetchId?: number
   pathWasRevalidated?: boolean

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -29,7 +29,7 @@ export function throwForSearchParamsAccessInUseCache(
   )
 
   Error.captureStackTrace(error, constructorOpt)
-  workStore.invalidUsageError ??= error
+  workStore.invalidDynamicUsageError ??= error
 
   throw error
 }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -253,8 +253,8 @@ async function collectResult(
   let idx = 0
   const bufferStream = new ReadableStream({
     pull(controller) {
-      if (workStore.invalidUsageError) {
-        controller.error(workStore.invalidUsageError)
+      if (workStore.invalidDynamicUsageError) {
+        controller.error(workStore.invalidDynamicUsageError)
       } else if (idx < buffer.length) {
         controller.enqueue(buffer[idx++])
       } else if (errors.length > 0) {
@@ -365,7 +365,6 @@ async function generateCacheEntryImpl(
   const resultPromise = createLazyResult(() => fn.apply(null, args))
 
   let errors: Array<unknown> = []
-  let timeoutErrorHandled = false
 
   // In the "Cache" environment, we only need to make sure that the error
   // digests are handled correctly. Error formatting and reporting is not
@@ -385,13 +384,6 @@ async function generateCacheEntryImpl(
       console.error(error)
     }
 
-    if (error === timeoutError) {
-      timeoutErrorHandled = true
-      // The timeout error already aborted the whole stream. We don't need
-      // to also push this error into the `errors` array.
-      return timeoutError.digest
-    }
-
     errors.push(error)
   }
 
@@ -404,6 +396,7 @@ async function generateCacheEntryImpl(
     // Otherwise we assume you stalled on hanging input and de-opt. This needs
     // to be lower than just the general timeout of 60 seconds.
     const timer = setTimeout(() => {
+      workStore.invalidDynamicUsageError = timeoutError
       timeoutAbortController.abort(timeoutError)
     }, 50000)
 
@@ -422,7 +415,7 @@ async function generateCacheEntryImpl(
         signal: abortSignal,
         temporaryReferences,
         onError(error) {
-          if (renderSignal.aborted && renderSignal.reason === error) {
+          if (abortSignal.aborted && abortSignal.reason === error) {
             return undefined
           }
 
@@ -433,11 +426,7 @@ async function generateCacheEntryImpl(
 
     clearTimeout(timer)
 
-    if (timeoutAbortController.signal.aborted && !timeoutErrorHandled) {
-      // When halting is enabled, the prerender will not call `onError` when
-      // it's aborted with the timeout abort signal, and hanging promises will
-      // also not be rejected. In this case, we're creating an erroring stream
-      // here, to ensure that the error is propagated to the server environment.
+    if (timeoutAbortController.signal.aborted) {
       stream = new ReadableStream({
         start(controller) {
           controller.error(timeoutError)

--- a/test/e2e/app-dir/use-cache-hanging-inputs/app/fallback-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/app/fallback-params/[slug]/page.tsx
@@ -1,0 +1,14 @@
+'use cache'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return <p>slug: {slug}</p>
+}
+
+// If generateStaticParams would be used here to define at least one set of
+// complete params, we would not yield a timeout error.

--- a/test/e2e/app-dir/use-cache-hanging-inputs/app/search-params-caught/page.tsx
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/app/search-params-caught/page.tsx
@@ -1,0 +1,28 @@
+async function getSearchParam({
+  searchParams,
+}: {
+  searchParams: Promise<{ n: string }>
+}): Promise<string> {
+  'use cache'
+
+  return (await searchParams).n
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ n: string }>
+}) {
+  let searchParam: string | undefined
+
+  try {
+    searchParam = await getSearchParam({ searchParams })
+  } catch {
+    // Ignore not having access to searchParams. This is still an invalid
+    // dynamic access though that we need to detect.
+  }
+
+  return (
+    <p>{searchParam ? `search param: ${searchParam}` : 'no search param'}</p>
+  )
+}

--- a/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise-nested/page.tsx
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise-nested/page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { setTimeout } from 'timers/promises'
 
 async function getUncachedData() {
-  await setTimeout(0)
+  await setTimeout(100)
 
   return Math.random()
 }

--- a/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise/page.tsx
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise/page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { setTimeout } from 'timers/promises'
 
 async function fetchUncachedData() {
-  await setTimeout(0)
+  await setTimeout(100)
 
   return Math.random()
 }

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -12,7 +12,7 @@ import stripAnsi from 'strip-ansi'
 
 const isExperimentalReact = process.env.__NEXT_EXPERIMENTAL_PPR
 
-const expectedErrorMessage =
+const expectedTimeoutErrorMessage =
   'Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".'
 
 describe('use-cache-hanging-inputs', () => {
@@ -38,21 +38,29 @@ describe('use-cache-hanging-inputs', () => {
 
         await openRedbox(browser)
 
+        const errorCount = await getRedboxTotalErrorCount(browser)
         const errorDescription = await getRedboxDescription(browser)
         const errorSource = await getRedboxSource(browser)
 
-        expect(errorDescription).toBe(expectedErrorMessage)
+        expect(errorCount).toBe(1)
+        expect(errorDescription).toBe(expectedTimeoutErrorMessage)
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
         if (isTurbopack) {
-          // TODO(veil): For Turbopack, a fix in the React Flight Client, where
-          // sourceURL is encoded, is needed for the error source and stack
-          // frames to be source mapped.
+          expect(errorSource).toMatchInlineSnapshot(`
+           "app/search-params/page.tsx (3:16) @ [project]/app/search-params/page.tsx [app-rsc] (ecmascript)
 
-          expect(errorSource).toBe(null)
+             1 | 'use cache'
+             2 |
+           > 3 | export default async function Page({
+               |                ^
+             4 |   searchParams,
+             5 | }: {
+             6 |   searchParams: Promise<{ n: string }>"
+          `)
 
-          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at [project]/app/search-params/page.tsx [app-rsc] (ecmascript)`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
@@ -67,8 +75,58 @@ describe('use-cache-hanging-inputs', () => {
              6 |   searchParams: Promise<{ n: string }>"
           `)
 
-          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at eval (app/search-params/page.tsx:3:15)`)
+        }
+      }, 180_000)
+    })
+
+    describe('when searchParams are used inside of "use cache", wrapped in try/catch', () => {
+      it('should show an error toast after a timeout', async () => {
+        const outputIndex = next.cliOutput.length
+        const browser = await next.browser('/search-params-caught?n=1')
+
+        // The request is pending while we stall on the hanging inputs, and
+        // playwright will wait for the load event before continuing. So we
+        // don't need to wait for the "use cache" timeout of 50 seconds here.
+
+        await openRedbox(browser)
+
+        const errorCount = await getRedboxTotalErrorCount(browser)
+        const errorDescription = await getRedboxDescription(browser)
+        const errorSource = await getRedboxSource(browser)
+
+        expect(errorCount).toBe(1)
+        expect(errorDescription).toBe(expectedTimeoutErrorMessage)
+
+        const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+        if (isTurbopack) {
+          expect(errorSource).toMatchInlineSnapshot(`
+           "app/search-params-caught/page.tsx (1:1) @ [project]/app/search-params-caught/page.tsx [app-rsc] (ecmascript)
+
+           > 1 | async function getSearchParam({
+               | ^
+             2 |   searchParams,
+             3 | }: {
+             4 |   searchParams: Promise<{ n: string }>"
+          `)
+
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
+    at [project]/app/search-params-caught/page.tsx [app-rsc] (ecmascript)`)
+        } else {
+          expect(errorSource).toMatchInlineSnapshot(`
+           "app/search-params-caught/page.tsx (1:1) @ eval
+
+           > 1 | async function getSearchParam({
+               | ^
+             2 |   searchParams,
+             3 | }: {
+             4 |   searchParams: Promise<{ n: string }>"
+          `)
+
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
+    at eval (app/search-params-caught/page.tsx:1:0)`)
         }
       }, 180_000)
     })
@@ -82,7 +140,7 @@ describe('use-cache-hanging-inputs', () => {
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
-        expect(cliOutput).not.toContain(`Error: ${expectedErrorMessage}`)
+        expect(cliOutput).not.toContain(`Error: ${expectedTimeoutErrorMessage}`)
       })
     })
 
@@ -97,21 +155,29 @@ describe('use-cache-hanging-inputs', () => {
 
         await openRedbox(browser)
 
+        const errorCount = await getRedboxTotalErrorCount(browser)
         const errorDescription = await getRedboxDescription(browser)
         const errorSource = await getRedboxSource(browser)
 
-        expect(errorDescription).toBe(expectedErrorMessage)
+        expect(errorCount).toBe(1)
+        expect(errorDescription).toBe(expectedTimeoutErrorMessage)
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
         if (isTurbopack) {
-          // TODO(veil): For Turbopack, a fix in the React Flight Client, where
-          // sourceURL is encoded, is needed for the error source and stack
-          // frames to be source mapped.
+          expect(errorSource).toMatchInlineSnapshot(`
+           "app/uncached-promise/page.tsx (10:13) @ [project]/app/uncached-promise/page.tsx [app-rsc] (ecmascript)
 
-          expect(errorSource).toBe(null)
+              8 | }
+              9 |
+           > 10 | const Foo = async ({ promise }) => {
+                |             ^
+             11 |   'use cache'
+             12 |
+             13 |   return ("
+          `)
 
-          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at [project]/app/uncached-promise/page.tsx [app-rsc] (ecmascript)`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
@@ -126,7 +192,7 @@ describe('use-cache-hanging-inputs', () => {
              13 |   return ("
           `)
 
-          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at eval (app/uncached-promise/page.tsx:10:12)`)
         }
       }, 180_000)
@@ -143,21 +209,29 @@ describe('use-cache-hanging-inputs', () => {
 
         await openRedbox(browser)
 
+        const errorCount = await getRedboxTotalErrorCount(browser)
         const errorDescription = await getRedboxDescription(browser)
         const errorSource = await getRedboxSource(browser)
 
-        expect(errorDescription).toBe(expectedErrorMessage)
+        expect(errorCount).toBe(1)
+        expect(errorDescription).toBe(expectedTimeoutErrorMessage)
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
         if (isTurbopack) {
-          // TODO(veil): For Turbopack, a fix in the React Flight Client, where
-          // sourceURL is encoded, is needed for the error source and stack
-          // frames to be source mapped.
+          expect(errorSource).toMatchInlineSnapshot(`
+           "app/uncached-promise-nested/page.tsx (16:1) @ [project]/app/uncached-promise-nested/page.tsx [app-rsc] (ecmascript)
 
-          expect(errorSource).toBe(null)
+             14 | }
+             15 |
+           > 16 | async function indirection(promise: Promise<number>) {
+                | ^
+             17 |   'use cache'
+             18 |
+             19 |   return getCachedData(promise)"
+          `)
 
-          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at [project]/app/uncached-promise-nested/page.tsx [app-rsc] (ecmascript)`)
         } else {
           expect(errorSource).toMatchInlineSnapshot(`
@@ -172,7 +246,7 @@ describe('use-cache-hanging-inputs', () => {
              19 |   return getCachedData(promise)"
           `)
 
-          expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at eval (app/uncached-promise-nested/page.tsx:16:0)`)
         }
       }, 180_000)
@@ -189,8 +263,11 @@ describe('use-cache-hanging-inputs', () => {
 
         await openRedbox(browser)
 
+        const errorCount = await getRedboxTotalErrorCount(browser)
         const errorDescription = await getRedboxDescription(browser)
         const errorSource = await getRedboxSource(browser)
+
+        expect(errorCount).toBe(1)
 
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
@@ -210,16 +287,22 @@ describe('use-cache-hanging-inputs', () => {
     at Page [Server] (<anonymous>)`
           )
         } else {
-          expect(errorDescription).toBe(expectedErrorMessage)
+          expect(errorDescription).toBe(expectedTimeoutErrorMessage)
 
           if (isTurbopack) {
-            // TODO(veil): For Turbopack, a fix in the React Flight Client, where
-            // sourceURL is encoded, is needed for the error source and stack
-            // frames to be source mapped.
+            expect(errorSource).toMatchInlineSnapshot(`
+             "app/bound-args/page.tsx (13:15) @ [project]/app/bound-args/page.tsx [app-rsc] (ecmascript)
 
-            expect(errorSource).toBe(null)
+               11 |   const uncachedDataPromise = fetchUncachedData()
+               12 |
+             > 13 |   const Foo = async () => {
+                  |               ^
+               14 |     'use cache'
+               15 |
+               16 |     return ("
+            `)
 
-            expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+            expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at [project]/app/bound-args/page.tsx [app-rsc] (ecmascript)`)
           } else {
             expect(errorSource).toMatchInlineSnapshot(`
@@ -234,7 +317,7 @@ describe('use-cache-hanging-inputs', () => {
                16 |     return ("
             `)
 
-            expect(cliOutput).toContain(`Error: ${expectedErrorMessage}
+            expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at eval (app/bound-args/page.tsx:13:14)`)
           }
         }
@@ -262,23 +345,41 @@ describe('use-cache-hanging-inputs', () => {
     it('should fail the build with errors after a timeout', async () => {
       const { cliOutput } = await next.build()
 
-      expect(cliOutput).toInclude(`Error: ${expectedErrorMessage}`)
-
       expect(cliOutput).toInclude(
-        'Error occurred prerendering page "/bound-args"'
+        createExpectedBuildErrorMessage('/error', 'kaputt!')
       )
 
       expect(cliOutput).toInclude(
-        'Error occurred prerendering page "/search-params"'
+        createExpectedBuildErrorMessage('/bound-args')
       )
 
       expect(cliOutput).toInclude(
-        'Error occurred prerendering page "/uncached-promise"'
+        createExpectedBuildErrorMessage('/fallback-params/[slug]')
       )
 
       expect(cliOutput).toInclude(
-        'Error occurred prerendering page "/uncached-promise-nested"'
+        createExpectedBuildErrorMessage('/search-params')
+      )
+
+      expect(cliOutput).toInclude(
+        createExpectedBuildErrorMessage('/search-params-caught')
+      )
+
+      expect(cliOutput).toInclude(
+        createExpectedBuildErrorMessage('/uncached-promise')
+      )
+
+      expect(cliOutput).toInclude(
+        createExpectedBuildErrorMessage('/uncached-promise-nested')
       )
     }, 180_000)
   }
 })
+
+function createExpectedBuildErrorMessage(
+  pathname: string,
+  errorMessage: string = expectedTimeoutErrorMessage
+) {
+  return `Error occurred prerendering page "${pathname}". Read more: https://nextjs.org/docs/messages/prerender-error
+Error: ${errorMessage}`
+}


### PR DESCRIPTION
When `dynamicIO` is enabled and a `"use cache"` function accesses dynamic request APIs, we fail the prerendering with a timeout error after 50 seconds.

This error could be swallowed in userland code however, when the cached function is wrapped in a try/catch block. That's not the intended behavior, so we now fail the prerendering (or dynamic validation in dev mode) with the timeout error in this case as well, using the same approach as in #77838.

This also works around a bug that led to the timeout errors not being source-mapped correctly with Turbopack.

In a future PR, we will adapt the behaviour for prerendering of fallback shells that are allowed to be empty, in which case the timeout must not fail the build.