### PR TITLE
chore(CI): Add Rspack labeler config

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -1,3 +1,4 @@
+// This is a JSON5 file, processed by https://github.com/vercel/next-labeler-webhook/
 {
   "labels": {
     "create-next-app": ["packages/create-next-app/**"],
@@ -6,6 +7,37 @@
     "Font (next/font)": ["**/*font*"],
     "tests": ["test/**", "bench/**"],
     "Turbopack": ["crates/next-*/**", "crates/napi/**", "turbopack/**"],
+    "Rspack": [
+      // Usernames sourced from: https://rspack.dev/misc/team/core-team
+      // This label determines whether or not to run the Rspack CI alongside the normal CI jobs
+      { "type": "user", "pattern": "9aoy" },
+      { "type": "user", "pattern": "ahabhgk" },
+      { "type": "user", "pattern": "bvanjoi" },
+      { "type": "user", "pattern": "chenjiahan" },
+      { "type": "user", "pattern": "CPunisher" },
+      { "type": "user", "pattern": "easy1090" },
+      { "type": "user", "pattern": "fi3ework" },
+      { "type": "user", "pattern": "GiveMe-A-Name" },
+      { "type": "user", "pattern": "h-a-n-a" },
+      { "type": "user", "pattern": "hardfist" },
+      { "type": "user", "pattern": "inottn" },
+      { "type": "user", "pattern": "jerrykingxyz" },
+      { "type": "user", "pattern": "JSerFeng" },
+      { "type": "user", "pattern": "lingyucoder" },
+      { "type": "user", "pattern": "nyqykk" },
+      { "type": "user", "pattern": "sanyuan0704" },
+      { "type": "user", "pattern": "ScriptedAlchemy" },
+      { "type": "user", "pattern": "SoonIter" },
+      { "type": "user", "pattern": "stormslowly" },
+      { "type": "user", "pattern": "SyMind" },
+      { "type": "user", "pattern": "Timeless0911" },
+      { "type": "user", "pattern": "valorkin" },
+      { "type": "user", "pattern": "xc2" },
+      { "type": "user", "pattern": "zackarychapple" },
+      { "type": "user", "pattern": "zoolsher" },
+      // these files are mostly webpack plugins/configs
+      "packages/next/src/build/**"
+    ],
     "created-by: Chrome Aurora": [
       { "type": "user", "pattern": "atcastle" },
       { "type": "user", "pattern": "devknoll" },


### PR DESCRIPTION
This should automatically add the `Rspack` label in most cases, which should let us run the rspack CI in theses cases.

There's an issue with the current CI config where the build-and-test job isn't triggered by label changes, so I'll need to make some changes there, but this is a start.

Closes PACK-4565