### PR TITLE
Update rust toolchain to 2025-05-12

### DIFF
--- a/crates/napi/build.rs
+++ b/crates/napi/build.rs
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Make the Next.js version available as a build-time environment variable
-    println!("cargo:rustc-env=NEXTJS_VERSION={}", nextjs_version);
+    println!("cargo:rustc-env=NEXTJS_VERSION={nextjs_version}");
 
     // Generates, stores build-time information as static values.
     // There are some places relying on correct values for this (i.e telemetry),

--- a/crates/napi/src/mdx.rs
+++ b/crates/napi/src/mdx.rs
@@ -40,5 +40,5 @@ pub fn mdx_compile_sync(value: String, option: Buffer) -> napi::Result<String> {
     let option: Options = serde_json::from_slice(&option)?;
 
     compile(value.as_str(), &option)
-        .map_err(|err| napi::Error::new(Status::GenericFailure, format!("{:?}", err)))
+        .map_err(|err| napi::Error::new(Status::GenericFailure, format!("{err:?}")))
 }

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -66,9 +66,9 @@ use crate::{register, util::DhatProfilerGuard};
 /// Used by [`benchmark_file_io`]. This is a noisy benchmark, so set the
 /// threshold high.
 const SLOW_FILESYSTEM_THRESHOLD: Duration = Duration::from_millis(100);
-static SOURCE_MAP_PREFIX: Lazy<String> = Lazy::new(|| format!("{}///", SOURCE_URL_PROTOCOL));
+static SOURCE_MAP_PREFIX: Lazy<String> = Lazy::new(|| format!("{SOURCE_URL_PROTOCOL}///"));
 static SOURCE_MAP_PREFIX_PROJECT: Lazy<String> =
-    Lazy::new(|| format!("{}///[{}]/", SOURCE_URL_PROTOCOL, PROJECT_FILESYSTEM_NAME));
+    Lazy::new(|| format!("{SOURCE_URL_PROTOCOL}///[{PROJECT_FILESYSTEM_NAME}]/"));
 
 #[napi(object)]
 #[derive(Clone, Debug)]
@@ -1213,7 +1213,7 @@ pub fn project_update_info_subscribe(
 
             if !matches!(status, Status::Ok) {
                 let error = anyhow!("Error calling JS function: {}", status);
-                eprintln!("{}", error);
+                eprintln!("{error}");
                 break;
             }
         }
@@ -1376,7 +1376,7 @@ pub async fn project_trace_source(
                 (
                     get_relative_path_to(
                         &current_directory_file_url,
-                        &format!("{}{}", project_root_uri, source_file),
+                        &format!("{project_root_uri}{source_file}"),
                     )
                     // TODO(sokra) remove this to include a ./ here to make it a relative path
                     .trim_start_matches("./")

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -471,7 +471,7 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
             );
             if !matches!(status, Status::Ok) {
                 let error = anyhow!("Error calling JS function: {}", status);
-                eprintln!("{}", error);
+                eprintln!("{error}");
                 return Err::<Vc<()>, _>(error);
             }
             Ok(Default::default())

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -119,7 +119,7 @@ impl Task for TransformTask {
                                     self.c.cm.new_source_file(
                                         FileName::Real(filename.into()).into(),
                                         read_to_string(filename).with_context(|| {
-                                            format!("Failed to read source code from {}", filename)
+                                            format!("Failed to read source code from {filename}")
                                         })?,
                                     )
                                 }
@@ -179,10 +179,7 @@ impl Task for TransformTask {
                     })
                     .map_err(|e| e.to_pretty_error())
                     .convert_err(),
-                Err(err) => Err(napi::Error::new(
-                    Status::GenericFailure,
-                    format!("{:?}", err),
-                )),
+                Err(err) => Err(napi::Error::new(Status::GenericFailure, format!("{err:?}"))),
             }
         })
     }
@@ -249,7 +246,7 @@ fn test_deser() {
 
     let tr: TransformOptions = serde_json::from_str(JSON_STR).unwrap();
 
-    println!("{:#?}", tr);
+    println!("{tr:#?}");
 }
 
 #[test]
@@ -258,5 +255,5 @@ fn test_deserialize_transform_regenerator() {
 
     let tr: TransformOptions = serde_json::from_str(JSON_STR).unwrap();
 
-    println!("{:#?}", tr);
+    println!("{tr:#?}");
 }

--- a/crates/napi/src/turbopack.rs
+++ b/crates/napi/src/turbopack.rs
@@ -180,7 +180,7 @@ impl FromNapiValue for NapiRouteHas {
             _ => {
                 return Err(napi::Error::new(
                     Status::GenericFailure,
-                    format!("invalid type for RouteHas: {}", type_),
+                    format!("invalid type for RouteHas: {type_}"),
                 ))
             }
         })

--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -108,7 +108,7 @@ pub fn log_internal_error_and_inform(internal_error: &anyhow::Error) {
             for line in new_lines {
                 match line {
                     Ok(line) => {
-                        writeln!(log_write, "{}", line).unwrap();
+                        writeln!(log_write, "{line}").unwrap();
                     }
                     Err(_) => {
                         break;
@@ -169,7 +169,7 @@ pub fn get_target_triple() -> &'static str {
 pub trait MapErr<T>: Into<Result<T, anyhow::Error>> {
     fn convert_err(self) -> napi::Result<T> {
         self.into()
-            .map_err(|err| napi::Error::new(Status::GenericFailure, format!("{:?}", err)))
+            .map_err(|err| napi::Error::new(Status::GenericFailure, format!("{err:?}")))
     }
 }
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1975,7 +1975,7 @@ impl Endpoint for AppEndpoint {
         }
         .instrument(span)
         .await
-        .with_context(|| format!("Failed to write app endpoint {}", page_name))
+        .with_context(|| format!("Failed to write app endpoint {page_name}"))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -51,7 +51,7 @@ pub(crate) async fn create_font_manifest(
         Default::default()
     } else if app_dir {
         let dir_str = dir.to_string().await?;
-        let page_path = format!("{}{}", dir_str, original_name).into();
+        let page_path = format!("{dir_str}{original_name}").into();
 
         NextFontManifest {
             app: [(page_path, font_paths)].into_iter().collect(),

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1196,7 +1196,7 @@ impl Project {
                     ConflictIssue {
                         path: self.project_path().to_resolved().await?,
                         title: StyledString::Text(
-                            format!("App Router and Pages Router both match path: {}", pathname)
+                            format!("App Router and Pages Router both match path: {pathname}")
                                 .into(),
                         )
                         .resolved_cell(),

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
             };
 
             let json = serde_json::to_string_pretty(&options).unwrap();
-            println!("{}", json);
+            println!("{json}");
         }
     }
 }

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -136,7 +136,7 @@ impl AppPageLoaderTreeBuilder {
         let metadata_manifest_route = get_metadata_route_name(manifest).await?;
         // prefix with base_path if it exists
         let manifest_route = if let Some(base_path) = &self.base_path {
-            format!("{}/{}", base_path, metadata_manifest_route)
+            format!("{base_path}/{metadata_manifest_route}")
         } else {
             metadata_manifest_route.to_string()
         };
@@ -250,7 +250,7 @@ impl AppPageLoaderTreeBuilder {
         let s = "      ";
         writeln!(self.loader_tree_code, "{s}(async (props) => [{{")?;
         let pathname_prefix = if let Some(base_path) = &self.base_path {
-            format!("{}/{}", base_path, app_page)
+            format!("{base_path}/{app_page}")
         } else {
             app_page.to_string()
         };

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -394,7 +394,7 @@ async fn parse_config_value(
                     invalid_config(
                         source,
                         span,
-                        &format!("`dynamic` has an invalid value: {}", err),
+                        &format!("`dynamic` has an invalid value: {err}"),
                         &value,
                     )
                     .await?;
@@ -455,7 +455,7 @@ async fn parse_config_value(
                     return invalid_config(
                         source,
                         span,
-                        &format!("`fetchCache` has an invalid value: {}", err),
+                        &format!("`fetchCache` has an invalid value: {err}"),
                         &value,
                     )
                     .await;
@@ -480,7 +480,7 @@ async fn parse_config_value(
                     return invalid_config(
                         source,
                         span,
-                        &format!("`runtime` has an invalid value: {}", err),
+                        &format!("`runtime` has an invalid value: {err}"),
                         &value,
                     )
                     .await;

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -375,7 +375,7 @@ async fn get_directory_tree_internal(
                     .map_or(file_name, |(basename, _)| basename);
                 let alt_path = file
                     .parent()
-                    .join(format!("{}.alt.txt", basename).into())
+                    .join(format!("{basename}.alt.txt").into())
                     .to_resolved()
                     .await?;
                 let alt_path = matches!(&*alt_path.get_type().await?, FileSystemEntryType::File)
@@ -568,9 +568,9 @@ fn conflict_issue(
     value_b: &AppPage,
 ) {
     let item_names = if a == b {
-        format!("{}s", a)
+        format!("{a}s")
     } else {
-        format!("{} and {}", a, b)
+        format!("{a} and {b}")
     };
 
     DirectoryTreeIssue {
@@ -1038,7 +1038,7 @@ async fn directory_tree_to_loader_tree_internal(
         }
 
         for key in keys_to_replace {
-            let subdir_name: RcStr = format!("@{}", key).into();
+            let subdir_name: RcStr = format!("@{key}").into();
 
             let default = if key == "children" {
                 modules.default

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -111,7 +111,7 @@ pub async fn get_app_page_entry(
     let source = VirtualSource::new_with_ident(
         source
             .ident()
-            .with_query(Vc::cell(format!("?{}", query).into())),
+            .with_query(Vc::cell(format!("?{query}").into())),
         AssetContent::file(file.into()),
     );
 

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -126,7 +126,7 @@ pub async fn dynamic_image_metadata_source(
             }}
         "#,
         exported_fields_excluding_default = exported_fields_excluding_default,
-        resource_path = StringifyJs(&format!("./{}.{}", stem, ext)),
+        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
         pathname_prefix = StringifyJs(&page.to_string()),
         page_segment = StringifyJs(stem),
         sizes = sizes,

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -247,7 +247,7 @@ pub fn is_metadata_route(mut route: &str) -> bool {
 
     let mut page = route.to_string();
     if !page.starts_with('/') {
-        page = format!("/{}", page);
+        page = format!("/{page}");
     }
 
     !page.ends_with("/page") && is_metadata_route_file(&page, &[], false)

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -240,7 +240,7 @@ async fn dynamic_text_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<dy
               }})
             }}
         "#,
-        resource_path = StringifyJs(&format!("./{}.{}", stem, ext)),
+        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
         content_type = StringifyJs(&content_type),
         file_type = StringifyJs(&stem),
         cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
@@ -332,7 +332,7 @@ async fn dynamic_site_map_route_source(
 
             {static_generation_code}
         "#,
-        resource_path = StringifyJs(&format!("./{}.{}", stem, ext)),
+        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
         content_type = StringifyJs(&content_type),
         file_type = StringifyJs(&stem),
         cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
@@ -396,7 +396,7 @@ async fn dynamic_image_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<d
                 return handler({{ params: restParams, id }})
             }}
         "#,
-        resource_path = StringifyJs(&format!("./{}.{}", stem, ext)),
+        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
     };
 
     let file = File::from(code);

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1118,7 +1118,7 @@ impl NextConfig {
         let string = string.await?;
         let mut jdeserializer = serde_json::Deserializer::from_str(&string);
         let config: NextConfig = serde_path_to_error::deserialize(&mut jdeserializer)
-            .with_context(|| format!("failed to parse next.config.js: {}", string))?;
+            .with_context(|| format!("failed to parse next.config.js: {string}"))?;
         Ok(config.cell())
     }
 
@@ -1463,7 +1463,7 @@ impl NextConfig {
         let this = self.await?;
 
         match &this.deployment_id {
-            Some(deployment_id) => Ok(Vc::cell(Some(format!("?dpl={}", deployment_id).into()))),
+            Some(deployment_id) => Ok(Vc::cell(Some(format!("?dpl={deployment_id}").into()))),
             None => Ok(Vc::cell(None)),
         }
     }
@@ -1617,7 +1617,7 @@ impl JsConfig {
     pub async fn from_string(string: Vc<RcStr>) -> Result<Vc<Self>> {
         let string = string.await?;
         let config: JsConfig = serde_json::from_str(&string)
-            .with_context(|| format!("failed to parse next.config.js: {}", string))?;
+            .with_context(|| format!("failed to parse next.config.js: {string}"))?;
 
         Ok(config.cell())
     }

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -39,7 +39,7 @@ pub async fn wrap_edge_entry(
                 }},
             }});
         "#,
-        StringifyJs(&format_args!("middleware_{}", pathname))
+        StringifyJs(&format_args!("middleware_{pathname}"))
     );
     let file = File::from(source);
 

--- a/crates/next-core/src/next_edge/route_regex.rs
+++ b/crates/next-core/src/next_edge/route_regex.rs
@@ -134,7 +134,7 @@ fn get_parametrized_route(route: &str) -> (String, FxHashMap<String, Group>) {
 pub fn get_route_regex(normalized_route: &str) -> RouteRegex {
     let (parameterized_route, groups) = get_parametrized_route(normalized_route);
     RouteRegex {
-        regex: format!("^{}(?:/)?$", parameterized_route),
+        regex: format!("^{parameterized_route}(?:/)?$"),
         groups,
     }
 }
@@ -175,7 +175,7 @@ fn get_safe_key_from_segment(
     // the named regex
     let mut cleaned_key = key.replace(|c: char| !c.is_alphanumeric(), "");
     if let Some(prefix) = key_prefix {
-        cleaned_key = format!("{}{}", prefix, cleaned_key);
+        cleaned_key = format!("{prefix}{cleaned_key}");
     }
     let mut invalid_key = false;
 
@@ -191,15 +191,15 @@ fn get_safe_key_from_segment(
         cleaned_key = get_safe_route_key();
     }
     if let Some(prefix) = key_prefix {
-        route_keys.insert(cleaned_key.clone(), format!("{}{}", prefix, key));
+        route_keys.insert(cleaned_key.clone(), format!("{prefix}{key}"));
     } else {
         route_keys.insert(cleaned_key.clone(), key);
     }
     match (repeat, optional) {
-        (true, true) => format!(r"(?:/(?P<{}>.+?))?", cleaned_key),
-        (true, false) => format!(r"/(?P<{}>.+?)", cleaned_key),
-        (false, true) => format!(r"(?:/(?P<{}>[^/]+?))?", cleaned_key),
-        (false, false) => format!(r"/(?P<{}>[^/]+?)", cleaned_key),
+        (true, true) => format!(r"(?:/(?P<{cleaned_key}>.+?))?"),
+        (true, false) => format!(r"/(?P<{cleaned_key}>.+?)"),
+        (false, true) => format!(r"(?:/(?P<{cleaned_key}>[^/]+?))?"),
+        (false, false) => format!(r"/(?P<{cleaned_key}>[^/]+?)"),
     }
 }
 
@@ -254,7 +254,7 @@ pub fn get_named_route_regex(normalized_route: &str) -> NamedRouteRegex {
     let regex = get_route_regex(normalized_route);
     NamedRouteRegex {
         regex,
-        named_regex: format!("^{}(?:/)?$", parameterized_route),
+        named_regex: format!("^{parameterized_route}(?:/)?$"),
         route_keys,
     }
 }
@@ -263,5 +263,5 @@ pub fn get_named_route_regex(normalized_route: &str) -> NamedRouteRegex {
 /// This is intended to be using for build time only.
 pub fn get_named_middleware_regex(normalized_route: &str) -> String {
     let (parameterized_route, _route_keys) = get_named_parametrized_route(normalized_route, true);
-    format!("^{}(?:/)?$", parameterized_route)
+    format!("^{parameterized_route}(?:/)?$")
 }

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -70,9 +70,8 @@ fn unsupported_module_source(root_path: Vc<FileSystemPath>, module: RcStr) -> Vc
     };
     let content = AssetContent::file(File::from(code).into());
     VirtualSource::new_with_ident(
-        AssetIdent::from_path(root_path).with_modifier(Vc::cell(
-            format!("unsupported edge import {}", module).into(),
-        )),
+        AssetIdent::from_path(root_path)
+            .with_modifier(Vc::cell(format!("unsupported edge import {module}").into())),
         content,
     )
 }

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -124,13 +124,13 @@ impl NextFontGoogleReplacer {
                         .weight
                         .await?
                         .as_ref()
-                        .map(|w| format!("fontWeight: {},\n", w))
+                        .map(|w| format!("fontWeight: {w},\n"))
                         .unwrap_or_else(|| "".to_owned()),
                     properties
                         .style
                         .await?
                         .as_ref()
-                        .map(|s| format!("fontStyle: \"{}\",\n", s))
+                        .map(|s| format!("fontStyle: \"{s}\",\n"))
                         .unwrap_or_else(|| "".to_owned()),
                 )
                 .into(),
@@ -367,8 +367,8 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
             name.push_str(".p")
         }
 
-        let font_virtual_path = next_js_file_path("internal/font/google".into())
-            .join(format!("/{}.{}", name, ext).into());
+        let font_virtual_path =
+            next_js_file_path("internal/font/google".into()).join(format!("/{name}.{ext}").into());
 
         // doesn't seem ideal to download the font into a string, but probably doesn't
         // really matter either.
@@ -438,7 +438,7 @@ async fn update_google_stylesheet(
 
         stylesheet = stylesheet.replace(
             &font_url,
-            &format!("{}?{}", GOOGLE_FONTS_INTERNAL_PREFIX, query_str),
+            &format!("{GOOGLE_FONTS_INTERNAL_PREFIX}?{query_str}"),
         )
     }
 
@@ -494,7 +494,7 @@ async fn get_stylesheet_url_from_options(
 
         let env = CommandLineProcessEnv::new();
         if let Some(url) = &*env.read("TURBOPACK_TEST_ONLY_MOCK_SERVER".into()).await? {
-            css_url = Some(format!("{}/css2", url));
+            css_url = Some(format!("{url}/css2"));
         }
     }
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -151,13 +151,13 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                         .weight
                         .await?
                         .as_ref()
-                        .map(|w| format!("fontWeight: {},\n", w))
+                        .map(|w| format!("fontWeight: {w},\n"))
                         .unwrap_or_else(|| "".to_owned()),
                     properties
                         .style
                         .await?
                         .as_ref()
-                        .map(|s| format!("fontStyle: \"{}\",\n", s))
+                        .map(|s| format!("fontStyle: \"{s}\",\n"))
                         .unwrap_or_else(|| "".to_owned()),
                 );
                 let js_asset = VirtualSource::new(
@@ -242,7 +242,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                     name.push_str(".p")
                 }
 
-                let font_virtual_path = lookup_path.join(format!("/{}.{}", name, ext).into());
+                let font_virtual_path = lookup_path.join(format!("/{name}.{ext}").into());
 
                 let font_file = lookup_path.join(path.clone()).read();
 

--- a/crates/next-core/src/next_font/local/options.rs
+++ b/crates/next-core/src/next_font/local/options.rs
@@ -149,7 +149,7 @@ impl Display for FontWeight {
             f,
             "{}",
             match self {
-                Self::Variable(start, end) => format!("{} {}", start, end),
+                Self::Variable(start, end) => format!("{start} {end}"),
                 Self::Fixed(val) => val.to_string(),
             }
         )
@@ -322,7 +322,7 @@ mod tests {
         );
 
         match request {
-            Ok(r) => panic!("Expected failure, received {:?}", r),
+            Ok(r) => panic!("Expected failure, received {r:?}"),
             Err(err) => {
                 assert!(err
                     .to_string()

--- a/crates/next-core/src/next_font/local/stylesheet.rs
+++ b/crates/next-core/src/next_font/local/stylesheet.rs
@@ -78,12 +78,12 @@ pub(super) async fn build_font_face_definitions(
                 .weight
                 .as_ref()
                 .or(options.default_weight.as_ref())
-                .map_or_else(|| "".to_owned(), |w| format!("font-weight: {};", w)),
+                .map_or_else(|| "".to_owned(), |w| format!("font-weight: {w};")),
             &font
                 .style
                 .as_ref()
                 .or(options.default_style.as_ref())
-                .map_or_else(|| "".to_owned(), |s| format!("font-style: {};", s)),
+                .map_or_else(|| "".to_owned(), |s| format!("font-style: {s};")),
         ));
     }
 

--- a/crates/next-core/src/next_font/stylesheet.rs
+++ b/crates/next-core/src/next_font/stylesheet.rs
@@ -67,13 +67,13 @@ pub(super) async fn build_font_class_rules(
             .weight
             .await?
             .as_ref()
-            .map(|w| format!("font-weight: {};\n", w))
+            .map(|w| format!("font-weight: {w};\n"))
             .unwrap_or_else(|| "".to_owned()),
         css_properties
             .style
             .await?
             .as_ref()
-            .map(|s| format!("font-style: {};\n", s))
+            .map(|s| format!("font-style: {s};\n"))
             .unwrap_or_else(|| "".to_owned()),
     );
 

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -56,7 +56,7 @@ pub(crate) async fn get_scoped_font_family(
     let font_family_base = font_family_name.await?.to_string();
     let font_family_name = match &*ty.await? {
         FontFamilyType::WebFont => font_family_base,
-        FontFamilyType::Fallback => format!("{} Fallback", font_family_base),
+        FontFamilyType::Fallback => format!("{font_family_base} Fallback"),
     };
 
     Ok(Vc::cell(font_family_name.into()))

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -462,6 +462,6 @@ pub fn get_client_reference_module_key(server_path: &str, export_name: &str) -> 
     if export_name == "*" {
         server_path.into()
     } else {
-        format!("{}#{}", server_path, export_name).into()
+        format!("{server_path}#{export_name}").into()
     }
 }

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -85,7 +85,7 @@ impl Issue for InvalidImportModuleIssue {
             StyledString::Line(
                 messages
                     .iter()
-                    .map(|v| StyledString::Text(format!("{}\n", v).into()))
+                    .map(|v| StyledString::Text(format!("{v}\n").into()))
                     .collect::<Vec<StyledString>>(),
             )
             .resolved_cell(),
@@ -374,7 +374,7 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
                     .find(|sub_path| path.is_match(sub_path));
 
                 if let Some(sub_path) = sub_path {
-                    ModuleFeatureTelemetry::new(format!("{}{}", module, sub_path).into(), 1)
+                    ModuleFeatureTelemetry::new(format!("{module}{sub_path}").into(), 1)
                         .resolved_cell()
                         .emit();
                 }

--- a/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -92,7 +92,7 @@ impl ModularizeImportsTransformer {
                                         modularize_imports::Transform::Vec(v.clone())
                                     }
                                     Transform::None => {
-                                        panic!("Missing transform value for package {}", k)
+                                        panic!("Missing transform value for package {k}")
                                     }
                                 },
                                 prevent_full_import: v.prevent_full_import,

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -92,11 +92,11 @@ impl CustomTransformer for NextPageStaticInfo {
                     )];
 
                     if let Some(runtime) = config_obj.get("runtime") {
-                        messages.push(format!("- `export const runtime = {}`", runtime));
+                        messages.push(format!("- `export const runtime = {runtime}`"));
                     }
 
                     if let Some(regions) = config_obj.get("regions") {
-                        messages.push(format!("- `export const preferredRegion = {}`", regions));
+                        messages.push(format!("- `export const preferredRegion = {regions}`"));
                     }
 
                     messages.push("Visit https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config for more information.".to_string());
@@ -164,7 +164,7 @@ impl Issue for PageStaticInfoIssue {
             StyledString::Line(
                 self.messages
                     .iter()
-                    .map(|v| StyledString::Text(format!("{}\n", v).into()))
+                    .map(|v| StyledString::Text(format!("{v}\n").into()))
                     .collect::<Vec<StyledString>>(),
             )
             .resolved_cell(),

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -71,7 +71,7 @@ pub async fn pathname_for_path(
         (PathType::Data, "") => "/index".into(),
         // `get_path_to` always strips the leading `/` from the path, so we need to add
         // it back here.
-        (_, path) => format!("/{}", path).into(),
+        (_, path) => format!("/{path}").into(),
     };
 
     Ok(Vc::cell(path))
@@ -84,7 +84,7 @@ pub fn get_asset_prefix_from_pathname(pathname: &str) -> String {
     if pathname == "/" {
         "/index".to_string()
     } else if pathname == "/index" || pathname.starts_with("/index/") {
-        format!("/index{}", pathname)
+        format!("/index{pathname}")
     } else {
         pathname.to_string()
     }
@@ -773,7 +773,7 @@ pub async fn load_next_js_template(
     // variable is missing, throw an error.
     let mut replaced = FxIndexSet::default();
     for (key, replacement) in &replacements {
-        let full = format!("'{}'", key);
+        let full = format!("'{key}'");
 
         if content.contains(&full) {
             replaced.insert(*key);
@@ -815,12 +815,12 @@ pub async fn load_next_js_template(
     // Replace the injections.
     let mut injected = FxIndexSet::default();
     for (key, injection) in &injections {
-        let full = format!("// INJECT:{}", key);
+        let full = format!("// INJECT:{key}");
 
         if content.contains(&full) {
             // Track all the injections to ensure that we're not missing any.
             injected.insert(*key);
-            content = content.replace(&full, &format!("const {} = {}", key, injection));
+            content = content.replace(&full, &format!("const {key} = {injection}"));
         }
     }
 
@@ -858,9 +858,9 @@ pub async fn load_next_js_template(
     // Replace the optional imports.
     let mut imports_added = FxIndexSet::default();
     for (key, import_path) in &imports {
-        let mut full = format!("// OPTIONAL_IMPORT:{}", key);
+        let mut full = format!("// OPTIONAL_IMPORT:{key}");
         let namespace = if !content.contains(&full) {
-            full = format!("// OPTIONAL_IMPORT:* as {}", key);
+            full = format!("// OPTIONAL_IMPORT:* as {key}");
             if content.contains(&full) {
                 true
             } else {
@@ -884,7 +884,7 @@ pub async fn load_next_js_template(
                 ),
             );
         } else {
-            content = content.replace(&full, &format!("const {} = null", key));
+            content = content.replace(&full, &format!("const {key} = null"));
         }
     }
 

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -351,7 +351,7 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
             vec![span],
         ),
         RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(span, segment, property) => (
-            format!("Route segment config \"{}\" is not compatible with `nextConfig.{}`. Please remove it.", segment, property),
+            format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`. Please remove it."),
             vec![span],
         ),
     };

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -21,7 +21,7 @@ use wasm_bindgen_futures::future_to_promise;
 pub mod mdx;
 
 fn convert_err(err: Error) -> JsValue {
-    format!("{:?}", err).into()
+    format!("{err:?}").into()
 }
 
 #[wasm_bindgen(js_name = "minifySync")]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-04-14"
+channel = "nightly-2025-05-12"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-esregex/src/lib.rs
+++ b/turbopack/crates/turbo-esregex/src/lib.rs
@@ -92,7 +92,7 @@ impl EsRegex {
         }
 
         let regex = if !applied_flags.is_empty() {
-            regex::Regex::new(&format!("(?{}){}", applied_flags, pattern))
+            regex::Regex::new(&format!("(?{applied_flags}){pattern}"))
         } else {
             regex::Regex::new(&pattern)
         };

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -364,7 +364,7 @@ mod tests {
                 swap(&mut warm_keys[i], &mut keys[j]);
             }
         }
-        println!("Number of compactions: {}", number_of_compactions);
+        println!("Number of compactions: {number_of_compactions}");
 
         assert!(containers.len() < 40);
         let coverage = total_coverage(&containers, (0, 10000));

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -258,8 +258,8 @@ impl TurboPersistence {
                             while !content.is_empty() {
                                 let seq = content.read_u32::<BE>()?;
                                 deleted_files.insert(seq);
-                                let sst_file = self.path.join(format!("{:08}.sst", seq));
-                                let blob_file = self.path.join(format!("{:08}.blob", seq));
+                                let sst_file = self.path.join(format!("{seq:08}.sst"));
+                                let blob_file = self.path.join(format!("{seq:08}.blob"));
                                 for path in [sst_file, blob_file] {
                                     if fs::exists(&path)? {
                                         fs::remove_file(path)?;
@@ -336,14 +336,14 @@ impl TurboPersistence {
 
     /// Opens a single SST file. This memory maps the file, but doesn't read it yet.
     fn open_sst(&self, seq: u32) -> Result<StaticSortedFile> {
-        let path = self.path.join(format!("{:08}.sst", seq));
+        let path = self.path.join(format!("{seq:08}.sst"));
         StaticSortedFile::open(seq, path)
-            .with_context(|| format!("Unable to open sst file {:08}.sst", seq))
+            .with_context(|| format!("Unable to open sst file {seq:08}.sst"))
     }
 
     /// Reads and decompresses a blob file. This is not backed by any cache.
     fn read_blob(&self, seq: u32) -> Result<ArcSlice<u8>> {
-        let path = self.path.join(format!("{:08}.blob", seq));
+        let path = self.path.join(format!("{seq:08}.blob"));
         let mmap = unsafe { Mmap::map(&File::open(&path)?)? };
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Sequential)?;
@@ -488,7 +488,7 @@ impl TurboPersistence {
             for seq in removed_ssts.iter() {
                 buf.write_u32::<BE>(*seq)?;
             }
-            let mut file = File::create(self.path.join(format!("{:08}.del", seq)))?;
+            let mut file = File::create(self.path.join(format!("{seq:08}.del")))?;
             file.write_all(&buf)?;
             file.sync_all()?;
         }
@@ -507,9 +507,9 @@ impl TurboPersistence {
 
         {
             let mut log = self.open_log()?;
-            writeln!(log, "Time {}", time)?;
+            writeln!(log, "Time {time}")?;
             let span = time.until(Timestamp::now())?;
-            writeln!(log, "Commit {seq:08} {:#}", span)?;
+            writeln!(log, "Commit {seq:08} {span:#}")?;
             for (index, family, min, max, size) in new_sst_info.iter() {
                 writeln!(
                     log,
@@ -522,10 +522,10 @@ impl TurboPersistence {
                 )?;
             }
             for (seq, _) in new_blob_files.iter() {
-                writeln!(log, "{:08} BLOB", seq)?;
+                writeln!(log, "{seq:08} BLOB")?;
             }
             for index in indicies_to_delete.iter() {
-                writeln!(log, "{:08} DELETED", index)?;
+                writeln!(log, "{index:08} DELETED")?;
             }
         }
 
@@ -735,7 +735,7 @@ impl TurboPersistence {
                                 total_key_size,
                                 total_value_size,
                             )?;
-                            Ok((seq, builder.write(&path.join(format!("{:08}.sst", seq)))?))
+                            Ok((seq, builder.write(&path.join(format!("{seq:08}.sst")))?))
                         }
 
                         let mut new_sst_files = Vec::new();
@@ -881,7 +881,7 @@ impl TurboPersistence {
                         let index = ssts_with_ranges[index].index;
                         let sst = &static_sorted_files[index];
                         let src_path = self.path.join(format!("{:08}.sst", sst.sequence_number()));
-                        let dst_path = self.path.join(format!("{:08}.sst", seq));
+                        let dst_path = self.path.join(format!("{seq:08}.sst"));
                         if fs::hard_link(&src_path, &dst_path).is_err() {
                             fs::copy(src_path, &dst_path)?;
                         }

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -388,7 +388,7 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
         lz4::compress_to_vec(value, &mut buffer, ACC_LEVEL_DEFAULT)
             .context("Compression of value for blob file failed")?;
 
-        let file = self.path.join(format!("{:08}.blob", seq));
+        let file = self.path.join(format!("{seq:08}.blob"));
         let mut file = File::create(&file).context("Unable to create blob file")?;
         file.write_all(&buffer)
             .context("Unable to write blob file")?;
@@ -410,10 +410,10 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
         let builder =
             StaticSortedFileBuilder::new(family, entries, total_key_size, total_value_size)?;
 
-        let path = self.path.join(format!("{:08}.sst", seq));
+        let path = self.path.join(format!("{seq:08}.sst"));
         let file = builder
             .write(&path)
-            .with_context(|| format!("Unable to write SST file {:08}.sst", seq))?;
+            .with_context(|| format!("Unable to write SST file {seq:08}.sst"))?;
 
         #[cfg(feature = "verify_sst_content")]
         {

--- a/turbopack/crates/turbo-static/src/main.rs
+++ b/turbopack/crates/turbo-static/src/main.rs
@@ -281,7 +281,7 @@ fn write_dep_tree(
             ident.name,
             ident.path,
             ident.range.start.line,
-            tags.iter().map(|t| format!("\"{}\"", t)).join(",")
+            tags.iter().map(|t| format!("\"{t}\"")).join(",")
         );
         node_ids.insert(ident, counter);
     }
@@ -297,6 +297,6 @@ fn write_dep_tree(
         let src_id = *node_ids.get(src).unwrap();
         let dst_id = *node_ids.get(dest).unwrap();
 
-        _ = writeln!(file, "CREATE (n_{})-[:{}]->(n_{})", src_id, style, dst_id,);
+        _ = writeln!(file, "CREATE (n_{src_id})-[:{style}]->(n_{dst_id})",);
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -534,10 +534,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     get!(task, Activeness).unwrap()
                 };
                 let listener = root.all_clean_event.listen_with_note(move || {
-                    format!(
-                        "try_read_task_output (strongly consistent) from {:?}",
-                        reader
-                    )
+                    format!("try_read_task_output (strongly consistent) from {reader:?}")
                 });
                 drop(task);
                 if !task_ids_to_schedule.is_empty() {
@@ -954,7 +951,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 persisted_task_cache_log,
                 task_snapshots,
             ) {
-                println!("Persisting failed: {:?}", err);
+                println!("Persisting failed: {err:?}");
                 return None;
             }
         }
@@ -989,7 +986,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
     fn stop(&self) {
         if let Err(err) = self.backing_storage.shutdown() {
-            println!("Shutting down failed: {}", err);
+            println!("Shutting down failed: {err}");
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -451,7 +451,7 @@ impl<B: BackingStorage> Debug for TaskGuardImpl<'_, B> {
             d.field("task_type", &task_type);
         };
         for (key, value) in self.task.iter_all() {
-            d.field(&format!("{:?}", key), &value);
+            d.field(&format!("{key:?}"), &value);
         }
         d.finish()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -60,10 +60,11 @@ impl UpdateOutputOperation {
             // Skip updating the output when the task is stale
             return;
         }
-        let children = ctx
-            .should_track_children()
-            .then(|| new_children.iter().copied().collect())
-            .unwrap_or_default();
+        let children = if ctx.should_track_children() {
+            new_children.iter().copied().collect()
+        } else {
+            Default::default()
+        };
 
         let old_error = task.remove(&CachedDataItemKey::Error {});
         let current_output = get!(task, Output);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -119,10 +119,11 @@ impl UpdateOutputOperation {
             value: output_value,
         });
 
-        let dependent_tasks = ctx
-            .should_track_dependencies()
-            .then(|| get_many!(task, OutputDependent { task } => task))
-            .unwrap_or_default();
+        let dependent_tasks = if ctx.should_track_dependencies() {
+            get_many!(task, OutputDependent { task } => task)
+        } else {
+            Default::default()
+        };
 
         let mut queue = AggregationUpdateQueue::new();
 

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -95,9 +95,7 @@ impl ActivenessState {
             active_counter: 0,
             root_ty: None,
             active_until_clean: false,
-            all_clean_event: Event::new(move || {
-                format!("ActivenessState::all_clean_event {:?}", id)
-            }),
+            all_clean_event: Event::new(move || format!("ActivenessState::all_clean_event {id:?}")),
         }
     }
 
@@ -345,9 +343,7 @@ impl Eq for InProgressCellState {}
 impl InProgressCellState {
     pub fn new(task_id: TaskId, cell: CellId) -> Self {
         InProgressCellState {
-            event: Event::new(move || {
-                format!("InProgressCellState::event ({} {:?})", task_id, cell)
-            }),
+            event: Event::new(move || format!("InProgressCellState::event ({task_id} {cell:?})")),
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-build/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-build/src/lib.rs
@@ -137,7 +137,7 @@ pub fn generate_register() {
                         ctx.process_item(&item).unwrap();
                     }
                 }
-                Err(err) => println!("{}", err),
+                Err(err) => println!("{err}"),
             }
         }
 
@@ -461,8 +461,7 @@ impl RegisterContext<'_> {
 
         assert!(
             self.values.insert(key, value).is_none(),
-            "{} is declared more than once",
-            ident
+            "{ident} is declared more than once"
         );
     }
 

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -196,20 +196,17 @@ impl Issue for FetchIssue {
 
         Ok(Vc::cell(Some(
             StyledString::Text(match kind {
-                FetchErrorKind::Connect => format!(
-                    "There was an issue establishing a connection while requesting {}.",
-                    url
-                )
-                .into(),
-                FetchErrorKind::Status(status) => format!(
-                    "Received response with status {} when requesting {}",
-                    status, url
-                )
-                .into(),
-                FetchErrorKind::Timeout => {
-                    format!("Connection timed out when requesting {}", url).into()
+                FetchErrorKind::Connect => {
+                    format!("There was an issue establishing a connection while requesting {url}.")
+                        .into()
                 }
-                FetchErrorKind::Other => format!("There was an issue requesting {}", url).into(),
+                FetchErrorKind::Status(status) => {
+                    format!("Received response with status {status} when requesting {url}").into()
+                }
+                FetchErrorKind::Timeout => {
+                    format!("Connection timed out when requesting {url}").into()
+                }
+                FetchErrorKind::Other => format!("There was an issue requesting {url}").into(),
             })
             .resolved_cell(),
         )))

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -100,7 +100,7 @@ async fn hash_directory(directory: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
             .join(",")
             .as_bytes(),
     );
-    println!("hash_directory({})", dir_path);
+    println!("hash_directory({dir_path})");
     Ok(hash)
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -156,7 +156,7 @@ impl ValueToString for AttachedFileSystem {
         let root_fs_str = self.root_fs.to_string().await?;
         let child_fs_str = self.child_fs.to_string().await?;
         Ok(Vc::cell(
-            format!("{}-with-{}", root_fs_str, child_fs_str).into(),
+            format!("{root_fs_str}-with-{child_fs_str}").into(),
         ))
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/json.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/json.rs
@@ -57,7 +57,7 @@ impl UnparseableJson {
     pub fn write_with_content(&self, writer: &mut impl Write, text: &str) -> std::fmt::Result {
         writeln!(writer, "{}", self.message)?;
         if let Some(path) = &self.path {
-            writeln!(writer, "  at {}", path)?;
+            writeln!(writer, "  at {path}")?;
         }
         match (self.start_location, self.end_location) {
             (Some((line, column)), Some((end_line, end_column))) => {
@@ -92,7 +92,7 @@ impl Display for UnparseableJson {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)?;
         if let Some(path) = &self.path {
-            write!(f, "  at {}", path)?;
+            write!(f, "  at {path}")?;
         }
         Ok(())
     }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -489,7 +489,7 @@ fn format_absolute_fs_path(path: &Path, name: &str, root_path: &Path) -> Option<
     let path = if let Ok(rel_path) = path.strip_prefix(root_path) {
         let path = if MAIN_SEPARATOR != '/' {
             let rel_path = rel_path.to_string_lossy().replace(MAIN_SEPARATOR, "/");
-            format!("[{name}]/{}", rel_path)
+            format!("[{name}]/{rel_path}")
         } else {
             format!("[{name}]/{}", rel_path.display())
         };
@@ -932,7 +932,7 @@ impl FileSystem for DiskFileSystem {
                         }
                     })
                     .await
-                    .with_context(|| format!("create symlink to {}", target))?;
+                    .with_context(|| format!("create symlink to {target}"))?;
                 }
                 LinkContent::Invalid => {
                     anyhow::bail!("invalid symlink target: {}", full_path.display())
@@ -1161,13 +1161,12 @@ impl FileSystemPath {
         // provided by the user, so we allow it.
         debug_assert!(
             MAIN_SEPARATOR != '\\' || !path.contains('\\'),
-            "path {} must not contain a Windows directory '\\', it must be normalized to Unix '/'",
-            path,
+            "path {path} must not contain a Windows directory '\\', it must be normalized to Unix \
+             '/'",
         );
         debug_assert!(
             normalize_path(&path).as_deref() == Some(&*path),
-            "path {} must be normalized",
-            path,
+            "path {path} must be normalized",
         );
         Self::cell(FileSystemPath { fs, path })
     }
@@ -1221,7 +1220,7 @@ impl FileSystemPath {
         if let (path, Some(ext)) = this.split_extension() {
             return Ok(Self::new_normalized(
                 *this.fs,
-                format!("{}{}.{}", path, appending, ext).into(),
+                format!("{path}{appending}.{ext}").into(),
             ));
         }
         Ok(Self::new_normalized(
@@ -1956,7 +1955,7 @@ mod mime_option_serde {
                 } else {
                     Mime::from_str(value)
                         .map(Some)
-                        .map_err(|e| E::custom(format!("{}", e)))
+                        .map_err(|e| E::custom(format!("{e}")))
                 }
             }
         }

--- a/turbopack/crates/turbo-tasks-fs/src/source_context.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/source_context.rs
@@ -94,7 +94,7 @@ pub struct SourceContextLines<'a>(pub Vec<SourceContextLine<'a>>);
 impl Display for SourceContextLines<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for line in &self.0 {
-            write!(f, "{}", line)?;
+            write!(f, "{line}")?;
         }
         Ok(())
     }
@@ -129,7 +129,7 @@ pub fn get_source_context<'a>(
             }
             let (a, b) = s.split_at(s.floor_char_boundary(98));
             let (_, c) = b.split_at(b.ceil_char_boundary(b.len() - 99));
-            Cow::Owned(format!("{}...{}", a, c))
+            Cow::Owned(format!("{a}...{c}"))
         }
         match (i.cmp(&start_line), i.cmp(&end_line)) {
             // outside

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -19,9 +19,8 @@ pub fn join_path(fs_path: &str, join: &str) -> Option<String> {
     // backslash.
     debug_assert!(
         !join.contains('\\'),
-        "joined path {} must not contain a Windows directory '\\', it must be normalized to Unix \
-         '/'",
-        join
+        "joined path {join} must not contain a Windows directory '\\', it must be normalized to \
+         Unix '/'"
     );
 
     // TODO: figure out why this freezes the benchmarks.

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -427,8 +427,7 @@ impl DiskWatcher {
                                     // notify or system weirdness.
                                     panic!(
                                         "Rename event does not contain source and destination \
-                                         paths {:#?}",
-                                        paths
+                                         paths {paths:#?}"
                                     );
                                 }
                             }
@@ -455,7 +454,7 @@ impl DiskWatcher {
                     }
                     // Error raised by notify watcher itself
                     Ok(Err(notify::Error { kind, paths })) => {
-                        println!("watch error ({:?}): {:?} ", paths, kind);
+                        println!("watch error ({paths:?}): {kind:?} ");
 
                         if paths.is_empty() {
                             batched_invalidate_path_and_children

--- a/turbopack/crates/turbo-tasks-macros-shared/src/expand.rs
+++ b/turbopack/crates/turbo-tasks-macros-shared/src/expand.rs
@@ -157,7 +157,7 @@ pub fn generate_destructuring<'a, I: Fn(&Field) -> bool>(
         .map(|(i, field)| match &field.ident {
             Some(ident) => (quote! { #ident }, quote! { #ident }),
             None => {
-                let ident = Ident::new(&format!("field_{}", i), field.span());
+                let ident = Ident::new(&format!("field_{i}"), field.span());
                 let index = syn::Index::from(i);
                 (quote! { #index: #ident }, quote! { #ident })
             }

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -92,7 +92,7 @@ impl Parse for ValueImplArguments {
                 (_, meta) => {
                     return Err(Error::new_spanned(
                         &meta,
-                        format!("unexpected {:?}, expected \"ident\"", meta),
+                        format!("unexpected {meta:?}, expected \"ident\""),
                     ))
                 }
             }
@@ -241,7 +241,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
                 let inline_function_ident = turbo_fn.inline_ident();
                 let inline_extension_trait_ident = Ident::new(
-                    &format!("{}_{}_{}_inline", ty_ident, trait_ident, ident),
+                    &format!("{ty_ident}_{trait_ident}_{ident}_inline"),
                     ident.span(),
                 );
                 let (inline_signature, inline_block) =

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -199,9 +199,9 @@ impl Parse for ValueArguments {
                     return Err(Error::new_spanned(
                         &meta,
                         format!(
-                            "unexpected {:?}, expected \"shared\", \"into\", \"serialization\", \
-                             \"cell\", \"eq\", \"transparent\", or \"operation\"",
-                            meta
+                            "unexpected {meta:?}, expected \"shared\", \"into\", \
+                             \"serialization\", \"cell\", \"eq\", \"transparent\", or \
+                             \"operation\""
                         ),
                     ))
                 }
@@ -255,8 +255,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
                 // the leading whitespace.
                 let doc_str = format!(
                     "\n\nThis is a [transparent value type][turbo_tasks::value#transparent] \
-                     wrapping [`{}`].",
-                    inner_type_string,
+                     wrapping [`{inner_type_string}`].",
                 );
 
                 attrs.push(parse_quote! {

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -110,7 +110,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             let is_self_used = is_self_used(default);
             let inline_function_ident = turbo_fn.inline_ident();
             let inline_extension_trait_ident =
-                Ident::new(&format!("{}_{}_inline", trait_ident, ident), ident.span());
+                Ident::new(&format!("{trait_ident}_{ident}_inline"), ident.span());
             let (inline_signature, inline_block) =
                 turbo_fn.inline_signature_and_block(default, is_self_used);
             let inline_attrs = filter_inline_attributes(&attrs[..]);

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/loom_tests.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/loom_tests.rs
@@ -217,7 +217,7 @@ fn fuzzy_loom_new() {
     for size in [10, 20] {
         for _ in 0..1000 {
             let seed = rand::random();
-            println!("Seed {} Size {}", seed, size);
+            println!("Seed {seed} Size {size}");
             fuzzy_loom(seed, size);
         }
     }

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/tests.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/tests.rs
@@ -86,11 +86,8 @@ fn check_invariants(ctx: &NodeAggregationContext<'_>, node_ids: impl IntoIterato
                         || aggregation_number == u32::MAX;
                     if !condition {
                         let msg = format!(
-                            "follower #{} {} -> #{} {}",
-                            node_value,
-                            aggregation_number,
-                            follower_value,
-                            follower_aggregation_number
+                            "follower #{node_value} {aggregation_number} -> #{follower_value} \
+                             {follower_aggregation_number}"
                         );
                         print(ctx, &find_root(node_id.clone()), true);
                         panic!("{msg}");
@@ -120,8 +117,8 @@ fn check_invariants(ctx: &NodeAggregationContext<'_>, node_ids: impl IntoIterato
                             upper.guard.value
                         };
                         let msg = format!(
-                            "follower #{} -> #{} is not connected to upper #{}",
-                            node_value, follower_value, upper_value,
+                            "follower #{node_value} -> #{follower_value} is not connected to \
+                             upper #{upper_value}",
                         );
                         print(ctx, &find_root(node_id.clone()), true);
                         panic!("{msg}");
@@ -193,10 +190,7 @@ fn print_graph<C: AggregationContext>(
         drop(node);
 
         if show_internal {
-            println!(
-                "\"{}\" [label=\"{}\\n{}\", style=filled, fillcolor=\"{}\"];",
-                name, name, n, color
-            );
+            println!("\"{name}\" [label=\"{name}\\n{n}\", style=filled, fillcolor=\"{color}\"];");
         } else {
             println!(
                 "\"{}\" [label=\"{}\\n{}\\n{}U {}F\", style=filled, fillcolor=\"{}\"];",
@@ -211,7 +205,7 @@ fn print_graph<C: AggregationContext>(
 
         for child_id in children {
             let child_name = name_fn(&child_id);
-            println!("\"{}\" -> \"{}\";", name, child_name);
+            println!("\"{name}\" -> \"{child_name}\";");
             if visited.insert(child_id.clone()) {
                 queue.push(child_id);
             }
@@ -219,20 +213,14 @@ fn print_graph<C: AggregationContext>(
         if show_internal {
             for upper_id in uppers {
                 let upper_name = name_fn(&upper_id);
-                println!(
-                    "\"{}\" -> \"{}\" [style=dashed, color=green];",
-                    name, upper_name
-                );
+                println!("\"{name}\" -> \"{upper_name}\" [style=dashed, color=green];");
                 if visited.insert(upper_id.clone()) {
                     queue.push(upper_id);
                 }
             }
             for follower_id in followers {
                 let follower_name = name_fn(&follower_id);
-                println!(
-                    "\"{}\" -> \"{}\" [style=dashed, color=red];",
-                    name, follower_name
-                );
+                println!("\"{name}\" -> \"{follower_name}\" [style=dashed, color=red];");
                 if visited.insert(follower_id.clone()) {
                     queue.push(follower_id);
                 }
@@ -805,7 +793,7 @@ fn performance(
             let n = guard.aggregation_node.aggregation_number();
             let f = guard.aggregation_node.followers().map_or(0, |f| f.len());
             let u = guard.aggregation_node.uppers().len();
-            print!(" -> {} [{}U {}F]", n, u, f);
+            print!(" -> {n} [{u}U {f}F]");
             if guard.children.is_empty() {
                 break;
             }
@@ -868,7 +856,7 @@ fn performance(
         node.add_child_unchecked(&ctx, inner_node.clone());
     }
     let root_duration = start.elapsed();
-    println!("Root: {:?}", root_duration);
+    println!("Root: {root_duration:?}");
 
     // Add another child
     let start = Instant::now();
@@ -877,7 +865,7 @@ fn performance(
         inner_node.add_child_unchecked(&ctx, node.clone());
     }
     let child_duration = start.elapsed();
-    println!("Child: {:?}", child_duration);
+    println!("Child: {child_duration:?}");
 
     print_aggregation_numbers(inner_node.clone());
 
@@ -922,7 +910,7 @@ fn many_children() {
         inner_node.add_child_unchecked(&ctx, node.clone());
     }
     let children_duration = start.elapsed();
-    println!("Children: {:?}", children_duration);
+    println!("Children: {children_duration:?}");
     for j in 0.. {
         let start = Instant::now();
         for i in 0..CHILDREN {
@@ -931,7 +919,7 @@ fn many_children() {
             inner_node.add_child_unchecked(&ctx, node.clone());
         }
         let dur = start.elapsed();
-        println!("Children: {:?}", dur);
+        println!("Children: {dur:?}");
         let is_slow = dur > children_duration * 2;
         if j > 10 && !is_slow {
             break;
@@ -1004,7 +992,7 @@ fn fuzzy_new() {
     for size in [10, 50, 100, 200, 1000] {
         for _ in 0..100 {
             let seed = rand::random();
-            println!("Seed {} Size {}", seed, size);
+            println!("Seed {seed} Size {size}");
             fuzzy(seed, size);
         }
     }

--- a/turbopack/crates/turbo-tasks-memory/src/count_hash_set.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/count_hash_set.rs
@@ -348,7 +348,7 @@ mod tests {
         assert!(set.is_empty());
 
         assert_eq!(
-            format!("{:?}", set),
+            format!("{set:?}"),
             "CountHashSet { inner: {}, negative_entries: 0 }"
         );
     }
@@ -392,7 +392,7 @@ mod tests {
         assert!(set.is_empty());
 
         assert_eq!(
-            format!("{:?}", set),
+            format!("{set:?}"),
             "CountHashSet { inner: {}, negative_entries: 0 }"
         );
     }

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -527,7 +527,7 @@ impl Backend for MemoryBackend {
                 match task.read_cell(
                     index,
                     self.gc_queue.as_ref(),
-                    move || format!("reading {} {} from {}", task_id, index, reader),
+                    move || format!("reading {task_id} {index} from {reader}"),
                     Some(reader),
                     self,
                     turbo_tasks,
@@ -564,7 +564,7 @@ impl Backend for MemoryBackend {
             match task.read_cell(
                 index,
                 self.gc_queue.as_ref(),
-                move || format!("reading {} {} untracked", task_id, index),
+                move || format!("reading {task_id} {index} untracked"),
                 None,
                 self,
                 turbo_tasks,

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -616,8 +616,8 @@ impl Task {
 
     fn format_description(ty: &TaskTypeForDescription, id: TaskId) -> String {
         match ty {
-            TaskTypeForDescription::Root => format!("[{}] root", id),
-            TaskTypeForDescription::Once => format!("[{}] once", id),
+            TaskTypeForDescription::Root => format!("[{id}] root"),
+            TaskTypeForDescription::Once => format!("[{id}] once"),
             TaskTypeForDescription::Persistent(ty) => format!("[{id}] {ty}"),
         }
     }
@@ -737,10 +737,7 @@ impl Task {
                 }
                 Dirty { .. } => {
                     let state_type = Task::state_string(&state);
-                    panic!(
-                        "{:?} execution started in unexpected state {}",
-                        self, state_type
-                    )
+                    panic!("{self:?} execution started in unexpected state {state_type}")
                 }
             };
             self.make_execution_future()
@@ -869,7 +866,7 @@ impl Task {
                 }
                 Ok(Err(mut err)) => {
                     if let Some(name) = self.get_function_name() {
-                        err = err.context(format!("Execution of {} failed", name));
+                        err = err.context(format!("Execution of {name} failed"));
                     }
                     state.output.error(err, turbo_tasks)
                 }

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -23,7 +23,7 @@ async fn dirty_in_progress() {
             (11, 13, 2, 2, ""),
         ];
         for (a, b, c, value, collectible) in cases {
-            println!("{} -> {} -> {} = {} {}", a, b, c, value, collectible);
+            println!("{a} -> {b} -> {c} = {value} {collectible}");
             let input = ChangingInput {
                 state: State::new(a),
             }
@@ -31,10 +31,10 @@ async fn dirty_in_progress() {
             let input_val = input.await?;
             let output = compute(input);
             output.await?;
-            println!("update to {}", b);
+            println!("update to {b}");
             input_val.state.set(b);
             tokio::time::sleep(Duration::from_millis(50)).await;
-            println!("update to {}", c);
+            println!("update to {c}");
             input_val.state.set(c);
             let read = output.strongly_consistent().await?;
             assert_eq!(read.value, value);

--- a/turbopack/crates/turbo-tasks-testing/tests/performance.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/performance.rs
@@ -31,7 +31,7 @@ where
         let start = std::time::Instant::now();
         f().await?;
         let warmup_call = start.elapsed();
-        println!("Subsequent call took {:?}", warmup_call);
+        println!("Subsequent call took {warmup_call:?}");
         warmup_calls.push(warmup_call);
     }
 
@@ -99,7 +99,7 @@ where
     let start = std::time::Instant::now();
     f().await?;
     let final_call = start.elapsed();
-    println!("Final call took {:?}", final_call);
+    println!("Final call took {final_call:?}");
 
     let target = subsequent / COUNT1;
 
@@ -114,20 +114,17 @@ where
 
     assert!(
         subsequent < limit * COUNT1,
-        "Each call should be less than {:?}",
-        limit
+        "Each call should be less than {limit:?}"
     );
 
     assert!(
         subsequent2 < limit * COUNT1,
-        "Each call should be less than {:?}",
-        limit
+        "Each call should be less than {limit:?}"
     );
 
     assert!(
         subsequent3 < limit * COUNT1,
-        "Each call should be less than {:?}",
-        limit
+        "Each call should be less than {limit:?}"
     );
 
     anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks-testing/tests/random_change.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/random_change.rs
@@ -64,7 +64,7 @@ async fn func(input: Vc<ValueContainer>, nesting: i32) -> Result<Vc<Value>> {
         return Ok(func(input, nesting + 1));
     }
     if nesting == *value {
-        println!("func {}", nesting);
+        println!("func {nesting}");
         return Ok(Value { value: *value }.cell());
     }
     bail!("func no longer valid {}", nesting)

--- a/turbopack/crates/turbo-tasks/src/debug/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/debug/mod.rs
@@ -72,7 +72,7 @@ pub trait ValueDebugFormat {
 
 impl ValueDebugFormat for String {
     fn value_debug_format(&self, _depth: usize) -> ValueDebugFormatString {
-        ValueDebugFormatString::Sync(format!("{:#?}", self))
+        ValueDebugFormatString::Sync(format!("{self:#?}"))
     }
 }
 
@@ -96,7 +96,7 @@ where
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
 
-        ValueDebugFormatString::Sync(format!("{:#?}", self))
+        ValueDebugFormatString::Sync(format!("{self:#?}"))
     }
 }
 
@@ -153,7 +153,7 @@ where
                     }
                 }
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }
@@ -184,7 +184,7 @@ where
                     }
                 }
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }
@@ -215,7 +215,7 @@ where
                     }
                 }
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }
@@ -234,7 +234,7 @@ where
             .iter()
             .map(|(key, value)| {
                 (
-                    format!("{:#?}", key),
+                    format!("{key:#?}"),
                     value.value_debug_format(depth.saturating_sub(1)),
                 )
             })
@@ -252,7 +252,7 @@ where
                     }
                 }
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }
@@ -271,7 +271,7 @@ where
             .iter()
             .map(|(key, value)| {
                 (
-                    format!("{:#?}", key),
+                    format!("{key:#?}"),
                     value.value_debug_format(depth.saturating_sub(1)),
                 )
             })
@@ -289,7 +289,7 @@ where
                     }
                 }
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }
@@ -317,7 +317,7 @@ where
                 };
                 values_string.insert(PassthroughDebug::new_string(value));
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }
@@ -358,7 +358,7 @@ where
                     PassthroughDebug::new_string(value),
                 );
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }

--- a/turbopack/crates/turbo-tasks/src/invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/invalidation.rs
@@ -302,7 +302,7 @@ impl Display for InvalidationReasonSet {
             }
             match entry {
                 MapEntry::Single { reason } => {
-                    write!(f, "{}", reason)?;
+                    write!(f, "{reason}")?;
                 }
                 MapEntry::Multiple { reasons } => {
                     let MapKey::Typed { kind } = key else {

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -21,9 +21,9 @@ pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> Stri
     match value.try_to_value_debug_string().await {
         Ok(result) => match result.await {
             Ok(result) => result.to_string(),
-            Err(err) => format!("{0:?}", err),
+            Err(err) => format!("{err:?}"),
         },
-        Err(err) => format!("{0:?}", err),
+        Err(err) => format!("{err:?}"),
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -770,7 +770,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                 let local_task_id = gts_write.create_local_task(LocalTask::Scheduled {
                     done_event: Event::new({
                         let ty = Arc::clone(&ty);
-                        move || format!("LocalTask({})::done_event", ty)
+                        move || format!("LocalTask({ty})::done_event")
                     }),
                 });
                 (
@@ -1578,10 +1578,7 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
 pub(crate) fn current_task(from: &str) -> TaskId {
     match CURRENT_TASK_STATE.try_with(|ts| ts.read().unwrap().task_id) {
         Ok(id) => id,
-        Err(_) => panic!(
-            "{} can only be used in the context of turbo_tasks task execution",
-            from
-        ),
+        Err(_) => panic!("{from} can only be used in the context of turbo_tasks task execution"),
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/output.rs
+++ b/turbopack/crates/turbo-tasks/src/output.rs
@@ -29,9 +29,9 @@ impl OutputContent {
 impl Display for OutputContent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Link(raw_vc) => write!(f, "link {:?}", raw_vc),
-            Self::Error(err) => write!(f, "error {}", err),
-            Self::Panic(Some(message)) => write!(f, "panic {}", message),
+            Self::Link(raw_vc) => write!(f, "link {raw_vc:?}"),
+            Self::Error(err) => write!(f, "error {err}"),
+            Self::Panic(Some(message)) => write!(f, "panic {message}"),
             Self::Panic(None) => write!(f, "panic"),
         }
     }

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -72,7 +72,7 @@ where
     if let Some(id) = map_by_value.get(&value) {
         id.clone()
     } else {
-        panic!("Use of unregistered {:?}", value);
+        panic!("Use of unregistered {value:?}");
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/task/local_task.rs
+++ b/turbopack/crates/turbo-tasks/src/task/local_task.rs
@@ -186,7 +186,7 @@ impl LocalTaskType {
             Err(name) => {
                 if !has_trait(value_type, trait_type) {
                     let traits = traits(value_type).iter().fold(String::new(), |mut out, t| {
-                        let _ = write!(out, " {}", t);
+                        let _ = write!(out, " {t}");
                         out
                     });
                     Err(anyhow!(

--- a/turbopack/crates/turbo-tasks/src/util.rs
+++ b/turbopack/crates/turbo-tasks/src/util.rs
@@ -104,11 +104,11 @@ impl Display for FormatDuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = self.0.as_secs();
         if s > 10 {
-            return write!(f, "{}s", s);
+            return write!(f, "{s}s");
         }
         let ms = self.0.as_millis();
         if ms > 10 {
-            return write!(f, "{}ms", ms);
+            return write!(f, "{ms}ms");
         }
         write!(f, "{}ms", (self.0.as_micros() as f32) / 1000.0)
     }
@@ -118,14 +118,14 @@ impl Debug for FormatDuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = self.0.as_secs();
         if s > 100 {
-            return write!(f, "{}s", s);
+            return write!(f, "{s}s");
         }
         let ms = self.0.as_millis();
         if ms > 10000 {
             return write!(f, "{:.2}s", (ms as f32) / 1000.0);
         }
         if ms > 100 {
-            return write!(f, "{}ms", ms);
+            return write!(f, "{ms}ms");
         }
         write!(f, "{}ms", (self.0.as_micros() as f32) / 1000.0)
     }
@@ -148,7 +148,7 @@ impl Display for FormatBytes {
         if b > KB {
             return write!(f, "{:.2}KiB", (b as f32) / 1_024.0);
         }
-        write!(f, "{}B", b)
+        write!(f, "{b}B")
     }
 }
 

--- a/turbopack/crates/turbopack-bench/src/lib.rs
+++ b/turbopack/crates/turbopack-bench/src/lib.rs
@@ -85,7 +85,7 @@ fn bench_startup_internal(
             let input = (bundler.as_ref(), &test_app);
             resume_on_error(AssertUnwindSafe(|| {
                 g.bench_with_input(
-                    BenchmarkId::new(bundler.get_name(), format!("{} modules", module_count)),
+                    BenchmarkId::new(bundler.get_name(), format!("{module_count} modules")),
                     &input,
                     |b, &(bundler, test_app)| {
                         let test_app = &**test_app;
@@ -172,7 +172,7 @@ fn bench_hmr_internal(
 
             resume_on_error(AssertUnwindSafe(|| {
                 g.bench_with_input(
-                    BenchmarkId::new(bundler.get_name(), format!("{} modules", module_count)),
+                    BenchmarkId::new(bundler.get_name(), format!("{module_count} modules")),
                     &input,
                     |b, &(bundler, test_app)| {
                         let test_app = &**test_app;
@@ -309,7 +309,7 @@ fn bench_hmr_internal(
                                                 FormatDuration(value / (iter as u32)),
                                                 iter,
                                                 if dropped > 0 {
-                                                    format!(" ({} dropped)", dropped)
+                                                    format!(" ({dropped} dropped)")
                                                 } else {
                                                     "".to_string()
                                                 }
@@ -481,7 +481,7 @@ fn bench_startup_cached_internal(
 
             resume_on_error(AssertUnwindSafe(|| {
                 g.bench_with_input(
-                    BenchmarkId::new(bundler.get_name(), format!("{} modules", module_count)),
+                    BenchmarkId::new(bundler.get_name(), format!("{module_count} modules")),
                     &input,
                     |b, &(bundler, test_app)| {
                         let test_app = &**test_app;

--- a/turbopack/crates/turbopack-bench/src/util/npm.rs
+++ b/turbopack/crates/turbopack-bench/src/util/npm.rs
@@ -43,7 +43,7 @@ pub fn install(install_dir: &Path, packages: &[NpmPackage<'_>]) -> Result<()> {
         });
 
         File::create(install_dir.join("package.json"))?
-            .write_all(format!("{:#}", package_json).as_bytes())?;
+            .write_all(format!("{package_json:#}").as_bytes())?;
     }
 
     let mut args = vec![

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -102,7 +102,7 @@ fn format_optional_path(
             if let Some(context) = context {
                 let option_context = Some(context.clone());
                 if last_context == option_context {
-                    writeln!(formatted_issue, " at {}", description)?;
+                    writeln!(formatted_issue, " at {description}")?;
                 } else {
                     writeln!(
                         formatted_issue,
@@ -113,7 +113,7 @@ fn format_optional_path(
                     last_context = option_context;
                 }
             } else {
-                writeln!(formatted_issue, " at {}", description)?;
+                writeln!(formatted_issue, " at {description}")?;
                 last_context = None;
             }
         }
@@ -167,7 +167,7 @@ pub fn format_issue(
             writeln!(styled_issue, "\ndocumentation: {documentation_link}").unwrap();
         }
         if let Some(path) = path {
-            writeln!(styled_issue, "{}", path).unwrap();
+            writeln!(styled_issue, "{path}").unwrap();
         }
     }
 
@@ -590,7 +590,7 @@ fn style_issue_source(plain_issue: &PlainIssue, context_path: &str) -> String {
                 start.column,
                 formatted_title
             ),
-            None => format!("{}  {}", context_path, formatted_title),
+            None => format!("{context_path}  {formatted_title}"),
         };
         styled_issue.push('\n');
         format_source_content(source, &mut styled_issue);

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
@@ -106,7 +106,7 @@ pub async fn app_vendors_split<'l>(
         }
     }
     if !chunk_group_specific_chunk_items.is_empty() {
-        let mut name = format!("{}-specific", name);
+        let mut name = format!("{name}-specific");
         make_chunk(
             chunk_group_specific_chunk_items,
             Vec::new(),
@@ -116,7 +116,7 @@ pub async fn app_vendors_split<'l>(
         .await?;
     }
     let mut remaining = Vec::new();
-    let mut key = format!("{}-app", name);
+    let mut key = format!("{name}-app");
     if !handle_split_group(
         &mut app_chunk_items,
         &mut key,
@@ -127,7 +127,7 @@ pub async fn app_vendors_split<'l>(
     {
         folder_split(app_chunk_items, 0, key.into(), split_context).await?;
     }
-    let mut key = format!("{}-vendors", name);
+    let mut key = format!("{name}-vendors");
     if !handle_split_group(
         &mut vendors_chunk_items,
         &mut key,
@@ -168,7 +168,7 @@ async fn package_name_split<'l>(
     }
     let mut remaining = Vec::new();
     for (package_name, mut list) in map {
-        let mut key = format!("{}-{}", name, package_name);
+        let mut key = format!("{name}-{package_name}");
         if !handle_split_group(&mut list, &mut key, split_context, Some(&mut remaining)).await? {
             folder_split(list, 0, key.into(), split_context).await?;
         }
@@ -216,7 +216,7 @@ async fn folder_split<'l>(
                 map = FxIndexMap::default();
                 continue;
             } else {
-                let mut key = format!("{}-{}", name, folder_name);
+                let mut key = format!("{name}-{folder_name}");
                 make_chunk(list, Vec::new(), &mut key, split_context).await?;
                 return Ok(());
             }
@@ -226,7 +226,7 @@ async fn folder_split<'l>(
     }
     let mut remaining = Vec::new();
     for (folder_name, (new_location, mut list)) in map {
-        let mut key = format!("{}-{}", name, folder_name);
+        let mut key = format!("{name}-{folder_name}");
         if !handle_split_group(&mut list, &mut key, split_context, Some(&mut remaining)).await? {
             if let Some(new_location) = new_location {
                 Box::pin(folder_split(

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -58,8 +58,8 @@ pub enum ModuleId {
 impl Display for ModuleId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ModuleId::Number(i) => write!(f, "{}", i),
-            ModuleId::String(s) => write!(f, "{}", s),
+            ModuleId::Number(i) => write!(f, "{i}"),
+            ModuleId::String(s) => write!(f, "{s}"),
         }
     }
 }

--- a/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
@@ -60,11 +60,11 @@ impl ModuleIdStrategy for GlobalModuleIdStrategy {
             ModuleIssue {
                 ident,
                 title: StyledString::Text(
-                    format!("ModuleId not found for ident: {:?}", ident_string).into(),
+                    format!("ModuleId not found for ident: {ident_string:?}").into(),
                 )
                 .resolved_cell(),
                 description: StyledString::Text(
-                    format!("ModuleId not found for ident: {:?}", ident_string).into(),
+                    format!("ModuleId not found for ident: {ident_string:?}").into(),
                 )
                 .resolved_cell(),
             }

--- a/turbopack/crates/turbopack-core/src/error.rs
+++ b/turbopack/crates/turbopack-core/src/error.rs
@@ -27,9 +27,9 @@ impl Display for PrettyPrintError<'_> {
                             header
                         });
                 match i {
-                    0 => write!(f, "{}", header)?,
-                    1 => write!(f, "\n\nCaused by:\n- {}", header)?,
-                    _ => write!(f, "\n- {}", header)?,
+                    0 => write!(f, "{header}")?,
+                    1 => write!(f, "\n\nCaused by:\n- {header}")?,
+                    _ => write!(f, "\n- {header}")?,
                 }
                 i += 1;
             } else {
@@ -54,10 +54,10 @@ impl Display for WithDash<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let mut lines = self.0.lines();
         if let Some(line) = lines.next() {
-            write!(f, "- {}", line)?;
+            write!(f, "- {line}")?;
         }
         for line in lines {
-            write!(f, "\n  {}", line)?;
+            write!(f, "\n  {line}")?;
         }
         Ok(())
     }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -76,7 +76,7 @@ impl ValueToString for AssetIdent {
 
                 let key_str = key.await?;
                 let asset_str = asset.to_string().await?;
-                write!(s, " {} => {:?}", key_str, asset_str)?;
+                write!(s, " {key_str} => {asset_str:?}")?;
             }
 
             s.push_str(" }");
@@ -101,7 +101,7 @@ impl ValueToString for AssetIdent {
         }
 
         if let Some(content_type) = &self.content_type {
-            write!(s, " <{}>", content_type)?;
+            write!(s, " <{content_type}>")?;
         }
 
         if !self.parts.is_empty() {
@@ -109,7 +109,7 @@ impl ValueToString for AssetIdent {
                 if !matches!(part, ModulePart::Facade) {
                     // facade is not included in ident as switching between facade and non-facade
                     // shouldn't change the ident
-                    write!(s, " <{}>", part)?;
+                    write!(s, " <{part}>")?;
                 }
             }
         }
@@ -327,7 +327,7 @@ impl AssetIdent {
         if has_hash {
             let hash = encode_hex(hasher.finish());
             let truncated_hash = &hash[..8];
-            write!(name, "_{}", truncated_hash)?;
+            write!(name, "_{truncated_hash}")?;
         }
 
         // Location in "path" where hashed and named parts are split.

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -672,7 +672,7 @@ impl Display for IssueStage {
             IssueStage::Unsupported => write!(f, "unsupported"),
             IssueStage::AppStructure => write!(f, "app structure"),
             IssueStage::Misc => write!(f, "misc"),
-            IssueStage::Other(s) => write!(f, "{}", s),
+            IssueStage::Other(s) => write!(f, "{s}"),
         }
     }
 }

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -70,7 +70,7 @@ impl Issue for ResolvingIssue {
             for request in request_parts {
                 match lookup_import_map(**import_map, *self.file_path, **request).await {
                     Ok(None) => {}
-                    Ok(Some(str)) => writeln!(description, "Import map: {}", str)?,
+                    Ok(Some(str)) => writeln!(description, "Import map: {str}")?,
                     Err(err) => {
                         writeln!(
                             description,

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -343,7 +343,7 @@ impl SingleModuleGraph {
                 }
             }
             if !duplicates.is_empty() {
-                panic!("Duplicate module idents in graph: {:#?}", duplicates);
+                panic!("Duplicate module idents in graph: {duplicates:#?}");
             }
         }
 

--- a/turbopack/crates/turbopack-core/src/package_json.rs
+++ b/turbopack/crates/turbopack-core/src/package_json.rs
@@ -44,7 +44,7 @@ pub async fn read_package_json(path: ResolvedVc<FileSystemPath>) -> Result<Vc<Op
                 let text = content.content().to_str()?;
                 e.write_with_content(&mut message, &text)?;
             } else {
-                write!(message, "{}", e)?;
+                write!(message, "{e}")?;
             }
             PackageJsonIssue {
                 error_message: message.into(),

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -141,7 +141,7 @@ impl ImportContext {
                 if i > 0 {
                     modifier.push(' ');
                 }
-                write!(modifier, "layer({})", layer)?
+                write!(modifier, "layer({layer})")?
             }
         }
         if !self.media.is_empty() {
@@ -163,7 +163,7 @@ impl ImportContext {
                 if i > 0 {
                     modifier.push(' ');
                 }
-                write!(modifier, "supports({})", supports)?
+                write!(modifier, "supports({supports})")?
             }
         }
         Ok(Vc::cell(modifier.into()))

--- a/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
@@ -146,7 +146,7 @@ where
                         value.value_debug_format(depth.saturating_sub(1)),
                     ),
                     AliasKey::Wildcard { suffix } => (
-                        format!("{}*{}", key, suffix),
+                        format!("{key}*{suffix}"),
                         value.value_debug_format(depth.saturating_sub(1)),
                     ),
                 })
@@ -165,7 +165,7 @@ where
                     }
                 }
             }
-            Ok(format!("{:#?}", values_string))
+            Ok(format!("{values_string:#?}"))
         }))
     }
 }
@@ -180,7 +180,7 @@ where
                 let key = String::from_utf8(key).expect("invalid UTF-8 key in AliasMap");
                 map.iter().map(move |(alias_key, value)| match alias_key {
                     AliasKey::Exact => (key.clone(), value),
-                    AliasKey::Wildcard { suffix } => (format!("{}*{}", key, suffix), value),
+                    AliasKey::Wildcard { suffix } => (format!("{key}*{suffix}"), value),
                 })
             }))
             .finish()
@@ -203,10 +203,7 @@ impl<T> AliasMap<T> {
         T: Debug,
     {
         if matches!(request, Pattern::Alternatives(_)) {
-            panic!(
-                "AliasMap::lookup must not be called on alternatives, received {:?}",
-                request
-            );
+            panic!("AliasMap::lookup must not be called on alternatives, received {request:?}");
         }
 
         // Invariant: prefixes should be sorted by increasing length (base lengths),

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -492,7 +492,7 @@ pub struct RequestKey {
 impl Display for RequestKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(request) = &self.request {
-            write!(f, "{}", request)?;
+            write!(f, "{request}")?;
         } else {
             write!(f, "<default>")?;
         }
@@ -502,7 +502,7 @@ impl Display for RequestKey {
                 if i > 0 {
                     write!(f, ", ")?;
                 }
-                write!(f, "{}={}", k, v)?;
+                write!(f, "{k}={v}")?;
             }
             write!(f, ")")?;
         }
@@ -538,7 +538,7 @@ impl ValueToString for ResolveResult {
             if i > 0 {
                 result.push_str(", ");
             }
-            write!(result, "{} -> ", request).unwrap();
+            write!(result, "{request} -> ").unwrap();
             match item {
                 ResolveResultItem::Source(a) => {
                     result.push_str(&a.ident().to_string().await?);
@@ -550,7 +550,7 @@ impl ValueToString for ResolveResult {
                 } => {
                     result.push_str("external ");
                     result.push_str(s);
-                    write!(result, " ({}, {})", ty, traced)?;
+                    write!(result, " ({ty}, {traced})")?;
                 }
                 ResolveResultItem::Ignore => {
                     result.push_str("ignore");
@@ -1029,7 +1029,7 @@ impl ResolveResult {
                         request: request_key
                             .request
                             .as_ref()
-                            .map(|r| format!("{}{}", r, remaining).into()),
+                            .map(|r| format!("{r}{remaining}").into()),
                         conditions: request_key.conditions.clone(),
                     },
                     v.clone(),
@@ -2040,7 +2040,7 @@ async fn resolve_internal_inline(
                 query: _,
                 fragment: _,
             } => {
-                let uri: RcStr = format!("{}{}", protocol, remainder).into();
+                let uri: RcStr = format!("{protocol}{remainder}").into();
                 *ResolveResult::primary_with_key(
                     RequestKey::new(uri.clone()),
                     ResolveResultItem::External {
@@ -2054,7 +2054,7 @@ async fn resolve_internal_inline(
                 if !has_alias {
                     ResolvingIssue {
                         severity: error_severity(options).await?,
-                        request_type: format!("unknown import: `{}`", path),
+                        request_type: format!("unknown import: `{path}`"),
                         request: request.to_resolved().await?,
                         file_path: lookup_path.to_resolved().await?,
                         resolve_options: options.to_resolved().await?,
@@ -2464,7 +2464,7 @@ async fn apply_in_package(
                 .to_resolved()
                 .await?,
             resolve_options: options.to_resolved().await?,
-            error_message: Some(format!("invalid alias field value: {}", value)),
+            error_message: Some(format!("invalid alias field value: {value}")),
             source: None,
         }
         .resolved_cell()
@@ -2894,7 +2894,7 @@ async fn handle_exports_imports_field(
     let mut conditions_state = FxHashMap::default();
 
     let query_str = query.await?;
-    let req = Pattern::Constant(format!("{}{}", path, query_str).into());
+    let req = Pattern::Constant(format!("{path}{query_str}").into());
 
     let values = exports_imports_field
         .lookup(&req)
@@ -3215,15 +3215,15 @@ impl Display for ModulePart {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ModulePart::Evaluation => f.write_str("module evaluation"),
-            ModulePart::Export(export) => write!(f, "export {}", export),
+            ModulePart::Export(export) => write!(f, "export {export}"),
             ModulePart::RenamedExport {
                 original_export,
                 export,
-            } => write!(f, "export {} as {}", original_export, export),
+            } => write!(f, "export {original_export} as {export}"),
             ModulePart::RenamedNamespace { export } => {
-                write!(f, "export * as {}", export)
+                write!(f, "export * as {export}")
             }
-            ModulePart::Internal(id) => write!(f, "internal part {}", id),
+            ModulePart::Internal(id) => write!(f, "internal part {id}"),
             ModulePart::Locals => f.write_str("locals"),
             ModulePart::Exports => f.write_str("exports"),
             ModulePart::Facade => f.write_str("facade"),

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -82,8 +82,8 @@ fn split_off_query_fragment(raw: RcStr) -> (Pattern, Vc<RcStr>, Vc<RcStr>) {
 
     (
         Pattern::Constant(raw.into()),
-        Vc::cell(format!("?{}", query).into()),
-        Vc::cell(format!("#{}", fragment).into()),
+        Vc::cell(format!("?{query}").into()),
+        Vc::cell(format!("#{fragment}").into()),
     )
 }
 
@@ -648,7 +648,7 @@ impl Request {
                 query,
                 fragment,
             } => {
-                let remainder = format!("{}{}", remainder, suffix).into();
+                let remainder = format!("{remainder}{suffix}").into();
                 Self::Uri {
                     protocol: protocol.clone(),
                     remainder,

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -859,7 +859,7 @@ impl Pattern {
                 }
             }
             Pattern::Alternatives(_) => {
-                panic!("for matching a Pattern must be normalized {:?}", self)
+                panic!("for matching a Pattern must be normalized {self:?}")
             }
             Pattern::Concatenation(list) => {
                 for part in list {
@@ -943,7 +943,7 @@ impl Pattern {
                 }
             }
             Pattern::Alternatives(_) => {
-                panic!("for matching a Pattern must be normalized {:?}", self)
+                panic!("for matching a Pattern must be normalized {self:?}")
             }
             Pattern::Concatenation(list) => {
                 for part in list {

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -412,7 +412,7 @@ impl SourceMap {
             Ok(
                 if let Some(path) = *origin.parent().try_join((&*source_request).into()).await? {
                     let path_str = path.to_string().await?;
-                    let source = format!("{SOURCE_URL_PROTOCOL}///{}", path_str);
+                    let source = format!("{SOURCE_URL_PROTOCOL}///{path_str}");
                     let source_content = if let Some(source_content) = source_content {
                         source_content
                     } else if let FileContent::Content(file) = &*path.read().await? {
@@ -430,7 +430,7 @@ impl SourceMap {
                         .replace_all(&source_request, |s: &regex::Captures<'_>| {
                             s[0].replace('.', "_")
                         });
-                    let source = format!("{SOURCE_URL_PROTOCOL}///{}/{}", origin_str, source);
+                    let source = format!("{SOURCE_URL_PROTOCOL}///{origin_str}/{source}");
                     let source_content = source_content.unwrap_or_else(|| {
                         format!(
                             "unable to access {source_request} in {origin_str} (it's leaving the \

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -86,7 +86,7 @@ pub async fn resolve_source_map_sources(
             .await?
         {
             let path_str = path.to_string().await?;
-            let source = format!("{SOURCE_URL_PROTOCOL}///{}", path_str);
+            let source = format!("{SOURCE_URL_PROTOCOL}///{path_str}");
             *original_source = source;
 
             if original_content.is_none() {
@@ -104,7 +104,7 @@ pub async fn resolve_source_map_sources(
             let source = INVALID_REGEX.replace_all(original_source, |s: &regex::Captures<'_>| {
                 s[0].replace('.', "_")
             });
-            *original_source = format!("{SOURCE_URL_PROTOCOL}///{}/{}", origin_str, source);
+            *original_source = format!("{SOURCE_URL_PROTOCOL}///{origin_str}/{source}");
             if original_content.is_none() {
                 *original_content = Some(format!(
                     "unable to access {original_source} in {origin_str} (it's leaving the \

--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -46,7 +46,7 @@ impl CompileTarget {
 
 impl Display for CompileTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/turbopack/crates/turbopack-create-test-app/src/test_app_builder.rs
+++ b/turbopack/crates/turbopack-create-test-app/src/test_app_builder.rs
@@ -521,7 +521,7 @@ impl TestAppBuilder {
             write_file(
                 "package.json",
                 path.join("package.json"),
-                format!("{:#}", package_json).as_bytes(),
+                format!("{package_json:#}").as_bytes(),
             )?;
         }
 

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -90,7 +90,7 @@ impl CssChunk {
                 MinifyType::NoMinify
             ) {
                 let id = css_item.asset_ident().to_string().await?;
-                writeln!(body, "/* {} */", id)?;
+                writeln!(body, "/* {id} */")?;
             }
 
             let close = write_import_context(&mut body, content.import_context).await?;

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -60,7 +60,7 @@ impl SingleItemCssChunk {
             MinifyType::NoMinify
         ) {
             let id = this.item.asset_ident().to_string().await?;
-            writeln!(code, "/* {} */", id)?;
+            writeln!(code, "/* {id} */")?;
         }
         let content = this.item.content().await?;
         let close = write_import_context(&mut code, content.import_context).await?;

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -170,7 +170,7 @@ impl CodeGenerateable for ImportAssetReference {
         } = &*this.request.await?
         {
             imports.push(CssImport::External(ResolvedVc::cell(
-                format!("{}{}", protocol, remainder).into(),
+                format!("{protocol}{remainder}").into(),
             )))
         }
 

--- a/turbopack/crates/turbopack-css/src/util.rs
+++ b/turbopack/crates/turbopack-css/src/util.rs
@@ -17,7 +17,7 @@ pub fn stringify_js(str: &str) -> String {
         }
     }
 
-    format!("\"{}\"", escaped)
+    format!("\"{escaped}\"")
 }
 
 #[cfg(test)]

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -208,11 +208,10 @@ impl DevHtmlAssetContent {
 
         for relative_path in &*self.chunk_paths {
             if relative_path.ends_with(".js") {
-                scripts.push(format!("<script src=\"{}\"></script>", relative_path));
+                scripts.push(format!("<script src=\"{relative_path}\"></script>"));
             } else if relative_path.ends_with(".css") {
                 stylesheets.push(format!(
-                    "<link data-turbopack rel=\"stylesheet\" href=\"{}\">",
-                    relative_path
+                    "<link data-turbopack rel=\"stylesheet\" href=\"{relative_path}\">"
                 ));
             } else {
                 anyhow::bail!("chunk with unknown asset type: {}", relative_path)

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -113,7 +113,7 @@ impl GetContentSourceContent for IntrospectionSource {
         let internal_ty = Vc::debug_identifier(*introspectable).await?;
         fn str_or_err(s: &Result<ReadRef<RcStr>>) -> Cow<'_, str> {
             s.as_ref().map_or_else(
-                |e| Cow::<'_, str>::Owned(format!("ERROR: {:?}", e)),
+                |e| Cow::<'_, str>::Owned(format!("ERROR: {e:?}")),
                 |d| Cow::Borrowed(&**d),
             )
         }

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -190,7 +190,7 @@ impl DevServerBuilder {
                                     return Ok(response);
                                 }
 
-                                println!("[404] {} (WebSocket)", path);
+                                println!("[404] {path} (WebSocket)");
                                 if path == "/_next/webpack-hmr" {
                                     // Special-case requests to webpack-hmr as these are made by
                                     // Next.js clients built

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -207,7 +207,7 @@ impl ValueToString for RouteTree {
         let mut result = "RouteTree(".to_string();
         for segment in base {
             match segment {
-                BaseSegment::Static(str) => write!(result, "/{}", str)?,
+                BaseSegment::Static(str) => write!(result, "/{str}")?,
                 BaseSegment::Dynamic => result.push_str("/[dynamic]"),
             }
         }
@@ -216,7 +216,7 @@ impl ValueToString for RouteTree {
         }
         for (key, tree) in static_segments {
             let tree = tree.to_string().await?;
-            write!(result, "{}: {}, ", key, tree)?;
+            write!(result, "{key}: {tree}, ")?;
         }
         if !sources.is_empty() {
             write!(result, "{} x source, ", sources.len())?;

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -190,7 +190,7 @@ impl Introspectable for PrefixedRouterContentSource {
     #[turbo_tasks::function]
     async fn details(&self) -> Result<Vc<RcStr>> {
         let prefix = self.prefix.await?;
-        Ok(Vc::cell(format!("prefix: '{}'", prefix).into()))
+        Ok(Vc::cell(format!("prefix: '{prefix}'").into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/src/update/server.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/server.rs
@@ -54,7 +54,7 @@ where
     pub fn run(self, tt: &dyn TurboTasksApi, ws: HyperWebsocket) {
         tt.run_once_process(Box::pin(async move {
             if let Err(err) = self.run_internal(ws).await {
-                println!("[UpdateServer]: error {:#}", err);
+                println!("[UpdateServer]: error {err:#}");
             }
             Ok(())
         }));

--- a/turbopack/crates/turbopack-ecmascript-hmr-protocol/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript-hmr-protocol/src/lib.rs
@@ -19,7 +19,7 @@ impl Display for ResourceIdentifier {
         write!(f, "{}", self.path)?;
         if let Some(headers) = &self.headers {
             for (key, value) in headers.iter() {
-                write!(f, " [{}: {}]", key, value)?;
+                write!(f, " [{key}: {value}]")?;
             }
         }
         Ok(())

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -61,13 +61,13 @@ enum Step {
 impl Display for Step {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Step::Enter(val) => write!(f, "Enter({})", val),
-            Step::EarlyVisit(val) => write!(f, "EarlyVisit({})", val),
-            Step::Leave(val) => write!(f, "Leave({})", val),
-            Step::LeaveVar(var) => write!(f, "LeaveVar({:?})", var),
-            Step::LeaveLate(val) => write!(f, "LeaveLate({})", val),
-            Step::Visit(val) => write!(f, "Visit({})", val),
-            Step::LeaveCall(func_ident) => write!(f, "LeaveCall({})", func_ident),
+            Step::Enter(val) => write!(f, "Enter({val})"),
+            Step::EarlyVisit(val) => write!(f, "EarlyVisit({val})"),
+            Step::Leave(val) => write!(f, "Leave({val})"),
+            Step::LeaveVar(var) => write!(f, "LeaveVar({var:?})"),
+            Step::LeaveLate(val) => write!(f, "LeaveLate({val})"),
+            Step::Visit(val) => write!(f, "Visit({val})"),
+            Step::LeaveCall(func_ident) => write!(f, "LeaveCall({func_ident})"),
             Step::TemporarySlot => write!(f, "TemporarySlot"),
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -639,7 +639,7 @@ impl Display for JsValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             JsValue::Constant(v) => write!(f, "{v}"),
-            JsValue::Url(url, kind) => write!(f, "{} {}", url, kind),
+            JsValue::Url(url, kind) => write!(f, "{url} {kind}"),
             JsValue::Array { items, mutable, .. } => write!(
                 f,
                 "{}[{}]",
@@ -671,12 +671,12 @@ impl Display for JsValue {
                     .collect::<Vec<_>>()
                     .join(" | ");
                 if let Some(logical_property) = logical_property {
-                    write!(f, "({}){{{}}}", list, logical_property)
+                    write!(f, "({list}){{{logical_property}}}")
                 } else {
-                    write!(f, "({})", list)
+                    write!(f, "({list})")
                 }
             }
-            JsValue::FreeVar(name) => write!(f, "FreeVar({:?})", name),
+            JsValue::FreeVar(name) => write!(f, "FreeVar({name:?})"),
             JsValue::Variable(name) => write!(f, "Variable({}#{:?})", name.0, name.1),
             JsValue::Concat(_, list) => write!(
                 f,
@@ -684,7 +684,7 @@ impl Display for JsValue {
                 list.iter()
                     .map(|v| v
                         .as_str()
-                        .map_or_else(|| format!("${{{}}}", v), |str| str.to_string()))
+                        .map_or_else(|| format!("${{{v}}}"), |str| str.to_string()))
                     .collect::<Vec<_>>()
                     .join("")
             ),
@@ -696,7 +696,7 @@ impl Display for JsValue {
                     .collect::<Vec<_>>()
                     .join(" + ")
             ),
-            JsValue::Not(_, value) => write!(f, "!({})", value),
+            JsValue::Not(_, value) => write!(f, "!({value})"),
             JsValue::Logical(_, op, list) => write!(
                 f,
                 "({})",
@@ -706,7 +706,7 @@ impl Display for JsValue {
                     .join(op.joiner())
             ),
             JsValue::Binary(_, a, op, b) => write!(f, "({}{}{})", a, op.joiner(), b),
-            JsValue::Tenary(_, test, cons, alt) => write!(f, "({} ? {} : {})", test, cons, alt),
+            JsValue::Tenary(_, test, cons, alt) => write!(f, "({test} ? {cons} : {alt})"),
             JsValue::New(_, callee, list) => write!(
                 f,
                 "new {}({})",
@@ -743,26 +743,26 @@ impl Display for JsValue {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            JsValue::Member(_, obj, prop) => write!(f, "{}[{}]", obj, prop),
+            JsValue::Member(_, obj, prop) => write!(f, "{obj}[{prop}]"),
             JsValue::Module(ModuleValue {
                 module: name,
                 annotations,
             }) => {
-                write!(f, "Module({}, {})", name, annotations)
+                write!(f, "Module({name}, {annotations})")
             }
             JsValue::Unknown { .. } => write!(f, "???"),
-            JsValue::WellKnownObject(obj) => write!(f, "WellKnownObject({:?})", obj),
-            JsValue::WellKnownFunction(func) => write!(f, "WellKnownFunction({:?})", func),
+            JsValue::WellKnownObject(obj) => write!(f, "WellKnownObject({obj:?})"),
+            JsValue::WellKnownFunction(func) => write!(f, "WellKnownFunction({func:?})"),
             JsValue::Function(_, func_ident, return_value) => {
-                write!(f, "Function#{}(return = {:?})", func_ident, return_value)
+                write!(f, "Function#{func_ident}(return = {return_value:?})")
             }
             JsValue::Argument(func_ident, index) => {
-                write!(f, "arguments[{}#{}]", index, func_ident)
+                write!(f, "arguments[{index}#{func_ident}]")
             }
-            JsValue::Iterated(_, iterable) => write!(f, "Iterated({})", iterable),
-            JsValue::TypeOf(_, operand) => write!(f, "typeof({})", operand),
-            JsValue::Promise(_, operand) => write!(f, "Promise<{}>", operand),
-            JsValue::Awaited(_, operand) => write!(f, "await({})", operand),
+            JsValue::Iterated(_, iterable) => write!(f, "Iterated({iterable})"),
+            JsValue::TypeOf(_, operand) => write!(f, "typeof({operand})"),
+            JsValue::Promise(_, operand) => write!(f, "Promise<{operand}>"),
+            JsValue::Awaited(_, operand) => write!(f, "await({operand})"),
         }
     }
 }
@@ -1201,8 +1201,7 @@ impl JsValue {
         assert_eq!(
             old,
             self.total_nodes(),
-            "total nodes not up to date {:?}",
-            self
+            "total nodes not up to date {self:?}"
         );
     }
 
@@ -1439,7 +1438,7 @@ impl JsValue {
                     ""
                 )
             ),
-            JsValue::Url(url, kind) => format!("{} {}", url, kind),
+            JsValue::Url(url, kind) => format!("{url} {kind}"),
             JsValue::Alternatives {
                 total_nodes: _,
                 values,
@@ -1458,17 +1457,17 @@ impl JsValue {
                     "| ",
                 );
                 if let Some(logical_property) = logical_property {
-                    format!("({}){{{}}}", list, logical_property)
+                    format!("({list}){{{logical_property}}}")
                 } else {
-                    format!("({})", list)
+                    format!("({list})")
                 }
             }
-            JsValue::FreeVar(name) => format!("FreeVar({})", name),
+            JsValue::FreeVar(name) => format!("FreeVar({name})"),
             JsValue::Variable(name) => {
                 format!("{}", name.0)
             }
             JsValue::Argument(_, index) => {
-                format!("arguments[{}]", index)
+                format!("arguments[{index}]")
             }
             JsValue::Concat(_, list) => format!(
                 "`{}`",
@@ -1654,7 +1653,7 @@ impl JsValue {
                 module: name,
                 annotations,
             }) => {
-                format!("module<{}, {}>", name, annotations)
+                format!("module<{name}, {annotations}>")
             }
             JsValue::Unknown {
                 original_value: inner,
@@ -1678,7 +1677,7 @@ impl JsValue {
                             ""
                         }
                     );
-                    format!("???*{}*", i)
+                    format!("???*{i}*")
                 } else {
                     let i = hints.len();
                     hints.push(String::new());
@@ -1692,7 +1691,7 @@ impl JsValue {
                             ""
                         }
                     );
-                    format!("???*{}*", i)
+                    format!("???*{i}*")
                 }
             }
             JsValue::WellKnownObject(obj) => {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -117,7 +117,7 @@ impl EcmascriptChunkItemContent {
         }
         if !args.is_empty() {
             let args = FormatIter(|| args.iter().copied().intersperse(", "));
-            writeln!(code, "var {{ {} }} = __turbopack_context__;", args)?;
+            writeln!(code, "var {{ {args} }} = __turbopack_context__;")?;
         }
 
         if self.options.async_module.is_some() {
@@ -264,8 +264,7 @@ async fn module_factory_with_code_generation_issue(
                     .await;
                 let id = id.as_ref().map_or_else(|_| "unknown", |id| &**id);
                 let error = error.context(format!(
-                    "An error occurred while generating the chunk item {}",
-                    id
+                    "An error occurred while generating the chunk item {id}"
                 ));
                 let error_message = format!("{}", PrettyPrintError(&error)).into();
                 let js_error_message = serde_json::to_string(&error_message)?;

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -63,8 +63,7 @@ async fn side_effects_from_package_json(
                                     StyledString::Text(
                                         format!(
                                             "Each element in sideEffects must be a string, but \
-                                             found {:?}",
-                                            side_effect
+                                             found {side_effect:?}"
                                         )
                                         .into(),
                                     )
@@ -110,8 +109,8 @@ async fn side_effects_from_package_json(
                     description: Some(
                         StyledString::Text(
                             format!(
-                                "sideEffects must be a boolean or an array, but found {:?}",
-                                side_effects
+                                "sideEffects must be a boolean or an array, but found \
+                                 {side_effects:?}"
                             )
                             .into(),
                         )

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1032,7 +1032,7 @@ async fn process_parse_result(
             let path = ident.path().to_string().await?;
             let error_messages = messages
                 .as_ref()
-                .and_then(|m| m.first().map(|f| format!("\n{}", f)))
+                .and_then(|m| m.first().map(|f| format!("\n{f}")))
                 .unwrap_or("".into());
             let msg = format!("Could not parse module '{path}'\n{error_messages}");
             let body = vec![

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -71,7 +71,7 @@ impl ReferencedAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<String> {
         let id = asset.chunk_item_id(Vc::upcast(chunking_context)).await?;
-        Ok(magic_identifier::mangle(&format!("imported module {}", id)))
+        Ok(magic_identifier::mangle(&format!("imported module {id}")))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -119,7 +119,7 @@ impl From<ImportMetaRef> for CodeGen {
 fn encode_path(path: &'_ str) -> Cow<'_, str> {
     let mut encoded = String::new();
     let mut start = 0;
-    for (i, c) in path.chars().enumerate() {
+    for (i, c) in path.char_indices() {
         let mapping = match c {
             '%' => "%25",
             '\\' => "%5C",

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -139,7 +139,7 @@ impl SinglePatternMapping {
             ),
             Self::External(request, ty) => throw_module_not_found_error_expr(
                 request,
-                &format!("Unsupported external type {:?} for commonjs reference", ty),
+                &format!("Unsupported external type {ty:?} for commonjs reference"),
             ),
         }
     }
@@ -205,10 +205,7 @@ impl SinglePatternMapping {
             #[allow(unreachable_patterns)]
             Self::External(request, ty) => throw_module_not_found_error_expr(
                 request,
-                &format!(
-                    "Unsupported external type {:?} for dynamic import reference",
-                    ty
-                ),
+                &format!("Unsupported external type {ty:?} for dynamic import reference"),
             ),
             Self::ModuleLoader(module_id) => {
                 quote!("($turbopack_require($id))($turbopack_import)" as Expr,
@@ -352,8 +349,7 @@ async fn to_single_pattern_mapping(
                 message: StyledString::Text(
                     format!(
                         "the reference resolves to a non-trivial result, which is not supported \
-                         yet: {:?}",
-                        resolve_item
+                         yet: {resolve_item:?}"
                     )
                     .into(),
                 )

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -86,10 +86,10 @@ impl fmt::Debug for ItemId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ItemId::Group(kind) => {
-                write!(f, "ItemId({:?})", kind)
+                write!(f, "ItemId({kind:?})")
             }
             ItemId::Item { index, kind } => {
-                write!(f, "ItemId({}, {:?})", index, kind)
+                write!(f, "ItemId({index}, {kind:?})")
             }
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -65,7 +65,7 @@ impl Module for SideEffectsModule {
 
         for (i, side_effect) in self.side_effects.iter().enumerate() {
             ident.add_asset(
-                ResolvedVc::cell(RcStr::from(format!("side effect {}", i))),
+                ResolvedVc::cell(RcStr::from(format!("side effect {i}"))),
                 side_effect.ident().to_resolved().await?,
             );
         }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/tests.rs
@@ -40,7 +40,7 @@ fn run(input: PathBuf) {
     let config = input.with_file_name("config.json");
     let config = std::fs::read_to_string(config).unwrap_or_else(|_| "{}".into());
     let config = serde_json::from_str::<TestConfig>(&config).unwrap_or_else(|_e| {
-        panic!("failed to parse config.json: {}", config);
+        panic!("failed to parse config.json: {config}");
     });
 
     testing::run_test(false, |cm, _handler| {
@@ -170,8 +170,7 @@ fn run(input: PathBuf) {
             s,
             "```mermaid\n{}```",
             render_mermaid(&mut condensed, &|buf: &Vec<ItemId>| format!(
-                "Items: {:?}",
-                buf
+                "Items: {buf:?}"
             ))
         )
         .unwrap();
@@ -203,7 +202,7 @@ fn run(input: PathBuf) {
                 if !skip_parts {
                     writeln!(s, "# Modules ({})", if is_debug { "dev" } else { "prod" }).unwrap();
                     for (i, module) in modules.iter().enumerate() {
-                        writeln!(s, "## Part {}", i).unwrap();
+                        writeln!(s, "## Part {i}").unwrap();
                         writeln!(s, "```js\n{}\n```", print(&cm, &[module])).unwrap();
                     }
                 }
@@ -226,7 +225,7 @@ fn run(input: PathBuf) {
 
                 let module = merger.merge_recursively(entry).unwrap();
 
-                writeln!(s, "## Merged ({})", title).unwrap();
+                writeln!(s, "## Merged ({title})").unwrap();
                 writeln!(s, "```js\n{}\n```", print(&cm, &[&module])).unwrap();
             };
         describe(

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -97,7 +97,7 @@ impl ModuleReference for WebpackChunkAssetReference {
                     Lit::Num(num) => format!("{num}"),
                     _ => todo!(),
                 };
-                let filename = format!("./chunks/{}.js", chunk_id).into();
+                let filename = format!("./chunks/{chunk_id}.js").into();
                 let source = Vc::upcast(FileSource::new(context_path.join(filename)));
 
                 *ModuleResolveResult::module(ResolvedVc::upcast(
@@ -120,7 +120,7 @@ impl ValueToString for WebpackChunkAssetReference {
             Lit::Num(num) => format!("{num}"),
             _ => todo!(),
         };
-        Vc::cell(format!("webpack chunk {}", chunk_id).into())
+        Vc::cell(format!("webpack chunk {chunk_id}").into())
     }
 }
 

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -149,7 +149,7 @@ impl EcmascriptChunkItem for JsonChunkItem {
                     let text = content.content().to_str()?;
                     e.write_with_content(&mut message, text.as_ref())?;
                 } else {
-                    write!(message, "{}", e)?;
+                    write!(message, "{e}")?;
                 }
 
                 Err(Error::msg(message))

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -47,8 +47,8 @@ pub enum FormattingMode {
 impl FormattingMode {
     pub fn magic_identifier<'a>(&self, content: impl Display + 'a) -> impl Display + 'a {
         match self {
-            FormattingMode::Plain => format!("{{{}}}", content),
-            FormattingMode::AnsiColors => format!("{{{}}}", content).italic().to_string(),
+            FormattingMode::Plain => format!("{{{content}}}"),
+            FormattingMode::AnsiColors => format!("{{{content}}}").italic().to_string(),
         }
     }
 
@@ -203,7 +203,7 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> OutputStreamHandler<R, W> {
         ) -> Result<()> {
             if let Ok(text) = std::str::from_utf8(bytes) {
                 let text = unmangle_identifiers(text, |content| {
-                    format!("{{{}}}", content).italic().to_string()
+                    format!("{{{content}}}").italic().to_string()
                 });
                 match apply_source_mapping(
                     text.as_ref(),

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -145,7 +145,7 @@ impl GetContentSourceContent for NodeApiContentSource {
                 original_url: original_url.clone(),
                 raw_query: raw_query.clone(),
                 raw_headers: raw_headers.clone(),
-                path: format!("/{}", path).into(),
+                path: format!("/{path}").into(),
                 data: Some(self.render_data.await?),
             }
             .resolved_cell(),

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -154,7 +154,7 @@ async fn static_error(
         .replace('<', "&lt;");
 
     if let Some(status) = status {
-        message.push_str(&format!("\n\nStatus: {}", status));
+        message.push_str(&format!("\n\nStatus: {status}"));
     }
 
     let mut body = "<script id=\"__NEXT_DATA__\" type=\"application/json\">{ \"props\": {} \

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -212,7 +212,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
         )
         .issue_file_path(
             entry.module.ident().path(),
-            format!("server-side rendering {}", pathname),
+            format!("server-side rendering {pathname}"),
         )
         .await?;
         Ok(match *result_op.connect().await? {

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -91,9 +91,9 @@ fn write_resolved(
     match resolved {
         Err(err) => {
             // There was an error resolving the source map
-            write!(writable, "{PADDING}at {}", original_frame)?;
+            write!(writable, "{PADDING}at {original_frame}")?;
             if *first_error {
-                write!(writable, "{PADDING}(error resolving source map: {})", err)?;
+                write!(writable, "{PADDING}(error resolving source map: {err})")?;
                 *first_error = false;
             } else {
                 write!(writable, "{PADDING}(error resolving source map)")?;
@@ -104,7 +104,7 @@ fn write_resolved(
             write!(
                 writable,
                 "{PADDING}{}",
-                formatting_mode.lowlight(&format_args!("[at {}]", original_frame))
+                formatting_mode.lowlight(&format_args!("[at {original_frame}]"))
             )?;
         }
         Ok(ResolvedSourceMapping::Mapped { frame }) => {
@@ -165,7 +165,7 @@ fn write_resolved(
                     let ctx = get_source_context(lines, line, column, line, column);
                     match formatting_mode {
                         FormattingMode::Plain => {
-                            write!(writable, "\n{}", ctx)?;
+                            write!(writable, "\n{ctx}")?;
                         }
                         FormattingMode::AnsiColors => {
                             writable.write_char('\n')?;

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -74,11 +74,8 @@ impl ValueToString for NodePreGypConfigReference {
         let config_file_pattern = self.config_file_pattern.to_string().await?;
         let compile_target = self.compile_target.await?;
         Ok(Vc::cell(
-            format!(
-                "node-gyp in {} with {} for {}",
-                context_dir, config_file_pattern, compile_target
-            )
-            .into(),
+            format!("node-gyp in {context_dir} with {config_file_pattern} for {compile_target}")
+                .into(),
         ))
     }
 }
@@ -116,7 +113,7 @@ pub async fn resolve_node_pre_gyp_files(
                 for version in node_pre_gyp_config.binary.napi_versions.iter() {
                     let native_binding_path = NAPI_VERSION_TEMPLATE.replace(
                         node_pre_gyp_config.binary.module_path.as_str(),
-                        format!("{}", version),
+                        format!("{version}"),
                     );
                     let platform = compile_target.platform;
                     let native_binding_path =
@@ -258,7 +255,7 @@ impl ValueToString for NodeGypBuildReference {
         let context_dir = self.context_dir.to_string().await?;
         let compile_target = self.compile_target.await?;
         Ok(Vc::cell(
-            format!("node-gyp in {} for {}", context_dir, compile_target).into(),
+            format!("node-gyp in {context_dir} for {compile_target}").into(),
         ))
     }
 }
@@ -291,7 +288,7 @@ pub async fn resolve_node_gyp_build_files(
                         let target_path = context_dir.join("build/Release".into());
                         let resolved_prebuilt_file = resolve_raw(
                             target_path,
-                            Pattern::new(Pattern::Constant(format!("{}.node", name).into())),
+                            Pattern::new(Pattern::Constant(format!("{name}.node").into())),
                             true,
                         )
                         .await?;
@@ -328,11 +325,11 @@ pub async fn resolve_node_gyp_build_files(
     let compile_target = compile_target.await?;
     let arch = compile_target.arch;
     let platform = compile_target.platform;
-    let prebuilt_dir = format!("{}-{}", platform, arch);
+    let prebuilt_dir = format!("{platform}-{arch}");
     Ok(resolve_raw(
         context_dir,
         Pattern::new(Pattern::Concatenation(vec![
-            Pattern::Constant(format!("prebuilds/{}/", prebuilt_dir).into()),
+            Pattern::Constant(format!("prebuilds/{prebuilt_dir}/").into()),
             Pattern::Dynamic,
             Pattern::Constant(".node".into()),
         ])),

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -69,7 +69,7 @@ pub async fn read_tsconfigs(
                     let text = content.content().to_str()?;
                     e.write_with_content(&mut message, text.as_ref())?;
                 } else {
-                    write!(message, "{}", e)?;
+                    write!(message, "{e}")?;
                 }
                 TsConfigIssue {
                     severity: IssueSeverity::Error.resolved_cell(),
@@ -100,7 +100,7 @@ pub async fn read_tsconfigs(
                         TsConfigIssue {
                             severity: IssueSeverity::Error.resolved_cell(),
                             source_ident: tsconfig.ident().to_resolved().await?,
-                            message: format!("extends: \"{}\" doesn't resolve correctly", extends)
+                            message: format!("extends: \"{extends}\" doesn't resolve correctly")
                                 .into(),
                         }
                         .resolved_cell()

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -109,7 +109,7 @@ pub async fn matches_expected(
         let p = &path.await?.path;
         if *UPDATE {
             remove_file(path).await?;
-            println!("removed file {}", p);
+            println!("removed file {p}");
         } else {
             bail!("expected file {}, but it was not emitted", p);
         }
@@ -129,7 +129,7 @@ pub async fn diff(path: Vc<FileSystemPath>, actual: Vc<AssetContent>) -> Result<
             if *UPDATE {
                 let content = File::from(RcStr::from(actual)).into();
                 path.write(content).await?;
-                println!("updated contents of {}", path_str);
+                println!("updated contents of {path_str}");
             } else {
                 if expected.is_none() {
                     eprintln!("new file {path_str} detected:");
@@ -172,14 +172,13 @@ async fn get_contents(file: Vc<AssetContent>, path: Vc<FileSystemPath>) -> Resul
                         Ok(str) => Some(str.trim().to_string()),
                         Err(_) => {
                             let hash = hash_xxh3_hash64(rope);
-                            Some(format!("Binary content {:016x}", hash))
+                            Some(format!("Binary content {hash:016x}"))
                         }
                     }
                 }
             },
             AssetContent::Redirect { target, link_type } => Some(format!(
-                "Redirect {{ target: {target}, link_type: {:?} }}",
-                link_type
+                "Redirect {{ target: {target}, link_type: {link_type:?} }}"
             )),
         },
     )
@@ -233,7 +232,7 @@ fn styled_string_to_file_safe_string(styled_string: &StyledString) -> String {
             string
         }
         StyledString::Text(string) => string.to_string(),
-        StyledString::Code(string) => format!("__c_{}__", string),
-        StyledString::Strong(string) => format!("__{}__", string),
+        StyledString::Code(string) => format!("__c_{string}__"),
+        StyledString::Strong(string) => format!("__{string}__"),
     }
 }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -155,11 +155,11 @@ fn get_messages(js_results: JsResult) -> Vec<String> {
     }
 
     for uncaught_exception in js_results.uncaught_exceptions {
-        messages.push(format!("Uncaught exception: {}", uncaught_exception));
+        messages.push(format!("Uncaught exception: {uncaught_exception}"));
     }
 
     for unhandled_rejection in js_results.unhandled_rejections {
-        messages.push(format!("Unhandled rejection: {}", unhandled_rejection));
+        messages.push(format!("Unhandled rejection: {unhandled_rejection}"));
     }
 
     messages
@@ -256,7 +256,7 @@ struct PreparedTest {
 #[turbo_tasks::function]
 async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
     let resource_path = canonicalize(&resource)?;
-    assert!(resource_path.exists(), "{} does not exist", resource);
+    assert!(resource_path.exists(), "{resource} does not exist");
     assert!(
         resource_path.is_dir(),
         "{} is not a directory. Execution tests must be directories.",

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -198,7 +198,7 @@ async fn run_inner_operation(resource: RcStr) -> Result<()> {
 #[turbo_tasks::function(operation)]
 async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let test_path = canonicalize(&resource)?;
-    assert!(test_path.exists(), "{} does not exist", resource);
+    assert!(test_path.exists(), "{resource} does not exist");
     assert!(
         test_path.is_dir(),
         "{} is not a directory. Snapshot tests must be directories.",

--- a/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
@@ -337,7 +337,7 @@ impl TraceFormat for HeaptrackFormat {
                             .context("function not found")?;
                         args.push((
                             "location".to_string(),
-                            format!("{} @ {file}:{line}", function),
+                            format!("{function} @ {file}:{line}"),
                         ));
                     }
 

--- a/turbopack/crates/turbopack-trace-server/src/reader/mod.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/mod.rs
@@ -272,12 +272,12 @@ impl TraceReader {
                                         read * 1000 / (start.elapsed().as_millis() + 1) as u64
                                     );
                                     if uncompressed != read {
-                                        print!(" ({} MB uncompressed)", uncompressed);
+                                        print!(" ({uncompressed} MB uncompressed)");
                                     }
                                     if stats.is_empty() {
                                         println!();
                                     } else {
-                                        println!(" - {}", stats);
+                                        println!(" - {stats}");
                                     }
                                 }
                             }
@@ -323,7 +323,7 @@ impl TraceReader {
         if let Some((total, start)) = initial_read.take() {
             if let Some(format) = format {
                 let stats = format.stats();
-                println!("{}", stats);
+                println!("{stats}");
             }
             if total > MIN_INITIAL_REPORT_SIZE {
                 println!(

--- a/turbopack/crates/turbopack-trace-server/src/reader/nextjs.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/nextjs.rs
@@ -108,16 +108,16 @@ enum TagValue<'a> {
 impl Display for TagValue<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TagValue::String(s) => write!(f, "{}", s),
-            TagValue::Number(n) => write!(f, "{}", n),
-            TagValue::Bool(b) => write!(f, "{}", b),
+            TagValue::String(s) => write!(f, "{s}"),
+            TagValue::Number(n) => write!(f, "{n}"),
+            TagValue::Bool(b) => write!(f, "{b}"),
             TagValue::Array(a) => {
                 write!(f, "[")?;
                 for (i, v) in a.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", v)?;
+                    write!(f, "{v}")?;
                 }
                 write!(f, "]")
             }

--- a/turbopack/crates/turbopack-trace-server/src/server.rs
+++ b/turbopack/crates/turbopack-trace-server/src/server.rs
@@ -128,7 +128,7 @@ pub fn serve(store: Arc<StoreContainer>, port: u16) {
         spawn(move || {
             let websocket = accept(stream.unwrap()).unwrap();
             if let Err(err) = handle_connection(websocket, store) {
-                eprintln!("Error: {:?}", err);
+                eprintln!("Error: {err:?}");
             }
         });
     }

--- a/turbopack/crates/turbopack-trace-server/src/viewer.rs
+++ b/turbopack/crates/turbopack-trace-server/src/viewer.rs
@@ -992,9 +992,11 @@ impl Viewer {
                                 }
                             }
                             ViewSpan {
-                                id: (!span.is_root())
-                                    .then(|| span.id().get() as u64)
-                                    .unwrap_or_default(),
+                                id: if !span.is_root() {
+                                    span.id().get() as u64
+                                } else {
+                                    Default::default()
+                                },
                                 start: entry.start,
                                 width: entry.width,
                                 category: category.to_string(),

--- a/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
@@ -176,7 +176,7 @@ impl ValuesVisitor {
 impl Visit for ValuesVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         let mut str = String::new();
-        let _ = write!(str, "{:?}", value);
+        let _ = write!(str, "{value:?}");
         self.values
             .push((field.name().into(), TraceValue::String(str.into())));
     }

--- a/turbopack/crates/turbopack-trace-utils/src/tracing.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/tracing.rs
@@ -114,11 +114,11 @@ pub enum TraceValue<'a> {
 impl Display for TraceValue<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            TraceValue::String(s) => write!(f, "{}", s),
-            TraceValue::Bool(b) => write!(f, "{}", b),
-            TraceValue::UInt(u) => write!(f, "{}", u),
-            TraceValue::Int(i) => write!(f, "{}", i),
-            TraceValue::Float(fl) => write!(f, "{}", fl),
+            TraceValue::String(s) => write!(f, "{s}"),
+            TraceValue::Bool(b) => write!(f, "{b}"),
+            TraceValue::UInt(u) => write!(f, "{u}"),
+            TraceValue::Int(i) => write!(f, "{i}"),
+            TraceValue::Float(fl) => write!(f, "{fl}"),
         }
     }
 }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -930,7 +930,7 @@ impl AssetContext for ModuleAssetContext {
         let mut globs = Vec::with_capacity(pkgs.len());
 
         for pkg in pkgs {
-            globs.push(Glob::new(format!("**/node_modules/{{{}}}/**", pkg).into()));
+            globs.push(Glob::new(format!("**/node_modules/{{{pkg}}}/**").into()));
         }
 
         Ok(Glob::alternatives(globs))

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -36,10 +36,7 @@ async fn package_import_map_from_import_mapping(
     package_mapping: ResolvedVc<ImportMapping>,
 ) -> Vc<ImportMap> {
     let mut import_map = ImportMap::default();
-    import_map.insert_exact_alias(
-        format!("@vercel/turbopack/{}", package_name),
-        package_mapping,
-    );
+    import_map.insert_exact_alias(format!("@vercel/turbopack/{package_name}"), package_mapping);
     import_map.cell()
 }
 
@@ -50,7 +47,7 @@ async fn package_import_map_from_context(
 ) -> Vc<ImportMap> {
     let mut import_map = ImportMap::default();
     import_map.insert_exact_alias(
-        format!("@vercel/turbopack/{}", package_name),
+        format!("@vercel/turbopack/{package_name}"),
         ImportMapping::PrimaryAlternative(package_name, Some(context_path)).resolved_cell(),
     );
     import_map.cell()

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -532,7 +532,7 @@ fn node_file_trace<B: Backend + 'static>(
                     }
                 }
                 Err(err) => {
-                    panic!("Execution failed: {:?}", err);
+                    panic!("Execution failed: {err:?}");
                 }
             };
 
@@ -643,7 +643,7 @@ async fn exec_node(directory: RcStr, path: Vc<FileSystemPath>) -> Result<Vc<Comm
         cmd.current_dir(current_dir);
     }
 
-    println!("[CMD]: {:#?}", cmd);
+    println!("[CMD]: {cmd:#?}");
 
     let output = timeout(Duration::from_secs(100), cmd.output())
         .await
@@ -707,10 +707,7 @@ async fn assert_output(
                 String::new()
             } else {
                 let stderr_diff = diff(&expected.stderr, &actual.stderr);
-                format!(
-                    "could not find `{}` in stderr\n{}",
-                    expected_stderr, stderr_diff
-                )
+                format!("could not find `{expected_stderr}` in stderr\n{stderr_diff}")
             }
         } else {
             diff(&expected.stderr, &actual.stderr)

--- a/turbopack/xtask/src/command.rs
+++ b/turbopack/xtask/src/command.rs
@@ -52,7 +52,7 @@ impl Command {
             cmd.current_dir(&current_dir);
         }
         if self.dry_run {
-            println!("{:?}", cmd);
+            println!("{cmd:?}");
             return;
         }
         let status = cmd.status();

--- a/turbopack/xtask/src/publish.rs
+++ b/turbopack/xtask/src/publish.rs
@@ -144,10 +144,7 @@ pub fn run_publish(name: &str) {
                 .join(&bin_file_name);
             let dist_path = target_dir.join(&bin_file_name);
             fs::copy(&artifact_path, &dist_path).unwrap_or_else(|e| {
-                panic!(
-                    "Copy file from [{:?}] to [{:?}] failed: {e}",
-                    artifact_path, dist_path
-                )
+                panic!("Copy file from [{artifact_path:?}] to [{dist_path:?}] failed: {e}")
             });
             Command::program("npm")
                 .args(["publish", "--access", "public", "--tag", tag])
@@ -157,10 +154,7 @@ pub fn run_publish(name: &str) {
         }
         let target_pkg_dir = temp_dir.join(pkg.name);
         fs::create_dir_all(&target_pkg_dir).unwrap_or_else(|e| {
-            panic!(
-                "Unable to create target npm directory [{:?}]: {e}",
-                target_pkg_dir
-            )
+            panic!("Unable to create target npm directory [{target_pkg_dir:?}]: {e}")
         });
         let optional_dependencies_with_version = optional_dependencies
             .into_iter()
@@ -295,7 +289,7 @@ pub fn run_bump(names: FxHashSet<String>, dry_run: bool) {
                 if semver_version.pre.is_empty() {
                     semver_version.patch += 1;
                     semver_version.pre =
-                        Prerelease::new(format!("{}.0", version_type).as_str()).unwrap();
+                        Prerelease::new(format!("{version_type}.0").as_str()).unwrap();
                 } else {
                     let mut prerelease_version = semver_version.pre.split('.');
                     let prerelease_type = prerelease_version
@@ -309,17 +303,16 @@ pub fn run_bump(names: FxHashSet<String>, dry_run: bool) {
                         .expect("prerelease version number should be u32");
                     if semver_version.pre.contains(version_type) {
                         version_number += 1;
-                        semver_version.pre = Prerelease::new(
-                            format!("{}.{}", version_type, version_number).as_str(),
-                        )
-                        .unwrap();
+                        semver_version.pre =
+                            Prerelease::new(format!("{version_type}.{version_number}").as_str())
+                                .unwrap();
                     } else {
                         // eg. current version is 1.0.0-beta.12, bump to 1.0.0-canary.0
                         if Prerelease::from_str(version_type).unwrap()
                             > Prerelease::from_str(prerelease_type).unwrap()
                         {
                             semver_version.pre =
-                                Prerelease::new(format!("{}.0", version_type).as_str()).unwrap();
+                                Prerelease::new(format!("{version_type}.0").as_str()).unwrap();
                         } else {
                             panic!(
                                 "Previous version is {prerelease_type}, so you can't bump to \

--- a/turbopack/xtask/src/visualize_bundler_bench.rs
+++ b/turbopack/xtask/src/visualize_bundler_bench.rs
@@ -135,7 +135,7 @@ pub fn generate(summary_path: PathBuf, filter_bundlers: Option<FxHashSet<&str>>)
         };
 
         let Ok(bundler) = Bundler::from_str(&function_id) else {
-            eprintln!("Skipping benchmark with unknown bundler: {}", function_id);
+            eprintln!("Skipping benchmark with unknown bundler: {function_id}");
             continue;
         };
 


### PR DESCRIPTION
Clippy now warns on [uninlined format strings](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args). Applied fixers with `cargo clippy --fix`.


Closes PACK-4582