### PR TITLE
Fix false-positive `"use cache"` misplacement error

### DIFF
--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -40,8 +40,8 @@ pub async fn get_server_actions_transform_rule(
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![transformer]),
+            append: ResolvedVc::cell(vec![]),
         }],
     ))
 }

--- a/test/development/app-dir/use-cache-errors/app/client-module.ts
+++ b/test/development/app-dir/use-cache-errors/app/client-module.ts
@@ -1,0 +1,5 @@
+'use client'
+
+export function useStuff() {
+  return 'stuff'
+}

--- a/test/development/app-dir/use-cache-errors/app/layout.tsx
+++ b/test/development/app-dir/use-cache-errors/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/use-cache-errors/app/module-with-use-cache.ts
+++ b/test/development/app-dir/use-cache-errors/app/module-with-use-cache.ts
@@ -1,0 +1,17 @@
+'use cache'
+
+// This file simulates adding a "use cache" directive to a client module that's
+// mistaken as a server module. It does not have itself a "use client"
+// directive, but is imported by a client module with a "use client" directive,
+// while also importing another client module with a "use client" directive.
+// Adding the "use cache" directive here, effectively forces the module to be a
+// server module, which then results in an error when trying to call the client
+// function.
+
+import { useStuff } from './client-module'
+
+export async function useCachedStuff() {
+  // Intentional misusage (using hooks in async functions).
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useStuff()
+}

--- a/test/development/app-dir/use-cache-errors/app/page.tsx
+++ b/test/development/app-dir/use-cache-errors/app/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useActionState } from 'react'
+import { useCachedStuff } from './module-with-use-cache'
+
+function OtherClientComponent({
+  getCachedStuff,
+}: {
+  getCachedStuff: () => Promise<string>
+}) {
+  const [result, formAction] = useActionState(getCachedStuff, null)
+
+  return (
+    <form action={formAction}>
+      <button id="action-button">Submit</button>
+      <p>{result}</p>
+    </form>
+  )
+}
+
+export default function Page() {
+  return <OtherClientComponent getCachedStuff={useCachedStuff} />
+}

--- a/test/development/app-dir/use-cache-errors/next.config.js
+++ b/test/development/app-dir/use-cache-errors/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    useCache: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
+++ b/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
@@ -19,6 +19,7 @@ describe('use-cache-errors', () => {
     await browser.elementById('action-button').click()
 
     if (isTurbopack) {
+      // TODO(veil): The wrong stack frame is used for the source snippet.
       await expect(browser).toDisplayRedbox(`
        {
          "description": "Attempted to call useStuff() from the server but useStuff is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.",
@@ -46,11 +47,6 @@ describe('use-cache-errors', () => {
          "stack": [
            "<FIXME-file-protocol>",
            "useCachedStuff app/module-with-use-cache.ts (16:18)",
-           "serializeThenable rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (808:22)",
-           "renderModelDestructive rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (1829:28)",
-           "retryTask rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (2512:31)",
-           "performWork rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (2585:11)",
-           "eval rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (2663:28)",
            "Page app/page.tsx (22:10)",
          ],
        }

--- a/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
+++ b/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
@@ -1,0 +1,60 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox } from '../../../lib/next-test-utils'
+
+describe('use-cache-errors', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not show a false-positive compiler error about a misplaced "use cache" directive', async () => {
+    // This is a regression test to ensure that an injected React Refresh
+    // statement (`var _s = __turbopack_context__.k.signature`) does not
+    // interfere with our "use cache" directive misplacement detection.
+    const browser = await next.browser('/')
+    await assertNoRedbox(browser)
+  })
+
+  it('should show a runtime error when calling the incorrectly used cache function', async () => {
+    const browser = await next.browser('/')
+    await browser.elementById('action-button').click()
+
+    if (isTurbopack) {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Attempted to call useStuff() from the server but useStuff is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.",
+         "environmentLabel": "Cache",
+         "label": "Runtime Error",
+         "source": "app/page.tsx (22:10) @ Page
+       > 22 |   return <OtherClientComponent getCachedStuff={useCachedStuff} />
+            |          ^",
+         "stack": [
+           "<FIXME-file-protocol>",
+           "<FIXME-file-protocol>",
+           "Page app/page.tsx (22:10)",
+         ],
+       }
+      `)
+    } else {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Attempted to call useStuff() from the server but useStuff is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.",
+         "environmentLabel": "Cache",
+         "label": "Runtime Error",
+         "source": "app/module-with-use-cache.ts (16:18) @ useCachedStuff
+       > 16 |   return useStuff()
+            |                  ^",
+         "stack": [
+           "<FIXME-file-protocol>",
+           "useCachedStuff app/module-with-use-cache.ts (16:18)",
+           "serializeThenable rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (808:22)",
+           "renderModelDestructive rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (1829:28)",
+           "retryTask rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (2512:31)",
+           "performWork rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (2585:11)",
+           "eval rsc:/Cache/webpack-internal:///(react-server)/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js (2663:28)",
+           "Page app/page.tsx (22:10)",
+         ],
+       }
+      `)
+    }
+  })
+})


### PR DESCRIPTION
This fixes an error where we incorrectly showed the following compiler error when using Turbopack:

```sh
Ecmascript file had an error
> 1 | 'use cache'
    | ^^^^^^^^^^^
  2 |
  3 | import { useStuff } from './client-module'
  4 |

The "use cache" directive must be at the top of the file.
```

The directive was regarded as not being at the top of the file, because the React transform (`EcmascriptInputTransform::React`) injects a variable declaration for React Refresh (e.g. `var _s = __turbopack_context__.k.signature`) at the top of the file, before the `"use cache"` directive.

We can fix this by ensuring that the server action transform (should really be called "server _function_ transform") runs first.

As a consequence, the transform now needs to be able to parse JSX AST nodes, which was already explicitly implemented.

closes NAR-130