### PR TITLE
fix(dev-overlay): Ignore right clicks on the indicator draggable

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/draggable.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/draggable.tsx
@@ -186,6 +186,9 @@ export function useDrag(options: UseDragOptions) {
   }
 
   function onPointerDown(e: React.PointerEvent) {
+    if (e.button !== 0) {
+      return // ignore right click
+    }
     origin.current = { x: e.clientX, y: e.clientY }
     state.current = 'press'
     window.addEventListener('pointermove', onPointerMove)


### PR DESCRIPTION
Without this change, right clicking on the indicator starts the drag action, which leads to janky behavior with the native browser context menu.

Only allow dragging with the primary mouse button.

I also tested this in the mobile simulator mode to make sure I didn't break anything there.

Closes PACK-4623