### PR TITLE
[release] create empty changeset for next when no changeset found during canary release

### DIFF
--- a/scripts/release/version-packages.ts
+++ b/scripts/release/version-packages.ts
@@ -43,6 +43,8 @@ async function versionPackages() {
       console.log(
         '▲   No changesets found for `next`, creating an empty changeset.'
       )
+      // TODO: Since this is temporary until we hard-require a changeset, we will
+      // need to remove this in the future to prevent publishing empty releases.
       await writeFile(
         join(process.cwd(), '.changeset', `next-canary-${Date.now()}.md`),
         `---\n'next': patch\n---`

--- a/scripts/release/version-packages.ts
+++ b/scripts/release/version-packages.ts
@@ -25,10 +25,24 @@ async function versionPackages() {
       stdio: 'inherit',
     })
 
-    // Create empty changeset for `next` to bump canary version even if
-    // there was no changeset.
-    const res = await execa('pnpm', ['changeset', 'version'])
-    if (res.stderr.includes('No unreleased changesets found, exiting.')) {
+    console.log(
+      '▲   Preparing to bump the canary version, checking if there are any changesets.'
+    )
+    // Create an empty changeset for `next` to bump the canary version
+    // even if there are no changesets for `next`.
+    const res = await execa('pnpm', ['changeset', 'status'], {
+      // If there are no changesets, this will error. Set reject: false
+      // to avoid trycatch and handle the rest based on the stdout.
+      reject: false,
+    })
+
+    console.log('▲   Changeset Status:')
+    console.log({ ...res })
+
+    if (!res.stdout.includes('- next')) {
+      console.log(
+        '▲   No changesets found for `next`, creating an empty changeset.'
+      )
       await writeFile(
         join(process.cwd(), '.changeset', `next-canary-${Date.now()}.md`),
         `---\n'next': patch\n---`


### PR DESCRIPTION
### Why?

When there are no changesets for `next`, the canary release won't be published even if there are new commits. If this is the case, add an empty changeset for `next` to let the canary release proceed.

Note that this will result in an empty Changelog and GitHub Release, but this PR does not cover handling that part.

### Testing Plan

Set env `RELEASE_TYPE=canary` and run `ci:version` locally to see the result.