### PR TITLE
perf(turbopack): Limit libuv worker threads of worker process

### DIFF
--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -354,6 +354,7 @@ impl NodeJsPoolProcess {
             .context("binding to a port")?;
         let port = listener.local_addr().context("getting port")?.port();
         let mut cmd = Command::new("node");
+        cmd.env("UV_THREADPOOL_SIZE", "1");
         cmd.current_dir(cwd);
         if debug {
             cmd.arg("--inspect-brk");

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -354,7 +354,7 @@ impl NodeJsPoolProcess {
             .context("binding to a port")?;
         let port = listener.local_addr().context("getting port")?.port();
         let mut cmd = Command::new("node");
-        cmd.env("UV_THREADPOOL_SIZE", "1");
+        cmd.env("UV_THREADPOOL_SIZE", "2");
         cmd.current_dir(cwd);
         if debug {
             cmd.arg("--inspect-brk");


### PR DESCRIPTION
### What?

Change the number of libuv worker threads from 4 to 2 for the Node.js processes we spawn.

### Why?

Numbers at https://vercel.slack.com/archives/C06PPGZ0FD3/p1747432167730419?thread_ts=1747426156.734189&cid=C06PPGZ0FD3


Closes PACK-4635