### PR TITLE
[build-sourcemaps] Remove unused static workers

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -783,9 +783,6 @@ async function writeFullyStaticExport(
   const exportApp = require('../export')
     .default as typeof import('../export').default
 
-  const pagesWorker = createStaticWorker(config)
-  const appWorker = createStaticWorker(config)
-
   await exportApp(
     dir,
     {
@@ -798,9 +795,6 @@ async function writeFullyStaticExport(
     },
     nextBuildSpan
   )
-
-  pagesWorker.end()
-  appWorker.end()
 }
 
 async function getBuildId(


### PR DESCRIPTION
These workers are spawned without actually doing something. Should be safe to remove. Or have a comment why they're needed still.

Became unused in https://github.com/vercel/next.js/pull/68546