### PR TITLE
[release] couple `next` and `@next/swc` versions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["next", "@next/swc"]],
   "linked": [],
   "access": "public",
   "baseBranch": "canary",

--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -11,9 +11,7 @@ const cwd = process.cwd()
   try {
     const publishSema = new Sema(2)
 
-    let version = JSON.parse(
-      await readFile(path.join(cwd, 'lerna.json'))
-    ).version
+    let version = require('@next/swc/package.json').version
 
     // Copy binaries to package folders, update version, and publish
     let nativePackagesDir = path.join(cwd, 'crates/napi/npm')


### PR DESCRIPTION
### Why?

Since Next.js emits a debug warning to help catch when a stale `@next/swc` version is being used, couple their versions to be published together.

https://github.com/vercel/next.js/blob/3f2a3647ee619c92f2d576b83dfde748003a7f31/packages/next/src/build/swc/index.ts#L131-L139
