### PR TITLE
Format css with Biome

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,8 @@
 *.d.mts
 *.json
 *.jsonc
+*.css
+*.scss
 
 # Temporarily continue to format files here until they're covered by Biome
 !examples/**/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,12 @@
   "[json]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[css]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   // Formatting using Rust-Analyzer for Rust.
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -15,7 +15,9 @@
       "**/*.cjs",
       "**/*.d.mts",
       "**/*.json",
-      "**/*.jsonc"
+      "**/*.jsonc",
+      "**/*.css",
+      "**/*.scss"
     ],
     "ignoreUnknown": false,
     "ignore": [
@@ -92,6 +94,8 @@
       "turbopack/crates/turbopack-tests/tests/**/static",
       "turbopack/crates/turbopack/tests/node-file-trace/integration",
 
+      // invalid css
+      "test/integration/css-features/fixtures/inline-comments/pages/global.css",
       // does not parse with the top-level return
       "turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js",
       // intentionally does not parse as esm
@@ -115,6 +119,14 @@
     "enabled": true,
     "indentStyle": "space",
     "formatWithErrors": true
+  },
+  "css": {
+    "parser": {
+      "cssModules": true
+    },
+    "formatter": {
+      "quoteStyle": "single"
+    }
   },
   "javascript": {
     "formatter": {

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,10 +2,10 @@ module.exports = {
   '*.{js,jsx,mjs,ts,tsx,mts,mdx}': [
     'cross-env ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.json --no-eslintrc --fix',
   ],
-  '*.{md,mdx,css,html,yml,yaml,scss}': [
+  '*.{md,mdx,html,yml,yaml}': [
     'prettier --with-node-modules --ignore-path .prettierignore --write',
   ],
-  '*.{js,jsx,ts,tsx,cjs,mjs,d.mts,json,jsonc}': [
+  '*.{js,jsx,ts,tsx,cjs,mjs,d.mts,json,jsonc,css,scss}': [
     'biome format --write --no-errors-on-unmatched',
   ],
   '*.rs': ['cargo fmt --'],

--- a/test/integration/critical-css/styles/index.module.css
+++ b/test/integration/critical-css/styles/index.module.css
@@ -1,8 +1,5 @@
 .hello {
-  font:
-    15px Helvetica,
-    Arial,
-    sans-serif;
+  font: 15px Helvetica, Arial, sans-serif;
   background: #eee;
   padding: 100px;
   text-align: center;

--- a/test/integration/css-features/fixtures/module-import-exports/pages/styles.module.css
+++ b/test/integration/css-features/fixtures/module-import-exports/pages/styles.module.css
@@ -1,4 +1,4 @@
-@value b1 from "./colors.module.css";
+@value b1 from './colors.module.css';
 
 .blk {
   color: b1;

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css
@@ -1,4 +1,4 @@
-@import url('./a.css') layer(layer) supports(not(display: inline-grid)) print;
+@import url('./a.css') layer(layer) supports(not (display: inline-grid)) print;
 
 .style {
   color: yellow;


### PR DESCRIPTION
This formats our css files with Biome. It continues to exempt examples and create-next-app templates. These will be addressed up the stack.