### PR TITLE
Format `examples/` with Biome

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,7 +14,6 @@
 *.scss
 
 # Temporarily continue to format files here until they're covered by Biome
-!examples/**/*
 !packages/create-next-app/**/*
 
 # Build artifacts

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -100,8 +100,11 @@
       "turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js",
       // intentionally does not parse as esm
       "test/integration/eslint/mjs-cjs-linting/pages/index.cjs",
+      // Uses nonstandard/future syntax
+      "examples/with-custom-babel-config",
       // Flow-type files as JS but contain annotations which do not parse
       "test/integration/babel/pages/index.js",
+      "examples/with-flow/",
       // This file is intentionally very large
       "test/integration/api-support/big.json",
       // empty files
@@ -111,7 +114,6 @@
       "test/*-tests-manifest.json",
 
       // biome migration
-      "examples/",
       "packages/create-next-app/"
     ]
   },
@@ -140,5 +142,22 @@
       // Many files that are "json" in the codebase allow comments
       "allowComments": true
     }
-  }
+  },
+  "overrides": [
+    {
+      "include": ["examples/**"],
+      "javascript": {
+        "formatter": {
+          "semicolons": "always",
+          "quoteStyle": "double",
+          "trailingCommas": "all"
+        }
+      },
+      "css": {
+        "formatter": {
+          "quoteStyle": "double"
+        }
+      }
+    }
+  ]
 }

--- a/examples/.prettierrc.json
+++ b/examples/.prettierrc.json
@@ -1,5 +1,3 @@
 {
-  "trailingComma": "all",
-  "singleQuote": false,
-  "semi": true
+  "singleQuote": false
 }

--- a/examples/basic-css/styles.module.css
+++ b/examples/basic-css/styles.module.css
@@ -1,8 +1,5 @@
 .hello {
-  font:
-    15px Helvetica,
-    Arial,
-    sans-serif;
+  font: 15px Helvetica, Arial, sans-serif;
   background: #eee;
   padding: 100px;
   text-align: center;

--- a/examples/blog/styles/main.css
+++ b/examples/blog/styles/main.css
@@ -31,14 +31,8 @@ body {
     "Segoe UI Symbol",
     "Noto Color Emoji";
   -webkit-font-smoothing: subpixel-antialiased;
-  font-feature-settings:
-    "case" 1,
-    "cpsp" 1,
-    "dlig" 1,
-    "cv01" 1,
-    "cv02",
-    "cv03" 1,
-    "cv04" 1;
+  font-feature-settings: "case" 1, "cpsp" 1, "dlig" 1, "cv01" 1, "cv02", "cv03"
+    1, "cv04" 1;
   font-variation-settings: "wght" 450;
   font-variant: common-ligatures contextual;
   letter-spacing: -0.02em;

--- a/examples/cms-buttercms/css/lineicons.css
+++ b/examples/cms-buttercms/css/lineicons.css
@@ -7,11 +7,9 @@ Author: lineicons.com
 @font-face {
   font-family: "LineIcons";
   src: url("fonts/LineIcons.eot");
-  src:
-    url("fonts/LineIcons.eot") format("embedded-opentype"),
-    url("fonts/LineIcons.woff2") format("woff2"),
-    url("fonts/LineIcons.woff") format("woff"),
-    url("fonts/LineIcons.ttf") format("truetype"),
+  src: url("fonts/LineIcons.eot") format("embedded-opentype"),
+    url("fonts/LineIcons.woff2") format("woff2"), url("fonts/LineIcons.woff")
+    format("woff"), url("fonts/LineIcons.ttf") format("truetype"),
     url("fonts/LineIcons.svg") format("svg");
   font-weight: normal;
   font-style: normal;
@@ -21,7 +19,7 @@ Author: lineicons.com
 -------------------------*/
 .lni {
   display: inline-block;
-  font: normal normal normal 1em/1 "LineIcons";
+  font: normal normal normal 1em / 1 "LineIcons";
   color: inherit;
   flex-shrink: 0;
   speak: none;

--- a/examples/cms-buttercms/css/main.css
+++ b/examples/cms-buttercms/css/main.css
@@ -937,11 +937,7 @@ p {
   height: 780px;
   display: flex;
   align-items: center;
-  background: linear-gradient(
-    180deg,
-    #c2fbff 0%,
-    rgba(255, 255, 255, 0) 93.47%
-  );
+  background: linear-gradient(180deg, #c2fbff 0%, rgba(255, 255, 255, 0) 93.47%);
   z-index: 1;
 }
 
@@ -1405,11 +1401,7 @@ p {
 .single-post-nav,
 .blog-roll-nav {
   align-items: center;
-  background: linear-gradient(
-    180deg,
-    #c2fbff 0%,
-    rgba(255, 255, 255, 0) 93.47%
-  );
+  background: linear-gradient(180deg, #c2fbff 0%, rgba(255, 255, 255, 0) 93.47%);
   display: flex;
   height: 400px;
   overflow: hidden;

--- a/examples/cms-buttercms/css/tiny-slider.min.css
+++ b/examples/cms-buttercms/css/tiny-slider.min.css
@@ -49,15 +49,9 @@
 .tns-gallery > .tns-item {
   position: absolute;
   left: -100%;
-  -webkit-transition:
-    transform 0s,
-    opacity 0s;
-  -moz-transition:
-    transform 0s,
-    opacity 0s;
-  transition:
-    transform 0s,
-    opacity 0s;
+  -webkit-transition: transform 0s, opacity 0s;
+  -moz-transition: transform 0s, opacity 0s;
+  transition: transform 0s, opacity 0s;
 }
 .tns-gallery > .tns-slide-active {
   position: relative;

--- a/examples/cms-sitecore-xmcloud/package.json
+++ b/examples/cms-sitecore-xmcloud/package.json
@@ -2,16 +2,11 @@
   "private": true,
   "config": {
     "appName": "xmcloud-nextjs-starter",
-    "rootPlaceholders": [
-      "jss-main"
-    ],
+    "rootPlaceholders": ["jss-main"],
     "sitecoreConfigPath": "/App_Config/Include/zzz",
     "graphQLEndpointPath": "/sitecore/api/graph/edge",
     "language": "en",
-    "templates": [
-      "nextjs",
-      "nextjs-sxa"
-    ]
+    "templates": ["nextjs", "nextjs-sxa"]
   },
   "engines": {
     "node": ">=12",

--- a/examples/cms-sitecore-xmcloud/src/lib/extract-path/index.ts
+++ b/examples/cms-sitecore-xmcloud/src/lib/extract-path/index.ts
@@ -19,7 +19,7 @@ export class PathExtractor {
     }
     let path = Array.isArray(params.path)
       ? params.path.join("/")
-      : params.path ?? "/";
+      : (params.path ?? "/");
 
     // Ensure leading '/'
     if (!path.startsWith("/")) {

--- a/examples/cms-wordpress/src/utils/nextSlugToWpSlug.ts
+++ b/examples/cms-wordpress/src/utils/nextSlugToWpSlug.ts
@@ -1,2 +1,2 @@
 export const nextSlugToWpSlug = (nextSlug: string) =>
-  nextSlug && Array.isArray(nextSlug) ? nextSlug.join("/") : nextSlug ?? "/";
+  nextSlug && Array.isArray(nextSlug) ? nextSlug.join("/") : (nextSlug ?? "/");

--- a/examples/markdoc/next.config.js
+++ b/examples/markdoc/next.config.js
@@ -1,6 +1,7 @@
 const withMarkdoc = require("@markdoc/next.js");
 
-module.exports =
-  withMarkdoc(/* config: https://markdoc.io/docs/nextjs#options */)({
-    pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdoc"],
-  });
+module.exports = withMarkdoc(
+  /* config: https://markdoc.io/docs/nextjs#options */
+)({
+  pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdoc"],
+});

--- a/examples/mdx-remote/app/globals.css
+++ b/examples/mdx-remote/app/globals.css
@@ -12,7 +12,7 @@
 
 html,
 body {
-  font: 100%/1.5 system-ui;
+  font: 100% / 1.5 system-ui;
   max-width: 100vw;
   overflow-x: hidden;
 }

--- a/examples/mdx/app/globals.css
+++ b/examples/mdx/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/mdx/app/page.module.css
+++ b/examples/mdx/app/page.module.css
@@ -51,9 +51,7 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition:
-    background 200ms,
-    border 200ms;
+  transition: background 200ms, border 200ms;
 }
 
 .card span {

--- a/examples/with-apollo/src/app/globals.css
+++ b/examples/with-apollo/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-clerk/styles/Home.module.css
+++ b/examples/with-clerk/styles/Home.module.css
@@ -67,9 +67,7 @@
   min-height: 135px;
   border: 2px solid #fff;
   border-radius: 0.5em;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card:empty {
@@ -84,38 +82,24 @@
       rgba(255, 255, 255, 0),
       rgba(255, 255, 255, 0.5) 50%,
       rgba(255, 255, 255, 0) 80%
-    ),
-    linear-gradient(#f2f2f2 16px, transparent 0),
+    ), linear-gradient(#f2f2f2 16px, transparent 0),
     linear-gradient(#f2f2f2 16px, transparent 0),
     linear-gradient(#f2f2f2 16px, transparent 0);
 
   background-repeat: repeat-y;
 
-  background-size:
-    100px 200px,
-    /* circle */ 50px 200px,
-    /* highlight */ 150px 200px,
-    350px 200px,
-    200px 200px;
+  background-size: 100px 200px, /* circle */ 50px 200px, /* highlight */ 150px
+    200px, 350px 200px, 200px 200px;
 
-  background-position:
-    0 0,
-    /* circle */ 0 0,
-    /* highlight */ 70px 36px,
-    70px 58px,
-    70px 80px;
+  background-position: 0 0, /* circle */ 0 0, /* highlight */ 70px 36px, 70px
+    58px, 70px 80px;
 
   animation: shine 1s infinite;
 }
 
 @keyframes shine {
   to {
-    background-position:
-      0 0,
-      100% 0,
-      70px 36px,
-      70px 58px,
-      70px 80px;
+    background-position: 0 0, 100% 0, 70px 36px, 70px 58px, 70px 80px;
   }
 }
 

--- a/examples/with-couchbase/styles/Home.module.css
+++ b/examples/with-couchbase/styles/Home.module.css
@@ -122,9 +122,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card:hover,

--- a/examples/with-cypress/styles/Home.module.css
+++ b/examples/with-cypress/styles/Home.module.css
@@ -93,9 +93,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
   width: 45%;
 }
 

--- a/examples/with-docker-compose/next-app/src/styles/Home.module.css
+++ b/examples/with-docker-compose/next-app/src/styles/Home.module.css
@@ -102,9 +102,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card:hover,

--- a/examples/with-docker-multi-env/styles/Home.module.css
+++ b/examples/with-docker-multi-env/styles/Home.module.css
@@ -96,9 +96,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card:hover,

--- a/examples/with-docker/styles/Home.module.css
+++ b/examples/with-docker/styles/Home.module.css
@@ -96,9 +96,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card:hover,

--- a/examples/with-elasticsearch/styles/Home.module.css
+++ b/examples/with-elasticsearch/styles/Home.module.css
@@ -53,9 +53,7 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition:
-    background 200ms,
-    border 200ms;
+  transition: background 200ms, border 200ms;
 }
 
 .card span {

--- a/examples/with-elasticsearch/styles/globals.css
+++ b/examples/with-elasticsearch/styles/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-electron-typescript/package.json
+++ b/examples/with-electron-typescript/package.json
@@ -30,9 +30,6 @@
   },
   "build": {
     "asar": true,
-    "files": [
-      "main",
-      "renderer/out"
-    ]
+    "files": ["main", "renderer/out"]
   }
 }

--- a/examples/with-electron/package.json
+++ b/examples/with-electron/package.json
@@ -11,10 +11,7 @@
   },
   "build": {
     "asar": true,
-    "files": [
-      "main",
-      "renderer/out"
-    ]
+    "files": ["main", "renderer/out"]
   },
   "devDependencies": {
     "electron": "^12.0.2",

--- a/examples/with-fauna/app/guestbook-page.tsx
+++ b/examples/with-fauna/app/guestbook-page.tsx
@@ -43,7 +43,9 @@ export default async function GuestbookPage({
       </div>
 
       <div className="mt-4 space-y-8 px-2">
-        {entries?.map((entry) => <EntryItem key={entry.id} entry={entry} />)}
+        {entries?.map((entry) => (
+          <EntryItem key={entry.id} entry={entry} />
+        ))}
       </div>
     </main>
   );

--- a/examples/with-formspree/styles/Home.module.css
+++ b/examples/with-formspree/styles/Home.module.css
@@ -96,9 +96,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card h3 {

--- a/examples/with-graphql-gateway/styles/Home.module.css
+++ b/examples/with-graphql-gateway/styles/Home.module.css
@@ -88,9 +88,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
   max-width: 300px;
 }
 

--- a/examples/with-graphql-hooks/src/app/globals.css
+++ b/examples/with-graphql-hooks/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-graphql-react/pages/index.js
+++ b/examples/with-graphql-react/pages/index.js
@@ -1,7 +1,10 @@
 import { useGraphQL } from "graphql-react";
 
 export default function IndexPage() {
-  const { loading, cacheValue: { data } = {} } = useGraphQL({
+  const {
+    loading,
+    cacheValue: { data } = {},
+  } = useGraphQL({
     fetchOptionsOverride(options) {
       options.url = "https://graphql-pokemon.vercel.app";
     },

--- a/examples/with-jest-babel/pages/index.module.css
+++ b/examples/with-jest-babel/pages/index.module.css
@@ -53,9 +53,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card:hover,

--- a/examples/with-jest/pages/index.module.css
+++ b/examples/with-jest/pages/index.module.css
@@ -53,9 +53,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .card:hover,

--- a/examples/with-jotai/styles/Home.module.css
+++ b/examples/with-jotai/styles/Home.module.css
@@ -94,9 +94,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
   width: 45%;
 }
 

--- a/examples/with-kea/package.json
+++ b/examples/with-kea/package.json
@@ -21,9 +21,7 @@
     "@babel/plugin-proposal-decorators": "7.22.5"
   },
   "babel": {
-    "presets": [
-      "next/babel"
-    ],
+    "presets": ["next/babel"],
     "plugins": [
       [
         "@babel/plugin-proposal-decorators",

--- a/examples/with-mantine/components/Card.tsx
+++ b/examples/with-mantine/components/Card.tsx
@@ -1,10 +1,10 @@
-import { Anchor, Text } from '@mantine/core'
+import { Anchor, Text } from "@mantine/core";
 
 type Props = {
-  title: string
-  description: string
-  link: string
-}
+  title: string;
+  description: string;
+  link: string;
+};
 
 const Card = (props: Props) => {
   return (
@@ -12,26 +12,26 @@ const Card = (props: Props) => {
       href={props.link}
       target="_blank"
       sx={{
-        border: '1px solid #eaeaea',
-        margin: '1rem',
-        padding: '1.5rem',
-        borderRadius: '10px',
-        textAlign: 'left',
-        color: 'black',
-        maxWidth: '300px',
-        transition: 'all 0.3s ease-in-out',
-        '&:hover': {
-          borderColor: '#0070f3',
-          color: '#0070f3',
+        border: "1px solid #eaeaea",
+        margin: "1rem",
+        padding: "1.5rem",
+        borderRadius: "10px",
+        textAlign: "left",
+        color: "black",
+        maxWidth: "300px",
+        transition: "all 0.3s ease-in-out",
+        "&:hover": {
+          borderColor: "#0070f3",
+          color: "#0070f3",
         },
       }}
     >
       <Text
         component="h2"
         sx={{
-          fontSize: '1.5rem',
-          fontWeight: 'bold',
-          textAlign: 'left',
+          fontSize: "1.5rem",
+          fontWeight: "bold",
+          textAlign: "left",
         }}
       >
         {props.title}
@@ -39,14 +39,14 @@ const Card = (props: Props) => {
       <Text
         component="p"
         sx={{
-          fontSize: '1rem',
-          textAlign: 'left',
+          fontSize: "1rem",
+          textAlign: "left",
         }}
       >
         {props.description}
       </Text>
     </Anchor>
-  )
-}
+  );
+};
 
-export default Card
+export default Card;

--- a/examples/with-mantine/components/Grid.tsx
+++ b/examples/with-mantine/components/Grid.tsx
@@ -1,28 +1,28 @@
-import { Box } from '@mantine/core'
-import { ReactNode } from 'react'
+import { Box } from "@mantine/core";
+import { ReactNode } from "react";
 
 type Props = {
-  children: ReactNode
-}
+  children: ReactNode;
+};
 
 const Grid = (props: Props) => {
   return (
     <Box
       sx={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(2, minmax(200px, 1fr))',
-        gridGap: '1rem',
-        justifyContent: 'center',
-        alignItems: 'center',
-        '@media (max-width: 800px)': {
-          gridTemplateColumns: 'repeat(1, minmax(200px, 1fr))',
-          gridGap: '0.2rem',
+        display: "grid",
+        gridTemplateColumns: "repeat(2, minmax(200px, 1fr))",
+        gridGap: "1rem",
+        justifyContent: "center",
+        alignItems: "center",
+        "@media (max-width: 800px)": {
+          gridTemplateColumns: "repeat(1, minmax(200px, 1fr))",
+          gridGap: "0.2rem",
         },
       }}
     >
       {props.children}
     </Box>
-  )
-}
+  );
+};
 
-export default Grid
+export default Grid;

--- a/examples/with-mantine/next.config.js
+++ b/examples/with-mantine/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/examples/with-mantine/pages/_app.tsx
+++ b/examples/with-mantine/pages/_app.tsx
@@ -1,6 +1,6 @@
-import '../styles/globals.css'
-import type { AppProps } from 'next/app'
-import { MantineProvider } from '@mantine/core'
+import "../styles/globals.css";
+import type { AppProps } from "next/app";
+import { MantineProvider } from "@mantine/core";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -8,7 +8,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       withGlobalStyles
       withNormalizeCSS
       theme={{
-        colorScheme: 'light',
+        colorScheme: "light",
         breakpoints: {
           xs: 500,
           sm: 800,
@@ -20,7 +20,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     >
       <Component {...pageProps} />
     </MantineProvider>
-  )
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/examples/with-mantine/pages/_document.tsx
+++ b/examples/with-mantine/pages/_document.tsx
@@ -1,10 +1,10 @@
-import { createGetInitialProps } from '@mantine/next'
-import Document, { Head, Html, Main, NextScript } from 'next/document'
+import { createGetInitialProps } from "@mantine/next";
+import Document, { Head, Html, Main, NextScript } from "next/document";
 
-const getInitialProps = createGetInitialProps()
+const getInitialProps = createGetInitialProps();
 
 export default class _Document extends Document {
-  static getInitialProps = getInitialProps
+  static getInitialProps = getInitialProps;
 
   render() {
     return (
@@ -15,6 +15,6 @@ export default class _Document extends Document {
           <NextScript />
         </body>
       </Html>
-    )
+    );
   }
 }

--- a/examples/with-mantine/pages/index.tsx
+++ b/examples/with-mantine/pages/index.tsx
@@ -1,17 +1,17 @@
-import type { NextPage } from 'next'
-import Head from 'next/head'
-import Image from 'next/image'
-import { Box, Code, Text } from '@mantine/core'
-import Card from '../components/Card'
-import Grid from '../components/Grid'
+import type { NextPage } from "next";
+import Head from "next/head";
+import Image from "next/image";
+import { Box, Code, Text } from "@mantine/core";
+import Card from "../components/Card";
+import Grid from "../components/Grid";
 
 const Home: NextPage = () => {
   return (
     <Box
       component="main"
       sx={{
-        paddingLeft: '2rem',
-        paddingRight: '2rem',
+        paddingLeft: "2rem",
+        paddingRight: "2rem",
       }}
     >
       <Head>
@@ -23,24 +23,24 @@ const Home: NextPage = () => {
       <Box
         component="main"
         sx={{
-          minHeight: '100vh',
-          display: 'flex',
-          paddingTop: '2rem',
-          paddingBottom: '2rem',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
+          minHeight: "100vh",
+          display: "flex",
+          paddingTop: "2rem",
+          paddingBottom: "2rem",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
         }}
       >
         <Text
           sx={{
-            color: '#0070f3',
-            fontSize: '2rem',
-            '@media (min-width: 800px)': {
-              fontSize: '3rem',
+            color: "#0070f3",
+            fontSize: "2rem",
+            "@media (min-width: 800px)": {
+              fontSize: "3rem",
             },
-            fontWeight: 'bold',
-            textAlign: 'center',
+            fontWeight: "bold",
+            textAlign: "center",
           }}
         >
           Welcome to <a href="https://nextjs.org">Next.js!</a>
@@ -48,21 +48,21 @@ const Home: NextPage = () => {
 
         <Text
           sx={{
-            color: 'black',
-            fontSize: '0.9rem',
-            '@media (min-width: 700px)': {
-              fontSize: '1.2rem',
+            color: "black",
+            fontSize: "0.9rem",
+            "@media (min-width: 700px)": {
+              fontSize: "1.2rem",
             },
-            padding: '1rem',
-            textAlign: 'center',
+            padding: "1rem",
+            textAlign: "center",
           }}
         >
-          Get started by editing{' '}
+          Get started by editing{" "}
           <Code
             sx={{
-              color: 'black',
-              fontSize: '0.8rem',
-              textAlign: 'center',
+              color: "black",
+              fontSize: "0.8rem",
+              textAlign: "center",
             }}
           >
             pages/index.tsx
@@ -96,13 +96,13 @@ const Home: NextPage = () => {
       <Box
         component="footer"
         sx={{
-          display: 'flex',
-          flex: '1',
-          paddingTop: '2rem',
-          paddingBottom: '2rem',
-          borderTop: '1px solid #eaeaea',
-          justifyContent: 'center',
-          alignItems: 'center',
+          display: "flex",
+          flex: "1",
+          paddingTop: "2rem",
+          paddingBottom: "2rem",
+          borderTop: "1px solid #eaeaea",
+          justifyContent: "center",
+          alignItems: "center",
         }}
       >
         <a
@@ -110,14 +110,14 @@ const Home: NextPage = () => {
           target="_blank"
           rel="noopener noreferrer"
         >
-          Powered by{' '}
-          <Box component="span" sx={{ height: '1rem', marginLeft: '1.5rem' }}>
+          Powered by{" "}
+          <Box component="span" sx={{ height: "1rem", marginLeft: "1.5rem" }}>
             <Image src="/vercel.svg" alt="Vercel Logo" width={72} height={16} />
           </Box>
         </a>
       </Box>
     </Box>
-  )
-}
+  );
+};
 
-export default Home
+export default Home;

--- a/examples/with-mantine/prettier.config.js
+++ b/examples/with-mantine/prettier.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  singleQuote: true,
-  semi: false,
-}

--- a/examples/with-next-translate/app/style.css
+++ b/examples/with-next-translate/app/style.css
@@ -82,9 +82,7 @@ code {
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
   cursor: pointer;
 }
 

--- a/examples/with-particles/styles/Home.module.css
+++ b/examples/with-particles/styles/Home.module.css
@@ -88,9 +88,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
   max-width: 300px;
 }
 

--- a/examples/with-passport-and-next-connect/pages/index.js
+++ b/examples/with-passport-and-next-connect/pages/index.js
@@ -2,7 +2,9 @@ import { useUser, fetcher } from "../lib/hooks";
 import useSWR from "swr";
 
 function UserList() {
-  const { data: { users } = {} } = useSWR("/api/users", fetcher);
+  const {
+    data: { users } = {},
+  } = useSWR("/api/users", fetcher);
   return (
     <>
       <h2>All users</h2>

--- a/examples/with-passport/lib/password-local.js
+++ b/examples/with-passport/lib/password-local.js
@@ -1,20 +1,18 @@
 import Local from "passport-local";
 import { findUser, validatePassword } from "./user";
 
-export const localStrategy = new Local.Strategy(function (
-  username,
-  password,
-  done,
-) {
-  findUser({ username })
-    .then((user) => {
-      if (user && validatePassword(user, password)) {
-        done(null, user);
-      } else {
-        done(new Error("Invalid username and password combination"));
-      }
-    })
-    .catch((error) => {
-      done(error);
-    });
-});
+export const localStrategy = new Local.Strategy(
+  function (username, password, done) {
+    findUser({ username })
+      .then((user) => {
+        if (user && validatePassword(user, password)) {
+          done(null, user);
+        } else {
+          done(new Error("Invalid username and password combination"));
+        }
+      })
+      .catch((error) => {
+        done(error);
+      });
+  },
+);

--- a/examples/with-playwright/styles/Home.module.css
+++ b/examples/with-playwright/styles/Home.module.css
@@ -92,9 +92,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
   width: 45%;
 }
 

--- a/examples/with-react-toolbox/package.json
+++ b/examples/with-react-toolbox/package.json
@@ -18,10 +18,7 @@
     "react-toolbox-themr": "^1.0.2"
   },
   "reactToolbox": {
-    "include": [
-      "BUTTON",
-      "DATE_PICKER"
-    ],
+    "include": ["BUTTON", "DATE_PICKER"],
     "customProperties": {
       "animation-duration": "0.3s",
       "color-accent": "var(--palette-pink-a200)",

--- a/examples/with-react-toolbox/public/theme.css
+++ b/examples/with-react-toolbox/public/theme.css
@@ -25,10 +25,8 @@
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
-  transition:
-    box-shadow 0.2s cubic-bezier(0.4, 0, 1, 1),
-    background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-    color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 1, 1), background-color 0.2s
+    cubic-bezier(0.4, 0, 0.2, 1), color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   white-space: nowrap;
   box-sizing: border-box;
   font-family: Roboto, Helvetica, Arial, sans-serif;
@@ -101,26 +99,18 @@
 }
 ._1ZxqC[disabled] {
   background-color: rgba(0, 0, 0, 0.12);
-  box-shadow:
-    0 2px 2px 0 rgba(0, 0, 0, 0.14),
-    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
     0 1px 5px 0 rgba(0, 0, 0, 0.12);
 }
 ._1ZxqC:active {
-  box-shadow:
-    0 2px 2px 0 rgba(0, 0, 0, 0.14),
-    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
     0 1px 5px 0 rgba(0, 0, 0, 0.12);
 }
 ._1ZxqC:focus:not(:active) {
-  box-shadow:
-    0 0 8px rgba(0, 0, 0, 0.18),
-    0 8px 16px rgba(0, 0, 0, 0.36);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.18), 0 8px 16px rgba(0, 0, 0, 0.36);
 }
 ._221ic {
-  box-shadow:
-    0 2px 2px 0 rgba(0, 0, 0, 0.14),
-    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
     0 1px 5px 0 rgba(0, 0, 0, 0.12);
 }
 ._1jWAQ {
@@ -128,9 +118,7 @@
 }
 ._3IRMZ {
   border-radius: 50%;
-  box-shadow:
-    0 1px 1.5px 0 rgba(0, 0, 0, 0.12),
-    0 1px 1px 0 rgba(0, 0, 0, 0.24);
+  box-shadow: 0 1px 1.5px 0 rgba(0, 0, 0, 0.12), 0 1px 1px 0 rgba(0, 0, 0, 0.24);
   font-size: 24px;
   height: 56px;
   width: 56px;
@@ -261,20 +249,13 @@
   opacity: 0.3;
   transition-property: -webkit-transform;
   transition-property: transform;
-  transition-property:
-    transform,
-    -webkit-transform;
+  transition-property: transform, -webkit-transform;
 }
 ._3SV_u:not(._3O2Ue):not(._2OZWa) {
   opacity: 0;
-  transition-property:
-    opacity,
-    -webkit-transform;
+  transition-property: opacity, -webkit-transform;
   transition-property: opacity, transform;
-  transition-property:
-    opacity,
-    transform,
-    -webkit-transform;
+  transition-property: opacity, transform, -webkit-transform;
 }
 ._2ISvI:not(.Cf3yF) > .x7MhN {
   cursor: pointer;
@@ -288,9 +269,7 @@
 ._1VWY- {
   display: inline-block;
   font-size: 14px;
-  transition:
-    opacity,
-    font-size 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity, font-size 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 ._3K2Ws {
   display: block;
@@ -440,14 +419,9 @@
 ._2bZap,
 .m5B3T {
   transition-duration: 350ms;
-  transition-property:
-    opacity,
-    -webkit-transform;
+  transition-property: opacity, -webkit-transform;
   transition-property: transform, opacity;
-  transition-property:
-    transform,
-    opacity,
-    -webkit-transform;
+  transition-property: transform, opacity, -webkit-transform;
   transition-timing-function: ease-in-out;
 }
 .Rk89h {
@@ -474,14 +448,9 @@
 .bGml_ {
   position: absolute;
   transition-duration: 0.35s;
-  transition-property:
-    opacity,
-    -webkit-transform;
+  transition-property: opacity, -webkit-transform;
   transition-property: transform, opacity;
-  transition-property:
-    transform,
-    opacity,
-    -webkit-transform;
+  transition-property: transform, opacity, -webkit-transform;
   transition-timing-function: ease-in-out;
 }
 .bGml_ {
@@ -707,9 +676,7 @@
 ._3lw90 {
   background-color: #fff;
   border-radius: 2px;
-  box-shadow:
-    0 19px 60px rgba(0, 0, 0, 0.3),
-    0 15px 20px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 19px 60px rgba(0, 0, 0, 0.3), 0 15px 20px rgba(0, 0, 0, 0.22);
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -723,16 +690,13 @@
   overflow: hidden;
   -webkit-transform: translateY(-40px);
   transform: translateY(-40px);
-  transition:
-    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    -webkit-transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  transition:
-    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  transition:
-    opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    -webkit-transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), -webkit-transform 0.3s
+    cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s
+    cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s
+    cubic-bezier(0.4, 0, 0.2, 1), -webkit-transform 0.3s
+    cubic-bezier(0.4, 0, 0.2, 1);
   transition-delay: 60ms;
 }
 ._3lw90._3ea_1 {

--- a/examples/with-redux/app/components/counter/Counter.module.css
+++ b/examples/with-redux/app/components/counter/Counter.module.css
@@ -69,9 +69,7 @@
   left: 0;
   top: 0;
   opacity: 0;
-  transition:
-    width 1s linear,
-    opacity 0.5s ease 1s;
+  transition: width 1s linear, opacity 0.5s ease 1s;
 }
 
 .asyncButton:active:after {

--- a/examples/with-sentry/styles/Home.module.css
+++ b/examples/with-sentry/styles/Home.module.css
@@ -57,9 +57,7 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition:
-    background 200ms,
-    border 200ms;
+  transition: background 200ms, border 200ms;
 }
 
 .card span {

--- a/examples/with-sentry/styles/globals.css
+++ b/examples/with-sentry/styles/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-stencil/package.json
+++ b/examples/with-stencil/package.json
@@ -1,8 +1,6 @@
 {
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "scripts": {
     "dev": "yarn --cwd packages/web-app dev",
     "build": "yarn --cwd packages/web-app build",

--- a/examples/with-stencil/packages/test-component/package.json
+++ b/examples/with-stencil/packages/test-component/package.json
@@ -10,10 +10,7 @@
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/test-component/test-component.js",
-  "files": [
-    "dist/",
-    "loader/"
-  ],
+  "files": ["dist/", "loader/"],
   "scripts": {
     "build": "stencil build --docs",
     "start": "stencil build --dev --watch --serve",

--- a/examples/with-storybook/app/globals.css
+++ b/examples/with-storybook/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-storybook/app/page.module.css
+++ b/examples/with-storybook/app/page.module.css
@@ -51,9 +51,7 @@
   border-radius: var(--border-radius);
   background: rgba(var(--card-rgb), 0);
   border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition:
-    background 200ms,
-    border 200ms;
+  transition: background 200ms, border 200ms;
 }
 
 .card span {

--- a/examples/with-stripe-typescript/styles.css
+++ b/examples/with-stripe-typescript/styles.css
@@ -113,9 +113,7 @@ li {
   width: 33%;
   margin: 0 20px 20px 0;
   text-decoration: none;
-  box-shadow:
-    -20px 20px 60px #abacad,
-    20px -20px 60px #ffffff;
+  box-shadow: -20px 20px 60px #abacad, 20px -20px 60px #ffffff;
 }
 .card h2 {
   color: #fff;
@@ -182,9 +180,7 @@ button:disabled {
   transition: box-shadow var(--transition-duration);
 }
 .card.elements-style-background:hover {
-  box-shadow:
-    20px 20px 60px #464e9c,
-    -20px -20px 60px #8896ff;
+  box-shadow: 20px 20px 60px #464e9c, -20px -20px 60px #8896ff;
 }
 .checkout-style {
   color: var(--checkout-color);
@@ -195,9 +191,7 @@ button:disabled {
   transition: box-shadow var(--transition-duration);
 }
 .card.checkout-style-background:hover {
-  box-shadow:
-    20px 20px 60px #614b91,
-    -20px -20px 60px #bd91ff;
+  box-shadow: 20px 20px 60px #614b91, -20px -20px 60px #bd91ff;
 }
 
 /* Test card number */
@@ -240,9 +234,7 @@ pre {
   background: var(--body-color);
   color: #6a7c94;
   border-radius: 50px;
-  box-shadow:
-    -20px 20px 60px #abacad,
-    20px -20px 60px #ffffff;
+  box-shadow: -20px 20px 60px #abacad, 20px -20px 60px #ffffff;
   display: flex;
   align-items: center;
   box-sizing: border-box;

--- a/examples/with-supertokens/app/page.module.css
+++ b/examples/with-supertokens/app/page.module.css
@@ -99,12 +99,8 @@
   border-radius: 9px;
   padding: 2px;
   background: linear-gradient(90.31deg, #ff9933 0.11%, #ff3f33 99.82%);
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
 }

--- a/examples/with-temporal/package.json
+++ b/examples/with-temporal/package.json
@@ -36,8 +36,6 @@
       "ts": "node --loader ts-node/esm"
     },
     "ext": "ts",
-    "watch": [
-      "temporal/src"
-    ]
+    "watch": ["temporal/src"]
   }
 }

--- a/examples/with-tigris/styles/Home.module.css
+++ b/examples/with-tigris/styles/Home.module.css
@@ -45,9 +45,7 @@
   font-weight: 400;
   line-height: 22px;
   letter-spacing: 0px;
-  transition:
-    background-color 0.2s,
-    box-shadow 0.2s;
+  transition: background-color 0.2s, box-shadow 0.2s;
   caret-color: #4ed9b2;
 }
 

--- a/examples/with-vitest/styles/Home.module.css
+++ b/examples/with-vitest/styles/Home.module.css
@@ -88,9 +88,7 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
   max-width: 300px;
 }
 

--- a/examples/with-xata/styles/root.css
+++ b/examples/with-xata/styles/root.css
@@ -87,7 +87,7 @@ section {
   padding: 5rem;
   grid-gap: 2rem;
   margin: 5rem auto;
-  border-radius: 30px/15px;
+  border-radius: 30px / 15px;
   border: dashed 2px var(--xata-accent);
   font-size: 1.2rem;
   text-align: center;
@@ -144,7 +144,7 @@ li {
   position: relative;
   padding: 1rem 2rem;
   border: solid 2px var(--text-color);
-  border-radius: 10px/5px;
+  border-radius: 10px / 5px;
 }
 
 object {

--- a/examples/with-yarn-workspaces/package.json
+++ b/examples/with-yarn-workspaces/package.json
@@ -1,8 +1,6 @@
 {
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "scripts": {
     "dev": "yarn --cwd packages/web-app dev",
     "build": "yarn --cwd packages/web-app build",

--- a/examples/with-zustand/src/components/clock.css
+++ b/examples/with-zustand/src/components/clock.css
@@ -2,10 +2,7 @@
   padding: 15px;
   display: inline-block;
   color: #82fa58;
-  font:
-    50px menlo,
-    monaco,
-    monospace;
+  font: 50px menlo, monaco, monospace;
   background-color: #000;
   border-radius: 4px;
 }

--- a/test/examples/examples.test.ts
+++ b/test/examples/examples.test.ts
@@ -1,68 +1,68 @@
-import { nextTestSetup } from 'e2e-utils'
-import path from 'path'
-import fs from 'fs-extra'
+import { nextTestSetup } from "e2e-utils";
+import path from "path";
+import fs from "fs-extra";
 
 const testedExamples = [
   // Internal features
-  'active-class-name',
-  'amp',
-  'api-routes-cors',
-  'api-routes-middleware',
-  'api-routes-rest',
-  'basic-css',
-  'blog',
-  'blog-starter',
-  'custom-server',
-  'hello-world',
-  'i18n-routing',
-  'i18n-routing-pages',
-  'image-component',
-  'mdx',
-  'next-forms',
-  'remove-console',
-  'reproduction-template',
-  'with-absolute-imports',
-  'with-context-api',
-  'with-shallow-routing',
-  'with-sitemap',
-  'with-typescript',
-  'with-typescript-types',
-  'with-web-worker',
-  'with-webassembly',
+  "active-class-name",
+  "amp",
+  "api-routes-cors",
+  "api-routes-middleware",
+  "api-routes-rest",
+  "basic-css",
+  "blog",
+  "blog-starter",
+  "custom-server",
+  "hello-world",
+  "i18n-routing",
+  "i18n-routing-pages",
+  "image-component",
+  "mdx",
+  "next-forms",
+  "remove-console",
+  "reproduction-template",
+  "with-absolute-imports",
+  "with-context-api",
+  "with-shallow-routing",
+  "with-sitemap",
+  "with-typescript",
+  "with-typescript-types",
+  "with-web-worker",
+  "with-webassembly",
 
   // Library integrations that we can't break
-  'mdx-pages',
-  'mdx-remote',
-  'with-jest',
-  'with-jest-babel',
-  'with-turbopack',
-]
+  "mdx-pages",
+  "mdx-remote",
+  "with-jest",
+  "with-jest-babel",
+  "with-turbopack",
+];
 
 describe.each(testedExamples)(`example '%s'`, (example) => {
   // If there is an issue during a build, jest won't tell us which example caused it
   // we need to log it ourselfs
   beforeAll(() => {
-    require('console').log(`Running example '${example}'`)
-  })
+    require("console").log(`Running example '${example}'`);
+  });
 
-  const exampleFiles = path.join(__dirname, '..', '..', 'examples', example)
-  const packageJson = fs.readJsonSync(path.join(exampleFiles, 'package.json'))
+  const exampleFiles = path.join(__dirname, "..", "..", "examples", example);
+  const packageJson = fs.readJsonSync(path.join(exampleFiles, "package.json"));
   describe(`example '${example}'`, () => {
     nextTestSetup({
       files: exampleFiles,
       dependencies: {
         // We need to make sure that these default dependencies are not installed by default
         // for our examples to ensure that they have all their dependencies in package.json
-        '@types/node': undefined,
-        '@types/react': undefined,
+        "@types/node": undefined,
+        "@types/react": undefined,
         next: undefined,
         react: undefined,
-        'react-dom': undefined,
+        "react-dom": undefined,
         typescript: undefined,
         ...packageJson.dependencies,
         ...packageJson.devDependencies,
       },
-    })
-    it('builds', () => {})
-  })
-})
+    });
+    it("builds", () => {});
+  });
+});


### PR DESCRIPTION
This extends #79251 to `examples/`. It also removes the custom prettier config for the `with-mantine` example and applies the standard examples formatting to it.