### PR TITLE
feat(turbopack) Added sending events to log how long writing entrypoints to disk takes.

### DIFF
--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -19,6 +19,7 @@ import loadConfig from '../../server/config'
 import { hasCustomExportOutput } from '../../export/utils'
 import { Telemetry } from '../../telemetry/storage'
 import { setGlobal } from '../../trace'
+import * as Log from '../output/log'
 
 export async function turbopackBuild(): Promise<{
   duration: number
@@ -87,6 +88,14 @@ export async function turbopackBuild(): Promise<{
     }
   )
   try {
+    ;(async function logCompilationEvents() {
+      for await (const event of project.compilationEventsSubscribe()) {
+        if (event.severity === 'EVENT') {
+          Log.event(event.message)
+        }
+      }
+    })()
+
     // Write an empty file in a known location to signal this was built with Turbopack
     await fs.writeFile(path.join(distDir, 'turbopack'), '')
 

--- a/turbopack/crates/turbo-tasks/src/message_queue.rs
+++ b/turbopack/crates/turbo-tasks/src/message_queue.rs
@@ -17,7 +17,7 @@ type CompilationEventChannel = mpsc::Sender<Arc<dyn CompilationEvent>>;
 
 pub struct CompilationEventQueue {
     event_history: ArcMx<VecDeque<Arc<dyn CompilationEvent>>>,
-    subscribers: DashMap<String, Vec<CompilationEventChannel>>,
+    subscribers: Arc<DashMap<String, Vec<CompilationEventChannel>>>,
 }
 
 impl Default for CompilationEventQueue {
@@ -27,7 +27,7 @@ impl Default for CompilationEventQueue {
 
         Self {
             event_history: Arc::new(Mutex::new(VecDeque::with_capacity(MAX_QUEUE_SIZE))),
-            subscribers,
+            subscribers: Arc::new(subscribers),
         }
     }
 }
@@ -125,6 +125,7 @@ pub enum Severity {
     Warning,
     Error,
     Fatal,
+    Event,
 }
 
 impl Display for Severity {
@@ -135,6 +136,7 @@ impl Display for Severity {
             Severity::Warning => write!(f, "WARNING"),
             Severity::Error => write!(f, "ERROR"),
             Severity::Fatal => write!(f, "FATAL"),
+            Severity::Event => write!(f, "EVENT"),
         }
     }
 }


### PR DESCRIPTION
## Add logging for entrypoint writing in Turbopack build

### What?
This PR adds diagnostic event logging for the entrypoint writing process during Turbopack builds, showing when the process starts and finishes along with timing information.

### Why?
This allows us to better track if we are bound by file IO in terms of performance as the number of cores increases.

### How?
- Added diagnostic events at the start and end of the `project_write_all_entrypoints_to_disk` function
- Added an `Event` severity level to the `Severity` enum to match the `Log` types in Next.js
- Implemented event subscription in the build process to capture and display these events