### PR TITLE
build(next-swc): Update `swc_core` to `v25.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7785571ebd752875029b305fd26735c525660e042e07330402388968e9722e5"
+checksum = "1d4d1ac485a2bed201ccf331ead87d97e1b33b239130b094a2226a7aa270b276"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4226,8 +4226,8 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "1.0.1"
-source = "git+https://github.com/kdy1/mdxjs-rs?branch=swc-core-24#f055669d7e6560d3eb0fab8a13eee2b03a91ccbc"
+version = "1.0.2"
+source = "git+https://github.com/kdy1/mdxjs-rs?branch=swc-core-25#b82ccfe50e3d3cff0819ae3ad6e026c69318e7b1"
 dependencies = [
  "markdown",
  "rustc-hash 2.1.1",
@@ -4388,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bce7fe9cb7884b5fc82c5ee55f49768f00e842248f885a348a89688c287264"
+checksum = "fe193e65e83c580cfc8d7c6530a853a8b0443206d652625fcee266644f4b9082"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -6040,9 +6040,9 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334c17d9a1710384f6a70a9edf998218296147423bc9b79371784d0249851a85"
+checksum = "b176c3d2f5bb36112bef54754648389ad6647ce0a19a5e1a16a66b82cc978b8b"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6168,9 +6168,9 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c851d6ee5ea7acd024905a111dc2a1e7c25288931315efbdb3dca2e9c25441e2"
+checksum = "eef3bc7f88475475cc7079f92189c1eb3c650210a0dd8c4851532bde7992b3d1"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7287,9 +7287,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.112.1"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b432fa1f2bf88c0ce047b1e3857a4c33888537de868e39c32765c3722262a2e5"
+checksum = "dbb50f5a791b70b725d8b2308676bc50876502952e62afab8dd444b5ac15c270"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -7306,9 +7306,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.88.0"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d49d78c38cac994f22e4b06f9481891d19f4b82d1c95e9e85b004337a88aa2"
+checksum = "c3b07a8f51fa6a4658a025ad7080729715f71a7eb136048ed347fa97af2009b3"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -7349,9 +7349,9 @@ checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
 
 [[package]]
 name = "swc"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e736e621b139ca403a185f2efdf7299b3b1850e65fdf718e72c9e8a9dd750200"
+checksum = "0faaca65307dd2162d5e27a1bc16b4884235e5a714f33846d08660fb3c9b61d7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7460,9 +7460,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "9.2.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56b6f5a8e5affa271b56757a93badee6f44defcd28f3ba106bb2603afe40d3d"
+checksum = "a53ebedaccf5e469fa3be2f54e432d9592c659a69eead0cc1b06f41f051e9d89"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7494,9 +7494,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0042d7baa47bfcd95c165a2e2f03384825ab6bcf525692361894c8105d60ec1c"
+checksum = "fde317abee9dacf6641db282ffd4447c735d37c172577f41a254d1930c551367"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7553,9 +7553,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676e3cab6fe72a559444ab7225470f8f98128726bf0c6f7f3d5c614c10a22b0d"
+checksum = "05fef1dbff000a009f955919fe16ac5ee20641fa7018aaa71d7230f5debe8991"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7588,9 +7588,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd778bc4e1601c6cc510542f1ec9f63207f4c703738e795b36a2de18eaeaf679"
+checksum = "0e2e5c7bac48a1c715147b7f2aa218cdbbb2557dcd96902cd9ae61b9a6f49f2f"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -7600,9 +7600,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7422302204a99d0f63c1876a6dd8e8c389c73a9d6838bdef502e74e21c5511"
+checksum = "2d8423f3d64a4ff2904a9e5e646563dc1c3cc33d16113450d296b3fc33d00260"
 dependencies = [
  "auto_impl",
  "bitflags 2.9.0",
@@ -7629,9 +7629,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa7c645a7a695c8ae1f9d69a5b95ad201c4a482bee5ca37c83ec2c1b3accb4a"
+checksum = "f2daa1254805271bd110bdb59297bd8c8ad954ded2db0aa5a685e46539bd78d6"
 dependencies = [
  "bitflags 2.9.0",
  "once_cell",
@@ -7646,9 +7646,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623222f50b32b61feb59e8fd4a69a27011b4d5006be6964ec40ce6e015a7bd3a"
+checksum = "c1c190c30cbafe0a5fa73c758f49d1bddfcc91ececbea21e0c3881526688513b"
 dependencies = [
  "rustc-hash 2.1.1",
  "serde",
@@ -7661,9 +7661,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d8f886ca5c6e01f110569661a3b8858b1446b082cb1ebcf7373628a27c6c84"
+checksum = "cc13c51d125d8311f535c16ca7900955e08cc21282310ec8a28373fe37404d53"
 dependencies = [
  "lexical",
  "serde",
@@ -7674,9 +7674,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad14e892b6e903fd4cf64a28c95afd3889b08b8331757e77553df8f94db34a1"
+checksum = "c19384972d97ca8b2256ebae54504144ee30615393456bb32898f0548bb3505c"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -7692,9 +7692,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdc773abf536501676628aef3138fb5ee0b6e2f74b50b92a55e6d01c71bc6b4"
+checksum = "c64de223005cc0d92eea793712ac4e9168577219adf0c38350209f484a5ab2e6"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
@@ -7708,9 +7708,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992563fbab95867e30a77abf59b0394cd00a31ecf14688a2da1b7c1c7955880f"
+checksum = "7995105f54a55711879f12ac595ce320dbcf539f696c14464a3b26bceca4ecfa"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7721,9 +7721,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0613d84468a6bb6d45d13c5a3368b37bd21f3067a089f69adac630dcb462a018"
+checksum = "ca03c581bf83773f6502eb9cce6807a0400556f981dbf2f6f85b5b098322df80"
 dependencies = [
  "bitflags 2.9.0",
  "bytecheck 0.8.0",
@@ -7746,9 +7746,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01b3de365a86b8f982cc162f257c82f84bda31d61084174a3be37e8ab15c0f4"
+checksum = "efa6c4eadc7cfb153b74ac0e7b4ab7b08f26be5b5678541da9bd582430848ffe"
 dependencies = [
  "ascii",
  "compact_str",
@@ -7781,9 +7781,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1f1a835abb761adfe909e84550ce80001663b301a02059ca98f98f9358e625"
+checksum = "9bc0972813548db39a05fedf5ead846e74296bada067ee276c9ab0b66f0a127c"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
@@ -7799,9 +7799,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611db1605bff05603aacaf5e14f58cf2339991cceef03817bb8ed19010d10506"
+checksum = "cbd9cce533424d8d1f7a9a29fb5889aa986b9710fa991db92fa086443d980dbf"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7812,9 +7812,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29eeb4ea7f2eee831e7f8c0c523577900470f5c3b3feb63515defc131f8c39f4"
+checksum = "a7913c4368e0489e759b5fcf753b666da22e62c5d0b0dfc84d17ec2007c576ba"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -7839,9 +7839,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c8cce4b0b0acfa156c235eca429d1bbffe3297cb48cd61578908ddcc5a8899"
+checksum = "904033d1bb157d0c98ecc1fa3033e81b067adcb12a54ba437e47344bb2d9539b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7856,9 +7856,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da9ff1172f67c8792b73d97a9c578e7de44b3af7a60991ce87145cf7f5372c8"
+checksum = "33a27d8ecbf0b16417e44fa979cb2847679b6f12a48f81defc520a9558e92ebc"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7874,9 +7874,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544ef337a40dfa7f3fe7b4c7e65bba99057258f3ecee79fa9052eac59f502b97"
+checksum = "c1f223933b2ceccd541ecbaa25369aaff8999ae431a56cb83a363a95abc163ba"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7893,9 +7893,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e116fb7a5a50251947160862c52596bdd2d8c417a1f9b8eb061d83bdfc699272"
+checksum = "edef2a29fa559fba37f3b1ab4ae0791d8f715c94850d78988a32af1278347cd3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7909,9 +7909,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e858e1fc3d5a4299a81ca25028f8a01feca8f1876db6d2e19bbe5a8bac39c8a"
+checksum = "8cd786103b7c18617a4308c89179df0f90a9f9f455fe4cedaf85a1cfd3ff0bf6"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7927,9 +7927,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba25f8d0c7f915525abe4f2efde17c7f04ecd7a1500acc82a36133bef7b9f60"
+checksum = "41713e150ba35137c870d746705774994ad51a57871b94b104f219ca3796fed4"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7943,9 +7943,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c412ba2452b20fdcb791448c6606ba43fa84f80e23b0b2fef0cc9ee02794d12c"
+checksum = "d28d04789fe0570be1c28d3d6370d532ba5bf2c1aa7c349e5512981b688815a6"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
@@ -7963,9 +7963,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059c8b419ce4a2e432ec1520dde77db3b8f45df552bf0b6bd974d8516986c9eb"
+checksum = "473af5a24b3683938e933d39ac370d8f82dcb3fdd3f588614706185d2bf12bcf"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7978,9 +7978,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "13.0.1"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd377cf6502daf10b2d7428ea35ae959ca3584a7c968c296af3bdd98e70cff12"
+checksum = "e63c840e1a16615e785bdb656d7bd16c0fcea8489464e723b37ae46301536f8b"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -7992,9 +7992,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d11c8e71901401b9aae2ece4946eeb7674b14b8301a53768afbbeeb0e48b599"
+checksum = "256ee9bd0c6928d71d635c7c5044d9125af37070ebd13ab16498303046b9e5d3"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8017,9 +8017,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b34165ed826fd794fb78ded5bed1a4d39d11a285b8f9fc6be93f52036da5294"
+checksum = "afdef224d9ad9a20cfaaf14abec264d877e3cbcb408e557d4be1e0962d25f915"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -8038,9 +8038,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb574d660c05f3483c984107452b386e45b95531bdb1253794077edc986f413"
+checksum = "92f5ea60d0f25a7abdc02ef025d773d3ac979a50b3446dd65ea745ef226d2259"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -8054,16 +8054,15 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_cached",
  "swc_common",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084389cc2cd71d643de71b6f1b758a509a36d5ca319954b3a6e0be9359c9309d"
+checksum = "e310cab11b33c3228975595acf6df886a71bb8180c8aae1bceae403abbd225ef"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8099,9 +8098,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250786944fbc05f6484eda9213df129ccfe17226ae9ad51b62fce2f72135dbee"
+checksum = "13a88f88646bf3efd7a614aec888c21b5a23bb8e63d7fbcf2df9fcf1a2c952d7"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8125,9 +8124,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05181442a89848184dd87be8d95b92d49d6af84d3e7a96b638c0492a45d03799"
+checksum = "d6f2bb9ff805848ec72a03c4966f91d32cce122f3a9b777646c438cbab333e31"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -8150,9 +8149,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3221879cd18131a3946f8f29d181fe239b58b6595ccefa7263a9395ad4b5e575"
+checksum = "d0ef3fa4e146eff07845cd58216c73b044ea577222227974150673b4f58a4353"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8168,9 +8167,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977386a831e9464cc99e914d5682621efca49c443e5c737a00a2babd6d1589aa"
+checksum = "46e67b2f453ea0e526056e97a4267e984c590cf03c91ca5d473d2b598c635082"
 dependencies = [
  "anyhow",
  "hex",
@@ -8181,9 +8180,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480fc38d0856bf840ddfef10d9953f2f4315227a1dda9c25d7a71b49f618fcb7"
+checksum = "86c77766fcc5e49fa8470de8369676bca55371ca58602fa81d49795c0452f4c1"
 dependencies = [
  "par-core",
  "swc_atoms",
@@ -8202,9 +8201,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6856da3da598f4da001b7e4ce225ee8970bc9d5cbaafcaf580190cf0a6031ec5"
+checksum = "206283c6813ea714ea7f73ba1a14d0af833c5c7a080a3d6f0999495c2b3fe3ad"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.9.0",
@@ -8227,9 +8226,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f84248f82bad599d250bbcd52cb4db6ff6409f48267fd6f001302a2e9716f80"
+checksum = "7665503a3c1dcecd12da1cf6fc15b77efd8a7e962bc109dc657780d5f395f8d9"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8241,9 +8240,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984d7c07ca905dc5d484ca6a3e5d7c452da231c5f9cf7b621237255e9e8e4986"
+checksum = "9d90c36d0756a6d2cfada472487a796f0cd23acdd1f80df35763497563b6282c"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -8291,9 +8290,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90467f0bee316134927e928e3b2c57e77a3ea59a7b1626d2db36d1cb9634cfd0"
+checksum = "ec0924a56c73464aa546c8961f2c8f07d7ef629a4fd7d330452d63cfa4ac33ac"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -8319,9 +8318,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b14c8f6c1c82b7556d7534de44714401901fcb9b618f817172015565ce7d47"
+checksum = "1cb5dc5b05c68214134c6d72ba4409a48110f6cfa930bea91a3941cb991d6faf"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.7.1",
@@ -8344,9 +8343,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193237e318421ef621c2b3958b4db174770c5280ef999f1878f2df93a2837ca6"
+checksum = "38564c381fb4bb1317be9dd7d7c465fd372fd9589ae38453b1a8e8355f6f277b"
 dependencies = [
  "either",
  "rustc-hash 2.1.1",
@@ -8364,9 +8363,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baae39c70229103a72090119887922fc5e32f934f5ca45c0423a5e65dac7e549"
+checksum = "c795f11596f149dbe79579773d13d463bd6ab4e456495c360e60463f3e279f68"
 dependencies = [
  "base64 0.22.1",
  "dashmap 5.5.3",
@@ -8391,9 +8390,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a905befc831be30430ab1e4af5aa6f2052ea397f44e1747c28a4d3859f4f84"
+checksum = "56f9e73a690d3e5bcbe211f22815cd2a0c884e542d709d632323e1cda7a699a5"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8418,9 +8417,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c65e0b49f7e2a2bd92f1d89c9a404de27232ce00f6a4053f04bda446d50e5c"
+checksum = "5b6845e968569f670fab573332245634bd00256814707173cc0fb6365af476ac"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
@@ -8437,9 +8436,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7858f1eccac3c8a85b97ba3820020583efa28bc766d253f0a93d7bbc54c985"
+checksum = "2edb37d49d187b687d45e93c7cf853fece54ec0fd3adc224c550b904345ddfc4"
 dependencies = [
  "bitflags 2.9.0",
  "indexmap 2.7.1",
@@ -8455,9 +8454,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "13.1.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ed837406d5dbbfbf5792b1dc90964245a0cf659753d4745fe177ffebe8598b9"
+checksum = "67a273fc67f40746fe7c24894ff470531b5b75b17b0f40531ded7cb08610b66f"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",
@@ -8477,9 +8476,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249dc9eede1a4ad59a038f9cfd61ce67845bd2c1392ade3586d714e7181f3c1a"
+checksum = "035bb30e8f9e077b94a2b403f5056faaf0d8417b5190b4bcf0be62768342eab2"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -8493,9 +8492,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.88.0"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5ca68aa427646f638dc1a29cbfe74f1cef75f85ef7f2575da84550e4c69ba"
+checksum = "be1a1ba26f59bf0461a1fede71c16ca2f95c6e46bb930e2863bc84cb222cbf79"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8529,9 +8528,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5be5f151485ec9372c23bbb132c4a829c879632db8b790439779b873970be"
+checksum = "c2c0fb3ceae263cc1d3fff8d00813409d5416ab8d2c047ecc1d4d6b44b118353"
 dependencies = [
  "anyhow",
  "miette",
@@ -8556,9 +8555,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9ded5a3355c56eb1148491c70bd4f85f7fcb706d40c0a86a67260cbcb560c3"
+checksum = "b0a9523aa3d6d0205b11da3a756ebe69f828f8b0264a4a850ece565bccd0b10c"
 dependencies = [
  "dashmap 5.5.3",
  "rustc-hash 2.1.1",
@@ -8593,9 +8592,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbd6dddc6f98f7ded495b918c80bc59c78d9b297ed98081e22def0f27a117f9"
+checksum = "4fc484423fef3772ad4d7e63075d5e6384cce4d205fe44e20cc2366501732dc0"
 dependencies = [
  "better_scoped_tls",
  "bytecheck 0.8.0",
@@ -8610,9 +8609,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "11.1.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397ed07e0a652da33372327862d8fb977176b21f903a9f90ed0885ca847844b5"
+checksum = "7f20a682157c971162957c76f71b9d83f77312f79ee61f7876964c6cf018fe42"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8639,9 +8638,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da642df4a69a4a4afae450487d354af66930c11d6b329e9044dc3c73cd693429"
+checksum = "edd7f450c1fc39c5909b8aae6cda9a000dafa441c8f60a8cf93e25706e728002"
 dependencies = [
  "once_cell",
  "regex",
@@ -8677,9 +8676,9 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d73c21cecc518e0107f890012a747fa679cb0faf04f32fc8f5bd618040eb8fe"
+checksum = "fff8ea3abcae914d0caf6adece374bb0e55aa96d74dbc7dd2ddf6ad4535cd3ba"
 dependencies = [
  "better_scoped_tls",
  "once_cell",
@@ -8691,9 +8690,9 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c01b8c9b645f4b3b39664477166876bdc239c9b5f785389e117dee822dbcec5"
+checksum = "ef615742050fb93f9a6c0b3019eac212fb2498e82b16646bb30b463b9a030fa9"
 dependencies = [
  "bitflags 2.9.0",
  "petgraph 0.7.1",
@@ -8884,9 +8883,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987241734b96bd71228f0395ab38e05b71ec7c6ded958538c5d3a1b67f6465ce"
+checksum = "a06bc54f1ba952d312b84bbccacf8b3155dcb590b71f452e680ea66b07a0416c"
 dependencies = [
  "ansi_term",
  "cargo_metadata 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,21 +297,21 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "24.0.0", features = [
+swc_core = { version = "25.0.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "10.0.0" }
+testing = { version = "11.0.0" }
 
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.18.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "1.0.1"
-modularize_imports = { version = "0.84.0" }
-styled_components = { version = "0.112.1" }
-styled_jsx = { version = "0.88.0" }
-swc_emotion = { version = "0.88.0" }
-swc_relay = { version = "0.58.0" }
+modularize_imports = { version = "0.85.0" }
+styled_components = { version = "0.113.0" }
+styled_jsx = { version = "0.89.0" }
+swc_emotion = { version = "0.89.0" }
+swc_relay = { version = "0.59.0" }
 
 # General Deps
 chromiumoxide = { version = "0.5.4", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,4 +430,4 @@ vergen-gitcl = { git = "https://github.com/bgw/vergen.git", branch = "bgw/no-opt
 webbrowser = "0.8.7"
 
 [patch.crates-io]
-mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-24" }
+mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-25" }

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -32,8 +32,8 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
-react_remove_properties = "0.38.0"
-remove_console = "0.39.0"
+react_remove_properties = "0.39.0"
+remove_console = "0.40.0"
 itertools = { workspace = true }
 auto-hash-map = { workspace = true }
 percent-encoding = "2.3.1"

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -62,8 +62,8 @@ turbopack-ecmascript-plugins = { workspace = true, optional = true }
 turbo-rcstr = { workspace = true }
 urlencoding = { workspace = true }
 
-react_remove_properties = "0.38.0"
-remove_console = "0.39.0"
+react_remove_properties = "0.39.0"
+remove_console = "0.40.0"
 preset_env_base = "3.0.1"
 
 [dev-dependencies]

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -3261,7 +3261,7 @@ fn program_to_data_url(
         }
     }
 
-    let map = cm.build_source_map_with_config(
+    let map = cm.build_source_map(
         &mappings,
         None,
         InlineSourcesContentConfig {

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -116,7 +116,7 @@ pub fn generate_js_source_map(
         None
     };
 
-    let map = files_map.build_source_map_with_config(
+    let map = files_map.build_source_map(
         &mappings,
         None,
         InlineSourcesContentConfig {


### PR DESCRIPTION
### What?

Update `swc_core` to `v25.0.0`

ChangeLog: https://github.com/swc-project/swc/compare/swc_core%40v24.0.0...swc_core%40v25.0.0

### Why?

https://github.com/swc-project/swc/pull/10474 is required for some tasks.


Closes PACK-4632