### PR TITLE
Turbopack: Make `turbo-tasks-malloc` crate Rust 2024

### DIFF
--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -3,7 +3,7 @@ name = "turbo-tasks-malloc"
 version = "0.1.0"
 description = "A wrapper around mimalloc or the system allocator that tracks allocations"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 autobenches = false
 
 [lib]

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -84,7 +84,7 @@ fn base_alloc() -> &'static impl GlobalAlloc {
 
 unsafe impl GlobalAlloc for TurboMalloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ret = base_alloc().alloc(layout);
+        let ret = unsafe { base_alloc().alloc(layout) };
         if !ret.is_null() {
             add(layout.size());
         }
@@ -92,12 +92,12 @@ unsafe impl GlobalAlloc for TurboMalloc {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        base_alloc().dealloc(ptr, layout);
+        unsafe { base_alloc().dealloc(ptr, layout) };
         remove(layout.size());
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ret = base_alloc().alloc_zeroed(layout);
+        let ret = unsafe { base_alloc().alloc_zeroed(layout) };
         if !ret.is_null() {
             add(layout.size());
         }
@@ -105,7 +105,7 @@ unsafe impl GlobalAlloc for TurboMalloc {
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let ret = base_alloc().realloc(ptr, layout, new_size);
+        let ret = unsafe { base_alloc().realloc(ptr, layout, new_size) };
         if !ret.is_null() {
             let old_size = layout.size();
             update(old_size, new_size);


### PR DESCRIPTION
Wrapped env setting in `unsafe` blocks. The calling functions were already `unsafe`.


Closes PACK-4601