### PR TITLE
Turbopack: remove dead code

### DIFF
--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -140,8 +140,9 @@ impl Introspectable for StaticAssetsContentSource {
                             .to_resolved()
                             .await?,
                         ),
-                        DirectoryEntry::Other(_) => todo!("what's DirectoryContent::Other?"),
-                        DirectoryEntry::Error => todo!(),
+                        DirectoryEntry::Other(_) | DirectoryEntry::Error => {
+                            todo!("unsupported DirectoryContent variant: {entry:?}")
+                        }
                     };
                     Ok((ResolvedVc::cell(name.clone()), child))
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -76,7 +76,7 @@ impl Module for AsyncLoaderModule {
 impl Asset for AsyncLoaderModule {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        todo!()
+        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -152,7 +152,7 @@ impl Module for ManifestAsyncModule {
 impl Asset for ManifestAsyncModule {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        todo!()
+        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -268,35 +268,3 @@ impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
         )
     }
 }
-
-/// A module that only has an ident and no content nor references.
-///
-/// It is used to include a module's ident in the module graph before the module
-/// itself is resolved, as is the case with NextServerComponentModule's
-/// "client modules" and "ssr modules".
-#[turbo_tasks::value]
-pub struct IncludeIdentModule {
-    ident: ResolvedVc<AssetIdent>,
-}
-
-#[turbo_tasks::value_impl]
-impl IncludeIdentModule {
-    #[turbo_tasks::function]
-    pub fn new(ident: ResolvedVc<AssetIdent>) -> Vc<Self> {
-        Self { ident }.cell()
-    }
-}
-
-impl Asset for IncludeIdentModule {
-    fn content(self: Vc<Self>) -> Vc<AssetContent> {
-        todo!("IncludeIdentModule doesn't implement content()")
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Module for IncludeIdentModule {
-    #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        *self.ident
-    }
-}

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -62,7 +62,7 @@ impl Module for WorkerLoaderModule {
 impl Asset for WorkerLoaderModule {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        todo!()
+        panic!("content() should not be called");
     }
 }
 


### PR DESCRIPTION
- `IncludeIdentModule` is unused (and incompatible with the ModuleGraph anyway)
- Cleanup some `todo!()`s

Closes PACK-4624