### PR TITLE
perf(turbopack): Use `Byte::from_static` when possible

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -181,7 +181,7 @@ impl RopeBuilder {
         self.finish();
 
         self.length += bytes.len();
-        self.committed.push(Local(bytes.into()));
+        self.committed.push(Local(Bytes::from_static(bytes)));
     }
 
     /// Concatenate another Rope instance into our builder.
@@ -323,7 +323,7 @@ impl Uncommitted {
     fn finish(&mut self) -> Option<Bytes> {
         match mem::take(self) {
             Self::None => None,
-            Self::Static(s) => Some(s.into()),
+            Self::Static(s) => Some(Bytes::from_static(s)),
             Self::Owned(mut v) => {
                 v.shrink_to_fit();
                 Some(v.into())


### PR DESCRIPTION
### What?

Use the `Bytes::from_static` method, which does not allocate at all. As the lifetime dispatch is unsound, `Bytes as From<&[u8]>` is very unlikely to be able to optimize it as `Bytes::from_static`.

### Why?

x-ref: Numbers at https://vercel.slack.com/archives/C06PPGZ0FD3/p1747238443434299?thread_ts=1746834549.272939&cid=C06PPGZ0FD3



Closes PACK-4611