### PR TITLE
chore(CI): Add back test retries (again) to arewerspackyet tests

### DIFF
--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -22,6 +22,4 @@ jobs:
       integration_groups: 12
       e2e_timeout_minutes: 90
       integration_timeout_minutes: 90
-      # We tend to timeout with 2 retries
-      num_retries: 0
     secrets: inherit

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -22,6 +22,4 @@ jobs:
       integration_groups: 16
       e2e_timeout_minutes: 90
       integration_timeout_minutes: 90
-      # We tend to timeout with 2 retries
-      num_retries: 0
     secrets: inherit


### PR DESCRIPTION
Test retries are important because of our high test flakiness. Without this, we may get false-positive failures detected in the manifests and the arewerspackyet dataset.

We had to disable test retries for arewerspackyet tests because we were suffering from timeouts in CI. Since then we've fixed this in a number of ways:

- I split 5 large test suites that were contributing most to long job execution duration when timing out into smaller test suites that can run in parallel.
- I reduced the per-test timeout from 4 minutes back down to 1 minute (same as the webpack tests use) for both Rspack and Turbopack.
- The Rspack team fixed the underlying regressions that were causing increased test failures in our CI. 🙏
- Going forward, I'm working on running Rspack CI in more places, so a regression on tests is will be much less likely in the first place.

Rspack test runs are taking <20 minutes (with a 90 minute timeout), so it seems safe to add back the default 2 retries!

This only impacts the nightly arewerspackyet CI runs, so the CI capacity hit from retries shouldn't be too significant.

Closes PACK-4580