### PR TITLE
Use `onPostpone` to determine if segment prefetch is partial

### DIFF
--- a/.changeset/shaggy-pears-tell.md
+++ b/.changeset/shaggy-pears-tell.md
@@ -1,0 +1,5 @@
+---
+"next": patch
+---
+
+Use `onPostpone` to determine if segment prefetch is partial

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4258,27 +4258,8 @@ async function collectSegmentData(
     serverModuleMap: null,
   }
 
-  // When dynamicIO is enabled, missing data is encoded to an infinitely hanging
-  // promise, the absence of which we use to determine if a segment is fully
-  // static or partially static. However, when dynamicIO is not enabled, this
-  // trick doesn't work.
-  //
-  // So if PPR is enabled, and dynamicIO is not, we have to be conservative and
-  // assume all segments are partial.
-  //
-  // TODO: When PPR is on, we can at least optimize the case where the entire
-  // page is static. Either by passing that as an argument to this function, or
-  // by setting a header on the response like the we do for full page RSC
-  // prefetches today. The latter approach might be simpler since it requires
-  // less plumbing, and the client has to check the header regardless to see if
-  // PPR is enabled.
-  const shouldAssumePartialData =
-    renderOpts.experimental.isRoutePPREnabled === true && // PPR is enabled
-    !renderOpts.experimental.dynamicIO // dynamicIO is disabled
-
   const staleTime = prerenderStore.stale
   return await ComponentMod.collectSegmentData(
-    shouldAssumePartialData,
     fullPageDataBuffer,
     staleTime,
     clientReferenceManifest.clientModules as ManifestNode,

--- a/test/e2e/app-dir/segment-cache/client-only-opt-in/next.config.js
+++ b/test/e2e/app-dir/segment-cache/client-only-opt-in/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     ppr: 'incremental',
-    dynamicIO: true,
     clientSegmentCache: 'client-only',
   },
 }

--- a/test/e2e/app-dir/segment-cache/export/next.config.js
+++ b/test/e2e/app-dir/segment-cache/export/next.config.js
@@ -4,8 +4,6 @@
 const nextConfig = {
   output: 'export',
   experimental: {
-    ppr: false,
-    dynamicIO: true,
     clientSegmentCache: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/next.config.js
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     ppr: 'incremental',
-    dynamicIO: true,
     clientSegmentCache: true,
   },
 }

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -97,6 +97,7 @@
       "test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts",
       "test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.prospective-fallback.test.ts",
       "test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts",
+      "test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts",
       "test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts",
       "test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts",


### PR DESCRIPTION
When dynamicIO is enabled, missing data is encoded to an infinitely hanging promise, the absence of which we use to determine if a segment is fully static or partially static. However, when dynamicIO is not enabled, this trick doesn't work.

Previously, if PPR is enabled, and dynamicIO is not, we were conservative and assumed that all segments are partial. That doesn't need to be the case, though. We can use the `onPostpone` callback of the `prerender` function to determine if a given RSC node is partial.

To make sure that this works as expected, we're disabling `dynamicIO` in `test/e2e/app-dir/segment-cache/incremental-opt-in`.

Without this change, the following tests would fail because additional requests for the PPR-enabled routes are triggered when `dynamicIO` is disabled:

- `when a link is prefetched with <Link prefetch=true>, no dynamic request is made on navigation`
- `when prefetching with prefetch=true, refetches cache entries that only contain partial data`
- `when prefetching with prefetch=true, refetches partial cache entries even if there's already a pending PPR request`

In addition, we're also disabling `dynamicIO` in `test/e2e/app-dir/segment-cache/client-only-opt-in` as well as
`test/e2e/app-dir/segment-cache/export`, to prepare for an upcoming change where `ppr` will be enabled automatically when `dynamicIO` is enabled. Those three tests are then not compatible with `dynamicIO` because they either rely on the `'incremental'` PPR config, or on `output: 'export'`.