### PR TITLE
fix: replaceIdentifiersInAst takes an expression, not a string

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1935,7 +1935,12 @@ export async function copy_vendor_react(task_) {
           const ast = parseFile(source, { sourceFileName: filepath })
           replaceIdentifiersInAst(
             ast,
-            new Map([['__turbopack_load__', '__turbopack_load_by_url__']])
+            new Map([
+              [
+                '__turbopack_load__',
+                parseExpression('__turbopack_load_by_url__'),
+              ],
+            ])
           )
           file.data = recast.print(ast).code
         } else if (


### PR DESCRIPTION
missed this one in #78916. Weirdly enough the replacement seems to be working fine -- i guess something in recast was parsing the string (i.e. `path.replace("__turbopack_load_by_url__")` worked somehow). but that's not allowed according to recast's types, so we shouldn't rely on that.