### PR TITLE
Turbopack build: Fix type: module with output: standalone

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1539,6 +1539,10 @@ export async function copyTracedFiles(
   staticPages: Set<string>
 ) {
   const outputPath = path.join(distDir, 'standalone')
+
+  // Clean up standalone directory first.
+  await fs.rm(outputPath, { recursive: true, force: true })
+
   let moduleType = false
   const nextConfig = {
     ...serverConfig,
@@ -1561,7 +1565,6 @@ export async function copyTracedFiles(
     await fs.writeFile(packageJsonOutputPath, packageJsonContent)
   } catch {}
   const copiedFiles = new Set()
-  await fs.rm(outputPath, { recursive: true, force: true })
 
   async function handleTraceFiles(traceFilePath: string) {
     const traceData = JSON.parse(await fs.readFile(traceFilePath, 'utf8')) as {

--- a/test/production/standalone-mode/type-module/index.test.ts
+++ b/test/production/standalone-mode/type-module/index.test.ts
@@ -1,5 +1,4 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import fs from 'fs-extra'
 import {
@@ -10,38 +9,21 @@ import {
 } from 'next-test-utils'
 
 describe('type-module', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          export default function Page() {
-            return <p>hello world</p>
-          }
-        `,
-        'next.config.mjs': `export default ${JSON.stringify({
-          output: 'standalone',
-        })}`,
-      },
-      packageJson: { type: 'module' },
-    })
-    await next.stop()
+  const { next } = nextTestSetup({
+    files: __dirname,
+    packageJson: {
+      type: 'module',
+    },
   })
 
-  afterAll(() => next.destroy())
-
   it('should work', async () => {
+    await next.stop()
     const standalonePath = join(next.testDir, '.next/standalone')
-    const staticSrc = join(next.testDir, '.next/static')
-
-    const staticDest = join(standalonePath, '.next/static')
-
-    await fs.move(staticSrc, staticDest)
 
     expect(fs.existsSync(join(standalonePath, 'package.json'))).toBe(true)
 
     const serverFile = join(standalonePath, 'server.js')
+
     const appPort = await findPort()
     const server = await initNextServerScript(
       serverFile,

--- a/test/production/standalone-mode/type-module/next.config.js
+++ b/test/production/standalone-mode/type-module/next.config.js
@@ -1,0 +1,4 @@
+export default {
+  output: 'standalone',
+  outputFileTracingRoot: '.',
+}

--- a/test/production/standalone-mode/type-module/next.config.js
+++ b/test/production/standalone-mode/type-module/next.config.js
@@ -1,4 +1,3 @@
 export default {
   output: 'standalone',
-  outputFileTracingRoot: '.',
 }

--- a/test/production/standalone-mode/type-module/package.json
+++ b/test/production/standalone-mode/type-module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/production/standalone-mode/type-module/pages/index.js
+++ b/test/production/standalone-mode/type-module/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -19583,8 +19583,8 @@
     "runtimeError": false
   },
   "test/production/standalone-mode/type-module/index.test.ts": {
-    "passed": [],
-    "failed": ["type-module should work"],
+    "passed": ["type-module should work"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

This PR ensures we first clean the `.next/standalone` folder before writing into it. 

Currently the order is:

1. Write package.json to `.next/standalone/package.json`
1. Delete `.next/standalone`
1. Check `.nft.json` files and write the files listed there to `.next/standalone`

Which in turn causes the package.json to not exist.

So why does this not fail with webpack? Well, what I found is that the `_app` `.nft.json` file somehow lists the project root `package.json` even though it does not use it. This means that after we delete `.next/standalone` the `package.json` will still end up in the eventual directory regardless.

It fails with Turbopack because Turbopack correctly does not include the package.json (as it's not used) and then the `package.json` is missing at runtime, causing the `server.js` which uses ESM to fail (because the detection for ESM is still valid regardless of deleting the folder).


New order is:

1. Delete `.next/standalone`
1. Write package.json to `.next/standalone/package.json`
1. Check `.nft.json` files and write the files listed there to `.next/standalone`

Closes PACK-4631