### PR TITLE
Turbopack: Make `turbopack-resolve` and `turbopack-trace-server` Rust 2024

### DIFF
--- a/turbopack/crates/turbopack-resolve/Cargo.toml
+++ b/turbopack/crates/turbopack-resolve/Cargo.toml
@@ -3,7 +3,7 @@ name = "turbopack-resolve"
 version = "0.1.0"
 description = "Methods to create and modify resolver options"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 autobenches = false
 
 [lib]

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -4,14 +4,14 @@ use turbopack_core::{
     issue::IssueSource,
     reference_type::{CommonJsReferenceSubType, EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::{
-        handle_resolve_error, handle_resolve_source_error,
+        ModuleResolveResult, ResolveResult, handle_resolve_error, handle_resolve_source_error,
         options::{
             ConditionValue, ResolutionConditions, ResolveInPackage, ResolveIntoPackage,
             ResolveOptions,
         },
         origin::{ResolveOrigin, ResolveOriginExt},
         parse::Request,
-        resolve, ModuleResolveResult, ResolveResult,
+        resolve,
     },
 };
 /// Retrieves the [ResolutionConditions] of the "into" and "in" package resolution options, so that

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -5,15 +5,15 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{
-    glob::Glob, json::parse_json_rope_with_source_context, DirectoryEntry, FileContent,
-    FileSystemEntryType, FileSystemPath,
+    DirectoryEntry, FileContent, FileSystemEntryType, FileSystemPath, glob::Glob,
+    json::parse_json_rope_with_source_context,
 };
 use turbopack_core::{
     asset::{Asset, AssetContent},
     file_source::FileSource,
     raw_module::RawModule,
     reference::ModuleReference,
-    resolve::{pattern::Pattern, resolve_raw, ModuleResolveResult, RequestKey, ResolveResultItem},
+    resolve::{ModuleResolveResult, RequestKey, ResolveResultItem, pattern::Pattern, resolve_raw},
     source::Source,
     target::{CompileTarget, Platform},
 };
@@ -103,7 +103,7 @@ pub async fn resolve_node_pre_gyp_files(
     let compile_target = compile_target.await?;
     if let Some(config_asset) = *config {
         if let AssetContent::File(file) = &*config_asset.content().await? {
-            if let FileContent::Content(ref config_file) = &*file.await? {
+            if let FileContent::Content(config_file) = &*file.await? {
                 let config_file_path = config_asset.ident().path();
                 let mut affecting_paths = vec![config_file_path];
                 let config_file_dir = config_file_path.parent();

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -2,12 +2,11 @@ use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::resolve::{
-    find_context_file,
+    AliasMap, AliasPattern, ExternalTraced, ExternalType, FindContextFileResult, find_context_file,
     options::{
         ConditionValue, ImportMap, ImportMapping, ResolutionConditions, ResolveInPackage,
         ResolveIntoPackage, ResolveModules, ResolveOptions,
     },
-    AliasMap, AliasPattern, ExternalTraced, ExternalType, FindContextFileResult,
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Write, mem::take};
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{fxindexset, ResolvedVc, Value, ValueDefault, Vc};
+use turbo_tasks::{ResolvedVc, Value, ValueDefault, Vc, fxindexset};
 use turbo_tasks_fs::{FileContent, FileJsonContent, FileSystemPath};
 use turbopack_core::{
     asset::Asset,
@@ -13,7 +13,7 @@ use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     reference_type::{ReferenceType, TypeScriptReferenceSubType},
     resolve::{
-        handle_resolve_error,
+        AliasPattern, ModuleResolveResult, handle_resolve_error,
         node::node_cjs_resolve_options,
         options::{
             ConditionValue, ImportMap, ImportMapping, ResolveIntoPackage, ResolveModules,
@@ -22,7 +22,7 @@ use turbopack_core::{
         origin::{ResolveOrigin, ResolveOriginExt},
         parse::Request,
         pattern::Pattern,
-        resolve, AliasPattern, ModuleResolveResult,
+        resolve,
     },
     source::{OptionSource, Source},
 };

--- a/turbopack/crates/turbopack-trace-server/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-server/Cargo.toml
@@ -3,7 +3,7 @@ name = "turbopack-trace-server"
 version = "0.1.0"
 description = "TBD"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 autobenches = false
 
 [[bin]]

--- a/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
@@ -1,12 +1,12 @@
 use std::{env, str::from_utf8, sync::Arc};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use indexmap::map::Entry;
 use rustc_demangle::demangle;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::TraceFormat;
-use crate::{span::SpanIndex, store_container::StoreContainer, timestamp::Timestamp, FxIndexMap};
+use crate::{FxIndexMap, span::SpanIndex, store_container::StoreContainer, timestamp::Timestamp};
 
 #[derive(Debug, Clone, Copy)]
 struct TraceNode {

--- a/turbopack/crates/turbopack-trace-server/src/reader/nextjs.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/nextjs.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 
 use super::TraceFormat;
-use crate::{span::SpanIndex, store_container::StoreContainer, timestamp::Timestamp, FxIndexMap};
+use crate::{FxIndexMap, span::SpanIndex, store_container::StoreContainer, timestamp::Timestamp};
 
 pub struct NextJsFormat {
     store: Arc<StoreContainer>,

--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -12,10 +12,10 @@ use turbopack_trace_utils::tracing::{TraceRow, TraceValue};
 
 use super::TraceFormat;
 use crate::{
+    FxIndexMap,
     span::SpanIndex,
     store_container::{StoreContainer, StoreWriteGuard},
     timestamp::Timestamp,
-    FxIndexMap,
 };
 
 #[derive(Default)]

--- a/turbopack/crates/turbopack-trace-server/src/server.rs
+++ b/turbopack/crates/turbopack-trace-server/src/server.rs
@@ -4,9 +4,9 @@ use std::{
     thread::spawn,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
-use tungstenite::{accept, Message};
+use tungstenite::{Message, accept};
 
 use crate::{
     store::SpanId,

--- a/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
@@ -5,12 +5,12 @@ use std::{
 };
 
 use crate::{
+    FxIndexMap,
     span::{SpanBottomUp, SpanGraphEvent, SpanIndex},
-    span_graph_ref::{event_map_to_list, SpanGraphEventRef, SpanGraphRef},
+    span_graph_ref::{SpanGraphEventRef, SpanGraphRef, event_map_to_list},
     span_ref::SpanRef,
     store::{SpanId, Store},
     timestamp::Timestamp,
-    FxIndexMap,
 };
 
 pub struct SpanBottomUpRef<'a> {

--- a/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
@@ -7,13 +7,13 @@ use std::{
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
+    FxIndexMap,
     bottom_up::build_bottom_up_graph,
     span::{SpanGraph, SpanGraphEvent, SpanIndex},
     span_bottom_up_ref::SpanBottomUpRef,
     span_ref::SpanRef,
     store::{SpanId, Store},
     timestamp::Timestamp,
-    FxIndexMap,
 };
 
 #[derive(Clone)]

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -10,13 +10,13 @@ use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterato
 use rustc_hash::FxHashSet;
 
 use crate::{
+    FxIndexMap,
     bottom_up::build_bottom_up_graph,
     span::{Span, SpanEvent, SpanExtra, SpanGraphEvent, SpanIndex, SpanNames, SpanTimeData},
     span_bottom_up_ref::SpanBottomUpRef,
-    span_graph_ref::{event_map_to_list, SpanGraphEventRef, SpanGraphRef},
+    span_graph_ref::{SpanGraphEventRef, SpanGraphRef, event_map_to_list},
     store::{SpanId, Store},
     timestamp::Timestamp,
-    FxIndexMap,
 };
 
 #[derive(Copy, Clone)]
@@ -187,7 +187,7 @@ impl<'a> SpanRef<'a> {
         })
     }
 
-    pub fn children(&self) -> impl DoubleEndedIterator<Item = SpanRef<'a>> + 'a {
+    pub fn children(&self) -> impl DoubleEndedIterator<Item = SpanRef<'a>> + 'a + use<'a> {
         self.span.events.iter().filter_map(|event| match event {
             SpanEvent::SelfTime { .. } => None,
             SpanEvent::Child { index } => Some(SpanRef {

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::{max, min},
     env,
     num::NonZeroUsize,
-    sync::{atomic::AtomicU64, OnceLock},
+    sync::{OnceLock, atomic::AtomicU64},
 };
 
 use rustc_hash::FxHashSet;

--- a/turbopack/crates/turbopack-trace-server/src/store_container.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store_container.rs
@@ -1,8 +1,8 @@
 use std::{
     ops::{Deref, DerefMut},
     sync::{
-        atomic::{AtomicBool, Ordering},
         RwLock, RwLockReadGuard, RwLockWriteGuard,
+        atomic::{AtomicBool, Ordering},
     },
 };
 

--- a/turbopack/crates/turbopack-trace-server/src/u64_empty_string.rs
+++ b/turbopack/crates/turbopack-trace-server/src/u64_empty_string.rs
@@ -1,4 +1,4 @@
-use serde::{de, Deserialize, Deserializer, Serializer};
+use serde::{Deserialize, Deserializer, Serializer, de};
 
 pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/turbopack/crates/turbopack-trace-server/src/u64_string.rs
+++ b/turbopack/crates/turbopack-trace-server/src/u64_string.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
-use serde::{de, Deserialize, Deserializer, Serializer};
+use serde::{Deserialize, Deserializer, Serializer, de};
 
 pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/turbopack/crates/turbopack-trace-server/src/viewer.rs
+++ b/turbopack/crates/turbopack-trace-server/src/viewer.rs
@@ -1,4 +1,4 @@
-use std::cmp::{max, Reverse};
+use std::cmp::{Reverse, max};
 
 use either::Either;
 use itertools::Itertools;
@@ -173,11 +173,7 @@ impl ValueMode {
 ///
 /// cases where count per time is very low is probably not important
 fn value_over_time(value: u64, time: Timestamp) -> u64 {
-    if *time == 0 {
-        0
-    } else {
-        value / *time
-    }
+    if *time == 0 { 0 } else { value / *time }
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
- Match ergonomics
- Marked trace server’s `SpanRef::children` as returning `use<‘a>`


Closes PACK-4598