### PR TITLE
[turbopack] Adopt `globset` instead of using our own glob implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7538,7 +7538,7 @@ checksum = "a01bfcbbdea182bdda93713aeecd997749ae324686bf7944f54d128e56be4ea9"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
- "globset",
+ "globset 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 2.7.1",
  "once_cell",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "git+https://github.com/lukesandberg/ripgrep?branch=serialize_globset#7c1f24bda92874ec316a70bada5f024e4dfc4ea6"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3328,7 +3340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
 dependencies = [
  "crossbeam-deque",
- "globset",
+ "globset 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "memchr",
  "regex-automata 0.4.9",
@@ -9728,6 +9740,7 @@ dependencies = [
  "dunce",
  "futures",
  "futures-retry",
+ "globset 0.4.16 (git+https://github.com/lukesandberg/ripgrep?branch=serialize_globset)",
  "include_dir",
  "indexmap 2.7.1",
  "jsonc-parser 0.21.0",

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -55,6 +55,8 @@ turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 unicode-segmentation = { workspace = true }
 urlencoding = { workspace = true }
+# Remove this once https://github.com/BurntSushi/ripgrep/pull/3048 is merged and released
+globset = {git = "https://github.com/lukesandberg/ripgrep", branch="serialize_globset" }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -86,7 +86,7 @@ impl TryFrom<GlobForm> for Glob {
 
     fn try_from(value: GlobForm) -> Result<Self, Self::Error> {
         if value.globs.len() == 1 {
-            return Ok(Glob::parse(value.globs[0].clone())?);
+            return Glob::parse(value.globs[0].clone());
         }
         let mut set = GlobSet::builder();
         for raw in &value.globs {


### PR DESCRIPTION
The `globset` implementation of globs is highly performant and supports more features than we do.

Notably, this adds support for character classes (e.g. everyones favorite `[a-zA-Z]`).  

From some simple benchmarking this is ~15x as fast as ours!  It is however missing two features:

1. Support for nested alternations. 
   * I sent https://github.com/BurntSushi/ripgrep/pull/3048 to upstream to address since this is trivial.  In the meantime this is pointing at my fork.  Happy to wait for it to land to land this.
2. Support for 'partial matches'.  
   * This is a unique feature of our `glob` implementation that allows us to check if a directory could possibly contain a glob match which can short circuit directory traversals.
   * This one is tricky.  Support for this could be added to `globset`, but it is _extremely_ non-trivial (a good implementation would require work in the regex-automaton crates), however after reflecting on our use of globs in turbopack I suspect that this feature is not that important and is generally mitigated by the improved matching performance.  The reason it isn't critical is for two reasons: 
      1. many globs are 'unrooted' (e.g. have a leading `**/`), so the partial match always succeeded.
      2. generally we are traversing the project directory and should expected to call `opendir` on every directory anyway, so turbo-task-caching should bail us out.

It is quite possible I am wrong about that last one, in which case I can pursue an implementation with upstream.

Finally, the main alternative is an implementation i have been poking at is https://github.com/vercel/next.js/pull/78976.  However, my recommendation is to not pursue that.  While it is using similar strategies, `globset` is using a far more advanced implementation of the same basic idea (automata), which is why they manage to be 5x faster than my implementation.

Closes PACK-4401
Fixes #72196

