### PR TITLE
Revert "build: Update `swc_core` to `v24.0.0`"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -77,14 +77,3 @@ rustflags = [
 
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
-
-[target.wasm32-unknown-unknown]
-rustflags = [
-  "--cfg",
-  "tokio_unstable",
-  "-Zshare-generics=y", # make the current crate share its generic instantiations
-  "-Zthreads=8", # parallel frontend https://blog.rust-lang.org/2023/11/09/parallel-rustc.html
-  "-Csymbol-mangling-version=v0",
-  "--cfg",
-  "getrandom_backend=\"wasm_js\"",
-]

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -440,7 +440,7 @@ jobs:
       - name: Install Rust
         uses: ./.github/actions/setup-rust
         with:
-          targets: wasm32-wasip1
+          targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -471,7 +471,7 @@ jobs:
       skipNativeBuild: 'yes'
       skipNativeInstall: 'yes'
       afterBuild: |
-        rustup target add wasm32-wasip1
+        rustup target add wasm32-unknown-unknown
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         node ./scripts/normalize-version-bump.js
         pnpm dlx turbo@${TURBO_VERSION} run build-wasm -- --target nodejs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
 dependencies = [
- "nom 7.1.3",
+ "nom",
  "vte",
 ]
 
@@ -607,7 +607,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "itertools 0.10.5",
  "log",
- "nom 7.1.3",
+ "nom",
  "num-rational",
  "v_frame",
 ]
@@ -711,16 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref 0.5.2",
- "vsimd",
-]
-
-[[package]]
 name = "better_scoped_tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,16 +750,16 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "23.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7785571ebd752875029b305fd26735c525660e042e07330402388968e9722e5"
+checksum = "30f941cf6bb72815380727ba180b6c34d9a70a2a2e7bc735f2dfc48b4ab4e540"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
  "js-sys",
  "once_cell",
  "serde",
- "serde-wasm-bindgen 0.4.5",
+ "serde-wasm-bindgen",
  "swc",
  "swc_common",
  "swc_ecma_ast",
@@ -895,7 +885,7 @@ dependencies = [
  "either",
  "indexmap 2.7.1",
  "itertools 0.13.0",
- "nom 7.1.3",
+ "nom",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1022,7 +1012,7 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
- "semver",
+ "semver 1.0.23",
  "serde",
  "toml 0.5.11",
  "url",
@@ -1045,7 +1035,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1059,7 +1049,7 @@ checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1108,7 +1098,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1132,12 +1122,6 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chromiumoxide"
@@ -2166,7 +2150,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88e3201db19ec4199af513d38c49fcbc5f8ca31d268f942e97324a826c9e9fdb"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -2635,16 +2619,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2682,9 +2664,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.16"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2831,7 +2813,7 @@ dependencies = [
  "base64 0.21.4",
  "byteorder",
  "flate2",
- "nom 7.1.3",
+ "nom",
  "num-traits",
 ]
 
@@ -2843,7 +2825,7 @@ checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version",
+ "rustc_version 0.4.0",
  "serde",
  "spin 0.9.8",
  "stable_deref_trait",
@@ -3061,25 +3043,7 @@ dependencies = [
  "hyper 0.14.28",
  "rustls 0.20.9",
  "tokio",
- "tokio-rustls 0.23.4",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http 1.1.0",
- "hyper 1.5.2",
- "hyper-util",
- "rustls 0.23.20",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.1",
- "tower-service",
- "webpki-roots 0.26.7",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3106,22 +3070,6 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.5.2",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -3920,12 +3868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libunwind"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6639b70a7ce854b79c70d7e83f16b5dc0137cc914f3d7d03803b513ecc67ac"
-
-[[package]]
 name = "libyml"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3949,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.66"
+version = "1.0.0-alpha.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a73ffa17de66534e4b527232f44aa0a89fad22c4f4e0735f9be35494f058e54"
+checksum = "c84f971730745f4aaac013b6cf4328baf1548efc973c0d95cfd843a3c1ca07af"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.9.0",
@@ -3989,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss-napi"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b254219299448a95dada4fa2b3bc70c73112d5d4858722b1e2b4ada1591ae22"
+checksum = "8f5e41d371670417f71b779fe6d66959a68c21fbda563a747d795ac525f72450"
 dependencies = [
  "cssparser",
  "lightningcss",
@@ -4117,12 +4059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "lsp-server"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4172,17 +4108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "macho-unwind-info"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4bdc8b0ce69932332cf76d24af69c3a155242af95c226b2ab6c2e371ed1149"
-dependencies = [
- "thiserror 2.0.12",
- "zerocopy 0.8.24",
- "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -4242,7 +4167,8 @@ dependencies = [
 [[package]]
 name = "mdxjs"
 version = "1.0.1"
-source = "git+https://github.com/kdy1/mdxjs-rs?branch=swc-core-24#f055669d7e6560d3eb0fab8a13eee2b03a91ccbc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d02eaea405978e623d6531b914e905f1bf2e7e197f8434bafb64cc4bcf7b1e"
 dependencies = [
  "markdown",
  "rustc-hash 2.1.1",
@@ -4403,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.84.0"
+version = "0.83.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bce7fe9cb7884b5fc82c5ee55f49768f00e842248f885a348a89688c287264"
+checksum = "74957b5e9687164f3221cb6f29f55fde71b74f61d6fea41b7b9dfca3670dc25e"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -4499,7 +4425,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver",
+ "semver 1.0.23",
  "syn 2.0.100",
 ]
 
@@ -4800,18 +4726,8 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -5104,12 +5020,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5162,9 +5072,9 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.28.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
+checksum = "dccbc6fb560df303a44e511618256029410efbc87779018f751ef12c488271fe"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -5184,7 +5094,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "485b74d7218068b2b7c0e3ff12fbc61ae11d57cb5d8224f525bd304c6be05bbb"
 dependencies = [
- "base64-simd 0.7.0",
+ "base64-simd",
  "data-url",
  "rkyv 0.7.45",
  "serde",
@@ -5587,7 +5497,7 @@ dependencies = [
  "from_variant",
  "once_cell",
  "rustc-hash 2.1.1",
- "semver",
+ "semver 1.0.23",
  "serde",
  "st-map",
  "tracing",
@@ -5828,61 +5738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
-dependencies = [
- "bytes",
- "cfg_aliases 0.2.1",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls 0.23.20",
- "socket2 0.5.8",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
-dependencies = [
- "bytes",
- "getrandom 0.3.3",
- "lru-slab",
- "rand 0.9.0",
- "ring 0.17.8",
- "rustc-hash 2.1.1",
- "rustls 0.23.20",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.12",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
-dependencies = [
- "cfg_aliases 0.2.1",
- "libc",
- "once_cell",
- "socket2 0.5.8",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5975,7 +5830,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -6055,9 +5910,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.38.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334c17d9a1710384f6a70a9edf998218296147423bc9b79371784d0249851a85"
+checksum = "d6426586a7a27681cb3134f2e9869868462d7d81a63590946154181e06ae8f79"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6183,9 +6038,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.39.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c851d6ee5ea7acd024905a111dc2a1e7c25288931315efbdb3dca2e9c25441e2"
+checksum = "4a10526f537614727e24afee3d9d689c0dd791b9e636c7c61a383243caa50a00"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6234,8 +6089,8 @@ dependencies = [
  "http 0.2.11",
  "http-body 0.4.5",
  "hyper 0.14.28",
- "hyper-rustls 0.23.2",
- "hyper-tls 0.5.0",
+ "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
@@ -6245,13 +6100,13 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.9",
- "rustls-pemfile 1.0.2",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6259,55 +6114,6 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.22.6",
  "winreg 0.10.1",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.5.2",
- "hyper-rustls 0.27.5",
- "hyper-tls 0.6.0",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls 0.23.20",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls 0.26.1",
- "tokio-socks",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots 0.26.7",
- "windows-registry",
 ]
 
 [[package]]
@@ -6428,7 +6234,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -6440,7 +6246,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
  "unicode-ident",
 ]
@@ -6453,7 +6259,7 @@ checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -6477,11 +6283,20 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -6548,22 +6363,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
-dependencies = [
- "web-time",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -6619,16 +6422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4950d85bc52415f8432144c97c4791bd0c4f7954de32a7270ee9cccd3c22b12b"
 
 [[package]]
-name = "saffron"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fb9a628596fc7590eb7edbf7b0613287be78df107f5f97b118aad59fb2eea9"
-dependencies = [
- "chrono",
- "nom 5.1.3",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6653,7 +6446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
- "indexmap 2.7.1",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -6731,6 +6523,15 @@ checksum = "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
@@ -6739,10 +6540,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "send-trace-to-jaeger"
 version = "0.1.0"
 dependencies = [
- "reqwest 0.11.17",
+ "reqwest",
  "serde_json",
 ]
 
@@ -6770,17 +6577,6 @@ name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",
@@ -7054,7 +6850,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
- "outref 0.1.0",
+ "outref",
 ]
 
 [[package]]
@@ -7175,16 +6971,17 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.2.0"
+version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd430118acc9fdd838557649b9b43fd0a78e3834d84a283b466f8e84720d6101"
+checksum = "27c4ea7042fd1a155ad95335b5d505ab00d5124ea0332a06c8390d200bb1a76a"
 dependencies = [
- "base64-simd 0.8.0",
+ "base64-simd",
  "bitvec",
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash 2.1.1",
+ "rustc-hash 1.1.0",
+ "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -7301,9 +7098,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.112.1"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b432fa1f2bf88c0ce047b1e3857a4c33888537de868e39c32765c3722262a2e5"
+checksum = "225e1cf78fe4cf3391d7fff6fff856743272e3f252a97ccdccfc61bf8afb300c"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -7320,9 +7117,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.88.0"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d49d78c38cac994f22e4b06f9481891d19f4b82d1c95e9e85b004337a88aa2"
+checksum = "ff697b859df5ad1510bbe438f43bef45a7b66cf41af8ef37e82bbfe9cfa1d75a"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -7363,9 +7160,9 @@ checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
 
 [[package]]
 name = "swc"
-version = "23.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e736e621b139ca403a185f2efdf7299b3b1850e65fdf718e72c9e8a9dd750200"
+checksum = "80c62891c5429818ccfd614cc1e6023ca005a8a893ef47a18c4620d5f1bf4e8e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7387,6 +7184,7 @@ dependencies = [
  "serde_json",
  "sourcemap",
  "swc_atoms",
+ "swc_cached",
  "swc_common",
  "swc_compiler_base",
  "swc_config",
@@ -7460,9 +7258,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "17.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb953a99152e2a62f6b84d6c144fc4adf9c406093b093046e90a681a76d93dd"
+checksum = "b1b74879da703e85dce2d15409cfac169dcff91b41b902e7cfc97199e19fd626"
 dependencies = [
  "anyhow",
  "crc",
@@ -7506,9 +7304,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "9.2.0"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56b6f5a8e5affa271b56757a93badee6f44defcd28f3ba106bb2603afe40d3d"
+checksum = "060d8a9a267de961d9ff62ef1edabb05a8e71543b5fdcc0fa43e7a247ea66c88"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7540,9 +7338,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "20.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0042d7baa47bfcd95c165a2e2f03384825ab6bcf525692361894c8105d60ec1c"
+checksum = "6ac447d455ed338b84dcd914e790525a12a2a2f91173359e5ac7d62b4915af39"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7568,20 +7366,16 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "3.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01bfcbbdea182bdda93713aeecd997749ae324686bf7944f54d128e56be4ea9"
+checksum = "eb63364aebd1a8490a80fa8933825c6916d4df55d5472312d5adb62c9fb4e4ba"
 dependencies = [
  "anyhow",
- "dashmap 5.5.3",
- "globset",
  "indexmap 2.7.1",
- "once_cell",
- "regex",
- "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sourcemap",
+ "swc_cached",
  "swc_config_macro",
 ]
 
@@ -7599,15 +7393,16 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "24.0.0"
+version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676e3cab6fe72a559444ab7225470f8f98128726bf0c6f7f3d5c614c10a22b0d"
+checksum = "5b746e119095da2de3ad1fbf6e090158977a89b342a0657c1c1ea652f3ff6048"
 dependencies = [
  "binding_macros",
  "swc",
  "swc_allocator",
  "swc_atoms",
  "swc_bundler",
+ "swc_cached",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -7828,9 +7623,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "14.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1f1a835abb761adfe909e84550ce80001663b301a02059ca98f98f9358e625"
+checksum = "cff1612d4d90df938533b5308634be1228c6bf14d7141c9f7787c99b5b26f4cc"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
@@ -7859,9 +7654,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "14.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29eeb4ea7f2eee831e7f8c0c523577900470f5c3b3feb63515defc131f8c39f4"
+checksum = "f2a2cf0263f34234cfcebde0545e4ed017e1b2b5667792c6902319d75df03110"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -8025,9 +7820,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "13.0.1"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd377cf6502daf10b2d7428ea35ae959ca3584a7c968c296af3bdd98e70cff12"
+checksum = "5e9adc21155b19e21ee6c304015f9ef1a8af41ee3123b849af02c708f33dea69"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -8064,9 +7859,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "14.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b34165ed826fd794fb78ded5bed1a4d39d11a285b8f9fc6be93f52036da5294"
+checksum = "10710ebbe155fd07b5be28a6af80c6f46c6385feeb3f6b3033d1d5d93b885312"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -8108,9 +7903,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "18.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084389cc2cd71d643de71b6f1b758a509a36d5ca319954b3a6e0be9359c9309d"
+checksum = "bca0ad5b72d8b440e701d47f544a728543414f6f165c6c61a899a76d3c7fdf9d"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8172,9 +7967,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "18.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05181442a89848184dd87be8d95b92d49d6af84d3e7a96b638c0492a45d03799"
+checksum = "551d1b1d3f27e9525b001fba9afd06294a5eaf8a8a9aff85da458a51e790ca1c"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -8182,7 +7977,7 @@ dependencies = [
  "once_cell",
  "preset_env_base",
  "rustc-hash 2.1.1",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "st-map",
@@ -8228,9 +8023,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "17.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480fc38d0856bf840ddfef10d9953f2f4315227a1dda9c25d7a71b49f618fcb7"
+checksum = "3f2813bad599d24b1aeba4c90891703a046d86b681b003863673f2b418dff185"
 dependencies = [
  "par-core",
  "swc_atoms",
@@ -8288,9 +8083,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "15.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984d7c07ca905dc5d484ca6a3e5d7c452da231c5f9cf7b621237255e9e8e4986"
+checksum = "012cd84fcc6c6fab718a177a3ffc360332d6bad29dbe19699be2ccbaba91e712"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -8338,9 +8133,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "15.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90467f0bee316134927e928e3b2c57e77a3ea59a7b1626d2db36d1cb9634cfd0"
+checksum = "4653a46bffad40875469a0b75f0b9c8f1e019ca7014a45e876c3a10aadd58721"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -8353,8 +8148,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
+ "swc_cached",
  "swc_common",
- "swc_config",
  "swc_ecma_ast",
  "swc_ecma_loader",
  "swc_ecma_parser",
@@ -8366,9 +8161,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "14.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b14c8f6c1c82b7556d7534de44714401901fcb9b618f817172015565ce7d47"
+checksum = "b5874d0c808f0e658882edf00fef3d206f01a22781c48ca9b1795cf025cc9650"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.7.1",
@@ -8411,9 +8206,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "15.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baae39c70229103a72090119887922fc5e32f934f5ca45c0423a5e65dac7e549"
+checksum = "e17564ef28b1183a5d79f890066f11aba4563f390708cb03a6738cbc24799210"
 dependencies = [
  "base64 0.22.1",
  "dashmap 5.5.3",
@@ -8465,9 +8260,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "15.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c65e0b49f7e2a2bd92f1d89c9a404de27232ce00f6a4053f04bda446d50e5c"
+checksum = "a647a99548ead69e5e87cf2b7caa7921e8a81e252e13e3180c3101a1d911fa6b"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
@@ -8502,9 +8297,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "13.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ed837406d5dbbfbf5792b1dc90964245a0cf659753d4745fe177ffebe8598b9"
+checksum = "bb6ecf7485a130df25c4ba4e27cfde0cc7bf45f453f40cf0c52eb69b3a4235d0"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",
@@ -8540,9 +8335,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.88.0"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5ca68aa427646f638dc1a29cbfe74f1cef75f85ef7f2575da84550e4c69ba"
+checksum = "64e92e65dcaad8ccc1c761861e865f708b4d06e0509ff5ee78b517f31f8e380d"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8670,9 +8465,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "11.1.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397ed07e0a652da33372327862d8fb977176b21f903a9f90ed0885ca847844b5"
+checksum = "90dfae08d9263608f63bc4c8f72166a78b36a4012d0bd38f9d71cb5b114ee0a2"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8699,9 +8494,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.58.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da642df4a69a4a4afae450487d354af66930c11d6b329e9044dc3c73cd693429"
+checksum = "8a8d515053fc21e1abb9abe80dd3dc3b66c6b31d4d50648ed8cbbde363d9624a"
 dependencies = [
  "once_cell",
  "regex",
@@ -8803,9 +8598,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -9167,16 +8959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
-dependencies = [
- "rustls 0.23.20",
- "tokio",
-]
-
-[[package]]
 name = "tokio-scoped"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9184,18 +8966,6 @@ checksum = "e4beb8ba13bc53ac53ce1d52b42f02e5d8060f0f42138862869beb769722b256"
 dependencies = [
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-socks"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
-dependencies = [
- "either",
- "futures-util",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
@@ -9264,7 +9034,6 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9764,7 +9533,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "httpmock",
- "reqwest 0.11.17",
+ "reqwest",
  "serde",
  "tokio",
  "turbo-rcstr",
@@ -10925,9 +10694,8 @@ dependencies = [
 
 [[package]]
 name = "virtual-fs"
-version = "0.600.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558995609ae4e69538c3f1eec3ad1d195ee8a1ed9d39768713728a57ed4ba6fe"
+version = "0.21.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10939,7 +10707,8 @@ dependencies = [
  "fs_extra",
  "futures",
  "getrandom 0.2.15",
- "indexmap 2.7.1",
+ "indexmap 1.9.3",
+ "lazy_static",
  "libc",
  "pin-project-lite",
  "replace_with",
@@ -10948,15 +10717,14 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "wasmer-package 0.600.0",
- "webc 9.0.0",
+ "wasmer-package 0.4.0",
+ "webc",
 ]
 
 [[package]]
 name = "virtual-mio"
-version = "0.600.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5564ace0b5098d394f6ca9aa62046da4e2e5912703cc7fec71a79dd3ae76b5d"
+version = "0.7.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10970,9 +10738,8 @@ dependencies = [
 
 [[package]]
 name = "virtual-net"
-version = "0.600.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b44e5bdba1d7f0223ee4f9e6aab55f993c610629503a855fc55fabd6c10f4e"
+version = "0.14.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10982,16 +10749,12 @@ dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "futures-util",
- "idna_adapter",
  "ipnet",
  "iprange",
- "libc",
- "mio 1.0.3",
  "pin-project-lite",
  "rkyv 0.8.9",
  "serde",
  "smoltcp",
- "socket2 0.5.8",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -11003,12 +10766,6 @@ name = "vlq"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -11145,11 +10902,10 @@ dependencies = [
  "anyhow",
  "console_error_panic_hook",
  "getrandom 0.2.15",
- "getrandom 0.3.3",
  "js-sys",
  "mdxjs",
  "next-custom-transforms",
- "serde-wasm-bindgen 0.4.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "swc_core",
  "tracing",
@@ -11237,36 +10993,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmer"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8204e4eb959d89b41d4a536e61ce73f5416bccc81c7d3b7fa993995538ee97"
+version = "5.0.5-rc1"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "bindgen",
  "bytes",
  "cfg-if",
  "cmake",
- "derive_more 1.0.0",
- "indexmap 2.7.1",
+ "indexmap 1.9.3",
  "js-sys",
  "more-asserts",
- "paste",
  "rustc-demangle",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "shared-buffer",
  "tar",
  "target-lexicon",
@@ -11279,16 +11019,15 @@ dependencies = [
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser 0.224.1",
+ "wasmparser 0.216.1",
  "wat",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "wasmer-cache"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3077ff8340cc09dcc53d4a140681ea7fb3d5525eb028f3853db1bc81434c3bad"
+version = "5.0.5-rc1"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "blake3",
  "hex",
@@ -11298,18 +11037,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690827b8ec4f3858d8b001d96ddfc25c28a255cbfa984ba5bd1ed173f29ffc2a"
+version = "5.0.5-rc1"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "backtrace",
  "bytes",
  "cfg-if",
  "enum-iterator",
  "enumset",
+ "lazy_static",
  "leb128",
  "libc",
- "macho-unwind-info",
  "memmap2 0.6.2",
  "more-asserts",
  "object 0.32.2",
@@ -11322,16 +11060,15 @@ dependencies = [
  "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser 0.224.1",
+ "wasmparser 0.216.1",
  "windows-sys 0.59.0",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a46a83b498a2f0dcdc2e97d611db9eae92a38f20fc5dac4709d645bdfd8d2d6"
+version = "5.0.5-rc1"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -11360,7 +11097,7 @@ dependencies = [
  "hex",
  "indexmap 2.7.1",
  "schemars",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "serde_yml",
@@ -11371,9 +11108,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-config"
-version = "0.600.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51dab2fa03bfb28b8b8c2f546531f56b341743557305e51ea621b1d8f7075b29"
+version = "0.12.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -11381,9 +11117,8 @@ dependencies = [
  "derive_builder 0.12.0",
  "hex",
  "indexmap 2.7.1",
- "saffron",
  "schemars",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "serde_yml",
@@ -11394,9 +11129,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaedaf20c22736904ad842127cdbe46432998dbcdd840b024dda856a8b52265"
+version = "5.0.5-rc1"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -11406,9 +11140,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-journal"
-version = "0.600.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd746264554197deae474fa069949c6352e2758dceb3157389af1436e121e9e"
+version = "0.18.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11422,13 +11155,11 @@ dependencies = [
  "rkyv 0.8.9",
  "serde",
  "serde_json",
- "shared-buffer",
  "thiserror 1.0.69",
  "tracing",
- "virtual-fs 0.600.0",
+ "virtual-fs 0.21.0",
  "virtual-net",
  "wasmer",
- "wasmer-config 0.600.0",
  "wasmer-wasix-types",
 ]
 
@@ -11444,7 +11175,7 @@ dependencies = [
  "ciborium",
  "flate2",
  "insta",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "sha2",
@@ -11455,23 +11186,21 @@ dependencies = [
  "toml 0.8.19",
  "url",
  "wasmer-config 0.10.0",
- "webc 7.0.0-rc.2",
+ "webc",
 ]
 
 [[package]]
 name = "wasmer-package"
-version = "0.600.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20614419fe563480822cec9f67818aced0b1b2cc26f88e96372bbaec9fd14c0f"
+version = "0.4.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "anyhow",
  "bytes",
  "cfg-if",
  "ciborium",
  "flate2",
- "ignore",
  "insta",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "sha2",
@@ -11481,16 +11210,14 @@ dependencies = [
  "thiserror 1.0.69",
  "toml 0.8.19",
  "url",
- "wasmer-config 0.600.0",
- "wasmer-types",
- "webc 9.0.0",
+ "wasmer-config 0.12.0",
+ "webc",
 ]
 
 [[package]]
 name = "wasmer-types"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b45fd1274b21365d3232732afe53c220ecbcdb78946405087e7016e7b2369a0"
+version = "5.0.5-rc1"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "bytecheck 0.6.11",
  "enum-iterator",
@@ -11504,15 +11231,13 @@ dependencies = [
  "sha2",
  "target-lexicon",
  "thiserror 1.0.69",
- "wasmparser 0.224.1",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4e7cec7b509e70664773f03907e6122d1633c100cb28009da770786806e6db"
+version = "5.0.5-rc1"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "backtrace",
  "cc",
@@ -11523,8 +11248,8 @@ dependencies = [
  "enum-iterator",
  "fnv",
  "indexmap 2.7.1",
+ "lazy_static",
  "libc",
- "libunwind",
  "mach2",
  "memoffset 0.9.0",
  "more-asserts",
@@ -11537,9 +11262,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasix"
-version = "0.600.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc74d209309baed0338fda8310847a9641bb77c2aeb1ae25af309006c22153f"
+version = "0.35.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11559,6 +11283,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "js-sys",
+ "lazy_static",
  "libc",
  "linked_hash_set",
  "lz4_flex",
@@ -11568,10 +11293,9 @@ dependencies = [
  "pin-project",
  "pin-utils",
  "rand 0.8.5",
- "reqwest 0.12.9",
  "rkyv 0.8.9",
  "rusty_pool",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11588,20 +11312,20 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "virtual-fs 0.600.0",
+ "virtual-fs 0.21.0",
  "virtual-mio",
  "virtual-net",
  "waker-fn",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasmer",
- "wasmer-config 0.600.0",
+ "wasmer-config 0.12.0",
  "wasmer-journal",
- "wasmer-package 0.600.0",
+ "wasmer-package 0.4.0",
  "wasmer-types",
  "wasmer-wasix-types",
  "web-sys",
- "webc 9.0.0",
+ "webc",
  "weezl",
  "windows-sys 0.59.0",
  "xxhash-rust",
@@ -11609,9 +11333,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasix-types"
-version = "0.600.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3732cc6f863b06ef80e066a3c2558c322de6fbe76caf704aefe9ca7ccaf25f10"
+version = "0.35.0"
+source = "git+https://github.com/kdy1/wasmer?branch=build-deps#afedc9315eb1c7fefddff7a3c6ada0235e78678a"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -11638,16 +11361,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
 dependencies = [
  "indexmap 2.7.1",
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.224.1"
+version = "0.216.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
+checksum = "1cc7c63191ae61c70befbe6045b9be65ef2082fa89421a386ae172cb1e08e92d"
 dependencies = [
+ "ahash 0.8.11",
  "bitflags 2.9.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.7.1",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -11677,16 +11404,6 @@ name = "web-sys"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11723,34 +11440,6 @@ dependencies = [
  "document-features",
  "ignore",
  "indexmap 1.9.3",
- "leb128",
- "lexical-sort",
- "libc",
- "once_cell",
- "path-clean 1.0.1",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2",
- "shared-buffer",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "webc"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38544ae3a351279fa913b4dee9c548f0aa3b27ca05756531c3f2e6bc4e22c27d"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "ciborium",
- "document-features",
- "ignore",
- "indexmap 2.7.1",
  "leb128",
  "lexical-sort",
  "libc",
@@ -11901,17 +11590,6 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-result"
@@ -12259,7 +11937,7 @@ dependencies = [
  "owo-colors 3.5.0",
  "plotters",
  "rustc-hash 2.1.1",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "tabled",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,7 +297,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "24.0.0", features = [
+swc_core = { version = "23.1.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
@@ -307,11 +307,11 @@ testing = { version = "10.0.0" }
 browserslist-rs = { version = "0.18.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "1.0.1"
-modularize_imports = { version = "0.84.0" }
-styled_components = { version = "0.112.1" }
-styled_jsx = { version = "0.88.0" }
-swc_emotion = { version = "0.88.0" }
-swc_relay = { version = "0.58.0" }
+modularize_imports = { version = "0.83.1" }
+styled_components = { version = "0.111.0" }
+styled_jsx = { version = "0.87.0" }
+swc_emotion = { version = "0.87.0" }
+swc_relay = { version = "0.57.0" }
 
 # General Deps
 chromiumoxide = { version = "0.5.4", features = [
@@ -366,7 +366,7 @@ lightningcss = { version = "1.0.0-alpha.65", features = [
   "visitor",
   "into_owned",
 ] }
-lightningcss-napi = { version = "0.4.4", default-features = false, features = [
+lightningcss-napi = { version = "0.4.3", default-features = false, features = [
   "visitor"
 ]}
 markdown = "1.0.0-alpha.18"
@@ -430,5 +430,9 @@ vergen-gitcl = { git = "https://github.com/bgw/vergen.git", branch = "bgw/no-opt
 webbrowser = "0.8.7"
 
 [patch.crates-io]
-mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-24" }
+# Remove this once https://github.com/wasmerio/wasmer/pull/5333 is merged and released
+wasmer = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
+wasmer-cache = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
+wasmer-compiler-cranelift = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
+wasmer-wasix = { git = "https://github.com/kdy1/wasmer", branch = "build-deps" }
 

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -32,8 +32,8 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
-react_remove_properties = "0.38.0"
-remove_console = "0.39.0"
+react_remove_properties = "0.37.0"
+remove_console = "0.38.0"
 itertools = { workspace = true }
 auto-hash-map = { workspace = true }
 percent-encoding = "2.3.1"
@@ -41,6 +41,7 @@ serde_path_to_error = { workspace = true }
 
 swc_core = { workspace = true, features = [
   "base",
+  "cached",
   "common_concurrent",
   "ecma_ast",
   "ecma_loader_lru",

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -36,6 +36,7 @@ dashmap = "6.1.0"
 
 swc_core = { workspace = true, features = [
   "base",
+  "cached",
   "common_concurrent",
   "ecma_ast",
   "ecma_codegen",
@@ -62,8 +63,8 @@ turbopack-ecmascript-plugins = { workspace = true, optional = true }
 turbo-rcstr = { workspace = true }
 urlencoding = { workspace = true }
 
-react_remove_properties = "0.38.0"
-remove_console = "0.39.0"
+react_remove_properties = "0.37.0"
+remove_console = "0.38.0"
 preset_env_base = "3.0.1"
 
 [dev-dependencies]

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -24,8 +24,7 @@ serde_json = "1"
 tracing = { version = "0.1.37" }
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
 wasm-bindgen-futures = "0.4.8"
-getrandom_2 = { version = "0.2.9", default-features = false, features = ["js"], package = "getrandom" }
-getrandom_3 = { version = "0.3.3", default-features = false, features = ["wasm_js"], package = "getrandom" }
+getrandom = { version = "0.2.9", default-features = false, features = ["js"] }
 js-sys = "0.3.59"
 serde-wasm-bindgen = "0.4.3"
 

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -12,7 +12,7 @@ use swc_core::{
         preset_env::{self, Targets},
         transforms::{
             base::{assumptions::Assumptions, feature::FeatureFlag, helpers::inject_helpers},
-            optimization::inline_globals,
+            optimization::inline_globals2,
             react::react,
         },
     },
@@ -134,8 +134,7 @@ impl EcmascriptInputTransform {
                 let mut typeofs: FxHashMap<Atom, Atom> = Default::default();
                 typeofs.insert(Atom::from("window"), Atom::from(&**window_value));
 
-                program.mutate(inline_globals(
-                    unresolved_mark,
+                program.mutate(inline_globals2(
                     Default::default(),
                     Default::default(),
                     Default::default(),

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css
@@ -1,4 +1,4 @@
 /* [project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css [test] (css) */
-.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)) tr td:first-child{text-wrap:nowrap}.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:initial}.prose :where(code):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:nowrap}
+.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:initial}.prose :where(table):not(:where([class~=not-prose],[class~=not-prose] *)) tr td:first-child{text-wrap:nowrap}.prose :where(code):not(:where([class~=not-prose],[class~=not-prose] *)){text-wrap:nowrap}
 
 /*# sourceMappingURL=b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map*/

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map
@@ -2,5 +2,5 @@
   "version": 3,
   "sources": [],
   "sections": [
-    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css"],"sourcesContent":[".prose :where(table):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  tr {\n    td:first-child {\n      text-wrap: nowrap;\n    }\n  }\n  text-wrap: initial;\n}\n\n.prose :where(code):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  text-wrap: nowrap;\n}\n"],"names":[],"mappings":"AAEI,6GAIQ,4FAGZ"}}]
+    {"offset": {"line": 1, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css"],"sourcesContent":[".prose :where(table):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  tr {\n    td:first-child {\n      text-wrap: nowrap;\n    }\n  }\n  text-wrap: initial;\n}\n\n.prose :where(code):not(:where([class~='not-prose'], [class~='not-prose'] *)) {\n  text-wrap: nowrap;\n}\n"],"names":[],"mappings":"AAAA,4FAEI,6GAOJ"}}]
 }


### PR DESCRIPTION
This seems to be failing to build on darwin still x-ref: https://github.com/vercel/next.js/actions/runs/14978295541/job/42077365728

Reverts vercel/next.js#79092