### PR TITLE
Upgrade lightningcss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.65"
+version = "1.0.0-alpha.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84f971730745f4aaac013b6cf4328baf1548efc973c0d95cfd843a3c1ca07af"
+checksum = "9a73ffa17de66534e4b527232f44aa0a89fad22c4f4e0735f9be35494f058e54"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.9.0",
@@ -3931,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss-napi"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5e41d371670417f71b779fe6d66959a68c21fbda563a747d795ac525f72450"
+checksum = "2b254219299448a95dada4fa2b3bc70c73112d5d4858722b1e2b4ada1591ae22"
 dependencies = [
  "cssparser",
  "lightningcss",
@@ -5072,9 +5072,9 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccbc6fb560df303a44e511618256029410efbc87779018f751ef12c488271fe"
+checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,12 +361,12 @@ indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
-lightningcss = { version = "1.0.0-alpha.65", features = [
+lightningcss = { version = "1.0.0-alpha.66", features = [
   "serde",
   "visitor",
   "into_owned",
 ] }
-lightningcss-napi = { version = "0.4.3", default-features = false, features = [
+lightningcss-napi = { version = "0.4.4", default-features = false, features = [
   "visitor"
 ]}
 markdown = "1.0.0-alpha.18"

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css
@@ -1,4 +1,4 @@
 /* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css [test] (css) */
-.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:initial}.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)) tr td:first-child{text-wrap:nowrap}.prose :where(code):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:nowrap}
+.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)) tr td:first-child{text-wrap:nowrap}.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:initial}.prose :where(code):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:nowrap}
 
 /*# sourceMappingURL=b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map
@@ -2,5 +2,5 @@
   "version": 3,
   "sources": [],
   "sections": [
-    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css"],"sourcesContent":[".prose :where(table):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  tr {\n    td:first-child {\n      text-wrap: nowrap;\n    }\n  }\n  text-wrap: initial;\n}\n\n.prose :where(code):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  text-wrap: nowrap;\n}\n"],"names":[],"mappings":"AAAA,4FAEI,6GAOJ"}}]
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css"],"sourcesContent":[".prose :where(table):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  tr {\n    td:first-child {\n      text-wrap: nowrap;\n    }\n  }\n  text-wrap: initial;\n}\n\n.prose :where(code):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  text-wrap: nowrap;\n}\n"],"names":[],"mappings":"AAEI,6GAIQ,4FAGZ"}}]
 }


### PR DESCRIPTION
Closes #78854
Closes #79052
Closes PACK-4540

One snapshot changed:
```css
.prose :where(table):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
  tr {
    td:first-child {
      text-wrap: nowrap;
    }
  }
  text-wrap: initial;
}

.prose :where(code):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
  text-wrap: nowrap;
}
```
became previously
```css
.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)){
    text-wrap:initial
}
.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)) tr td:first-child{
    text-wrap:nowrap
}
.prose :where(code):not(:where([class~=not-prose],[class~=not-prose] *)){
    text-wrap:nowrap
}
```
while the new output is
```css
.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)) tr td:first-child{
    text-wrap:nowrap
}
.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)){
    text-wrap:initial
}
.prose :where(code):not(:where([class~=not-prose],[class~=not-prose] *)){
    text-wrap:nowrap
}
```