### PR TITLE
perf(turbopack): Precompute source ident for `RuleCondition#matches`

### DIFF
--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -56,8 +56,12 @@ impl ModuleRule {
         path: &FileSystemPath,
         reference_type: &ReferenceType,
     ) -> Result<bool> {
+        let source_ident = source.ident().await?;
+
         Ok(self.match_mode.matches(reference_type)
-            && self.condition.matches(source, path, reference_type).await?)
+            && self
+                .condition
+                .matches(source, &source_ident, path, reference_type)?)
     }
 }
 

--- a/turbopack/crates/turbopack/src/module_options/transition_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/transition_rule.rs
@@ -55,7 +55,11 @@ impl TransitionRule {
         path: &FileSystemPath,
         reference_type: &ReferenceType,
     ) -> Result<bool> {
+        let source_ident = source.ident().await?;
+
         Ok(self.match_mode.matches(reference_type)
-            && self.condition.matches(source, path, reference_type).await?)
+            && self
+                .condition
+                .matches(source, &source_ident, path, reference_type)?)
     }
 }


### PR DESCRIPTION
### What?

Precompute the source identifier before calling `RuleCondition#matches`.

This is an easy way to optimize `RuleCondition#matches`. It may regress because turbopack now always computes `source.ident()`, but I assume the identifier of the source is computed anyway. If this does not work, I'll refactor `RuleCondition` to sync vs async variant.

### Why?

According to the heaptrack profiling result, `Box::pin` in the previous code allocated more than a GB of memory.


### How?

 - Closes PACK-4560
