### PR TITLE
Turbopack: Make `turbo-tasks-memory` crate Rust 2024

### DIFF
--- a/turbopack/crates/turbo-tasks-memory/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-memory/Cargo.toml
@@ -3,7 +3,7 @@ name = "turbo-tasks-memory"
 version = "0.1.0"
 description = "TBD"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 autobenches = false
 
 [lib]

--- a/turbopack/crates/turbo-tasks-memory/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-memory/benches/mod.rs
@@ -1,7 +1,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 pub(crate) mod scope_stress;
 pub(crate) mod stress;

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/aggregation_data.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/aggregation_data.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use super::{
-    increase_aggregation_number_internal, AggregationContext, AggregationNode, AggregationNodeGuard,
+    AggregationContext, AggregationNode, AggregationNodeGuard, increase_aggregation_number_internal,
 };
 use crate::aggregation::{balance_queue::BalanceQueue, increase::IncreaseReason};
 

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/balance_edge.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/balance_edge.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 
 use super::{
+    AggregationContext, AggregationNode, PreparedInternalOperation, PreparedOperation, StackVec,
     balance_queue::BalanceQueue,
     in_progress::{is_in_progress, start_in_progress_all, start_in_progress_count},
     increase::IncreaseReason,
@@ -8,7 +9,6 @@ use super::{
     notify_lost_follower::notify_lost_follower,
     notify_new_follower::notify_new_follower,
     util::{get_aggregated_add_change, get_aggregated_remove_change, get_followers_or_children},
-    AggregationContext, AggregationNode, PreparedInternalOperation, PreparedOperation, StackVec,
 };
 
 // Migrate followers to uppers or uppers to followers depending on the

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/balance_queue.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/balance_queue.rs
@@ -2,7 +2,7 @@ use std::{hash::Hash, mem::take};
 
 use turbo_tasks::FxIndexSet;
 
-use super::{balance_edge, AggregationContext};
+use super::{AggregationContext, balance_edge};
 
 /// Enqueued edges that need to be balanced. Deduplicates edges and keeps track
 /// of aggregation numbers read during balancing.

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/followers.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/followers.rs
@@ -1,9 +1,9 @@
 use super::{
+    AggregationContext, AggregationNode, StackVec,
     balance_queue::BalanceQueue,
     in_progress::start_in_progress_all,
     notify_new_follower,
-    optimize::{optimize_aggregation_number_for_followers, MAX_FOLLOWERS},
-    AggregationContext, AggregationNode, StackVec,
+    optimize::{MAX_FOLLOWERS, optimize_aggregation_number_for_followers},
 };
 
 /// Add a follower to a node. Followers will be propagated to the uppers of the

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/in_progress.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/in_progress.rs
@@ -1,6 +1,6 @@
 use std::{hash::Hash, mem::take};
 
-use super::{balance_queue::BalanceQueue, AggregationContext, AggregationNode, StackVec};
+use super::{AggregationContext, AggregationNode, StackVec, balance_queue::BalanceQueue};
 
 impl<I: Clone + Eq + Hash, D> AggregationNode<I, D> {
     /// Finishes an in progress operation. This might enqueue balancing

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/increase.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/increase.rs
@@ -1,8 +1,8 @@
 use std::{hash::Hash, mem::take};
 
 use super::{
-    balance_queue::BalanceQueue, AggegatingNode, AggregationContext, AggregationNode,
-    AggregationNodeGuard, PreparedInternalOperation, PreparedOperation, StackVec,
+    AggegatingNode, AggregationContext, AggregationNode, AggregationNodeGuard,
+    PreparedInternalOperation, PreparedOperation, StackVec, balance_queue::BalanceQueue,
 };
 pub(super) const LEAF_NUMBER: u32 = 16;
 

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/loom_tests.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/loom_tests.rs
@@ -2,20 +2,20 @@ use std::{
     fmt::Debug,
     hash::Hash,
     ops::{Deref, DerefMut},
-    sync::{atomic::AtomicU32, Arc},
+    sync::{Arc, atomic::AtomicU32},
 };
 
 use loom::{
     sync::{Mutex, MutexGuard},
     thread,
 };
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use ref_cast::RefCast;
 use rstest::*;
 
 use super::{
-    aggregation_data, handle_new_edge, AggregationContext, AggregationNode, AggregationNodeGuard,
-    PreparedOperation,
+    AggregationContext, AggregationNode, AggregationNodeGuard, PreparedOperation, aggregation_data,
+    handle_new_edge,
 };
 
 struct Node {

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/lost_edge.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/lost_edge.rs
@@ -1,9 +1,9 @@
 use std::hash::Hash;
 
 use super::{
+    AggregationContext, AggregationNode, PreparedInternalOperation, PreparedOperation, StackVec,
     balance_queue::BalanceQueue, in_progress::start_in_progress_count,
-    notify_lost_follower::PreparedNotifyLostFollower, AggregationContext, AggregationNode,
-    PreparedInternalOperation, PreparedOperation, StackVec,
+    notify_lost_follower::PreparedNotifyLostFollower,
 };
 
 impl<I: Clone + Eq + Hash, D> AggregationNode<I, D> {

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/mod.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/mod.rs
@@ -24,12 +24,12 @@ mod tests;
 mod uppers;
 mod util;
 
-pub use aggregation_data::{aggregation_data, AggregationDataGuard};
+pub use aggregation_data::{AggregationDataGuard, aggregation_data};
 use balance_edge::balance_edge;
 use increase::increase_aggregation_number_internal;
 pub use new_edge::handle_new_edge;
 use notify_new_follower::notify_new_follower;
-pub use root_query::{query_root_info, RootQuery};
+pub use root_query::{RootQuery, query_root_info};
 
 use self::balance_queue::BalanceQueue;
 
@@ -195,10 +195,10 @@ impl<C: AggregationContext, T: PreparedInternalOperation<C>, const N: usize>
 pub trait AggregationContext {
     type NodeRef: Clone + Eq + Hash + Debug + 'static;
     type Guard<'l>: AggregationNodeGuard<
-        NodeRef = Self::NodeRef,
-        Data = Self::Data,
-        DataChange = Self::DataChange,
-    >
+            NodeRef = Self::NodeRef,
+            Data = Self::Data,
+            DataChange = Self::DataChange,
+        >
     where
         Self: 'l;
     type Data: 'static;

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/new_edge.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/new_edge.rs
@@ -1,14 +1,14 @@
 use super::{
+    AggregationContext, AggregationNode, PreparedInternalOperation, PreparedOperation, StackVec,
     balance_queue::BalanceQueue,
     in_progress::start_in_progress_all,
     increase::{
-        increase_aggregation_number_immediately, IncreaseReason,
-        PreparedInternalIncreaseAggregationNumber, LEAF_NUMBER,
+        IncreaseReason, LEAF_NUMBER, PreparedInternalIncreaseAggregationNumber,
+        increase_aggregation_number_immediately,
     },
     increase_aggregation_number_internal, notify_new_follower,
     notify_new_follower::PreparedNotifyNewFollower,
     optimize::optimize_aggregation_number_for_uppers,
-    AggregationContext, AggregationNode, PreparedInternalOperation, PreparedOperation, StackVec,
 };
 
 const BUFFER_SPACE: u32 = 2;
@@ -25,7 +25,7 @@ pub fn handle_new_edge<C: AggregationContext>(
     origin_id: &C::NodeRef,
     target_id: &C::NodeRef,
     number_of_children: usize,
-) -> impl PreparedOperation<C> {
+) -> impl PreparedOperation<C> + use<C> {
     match **origin {
         AggregationNode::Leaf {
             ref mut aggregation_number,

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/notify_lost_follower.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/notify_lost_follower.rs
@@ -1,11 +1,11 @@
 use std::{hash::Hash, thread::yield_now};
 
 use super::{
+    AggegatingNode, AggregationContext, AggregationNode, AggregationNodeGuard,
+    PreparedInternalOperation, PreparedOperation, StackVec,
     balance_queue::BalanceQueue,
     in_progress::{finish_in_progress_without_node, start_in_progress, start_in_progress_all},
     util::get_aggregated_remove_change,
-    AggegatingNode, AggregationContext, AggregationNode, AggregationNodeGuard,
-    PreparedInternalOperation, PreparedOperation, StackVec,
 };
 use crate::count_hash_set::RemoveIfEntryResult;
 

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/notify_new_follower.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/notify_new_follower.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, hash::Hash};
 
 use super::{
+    AggregationContext, AggregationNode, PreparedInternalOperation, StackVec,
     balance_queue::BalanceQueue,
     followers::add_follower,
     in_progress::{finish_in_progress_without_node, start_in_progress},
@@ -8,7 +9,6 @@ use super::{
     increase_aggregation_number_internal,
     optimize::optimize_aggregation_number_for_uppers,
     uppers::add_upper,
-    AggregationContext, AggregationNode, PreparedInternalOperation, StackVec,
 };
 
 const MAX_AFFECTED_NODES: usize = 4096;

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/optimize.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/optimize.rs
@@ -1,9 +1,9 @@
 use tracing::Level;
 
 use super::{
-    balance_queue::BalanceQueue,
-    increase::{increase_aggregation_number_internal, IncreaseReason, LEAF_NUMBER},
     AggregationContext, StackVec,
+    balance_queue::BalanceQueue,
+    increase::{IncreaseReason, LEAF_NUMBER, increase_aggregation_number_internal},
 };
 
 pub const MAX_UPPERS: usize = 512;

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/tests.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/tests.rs
@@ -4,14 +4,14 @@ use std::{
     iter::once,
     ops::{ControlFlow, Deref, DerefMut},
     sync::{
-        atomic::{AtomicU32, Ordering},
         Arc,
+        atomic::{AtomicU32, Ordering},
     },
     time::Instant,
 };
 
 use parking_lot::{Mutex, MutexGuard};
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use ref_cast::RefCast;
 use rstest::*;
 use rustc_hash::FxHashSet;
@@ -19,10 +19,10 @@ use turbo_tasks::FxIndexSet;
 
 use self::aggregation_data::prepare_aggregation_data;
 use super::{
-    aggregation_data, handle_new_edge, lost_edge::handle_lost_edges, AggregationContext,
-    AggregationNode, AggregationNodeGuard, RootQuery,
+    AggregationContext, AggregationNode, AggregationNodeGuard, RootQuery, aggregation_data,
+    handle_new_edge, lost_edge::handle_lost_edges,
 };
-use crate::aggregation::{query_root_info, PreparedOperation, StackVec};
+use crate::aggregation::{PreparedOperation, StackVec, query_root_info};
 
 fn find_root(mut node: NodeRef) -> NodeRef {
     loop {

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/uppers.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/uppers.rs
@@ -1,9 +1,9 @@
 use super::{
-    balance_queue::BalanceQueue,
-    in_progress::start_in_progress_count,
-    optimize::{optimize_aggregation_number_for_uppers, MAX_UPPERS},
     AggegatingNode, AggregationContext, AggregationNode, AggregationNodeGuard,
     PreparedInternalOperation, PreparedOperation, StackVec,
+    balance_queue::BalanceQueue,
+    in_progress::start_in_progress_count,
+    optimize::{MAX_UPPERS, optimize_aggregation_number_for_uppers},
 };
 
 /// Adds an upper node to a node. Returns the number of affected nodes by this

--- a/turbopack/crates/turbo-tasks-memory/src/cell.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/cell.rs
@@ -1,9 +1,9 @@
 use std::{fmt::Debug, mem::replace};
 
 use turbo_tasks::{
+    TaskId, TaskIdSet, TurboTasksBackendApi,
     backend::CellContent,
     event::{Event, EventListener},
-    TaskId, TaskIdSet, TurboTasksBackendApi,
 };
 
 use crate::MemoryBackend;

--- a/turbopack/crates/turbo-tasks-memory/src/count_hash_set.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/count_hash_set.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use auto_hash_map::{
-    map::{Entry, Iter, RawEntry},
     AutoMap,
+    map::{Entry, Iter, RawEntry},
 };
 use rustc_hash::FxHasher;
 
@@ -277,11 +277,7 @@ impl<T: Eq + Hash + Clone, H: BuildHasher + Default> CountHashSet<T, H> {
 }
 
 fn filter<'a, T>((k, v): (&'a T, &'a isize)) -> Option<&'a T> {
-    if *v > 0 {
-        Some(k)
-    } else {
-        None
-    }
+    if *v > 0 { Some(k) } else { None }
 }
 
 type InnerIter<'a, T> =

--- a/turbopack/crates/turbo-tasks-memory/src/edges_set.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/edges_set.rs
@@ -1,6 +1,6 @@
 use std::{hash::BuildHasherDefault, mem::replace};
 
-use auto_hash_map::{map::Entry, AutoMap, AutoSet};
+use auto_hash_map::{AutoMap, AutoSet, map::Entry};
 use either::Either;
 use rustc_hash::FxHasher;
 use smallvec::SmallVec;

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -5,19 +5,21 @@ use std::{
     num::NonZeroU32,
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use auto_hash_map::AutoMap;
-use dashmap::{mapref::entry::Entry, DashMap};
+use dashmap::{DashMap, mapref::entry::Entry};
 use rustc_hash::FxHasher;
 use tracing::trace_span;
 use turbo_prehash::{BuildHasherExt, PassThroughHash, PreHashed};
 use turbo_tasks::{
+    CellId, FunctionId, RawVc, ReadCellOptions, ReadConsistency, TRANSIENT_TASK_BIT, TaskId,
+    TaskIdSet, TraitTypeId, TurboTasksBackendApi, Unused, ValueTypeId,
     backend::{
         Backend, BackendJobId, CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec,
         TransientTaskType, TypedCellContent,
@@ -25,8 +27,6 @@ use turbo_tasks::{
     event::EventListener,
     task_statistics::TaskStatisticsApi,
     util::{IdFactoryWithReuse, NoMoveVec},
-    CellId, FunctionId, RawVc, ReadCellOptions, ReadConsistency, TaskId, TaskIdSet, TraitTypeId,
-    TurboTasksBackendApi, Unused, ValueTypeId, TRANSIENT_TASK_BIT,
 };
 
 use crate::{

--- a/turbopack/crates/turbo-tasks-memory/src/output.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/output.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, fmt::Debug, mem::take};
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result, anyhow};
 use turbo_tasks::{
-    util::SharedError, OutputContent, RawVc, TaskId, TaskIdSet, TurboTasksBackendApi,
+    OutputContent, RawVc, TaskId, TaskIdSet, TurboTasksBackendApi, util::SharedError,
 };
 
 use crate::MemoryBackend;

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -6,7 +6,7 @@ use std::{
     mem::{replace, take},
     num::NonZeroU32,
     pin::Pin,
-    sync::{atomic::AtomicU32, Arc},
+    sync::{Arc, atomic::AtomicU32},
     time::Duration,
 };
 
@@ -19,22 +19,23 @@ use smallvec::SmallVec;
 use tracing::Span;
 use turbo_prehash::PreHashed;
 use turbo_tasks::{
+    CellId, Invalidator, RawVc, ReadConsistency, TaskId, TaskIdSet, TraitTypeId,
+    TurboTasksBackendApi, TurboTasksBackendApiExt, ValueTypeId,
     backend::{CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec},
     event::{Event, EventListener},
-    get_invalidator, registry, CellId, Invalidator, RawVc, ReadConsistency, TaskId, TaskIdSet,
-    TraitTypeId, TurboTasksBackendApi, TurboTasksBackendApiExt, ValueTypeId,
+    get_invalidator, registry,
 };
 
 use crate::{
+    MemoryBackend,
     aggregation::{
-        aggregation_data, handle_new_edge, query_root_info, AggregationDataGuard, PreparedOperation,
+        AggregationDataGuard, PreparedOperation, aggregation_data, handle_new_edge, query_root_info,
     },
     cell::{Cell, ReadContentError},
     edges_set::{TaskEdge, TaskEdgesList, TaskEdgesSet},
     gc::{GcQueue, GcTaskState},
     output::Output,
     task::aggregation::{TaskAggregationContext, TaskChange},
-    MemoryBackend,
 };
 
 pub type NativeTaskFuture = Pin<Box<dyn Future<Output = Result<RawVc>> + Send>>;
@@ -625,12 +626,12 @@ impl Task {
     fn get_event_description_static(
         id: TaskId,
         ty: &TaskType,
-    ) -> impl Fn() -> String + Send + Sync + Clone {
+    ) -> impl Fn() -> String + Send + Sync + Clone + 'static {
         let ty = TaskTypeForDescription::from(ty);
         move || Self::format_description(&ty, id)
     }
 
-    fn get_event_description(&self) -> impl Fn() -> String + Send + Sync + Clone {
+    fn get_event_description(&self) -> impl Fn() -> String + Send + Sync + Clone + 'static {
         Self::get_event_description_static(self.id, &self.ty)
     }
 

--- a/turbopack/crates/turbo-tasks-memory/src/task/aggregation.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task/aggregation.rs
@@ -6,25 +6,25 @@ use std::{
     sync::atomic::AtomicU32,
 };
 
-use auto_hash_map::{map::Entry, AutoMap};
+use auto_hash_map::{AutoMap, map::Entry};
 use either::Either;
 use parking_lot::Mutex;
 use rustc_hash::FxHasher;
 use turbo_tasks::{
-    backend::TaskCollectiblesMap, event::Event, RawVc, TaskId, TaskIdSet, TraitTypeId,
-    TurboTasksBackendApi,
+    RawVc, TaskId, TaskIdSet, TraitTypeId, TurboTasksBackendApi, backend::TaskCollectiblesMap,
+    event::Event,
 };
 
 use super::{
-    meta_state::{FullTaskWriteGuard, TaskMetaStateWriteGuard},
     InProgressState, TaskStateType,
+    meta_state::{FullTaskWriteGuard, TaskMetaStateWriteGuard},
 };
 use crate::{
-    aggregation::{
-        aggregation_data, AggregationContext, AggregationDataGuard, AggregationNode,
-        AggregationNodeGuard, RootQuery,
-    },
     MemoryBackend,
+    aggregation::{
+        AggregationContext, AggregationDataGuard, AggregationNode, AggregationNodeGuard, RootQuery,
+        aggregation_data,
+    },
 };
 
 pub enum RootType {

--- a/turbopack/crates/turbo-tasks-testing/tests/scope_stress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/scope_stress.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use anyhow::Result;
-use turbo_tasks::{run_once, Completion, TryJoinIterExt, Vc};
-use turbo_tasks_testing::{register, run_with_tt, Registration};
+use turbo_tasks::{Completion, TryJoinIterExt, Vc, run_once};
+use turbo_tasks_testing::{Registration, register, run_with_tt};
 
 static REGISTRATION: Registration = register!();
 


### PR DESCRIPTION
Isolated `cargo fmt` changes into their own commit. Please review the first commit for core changes.

- `gen` is now a reserved word
- Marked `get_event_description_static` and `get_event_description` as `'static`
- Marked `handle_new_edge` as `use<C>`


Closes PACK-4597