### PR TITLE
Turbopack: refactor into `traverse_edges_fixed_point`

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -342,6 +342,8 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
             (ChunkGroupId, FxIndexSet<ResolvedVc<Box<dyn Module>>>),
         > = FxIndexMap::default();
 
+        // For each module, the indices in the bitmap store which chunk groups in `chunk_groups_map`
+        // that module is part of.
         let mut module_chunk_groups: FxHashMap<ResolvedVc<Box<dyn Module>>, RoaringBitmapWrapper> =
             FxHashMap::default();
 

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::BinaryHeap,
     hash::Hash,
     ops::{Deref, DerefMut},
 };
@@ -8,7 +7,7 @@ use anyhow::{bail, Result};
 use either::Either;
 use indexmap::map::Entry;
 use roaring::RoaringBitmap;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
@@ -20,10 +19,7 @@ use turbo_tasks::{
 use crate::{
     chunk::ChunkingType,
     module::Module,
-    module_graph::{
-        get_node, get_node_idx, traced_di_graph::iter_neighbors_rev, GraphNodeIndex,
-        GraphTraversalAction, ModuleGraph, SingleModuleGraphModuleNode, SingleModuleGraphNode,
-    },
+    module_graph::{GraphTraversalAction, ModuleGraph, SingleModuleGraphModuleNode},
 };
 
 #[derive(
@@ -308,17 +304,16 @@ impl Deref for ChunkGroupId {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct NodeWithPriority {
+struct TraversalPriority {
     depth: usize,
     chunk_group_len: u64,
-    node: GraphNodeIndex,
 }
-impl PartialOrd for NodeWithPriority {
+impl PartialOrd for TraversalPriority {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
-impl Ord for NodeWithPriority {
+impl Ord for TraversalPriority {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // BinaryHeap prioritizes high values
 
@@ -327,10 +322,7 @@ impl Ord for NodeWithPriority {
         // Smaller group length has higher priority
         let chunk_group_len_order = self.chunk_group_len.cmp(&other.chunk_group_len).reverse();
 
-        depth_order
-            .then(chunk_group_len_order)
-            // include GraphNodeIndex for total and deterministic ordering
-            .then(other.node.cmp(&self.node))
+        depth_order.then(chunk_group_len_order)
     }
 }
 
@@ -357,30 +349,34 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
         let module_count = graphs.iter().map(|g| g.graph.node_count()).sum::<usize>();
         span.record("module_count", module_count);
 
-        // First, compute the depth for each module in the graph
-        let mut module_depth: FxHashMap<ResolvedVc<Box<dyn Module>>, usize> = FxHashMap::default();
         // use all entries from all graphs
         let entries = graphs
             .iter()
             .flat_map(|g| g.entries.iter())
             .collect::<Vec<_>>();
-        graph
-            .traverse_edges_from_entries_bfs(
-                entries.iter().flat_map(|e| e.entries()),
-                |parent, node| {
-                    if let Some((parent, _)) = parent {
-                        let parent_depth = *module_depth.get(&parent.module).unwrap();
-                        module_depth.entry(node.module).or_insert(parent_depth + 1);
-                    } else {
-                        module_depth.insert(node.module, 0);
-                    };
 
-                    module_chunk_groups.insert(node.module, RoaringBitmapWrapper::default());
+        // First, compute the depth for each module in the graph
+        let module_depth: FxHashMap<ResolvedVc<Box<dyn Module>>, usize> = {
+            let mut module_depth = FxHashMap::default();
+            graph
+                .traverse_edges_from_entries_bfs(
+                    entries.iter().flat_map(|e| e.entries()),
+                    |parent, node| {
+                        if let Some((parent, _)) = parent {
+                            let parent_depth = *module_depth.get(&parent.module).unwrap();
+                            module_depth.entry(node.module).or_insert(parent_depth + 1);
+                        } else {
+                            module_depth.insert(node.module, 0);
+                        };
 
-                    GraphTraversalAction::Continue
-                },
-            )
-            .await?;
+                        module_chunk_groups.insert(node.module, RoaringBitmapWrapper::default());
+
+                        GraphTraversalAction::Continue
+                    },
+                )
+                .await?;
+            module_depth
+        };
 
         // ----
 
@@ -446,205 +442,171 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraph) -> Result<Vc<ChunkGro
             })
             .collect::<FxHashMap<_, _>>();
 
-        let mut visitor =
-            |parent_info: Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
-             node: &'_ SingleModuleGraphModuleNode,
-             module_chunk_groups: &mut FxHashMap<
-                ResolvedVc<Box<dyn Module>>,
-                RoaringBitmapWrapper,
-            >|
-             -> GraphTraversalAction {
-                enum ChunkGroupInheritance<It: Iterator<Item = ChunkGroupKey>> {
-                    Inherit(ResolvedVc<Box<dyn Module>>),
-                    ChunkGroup(It),
-                }
-                let chunk_groups = if let Some((parent, chunking_type)) = parent_info {
-                    match chunking_type {
-                        ChunkingType::Parallel { .. } => {
-                            ChunkGroupInheritance::Inherit(parent.module)
-                        }
-                        ChunkingType::Async => ChunkGroupInheritance::ChunkGroup(Either::Left(
-                            std::iter::once(ChunkGroupKey::Async(node.module)),
-                        )),
-                        ChunkingType::Isolated {
-                            merge_tag: None, ..
-                        } => ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
-                            ChunkGroupKey::Isolated(node.module),
-                        ))),
-                        ChunkingType::Shared {
-                            merge_tag: None, ..
-                        } => ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
-                            ChunkGroupKey::Shared(node.module),
-                        ))),
-                        ChunkingType::Isolated {
-                            merge_tag: Some(merge_tag),
-                            ..
-                        } => {
-                            let parents = module_chunk_groups.get(&parent.module).unwrap();
-                            let chunk_groups =
-                                parents.iter().map(|parent| ChunkGroupKey::IsolatedMerged {
-                                    parent: ChunkGroupId(parent),
-                                    merge_tag: merge_tag.clone(),
-                                });
-                            ChunkGroupInheritance::ChunkGroup(Either::Right(Either::Left(
-                                chunk_groups,
-                            )))
-                        }
-                        ChunkingType::Shared {
-                            merge_tag: Some(merge_tag),
-                            ..
-                        } => {
-                            let parents = module_chunk_groups.get(&parent.module).unwrap();
-                            let chunk_groups =
-                                parents.iter().map(|parent| ChunkGroupKey::SharedMerged {
-                                    parent: ChunkGroupId(parent),
-                                    merge_tag: merge_tag.clone(),
-                                });
-                            ChunkGroupInheritance::ChunkGroup(Either::Right(Either::Right(
-                                chunk_groups,
-                            )))
-                        }
-                        ChunkingType::Traced => {
-                            // Traced modules are not placed in chunk groups
-                            return GraphTraversalAction::Skip;
-                        }
+        let visit_count = graph
+            .traverse_edges_fixed_point(
+                entries.iter().flat_map(|e| e.entries()).map(|e| {
+                    (
+                        e,
+                        TraversalPriority {
+                            depth: *module_depth.get(&e).unwrap(),
+                            chunk_group_len: 0,
+                        },
+                    )
+                }),
+                &mut module_chunk_groups,
+                |parent_info: Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+                 node: &'_ SingleModuleGraphModuleNode,
+                 module_chunk_groups: &mut FxHashMap<
+                    ResolvedVc<Box<dyn Module>>,
+                    RoaringBitmapWrapper,
+                >|
+                 -> GraphTraversalAction {
+                    enum ChunkGroupInheritance<It: Iterator<Item = ChunkGroupKey>> {
+                        Inherit(ResolvedVc<Box<dyn Module>>),
+                        ChunkGroup(It),
                     }
-                } else {
-                    ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
-                        entry_chunk_group_keys.get(&node.module).unwrap().clone(),
-                    )))
-                };
-
-                match chunk_groups {
-                    ChunkGroupInheritance::ChunkGroup(chunk_groups) => {
-                        // Start of a new chunk group, don't inherit anything from parent
-                        let chunk_group_ids = chunk_groups.map(|chunk_group| {
-                            let len = chunk_groups_map.len();
-                            let is_merged = matches!(
-                                chunk_group,
-                                ChunkGroupKey::IsolatedMerged { .. }
-                                    | ChunkGroupKey::SharedMerged { .. }
-                            );
-                            match chunk_groups_map.entry(chunk_group) {
-                                Entry::Occupied(mut e) => {
-                                    let (id, merged_entries) = e.get_mut();
-                                    if is_merged {
-                                        merged_entries.insert(node.module);
-                                    }
-                                    **id
-                                }
-                                Entry::Vacant(e) => {
-                                    let chunk_group_id = len as u32;
-                                    let mut set = FxIndexSet::default();
-                                    if is_merged {
-                                        set.insert(node.module);
-                                    }
-                                    e.insert((ChunkGroupId(chunk_group_id), set));
-                                    chunk_group_id
-                                }
+                    let chunk_groups = if let Some((parent, chunking_type)) = parent_info {
+                        match chunking_type {
+                            ChunkingType::Parallel { .. } => {
+                                ChunkGroupInheritance::Inherit(parent.module)
                             }
-                        });
-
-                        let chunk_groups =
-                            RoaringBitmapWrapper(RoaringBitmap::from_iter(chunk_group_ids));
-
-                        // Assign chunk group to the target node (the entry of the chunk group)
-                        let bitset = module_chunk_groups.get_mut(&node.module).unwrap();
-                        if chunk_groups.is_proper_superset(bitset) {
-                            // Add bits from parent, and continue traversal because changed
-                            **bitset |= chunk_groups.into_inner();
-
-                            GraphTraversalAction::Continue
-                        } else {
-                            // Unchanged, no need to forward to children
-                            GraphTraversalAction::Skip
+                            ChunkingType::Async => ChunkGroupInheritance::ChunkGroup(Either::Left(
+                                std::iter::once(ChunkGroupKey::Async(node.module)),
+                            )),
+                            ChunkingType::Isolated {
+                                merge_tag: None, ..
+                            } => ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
+                                ChunkGroupKey::Isolated(node.module),
+                            ))),
+                            ChunkingType::Shared {
+                                merge_tag: None, ..
+                            } => ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
+                                ChunkGroupKey::Shared(node.module),
+                            ))),
+                            ChunkingType::Isolated {
+                                merge_tag: Some(merge_tag),
+                                ..
+                            } => {
+                                let parents = module_chunk_groups.get(&parent.module).unwrap();
+                                let chunk_groups =
+                                    parents.iter().map(|parent| ChunkGroupKey::IsolatedMerged {
+                                        parent: ChunkGroupId(parent),
+                                        merge_tag: merge_tag.clone(),
+                                    });
+                                ChunkGroupInheritance::ChunkGroup(Either::Right(Either::Left(
+                                    chunk_groups,
+                                )))
+                            }
+                            ChunkingType::Shared {
+                                merge_tag: Some(merge_tag),
+                                ..
+                            } => {
+                                let parents = module_chunk_groups.get(&parent.module).unwrap();
+                                let chunk_groups =
+                                    parents.iter().map(|parent| ChunkGroupKey::SharedMerged {
+                                        parent: ChunkGroupId(parent),
+                                        merge_tag: merge_tag.clone(),
+                                    });
+                                ChunkGroupInheritance::ChunkGroup(Either::Right(Either::Right(
+                                    chunk_groups,
+                                )))
+                            }
+                            ChunkingType::Traced => {
+                                // Traced modules are not placed in chunk groups
+                                return GraphTraversalAction::Skip;
+                            }
                         }
-                    }
-                    ChunkGroupInheritance::Inherit(parent) => {
-                        // Inherit chunk groups from parent, merge parent chunk groups into current
+                    } else {
+                        ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
+                            entry_chunk_group_keys.get(&node.module).unwrap().clone(),
+                        )))
+                    };
 
-                        if parent == node.module {
-                            // A self-reference
-                            GraphTraversalAction::Skip
-                        } else {
-                            // Fast path
-                            let [Some(parent_chunk_groups), Some(current_chunk_groups)] =
-                                module_chunk_groups.get_disjoint_mut([&parent, &node.module])
-                            else {
-                                // All modules are inserted in the previous iteration
-                                unreachable!()
-                            };
+                    match chunk_groups {
+                        ChunkGroupInheritance::ChunkGroup(chunk_groups) => {
+                            // Start of a new chunk group, don't inherit anything from parent
+                            let chunk_group_ids = chunk_groups.map(|chunk_group| {
+                                let len = chunk_groups_map.len();
+                                let is_merged = matches!(
+                                    chunk_group,
+                                    ChunkGroupKey::IsolatedMerged { .. }
+                                        | ChunkGroupKey::SharedMerged { .. }
+                                );
+                                match chunk_groups_map.entry(chunk_group) {
+                                    Entry::Occupied(mut e) => {
+                                        let (id, merged_entries) = e.get_mut();
+                                        if is_merged {
+                                            merged_entries.insert(node.module);
+                                        }
+                                        **id
+                                    }
+                                    Entry::Vacant(e) => {
+                                        let chunk_group_id = len as u32;
+                                        let mut set = FxIndexSet::default();
+                                        if is_merged {
+                                            set.insert(node.module);
+                                        }
+                                        e.insert((ChunkGroupId(chunk_group_id), set));
+                                        chunk_group_id
+                                    }
+                                }
+                            });
 
-                            if current_chunk_groups.is_empty() {
-                                // Initial visit, clone instead of merging
-                                *current_chunk_groups = parent_chunk_groups.clone();
-                                GraphTraversalAction::Continue
-                            } else if parent_chunk_groups.is_proper_superset(current_chunk_groups) {
+                            let chunk_groups =
+                                RoaringBitmapWrapper(RoaringBitmap::from_iter(chunk_group_ids));
+
+                            // Assign chunk group to the target node (the entry of the chunk group)
+                            let bitset = module_chunk_groups.get_mut(&node.module).unwrap();
+                            if chunk_groups.is_proper_superset(bitset) {
                                 // Add bits from parent, and continue traversal because changed
-                                **current_chunk_groups |= &**parent_chunk_groups;
+                                **bitset |= chunk_groups.into_inner();
+
                                 GraphTraversalAction::Continue
                             } else {
                                 // Unchanged, no need to forward to children
                                 GraphTraversalAction::Skip
                             }
                         }
+                        ChunkGroupInheritance::Inherit(parent) => {
+                            // Inherit chunk groups from parent, merge parent chunk groups into
+                            // current
+
+                            if parent == node.module {
+                                // A self-reference
+                                GraphTraversalAction::Skip
+                            } else {
+                                // Fast path
+                                let [Some(parent_chunk_groups), Some(current_chunk_groups)] =
+                                    module_chunk_groups.get_disjoint_mut([&parent, &node.module])
+                                else {
+                                    // All modules are inserted in the previous iteration
+                                    unreachable!()
+                                };
+
+                                if current_chunk_groups.is_empty() {
+                                    // Initial visit, clone instead of merging
+                                    *current_chunk_groups = parent_chunk_groups.clone();
+                                    GraphTraversalAction::Continue
+                                } else if parent_chunk_groups
+                                    .is_proper_superset(current_chunk_groups)
+                                {
+                                    // Add bits from parent, and continue traversal because changed
+                                    **current_chunk_groups |= &**parent_chunk_groups;
+                                    GraphTraversalAction::Continue
+                                } else {
+                                    // Unchanged, no need to forward to children
+                                    GraphTraversalAction::Skip
+                                }
+                            }
+                        }
                     }
-                }
-            };
-
-        let mut visit_count = 0usize;
-
-        {
-            let mut queue_set = FxHashSet::default();
-            let mut queue = BinaryHeap::with_capacity(entries.len());
-            for e in entries.iter().flat_map(|e| e.entries()) {
-                queue.push(NodeWithPriority {
-                    depth: *module_depth.get(&e).unwrap(),
-                    chunk_group_len: 0,
-                    node: ModuleGraph::get_entry(&graphs, e).await?,
-                });
-            }
-            for entry_node in &queue {
-                visitor(
-                    None,
-                    get_node!(graphs, entry_node.node)?,
-                    &mut module_chunk_groups,
-                );
-            }
-            while let Some(NodeWithPriority { node, .. }) = queue.pop() {
-                queue_set.remove(&node);
-                let (node_weight, node) = get_node_idx!(graphs, node)?;
-                let graph = &graphs[node.graph_idx].graph;
-                let neighbors = iter_neighbors_rev(graph, node.node_idx);
-
-                visit_count += 1;
-
-                for (edge, succ) in neighbors {
-                    let succ = GraphNodeIndex {
-                        graph_idx: node.graph_idx,
-                        node_idx: succ,
-                    };
-                    let (succ_weight, succ) = get_node_idx!(graphs, succ)?;
-                    let edge_weight = graph.edge_weight(edge).unwrap();
-                    let action = visitor(
-                        Some((node_weight, edge_weight)),
-                        succ_weight,
-                        &mut module_chunk_groups,
-                    );
-
-                    if action == GraphTraversalAction::Continue && queue_set.insert(succ) {
-                        queue.push(NodeWithPriority {
-                            depth: *module_depth.get(&succ_weight.module).unwrap(),
-                            chunk_group_len: module_chunk_groups
-                                .get(&succ_weight.module)
-                                .unwrap()
-                                .len(),
-                            node: succ,
-                        });
-                    }
-                }
-            }
-        }
+                },
+                |successor, module_chunk_groups| TraversalPriority {
+                    depth: *module_depth.get(&successor.module).unwrap(),
+                    chunk_group_len: module_chunk_groups.get(&successor.module).unwrap().len(),
+                },
+            )
+            .await?;
 
         span.record("visit_count", visit_count);
         span.record("chunk_group_count", chunk_groups_map.len());

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1174,7 +1174,8 @@ impl ModuleGraph {
     /// the graph.
     ///
     /// Nodes are (re)visited according to the returned priority of the node, prioritizing high
-    /// values.
+    /// values. This priority is intended to be used a heuristic to reduce the number of
+    /// retraversals.
     ///
     /// * `entries` - The entry modules to start the traversal from
     /// * `state` - The state to be passed to the callbacks
@@ -1186,8 +1187,9 @@ impl ModuleGraph {
     ///    - Receives: target &SingleModuleGraphNode, state &S
     ///    - Return a priority value for the node
     ///
-    /// Returns the number of node visits (i.e. higher than the node count if there are revisits).
-    pub async fn traverse_edges_fixed_point<S, P: Ord>(
+    /// Returns the number of node visits (i.e. higher than the node count if there are
+    /// retraversals).
+    pub async fn traverse_edges_fixed_point_with_priority<S, P: Ord>(
         &self,
         entries: impl IntoIterator<Item = (ResolvedVc<Box<dyn Module>>, P)>,
         state: &mut S,

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{BinaryHeap, HashSet, VecDeque},
     future::Future,
 };
 
@@ -1155,6 +1155,8 @@ impl ModuleGraph {
         Ok(())
     }
 
+    /// Traverse all cycles in the graph (where the edge filter returns true for the whole cycle)
+    /// and call the visitor with the nodes in the cycle.
     pub async fn traverse_cycles(
         &self,
         edge_filter: impl Fn(&ChunkingType) -> bool,
@@ -1164,6 +1166,106 @@ impl ModuleGraph {
             graph.await?.traverse_cycles(&edge_filter, &mut visit_cycle);
         }
         Ok(())
+    }
+
+    /// Traverses all reachable nodes and also continue revisiting them as long the visitor returns
+    /// GraphTraversalAction::Continue. The visitor is responsible for the runtime complexity and
+    /// eventual termination of the traversal. This corresponds to computing a fixed point state for
+    /// the graph.
+    ///
+    /// Nodes are (re)visited according to the returned priority of the node, prioritizing high
+    /// values.
+    ///
+    /// * `entries` - The entry modules to start the traversal from
+    /// * `state` - The state to be passed to the callbacks
+    /// * `visit` - Called for a specific edge
+    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///      &SingleModuleGraphNode, state &S
+    ///    - Return [GraphTraversalAction]s to control the traversal
+    /// * `priority` - Called for before visiting the children of a node to determine its priority.
+    ///    - Receives: target &SingleModuleGraphNode, state &S
+    ///    - Return a priority value for the node
+    ///
+    /// Returns the number of node visits (i.e. higher that the node count if there are revisits).
+    pub async fn traverse_edges_fixed_point<S, P: Ord>(
+        &self,
+        entries: impl IntoIterator<Item = (ResolvedVc<Box<dyn Module>>, P)>,
+        state: &mut S,
+        mut visit: impl FnMut(
+            Option<(&'_ SingleModuleGraphModuleNode, &'_ ChunkingType)>,
+            &'_ SingleModuleGraphModuleNode,
+            &mut S,
+        ) -> GraphTraversalAction,
+        priority: impl Fn(&'_ SingleModuleGraphModuleNode, &mut S) -> P,
+    ) -> Result<usize> {
+        let graphs = self.get_graphs().await?;
+
+        #[derive(PartialEq, Eq)]
+        struct NodeWithPriority<T: Ord> {
+            node: GraphNodeIndex,
+            priority: T,
+        }
+        impl<T: Ord> PartialOrd for NodeWithPriority<T> {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl<T: Ord> Ord for NodeWithPriority<T> {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                // BinaryHeap prioritizes high values
+
+                self.priority
+                    .cmp(&other.priority)
+                    // include GraphNodeIndex for total and deterministic ordering
+                    .then(other.node.cmp(&self.node))
+            }
+        }
+
+        let mut queue_set = FxHashSet::default();
+        let mut queue = BinaryHeap::from_iter(
+            entries
+                .into_iter()
+                .map(async |(m, priority)| {
+                    Ok(NodeWithPriority {
+                        node: ModuleGraph::get_entry(&graphs, m).await?,
+                        priority,
+                    })
+                })
+                .try_join()
+                .await?,
+        );
+        for entry_node in &queue {
+            visit(None, get_node!(graphs, entry_node.node)?, state);
+        }
+
+        let mut visit_count = 0usize;
+        while let Some(NodeWithPriority { node, .. }) = queue.pop() {
+            queue_set.remove(&node);
+            let (node_weight, node) = get_node_idx!(graphs, node)?;
+            let graph = &graphs[node.graph_idx].graph;
+            let neighbors = iter_neighbors_rev(graph, node.node_idx);
+
+            visit_count += 1;
+
+            for (edge, succ) in neighbors {
+                let succ = GraphNodeIndex {
+                    graph_idx: node.graph_idx,
+                    node_idx: succ,
+                };
+                let (succ_weight, succ) = get_node_idx!(graphs, succ)?;
+                let edge_weight = graph.edge_weight(edge).unwrap();
+                let action = visit(Some((node_weight, edge_weight)), succ_weight, state);
+
+                if action == GraphTraversalAction::Continue && queue_set.insert(succ) {
+                    queue.push(NodeWithPriority {
+                        node: succ,
+                        priority: priority(succ_weight, state),
+                    });
+                }
+            }
+        }
+
+        Ok(visit_count)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1186,7 +1186,7 @@ impl ModuleGraph {
     ///    - Receives: target &SingleModuleGraphNode, state &S
     ///    - Return a priority value for the node
     ///
-    /// Returns the number of node visits (i.e. higher that the node count if there are revisits).
+    /// Returns the number of node visits (i.e. higher than the node count if there are revisits).
     pub async fn traverse_edges_fixed_point<S, P: Ord>(
         &self,
         entries: impl IntoIterator<Item = (ResolvedVc<Box<dyn Module>>, P)>,


### PR DESCRIPTION
Abstract the existing ad-hoc traversal logic into a function

**View diff without whitespace, the chunk_group_info visitor was merely reindented**

Part of PACK-2960

Closes PACK-4581