### PR TITLE
bugfix (pages): assetPrefix should not cause hard nav in development

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -334,9 +334,10 @@ export async function initialize(opts: {
         // so that the development bundler can find the correct file
         if (config.basePath && pathHasPrefix(origUrl, config.basePath)) {
           req.url = removePathPrefix(origUrl, config.basePath)
-        }
-
-        if (config.assetPrefix && pathHasPrefix(origUrl, config.assetPrefix)) {
+        } else if (
+          config.assetPrefix &&
+          pathHasPrefix(origUrl, config.assetPrefix)
+        ) {
           req.url = removePathPrefix(origUrl, config.assetPrefix)
         }
 
@@ -379,9 +380,10 @@ export async function initialize(opts: {
 
         if (config.basePath && pathHasPrefix(origUrl, config.basePath)) {
           req.url = removePathPrefix(origUrl, config.basePath)
-        }
-
-        if (config.assetPrefix && pathHasPrefix(origUrl, config.assetPrefix)) {
+        } else if (
+          config.assetPrefix &&
+          pathHasPrefix(origUrl, config.assetPrefix)
+        ) {
           req.url = removePathPrefix(origUrl, config.assetPrefix)
         }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -327,11 +327,19 @@ export async function initialize(opts: {
         if (blockCrossSite(req, res, config.allowedDevOrigins, opts.hostname)) {
           return
         }
+
         const origUrl = req.url || '/'
 
+        // both the basePath and assetPrefix need to be stripped from the URL
+        // so that the development bundler can find the correct file
         if (config.basePath && pathHasPrefix(origUrl, config.basePath)) {
           req.url = removePathPrefix(origUrl, config.basePath)
         }
+
+        if (config.assetPrefix && pathHasPrefix(origUrl, config.assetPrefix)) {
+          req.url = removePathPrefix(origUrl, config.assetPrefix)
+        }
+
         const parsedUrl = url.parse(req.url || '/')
 
         const hotReloaderResult = await developmentBundler.hotReloader.run(
@@ -343,6 +351,7 @@ export async function initialize(opts: {
         if (hotReloaderResult.finished) {
           return hotReloaderResult
         }
+
         req.url = origUrl
       }
 
@@ -370,6 +379,10 @@ export async function initialize(opts: {
 
         if (config.basePath && pathHasPrefix(origUrl, config.basePath)) {
           req.url = removePathPrefix(origUrl, config.basePath)
+        }
+
+        if (config.assetPrefix && pathHasPrefix(origUrl, config.assetPrefix)) {
+          req.url = removePathPrefix(origUrl, config.assetPrefix)
         }
 
         if (resHeaders) {

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -189,8 +189,21 @@ export function getResolveRoutes(
         parsedUrl.pathname || '',
         config.basePath
       )
+      let normalizedPath = parsedUrl.pathname || '/'
+
+      if (config.basePath && pathHasPrefix(normalizedPath, config.basePath)) {
+        normalizedPath = removePathPrefix(normalizedPath, config.basePath)
+      }
+
+      if (
+        config.assetPrefix &&
+        pathHasPrefix(normalizedPath, config.assetPrefix)
+      ) {
+        normalizedPath = removePathPrefix(normalizedPath, config.assetPrefix)
+      }
+
       initialLocaleResult = normalizeLocalePath(
-        removePathPrefix(parsedUrl.pathname || '/', config.basePath),
+        normalizedPath,
         config.i18n.locales
       )
 

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -193,9 +193,7 @@ export function getResolveRoutes(
 
       if (config.basePath && pathHasPrefix(normalizedPath, config.basePath)) {
         normalizedPath = removePathPrefix(normalizedPath, config.basePath)
-      }
-
-      if (
+      } else if (
         config.assetPrefix &&
         pathHasPrefix(normalizedPath, config.assetPrefix)
       ) {

--- a/test/development/basic/asset-prefix/asset-prefix.test.ts
+++ b/test/development/basic/asset-prefix/asset-prefix.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { check, retry } from 'next-test-utils'
 
 describe('asset-prefix', () => {
   const { next } = nextTestSetup({
@@ -11,7 +11,7 @@ describe('asset-prefix', () => {
     const browser = await next.browser('/')
     await browser.eval(`window.__v = 1`)
 
-    expect(await browser.elementByCss('div').text()).toBe('Hello World')
+    expect(await browser.elementByCss('#text').text()).toBe('Hello World')
 
     await check(async () => {
       const logs = await browser.log()
@@ -21,6 +21,16 @@ describe('asset-prefix', () => {
       return hasError ? 'error' : 'success'
     }, 'success')
 
+    expect(await browser.eval(`window.__v`)).toBe(1)
+  })
+
+  it('should navigate to another page without hard navigating', async () => {
+    const browser = await next.browser('/')
+    await browser.eval(`window.__v = 1`)
+    await browser.elementByCss('[href="/page2"]').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('div').text()).toBe('Page 2')
+    })
     expect(await browser.eval(`window.__v`)).toBe(1)
   })
 

--- a/test/development/basic/asset-prefix/fixture/next.config.js
+++ b/test/development/basic/asset-prefix/fixture/next.config.js
@@ -1,4 +1,4 @@
-const ASSET_PREFIX = 'custom-asset-prefix'
+const ASSET_PREFIX = '/custom-asset-prefix'
 
 module.exports = {
   assetPrefix: ASSET_PREFIX,

--- a/test/development/basic/asset-prefix/fixture/pages/index.js
+++ b/test/development/basic/asset-prefix/fixture/pages/index.js
@@ -1,5 +1,11 @@
+import Link from 'next/link'
 import React from 'react'
 
 export default function Page() {
-  return <div>Hello World</div>
+  return (
+    <>
+      <div id="text">Hello World</div>
+      <Link href="/page2">Page 2</Link>
+    </>
+  )
 }

--- a/test/development/basic/asset-prefix/fixture/pages/page2.js
+++ b/test/development/basic/asset-prefix/fixture/pages/page2.js
@@ -1,0 +1,3 @@
+export default function Page2() {
+  return <div>Page 2</div>
+}


### PR DESCRIPTION
In development when handling the page request, we are sending the parsedUrl with the basePath stripped but not assetPrefix. As a result, when setting an assetPrefix, the chunk would 404 which causes a hard nav. It'd then recover and work correctly on subsequent navs.

This applies the exact same handling we had for basePath, but for assetPrefix.

Fixes #77241