### PR TITLE
Add initial modifyConfig hook

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -317,6 +317,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     excludeDefaultMomentLocales: z.boolean().optional(),
     experimental: z
       .strictObject({
+        adapterPath: z.string().optional(),
         useSkewCookie: z.boolean().optional(),
         nodeMiddleware: z.boolean().optional(),
         after: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -26,6 +26,13 @@ export type NextConfigComplete = Required<NextConfig> & {
   experimental: Omit<ExperimentalConfig, 'turbo'>
 }
 
+export interface NextAdapter {
+  name: string
+  modifyConfig(
+    config: NextConfigComplete
+  ): Promise<NextConfigComplete> | NextConfigComplete
+}
+
 export type I18NDomains = readonly DomainLocale[]
 
 export interface I18NConfig {
@@ -273,6 +280,7 @@ export interface LoggingConfig {
 }
 
 export interface ExperimentalConfig {
+  adapterPath?: string
   useSkewCookie?: boolean
   nodeMiddleware?: boolean
   cacheHandlers?: {
@@ -1244,6 +1252,7 @@ export const defaultConfig: NextConfig = {
   outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
   allowedDevOrigins: undefined,
   experimental: {
+    adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
     useSkewCookie: false,
     nodeMiddleware: false,
     cacheLife: {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -4,13 +4,19 @@ import { pathToFileURL } from 'url'
 import findUp from 'next/dist/compiled/find-up'
 import * as Log from '../build/output/log'
 import * as ciEnvironment from '../server/ci-info'
-import { CONFIG_FILES, PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
+import {
+  CONFIG_FILES,
+  PHASE_DEVELOPMENT_SERVER,
+  PHASE_PRODUCTION_BUILD,
+  PHASE_PRODUCTION_SERVER,
+} from '../shared/lib/constants'
 import { defaultConfig, normalizeConfig } from './config-shared'
 import type {
   ExperimentalConfig,
   NextConfigComplete,
   NextConfig,
   TurbopackLoaderItem,
+  NextAdapter,
 } from './config-shared'
 
 import { loadWebpackHook } from './config-utils'
@@ -31,6 +37,7 @@ import { normalizeZodErrors } from '../shared/lib/zod'
 import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot'
 import { findDir } from '../lib/find-pages-dir'
 import { CanaryOnlyError, isStableBuild } from '../shared/lib/canary-only'
+import { interopDefault } from '../lib/interop-default'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
@@ -1091,6 +1098,33 @@ function assignDefaults(
   return result
 }
 
+async function applyModifyConfig(
+  config: NextConfigComplete,
+  phase: string,
+  silent: boolean
+): Promise<NextConfigComplete> {
+  if (
+    // TODO: should this be called for server start as
+    // adapters shouldn't be relying on "next start"
+    [PHASE_PRODUCTION_BUILD, PHASE_PRODUCTION_SERVER].includes(phase) &&
+    config.experimental?.adapterPath
+  ) {
+    const adapterMod = interopDefault(
+      await import(
+        pathToFileURL(require.resolve(config.experimental.adapterPath)).href
+      )
+    ) as NextAdapter
+
+    if (typeof adapterMod.modifyConfig === 'function') {
+      if (!silent) {
+        Log.info(`Applying modifyConfig from ${adapterMod.name}`)
+      }
+      config = await adapterMod.modifyConfig(config)
+    }
+  }
+  return config
+}
+
 export default async function loadConfig(
   phase: string,
   dir: string,
@@ -1121,6 +1155,8 @@ export default async function loadConfig(
   }
 
   if (process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
+    // we don't apply assignDefaults or modifyConfig here as it
+    // has already been applied
     return JSON.parse(process.env.__NEXT_PRIVATE_STANDALONE_CONFIG)
   }
 
@@ -1137,15 +1173,19 @@ export default async function loadConfig(
   let configFileName = 'next.config.js'
 
   if (customConfig) {
-    return assignDefaults(
-      dir,
-      {
-        configOrigin: 'server',
-        configFileName,
-        ...customConfig,
-      },
+    return await applyModifyConfig(
+      assignDefaults(
+        dir,
+        {
+          configOrigin: 'server',
+          configFileName,
+          ...customConfig,
+        },
+        silent
+      ) as NextConfigComplete,
+      phase,
       silent
-    ) as NextConfigComplete
+    )
   }
 
   const path = await findUp(CONFIG_FILES, { cwd: dir })
@@ -1334,7 +1374,7 @@ export default async function loadConfig(
       },
       silent
     ) as NextConfigComplete
-    return completeConfig
+    return await applyModifyConfig(completeConfig, phase, silent)
   } else {
     const configBaseName = basename(CONFIG_FILES[0], extname(CONFIG_FILES[0]))
     const unsupportedConfig = findUp.sync(
@@ -1366,7 +1406,7 @@ export default async function loadConfig(
   ) as NextConfigComplete
   completeConfig.configFileName = configFileName
   setHttpClientAndAgentOptions(completeConfig)
-  return completeConfig
+  return await applyModifyConfig(completeConfig, phase, silent)
 }
 
 export type ConfiguredExperimentalFeature =

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('adapter-config', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should apply modifyConfig from adapter', async () => {
+    // we apply basePath /docs so ensure that applied
+    const res = await next.fetch('/')
+    expect(res.status).toBe(404)
+
+    const res2 = await next.fetch('/docs')
+    expect(res2.status).toBe(200)
+    expect(await res2.text()).toContain('hello world')
+
+    expect(next.cliOutput).toContain('called modify config in adapter')
+  })
+})

--- a/test/production/adapter-config/my-adapter.mjs
+++ b/test/production/adapter-config/my-adapter.mjs
@@ -1,0 +1,11 @@
+/** @type {import('next').NextAdapter } */
+const myAdapter = {
+  name: 'my-custom-adapter',
+  modifyConfig: (config) => {
+    console.log('called modify config in adapter')
+    config.basePath = '/docs'
+    return config
+  },
+}
+
+export default myAdapter

--- a/test/production/adapter-config/next.config.mjs
+++ b/test/production/adapter-config/next.config.mjs
@@ -1,0 +1,11 @@
+import Module from 'module'
+const require = Module.createRequire(import.meta.url)
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    adapterPath: require.resolve('./my-adapter.mjs'),
+  },
+}
+
+export default nextConfig

--- a/test/production/adapter-config/pages/index.tsx
+++ b/test/production/adapter-config/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
This adds the initial `modifyConfig` hook for adapters and exposes the initial interface. This is still experimental while it is being validated so should not be leveraged at this time. Once validated it will be documented and stabilized. 