### PR TITLE
perf(turbopack): Use rayon threadpool for `minify()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10162,6 +10162,7 @@ dependencies = [
  "par-core",
  "parking_lot",
  "petgraph 0.6.3",
+ "rayon",
  "regex",
  "rustc-hash 2.1.1",
  "serde",

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -128,7 +128,7 @@ impl EcmascriptBrowserChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(&code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -194,7 +194,7 @@ impl EcmascriptBrowserEvaluateChunk {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(&code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -44,6 +44,7 @@ turbopack-resolve = { workspace = true }
 turbopack-swc-utils = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
+rayon = { workspace = true }
 
 swc_core = { workspace = true, features = [
   "ecma_ast",

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -31,7 +31,7 @@ use turbopack_core::{
 use crate::parse::generate_js_source_map;
 
 #[instrument(level = Level::INFO, skip_all)]
-pub fn minify(code: &Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
+pub async fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
     let source_maps = source_maps
         .then(|| code.generate_source_map_ref())
         .transpose()?;

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -32,6 +32,17 @@ use crate::parse::generate_js_source_map;
 
 #[instrument(level = Level::INFO, skip_all)]
 pub async fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    rayon::spawn(move || {
+        let result = minify_inner(code, source_maps, mangle);
+        tx.send(result).unwrap();
+    });
+
+    rx.await.unwrap()
+}
+
+fn minify_inner(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
     let source_maps = source_maps
         .then(|| code.generate_source_map_ref())
         .transpose()?;
@@ -139,8 +150,8 @@ pub async fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -
                 src_map_buf,
                 Some(original_map),
                 // We do not inline source contents.
-                // We provide a synthesized value to `cm.new_source_file` above, so it cannot be
-                // the value user expect anyway.
+                // We provide a synthesized value to `cm.new_source_file` above, so it cannot
+                // be the value user expect anyway.
                 false,
             )?),
         );

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -78,7 +78,7 @@ impl EcmascriptBuildNodeChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(&code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())


### PR DESCRIPTION
### What?

Run `minify()` on the `rayon` threadpool instead of the `tokio` threadpool.

### Why?

ES minification is a very CPU-intensive operation, and more importantly, it calls `rayon` internally anyway. So it's better to run it from the rayon thread pool from the start.

It seems like this PR makes the total build ~ 3% faster, at the cost of a small RSS increase.

x-ref: Numbers at https://vercel.slack.com/archives/C06PPGZ0FD3/p1747349799503749?thread_ts=1747349784.352809&cid=C06PPGZ0FD3

Closes PACK-4626