### PR TITLE
Repro of infinite Suspense fallback with staleTimes and middleware rewrites

### DIFF
--- a/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/SwitchVariant.jsx
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/SwitchVariant.jsx
@@ -1,0 +1,20 @@
+'use client'
+
+export function SwitchVariant() {
+  return (
+    <>
+      <button
+        id="switch-to-variant-a"
+        onClick={() => (document.cookie = 'variant=a')}
+      >
+        Variant A
+      </button>
+      <button
+        id="switch-to-variant-b"
+        onClick={() => (document.cookie = 'variant=b')}
+      >
+        Variant B
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/layout.jsx
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/layout.jsx
@@ -1,0 +1,16 @@
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return [{ variant: 'a' }, { variant: 'b' }]
+}
+
+export default async function RootLayout({ children, params }) {
+  return (
+    <html lang="en">
+      <body>
+        <p>variant: {(await params).variant}</p>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/other/loading.jsx
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/other/loading.jsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="suspense-fallback">Loading...</div>
+}

--- a/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/other/page.jsx
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/other/page.jsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export const revalidate = 0
+
+export default function Page() {
+  return (
+    <>
+      <div id="other-page">Other Page</div>
+
+      <Link id="link-to-home-page" href="/">
+        To to home page
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/page.jsx
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/app/[variant]/page.jsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+import { SwitchVariant } from './SwitchVariant'
+
+export default function Home() {
+  return (
+    <>
+      <div id="home-page">Home Page</div>
+      <SwitchVariant />
+      <Link href="/other" id="link-to-other-page">
+        To to other page
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/rewrite-suspense-stale-times/middleware.js
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/middleware.js
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+  ],
+}
+
+export default function middleware(req) {
+  if (
+    req.nextUrl.pathname.startsWith('/a') ||
+    req.nextUrl.pathname.startsWith('/b')
+  ) {
+    return NextResponse.next()
+  }
+
+  const variant = req.cookies.get('variant')?.value ?? 'a'
+
+  return NextResponse.rewrite(
+    new URL(
+      `/${variant}${req.nextUrl.pathname}${req.nextUrl.search}`,
+      req.url
+    ).toString()
+  )
+}

--- a/test/e2e/app-dir/rewrite-suspense-stale-times/next.config.js
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    staleTimes: {
+      dynamic: 30,
+      static: 30,
+    },
+  },
+}

--- a/test/e2e/app-dir/rewrite-suspense-stale-times/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-suspense-stale-times/rewrite-headers.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('rewrite-headers', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    // TODO: re-enable once changes in infrastructure are merged
+    skipDeployment: true,
+  })
+
+  it('should not get stuck on suspense after navigating and then changing the variant', async () => {
+    const browser = await next.browser('/')
+
+    expect(await browser.elementByCss('#home-page').text()).toBe('Home Page')
+    await browser.elementByCss('#switch-to-variant-b').click()
+    await browser.elementByCss('#link-to-other-page').click()
+
+    expect(await browser.elementByCss('#suspense-fallback').text()).toBe(
+      'Loading...'
+    )
+    expect(
+      await (await browser.elementByCss('#other-page')).textContent()
+    ).toBe('Other Page')
+    await browser.elementByCss('#link-to-home-page').click()
+
+    expect(await browser.elementByCss('#home-page').text()).toBe('Home Page')
+    await browser.elementByCss('#link-to-other-page').click()
+
+    expect(await browser.elementByCss('#suspense-fallback').text()).toBe(
+      'Loading...'
+    )
+    expect(
+      await (await browser.elementByCss('#other-page')).textContent()
+    ).toBe('Other Page') // Fails here
+  })
+})


### PR DESCRIPTION
I've found a scenario where a middleware rewrite that changes while the page is open can cause a infinite suspense fallback. Only happens when using `experimental.staleTimes`. Seems like it's a bug.

The PR contains a reproduction in the form form of a failing E2E test. I haven't spent time looking at your E2E testing conventions, so I may be doing something in an odd way. Also it's possible that the some parts of the code might no actually be the cause of the bug. It's an extraction from a private repo.

Hope works, otherwise I'm happy to open an issue. This just seemed like a more convenient way to demonstrate. Left this in draft because my tests probably aren't that solid, but to be clear, the issue is reproducing with the current diff.


https://github.com/user-attachments/assets/4b8df12a-4d21-4178-85d2-70df8b9fa878


