### PR TITLE
Turbopack: Make `turbopack-core` Rust 2024

### DIFF
--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "turbopack-core"
 version = "0.1.0"
 description = "TBD"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 autobenches = false
 
 [lib]

--- a/turbopack/crates/turbopack-core/src/changed.rs
+++ b/turbopack/crates/turbopack-core/src/changed.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{
-    graph::{GraphTraversal, NonDeterministic},
     Completion, Completions, ResolvedVc, TryJoinIterExt, Vc,
+    graph::{GraphTraversal, NonDeterministic},
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -5,20 +5,20 @@ use rustc_hash::FxHashMap;
 use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Value, Vc};
 
 use super::{
-    availability_info::AvailabilityInfo, chunking::make_chunks, Chunk, ChunkGroupContent,
-    ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkingContext,
+    Chunk, ChunkGroupContent, ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkingContext,
+    availability_info::AvailabilityInfo, chunking::make_chunks,
 };
 use crate::{
     chunk::{
-        chunk_item_batch::{ChunkItemBatchGroup, ChunkItemOrBatchWithAsyncModuleInfo},
         ChunkableModule, ChunkingType,
+        chunk_item_batch::{ChunkItemBatchGroup, ChunkItemOrBatchWithAsyncModuleInfo},
     },
     environment::ChunkLoading,
     module::Module,
     module_graph::{
+        GraphTraversalAction, ModuleGraph,
         module_batch::{ChunkableModuleBatchGroup, ChunkableModuleOrBatch, ModuleOrBatch},
         module_batches::{BatchingConfig, ModuleBatchesGraphEdge},
-        GraphTraversalAction, ModuleGraph,
     },
     output::OutputAssets,
     reference::ModuleReference,
@@ -32,9 +32,10 @@ pub struct MakeChunkGroupResult {
 
 /// Creates a chunk group from a set of entries.
 pub async fn make_chunk_group(
-    chunk_group_entries: impl IntoIterator<IntoIter = impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + Send>
-        + Send
-        + Clone,
+    chunk_group_entries: impl IntoIterator<
+        IntoIter = impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + Send,
+    > + Send
+    + Clone,
     module_graph: Vc<ModuleGraph>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     availability_info: AvailabilityInfo,
@@ -182,8 +183,9 @@ pub async fn references_to_output_assets(
 
 pub async fn chunk_group_content(
     module_graph: Vc<ModuleGraph>,
-    chunk_group_entries: impl IntoIterator<IntoIter = impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + Send>
-        + Send,
+    chunk_group_entries: impl IntoIterator<
+        IntoIter = impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + Send,
+    > + Send,
     availability_info: AvailabilityInfo,
     can_split_async: bool,
     should_trace: bool,

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
@@ -4,19 +4,19 @@ use anyhow::Result;
 use either::Either;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use turbo_tasks::{
-    trace::TraceRawVcs, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput,
-    TryFlatJoinIterExt, TryJoinIterExt, Vc,
+    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt,
+    Vc, trace::TraceRawVcs,
 };
 
 use crate::{
     chunk::{ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkType, ChunkableModule, ChunkingContext},
     module_graph::{
+        ModuleGraph,
         async_module_info::AsyncModulesInfo,
         chunk_group_info::RoaringBitmapWrapper,
         module_batch::{ChunkableModuleBatchGroup, ChunkableModuleOrBatch, ModuleBatch},
-        ModuleGraph,
     },
 };
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, mem::take};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use either::Either;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -8,8 +8,8 @@ use tracing::Level;
 use turbo_tasks::{FxIndexMap, ResolvedVc, TryJoinIterExt, ValueToString};
 
 use crate::chunk::{
-    chunking::{make_chunk, ChunkItemOrBatchWithInfo, SplitContext},
     ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkType, ChunkingContext,
+    chunking::{ChunkItemOrBatchWithInfo, SplitContext, make_chunk},
 };
 
 /// Handle chunk items based on their total size. If the total size is too

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -3,12 +3,12 @@ use std::{future::IntoFuture, mem::replace};
 use anyhow::Result;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use tracing::{Instrument, Level};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ReadRef,
-    ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 
 use super::{Chunk, ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkType, ChunkingContext};

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -3,16 +3,16 @@ use std::{borrow::Cow, collections::BinaryHeap, hash::BuildHasherDefault, mem::t
 use anyhow::Result;
 use rustc_hash::FxHasher;
 use smallvec::SmallVec;
-use tracing::{field::Empty, Instrument};
+use tracing::{Instrument, field::Empty};
 use turbo_prehash::BuildHasherExt;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
 
 use crate::{
     chunk::{
-        chunking::{make_chunk, ChunkItemOrBatchWithInfo, SplitContext},
         ChunkItemBatchGroup, ChunkItemWithAsyncModuleInfo, ChunkingConfig,
+        chunking::{ChunkItemOrBatchWithInfo, SplitContext, make_chunk},
     },
-    module_graph::{chunk_group_info::RoaringBitmapWrapper, ModuleGraph},
+    module_graph::{ModuleGraph, chunk_group_info::RoaringBitmapWrapper},
 };
 
 pub async fn make_production_chunks(

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -5,10 +5,10 @@ use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{
     chunk::{
-        chunking::{make_chunk, ChunkItemOrBatchWithInfo, SplitContext},
         ChunkItemBatchGroup, ChunkItemWithAsyncModuleInfo, ChunkingConfig, ChunkingContext,
+        chunking::{ChunkItemOrBatchWithInfo, SplitContext, make_chunk},
     },
-    module_graph::{style_groups::StyleGroupsConfig, ModuleGraph},
+    module_graph::{ModuleGraph, style_groups::StyleGroupsConfig},
 };
 
 pub async fn make_style_production_chunks(

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -2,18 +2,18 @@ use anyhow::Result;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, TaskInput, Upcast, Value, Vc};
+use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Upcast, Value, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
-use super::{availability_info::AvailabilityInfo, ChunkableModule, EvaluatableAssets};
+use super::{ChunkableModule, EvaluatableAssets, availability_info::AvailabilityInfo};
 use crate::{
     asset::Asset,
     chunk::{ChunkItem, ChunkType, ModuleId},
     environment::Environment,
     ident::AssetIdent,
     module::Module,
-    module_graph::{chunk_group_info::ChunkGroup, module_batches::BatchingConfig, ModuleGraph},
+    module_graph::{ModuleGraph, chunk_group_info::ChunkGroup, module_batches::BatchingConfig},
     output::{OutputAsset, OutputAssets},
 };
 

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Upcast, Value, ValueToString, Vc};
 
 use super::ChunkableModule;

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -17,15 +17,15 @@ use auto_hash_map::AutoSet;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput,
-    Upcast, ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, Upcast, ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_hash::DeterministicHash;
 
 pub use self::{
     chunk_item_batch::{
-        batch_info, ChunkItemBatchGroup, ChunkItemBatchWithAsyncModuleInfo,
-        ChunkItemOrBatchWithAsyncModuleInfo,
+        ChunkItemBatchGroup, ChunkItemBatchWithAsyncModuleInfo,
+        ChunkItemOrBatchWithAsyncModuleInfo, batch_info,
     },
     chunking_context::{
         ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs, ChunkingContext,
@@ -39,8 +39,8 @@ use crate::{
     ident::AssetIdent,
     module::Module,
     module_graph::{
-        module_batch::{ChunkableModuleOrBatch, ModuleBatchGroup},
         ModuleGraph,
+        module_batch::{ChunkableModuleOrBatch, ModuleBatchGroup},
     },
     output::OutputAssets,
     reference::ModuleReference,

--- a/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rustc_hash::FxHashMap;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_hash::hash_xxh3_hash64;
@@ -6,7 +6,7 @@ use turbo_tasks_hash::hash_xxh3_hash64;
 use super::ModuleId;
 use crate::{
     ident::AssetIdent,
-    issue::{module::ModuleIssue, IssueExt, StyledString},
+    issue::{IssueExt, StyledString, module::ModuleIssue},
 };
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, NonLocalValue, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::environment::Environment;

--- a/turbopack/crates/turbopack-core/src/condition.rs
+++ b/turbopack/crates/turbopack-core/src/condition.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use futures::{stream, StreamExt};
+use futures::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc};
+use turbo_tasks::{NonLocalValue, ResolvedVc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue)]

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -1,14 +1,14 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
-use turbo_tasks_fs::{glob::Glob, FileSystemPath};
+use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
 use crate::{
     compile_time_info::CompileTimeInfo,
     issue::module::emit_unknown_module_type_error,
     module::{Module, OptionModule},
     reference_type::ReferenceType,
-    resolve::{options::ResolveOptions, parse::Request, ModuleResolveResult, ResolveResult},
+    resolve::{ModuleResolveResult, ResolveResult, options::ResolveOptions, parse::Request},
     source::Source,
 };
 

--- a/turbopack/crates/turbopack-core/src/data_uri_source.rs
+++ b/turbopack/crates/turbopack-core/src/data_uri_source.rs
@@ -1,7 +1,7 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{rope::Rope, File, FileContent, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 
 use crate::{

--- a/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
+++ b/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use auto_hash_map::AutoSet;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{emit, CollectiblesSource, FxIndexMap, ResolvedVc, Upcast, Vc};
+use turbo_tasks::{CollectiblesSource, FxIndexMap, ResolvedVc, Upcast, Vc, emit};
 
 #[turbo_tasks::value(serialization = "none")]
 #[derive(Clone, Debug)]

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use swc_core::ecma::preset_env::{Version, Versions};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TaskInput, Value, Vc};

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
-use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64, DeterministicHash, Xxh3Hash64Hasher};
+use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher, encode_hex, hash_xxh3_hash64};
 
 use crate::resolve::ModulePart;
 

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -3,8 +3,8 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 
 use super::{
-    utils::{children_from_module_references, content_to_details},
     Introspectable, IntrospectableChildren,
+    utils::{children_from_module_references, content_to_details},
 };
 use crate::{asset::Asset, module::Module};
 

--- a/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
@@ -3,8 +3,8 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 
 use super::{
-    utils::{children_from_output_assets, content_to_details},
     Introspectable, IntrospectableChildren,
+    utils::{children_from_output_assets, content_to_details},
 };
 use crate::{asset::Asset, output::OutputAsset};
 

--- a/turbopack/crates/turbopack-core/src/introspect/source.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/source.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 
-use super::{utils::content_to_details, Introspectable};
+use super::{Introspectable, utils::content_to_details};
 use crate::{asset::Asset, source::Source};
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -4,7 +4,7 @@ use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 use turbo_tasks_fs::FileContent;
 
 use super::{
-    module::IntrospectableModule, output_asset::IntrospectableOutputAsset, IntrospectableChildren,
+    IntrospectableChildren, module::IntrospectableModule, output_asset::IntrospectableOutputAsset,
 };
 use crate::{
     asset::AssetContent,

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -5,19 +5,19 @@ pub mod resolve;
 
 use std::{
     borrow::Cow,
-    cmp::{min, Ordering},
+    cmp::{Ordering, min},
     fmt::{Display, Formatter},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use auto_hash_map::AutoSet;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    emit, trace::TraceRawVcs, CollectiblesSource, NonLocalValue, OperationVc, RawVc, ReadRef,
-    ResolvedVc, TaskInput, TransientInstance, TransientValue, TryJoinIterExt, Upcast,
-    ValueToString, Vc,
+    CollectiblesSource, NonLocalValue, OperationVc, RawVc, ReadRef, ResolvedVc, TaskInput,
+    TransientInstance, TransientValue, TryJoinIterExt, Upcast, ValueToString, Vc, emit,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileContent, FileLine, FileLinesContent, FileSystemPath};
 use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher};

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, ResolvedVc, Vc};
+use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 
 use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences};
 

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use either::Either;
 use indexmap::map::Entry;
 use roaring::RoaringBitmap;
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc,
-    TaskInput, TryJoinIterExt, ValueToString, Vc,
+    FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString,
+    Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -3,7 +3,7 @@ use std::{
     future::Future,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
     visit::{Dfs, EdgeRef, IntoNodeReferences, NodeIndexable, VisitMap, Visitable},
@@ -13,10 +13,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Span};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
-    trace::TraceRawVcs,
     CollectiblesSource, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt,
     ValueToString, Vc,
+    graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
+    trace::TraceRawVcs,
 };
 
 use crate::{
@@ -24,11 +24,11 @@ use crate::{
     issue::Issue,
     module::Module,
     module_graph::{
-        async_module_info::{compute_async_module_info, AsyncModulesInfo},
-        chunk_group_info::{compute_chunk_group_info, ChunkGroupEntry, ChunkGroupInfo},
-        module_batches::{compute_module_batches, ModuleBatchesGraph},
-        style_groups::{compute_style_groups, StyleGroups, StyleGroupsConfig},
-        traced_di_graph::{iter_neighbors_rev, TracedDiGraph},
+        async_module_info::{AsyncModulesInfo, compute_async_module_info},
+        chunk_group_info::{ChunkGroupEntry, ChunkGroupInfo, compute_chunk_group_info},
+        module_batches::{ModuleBatchesGraph, compute_module_batches},
+        style_groups::{StyleGroups, StyleGroupsConfig, compute_style_groups},
+        traced_di_graph::{TracedDiGraph, iter_neighbors_rev},
     },
     reference::primary_chunkable_referenced_modules,
 };

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt,
-    ValueToString, Vc,
+    NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc,
+    trace::TraceRawVcs,
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::{hash_map::Entry, VecDeque},
+    collections::{VecDeque, hash_map::Entry},
     hash::BuildHasherDefault,
     mem::take,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use either::Either;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
@@ -12,18 +12,18 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_prehash::BuildHasherExt;
 use turbo_tasks::{
-    trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput,
-    TryJoinIterExt, ValueToString, Vc,
+    FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString,
+    Vc, trace::TraceRawVcs,
 };
 
 use crate::{
     chunk::{ChunkableModule, ChunkingType},
     module::Module,
     module_graph::{
+        GraphTraversalAction, ModuleGraph,
         chunk_group_info::{ChunkGroupInfo, ChunkGroupKey, RoaringBitmapWrapper},
         module_batch::{ModuleBatch, ModuleBatchGroup, ModuleOrBatch},
-        traced_di_graph::{iter_neighbors_rev, TracedDiGraph},
-        GraphTraversalAction, ModuleGraph,
+        traced_di_graph::{TracedDiGraph, iter_neighbors_rev},
     },
 };
 #[turbo_tasks::value]

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -6,20 +6,19 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput,
-    TryJoinIterExt, ValueToString, Vc,
+    FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString,
+    Vc, trace::TraceRawVcs,
 };
 
 use crate::{
     chunk::{
-        chunk_item_batch::attach_async_info_to_chunkable_module, ChunkItem,
-        ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
-        ChunkableModule, ChunkingContext,
+        ChunkItem, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
+        ChunkableModule, ChunkingContext, chunk_item_batch::attach_async_info_to_chunkable_module,
     },
     module::{Module, StyleType},
     module_graph::{
-        module_batch::ModuleOrBatch, module_batches::ModuleBatchesGraphEdge, GraphTraversalAction,
-        ModuleGraph,
+        GraphTraversalAction, ModuleGraph, module_batch::ModuleOrBatch,
+        module_batches::ModuleBatchesGraphEdge,
     },
 };
 
@@ -202,16 +201,15 @@ pub async fn compute_style_groups(
 
                 // module is a dependency of dependent when it's included in all chunk groups of
                 // dependent with an index lower than the index of the dependent
-                let is_dependent =
-                    info.chunk_group_indicies.len() >= dependent_info.chunk_group_indicies.len()
-                        && dependent_info.chunk_group_indicies.iter().all(
-                            |(idx, &dependent_pos)| {
-                                info.chunk_group_indicies
-                                    .get(idx)
-                                    .is_some_and(|&module_pos| module_pos < dependent_pos)
-                            },
-                        );
-                is_dependent
+                info.chunk_group_indicies.len() >= dependent_info.chunk_group_indicies.len()
+                    && dependent_info
+                        .chunk_group_indicies
+                        .iter()
+                        .all(|(idx, &dependent_pos)| {
+                            info.chunk_group_indicies
+                                .get(idx)
+                                .is_some_and(|&module_pos| module_pos < dependent_pos)
+                        })
             })
             .collect::<Vec<_>>();
 

--- a/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
@@ -3,9 +3,9 @@ use std::ops::Deref;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
+    NonLocalValue,
     debug::ValueDebugFormat,
     trace::{TraceRawVcs, TraceRawVcsContext},
-    NonLocalValue,
 };
 
 #[derive(Clone, Debug, ValueDebugFormat, Serialize, Deserialize)]

--- a/turbopack/crates/turbopack-core/src/package_json.rs
+++ b/turbopack/crates/turbopack-core/src/package_json.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, NonLocalValue, ReadRef, ResolvedVc, Vc,
+    NonLocalValue, ReadRef, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileContent, FileJsonContent, FileSystemPath};
 

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    graph::{AdjacencyMap, GraphTraversal},
     FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
+    graph::{AdjacencyMap, GraphTraversal},
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -9,7 +9,7 @@ use crate::{
     raw_module::RawModule,
     resolve::ModuleResolveResult,
     source_map::{
-        utils::resolve_source_map_sources, GenerateSourceMap, OptionStringifiedSourceMap,
+        GenerateSourceMap, OptionStringifiedSourceMap, utils::resolve_source_map_sources,
     },
 };
 

--- a/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
@@ -6,16 +6,16 @@ use std::{
 
 use patricia_tree::PatriciaMap;
 use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
     de::{MapAccess, Visitor},
     ser::SerializeMap,
-    Deserialize, Deserializer, Serialize, Serializer,
 };
 use serde_bytes::{ByteBuf, Bytes};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::{internal::PassthroughDebug, ValueDebugFormat, ValueDebugFormatString},
-    trace::{TraceRawVcs, TraceRawVcsContext},
     NonLocalValue,
+    debug::{ValueDebugFormat, ValueDebugFormatString, internal::PassthroughDebug},
+    trace::{TraceRawVcs, TraceRawVcsContext},
 };
 
 use super::pattern::Pattern;

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -6,23 +6,23 @@ use std::{
     iter::once,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    trace::TraceRawVcs, FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, SliceMap,
-    TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
+    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, SliceMap, TaskInput,
+    TryJoinIterExt, Value, ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
-    util::normalize_request, FileSystemEntryType, FileSystemPath, RealPathResult,
+    FileSystemEntryType, FileSystemPath, RealPathResult, util::normalize_request,
 };
 
 use self::{
     options::{
-        resolve_modules_options, ConditionValue, ImportMapResult, ResolveInPackage,
-        ResolveIntoPackage, ResolveModules, ResolveModulesOptions, ResolveOptions,
+        ConditionValue, ImportMapResult, ResolveInPackage, ResolveIntoPackage, ResolveModules,
+        ResolveModulesOptions, ResolveOptions, resolve_modules_options,
     },
     origin::{ResolveOrigin, ResolveOriginExt},
     parse::Request,
@@ -35,17 +35,17 @@ use crate::{
     data_uri_source::DataUriSource,
     file_source::FileSource,
     issue::{
-        module::emit_unknown_module_type_error, resolve::ResolvingIssue, IssueExt, IssueSource,
+        IssueExt, IssueSource, module::emit_unknown_module_type_error, resolve::ResolvingIssue,
     },
     module::{Module, Modules, OptionModule},
     output::{OutputAsset, OutputAssets},
-    package_json::{read_package_json, PackageJsonIssue},
+    package_json::{PackageJsonIssue, read_package_json},
     raw_module::RawModule,
     reference_type::ReferenceType,
     resolve::{
         node::{node_cjs_resolve_options, node_esm_resolve_options},
         parse::stringify_data_uri,
-        pattern::{read_matches, PatternMatch},
+        pattern::{PatternMatch, read_matches},
         plugin::AfterResolvePlugin,
     },
     source::{OptionSource, Source, Sources},

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -1,21 +1,21 @@
 use std::{collections::BTreeMap, future::Future, pin::Pin};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexSet, NonLocalValue, ResolvedVc,
-    TryJoinIterExt, Value, ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{glob::Glob, FileSystemPath};
+use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
 use super::{
+    AliasPattern, ExternalType, ResolveResult, ResolveResultItem,
     alias_map::{AliasMap, AliasTemplate},
     pattern::Pattern,
     plugin::BeforeResolvePlugin,
-    AliasPattern, ExternalType, ResolveResult, ResolveResultItem,
 };
-use crate::resolve::{parse::Request, plugin::AfterResolvePlugin, ExternalTraced};
+use crate::resolve::{ExternalTraced, parse::Request, plugin::AfterResolvePlugin};
 
 #[turbo_tasks::value(shared)]
 #[derive(Hash, Debug)]

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -5,7 +5,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Upcast, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
-use super::{options::ResolveOptions, parse::Request, ModuleResolveResult};
+use super::{ModuleResolveResult, options::ResolveOptions, parse::Request};
 use crate::{context::AssetContext, module::OptionModule, reference_type::ReferenceType};
 
 /// A location where resolving can occur from. It carries some meta information

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, VecDeque},
+    collections::{VecDeque, hash_map::Entry},
     fmt::Display,
     mem::take,
 };
@@ -12,12 +12,12 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, NonLocalValue, ResolvedVc, Value, ValueToString,
-    Vc,
+    NonLocalValue, ResolvedVc, Value, ValueToString, Vc, debug::ValueDebugFormat,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
-    util::normalize_path, FileSystemPath, LinkContent, LinkType, RawDirectoryContent,
-    RawDirectoryEntry,
+    FileSystemPath, LinkContent, LinkType, RawDirectoryContent, RawDirectoryEntry,
+    util::normalize_path,
 };
 
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]
@@ -32,7 +32,7 @@ pub enum Pattern {
 
 fn concatenation_push_or_merge_item(list: &mut Vec<Pattern>, pat: Pattern) {
     if let Pattern::Constant(ref s) = pat {
-        if let Some(Pattern::Constant(ref mut last)) = list.last_mut() {
+        if let Some(Pattern::Constant(last)) = list.last_mut() {
             let mut buf = last.to_string();
             buf.push_str(s);
             *last = buf.into();
@@ -44,7 +44,7 @@ fn concatenation_push_or_merge_item(list: &mut Vec<Pattern>, pat: Pattern) {
 
 fn concatenation_push_front_or_merge_item(list: &mut Vec<Pattern>, pat: Pattern) {
     if let Pattern::Constant(s) = pat {
-        if let Some(Pattern::Constant(ref mut first)) = list.iter_mut().next() {
+        if let Some(Pattern::Constant(first)) = list.iter_mut().next() {
             let mut buf = s.into_owned();
             buf.push_str(first);
 
@@ -398,7 +398,7 @@ impl Pattern {
                 concatenation_extend_or_merge_items(&mut more, take(list).into_iter());
                 *list = more;
             }
-            (Pattern::Concatenation(ref mut list), pat) => {
+            (Pattern::Concatenation(list), pat) => {
                 concatenation_push_front_or_merge_item(list, pat);
             }
             (this, Pattern::Concatenation(mut list)) => {
@@ -1058,16 +1058,16 @@ impl Pattern {
                 while let Some(part) = iter.next() {
                     match part.next_constants_internal(value, any_offset) {
                         NextConstantUntilResult::NoMatch => {
-                            return NextConstantUntilResult::NoMatch
+                            return NextConstantUntilResult::NoMatch;
                         }
                         NextConstantUntilResult::PartialDynamic => {
-                            return NextConstantUntilResult::PartialDynamic
+                            return NextConstantUntilResult::PartialDynamic;
                         }
                         NextConstantUntilResult::Partial(r, end) => {
                             return NextConstantUntilResult::Partial(
                                 r,
                                 end && iter.next().is_none(),
-                            )
+                            );
                         }
                         NextConstantUntilResult::Consumed(new_value, new_any_offset) => {
                             value = new_value;
@@ -1739,7 +1739,7 @@ mod tests {
     use rstest::*;
     use turbo_rcstr::RcStr;
 
-    use super::{longest_common_prefix, longest_common_suffix, split_last_segment, Pattern};
+    use super::{Pattern, longest_common_prefix, longest_common_suffix, split_last_segment};
 
     #[test]
     fn longest_common_prefix_test() {
@@ -1830,9 +1830,11 @@ mod tests {
 
     #[test]
     fn with_normalized_path() {
-        assert!(Pattern::Constant("a/../..".into())
-            .with_normalized_path()
-            .is_none());
+        assert!(
+            Pattern::Constant("a/../..".into())
+                .with_normalized_path()
+                .is_none()
+        );
         assert_eq!(
             Pattern::Constant("a/b/../c".into())
                 .with_normalized_path()

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
-use turbo_tasks_fs::{glob::Glob, FileSystemPath};
+use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
 use crate::{
     reference_type::ReferenceType,
-    resolve::{parse::Request, ResolveResultOption},
+    resolve::{ResolveResultOption, parse::Request},
 };
 
 /// A condition which determines if the hooks of a resolve plugin gets called.

--- a/turbopack/crates/turbopack-core/src/resolve/remap.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/remap.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fmt::Display, ops::Deref};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -9,13 +9,14 @@ use sourcemap::{DecodedMap, SourceMap as RegularMap, SourceMapBuilder, SourceMap
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{
-    rope::{Rope, RopeBuilder},
     File, FileContent, FileSystem, FileSystemPath, VirtualFileSystem,
+    rope::{Rope, RopeBuilder},
 };
 
 use crate::{
-    asset::AssetContent, source::Source, source_map::utils::add_default_ignore_list,
-    source_pos::SourcePos, virtual_source::VirtualSource, SOURCE_URL_PROTOCOL,
+    SOURCE_URL_PROTOCOL, asset::AssetContent, source::Source,
+    source_map::utils::add_default_ignore_list, source_pos::SourcePos,
+    virtual_source::VirtualSource,
 };
 
 pub(crate) mod source_map_asset;

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexSet, NonLocalValue, ResolvedVc,
-    ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{File, FileSystemPath};
 

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{
-    rope::Rope, util::uri_from_file, DiskFileSystem, FileContent, FileSystemPath,
+    DiskFileSystem, FileContent, FileSystemPath, rope::Rope, util::uri_from_file,
 };
 
 use crate::SOURCE_URL_PROTOCOL;

--- a/turbopack/crates/turbopack-core/src/source_pos.rs
+++ b/turbopack/crates/turbopack-core/src/source_pos.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, TaskInput};
+use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 use turbo_tasks_hash::DeterministicHash;
 
 /// LINE FEED (LF), one of the basic JS line terminators.
@@ -52,7 +52,7 @@ impl SourcePos {
         // JS source text is interpreted as UCS-2, which is basically UTF-16 with less
         // restrictions. We cannot iterate UTF-8 bytes here, 2-byte UTF-8 octets
         // should count as a 1 char and not 2.
-        let SourcePos {
+        let &mut SourcePos {
             mut line,
             mut column,
         } = self;

--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, Vc};
+use turbo_tasks::{NonLocalValue, Vc, trace::TraceRawVcs};
 
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]
 #[derive(Hash, Debug, Copy, Clone)]

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, IntoTraitRef, NonLocalValue, OperationValue,
-    ReadRef, ResolvedVc, State, TraitRef, Vc,
+    IntoTraitRef, NonLocalValue, OperationValue, ReadRef, ResolvedVc, State, TraitRef, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileContent, LinkType};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
@@ -268,8 +268,7 @@ pub struct VersionState {
 impl VersionState {
     #[turbo_tasks::function]
     pub fn get(&self) -> Vc<Box<dyn Version>> {
-        let version = TraitRef::cell(self.version.get().0.clone());
-        version
+        TraitRef::cell(self.version.get().0.clone())
     }
 }
 


### PR DESCRIPTION
These were all:

- https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html
- https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return


Closes PACK-4600