### PR TITLE
Enable `ppr` when `dynamicIO` is enabled

### DIFF
--- a/.changeset/dry-roses-nail.md
+++ b/.changeset/dry-roses-nail.md
@@ -1,0 +1,5 @@
+---
+"next": patch
+---
+
+Enable `ppr` when `dynamicIO` is enabled

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -679,5 +679,6 @@
   "678": "CacheSignal got more endRead() calls than beginRead() calls",
   "679": "A CacheSignal cannot subscribe to itself",
   "680": "CacheSignal cannot be used in the edge runtime, because `dynamicIO` does not support it.",
-  "681": "Dynamic imports should not be instrumented in the edge runtime, because `dynamicIO` doesn't support it"
+  "681": "Dynamic imports should not be instrumented in the edge runtime, because `dynamicIO` doesn't support it",
+  "682": "\\`experimental.ppr\\` can not be \\`%s\\` when \\`experimental.dynamicIO\\` is \\`true\\`. PPR is implicitly enabled when Dynamic IO is enabled."
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -637,8 +637,10 @@ export interface ExperimentalConfig {
   serverComponentsHmrCache?: boolean
 
   /**
-   * When enabled will cause IO in App Router to be excluded from prerenders
-   * unless explicitly cached.
+   * When enabled, will cause IO in App Router to be excluded from prerenders,
+   * unless explicitly cached. This also enables the experimental Partial
+   * Prerendering feature of Next.js, and it enables `react@experimental` being
+   * used for the `app` directory.
    */
   dynamicIO?: boolean
 
@@ -1198,7 +1200,7 @@ export interface NextConfig extends Record<string, any> {
   htmlLimitedBots?: RegExp
 }
 
-export const defaultConfig: NextConfig = {
+export const defaultConfig = {
   env: {},
   webpack: null,
   eslint: {
@@ -1391,7 +1393,7 @@ export const defaultConfig: NextConfig = {
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,
-}
+} satisfies NextConfig
 
 export async function normalizeConfig(phase: string, config: any) {
   if (typeof config === 'function') {

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -136,4 +136,44 @@ describe('loadConfig', () => {
       )
     })
   })
+
+  describe('with a canary version', () => {
+    beforeAll(() => {
+      process.env.__NEXT_VERSION = '15.4.0-canary.35'
+    })
+
+    afterAll(() => {
+      delete process.env.__NEXT_VERSION
+    })
+
+    it('errors when dynamicIO is enabled but PPR is disabled', async () => {
+      await expect(
+        loadConfig('', __dirname, {
+          customConfig: {
+            experimental: {
+              dynamicIO: true,
+              ppr: false,
+            },
+          },
+        })
+      ).rejects.toThrow(
+        '`experimental.ppr` can not be `false` when `experimental.dynamicIO` is `true`. PPR is implicitly enabled when Dynamic IO is enabled.'
+      )
+    })
+
+    it('errors when dynamicIO is enabled but PPR set to "incremental"', async () => {
+      await expect(
+        loadConfig('', __dirname, {
+          customConfig: {
+            experimental: {
+              dynamicIO: true,
+              ppr: 'incremental',
+            },
+          },
+        })
+      ).rejects.toThrow(
+        '`experimental.ppr` can not be `"incremental"` when `experimental.dynamicIO` is `true`. PPR is implicitly enabled when Dynamic IO is enabled.'
+      )
+    })
+  })
 })


### PR DESCRIPTION
With this PR, we're automatically enabling `ppr` when `dynamicIO` is enabled, and forbid using `ppr: 'incremental'` or `ppr: false` together with `dynamicIO: true`.

While implementing the config validation, I noticed that the `userConfig`, `config`, and `result` objects in `assignDefaults` were untyped. This is fixed now.