### PR TITLE
Remove obsolete `ppr` configs from Dynamic IO tests

### DIFF
--- a/test/development/app-dir/dynamic-io-dev-cache-scope/next.config.js
+++ b/test/development/app-dir/dynamic-io-dev-cache-scope/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
   },
 }
 

--- a/test/development/app-dir/dynamic-io-dev-errors/next.config.js
+++ b/test/development/app-dir/dynamic-io-dev-errors/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
   },
 }
 

--- a/test/development/app-dir/dynamic-io-dev-warmup/next.config.js
+++ b/test/development/app-dir/dynamic-io-dev-warmup/next.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
   },
 }

--- a/test/development/app-dir/dynamic-io-warnings/next.config.js
+++ b/test/development/app-dir/dynamic-io-warnings/next.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
   },
 }

--- a/test/e2e/app-dir/dynamic-io-dynamic-imports/bundled/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-dynamic-imports/bundled/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     prerenderEarlyExit: false,
   },

--- a/test/e2e/app-dir/dynamic-io-dynamic-imports/external/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-dynamic-imports/external/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
   },
   serverExternalPackages: ['external-esm-pkg-with-async-import'],

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-boundary/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-boundary/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-dynamic-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-dynamic-route/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-route/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/next.config.js
@@ -3,8 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
-    pprFallbacks: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: false,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-dynamic-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-dynamic-route/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-static-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-static-route/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: false,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: false,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/static/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/static/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-with-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-without-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-with-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-with-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-without-fallback/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-request-apis/fixtures/reject-hanging-promises-dynamic/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-request-apis/fixtures/reject-hanging-promises-dynamic/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io-request-apis/fixtures/reject-hanging-promises-static/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-request-apis/fixtures/reject-hanging-promises-static/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     serverMinification: true,
   },

--- a/test/e2e/app-dir/dynamic-io/next.config.js
+++ b/test/e2e/app-dir/dynamic-io/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
   },
 }

--- a/test/e2e/app-dir/empty-fallback-shells/next.config.js
+++ b/test/e2e/app-dir/empty-fallback-shells/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
   },
 }
 

--- a/test/e2e/app-dir/node-extensions/fixtures/random/dynamic-io/next.config.js
+++ b/test/e2e/app-dir/node-extensions/fixtures/random/dynamic-io/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
   },
 }

--- a/test/e2e/app-dir/ppr-missing-root-params/fixtures/multiple/next.config.js
+++ b/test/e2e/app-dir/ppr-missing-root-params/fixtures/multiple/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
   },
 }

--- a/test/e2e/app-dir/ppr-missing-root-params/fixtures/nested/next.config.js
+++ b/test/e2e/app-dir/ppr-missing-root-params/fixtures/nested/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
   },
 }

--- a/test/e2e/app-dir/ppr-missing-root-params/fixtures/single/next.config.js
+++ b/test/e2e/app-dir/ppr-missing-root-params/fixtures/single/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/basic/next.config.js
+++ b/test/e2e/app-dir/segment-cache/basic/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
   },

--- a/test/e2e/app-dir/segment-cache/dynamic-on-hover/next.config.js
+++ b/test/e2e/app-dir/segment-cache/dynamic-on-hover/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
     dynamicOnHover: true,

--- a/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
   },

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/next.config.js
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
   },

--- a/test/e2e/app-dir/segment-cache/prefetch-auto/next.config.js
+++ b/test/e2e/app-dir/segment-cache/prefetch-auto/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/next.config.js
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
   },

--- a/test/e2e/app-dir/segment-cache/revalidation/next.config.js
+++ b/test/e2e/app-dir/segment-cache/revalidation/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
   },

--- a/test/e2e/app-dir/segment-cache/search-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/search-params/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
   },

--- a/test/e2e/app-dir/segment-cache/staleness/next.config.js
+++ b/test/e2e/app-dir/segment-cache/staleness/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: true,
     dynamicIO: true,
     clientSegmentCache: true,
     staleTimes: {

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     cpus: 1,
-    ppr: true,
     dynamicIO: true,
     serverSourceMaps: true,
   },

--- a/test/e2e/app-dir/use-cache-close-over-function/next.config.js
+++ b/test/e2e/app-dir/use-cache-close-over-function/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
     serverSourceMaps: true,
   },
 }

--- a/test/e2e/app-dir/use-cache-custom-handler/next.config.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
     cacheHandlers: {
       default: require.resolve('./handler.js'),
       legacy: require.resolve('./legacy-handler.js'),

--- a/test/e2e/app-dir/use-cache-hanging-inputs/next.config.js
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   experimental: {
     dynamicIO: true,
     prerenderEarlyExit: false,
-    ppr: true,
   },
 }
 

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/next.config.js
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
   },
 }
 

--- a/test/e2e/app-dir/use-cache-route-handler-only/next.config.js
+++ b/test/e2e/app-dir/use-cache-route-handler-only/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    ppr: true,
   },
 }
 


### PR DESCRIPTION
Now that `ppr` is enabled by default when `dynamicIO` is enabled, we can remove the obsolete `ppr: true` configs from the Dynamic IO tests.