### PR TITLE
Turbopack: Make `napi` crate Rust 2024

### DIFF
--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "next-swc-napi"
 version = "0.0.0"
 publish = false

--- a/crates/napi/src/mdx.rs
+++ b/crates/napi/src/mdx.rs
@@ -1,4 +1,4 @@
-use mdxjs::{compile, Options};
+use mdxjs::{Options, compile};
 use napi::bindgen_prelude::*;
 
 pub struct MdxCompileTask {

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -30,8 +30,8 @@ use napi::bindgen_prelude::*;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
-    base::{config::JsMinifyOptions, try_with_handler, TransformOutput},
-    common::{errors::ColorConfig, sync::Lrc, FileName, SourceFile, SourceMap, GLOBALS},
+    base::{TransformOutput, config::JsMinifyOptions, try_with_handler},
+    common::{FileName, GLOBALS, SourceFile, SourceMap, errors::ColorConfig, sync::Lrc},
 };
 
 use crate::{get_compiler, util::MapErr};

--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -1,13 +1,13 @@
 use std::{ops::Deref, sync::Arc};
 
 use anyhow::Result;
-use napi::{bindgen_prelude::External, JsFunction};
+use napi::{JsFunction, bindgen_prelude::External};
 use next_api::{
     operation::OptionEndpoint,
     paths::ServerPath,
     route::{
-        endpoint_client_changed_operation, endpoint_server_changed_operation,
-        endpoint_write_to_disk_operation, EndpointOutputPaths,
+        EndpointOutputPaths, endpoint_client_changed_operation, endpoint_server_changed_operation,
+        endpoint_write_to_disk_operation,
     },
 };
 use tracing::Instrument;
@@ -15,8 +15,8 @@ use turbo_tasks::{Completion, Effects, OperationVc, ReadRef, Vc};
 use turbopack_core::{diagnostics::PlainDiagnostic, error::PrettyPrintError, issue::PlainIssue};
 
 use super::utils::{
-    strongly_consistent_catch_collectables, subscribe, NapiDiagnostic, NapiIssue, RootTask,
-    TurbopackResult, VcArc,
+    NapiDiagnostic, NapiIssue, RootTask, TurbopackResult, VcArc,
+    strongly_consistent_catch_collectables, subscribe,
 };
 
 #[napi(object)]

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1,10 +1,10 @@
 use std::{io::Write, path::PathBuf, sync::Arc, thread, time::Duration};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use napi::{
-    bindgen_prelude::{within_runtime_if_available, External},
-    threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
     JsFunction, Status,
+    bindgen_prelude::{External, within_runtime_if_available},
+    threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 use next_api::{
     entrypoints::Entrypoints,
@@ -19,31 +19,31 @@ use next_api::{
     route::Endpoint,
 };
 use next_core::tracing_presets::{
-    TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBOPACK_TARGETS,
-    TRACING_NEXT_TURBO_TASKS_TARGETS,
+    TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBO_TASKS_TARGETS,
+    TRACING_NEXT_TURBOPACK_TARGETS,
 };
 use once_cell::sync::Lazy;
 use rand::Rng;
 use tokio::{io::AsyncWriteExt, time::Instant};
 use tracing::Instrument;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Registry};
+use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    get_effects, Completion, Effects, FxIndexSet, OperationVc, ReadRef, ResolvedVc,
-    TransientInstance, TryJoinIterExt, UpdateInfo, Vc,
+    Completion, Effects, FxIndexSet, OperationVc, ReadRef, ResolvedVc, TransientInstance,
+    TryJoinIterExt, UpdateInfo, Vc, get_effects,
 };
 use turbo_tasks_fs::{
-    get_relative_path_to, util::uri_from_file, DiskFileSystem, FileContent, FileSystem,
-    FileSystemPath,
+    DiskFileSystem, FileContent, FileSystem, FileSystemPath, get_relative_path_to,
+    util::uri_from_file,
 };
 use turbopack_core::{
+    PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
     diagnostics::PlainDiagnostic,
     error::PrettyPrintError,
     issue::PlainIssue,
     output::{OutputAsset, OutputAssets},
     source_map::{OptionSourceMap, OptionStringifiedSourceMap, SourceMap, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
-    PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
 };
 use turbopack_ecmascript_hmr_protocol::{ClientUpdateInstruction, ResourceIdentifier};
 use turbopack_trace_utils::{
@@ -57,8 +57,8 @@ use url::Url;
 use super::{
     endpoint::ExternalEndpoint,
     utils::{
-        create_turbo_tasks, get_diagnostics, get_issues, subscribe, NapiDiagnostic, NapiIssue,
-        NextTurboTasks, RootTask, TurbopackResult, VcArc,
+        NapiDiagnostic, NapiIssue, NextTurboTasks, RootTask, TurbopackResult, VcArc,
+        create_turbo_tasks, get_diagnostics, get_issues, subscribe,
     },
 };
 use crate::{register, util::DhatProfilerGuard};

--- a/crates/napi/src/parse.rs
+++ b/crates/napi/src/parse.rs
@@ -5,7 +5,7 @@ use napi::bindgen_prelude::*;
 use swc_core::{
     base::{config::ParseOptions, try_with_handler},
     common::{
-        comments::Comments, errors::ColorConfig, FileName, FilePathMapping, SourceMap, GLOBALS,
+        FileName, FilePathMapping, GLOBALS, SourceMap, comments::Comments, errors::ColorConfig,
     },
 };
 

--- a/crates/napi/src/react_compiler.rs
+++ b/crates/napi/src/react_compiler.rs
@@ -3,10 +3,10 @@ use std::{path::PathBuf, sync::Arc};
 use napi::bindgen_prelude::*;
 use next_custom_transforms::react_compiler;
 use swc_core::{
-    common::{SourceMap, GLOBALS},
+    common::{GLOBALS, SourceMap},
     ecma::{
         ast::EsVersion,
-        parser::{parse_file_as_program, Syntax, TsSyntax},
+        parser::{Syntax, TsSyntax, parse_file_as_program},
     },
 };
 

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -29,19 +29,19 @@ DEALINGS IN THE SOFTWARE.
 use std::{
     cell::RefCell,
     fs::read_to_string,
-    panic::{catch_unwind, AssertUnwindSafe},
+    panic::{AssertUnwindSafe, catch_unwind},
     rc::Rc,
 };
 
-use anyhow::{anyhow, bail, Context as _};
+use anyhow::{Context as _, anyhow, bail};
 use napi::bindgen_prelude::*;
-use next_custom_transforms::chain_transforms::{custom_before_pass, TransformOptions};
+use next_custom_transforms::chain_transforms::{TransformOptions, custom_before_pass};
 use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     atoms::Atom,
-    base::{try_with_handler, Compiler, TransformOutput},
-    common::{comments::SingleThreadedComments, errors::ColorConfig, FileName, Mark, GLOBALS},
+    base::{Compiler, TransformOutput, try_with_handler},
+    common::{FileName, GLOBALS, Mark, comments::SingleThreadedComments, errors::ColorConfig},
     ecma::ast::noop_pass,
 };
 

--- a/crates/napi/src/turbopack.rs
+++ b/crates/napi/src/turbopack.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 use napi::bindgen_prelude::*;
 use next_build::{
-    build_options::{BuildContext, DefineEnv},
     BuildOptions as NextBuildOptions,
+    build_options::{BuildContext, DefineEnv},
 };
 use next_core::next_config::{Rewrite, Rewrites, RouteHas};
 
@@ -159,7 +159,7 @@ pub enum NapiRouteHas {
 
 impl FromNapiValue for NapiRouteHas {
     unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> Result<Self> {
-        let object = Object::from_napi_value(env, napi_val)?;
+        let object = unsafe { Object::from_napi_value(env, napi_val)? };
         let type_ = object.get_named_property::<String>("type")?;
         Ok(match type_.as_str() {
             "header" => NapiRouteHas::Header {
@@ -181,7 +181,7 @@ impl FromNapiValue for NapiRouteHas {
                 return Err(napi::Error::new(
                     Status::GenericFailure,
                     format!("invalid type for RouteHas: {type_}"),
-                ))
+                ));
             }
         })
     }

--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -42,7 +42,7 @@ use once_cell::sync::Lazy;
 use owo_colors::OwoColorize;
 use terminal_hyperlink::Hyperlink;
 use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
-use tracing_subscriber::{filter, prelude::*, util::SubscriberInitExt, Layer};
+use tracing_subscriber::{Layer, filter, prelude::*, util::SubscriberInitExt};
 use turbopack_core::error::PrettyPrintError;
 
 static LOG_THROTTLE: Mutex<Option<Instant>> = Mutex::new(None);


### PR DESCRIPTION
This required explicitly wrapping certain calls in `unsafe` blocks.


Closes PACK-4592