### PR TITLE
perf(turbopack): Implement `ShrinkToFit` for `AutoMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "rustc-hash 2.1.1",
  "serde",
+ "shrink-to-fit",
  "smallvec",
 ]
 
@@ -6985,6 +6986,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "939a4c696178684fc5fc1426625b882805418bbb56e056d21f9d4946a9d6ff51"
 dependencies = [
+ "hashbrown 0.15.2",
  "indexmap 2.7.1",
  "serde_json",
  "shrink-to-fit-macro",

--- a/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
@@ -13,3 +13,4 @@ hashbrown = { workspace = true, features = ["serde"]}
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 smallvec = { workspace = true }
+shrink-to-fit = { workspace = true, features = ["hashbrown"] }

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -911,10 +911,10 @@ where
         match self {
             AutoMap::List(list) => list.shrink_to_fit(),
             AutoMap::Map(map) => {
-                hashbrown::HashMap::shrink_to_fit(map);
-
                 if map.len() < MIN_HASH_SIZE {
                     self.convert_to_list();
+                } else {
+                    hashbrown::HashMap::shrink_to_fit(map);
                 }
             }
         }

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -12,6 +12,7 @@ use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeMap,
 };
+use shrink_to_fit::ShrinkToFit;
 use smallvec::SmallVec;
 
 use crate::{MAX_LIST_SIZE, MIN_HASH_SIZE};
@@ -900,6 +901,21 @@ where
     }
 }
 
+impl<K, V, H, const I: usize> ShrinkToFit for AutoMap<K, V, H, I>
+where
+    K: Eq + Hash,
+    V: Eq,
+    H: BuildHasher + Default,
+{
+    fn shrink_to_fit(&mut self) {
+        match self {
+            AutoMap::List(list) => list.shrink_to_fit(),
+            AutoMap::Map(map) => {
+                hashbrown::HashMap::shrink_to_fit(map);
+            }
+        }
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -908,14 +908,14 @@ where
     H: BuildHasher + Default,
 {
     fn shrink_to_fit(&mut self) {
+        if self.len() < MIN_HASH_SIZE {
+            self.convert_to_list();
+        }
+
         match self {
             AutoMap::List(list) => list.shrink_to_fit(),
             AutoMap::Map(map) => {
-                if map.len() < MIN_HASH_SIZE {
-                    self.convert_to_list();
-                } else {
-                    hashbrown::HashMap::shrink_to_fit(map);
-                }
+                hashbrown::HashMap::shrink_to_fit(map);
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -912,6 +912,10 @@ where
             AutoMap::List(list) => list.shrink_to_fit(),
             AutoMap::Map(map) => {
                 hashbrown::HashMap::shrink_to_fit(map);
+
+                if map.len() < MIN_HASH_SIZE {
+                    self.convert_to_list();
+                }
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
@@ -6,6 +6,7 @@ use std::{
 
 use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
+use shrink_to_fit::ShrinkToFit;
 
 use crate::AutoMap;
 
@@ -237,6 +238,16 @@ where
 {
     fn from(array: [K; N]) -> Self {
         Self::from_iter(array)
+    }
+}
+
+impl<K, H, const I: usize> ShrinkToFit for AutoSet<K, H, I>
+where
+    K: Eq + Hash,
+    H: BuildHasher + Default,
+{
+    fn shrink_to_fit(&mut self) {
+        self.map.shrink_to_fit();
     }
 }
 


### PR DESCRIPTION
### What?

Implement `ShrinkToFit` for `AutoMap`, which can be used in a `Vc`

### Why?

For consistency and to reduce max RSS

Closes PACK-4622