### PR TITLE
Add `rustc-ice` files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ tarballs/
 packages/**/*.tgz
 .errors/
 
+# rust compiler crashes
+rustc-ice-*.txt
+
 # dependencies
 node_modules
 package-lock.json


### PR DESCRIPTION
We are using some rustc features that routinely lead to compiler crashes which get dumped as `rustc-ice` files.

We never want to commit these.


Closes PACK-4607