### PR TITLE
Always pass implicit/soft tags into the `CacheHandler.get` method

### DIFF
--- a/.changeset/lovely-bulldogs-dress.md
+++ b/.changeset/lovely-bulldogs-dress.md
@@ -1,0 +1,5 @@
+---
+"next": patch
+---
+
+Always pass implicit/soft tags into the `CacheHandler.get` method

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -744,15 +744,10 @@ export function cache(
 
         let entry = shouldForceRevalidate(workStore, workUnitStore)
           ? undefined
-          : 'getExpiration' in cacheHandler
-            ? await cacheHandler.get(serializedCacheKey)
-            : // Legacy cache handlers require implicit tags to be passed in,
-              // instead of checking their staleness here, as we do for modern
-              // cache handlers (see below).
-              await cacheHandler.get(
-                serializedCacheKey,
-                workUnitStore?.implicitTags?.tags ?? []
-              )
+          : await cacheHandler.get(
+              serializedCacheKey,
+              workUnitStore?.implicitTags?.tags ?? []
+            )
 
         if (entry) {
           const implicitTags = workUnitStore?.implicitTags?.tags ?? []

--- a/test/e2e/app-dir/use-cache-custom-handler/handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/handler.js
@@ -7,9 +7,9 @@ const defaultCacheHandler =
  * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandlerV2}
  */
 const cacheHandler = {
-  async get(cacheKey) {
-    console.log('ModernCustomCacheHandler::get', cacheKey)
-    return defaultCacheHandler.get(cacheKey)
+  async get(cacheKey, softTags) {
+    console.log('ModernCustomCacheHandler::get', cacheKey, softTags)
+    return defaultCacheHandler.get(cacheKey, softTags)
   },
 
   async set(cacheKey, pendingEntry) {

--- a/test/e2e/app-dir/use-cache-custom-handler/legacy-handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/legacy-handler.js
@@ -13,7 +13,7 @@ const cacheHandler = {
       cacheKey,
       JSON.stringify(softTags)
     )
-    return defaultCacheHandler.get(cacheKey)
+    return defaultCacheHandler.get(cacheKey, softTags)
   },
 
   async set(cacheKey, pendingEntry) {

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -28,7 +28,7 @@ describe('use-cache-custom-handler', () => {
     expect(cliOutput).toContain('ModernCustomCacheHandler::refreshTags')
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]{21})","([0-9a-f]{2})+",\[\]\] \[ '_N_T_\/layout', '_N_T_\/page', '_N_T_\/' \]/
     )
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(


### PR DESCRIPTION
This allows a cache handler to check the timestamp of a cache entry against the latest expiration of the given soft tags, and discarding the entry if it's stale. Subsequently, it does not need to consult a potentially separate tags service to retrieve a value in the `CacheHandler.getExpiration` call for those tags, so that Next.js could handle the expiration check. It can return `Infinity` instead.