### PR TITLE
[release] use changesets/action for canary release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["next", "@next/swc"]],
   "linked": [],
   "access": "public",
   "baseBranch": "canary",

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -610,6 +610,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
 
       - name: Upload npm log artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           # TODO: Remove the new release check once the new release workflow is fully replaced.
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-          if [[ $RELEASE_CHECK =~ ^Version\ Packages$ ]];
+          if [[ $RELEASE_CHECK =~ ^Version\ Packages\ \((canary|stable)\)$ ]];
           then
             echo "__NEW_RELEASE=true" >> $GITHUB_ENV
           elif [[ $RELEASE_CHECK = v* ]];

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,7 +20,8 @@ env:
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
   MACOSX_DEPLOYMENT_TARGET: 11.0
   # This will become "true" if the latest commit is
-  # "Version Packages", set from check-is-release.js
+  # "Version Packages (canary|release-candidate|stable)"
+  # set from scripts/check-is-release.js
   __NEW_RELEASE: 'false'
 
 jobs:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,7 +20,7 @@ env:
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
   MACOSX_DEPLOYMENT_TARGET: 11.0
   # This will become "true" if the latest commit is
-  # "Version Packages (canary|stable)"
+  # "Version Packages" or "Version Pacakges (canary)"
   # set from scripts/check-is-release.js
   __NEW_RELEASE: 'false'
 
@@ -50,7 +50,7 @@ jobs:
         run: |
           # TODO: Remove the new release check once the new release workflow is fully replaced.
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-          if [[ $RELEASE_CHECK =~ ^Version\ Packages\ \((canary|stable)\)$ ]];
+          if [[ $RELEASE_CHECK =~ ^Version\ Packages(\ \(canary\))?$ ]];
           then
             echo "__NEW_RELEASE=true" >> $GITHUB_ENV
           elif [[ $RELEASE_CHECK = v* ]];
@@ -608,8 +608,6 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm ci:publish
-          title: Version Packages (${{ github.event.inputs.releaseType }})
-          commit: Version Packages (${{ github.event.inputs.releaseType }})
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,7 +20,7 @@ env:
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
   MACOSX_DEPLOYMENT_TARGET: 11.0
   # This will become "true" if the latest commit is
-  # "Version Packages (canary|release-candidate|stable)"
+  # "Version Packages (canary|stable)"
   # set from scripts/check-is-release.js
   __NEW_RELEASE: 'false'
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -607,10 +607,19 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm ci:publish
+          title: Version Packages (${{ github.event.inputs.releaseType }})
+          commit: Version Packages (${{ github.event.inputs.releaseType }})
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
           RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
+
+      # Add label to verify the PR is created from this workflow.
+      - name: Add label to PR
+        if: steps.changesets.outputs.pullRequestNumber
+        run: 'gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "created-by: CI"'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload npm log artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/force_merge_canary_release_pr.yml
+++ b/.github/workflows/force_merge_canary_release_pr.yml
@@ -2,9 +2,8 @@ name: Force Merge Canary Release PR
 
 on: pull_request
 
-# Limit the permissions of GITHUB_TOKEN for this
-# workflow which is security good practice.
 permissions:
+  # To bypass and merge PR
   pull-requests: write
 
 jobs:

--- a/.github/workflows/force_merge_canary_release_pr.yml
+++ b/.github/workflows/force_merge_canary_release_pr.yml
@@ -1,0 +1,24 @@
+name: Force Merge Canary Release PR
+
+on: pull_request
+
+# Limit the permissions of GITHUB_TOKEN for this
+# workflow which is good practice.
+permissions:
+  pull-requests: write
+
+jobs:
+  force-merge-canary-release-pr:
+    runs-on: ubuntu-latest
+    # Validate the login, PR title, and the label to ensure the PR is
+    # from the release PR and prevent spoofing.
+    if: |
+      github.event.pull_request.user.login == 'vercel-release-bot' &&
+      github.event.pull_request.title == 'Version Packages (canary)' &&
+      contains(github.event.pull_request.labels.*.name, 'created-by: CI')
+    steps:
+      - name: Bypass required status checks and merge PR
+        run: gh pr merge --admin --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/force_merge_canary_release_pr.yml
+++ b/.github/workflows/force_merge_canary_release_pr.yml
@@ -3,7 +3,7 @@ name: Force Merge Canary Release PR
 on: pull_request
 
 # Limit the permissions of GITHUB_TOKEN for this
-# workflow which is good practice.
+# workflow which is security good practice.
 permissions:
   pull-requests: write
 

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -2,8 +2,10 @@ name: Trigger Release (New)
 
 on:
   # Run every day at 23:15 UTC
-  schedule:
-    - cron: '15 23 * * *'
+  # TODO: Disabled cron for now, but uncomment
+  # once replaced the old release workflow.
+  # schedule:
+  #   - cron: '15 23 * * *'
   # Run manually
   workflow_dispatch:
     inputs:

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -8,8 +8,7 @@ on:
         required: true
         type: choice
         options:
-          # TODO: Follow up enable the case.
-          # - canary
+          - canary
           - stable
           # TODO: Follow up enable the case.
           # - release-candidate

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -1,12 +1,18 @@
 name: Trigger Release (New)
 
 on:
+  # Run every day at 23:15 UTC
+  schedule:
+    - cron: '15 23 * * *'
+  # Run manually
   workflow_dispatch:
     inputs:
       releaseType:
         description: Release Type
         required: true
         type: choice
+        # Cron job will run canary release
+        default: canary
         options:
           - canary
           - stable
@@ -24,6 +30,11 @@ env:
   NAPI_CLI_VERSION: 2.14.7
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20
+
+# Limit the permissions of GITHUB_TOKEN for this
+# workflow which is good practice.
+permissions:
+  pull-requests: write
 
 jobs:
   start:

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -32,7 +32,7 @@ env:
   NODE_LTS_VERSION: 20
 
 # Limit the permissions of GITHUB_TOKEN for this
-# workflow which is good practice.
+# workflow which is good security practice.
 permissions:
   pull-requests: write
 

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -33,9 +33,8 @@ env:
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20
 
-# Limit the permissions of GITHUB_TOKEN for this
-# workflow which is good security practice.
 permissions:
+  # To create PR
   pull-requests: write
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "turbo run dev --parallel",
     "pack-next": "tsx scripts/pack-next.ts",
     "ci:version": "tsx ./scripts/release/version-packages.ts",
-    "ci:publish": "changeset publish",
+    "ci:publish": "tsx ./scripts/release/publish-npm.ts",
     "test-types": "tsc",
     "test-unit": "jest test/unit/ packages/next/ packages/font",
     "test-dev": "cross-env NEXT_TEST_MODE=dev pnpm testheadless",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lerna": "lerna",
     "dev": "turbo run dev --parallel",
     "pack-next": "tsx scripts/pack-next.ts",
-    "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
+    "ci:version": "tsx ./scripts/release/version-packages.ts",
     "ci:publish": "changeset publish",
     "test-types": "tsc",
     "test-unit": "jest test/unit/ packages/next/ packages/font",

--- a/scripts/check-is-release.js
+++ b/scripts/check-is-release.js
@@ -13,8 +13,7 @@ const checkIsRelease = async () => {
 
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
-  const newPublishMsgRegex =
-    /^Version Packages \((canary|release-candidate|stable)\)$/
+  const newPublishMsgRegex = /^Version Packages( \(canary\))?$/
 
   if (publishMsgRegex.test(versionString)) {
     console.log(versionString)

--- a/scripts/check-is-release.js
+++ b/scripts/check-is-release.js
@@ -13,7 +13,8 @@ const checkIsRelease = async () => {
 
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
-  const newPublishMsgRegex = /^Version Packages$/
+  const newPublishMsgRegex =
+    /^Version Packages \((canary|release-candidate|stable)\)$/
 
   if (publishMsgRegex.test(versionString)) {
     console.log(versionString)

--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -11,9 +11,7 @@ const cwd = process.cwd()
   try {
     const publishSema = new Sema(2)
 
-    let version = JSON.parse(
-      await readFile(path.join(cwd, 'lerna.json'))
-    ).version
+    let version = require('@next/swc/package.json').version
 
     // Copy binaries to package folders, update version, and publish
     let nativePackagesDir = path.join(cwd, 'crates/napi/npm')

--- a/scripts/release/publish-npm.ts
+++ b/scripts/release/publish-npm.ts
@@ -1,0 +1,20 @@
+import execa from 'execa'
+
+async function publishNpm() {
+  const releaseType = process.env.RELEASE_TYPE
+  const tag =
+    releaseType === 'canary'
+      ? 'canary'
+      : releaseType === 'release-candidate'
+        ? 'rc'
+        : 'latest'
+
+  await execa('pnpm', ['publish', '--recursive', '--tag', tag], {
+    stdio: 'inherit',
+  })
+  await execa('pnpm', ['changeset', 'tag'], {
+    stdio: 'inherit',
+  })
+}
+
+publishNpm()

--- a/scripts/release/publish-npm.ts
+++ b/scripts/release/publish-npm.ts
@@ -9,11 +9,7 @@ async function publishNpm() {
         ? 'rc'
         : 'latest'
 
-  await execa('pnpm', ['publish', '--recursive', '--tag', tag], {
-    stdio: 'inherit',
-  })
-  // The tag will be pushed when changesets/action releases the GitHub Release.
-  await execa('pnpm', ['changeset', 'tag'], {
+  await execa('pnpm', ['changeset', 'publish', '--tag', tag], {
     stdio: 'inherit',
   })
 }

--- a/scripts/release/publish-npm.ts
+++ b/scripts/release/publish-npm.ts
@@ -12,6 +12,7 @@ async function publishNpm() {
   await execa('pnpm', ['publish', '--recursive', '--tag', tag], {
     stdio: 'inherit',
   })
+  // The tag will be pushed when changesets/action releases the GitHub Release.
   await execa('pnpm', ['changeset', 'tag'], {
     stdio: 'inherit',
   })

--- a/scripts/release/version-packages.ts
+++ b/scripts/release/version-packages.ts
@@ -23,6 +23,8 @@ async function versionPackages() {
     await execa('pnpm', ['changeset', 'pre', 'enter', 'canary'], {
       stdio: 'inherit',
     })
+    // TODO: Create empty changeset for `next` to bump canary version
+    // even if there is no changeset.
   }
 
   await execa('pnpm', ['changeset', 'version'], {

--- a/scripts/release/version-packages.ts
+++ b/scripts/release/version-packages.ts
@@ -1,0 +1,36 @@
+import execa from 'execa'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+async function versionPackages() {
+  const preConfigPath = join(process.cwd(), '.changeset', 'pre.json')
+
+  // Exit previous pre mode to prepare for the next release.
+  if (existsSync(preConfigPath)) {
+    if (require(preConfigPath).mode !== 'exit') {
+      // Since current repository is in pre mode, need
+      // to exit before versioning the packages.
+      await execa('pnpm', ['changeset', 'pre', 'exit'], {
+        stdio: 'inherit',
+      })
+    }
+  }
+
+  const releaseType = process.env.RELEASE_TYPE
+
+  if (releaseType === 'canary') {
+    // Enter pre mode as "canary" tag.
+    await execa('pnpm', ['changeset', 'pre', 'enter', 'canary'], {
+      stdio: 'inherit',
+    })
+  }
+
+  await execa('pnpm', ['changeset', 'version'], {
+    stdio: 'inherit',
+  })
+  await execa('pnpm', ['install', '--no-frozen-lockfile'], {
+    stdio: 'inherit',
+  })
+}
+
+versionPackages()


### PR DESCRIPTION
This PR uses `changesets/action` to handle the canary release. Since the action creates a Version Packages PR by default, I added a GH Action that checks if the PR is released from the correct release workflow. It triple-verifies via the user login (`vercel-release-bot`), PR title (`Version Packages (canary)`), and a label (`created-by: CI`) to ensure the opened PR is not trying to spoof.

After the validation, the PR bypasses required checks, is merged into the canary branch, and proceeds with the rest of the release process.

### Testing Plan

Try running `ci:version` and `ci:publish` locally, and handle the release type via env `RELEASE_TYPE`.

Confirmed the CI force merge on https://github.com/devjiwonchoi/lab-releases/pull/13