### PR TITLE
Prettier ignore changeset's format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@ packages/next/wasm/@next
 packages/next/errors.json
 
 .github/actions/next-stats-action/.work
+.changeset/*.md
 
 crates/**/tests/**/output*
 crates/core/tests/loader/issue-32553/input.js


### PR DESCRIPTION
### Why?

When adding changesets via the changeset/bot, it uses double quotes, which fails lint. The lint is not really important for changesets, so ignore running prettier for `.changeset/*.md`.

![CleanShot 2025-05-14 at 14 26 17@2x](https://github.com/user-attachments/assets/5371209d-e9d1-4627-840c-0615b1e2923e)

https://github.com/vercel/next.js/actions/runs/15020159472/job/42207301914?pr=79193#step:34:45