### PR TITLE
[dynamicIO] model pathname access in metadata as async 

### DIFF
--- a/packages/next/src/lib/metadata/metadata-context.tsx
+++ b/packages/next/src/lib/metadata/metadata-context.tsx
@@ -1,43 +1,11 @@
 import type { AppRenderContext } from '../../server/app-render/app-render'
 import type { MetadataContext } from './types/resolvers'
-import type { WorkStore } from '../../server/app-render/work-async-storage.external'
-import { trackFallbackParamAccessed } from '../../server/app-render/dynamic-rendering'
 
 export function createMetadataContext(
-  pathname: string,
   renderOpts: AppRenderContext['renderOpts']
 ): MetadataContext {
   return {
-    pathname,
     trailingSlash: renderOpts.trailingSlash,
     isStaticMetadataRouteFile: false,
-  }
-}
-
-export function createTrackedMetadataContext(
-  pathname: string,
-  renderOpts: AppRenderContext['renderOpts'],
-  workStore: WorkStore | null
-): MetadataContext {
-  return {
-    // Use the regular metadata context, but we trap the pathname access.
-    ...createMetadataContext(pathname, renderOpts),
-
-    // Setup the trap around the pathname access so we can track when the
-    // pathname is accessed while resolving metadata which would indicate it's
-    // being used to resolve a relative URL. If that's the case, we don't want
-    // to provide it, and instead we should error.
-    get pathname() {
-      if (
-        workStore &&
-        workStore.isStaticGeneration &&
-        workStore.fallbackRouteParams &&
-        workStore.fallbackRouteParams.size > 0
-      ) {
-        trackFallbackParamAccessed(workStore, 'metadata relative url resolving')
-      }
-
-      return pathname
-    },
   }
 }

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../client/components/metadata/async-metadata'
 import { isPostpone } from '../../server/lib/router-utils/is-postpone'
 import { createServerSearchParamsForMetadata } from '../../server/request/search-params'
+import { createServerPathnameForMetadata } from '../../server/request/pathname'
 
 // Use a promise to share the status of the metadata resolving,
 // returning two components `MetadataTree` and `MetadataOutlet`
@@ -53,6 +54,7 @@ import { createServerSearchParamsForMetadata } from '../../server/request/search
 // and the error will be caught by the error boundary and trigger fallbacks.
 export function createMetadataComponents({
   tree,
+  pathname,
   parsedQuery,
   metadataContext,
   getDynamicParamFromSegment,
@@ -64,6 +66,7 @@ export function createMetadataComponents({
   serveStreamingMetadata,
 }: {
   tree: LoaderTree
+  pathname: string
   parsedQuery: SearchParams
   metadataContext: MetadataContext
   getDynamicParamFromSegment: GetDynamicParamFromSegment
@@ -82,6 +85,10 @@ export function createMetadataComponents({
 } {
   const searchParams = createServerSearchParamsForMetadata(
     parsedQuery,
+    workStore
+  )
+  const pathnameForMetadata = createServerPathnameForMetadata(
+    pathname,
     workStore
   )
 
@@ -143,6 +150,7 @@ export function createMetadataComponents({
   function metadata() {
     return getResolvedMetadata(
       tree,
+      pathnameForMetadata,
       searchParams,
       getDynamicParamFromSegment,
       metadataContext,
@@ -167,6 +175,7 @@ export function createMetadataComponents({
         try {
           result = await getNotFoundMetadata(
             tree,
+            pathnameForMetadata,
             searchParams,
             getDynamicParamFromSegment,
             metadataContext,
@@ -252,6 +261,7 @@ export function createMetadataComponents({
 const getResolvedMetadata = cache(getResolvedMetadataImpl)
 async function getResolvedMetadataImpl(
   tree: LoaderTree,
+  pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
@@ -261,6 +271,7 @@ async function getResolvedMetadataImpl(
   const errorConvention = errorType === 'redirect' ? undefined : errorType
   return renderMetadata(
     tree,
+    pathname,
     searchParams,
     getDynamicParamFromSegment,
     metadataContext,
@@ -272,6 +283,7 @@ async function getResolvedMetadataImpl(
 const getNotFoundMetadata = cache(getNotFoundMetadataImpl)
 async function getNotFoundMetadataImpl(
   tree: LoaderTree,
+  pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
@@ -280,6 +292,7 @@ async function getNotFoundMetadataImpl(
   const notFoundErrorConvention = 'not-found'
   return renderMetadata(
     tree,
+    pathname,
     searchParams,
     getDynamicParamFromSegment,
     metadataContext,
@@ -325,6 +338,7 @@ async function getNotFoundViewportImpl(
 
 async function renderMetadata(
   tree: LoaderTree,
+  pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
@@ -333,6 +347,7 @@ async function renderMetadata(
 ) {
   const resolvedMetadata = await resolveMetadata(
     tree,
+    pathname,
     searchParams,
     errorConvention,
     getDynamicParamFromSegment,

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -13,8 +13,9 @@ function accumulateMetadata(metadataItems: MetadataItems) {
     item[0],
     item[1],
   ])
-  return originAccumulateMetadata(fullMetadataItems, {
-    pathname: '/test',
+  const route = '/test'
+  const pathname = Promise.resolve('/test')
+  return originAccumulateMetadata(route, fullMetadataItems, pathname, {
     trailingSlash: false,
     isStaticMetadataRouteFile: false,
   })

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -105,15 +105,16 @@ function isFavicon(icon: IconDescriptor | undefined): boolean {
   )
 }
 
-function mergeStaticMetadata(
+async function mergeStaticMetadata(
   source: Metadata | null,
   target: ResolvedMetadata,
   staticFilesMetadata: StaticMetadata,
   metadataContext: MetadataContext,
   titleTemplates: TitleTemplates,
-  leafSegmentStaticIcons: StaticIcons
-) {
-  if (!staticFilesMetadata) return
+  leafSegmentStaticIcons: StaticIcons,
+  pathname: Promise<string>
+): Promise<ResolvedMetadata> {
+  if (!staticFilesMetadata) return target
   const { icon, apple, openGraph, twitter, manifest } = staticFilesMetadata
 
   // Keep updating the static icons in the most leaf node
@@ -138,9 +139,10 @@ function mergeStaticMetadata(
 
   // file based metadata is specified and current level metadata openGraph.images is not specified
   if (openGraph && !source?.openGraph?.hasOwnProperty('images')) {
-    const resolvedOpenGraph = resolveOpenGraph(
+    const resolvedOpenGraph = await resolveOpenGraph(
       { ...target.openGraph, images: openGraph } as OpenGraph,
       target.metadataBase,
+      pathname,
       { ...metadataContext, isStaticMetadataRouteFile: true },
       titleTemplates.openGraph
     )
@@ -154,23 +156,27 @@ function mergeStaticMetadata(
 }
 
 // Merge the source metadata into the resolved target metadata.
-function mergeMetadata({
-  source,
-  target,
-  staticFilesMetadata,
-  titleTemplates,
-  metadataContext,
-  buildState,
-  leafSegmentStaticIcons,
-}: {
-  source: Metadata | null
-  target: ResolvedMetadata
-  staticFilesMetadata: StaticMetadata
-  titleTemplates: TitleTemplates
-  metadataContext: MetadataContext
-  buildState: BuildState
-  leafSegmentStaticIcons: StaticIcons
-}): void {
+async function mergeMetadata(
+  route: string,
+  pathname: Promise<string>,
+  {
+    source,
+    target,
+    staticFilesMetadata,
+    titleTemplates,
+    metadataContext,
+    buildState,
+    leafSegmentStaticIcons,
+  }: {
+    source: Metadata | null
+    target: ResolvedMetadata
+    staticFilesMetadata: StaticMetadata
+    titleTemplates: TitleTemplates
+    metadataContext: MetadataContext
+    buildState: BuildState
+    leafSegmentStaticIcons: StaticIcons
+  }
+): Promise<ResolvedMetadata> {
   // If there's override metadata, prefer it otherwise fallback to the default metadata.
   const metadataBase =
     typeof source?.metadataBase !== 'undefined'
@@ -185,17 +191,19 @@ function mergeMetadata({
         break
       }
       case 'alternates': {
-        target.alternates = resolveAlternates(
+        target.alternates = await resolveAlternates(
           source.alternates,
           metadataBase,
+          pathname,
           metadataContext
         )
         break
       }
       case 'openGraph': {
-        target.openGraph = resolveOpenGraph(
+        target.openGraph = await resolveOpenGraph(
           source.openGraph,
           metadataBase,
+          pathname,
           metadataContext,
           titleTemplates.openGraph
         )
@@ -243,17 +251,19 @@ function mergeMetadata({
         break
       }
       case 'itunes': {
-        target[key] = resolveItunes(
+        target[key] = await resolveItunes(
           source.itunes,
           metadataBase,
+          pathname,
           metadataContext
         )
         break
       }
       case 'pagination': {
-        target.pagination = resolvePagination(
+        target.pagination = await resolvePagination(
           source.pagination,
           metadataBase,
+          pathname,
           metadataContext
         )
         break
@@ -288,20 +298,21 @@ function mergeMetadata({
           source[key] != null
         ) {
           buildState.warnings.add(
-            `Unsupported metadata ${key} is configured in metadata export in ${metadataContext.pathname}. Please move it to viewport export instead.\nRead more: https://nextjs.org/docs/app/api-reference/functions/generate-viewport`
+            `Unsupported metadata ${key} is configured in metadata export in ${route}. Please move it to viewport export instead.\nRead more: https://nextjs.org/docs/app/api-reference/functions/generate-viewport`
           )
         }
         break
       }
     }
   }
-  mergeStaticMetadata(
+  return mergeStaticMetadata(
     source,
     target,
     staticFilesMetadata,
     metadataContext,
     titleTemplates,
-    leafSegmentStaticIcons
+    leafSegmentStaticIcons,
+    pathname
   )
 }
 
@@ -903,10 +914,12 @@ function resolvePendingResult<
 }
 
 export async function accumulateMetadata(
+  route: string,
   metadataItems: MetadataItems,
+  pathname: Promise<string>,
   metadataContext: MetadataContext
 ): Promise<ResolvedMetadata> {
-  const resolvedMetadata = createDefaultMetadata()
+  let resolvedMetadata = createDefaultMetadata()
 
   let titleTemplates: TitleTemplates = {
     title: null,
@@ -960,7 +973,7 @@ export async function accumulateMetadata(
       metadata = pendingMetadata
     }
 
-    mergeMetadata({
+    resolvedMetadata = await mergeMetadata(route, pathname, {
       target: resolvedMetadata,
       source: metadata,
       metadataContext,
@@ -1055,6 +1068,7 @@ export async function accumulateViewport(
 // Exposed API for metadata component, that directly resolve the loader tree and related context as resolved metadata.
 export async function resolveMetadata(
   tree: LoaderTree,
+  pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
@@ -1068,7 +1082,12 @@ export async function resolveMetadata(
     getDynamicParamFromSegment,
     workStore
   )
-  return accumulateMetadata(metadataItems, metadataContext)
+  return accumulateMetadata(
+    workStore.route,
+    metadataItems,
+    pathname,
+    metadataContext
+  )
 }
 
 // Exposed API for viewport component, that directly resolve the loader tree and related context as resolved viewport.

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
@@ -38,15 +38,16 @@ describe('resolveImages', () => {
 })
 
 describe('resolveOpenGraph', () => {
-  it('should return null if the value is an empty string', () => {
+  it('should return null if the value is an empty string', async () => {
+    const pathname = Promise.resolve('')
     expect(
-      resolveOpenGraph(
+      await resolveOpenGraph(
         // pass authors as empty string
         { type: 'article', authors: '' },
         null,
+        pathname,
         {
           trailingSlash: false,
-          pathname: '',
           isStaticMetadataRouteFile: false,
         },
         ''
@@ -62,14 +63,15 @@ describe('resolveOpenGraph', () => {
     })
   })
 
-  it('should return null if the value is null', () => {
+  it('should return null if the value is null', async () => {
+    const pathname = Promise.resolve('')
     expect(
-      resolveOpenGraph(
+      await resolveOpenGraph(
         { type: 'article', authors: null },
         null,
+        pathname,
         {
           trailingSlash: false,
-          pathname: '',
           isStaticMetadataRouteFile: false,
         },
         ''

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -6,6 +6,7 @@ import type {
 } from '../types/opengraph-types'
 import type {
   FieldResolverExtraArgs,
+  AsyncFieldResolverExtraArgs,
   MetadataContext,
 } from '../types/resolvers'
 import type { ResolvedTwitterMetadata, Twitter } from '../types/twitter-types'
@@ -157,10 +158,16 @@ function getFieldsByOgType(ogType: OpenGraphType | undefined) {
   return ogTypeToFields[ogType].concat(OgTypeFields.basic)
 }
 
-export const resolveOpenGraph: FieldResolverExtraArgs<
+export const resolveOpenGraph: AsyncFieldResolverExtraArgs<
   'openGraph',
-  [ResolvedMetadataBase, MetadataContext, string | null]
-> = (openGraph, metadataBase, metadataContext, titleTemplate) => {
+  [ResolvedMetadataBase, Promise<string>, MetadataContext, string | null]
+> = async (
+  openGraph,
+  metadataBase,
+  pathname,
+  metadataContext,
+  titleTemplate
+) => {
   if (!openGraph) return null
 
   function resolveProps(target: ResolvedOpenGraph, og: OpenGraph) {
@@ -191,6 +198,7 @@ export const resolveOpenGraph: FieldResolverExtraArgs<
     ? resolveAbsoluteUrlWithPathname(
         openGraph.url,
         metadataBase,
+        await pathname,
         metadataContext
       )
     : null

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -50,13 +50,13 @@ describe('metadata: resolveUrl', () => {
 describe('resolveAbsoluteUrlWithPathname', () => {
   describe('trailingSlash is false', () => {
     const metadataBase = new URL('https://example.com/')
+    const pathname = '/'
     const opts = {
       trailingSlash: false,
-      pathname: '/',
       isStaticMetadataRouteFile: false,
     }
     const resolver = (url: string | URL) =>
-      resolveAbsoluteUrlWithPathname(url, metadataBase, opts)
+      resolveAbsoluteUrlWithPathname(url, metadataBase, pathname, opts)
     it('should resolve absolute internal url', () => {
       expect(resolver('https://example.com/foo')).toBe(
         'https://example.com/foo'
@@ -66,13 +66,13 @@ describe('resolveAbsoluteUrlWithPathname', () => {
 
   describe('trailingSlash is true', () => {
     const metadataBase = new URL('https://example.com/')
+    const pathname = '/'
     const opts = {
       trailingSlash: true,
-      pathname: '/',
       isStaticMetadataRouteFile: false,
     }
     const resolver = (url: string | URL) =>
-      resolveAbsoluteUrlWithPathname(url, metadataBase, opts)
+      resolveAbsoluteUrlWithPathname(url, metadataBase, pathname, opts)
     it('should add trailing slash to relative url', () => {
       expect(resolver('/foo')).toBe('https://example.com/foo/')
     })

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -98,7 +98,8 @@ function isFilePattern(pathname: string): boolean {
 function resolveAbsoluteUrlWithPathname(
   url: string | URL,
   metadataBase: URL | null,
-  { trailingSlash, pathname }: MetadataContext
+  pathname: string,
+  { trailingSlash }: MetadataContext
 ): string {
   // Resolve url with pathname that always starts with `/`
   url = resolveRelativeUrl(url, pathname)

--- a/packages/next/src/lib/metadata/types/resolvers.ts
+++ b/packages/next/src/lib/metadata/types/resolvers.ts
@@ -13,8 +13,14 @@ export type FieldResolverExtraArgs<
   ResolvedData = ResolvedMetadata,
 > = (T: Data[Key], ...args: ExtraArgs) => ResolvedData[Key]
 
+export type AsyncFieldResolverExtraArgs<
+  Key extends keyof Data & keyof ResolvedData,
+  ExtraArgs extends unknown[] = any[],
+  Data = Metadata,
+  ResolvedData = ResolvedMetadata,
+> = (T: Data[Key], ...args: ExtraArgs) => Promise<ResolvedData[Key]>
+
 export type MetadataContext = {
-  pathname: string
   trailingSlash: boolean
   isStaticMetadataRouteFile: boolean
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -55,10 +55,7 @@ import {
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_HMR_REFRESH_HASH_COOKIE,
 } from '../../client/components/app-router-headers'
-import {
-  createTrackedMetadataContext,
-  createMetadataContext,
-} from '../../lib/metadata/metadata-context'
+import { createMetadataContext } from '../../lib/metadata/metadata-context'
 import { createRequestStoreForRender } from '../async-storage/request-store'
 import { createWorkStore } from '../async-storage/work-store'
 import {
@@ -496,11 +493,8 @@ async function generateDynamicRSCPayload(
     } = createMetadataComponents({
       tree: loaderTree,
       parsedQuery: query,
-      metadataContext: createTrackedMetadataContext(
-        url.pathname,
-        ctx.renderOpts,
-        workStore
-      ),
+      pathname: url.pathname,
+      metadataContext: createMetadataContext(ctx.renderOpts),
       getDynamicParamFromSegment,
       appUsingSizeAdjustment,
       workStore,
@@ -823,11 +817,8 @@ async function getRSCPayload(
     // TODO: remove this condition and keep it undefined when global-not-found is stabilized.
     errorType: is404 && !hasGlobalNotFound ? 'not-found' : undefined,
     parsedQuery: query,
-    metadataContext: createTrackedMetadataContext(
-      url.pathname,
-      ctx.renderOpts,
-      workStore
-    ),
+    pathname: url.pathname,
+    metadataContext: createMetadataContext(ctx.renderOpts),
     getDynamicParamFromSegment,
     appUsingSizeAdjustment,
     workStore,
@@ -945,9 +936,8 @@ async function getErrorRSCPayload(
   const { MetadataTree, ViewportTree } = createMetadataComponents({
     tree,
     parsedQuery: query,
-    // We create an untracked metadata context here because we can't postpone
-    // again during the error render.
-    metadataContext: createMetadataContext(url.pathname, ctx.renderOpts),
+    pathname: url.pathname,
+    metadataContext: createMetadataContext(ctx.renderOpts),
     errorType,
     getDynamicParamFromSegment,
     appUsingSizeAdjustment,

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -1,0 +1,99 @@
+import type { WorkStore } from '../app-render/work-async-storage.external'
+
+import {
+  postponeWithTracking,
+  type DynamicTrackingState,
+} from '../app-render/dynamic-rendering'
+
+import {
+  workUnitAsyncStorage,
+  type PrerenderStore,
+} from '../app-render/work-unit-async-storage.external'
+import { makeHangingPromise } from '../dynamic-rendering-utils'
+
+export function createServerPathnameForMetadata(
+  underlyingPathname: string,
+  workStore: WorkStore
+): Promise<string> {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  if (workUnitStore) {
+    switch (workUnitStore.type) {
+      case 'prerender':
+      case 'prerender-ppr':
+      case 'prerender-legacy': {
+        return createPrerenderPathname(
+          underlyingPathname,
+          workStore,
+          workUnitStore
+        )
+      }
+      default:
+      // fallthrough
+    }
+  }
+  return createRenderPathname(underlyingPathname)
+}
+
+function createPrerenderPathname(
+  underlyingPathname: string,
+  workStore: WorkStore,
+  prerenderStore: PrerenderStore
+): Promise<string> {
+  const fallbackParams = workStore.fallbackRouteParams
+  if (fallbackParams && fallbackParams.size > 0) {
+    switch (prerenderStore.type) {
+      case 'prerender':
+        return makeHangingPromise<string>(
+          prerenderStore.renderSignal,
+          '`pathname`'
+        )
+      case 'prerender-ppr':
+        return makeErroringPathname(workStore, prerenderStore.dynamicTracking)
+        break
+      default:
+        return makeErroringPathname(workStore, null)
+    }
+  }
+
+  // We don't have any fallback params so we have an entirely static safe params object
+  return Promise.resolve(underlyingPathname)
+}
+
+function makeErroringPathname<T>(
+  workStore: WorkStore,
+  dynamicTracking: null | DynamicTrackingState
+): Promise<T> {
+  let reject: null | ((reason: unknown) => void) = null
+  const promise = new Promise<T>((_, re) => {
+    reject = re
+  })
+
+  const originalThen = promise.then.bind(promise)
+
+  // We instrument .then so that we can generate a tracking event only if you actually
+  // await this promise, not just that it is created.
+  promise.then = (onfulfilled, onrejected) => {
+    if (reject) {
+      try {
+        postponeWithTracking(
+          workStore.route,
+          'metadata relative url resolving',
+          dynamicTracking
+        )
+      } catch (error) {
+        reject(error)
+        reject = null
+      }
+    }
+    return originalThen(onfulfilled, onrejected)
+  }
+
+  // We wrap in a noop proxy to trick the runtime into thinking it
+  // isn't a native promise (it's not really). This is so that awaiting
+  // the promise will call the `then` property triggering the lazy postpone
+  return new Proxy(promise, {})
+}
+
+function createRenderPathname(underlyingPathname: string): Promise<string> {
+  return Promise.resolve(underlyingPathname)
+}


### PR DESCRIPTION
reading the pathname is akin to reading params and it should be an async function so metadata can postpone during prerendering just like usercode can.

Unforutnately the current metadata merging implementation was synchronous. It might be tempting to just await the pathname high up and let the merge continue to be sync but this might trigger dynamic metadata when not necessary since only certain metadata properties require the pathname. In an effort to maximize which metadata can be prerendered I converted the necessary merging functions to be async and passed a promise in that will exhibit the correct semantics when accessed when dynamicIO is enabled.