### PR TITLE
Reference the workUnitStore when determining bailout to CSR

### DIFF
--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -1,10 +1,21 @@
 import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { workAsyncStorage } from '../../server/app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from '../../server/app-render/work-unit-async-storage.external'
 
 export function bailoutToClientRendering(reason: string): void | never {
   const workStore = workAsyncStorage.getStore()
 
   if (workStore?.forceStatic) return
 
-  if (workStore?.isStaticGeneration) throw new BailoutToCSRError(reason)
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (workUnitStore) {
+    switch (workUnitStore.type) {
+      case 'prerender':
+      case 'prerender-ppr':
+      case 'prerender-legacy':
+        throw new BailoutToCSRError(reason)
+      default:
+    }
+  }
 }


### PR DESCRIPTION
When useSearchParams is determining if it should bail out to client side rendering it currently consults the worksStore. This is not semantically correct since the workStore does not represent a particular render. This change updates it to reference the workUnitStore where we can correctly identify what type of render we are within