### PR TITLE
Revert toolchain update to 2025-05-12

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-05-12"
+channel = "nightly-2025-04-14"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
This partially reverts commit 1866e4403b0956a8325489a67811032cca05fc19, reverting the toolchain update but keeping the clippy fixes.


Closes PACK-4586