### PR TITLE
fix(CI): Remove comments from labeler config

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -1,4 +1,3 @@
-// This is a JSON5 file, processed by https://github.com/vercel/next-labeler-webhook/
 {
   "labels": {
     "create-next-app": ["packages/create-next-app/**"],
@@ -8,8 +7,6 @@
     "tests": ["test/**", "bench/**"],
     "Turbopack": ["crates/next-*/**", "crates/napi/**", "turbopack/**"],
     "Rspack": [
-      // Usernames sourced from: https://rspack.dev/misc/team/core-team
-      // This label determines whether or not to run the Rspack CI alongside the normal CI jobs
       { "type": "user", "pattern": "9aoy" },
       { "type": "user", "pattern": "ahabhgk" },
       { "type": "user", "pattern": "bvanjoi" },
@@ -35,7 +32,6 @@
       { "type": "user", "pattern": "xc2" },
       { "type": "user", "pattern": "zackarychapple" },
       { "type": "user", "pattern": "zoolsher" },
-      // these files are mostly webpack plugins/configs
       "packages/next/src/build/**"
     ],
     "created-by: Chrome Aurora": [


### PR DESCRIPTION
The labeler reads this as json5 here: https://github.com/vercel/next-labeler-webhook/blob/1ecc3b54c2b03fae950c7cb2dd859cf63c3e8684/src/app/api/label/utils/fetchConfig.ts#L1

But apparently something else is also reading it and expecting JSON?

![Screenshot 2025-05-09 at 4.47.49 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/625ba150-a5d1-4e93-b6f8-37907f93a06b.png)

Closes PACK-4568