### PR TITLE
Hmr latency report w/ early return

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
@@ -20,13 +20,14 @@ export default function reportHmrLatency(
   updatedModules: ReadonlyArray<string | number>,
   startMsSinceEpoch: number,
   endMsSinceEpoch: number,
-  hasUpdate: boolean = true
+  hasUpdate = true
 ) {
-  const latencyMs = endMsSinceEpoch - startMsSinceEpoch
-  console.log(`[Fast Refresh] done in ${latencyMs}ms`)
   if (!hasUpdate) {
     return
   }
+
+  const latencyMs = endMsSinceEpoch - startMsSinceEpoch
+  console.log(`[Fast Refresh] done in ${latencyMs}ms`)
   sendMessage(
     JSON.stringify({
       event: 'client-hmr-latency',


### PR DESCRIPTION
Right now `reportHmrLatency` logs even if there is no update.

This causes it to print: `[Fast Refresh] done in NaNms`, because `startMsSinceEpoch` has not yet been set.

### TODO

- [x] look at failed tests

Fixes: #79279