### PR TITLE
Reland: Fix false-positive `"use cache"` misplacement error

### DIFF
--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -40,8 +40,8 @@ pub async fn get_server_actions_transform_rule(
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            prepend: ResolvedVc::cell(vec![transformer]),
+            append: ResolvedVc::cell(vec![]),
         }],
     ))
 }

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1539,6 +1539,9 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                     }
                                 }
                             }
+                            Decl::TsInterface(_) => {}
+                            Decl::TsTypeAlias(_) => {}
+                            Decl::TsEnum(_) => {}
                             _ => {
                                 disallowed_export_span = *span;
                             }
@@ -1661,6 +1664,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 }
                             }
                         }
+                        DefaultDecl::TsInterfaceDecl(_) => {}
                         _ => {
                             disallowed_export_span = *span;
                         }

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -538,18 +538,26 @@ fn next_font_loaders_fixture(input: PathBuf) {
     );
 }
 
-#[fixture("tests/fixture/server-actions/**/input.js")]
+#[fixture("tests/fixture/server-actions/**/input.*")]
 fn server_actions_fixture(input: PathBuf) {
-    let output = input.parent().unwrap().join("output.js");
+    let (input_syntax, extension) = if input.extension() == Some("ts".as_ref()) {
+        (Syntax::Typescript(Default::default()), "ts")
+    } else {
+        (syntax(), "js")
+    };
+
+    let output = input.parent().unwrap().join(format!("output.{extension}"));
     let is_react_server_layer = input.iter().any(|s| s.to_str() == Some("server-graph"));
     let is_development = input.iter().any(|s| s.to_str() == Some("development"));
+
     let mode = if input.iter().any(|s| s.to_str() == Some("turbopack")) {
         ServerActionsMode::Turbopack
     } else {
         ServerActionsMode::Webpack
     };
+
     test_fixture(
-        syntax(),
+        input_syntax,
         &|tr| {
             (
                 resolver(Mark::new(), Mark::new(), false),

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/60/input.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/60/input.ts
@@ -1,0 +1,10 @@
+'use cache'
+
+// Exported TypeScript nodes should be ignored when validating that all module
+// exports are async functions.
+export type T = {}
+export interface I {}
+export enum E {}
+export default interface D {}
+
+export async function Page() {}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/60/output.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/60/output.ts
@@ -1,0 +1,19 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+// Exported TypeScript nodes should be ignored when validating that all module
+// exports are async functions.
+export type T = {
+};
+export interface I {
+}
+export enum E {
+}
+export default interface D {
+}
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, async function Page() {});
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
+    value: "Page",
+    writable: false
+});
+export var Page = registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/tsconfig.json
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/tsconfig.json
@@ -23,7 +23,7 @@
     "moduleDetection": "force"
   },
   "files": ["./index.ts"], // loads ambient declarations for modules used in tests
-  "include": ["./**/*/input.js", "./**/*/output.js"],
+  "include": ["./**/*/input.*", "./**/*/output.*"],
   "exclude": [
     // FIXME: invalid transformation of hoisted functions (https://github.com/vercel/next.js/issues/57392)
     "./server-graph/25/output.js",

--- a/test/development/app-dir/use-cache-errors/app/client-module.ts
+++ b/test/development/app-dir/use-cache-errors/app/client-module.ts
@@ -1,0 +1,5 @@
+'use client'
+
+export function useStuff() {
+  return 'stuff'
+}

--- a/test/development/app-dir/use-cache-errors/app/layout.tsx
+++ b/test/development/app-dir/use-cache-errors/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/use-cache-errors/app/module-with-use-cache.ts
+++ b/test/development/app-dir/use-cache-errors/app/module-with-use-cache.ts
@@ -1,0 +1,17 @@
+'use cache'
+
+// This file simulates adding a "use cache" directive to a client module that's
+// mistaken as a server module. It does not have itself a "use client"
+// directive, but is imported by a client module with a "use client" directive,
+// while also importing another client module with a "use client" directive.
+// Adding the "use cache" directive here, effectively forces the module to be a
+// server module, which then results in an error when trying to call the client
+// function.
+
+import { useStuff } from './client-module'
+
+export async function useCachedStuff() {
+  // Intentional misusage (using hooks in async functions).
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useStuff()
+}

--- a/test/development/app-dir/use-cache-errors/app/page.tsx
+++ b/test/development/app-dir/use-cache-errors/app/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useActionState } from 'react'
+import { useCachedStuff } from './module-with-use-cache'
+
+function OtherClientComponent({
+  getCachedStuff,
+}: {
+  getCachedStuff: () => Promise<string>
+}) {
+  const [result, formAction] = useActionState(getCachedStuff, null)
+
+  return (
+    <form action={formAction}>
+      <button id="action-button">Submit</button>
+      <p>{result}</p>
+    </form>
+  )
+}
+
+export default function Page() {
+  return <OtherClientComponent getCachedStuff={useCachedStuff} />
+}

--- a/test/development/app-dir/use-cache-errors/next.config.js
+++ b/test/development/app-dir/use-cache-errors/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    useCache: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
+++ b/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
@@ -1,0 +1,56 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox } from '../../../lib/next-test-utils'
+
+describe('use-cache-errors', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not show a false-positive compiler error about a misplaced "use cache" directive', async () => {
+    // This is a regression test to ensure that an injected React Refresh
+    // statement (`var _s = __turbopack_context__.k.signature`) does not
+    // interfere with our "use cache" directive misplacement detection.
+    const browser = await next.browser('/')
+    await assertNoRedbox(browser)
+  })
+
+  it('should show a runtime error when calling the incorrectly used cache function', async () => {
+    const browser = await next.browser('/')
+    await browser.elementById('action-button').click()
+
+    if (isTurbopack) {
+      // TODO(veil): The wrong stack frame is used for the source snippet.
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Attempted to call useStuff() from the server but useStuff is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.",
+         "environmentLabel": "Cache",
+         "label": "Runtime Error",
+         "source": "app/page.tsx (22:10) @ Page
+       > 22 |   return <OtherClientComponent getCachedStuff={useCachedStuff} />
+            |          ^",
+         "stack": [
+           "<FIXME-file-protocol>",
+           "<FIXME-file-protocol>",
+           "Page app/page.tsx (22:10)",
+         ],
+       }
+      `)
+    } else {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Attempted to call useStuff() from the server but useStuff is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.",
+         "environmentLabel": "Cache",
+         "label": "Runtime Error",
+         "source": "app/module-with-use-cache.ts (16:18) @ useCachedStuff
+       > 16 |   return useStuff()
+            |                  ^",
+         "stack": [
+           "<FIXME-file-protocol>",
+           "useCachedStuff app/module-with-use-cache.ts (16:18)",
+           "Page app/page.tsx (22:10)",
+         ],
+       }
+      `)
+    }
+  })
+})


### PR DESCRIPTION
_Relanding #79151, now ignoring TS AST nodes when checking whether all exported module items are async functions._

This fixes an error where we incorrectly showed the following compiler error when using Turbopack:

```sh
Ecmascript file had an error
> 1 | 'use cache'
    | ^^^^^^^^^^^
  2 |
  3 | import { useStuff } from './client-module'
  4 |

The "use cache" directive must be at the top of the file.
```

The directive was regarded as not being at the top of the file, because the React transform (`EcmascriptInputTransform::React`) injects a variable declaration for React Refresh (e.g. `var _s = __turbopack_context__.k.signature`) at the top of the file, before the `"use cache"` directive.

We can fix this by ensuring that the server action transform (should really be called "server _function_ transform") runs first.

As a consequence, the transform now needs to be able to parse JSX AST nodes, which was already explicitly implemented.

closes NAR-130

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
