### PR TITLE
[ts-next-plugin] add testing utils

### DIFF
--- a/test/development/typescript-plugin/index.test.ts
+++ b/test/development/typescript-plugin/index.test.ts
@@ -1,0 +1,18 @@
+import type { PluginLanguageService } from './test-utils'
+import { getPluginLanguageService } from './test-utils'
+
+describe('typescript-plugin', () => {
+  let languageService: PluginLanguageService
+
+  beforeAll(() => {
+    languageService = getPluginLanguageService(__dirname)
+  })
+
+  it('should be able to get the language service', () => {
+    expect(languageService).toBeDefined()
+    const capturedLogs = languageService.getCapturedLogs()
+    expect(capturedLogs).toContain(
+      '[next] Initialized Next.js TypeScript plugin'
+    )
+  })
+})

--- a/test/development/typescript-plugin/test-utils.ts
+++ b/test/development/typescript-plugin/test-utils.ts
@@ -1,0 +1,70 @@
+import tsNextPluginFactory from 'next'
+import ts from 'typescript'
+export { NEXT_TS_ERRORS } from 'next/dist/server/typescript/constant'
+
+export type PluginLanguageService = ts.LanguageService & {
+  getCapturedLogs: () => string
+}
+
+export function getPluginLanguageService(dir: string): PluginLanguageService {
+  const files = ts.sys.readDirectory(dir)
+
+  const compilerOptions = ts.getDefaultCompilerOptions()
+  const compilerHost = ts.createCompilerHost(compilerOptions)
+
+  let logs = ''
+  const logger = {
+    info: (...args: any[]) => {
+      const message = args
+        .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+        .join(' ')
+      logs += message + '\n'
+      console.log(...args)
+    },
+  }
+
+  const languageServiceHost: ts.LanguageServiceHost = {
+    ...compilerHost,
+    getCompilationSettings: () => compilerOptions,
+    getScriptFileNames: () => files,
+    getScriptSnapshot: (fileName) => {
+      const contents = ts.sys.readFile(fileName)
+      if (contents && typeof contents === 'string') {
+        return ts.ScriptSnapshot.fromString(contents)
+      }
+      return
+    },
+    getScriptVersion: () => '0',
+    writeFile: ts.sys.writeFile,
+  }
+
+  const languageService = ts.createLanguageService(languageServiceHost)
+
+  const pluginCreateInfo: ts.server.PluginCreateInfo = {
+    project: {
+      projectService: {
+        logger,
+      },
+      getCurrentDirectory: () => dir,
+    } as unknown as ts.server.Project,
+    languageService,
+    languageServiceHost,
+    serverHost: null,
+    config: {},
+  }
+
+  const plugin: ts.server.PluginModule = (
+    tsNextPluginFactory as unknown as ts.server.PluginModuleFactory
+  )({ typescript: ts })
+
+  const service = plugin.create(pluginCreateInfo) as PluginLanguageService
+
+  // Add a custom method to get captured logs
+  service.getCapturedLogs = () => logs
+
+  return service
+}
+
+export function getTsFiles(dir: string): string[] {
+  return ts.sys.readDirectory(dir)
+}


### PR DESCRIPTION
Ported from https://github.com/vercel/next.js/pull/78505, this PR adds testing utils and a basic log test for the Next.js TypeScript language service plugin.

Closes NEXT-4007