### PR TITLE
Rename `define-env-plugin.ts` to `define-env.ts`

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -1,21 +1,17 @@
-import type {
-  I18NDomains,
-  NextConfigComplete,
-} from '../../../server/config-shared'
-import type { MiddlewareMatcher } from '../../analysis/get-page-static-info'
-import { needsExperimentalReact } from '../../../lib/needs-experimental-react'
-import { checkIsAppPPREnabled } from '../../../server/lib/experimental/ppr'
+import type { I18NDomains, NextConfigComplete } from '../server/config-shared'
+import type { MiddlewareMatcher } from './analysis/get-page-static-info'
+import { needsExperimentalReact } from '../lib/needs-experimental-react'
+import { checkIsAppPPREnabled } from '../server/lib/experimental/ppr'
 import {
   getNextConfigEnv,
   getNextPublicEnvironmentVariables,
-} from '../../../lib/static-env'
-import getWebpackBundler from '../../../shared/lib/get-webpack-bundler'
+} from '../lib/static-env'
 
 type BloomFilter = ReturnType<
-  import('../../../shared/lib/bloom-filter').BloomFilter['export']
+  import('../shared/lib/bloom-filter').BloomFilter['export']
 >
 
-export interface DefineEnvPluginOptions {
+export interface DefineEnvOptions {
   isTurbopack: boolean
   clientRouterFilters?: {
     staticFilter: BloomFilter
@@ -102,7 +98,7 @@ export function getDefineEnv({
   isNodeServer,
   middlewareMatchers,
   omitNonDeterministic,
-}: DefineEnvPluginOptions): SerializedDefineEnv {
+}: DefineEnvOptions): SerializedDefineEnv {
   const nextPublicEnv = getNextPublicEnvironmentVariables()
   const nextConfigEnv = getNextConfigEnv(config)
 
@@ -319,8 +315,4 @@ export function getDefineEnv({
   }
 
   return serializedDefineEnv
-}
-
-export function getDefineEnvPlugin(options: DefineEnvPluginOptions) {
-  return new (getWebpackBundler().DefinePlugin)(getDefineEnv(options))
 }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -16,10 +16,7 @@ import type {
   TurbopackRuleConfigItemOrShortcut,
 } from '../../server/config-shared'
 import { isDeepStrictEqual } from 'util'
-import {
-  type DefineEnvPluginOptions,
-  getDefineEnv,
-} from '../webpack/plugins/define-env-plugin'
+import { type DefineEnvOptions, getDefineEnv } from '../define-env'
 import { getReactCompilerLoader } from '../get-babel-loader-config'
 import type {
   NapiPartialProjectOptions,
@@ -393,7 +390,7 @@ export function createDefineEnv({
   hasRewrites,
   middlewareMatchers,
 }: Omit<
-  DefineEnvPluginOptions,
+  DefineEnvOptions,
   'isClient' | 'isNodeOrEdgeCompilation' | 'isEdgeServer' | 'isNodeServer'
 >): DefineEnv {
   let defineEnv: DefineEnv = {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -5,6 +5,7 @@ import crypto from 'crypto'
 import { webpack } from 'next/dist/compiled/webpack/webpack'
 import path from 'path'
 
+import { getDefineEnv } from './define-env'
 import { escapeStringRegexp } from '../shared/lib/escape-regexp'
 import { WEBPACK_LAYERS, WEBPACK_RESOURCE_QUERIES } from '../lib/constants'
 import type { WebpackLayerName } from '../lib/constants'
@@ -68,7 +69,6 @@ import { getSupportedBrowsers } from './utils'
 import { MemoryWithGcCachePlugin } from './webpack/plugins/memory-with-gc-cache-plugin'
 import { getBabelConfigFile } from './get-babel-config-file'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
-import { getDefineEnvPlugin } from './webpack/plugins/define-env-plugin'
 import type { SWCLoaderOptions } from './webpack/loaders/next-swc-loader'
 import { isResourceInPackages, makeExternalHandler } from './handle-externals'
 import {
@@ -1925,20 +1925,23 @@ export default async function getBaseWebpackConfig(
           // Avoid process being overridden when in web run time
           ...(isClient && { process: [require.resolve('process')] }),
         }),
-      getDefineEnvPlugin({
-        isTurbopack: false,
-        config,
-        dev,
-        distDir,
-        fetchCacheKeyPrefix,
-        hasRewrites,
-        isClient,
-        isEdgeServer,
-        isNodeOrEdgeCompilation,
-        isNodeServer,
-        middlewareMatchers,
-        omitNonDeterministic: isCompileMode,
-      }),
+
+      new (getWebpackBundler().DefinePlugin)(
+        getDefineEnv({
+          isTurbopack: false,
+          config,
+          dev,
+          distDir,
+          fetchCacheKeyPrefix,
+          hasRewrites,
+          isClient,
+          isEdgeServer,
+          isNodeOrEdgeCompilation,
+          isNodeServer,
+          middlewareMatchers,
+          omitNonDeterministic: isCompileMode,
+        })
+      ),
       isClient &&
         new ReactLoadablePlugin({
           filename: REACT_LOADABLE_MANIFEST,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -31,7 +31,6 @@ import {
   EVENT_BUILD_FEATURE_USAGE,
   eventCliSession,
 } from '../../../telemetry/events'
-import { getDefineEnv } from '../../../build/webpack/plugins/define-env-plugin'
 import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import {
   getStaticInfoIncludingLayouts,
@@ -83,6 +82,7 @@ import {
   ModuleBuildError,
   TurbopackInternalError,
 } from '../../../shared/lib/turbopack/utils'
+import { getDefineEnv } from '../../../build/define-env'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance


### PR DESCRIPTION
This code is by both webpack and Turbopack, but was in a file called `packages/next/src/build/webpack/plugins/define-env-plugin.ts`, and the actual webpack plugin code was only a single line by a single caller.

This renames the file to `packages/next/src/build/define-env.ts` and inlines the actual webpack plugin construction into the webpack config building code.


Closes PACK-4618