### PR TITLE
Turbopack: Make `turbo-rcstr` crate Rust 2024

### DIFF
--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turbo-rcstr"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [features]

--- a/turbopack/crates/turbo-rcstr/benches/mod.rs
+++ b/turbopack/crates/turbo-rcstr/benches/mod.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use turbo_rcstr::RcStr;
 
 // map has a fast-path if the Arc is uniquely owned

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -3,8 +3,8 @@ use std::ptr::NonNull;
 use triomphe::Arc;
 
 use crate::{
-    tagged_value::{TaggedValue, MAX_INLINE_LEN},
-    RcStr, INLINE_TAG_INIT, LEN_OFFSET, TAG_MASK,
+    INLINE_TAG_INIT, LEN_OFFSET, RcStr, TAG_MASK,
+    tagged_value::{MAX_INLINE_LEN, TaggedValue},
 };
 
 pub unsafe fn cast(ptr: TaggedValue) -> *const String {
@@ -12,13 +12,13 @@ pub unsafe fn cast(ptr: TaggedValue) -> *const String {
 }
 
 pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i String {
-    &*cast(ptr)
+    unsafe { &*cast(ptr) }
 }
 
 /// Caller should call `forget` (or `clone`) on the returned `Arc`
 pub unsafe fn restore_arc(v: TaggedValue) -> Arc<String> {
     let ptr = v.get_ptr() as *const String;
-    Arc::from_raw(ptr)
+    unsafe { Arc::from_raw(ptr) }
 }
 
 /// This can create any kind of [Atom], although this lives in the `dynamic`

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::OsStr,
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
-    mem::{forget, ManuallyDrop},
+    mem::{ManuallyDrop, forget},
     num::NonZeroU8,
     ops::Deref,
     path::{Path, PathBuf},

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -135,9 +135,9 @@ impl TaggedValue {
         // All except the lowest byte, which is first in little-endian, last in
         // big-endian.
         if cfg!(target_endian = "little") {
-            data = data.offset(1);
+            data = unsafe { data.offset(1) };
         }
         let len = std::mem::size_of::<TaggedValue>() - 1;
-        slice::from_raw_parts_mut(data, len)
+        unsafe { slice::from_raw_parts_mut(data, len) }
     }
 }


### PR DESCRIPTION
This required explicitly wrapping certain calls in `unsafe` blocks. The calling functions were already marked `unsafe`.


Closes PACK-4593