### PR TITLE
Turbopack: Allow fully dynamic import() in node_modules

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -357,6 +357,8 @@ pub async fn get_client_module_options_context(
     let foreign_codes_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_typeof_window_inlining: None,
+            // Ignore e.g. import(`${url}`) requests in node_modules.
+            ignore_dynamic_requests: true,
             ..module_options_context.ecmascript
         },
         enable_webpack_loaders: foreign_enable_webpack_loaders,

--- a/test/e2e/app-dir/monaco-editor/app/layout.tsx
+++ b/test/e2e/app-dir/monaco-editor/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en" className="w-full h-full">
+      <body className={`w-full h-full`}>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/monaco-editor/app/page.tsx
+++ b/test/e2e/app-dir/monaco-editor/app/page.tsx
@@ -1,0 +1,9 @@
+import { Editor } from '../components/editor/editor'
+export default function Home() {
+  return (
+    <>
+      <h1>Editor Page</h1>
+      <Editor />
+    </>
+  )
+}

--- a/test/e2e/app-dir/monaco-editor/components/editor/editor.tsx
+++ b/test/e2e/app-dir/monaco-editor/components/editor/editor.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { RefObject, Suspense, use, useEffect, useRef } from 'react'
+
+// The monaco module uses `window` in the module scope, so when it executes it immediately throws.
+// In order to avoid executing it on the server it's only imported in the browser.
+// We leverage `use` to wait for the promise.
+const maybeMonaco = typeof window === 'undefined' ? null : import('./monaco')
+
+function LazyMonaco({
+  editorRef,
+}: {
+  editorRef: RefObject<HTMLDivElement | null>
+}) {
+  const { monaco } = maybeMonaco === null ? {} : use(maybeMonaco)
+
+  useEffect(() => {
+    if (monaco && editorRef.current) {
+      const monacoEditor = monaco.editor.create(editorRef.current, {
+        value: "console.log('Hello, world!');",
+        language: 'javascript',
+        automaticLayout: true,
+      })
+
+      return () => {
+        monacoEditor.dispose()
+      }
+    }
+  }, [monaco, editorRef])
+
+  return null
+}
+
+export function Editor() {
+  const editorRef = useRef<HTMLDivElement>(null)
+  return (
+    <>
+      <Suspense fallback="initalizing monaco">
+        <LazyMonaco editorRef={editorRef} />
+        <div id="editor" ref={editorRef} className="h-full" />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/monaco-editor/components/editor/monaco.ts
+++ b/test/e2e/app-dir/monaco-editor/components/editor/monaco.ts
@@ -1,0 +1,152 @@
+// (1) Desired editor features:
+// BEGIN_FEATURES
+// import "monaco-editor/esm/vs/editor/browser/controller/coreCommands.js";
+// import 'monaco-editor/esm/vs/editor/browser/widget/codeEditorWidget.js';
+// import 'monaco-editor/esm/vs/editor/browser/widget/diffEditorWidget.js';
+// import 'monaco-editor/esm/vs/editor/browser/widget/diffNavigator.js';
+// import 'monaco-editor/esm/vs/editor/contrib/anchorSelect/anchorSelect.js';
+// import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/bracketMatching.js';
+// import 'monaco-editor/esm/vs/editor/contrib/caretOperations/caretOperations.js';
+// import 'monaco-editor/esm/vs/editor/contrib/caretOperations/transpose.js';
+// import 'monaco-editor/esm/vs/editor/contrib/clipboard/clipboard.js';
+// import 'monaco-editor/esm/vs/editor/contrib/codeAction/codeActionContributions.js';
+// import 'monaco-editor/esm/vs/editor/contrib/codelens/codelensController.js';
+// import 'monaco-editor/esm/vs/editor/contrib/colorPicker/colorContributions.js';
+// import 'monaco-editor/esm/vs/editor/contrib/comment/comment.js';
+// import 'monaco-editor/esm/vs/editor/contrib/contextmenu/contextmenu.js';
+// import 'monaco-editor/esm/vs/editor/contrib/cursorUndo/cursorUndo.js';
+// import 'monaco-editor/esm/vs/editor/contrib/dnd/dnd.js';
+// import 'monaco-editor/esm/vs/editor/contrib/documentSymbols/documentSymbols.js';
+// import "monaco-editor/esm/vs/editor/contrib/find/browser/findController.js";
+// import 'monaco-editor/esm/vs/editor/contrib/folding/folding.js';
+// import 'monaco-editor/esm/vs/editor/contrib/fontZoom/fontZoom.js';
+// import 'monaco-editor/esm/vs/editor/contrib/format/formatActions.js';
+// import 'monaco-editor/esm/vs/editor/contrib/gotoError/gotoError.js';
+// import 'monaco-editor/esm/vs/editor/contrib/gotoSymbol/goToCommands.js';
+// import 'monaco-editor/esm/vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition.js';
+// import 'monaco-editor/esm/vs/editor/contrib/hover/hover.js';
+// import 'monaco-editor/esm/vs/editor/contrib/inPlaceReplace/inPlaceReplace.js';
+// import 'monaco-editor/esm/vs/editor/contrib/indentation/indentation.js';
+// import 'monaco-editor/esm/vs/editor/contrib/inlineHints/inlineHintsController.js';
+// import 'monaco-editor/esm/vs/editor/contrib/linesOperations/linesOperations.js';
+// import 'monaco-editor/esm/vs/editor/contrib/linkedEditing/linkedEditing.js';
+// import 'monaco-editor/esm/vs/editor/contrib/links/links.js';
+// import 'monaco-editor/esm/vs/editor/contrib/multicursor/multicursor.js';
+// import 'monaco-editor/esm/vs/editor/contrib/parameterHints/parameterHints.js';
+// import 'monaco-editor/esm/vs/editor/contrib/rename/rename.js';
+// import 'monaco-editor/esm/vs/editor/contrib/smartSelect/smartSelect.js';
+// import 'monaco-editor/esm/vs/editor/contrib/snippet/snippetController2.js';
+// import 'monaco-editor/esm/vs/editor/contrib/suggest/suggestController.js';
+// import 'monaco-editor/esm/vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode.js';
+// import 'monaco-editor/esm/vs/editor/contrib/unusualLineTerminators/unusualLineTerminators.js';
+// import 'monaco-editor/esm/vs/editor/contrib/viewportSemanticTokens/viewportSemanticTokens.js';
+// import 'monaco-editor/esm/vs/editor/contrib/wordHighlighter/wordHighlighter.js';
+// import 'monaco-editor/esm/vs/editor/contrib/wordOperations/wordOperations.js';
+// import 'monaco-editor/esm/vs/editor/contrib/wordPartOperations/wordPartOperations.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/inspectTokens/inspectTokens.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneHelpQuickAccess.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/referenceSearch/standaloneReferenceSearch.js';
+// import 'monaco-editor/esm/vs/editor/standalone/browser/toggleHighContrast/toggleHighContrast.js';
+// END_FEATURES
+import * as monacoModule from 'monaco-editor/esm/vs/editor/editor.api.js'
+
+// (2) Desired languages:
+// BEGIN_LANGUAGES
+// import 'monaco-editor/esm/vs/language/css/monaco.contribution.js';
+// import 'monaco-editor/esm/vs/language/html/monaco.contribution.js';
+// import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
+// import 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/abap/abap.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/apex/apex.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/azcli/azcli.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/bat/bat.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/cameligo/cameligo.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/clojure/clojure.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/coffee/coffee.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/cpp/cpp.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/csharp/csharp.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/csp/csp.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/css/css.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/dart/dart.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/dockerfile/dockerfile.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/ecl/ecl.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/fsharp/fsharp.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/go/go.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/handlebars/handlebars.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/hcl/hcl.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/html/html.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/ini/ini.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/java/java.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/julia/julia.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/kotlin/kotlin.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/less/less.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/lexon/lexon.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/lua/lua.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/m3/m3.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/mips/mips.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/msdax/msdax.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/mysql/mysql.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/objective-c/objective-c.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/pascal/pascal.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/pascaligo/pascaligo.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/perl/perl.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/pgsql/pgsql.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/php/php.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/postiats/postiats.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/powerquery/powerquery.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/powershell/powershell.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/pug/pug.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/python/python.contribution.js'
+// import 'monaco-editor/esm/vs/basic-languages/r/r.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/razor/razor.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/redis/redis.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/redshift/redshift.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/restructuredtext/restructuredtext.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/ruby/ruby.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/rust/rust.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/sb/sb.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/scala/scala.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/scheme/scheme.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/scss/scss.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/shell/shell.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/solidity/solidity.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/sophia/sophia.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/st/st.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/swift/swift.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/systemverilog/systemverilog.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/tcl/tcl.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/twig/twig.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/vb/vb.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/xml/xml.contribution.js';
+// import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
+// END_LANGUAGES
+
+self.MonacoEnvironment = {
+  getWorkerUrl: function (moduleId, label) {
+    // if (label === 'json') {
+    // 	return './json.worker.bundle.js';
+    // }
+    // if (label === 'css' || label === 'scss' || label === 'less') {
+    // 	return './css.worker.bundle.js';
+    // }
+    // if (label === 'html' || label === 'handlebars' || label === 'razor') {
+    // 	return './html.worker.bundle.js';
+    // }
+    // if (label === 'typescript' || label === 'javascript') {
+    // 	return './ts.worker.bundle.js';
+    // }
+    return './editor.worker.bundle.js'
+  },
+}
+
+export const monaco = monacoModule

--- a/test/e2e/app-dir/monaco-editor/monaco-editor.test.ts
+++ b/test/e2e/app-dir/monaco-editor/monaco-editor.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('monaco-editor', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      'monaco-editor': '^0.52.2',
+    },
+  })
+
+  // Recommended for tests that need a full browser
+  it('should load monaco-editor', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('h1').text()).toBe('Editor Page')
+    expect(
+      await browser.waitForElementByCss('.monaco-editor').getAttribute('role')
+    ).toBe('code')
+  })
+})

--- a/test/e2e/app-dir/monaco-editor/next.config.js
+++ b/test/e2e/app-dir/monaco-editor/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
## What?

Allows e.g. ```import(`${url}`)``` when in node_modules. This makes monaco-editor work automatically when it's correctly imported in e.g. a `useEffect`.

- [x] Apply change 
- [x] Verify against local reproduction
- [x] Add test case

Fixes #72613
Fixes PACK-4602