### PR TITLE
Rust: restore toolchain 2025-05-12

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -34,9 +34,6 @@ rustflags = [
   "target-feature=+crt-static"
 ]
 
-[target.aarch64-pc-windows-msvc]
-linker = "rust-lld"
-
 [target.'cfg(target_os = "macos")']
 linker = "rust-lld"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-04-14"
+channel = "nightly-2025-05-12"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
This restores #79117.

https://github.com/rust-lang/rust/issues/71520 broke Windows on arm64 when using rust-lld, so this disables that for now.

Test Plan: `pnpm --filter=@next/swc run build-native-no-plugin-release --target aarch64-pc-windows-msvc` on Windows on arm64.

Closes PACK-4590