### PR TITLE
Fix dangling promise in unstable-cache

### DIFF
--- a/.changeset/loose-cows-pump.md
+++ b/.changeset/loose-cows-pump.md
@@ -1,0 +1,5 @@
+---
+'next': patch
+---
+
+Fix dangling promise in unstable_cache

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -275,7 +275,14 @@ export function unstable_cache<T extends Callback>(
         )
 
         if (!workStore.isDraftMode) {
-          cacheNewResult(
+          if (!workStore.pendingRevalidates) {
+            workStore.pendingRevalidates = {}
+          }
+
+          // We need to push the cache result promise to pending
+          // revalidates otherwise it won't be awaited and is just
+          // dangling
+          workStore.pendingRevalidates[invocationKey] = cacheNewResult(
             result,
             incrementalCache,
             cacheKey,
@@ -330,7 +337,11 @@ export function unstable_cache<T extends Callback>(
           cb,
           ...args
         )
-        cacheNewResult(
+
+        // we need to wait setting the new cache result here as
+        // we don't have pending revalidates on workStore to
+        // push to and we can't have a dangling promise
+        await cacheNewResult(
           result,
           incrementalCache,
           cacheKey,


### PR DESCRIPTION
While investigating an issue with intermittent `unstable_cache` calls failing to set noticed we have these dangling promises which cause "racey" behavior with setting to a cache in environments where the function stops after the request is finished. 

These have been present since https://github.com/vercel/next.js/commit/b305c2d309b4d4923c3b11f7e258077729ab28fb altho since racey may or may not have been noticed. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1747322956802819?thread_ts=1746633220.634939&cid=C02K2HCH5V4)