### PR TITLE
perf(turbopack): Drop AST node before generating source maps

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1123,6 +1123,7 @@ async fn emit_content(content: CodeGenResult) -> Result<Vc<EcmascriptModuleConte
         };
 
         emitter.emit_program(&program)?;
+        drop(program);
     }
 
     let source_map = if generate_source_map {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1123,6 +1123,7 @@ async fn emit_content(content: CodeGenResult) -> Result<Vc<EcmascriptModuleConte
         };
 
         emitter.emit_program(&program)?;
+        // Drop the AST eagerly so we don't keep it in memory while generating source maps
         drop(program);
     }
 


### PR DESCRIPTION
### What?

Source map generation uses lots of memory, so drop another memory hog before performing it.

For `minify()`, we were already doing it, although it seems unintentional.

### Why?

x-ref: Numbers in https://vercel.slack.com/archives/C06PPGZ0FD3/p1747245989125859?thread_ts=1746834549.272939&cid=C06PPGZ0FD3

Closes PACK-4614