### PR TITLE
Remove uses of `read_glob` from `node_native_bindings`

### DIFF
--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -60,12 +60,13 @@ impl CompileTarget {
         }
     }
 
+    /// Returns the expected extension of the dynamic library, including the `.`.
     pub fn dylib_ext(&self) -> &'static str {
         let platform = self.platform;
         match platform {
-            Platform::Win32 => "dll",
-            Platform::Darwin => "dylib",
-            _ => "so",
+            Platform::Win32 => ".dll",
+            Platform::Darwin => ".dylib",
+            _ => ".so",
         }
     }
 

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -141,7 +141,7 @@ pub async fn resolve_node_pre_gyp_files(
                         let extension = compile_target.dylib_ext();
                         for (key, entry) in entries
                             .iter()
-                            .filter(|(k, _)| k.as_str().ends_with(extension))
+                            .filter(|(k, _)| k.ends_with(extension))
                         {
                             if let &DirectoryEntry::File(dylib) | &DirectoryEntry::Symlink(dylib) =
                                 entry

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -132,11 +132,11 @@ pub async fn resolve_node_pre_gyp_files(
                         )
                         .into();
 
-                    let dir = config_file_dir
+                    if let DirectoryContent::Entries(entries) = &*config_file_dir
                         .join(native_binding_path.clone())
                         .read_dir()
-                        .await?;
-                    if let DirectoryContent::Entries(entries) = &*dir {
+                        .await?
+                    {
                         let extension = format!("*.{}", compile_target.dylib_ext());
                         for (key, entry) in entries
                             .iter()
@@ -166,13 +166,13 @@ pub async fn resolve_node_pre_gyp_files(
                         );
                     }
                 }
-                let dir = config_file_dir
+                if let DirectoryContent::Entries(entries) = &*config_file_dir
                     // TODO
                     // read the dependencies path from `bindings.gyp`
                     .join("deps/lib".into())
                     .read_dir()
-                    .await?;
-                if let DirectoryContent::Entries(entries) = &*dir {
+                    .await?
+                {
                     for (key, entry) in entries.iter() {
                         match *entry {
                             DirectoryEntry::File(dylib) => {

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -139,10 +139,7 @@ pub async fn resolve_node_pre_gyp_files(
                         .await?
                     {
                         let extension = compile_target.dylib_ext();
-                        for (key, entry) in entries
-                            .iter()
-                            .filter(|(k, _)| k.ends_with(extension))
-                        {
+                        for (key, entry) in entries.iter().filter(|(k, _)| k.ends_with(extension)) {
                             if let &DirectoryEntry::File(dylib) | &DirectoryEntry::Symlink(dylib) =
                                 entry
                             {

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -132,15 +132,16 @@ pub async fn resolve_node_pre_gyp_files(
                         )
                         .into();
 
+                    // Find all dynamic libraries in the given directory.
                     if let DirectoryContent::Entries(entries) = &*config_file_dir
                         .join(native_binding_path.clone())
                         .read_dir()
                         .await?
                     {
-                        let extension = format!("*.{}", compile_target.dylib_ext());
+                        let extension = compile_target.dylib_ext();
                         for (key, entry) in entries
                             .iter()
-                            .filter(|(k, _)| k.as_str().ends_with(&extension))
+                            .filter(|(k, _)| k.as_str().ends_with(extension))
                         {
                             if let &DirectoryEntry::File(dylib) | &DirectoryEntry::Symlink(dylib) =
                                 entry


### PR DESCRIPTION
Remove two calls to `read_glob` that could be trivially satisfied by `read_dir`.  This makes it clearer that the reads are shallow and avoids allocating extra maps and `globs` (smaller vc-cell keys, etc)


Closes PACK-4606