### PR TITLE
next.config.ts: Implement `compiler.defineServer` for server-only constants

### DIFF
--- a/docs/03-architecture/nextjs-compiler.mdx
+++ b/docs/03-architecture/nextjs-compiler.mdx
@@ -265,14 +265,17 @@ This option has been superseded by [`optimizePackageImports`](/docs/app/api-refe
 The `define` option allows you to statically replace variables in your code at build-time.
 The option takes an object as key-value pairs, where the keys are the variables that should be replaced with the corresponding values.
 
-Use the `compiler.define` field in `next.config.js`:
+Use the `compiler.define` field in `next.config.js` to define variables for all environments (server, edge, and client). Or, use `compiler.defineServer` to define variables only for server-side (server and edge) code:
 
 ```js filename="next.config.js"
 module.exports = {
   compiler: {
     define: {
-      MY_STRING_VARIABLE: JSON.stringify('my-string'),
-      MY_NUMBER_VARIABLE: '42',
+      MY_VARIABLE: 'my-string',
+      'process.env.MY_ENV_VAR': 'my-env-var',
+    },
+    defineServer: {
+      MY_SERVER_VARIABLE: 'my-server-var',
     },
   },
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -680,5 +680,7 @@
   "679": "A CacheSignal cannot subscribe to itself",
   "680": "CacheSignal cannot be used in the edge runtime, because `dynamicIO` does not support it.",
   "681": "Dynamic imports should not be instrumented in the edge runtime, because `dynamicIO` doesn't support it",
-  "682": "\\`experimental.ppr\\` can not be \\`%s\\` when \\`experimental.dynamicIO\\` is \\`true\\`. PPR is implicitly enabled when Dynamic IO is enabled."
+  "682": "\\`experimental.ppr\\` can not be \\`%s\\` when \\`experimental.dynamicIO\\` is \\`true\\`. PPR is implicitly enabled when Dynamic IO is enabled.",
+  "683": "The \\`compiler.define\\` option is configured to replace the \\`%s\\` variable. This variable is either part of a Next.js built-in or is already configured.",
+  "684": "The \\`compiler.defineServer\\` option is configured to replace the \\`%s\\` variable. This variable is either part of a Next.js built-in or is already configured."
 }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -411,7 +411,6 @@ export function createDefineEnv({
         hasRewrites,
         isClient: variant === 'client',
         isEdgeServer: variant === 'edge',
-        isNodeOrEdgeCompilation: variant === 'nodejs' || variant === 'edge',
         isNodeServer: variant === 'nodejs',
         middlewareMatchers,
       })

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1937,7 +1937,6 @@ export default async function getBaseWebpackConfig(
           hasRewrites,
           isClient,
           isEdgeServer,
-          isNodeOrEdgeCompilation,
           isNodeServer,
           middlewareMatchers,
           omitNonDeterministic: isCompileMode,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -270,6 +270,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
           }),
         ]),
         define: z.record(z.string(), z.string()).optional(),
+        defineServer: z.record(z.string(), z.string()).optional(),
         runAfterProductionCompile: z
           .function()
           .returns(z.promise(z.void()))

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1086,6 +1086,12 @@ export interface NextConfig extends Record<string, any> {
     define?: Record<string, string>
 
     /**
+     * Replaces server-only (Node.js and Edge) variables in your code during compile time.
+     * Each key will be replaced with the respective values.
+     */
+    defineServer?: Record<string, string>
+
+    /**
      * A hook function that executes after production build compilation finishes,
      * but before running post-compilation tasks such as type checking and
      * static page generation.

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -738,7 +738,6 @@ async function startWatcher(opts: SetupOpts) {
                   hasRewrites,
                   isClient,
                   isEdgeServer,
-                  isNodeOrEdgeCompilation: isNodeServer || isEdgeServer,
                   isNodeServer,
                   middlewareMatchers: undefined,
                 })

--- a/test/e2e/define/app/client-component.js
+++ b/test/e2e/define/app/client-component.js
@@ -6,3 +6,13 @@ export function ClientValue() {
     <>{typeof MY_MAGIC_VARIABLE === 'string' ? MY_MAGIC_VARIABLE : 'not set'}</>
   )
 }
+
+export function ClientExpr() {
+  return (
+    <>
+      {typeof process.env.MY_MAGIC_EXPR === 'string'
+        ? process.env.MY_MAGIC_EXPR
+        : 'not set'}
+    </>
+  )
+}

--- a/test/e2e/define/app/with-server-only/client-component.js
+++ b/test/e2e/define/app/with-server-only/client-component.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-undef */
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export function ClientValue() {
+  const [serverVar, setServerVar] = useState('<loading>')
+  // Use `useEffect` to only evaluate this in the actual browser as client
+  // components are still SSRed
+  useEffect(() => {
+    setServerVar(
+      typeof MY_SERVER_VARIABLE === 'string' ? MY_SERVER_VARIABLE : 'not set'
+    )
+  }, [setServerVar])
+
+  return <>{serverVar}</>
+}
+
+export function ClientExpr() {
+  const [serverExpr, setServerExpr] = useState('<loading>')
+  useEffect(() => {
+    setServerExpr(
+      typeof process.env.MY_MAGIC_SERVER_EXPR === 'string'
+        ? process.env.MY_MAGIC_SERVER_EXPR
+        : 'not set'
+    )
+  }, [setServerExpr])
+
+  return <>{serverExpr}</>
+}

--- a/test/e2e/define/app/with-server-only/page.js
+++ b/test/e2e/define/app/with-server-only/page.js
@@ -6,15 +6,17 @@ export default function Page() {
     <ul>
       <li>
         Server value:{' '}
-        {typeof MY_MAGIC_VARIABLE === 'string' ? MY_MAGIC_VARIABLE : 'not set'}
+        {typeof MY_SERVER_VARIABLE === 'string'
+          ? MY_SERVER_VARIABLE
+          : 'not set'}
       </li>
       <li>
         Client value: <ClientValue />
       </li>
       <li>
         Server expr:{' '}
-        {typeof process.env.MY_MAGIC_EXPR === 'string'
-          ? process.env.MY_MAGIC_EXPR
+        {typeof process.env.MY_MAGIC_SERVER_EXPR === 'string'
+          ? process.env.MY_MAGIC_SERVER_EXPR
           : 'not set'}
       </li>
       <li>

--- a/test/e2e/define/define.test.ts
+++ b/test/e2e/define/define.test.ts
@@ -5,17 +5,55 @@ describe('compiler.define', () => {
     files: __dirname,
   })
 
-  it('should render the magic variable on server side', async () => {
-    const res = await next.fetch('/')
-    const html = (await res.text()).replaceAll(/<!-- -->/g, '')
-    expect(html).toContain('Server value: foobar')
-    expect(html).toContain('Client value: foobar')
+  describe('compiler.define', () => {
+    let loadedText
+    beforeEach(async () => {
+      let browser = await next.browser('/')
+      loadedText = await browser.elementByCss('body').text()
+    })
+
+    it('should render the magic variable on server side', async () => {
+      expect(loadedText).toContain('Server value: foobar')
+      expect(loadedText).toContain('Client value: foobar')
+    })
+
+    it('should render the magic variable on client side', async () => {
+      expect(loadedText).toContain('Server value: foobar')
+      expect(loadedText).toContain('Client value: foobar')
+    })
+
+    it('should render the magic expression on server side', async () => {
+      expect(loadedText).toContain('Server expr: barbaz')
+      expect(loadedText).toContain('Client expr: barbaz')
+    })
+
+    it('should render the magic expression on client side', async () => {
+      expect(loadedText).toContain('Server expr: barbaz')
+      expect(loadedText).toContain('Client expr: barbaz')
+    })
   })
 
-  it('should render the magic variable on client side', async () => {
-    const browser = await next.browser('/')
-    const text = await browser.elementByCss('body').text()
-    expect(text).toContain('Server value: foobar')
-    expect(text).toContain('Client value: foobar')
+  describe('compiler.defineServer', () => {
+    let loadedText
+    beforeEach(async () => {
+      let browser = await next.browser('/with-server-only')
+      loadedText = await browser.elementByCss('body').text()
+    })
+
+    it('should render the inlined variable on server side', async () => {
+      expect(loadedText).toContain('Server value: server')
+    })
+
+    it('should not render the inlined variable on client side', async () => {
+      expect(loadedText).toContain('Client value: not set')
+    })
+
+    it('should render the inlined expression on server side', async () => {
+      expect(loadedText).toContain('Server expr: serverbarbaz')
+    })
+
+    it('should not render the inlined expression on client side', async () => {
+      expect(loadedText).toContain('Client expr: not set')
+    })
   })
 })

--- a/test/e2e/define/next.config.js
+++ b/test/e2e/define/next.config.js
@@ -2,6 +2,11 @@ module.exports = {
   compiler: {
     define: {
       MY_MAGIC_VARIABLE: 'foobar',
+      'process.env.MY_MAGIC_EXPR': 'barbaz',
+    },
+    defineServer: {
+      MY_SERVER_VARIABLE: 'server',
+      'process.env.MY_MAGIC_SERVER_EXPR': 'serverbarbaz',
     },
   },
 }


### PR DESCRIPTION
Like `compiler.define`, this allows users to create compile-time constants both Turbopack and webpack from a single API. `compiler.defineServer` instead only makes these constants available for server or edge environments, not the client environment.

Part of PACK-4075

Closes PACK-4637