### PR TITLE
better types in next-swc-loader

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -677,5 +677,6 @@
   "676": "Invariant: missing internal router-server-methods this is an internal bug",
   "677": "`trackDynamicImport` should always receive a promise. Something went wrong in the dynamic imports transform.",
   "678": "CacheSignal got more endRead() calls than beginRead() calls",
-  "679": "A CacheSignal cannot subscribe to itself"
+  "679": "A CacheSignal cannot subscribe to itself",
+  "680": "Reading the file from the filesystem is not supported by the WASM bindings."
 }

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -25,7 +25,7 @@ export interface Binding {
   }
   minify(src: string, options: any): Promise<any>
   minifySync(src: string, options: any): any
-  transform(src: string, options: any): Promise<any>
+  transform(src: string | Buffer | undefined, options: any): Promise<any>
   transformSync(src: string, options: any): any
   parse(src: string, options: any): Promise<string>
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -510,6 +510,7 @@ export default async function getBaseWebpackConfig(
             'swc'
           ),
           serverReferenceHashSalt: encryptionKey,
+          nextConfig: config,
 
           // rspack specific options
           pnp: Boolean(process.versions.pnp),


### PR DESCRIPTION
`next-swc-loader` was typed as if it accepted strings despite being marked as `raw = true`, meaning that webpack will actually give it Buffers.
Fixing the types revealed an implicit coercion of the buffer to a string when testing the source for `FORCE_TRANSPILE_CONDITIONS`.

I've also updated the types for `transform()` -- in reality we're passing `string | Buffer | undefined` (and the bindings handle all of those), but this was hidden behind a `transform(source as any)`.