### PR TITLE
Turbopack: Make `turbo-backend` crate Rust 2024

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -3,7 +3,7 @@ name = "turbo-tasks-backend"
 version = "0.1.0"
 description = "TBD"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 autobenches = false
 
 [lib]

--- a/turbopack/crates/turbo-tasks-backend/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/mod.rs
@@ -1,7 +1,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 pub(crate) mod scope_stress;
 pub(crate) mod stress;

--- a/turbopack/crates/turbo-tasks-backend/benches/scope_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/scope_stress.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use criterion::{BenchmarkId, Criterion};
 use turbo_tasks::{Completion, ReadConsistency, TryJoinIterExt, TurboTasks, Vc};
-use turbo_tasks_backend::{noop_backing_storage, BackendOptions, TurboTasksBackend};
+use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
 use super::register;
 

--- a/turbopack/crates/turbo-tasks-backend/benches/stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/stress.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use criterion::{BenchmarkId, Criterion};
 use turbo_tasks::{ReadConsistency, TryJoinIterExt, TurboTasks, Vc};
-use turbo_tasks_backend::{noop_backing_storage, BackendOptions, TurboTasksBackend};
+use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
 use super::register;
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1,6 +1,6 @@
 use std::{
-    cmp::{max, Ordering},
-    collections::{hash_map::Entry as HashMapEntry, VecDeque},
+    cmp::{Ordering, max},
+    collections::{VecDeque, hash_map::Entry as HashMapEntry},
     hash::Hash,
     mem::take,
     num::NonZeroU32,
@@ -8,8 +8,8 @@ use std::{
 
 use indexmap::map::Entry;
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
-use smallvec::{smallvec, SmallVec};
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeSeq};
+use smallvec::{SmallVec, smallvec};
 #[cfg(any(
     feature = "trace_aggregation_update",
     feature = "trace_find_and_schedule"
@@ -21,10 +21,9 @@ use turbo_tasks::{FxIndexMap, SessionId, TaskId};
 use crate::backend::operation::invalidate::TaskDirtyCause;
 use crate::{
     backend::{
-        get_mut, get_mut_or_insert_with,
-        operation::{invalidate::make_task_dirty, ExecuteContext, Operation, TaskGuard},
+        TaskDataCategory, get_mut, get_mut_or_insert_with,
+        operation::{ExecuteContext, Operation, TaskGuard, invalidate::make_task_dirty},
         storage::{count, get, get_many, iter_many, remove, update, update_count},
-        TaskDataCategory,
     },
     data::{
         ActivenessState, AggregationNumber, CachedDataItem, CachedDataItemKey, CollectibleRef,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -9,17 +9,16 @@ use turbo_tasks::TaskId;
 use crate::backend::operation::invalidate::TaskDirtyCause;
 use crate::{
     backend::{
-        get, get_many,
+        TaskDataCategory, get, get_many,
         operation::{
+            AggregatedDataUpdate, ExecuteContext, Operation, TaskGuard,
             aggregation_update::{
-                get_aggregation_number, get_uppers, is_aggregating_node, AggregationUpdateJob,
-                AggregationUpdateQueue, InnerOfUppersLostFollowersJob,
+                AggregationUpdateJob, AggregationUpdateQueue, InnerOfUppersLostFollowersJob,
+                get_aggregation_number, get_uppers, is_aggregating_node,
             },
             invalidate::make_task_dirty,
-            AggregatedDataUpdate, ExecuteContext, Operation, TaskGuard,
         },
         storage::update_count,
-        TaskDataCategory,
     },
     data::{CachedDataItemKey, CellRef, CollectibleRef, CollectiblesRef},
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -3,12 +3,11 @@ use turbo_tasks::TaskId;
 
 use crate::{
     backend::{
-        get_mut,
+        TaskDataCategory, get_mut,
         operation::{
-            aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue},
             ExecuteContext, Operation, TaskGuard,
+            aggregation_update::{AggregationUpdateJob, AggregationUpdateQueue},
         },
-        TaskDataCategory,
     },
     data::{CachedDataItem, CachedDataItemKey, InProgressState, InProgressStateInner},
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -4,8 +4,9 @@ use turbo_tasks::TaskId;
 
 use crate::{
     backend::operation::{
+        AggregationUpdateJob, AggregationUpdateQueue, TaskGuard,
         aggregation_update::InnerOfUppersHasNewFollowersJob, get_aggregation_number, get_uppers,
-        is_aggregating_node, AggregationUpdateJob, AggregationUpdateQueue, TaskGuard,
+        is_aggregating_node,
     },
     data::CachedDataItem,
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -4,14 +4,14 @@ use turbo_tasks::TaskId;
 
 use crate::{
     backend::{
+        TaskDataCategory,
         operation::{
+            ExecuteContext, Operation, TaskGuard,
             aggregation_update::{
                 AggregatedDataUpdate, AggregationUpdateJob, AggregationUpdateQueue,
             },
-            ExecuteContext, Operation, TaskGuard,
         },
         storage::{get, get_mut},
-        TaskDataCategory,
     },
     data::{
         CachedDataItem, CachedDataItemKey, CachedDataItemValue, DirtyState, InProgressState,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -18,8 +18,8 @@ use turbo_tasks::{KeyValuePair, SessionId, TaskId, TurboTasksBackendApi};
 
 use crate::{
     backend::{
-        storage::{SpecificTaskDataCategory, StorageWriteGuard},
         OperationGuard, TaskDataCategory, TransientTask, TurboTasksBackend, TurboTasksBackendInner,
+        storage::{SpecificTaskDataCategory, StorageWriteGuard},
     },
     backing_storage::BackingStorage,
     data::{
@@ -645,8 +645,8 @@ impl_operation!(AggregationUpdate aggregation_update::AggregationUpdateQueue);
 pub use self::invalidate::TaskDirtyCause;
 pub use self::{
     aggregation_update::{
-        get_aggregation_number, get_uppers, is_aggregating_node, is_root_node,
-        AggregatedDataUpdate, AggregationUpdateJob,
+        AggregatedDataUpdate, AggregationUpdateJob, get_aggregation_number, get_uppers,
+        is_aggregating_node, is_root_node,
     },
     cleanup_old_edges::OutdatedEdge,
     connect_children::connect_children,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
@@ -6,7 +6,7 @@ use turbo_tasks::TaskId;
 use crate::backend::{
     get,
     operation::{
-        is_aggregating_node, is_root_node, AggregationUpdateJob, AggregationUpdateQueue, TaskGuard,
+        AggregationUpdateJob, AggregationUpdateQueue, TaskGuard, is_aggregating_node, is_root_node,
     },
 };
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -1,12 +1,12 @@
-use turbo_tasks::{backend::CellContent, CellId, TaskId};
+use turbo_tasks::{CellId, TaskId, backend::CellContent};
 
 #[cfg(feature = "trace_task_dirty")]
 use crate::backend::operation::invalidate::TaskDirtyCause;
 use crate::{
     backend::{
+        TaskDataCategory,
         operation::{ExecuteContext, InvalidateOperation, TaskGuard},
         storage::{get_many, remove},
-        TaskDataCategory,
     },
     data::{CachedDataItem, CachedDataItemKey},
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -5,13 +5,12 @@ use turbo_tasks::TaskId;
 
 use crate::{
     backend::{
-        get_many,
+        TaskDataCategory, get_many,
         operation::{
-            get_aggregation_number, is_root_node, AggregatedDataUpdate, AggregationUpdateJob,
-            AggregationUpdateQueue, ExecuteContext, Operation,
+            AggregatedDataUpdate, AggregationUpdateJob, AggregationUpdateQueue, ExecuteContext,
+            Operation, get_aggregation_number, is_root_node,
         },
         storage::{get, update_count},
-        TaskDataCategory,
     },
     data::CollectibleRef,
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -1,19 +1,19 @@
 use std::{borrow::Cow, mem::take};
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{util::SharedError, RawVc, TaskId};
+use turbo_tasks::{RawVc, TaskId, util::SharedError};
 
 #[cfg(feature = "trace_task_dirty")]
 use crate::backend::operation::invalidate::TaskDirtyCause;
 use crate::{
     backend::{
+        TaskDataCategory,
         operation::{
-            invalidate::{make_task_dirty, make_task_dirty_internal},
             AggregationUpdateQueue, ExecuteContext, Operation, TaskGuard,
+            invalidate::{make_task_dirty, make_task_dirty_internal},
         },
         storage::{get, get_many},
-        TaskDataCategory,
     },
     data::{
         CachedDataItem, CachedDataItemKey, CellRef, InProgressState, InProgressStateInner,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -1,7 +1,7 @@
 use std::{
     hash::Hash,
     ops::{Deref, DerefMut},
-    sync::{atomic::AtomicBool, Arc},
+    sync::{Arc, atomic::AtomicBool},
     thread::available_parallelism,
 };
 
@@ -16,7 +16,7 @@ use crate::{
         CachedDataItemValue, CachedDataItemValueRef, CachedDataItemValueRefMut, OutputValue,
     },
     data_storage::{AutoMapStorage, OptionStorage},
-    utils::dash_map_multi::{get_multiple_mut, RefMut},
+    utils::dash_map_multi::{RefMut, get_multiple_mut},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -654,8 +654,7 @@ impl Storage {
 
         // The number of shards is much larger than the number of threads, so the effect of the
         // locks held is negligible.
-        let shards = self
-            .modified
+        self.modified
             .shards()
             .par_iter()
             .with_max_len(1)
@@ -696,9 +695,7 @@ impl Storage {
                     process_snapshot,
                 }
             })
-            .collect::<Vec<_>>();
-
-        shards
+            .collect::<Vec<_>>()
     }
 
     /// Start snapshot mode.
@@ -891,9 +888,7 @@ impl DerefMut for StorageWriteGuard<'_> {
 }
 
 macro_rules! count {
-    ($task:ident, $key:ident) => {{
-        $task.count($crate::data::CachedDataItemType::$key)
-    }};
+    ($task:ident, $key:ident) => {{ $task.count($crate::data::CachedDataItemType::$key) }};
 }
 
 macro_rules! get {

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use smallvec::SmallVec;
-use turbo_tasks::{backend::CachedTaskType, SessionId, TaskId};
+use turbo_tasks::{SessionId, TaskId, backend::CachedTaskType};
 
 use crate::{
     backend::{AnyOperation, TaskDataCategory},

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -3,10 +3,10 @@ use std::cmp::Ordering;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
+    CellId, KeyValuePair, SessionId, TaskId, TraitTypeId, TypedSharedReference, ValueTypeId,
     event::{Event, EventListener},
     registry,
     util::SharedError,
-    CellId, KeyValuePair, SessionId, TaskId, TraitTypeId, TypedSharedReference, ValueTypeId,
 };
 
 use crate::{

--- a/turbopack/crates/turbo-tasks-backend/src/data_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data_storage.rs
@@ -1,6 +1,6 @@
 use std::hash::{BuildHasherDefault, Hash};
 
-use auto_hash_map::{map::Entry, AutoMap};
+use auto_hash_map::{AutoMap, map::Entry};
 use rustc_hash::FxHasher;
 
 pub trait Storage {
@@ -17,7 +17,7 @@ pub trait Storage {
     fn get(&self, key: &Self::K) -> Option<&Self::V>;
     fn get_mut(&mut self, key: &Self::K) -> Option<&mut Self::V>;
     fn get_mut_or_insert_with(&mut self, key: Self::K, f: impl FnOnce() -> Self::V)
-        -> &mut Self::V;
+    -> &mut Self::V;
     fn extract_if<'l, F>(&'l mut self, f: F) -> impl Iterator<Item = (Self::K, Self::V)>
     where
         F: for<'a, 'b> FnMut(&'a Self::K, &'b mut Self::V) -> bool + 'l;
@@ -93,11 +93,7 @@ impl<V> Storage for OptionStorage<V> {
     }
 
     fn len(&self) -> usize {
-        if self.value.is_some() {
-            1
-        } else {
-            0
-        }
+        if self.value.is_some() { 1 } else { 0 }
     }
 
     fn iter(&self) -> Self::Iterator<'_> {

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -1,7 +1,7 @@
 use std::{
     path::PathBuf,
     sync::Arc,
-    thread::{spawn, JoinHandle},
+    thread::{JoinHandle, spawn},
 };
 
 use anyhow::Result;
@@ -162,7 +162,7 @@ impl<'a> ConcurrentWriteBatch<'a> for TurboWriteBatch<'a> {
     }
 
     unsafe fn flush(&self, key_space: KeySpace) -> Result<()> {
-        self.batch.flush(key_space as u32)
+        unsafe { self.batch.flush(key_space as u32) }
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -1,11 +1,11 @@
 use std::{borrow::Borrow, cmp::max, sync::Arc};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use serde::Serialize;
 use smallvec::SmallVec;
 use tracing::Span;
-use turbo_tasks::{backend::CachedTaskType, turbo_tasks_scope, SessionId, TaskId};
+use turbo_tasks::{SessionId, TaskId, backend::CachedTaskType, turbo_tasks_scope};
 
 use crate::{
     backend::{AnyOperation, TaskDataCategory},
@@ -180,7 +180,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
 
         // Start organizing the updates in parallel
         match &mut batch {
-            WriteBatch::Concurrent(ref batch, _) => {
+            &mut WriteBatch::Concurrent(ref batch, _) => {
                 {
                     let _span = tracing::trace_span!("update task data").entered();
                     process_task_data(snapshots, Some(batch))?;

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -41,7 +41,7 @@ pub fn lmdb_backing_storage(
     version_info: &GitVersionInfo,
 ) -> Result<LmdbBackingStorage> {
     use crate::database::{
-        fresh_db_optimization::{is_fresh, FreshDbOptimization},
+        fresh_db_optimization::{FreshDbOptimization, is_fresh},
         read_transaction_cache::ReadTransactionCache,
         startup_cache::StartupCacheLayer,
     };

--- a/turbopack/crates/turbo-tasks-backend/src/utils/swap_retain.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/swap_retain.rs
@@ -40,7 +40,7 @@ pub fn swap_retain<T>(vec: &mut impl VecLike<T>, mut f: impl FnMut(&mut T) -> bo
 
 #[cfg(test)]
 mod tests {
-    use smallvec::{smallvec, SmallVec};
+    use smallvec::{SmallVec, smallvec};
 
     use super::swap_retain;
 

--- a/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
@@ -3,8 +3,8 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput, Vc};
-use turbo_tasks_testing::{register, run_without_cache_check, Registration};
+use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
+use turbo_tasks_testing::{Registration, register, run_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 
@@ -32,10 +32,12 @@ async fn test_trace_transient() {
         anyhow::Ok(())
     })
     .await;
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains(&EXPECTED_TRACE.escape_debug().to_string()));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains(&EXPECTED_TRACE.escape_debug().to_string())
+    );
 }
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
@@ -2,8 +2,8 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput};
-use turbo_tasks_testing::{register, run_without_cache_check, Registration};
+use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, trace::TraceRawVcs};
+use turbo_tasks_testing::{Registration, register, run_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 
@@ -19,10 +19,12 @@ async fn test_transient_emit_from_persistent() {
         anyhow::Ok(())
     })
     .await;
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains(&EXPECTED_MSG.escape_debug().to_string()));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains(&EXPECTED_MSG.escape_debug().to_string())
+    );
 }
 
 #[turbo_tasks::function(operation)]

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -2,10 +2,10 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/basic.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/basic.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/call_types.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/call_types.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
@@ -9,8 +9,8 @@ use auto_hash_map::AutoSet;
 use rustc_hash::FxHashSet;
 use tokio::time::sleep;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{emit, CollectiblesSource, ResolvedVc, ValueToString, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks::{CollectiblesSource, ResolvedVc, ValueToString, Vc, emit};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/debug.rs
@@ -4,8 +4,8 @@
 
 use std::sync::Mutex;
 
-use turbo_tasks::{debug::ValueDebug, ResolvedVc, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks::{ResolvedVc, Vc, debug::ValueDebug};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/detached.rs
@@ -3,15 +3,15 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use tokio::{
-    sync::{watch, Notify},
-    time::{sleep, timeout, Duration},
+    sync::{Notify, watch},
+    time::{Duration, sleep, timeout},
 };
 use turbo_tasks::{
-    prevent_gc,
+    State, TransientInstance, Vc, prevent_gc,
     trace::{TraceRawVcs, TraceRawVcsContext},
-    turbo_tasks, State, TransientInstance, Vc,
+    turbo_tasks,
 };
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -4,10 +4,10 @@
 
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{emit, CollectiblesSource, ResolvedVc, State, ValueToString, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks::{CollectiblesSource, ResolvedVc, State, ValueToString, Vc, emit};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{State, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/filter_unused_args.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/filter_unused_args.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/local_tasks.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/local_tasks.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use anyhow::Result;
-use turbo_tasks::{test_helpers::current_task_for_testing, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks::{Vc, test_helpers::current_task_for_testing};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/operation_vc.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/operation_vc.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{OperationVc, ResolvedVc, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/performance.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/performance.rs
@@ -6,7 +6,7 @@ use std::{future::Future, time::Duration};
 
 use anyhow::Result;
 use turbo_tasks::{TransientInstance, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/random_change.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/random_change.rs
@@ -2,10 +2,10 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rand::Rng;
 use turbo_tasks::{State, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/read_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/read_ref_cell.rs
@@ -5,8 +5,8 @@
 use std::sync::Mutex;
 
 use anyhow::Result;
-use turbo_tasks::{get_invalidator, Invalidator, ReadRef, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks::{Invalidator, ReadRef, Vc, get_invalidator};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{State, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
@@ -2,10 +2,10 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // clippy bug causes false positive
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{emit, CollectiblesSource, ResolvedVc, State, ValueToString, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks::{CollectiblesSource, ResolvedVc, State, ValueToString, Vc, emit};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/resolved_vc.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/resolved_vc.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{ReadRef, ResolvedVc, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/shrink_to_fit.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/shrink_to_fit.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/task_statistics.rs
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde_json::json;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{register, run_without_cache_check, Registration};
+use turbo_tasks_testing::{Registration, register, run_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/trait_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/trait_ref_cell.rs
@@ -5,8 +5,8 @@
 use std::sync::Mutex;
 
 use anyhow::Result;
-use turbo_tasks::{get_invalidator, IntoTraitRef, Invalidator, TraitRef, Vc};
-use turbo_tasks_testing::{register, run, Registration};
+use turbo_tasks::{IntoTraitRef, Invalidator, TraitRef, Vc, get_invalidator};
+use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 

--- a/turbopack/crates/turbo-tasks-testing/tests/transient_vc.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/transient_vc.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{TaskInput, TransientValue, Vc};
-use turbo_tasks_testing::{register, run_without_cache_check, Registration};
+use turbo_tasks_testing::{Registration, register, run_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 


### PR DESCRIPTION
- This required explicitly wrapping certain calls in `unsafe` blocks. The calling functions were already marked `unsafe`.
- Made this implied reference pattern explicit:
```
    |
183 |             &mut WriteBatch::Concurrent(ref batch, _) => {
    |             ++++
```


Closes PACK-4594