### PR TITLE
docs: Fix grammar on `Update static-exports.mdx`

### DIFF
--- a/docs/02-pages/02-guides/static-exports.mdx
+++ b/docs/02-pages/02-guides/static-exports.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to create an static export of your Next.js application
+title: How to create a static export of your Next.js application
 nav_title: Static Exports
 description: Next.js enables starting as a static site or Single-Page Application (SPA), then later optionally upgrading to use features that require a server.
 source: app/guides/static-exports


### PR DESCRIPTION
This PR fixes a grammar mistake on the [**Static Exports**](https://nextjs.org/docs/pages/guides/static-exports) page:

Before | After
--- | ---
How to create **an** static export of your Next.js application | How to create **a** static export of your Next.js application