### PR TITLE
perf(turbopack): Update `sourcemap` to make `flatten()` faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7161,9 +7161,9 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.2.0"
+version = "9.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd430118acc9fdd838557649b9b43fd0a78e3834d84a283b466f8e84720d6101"
+checksum = "bdee719193ae5c919a3ee43f64c2c0dd87f9b9a451d67918a2a5ec2e3c70561c"
 dependencies = [
  "base64-simd 0.8.0",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,7 +407,7 @@ smallvec = { version = "1.13.1", features = [
   "union",
   "const_new",
 ] }
-sourcemap = "9.0.0"
+sourcemap = "9.2.1"
 strsim = "0.11.1"
 shrink-to-fit = "0.2.10"
 swc-rustc-hash = { package = "rustc-hash", version = "1.1.0" } # used with swc


### PR DESCRIPTION
### What?

Update the `sourcemap` crate to the latest version.

### Why?

To apply https://github.com/getsentry/rust-sourcemap/pull/121


Closes PACK-4628