### PR TITLE
perf(turbopack): Do not inline synthesized content for sourcemaps

### DIFF
--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -432,7 +432,7 @@ fn generate_minimal_source_map(filename: String, source: String) -> Result<Rope>
     }
     let sm: Arc<SourceMap> = Default::default();
     sm.new_source_file(FileName::Custom(filename).into(), source);
-    let map = generate_js_source_map(sm, mappings, None)?;
+    let map = generate_js_source_map(sm, mappings, None, true)?;
     Ok(map)
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1131,9 +1131,15 @@ async fn emit_content(content: CodeGenResult) -> Result<Vc<EcmascriptModuleConte
                 source_map.clone(),
                 mappings,
                 original_source_map.generate_source_map().await?.as_ref(),
+                true,
             )?)
         } else {
-            Some(generate_js_source_map(source_map.clone(), mappings, None)?)
+            Some(generate_js_source_map(
+                source_map.clone(),
+                mappings,
+                None,
+                true,
+            )?)
         }
     } else {
         None

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -134,7 +134,15 @@ pub fn minify(code: &Code, source_maps: bool, mangle: Option<MangleType>) -> Res
         src_map_buf.shrink_to_fit();
         builder.push_source(
             &src.into(),
-            Some(generate_js_source_map(cm, src_map_buf, Some(original_map))?),
+            Some(generate_js_source_map(
+                cm,
+                src_map_buf,
+                Some(original_map),
+                // We do not inline source contents.
+                // We provide a synthesized value to `cm.new_source_file` above, so it cannot be
+                // the value user expect anyway.
+                false,
+            )?),
         );
     } else {
         builder.push_source(&src.into(), None);

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -103,6 +103,7 @@ pub fn generate_js_source_map(
     files_map: Arc<swc_core::common::SourceMap>,
     mappings: Vec<(BytePos, LineCol)>,
     original_source_map: Option<&Rope>,
+    inline_sources_content: bool,
 ) -> Result<Rope> {
     let input_map = if let Some(original_source_map) = original_source_map {
         Some(match sourcemap::decode(original_source_map.read())? {
@@ -115,8 +116,13 @@ pub fn generate_js_source_map(
         None
     };
 
-    let map =
-        files_map.build_source_map_with_config(&mappings, None, InlineSourcesContentConfig {});
+    let map = files_map.build_source_map_with_config(
+        &mappings,
+        None,
+        InlineSourcesContentConfig {
+            inline_sources_content,
+        },
+    );
 
     let mut map = match input_map {
         Some(mut input_map) => {
@@ -135,7 +141,9 @@ pub fn generate_js_source_map(
 /// A config to generate a source map which includes the source content of every
 /// source file. SWC doesn't inline sources content by default when generating a
 /// sourcemap, so we need to provide a custom config to do it.
-pub struct InlineSourcesContentConfig {}
+pub struct InlineSourcesContentConfig {
+    inline_sources_content: bool,
+}
 
 impl SourceMapGenConfig for InlineSourcesContentConfig {
     fn file_name_to_source(&self, f: &FileName) -> String {
@@ -148,7 +156,7 @@ impl SourceMapGenConfig for InlineSourcesContentConfig {
     }
 
     fn inline_sources_content(&self, _f: &FileName) -> bool {
-        true
+        self.inline_sources_content
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -120,7 +120,13 @@ pub fn generate_js_source_map(
         &mappings,
         None,
         InlineSourcesContentConfig {
-            inline_sources_content,
+            // If we are going to adjust the source map, we are going to throw the source contents
+            // of this source map away regardless.
+            //
+            // In other words, we don't need the content of `B` in source map chain of A -> B -> C.
+            // We only need the source content of `A`, and a way to map the content of `B` back to
+            // `A`, while constructing the final source map, `C`.
+            inline_sources_content: inline_sources_content && input_map.is_none(),
         },
     );
 


### PR DESCRIPTION
### What?

Disable `inline_sources_content` of SWC source map generator for `minify()`.

### Why?

Regardless, it's the wrong value from the user's perspective, so we cannot use it anyway.


build_sourcemap will fill the sourcemap with the content provided by the value passed to cm.new_source_file at https://github.com/vercel/next.js/blob/bcd799fc688fc3b1535150e24c6057033e29bf3c/turbopack/crates/turbopack-ecmascript/src/minify.rs#L41-L44
>
but for minify(), it's not the input string (written by the user) but it's a codegen-ed string.


Also, `sourcemap::SourceMap::adjust_mappings` says

> /// This function assumes that `adjustment` contains no relevant information except for mappings.
> ///  All information about sources and names is copied from `self`.

so we do not need inline source contents regardless if we are going to call it.

Closes PACK-4609