### PR TITLE
perf(turbopack): Remove needless clone of SWC AST

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -680,7 +680,6 @@ impl EsmExports {
         Ok(CodeGeneration::new(
             vec![],
             [dynamic_stmt
-                .clone()
                 .map(|stmt| CodeGenerationHoistedStmt::new("__turbopack_dynamic__".into(), stmt))]
             .into_iter()
             .flatten()
@@ -689,7 +688,7 @@ impl EsmExports {
                 "__turbopack_esm__".into(),
                 quote!("$turbopack_esm($getters);" as Stmt,
                     turbopack_esm: Expr = TURBOPACK_ESM.into(),
-                    getters: Expr = getters.clone()
+                    getters: Expr = getters
                 ),
             )],
         ))


### PR DESCRIPTION
### What?

Part of the memory usage reduction task.

### Why?

We don't need to clone the AST.


Closes PACK-4566