### PR TITLE
docs: improve  `'use client'` directive and client components

### DIFF
--- a/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
+++ b/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
@@ -18,7 +18,7 @@ There are a couple of benefits to doing the rendering work on the client, includ
 
 To use Client Components, you can add the React [`'use client'` directive](https://react.dev/reference/react/use-client) at the top of a file, above your imports.
 
-`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle. The props of Client Components exported from a file with the `'use client'` directive must be [serializable](https://react.dev/reference/rsc/use-client#serializable-types) by React to allow data to be passed from the server to the client across the boundary.
+`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle. The props of components exported from a file with the `'use client'` directive must be [serializable](https://react.dev/reference/rsc/use-client#serializable-types) by React to allow data to be passed from the server to the client across the boundary.
 
 ```tsx filename="app/counter.tsx" highlight={1} switcher
 'use client'

--- a/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
+++ b/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
@@ -18,7 +18,7 @@ There are a couple of benefits to doing the rendering work on the client, includ
 
 To use Client Components, you can add the React [`'use client'` directive](https://react.dev/reference/react/use-client) at the top of a file, above your imports.
 
-`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle.
+`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle. The props of the Client Components defined inside the file of the `'use client'` directive must be [serializable](https://react.dev/reference/rsc/use-client#serializable-types) by React so that the data can be passed from the server to the client over the boundary.
 
 ```tsx filename="app/counter.tsx" highlight={1} switcher
 'use client'

--- a/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
+++ b/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
@@ -18,7 +18,7 @@ There are a couple of benefits to doing the rendering work on the client, includ
 
 To use Client Components, you can add the React [`'use client'` directive](https://react.dev/reference/react/use-client) at the top of a file, above your imports.
 
-`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle. The props of Client Components exported from a file with the `'use client'` directive must be serializable by React to allow data to be passed from the server to the client across the boundary.
+`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle. The props of Client Components exported from a file with the `'use client'` directive must be [serializable](https://react.dev/reference/rsc/use-client#serializable-types) by React to allow data to be passed from the server to the client across the boundary.
 
 ```tsx filename="app/counter.tsx" highlight={1} switcher
 'use client'

--- a/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
+++ b/docs/01-app/03-building-your-application/03-rendering/02-client-components.mdx
@@ -18,7 +18,7 @@ There are a couple of benefits to doing the rendering work on the client, includ
 
 To use Client Components, you can add the React [`'use client'` directive](https://react.dev/reference/react/use-client) at the top of a file, above your imports.
 
-`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle. The props of the Client Components defined inside the file of the `'use client'` directive must be [serializable](https://react.dev/reference/rsc/use-client#serializable-types) by React so that the data can be passed from the server to the client over the boundary.
+`'use client'` is used to declare a [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle. The props of Client Components exported from a file with the `'use client'` directive must be serializable by React to allow data to be passed from the server to the client across the boundary.
 
 ```tsx filename="app/counter.tsx" highlight={1} switcher
 'use client'

--- a/docs/01-app/05-api-reference/01-directives/use-client.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-client.mdx
@@ -7,7 +7,7 @@ The `'use client'` directive declares an entry point for the components to be re
 
 > **Good to know:**
 >
-> You do not need to add the `'use client'` directive to every file that contains Client Components. You only need to add it to the files whose components you want to render directly within Server Components. The `'use client'` directive defines the client-server [boundary](https://nextjs.org/docs/app/building-your-application/rendering#network-boundary), and the components exported from its file serve as entry points to the client.
+> You do not need to add the `'use client'` directive to every file that contains Client Components. You only need to add it to the files whose components you want to render directly within Server Components. The `'use client'` directive defines the client-server [boundary](https://nextjs.org/docs/app/building-your-application/rendering#network-boundary), and the components exported from such a file serve as entry points to the client.
 
 ## Usage
 

--- a/docs/01-app/05-api-reference/01-directives/use-client.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-client.mdx
@@ -49,7 +49,7 @@ export default function Counter() {
 
 When using the `'use client'` directive, the props of the Client Components must be [serializable](https://react.dev/reference/rsc/use-client#serializable-types). This means the props need to be in a format that React can serialize when sending data from the server to the client.
 
-```tsx filename="app/components/counter.tsx" highlight={3} switcher
+```tsx filename="app/components/counter.tsx" highlight={4} switcher
 'use client'
 
 export default function Counter({
@@ -66,7 +66,7 @@ export default function Counter({
 }
 ```
 
-```jsx filename="app/components/counter.js" highlight={3} switcher
+```jsx filename="app/components/counter.js" highlight={4} switcher
 'use client'
 
 export default function Counter({

--- a/docs/01-app/05-api-reference/01-directives/use-client.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-client.mdx
@@ -53,14 +53,11 @@ When using the `'use client'` directive, the props of the Client Components must
 'use client'
 
 export default function Counter({
-  useState /* ❌ Function is not serializable */,
+  onClick /* ❌ Function is not serializable */,
 }) {
-  const [count, setCount] = useState(0)
-
   return (
     <div>
-      <p>Count: {count}</p>
-      <button onClick={() => setCount(count + 1)}>Increment</button>
+      <button onClick={onClick}>Increment</button>
     </div>
   )
 }
@@ -70,14 +67,11 @@ export default function Counter({
 'use client'
 
 export default function Counter({
-  useState /* ❌ Function is not serializable */,
+  onClick /* ❌ Function is not serializable */,
 }) {
-  const [count, setCount] = useState(0)
-
   return (
     <div>
-      <p>Count: {count}</p>
-      <button onClick={() => setCount(count + 1)}>Increment</button>
+      <button onClick={onClick}>Increment</button>
     </div>
   )
 }

--- a/docs/01-app/05-api-reference/01-directives/use-client.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-client.mdx
@@ -52,8 +52,9 @@ When using the `'use client'` directive, the props of the Client Components must
 ```tsx filename="app/components/counter.tsx" highlight={3} switcher
 'use client'
 
-export default function Counter({ useState }) {
-  // ❌ Function is not serializable
+export default function Counter({
+  useState /* ❌ Function is not serializable */,
+}) {
   const [count, setCount] = useState(0)
 
   return (
@@ -68,8 +69,9 @@ export default function Counter({ useState }) {
 ```jsx filename="app/components/counter.js" highlight={3} switcher
 'use client'
 
-export default function Counter({ useState }) {
-  // ❌ Function is not serializable
+export default function Counter({
+  useState /* ❌ Function is not serializable */,
+}) {
   const [count, setCount] = useState(0)
 
   return (

--- a/docs/01-app/05-api-reference/01-directives/use-client.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-client.mdx
@@ -3,11 +3,15 @@ title: use client
 description: Learn how to use the use client directive to render a component on the client.
 ---
 
-The `'use client'` directive designates a component to be rendered on the **client side** and should be used when creating interactive user interfaces (UI) that require client-side JavaScript capabilities, such as state management, event handling, and access to browser APIs. This is a React feature.
+The `'use client'` directive declares an entry point for the components to be rendered on the **client side** and should be used when creating interactive user interfaces (UI) that require client-side JavaScript capabilities, such as state management, event handling, and access to browser APIs. This is a React feature.
+
+> **Good to know:**
+>
+> `'use client'` is used to declare an entry point [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle.
 
 ## Usage
 
-To designate a component as a Client Component, add the `'use client'` directive **at the top of the file**, before any imports:
+To declare an entry point for the Client Components, add the `'use client'` directive **at the top of the file**, before any imports:
 
 ```tsx filename="app/components/counter.tsx" highlight={1} switcher
 'use client'
@@ -32,6 +36,40 @@ export default function Counter() {
 import { useState } from 'react'
 
 export default function Counter() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+    </div>
+  )
+}
+```
+
+When using the `'use client'` directive, the props of the Client Components must be [serializable](https://react.dev/reference/rsc/use-client#serializable-types). This means the props need to be in a format that React can serialize when sending data from the server to the client.
+
+```tsx filename="app/components/counter.tsx" highlight={3} switcher
+'use client'
+
+export default function Counter({ useState }) {
+  // ❌ Function is not serializable
+  const [count, setCount] = useState(0)
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+    </div>
+  )
+}
+```
+
+```jsx filename="app/components/counter.js" highlight={3} switcher
+'use client'
+
+export default function Counter({ useState }) {
+  // ❌ Function is not serializable
   const [count, setCount] = useState(0)
 
   return (

--- a/docs/01-app/05-api-reference/01-directives/use-client.mdx
+++ b/docs/01-app/05-api-reference/01-directives/use-client.mdx
@@ -7,7 +7,7 @@ The `'use client'` directive declares an entry point for the components to be re
 
 > **Good to know:**
 >
-> `'use client'` is used to declare an entry point [boundary](/docs/app/building-your-application/rendering#network-boundary) between a Server and Client Component modules. This means that by defining a `'use client'` in a file, all other modules imported into it, including child components, are considered part of the client bundle.
+> You do not need to add the `'use client'` directive to every file that contains Client Components. You only need to add it to the files whose components you want to render directly within Server Components. The `'use client'` directive defines the client-server [boundary](https://nextjs.org/docs/app/building-your-application/rendering#network-boundary), and the components exported from its file serve as entry points to the client.
 
 ## Usage
 


### PR DESCRIPTION
### Why?

Our docs mention the `'use client'` directive to "designate a Client Component,"  but this can easily lead to misunderstanding that the users need to mark the directive to write a Client Component. This chains to ambiguity on the concept that the entry point Client Components' props must be serializable.

It is essential to emphasize that this directive serves as the **entry point** for the client-server **boundary**, not a Client Component opt-in feature.

