### PR TITLE
Fork the globset strategy for turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9736,6 +9736,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "rayon",
+ "regex",
  "rstest",
  "rustc-hash 2.1.1",
  "serde",

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -119,8 +119,8 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     request_glob,
                 }) = *exception_glob
                 {
-                    let path_match = path_glob.await?.execute(&raw_fs_path.path);
-                    let request_match = request_glob.await?.execute(&request_str);
+                    let path_match = path_glob.await?.matches(&raw_fs_path.path);
+                    let request_match = request_glob.await?.matches(&request_str);
                     if path_match || request_match {
                         return Ok(ResolveResultOption::none());
                     }
@@ -135,8 +135,8 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     request_glob,
                 }) = *external_glob
                 {
-                    let path_match = path_glob.await?.execute(&raw_fs_path.path);
-                    let request_match = request_glob.await?.execute(&request_str);
+                    let path_match = path_glob.await?.matches(&raw_fs_path.path);
+                    let request_match = request_glob.await?.matches(&request_str);
 
                     if !path_match && !request_match {
                         return Ok(ResolveResultOption::none());

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -41,6 +41,7 @@ mime = { workspace = true }
 notify = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
+regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_bytes = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -1,34 +1,8 @@
-use std::mem::take;
-
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Error, Result};
+use regex::bytes::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{NonLocalValue, TryJoinIterExt, Vc, trace::TraceRawVcs};
-use unicode_segmentation::GraphemeCursor;
-
-#[derive(PartialEq, Eq, Debug, Clone, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
-enum GlobPart {
-    /// `/**/`: Matches any path of directories
-    AnyDirectories,
-
-    /// `*`: Matches any filename (no path separator)
-    AnyFile,
-
-    /// `?`: Matches a single filename character (no path separator)
-    AnyFileChar,
-
-    /// `/`: Matches the path separator
-    PathSeparator,
-
-    /// `[abc]`: Matches any char of the list
-    FileChar(Vec<char>),
-
-    /// `abc`: Matches literal filename
-    File(String),
-
-    /// `{a,b,c}`: Matches any of the globs in the list
-    Alternatives(Vec<Glob>),
-}
+use turbo_tasks::Vc;
 
 // Examples:
 // - file.js = File(file.js)
@@ -42,360 +16,71 @@ enum GlobPart {
 // Note: a/**/b does match a/b, so we need some special logic about path
 // separators
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(eq = "manual")]
 #[derive(Debug, Clone)]
+#[serde(into = "GlobForm", try_from = "GlobForm")]
 pub struct Glob {
-    expression: Vec<GlobPart>,
+    glob: String,
+    #[turbo_tasks(trace_ignore)]
+    regex: Regex,
+    #[turbo_tasks(trace_ignore)]
+    directory_match_regex: Regex,
+}
+impl PartialEq for Glob {
+    fn eq(&self, other: &Self) -> bool {
+        self.glob == other.glob
+    }
+}
+impl Eq for Glob {}
+
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+#[repr(transparent)]
+struct GlobForm {
+    glob: String,
+}
+impl From<Glob> for GlobForm {
+    fn from(value: Glob) -> Self {
+        Self { glob: value.glob }
+    }
+}
+impl TryFrom<GlobForm> for Glob {
+    type Error = anyhow::Error;
+    fn try_from(value: GlobForm) -> Result<Self, Self::Error> {
+        Glob::parse(&value.glob)
+    }
 }
 
 impl Glob {
     pub fn execute(&self, path: &str) -> bool {
-        // TODO(lukesandberg): deprecate this implicit behavior
-        let match_partial = path.ends_with('/');
-        self.iter_matches(path, true, match_partial)
-            .any(|result| matches!(result, ("", _)))
+        self.regex.is_match(path.as_bytes())
     }
 
-    // Returns true if the glob could match a filename underneath this `path` where the path
-    // represents a directory.
-    pub fn match_in_directory(&self, path: &str) -> bool {
-        debug_assert!(!path.ends_with('/'));
-        // TODO(lukesandberg): see if we can avoid this allocation by changing the matching
-        // algorithm
-        let path = format!("{path}/");
-        self.iter_matches(&path, true, true)
-            .any(|result| matches!(result, ("", _)))
+    // Returns true if the glob matches the given path.
+    pub fn matches(&self, path: &str) -> bool {
+        self.regex.is_match(path.as_bytes())
     }
 
-    fn iter_matches<'a>(
-        &'a self,
-        path: &'a str,
-        previous_part_is_path_separator_equivalent: bool,
-        match_in_directory: bool,
-    ) -> GlobMatchesIterator<'a> {
-        GlobMatchesIterator {
-            current: path,
-            glob: self,
-            match_in_directory,
-            is_path_separator_equivalent: previous_part_is_path_separator_equivalent,
-            stack: Vec::new(),
-            index: 0,
-        }
+    // Returns true if the glob couldn't possibly match a filename underneath this `path` where the
+    // path represents a directory.
+    pub fn can_skip_directory(&self, path: &str) -> bool {
+        debug_assert!(
+            !path.ends_with('/'),
+            "Path should be a directory name and not end with /"
+        );
+        !self.directory_match_regex.is_match(path.as_bytes())
     }
 
     pub fn parse(input: &str) -> Result<Glob> {
-        let mut current = input;
-        let mut expression = Vec::new();
+        let tokens: Tokens = Parser::new(input).parse()?;
+        let regex = new_regex(tokens.to_regex().as_str());
+        let directory_match_regex = new_regex(tokens.to_directory_match_regex().as_str());
 
-        while !current.is_empty() {
-            let (part, remainder) = GlobPart::parse(current, false)
-                .with_context(|| anyhow!("Failed to parse glob {input}"))?;
-            expression.push(part);
-            current = remainder;
-        }
-
-        Ok(Glob { expression })
-    }
-}
-
-struct GlobMatchesIterator<'a> {
-    current: &'a str,
-    glob: &'a Glob,
-    // In this mode we are checking if the glob might match something in the directory represented
-    // by this path.
-    match_in_directory: bool,
-    is_path_separator_equivalent: bool,
-    stack: Vec<GlobPartMatchesIterator<'a>>,
-    index: usize,
-}
-
-impl<'a> Iterator for GlobMatchesIterator<'a> {
-    type Item = (&'a str, bool);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(part) = self.glob.expression.get(self.index) {
-                let iter = if let Some(iter) = self.stack.get_mut(self.index) {
-                    iter
-                } else {
-                    let iter = part.iter_matches(
-                        self.current,
-                        self.is_path_separator_equivalent,
-                        self.match_in_directory,
-                    );
-                    self.stack.push(iter);
-                    self.stack.last_mut().unwrap()
-                };
-                if let Some((new_path, new_is_path_separator_equivalent)) = iter.next() {
-                    self.current = new_path;
-                    self.is_path_separator_equivalent = new_is_path_separator_equivalent;
-
-                    self.index += 1;
-
-                    if self.match_in_directory && self.current.is_empty() {
-                        return Some(("", self.is_path_separator_equivalent));
-                    }
-                } else {
-                    if self.index == 0 {
-                        // failed to match
-                        return None;
-                    }
-                    // backtrack
-                    self.stack.pop();
-                    self.index -= 1;
-                }
-            } else {
-                // end of expression, matched successfully
-
-                // backtrack for the next iteration
-                self.index -= 1;
-
-                return Some((self.current, self.is_path_separator_equivalent));
-            }
-        }
-    }
-}
-
-impl GlobPart {
-    /// Iterates over all possible matches of this part with the provided path.
-    /// The least greedy match is returned first. This is usually used for
-    /// backtracking. The string slice returned is the remaining part or the
-    /// path. The boolean flag returned specifies if the matched part should
-    /// be considered as path-separator equivalent.
-    fn iter_matches<'a>(
-        &'a self,
-        path: &'a str,
-        previous_part_is_path_separator_equivalent: bool,
-        match_in_directory: bool,
-    ) -> GlobPartMatchesIterator<'a> {
-        GlobPartMatchesIterator {
-            path,
-            part: self,
-            match_in_directory,
-            previous_part_is_path_separator_equivalent,
-            cursor: GraphemeCursor::new(0, path.len(), true),
-            index: 0,
-            glob_iterator: None,
-        }
-    }
-
-    fn parse(input: &str, inside_of_braces: bool) -> Result<(GlobPart, &str)> {
-        debug_assert!(!input.is_empty());
-        let two_chars = {
-            let mut chars = input.chars();
-            (chars.next().unwrap(), chars.next())
-        };
-        match two_chars {
-            ('/', _) => Ok((GlobPart::PathSeparator, &input[1..])),
-            ('*', Some('*')) => Ok((GlobPart::AnyDirectories, &input[2..])),
-            ('*', _) => Ok((GlobPart::AnyFile, &input[1..])),
-            ('?', _) => Ok((GlobPart::AnyFileChar, &input[1..])),
-            ('[', Some('[')) => todo!("glob char classes are not implemented yet"),
-            ('[', _) => todo!("glob char sequences are not implemented yet"),
-            ('{', Some(_)) => {
-                let mut current = &input[1..];
-                let mut alternatives = Vec::new();
-                let mut expression = Vec::new();
-
-                loop {
-                    let (part, remainder) = GlobPart::parse(current, true)?;
-                    expression.push(part);
-                    current = remainder;
-                    match current.chars().next() {
-                        Some(',') => {
-                            alternatives.push(Glob {
-                                expression: take(&mut expression),
-                            });
-                            current = &current[1..];
-                        }
-                        Some('}') => {
-                            alternatives.push(Glob {
-                                expression: take(&mut expression),
-                            });
-                            current = &current[1..];
-                            break;
-                        }
-                        None => bail!("Unterminated glob braces"),
-                        _ => {
-                            // next part of the glob
-                        }
-                    }
-                }
-
-                Ok((GlobPart::Alternatives(alternatives), current))
-            }
-            ('{', None) => {
-                bail!("Unterminated glob braces")
-            }
-            _ => {
-                let mut is_escaped = false;
-                let mut literal = String::new();
-
-                let mut cursor = GraphemeCursor::new(0, input.len(), true);
-
-                let mut start = cursor.cur_cursor();
-                let mut end_cursor = cursor
-                    .next_boundary(input, 0)
-                    .map_err(|e| anyhow!("{:?}", e))?;
-
-                while let Some(end) = end_cursor {
-                    let c = &input[start..end];
-                    if is_escaped {
-                        is_escaped = false;
-                    } else if c == "\\" {
-                        is_escaped = true;
-                    } else if c == "/"
-                        || c == "*"
-                        || c == "?"
-                        || c == "["
-                        || c == "{"
-                        || (inside_of_braces && (c == "," || c == "}"))
-                    {
-                        break;
-                    }
-                    literal.push_str(c);
-
-                    start = cursor.cur_cursor();
-                    end_cursor = cursor
-                        .next_boundary(input, end)
-                        .map_err(|e| anyhow!("{:?}", e))?;
-                }
-
-                Ok((GlobPart::File(literal), &input[start..]))
-            }
-        }
-    }
-}
-
-struct GlobPartMatchesIterator<'a> {
-    path: &'a str,
-    part: &'a GlobPart,
-    match_in_directory: bool,
-    previous_part_is_path_separator_equivalent: bool,
-    cursor: GraphemeCursor,
-    index: usize,
-    glob_iterator: Option<Box<GlobMatchesIterator<'a>>>,
-}
-
-impl<'a> Iterator for GlobPartMatchesIterator<'a> {
-    type Item = (&'a str, bool);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.part {
-            GlobPart::AnyDirectories => {
-                if self.cursor.cur_cursor() == 0 {
-                    let Ok(Some(_)) = self.cursor.next_boundary(self.path, 0) else {
-                        return None;
-                    };
-                    return Some((self.path, true));
-                }
-
-                if self.cursor.cur_cursor() == self.path.len() {
-                    return None;
-                }
-
-                loop {
-                    let start = self.cursor.cur_cursor();
-                    // next_boundary does not set cursor offset to the end of the string
-                    // if there is no next boundary - manually set cursor to the end
-                    let end = match self.cursor.next_boundary(self.path, 0) {
-                        Ok(end) => {
-                            if let Some(end) = end {
-                                end
-                            } else {
-                                self.cursor.set_cursor(self.path.len());
-                                self.cursor.cur_cursor()
-                            }
-                        }
-                        _ => return None,
-                    };
-
-                    if &self.path[start..end] == "/" {
-                        return Some((&self.path[end..], true));
-                    } else if start == end {
-                        return Some((&self.path[start..], false));
-                    }
-                }
-            }
-            GlobPart::AnyFile => {
-                let Ok(Some(c)) = self.cursor.next_boundary(self.path, 0) else {
-                    return None;
-                };
-
-                let idx = self.path[0..c].len();
-
-                // TODO verify if `*` does match zero chars?
-                if let Some(slice) = self.path.get(0..c) {
-                    if slice.ends_with('/') {
-                        None
-                    } else {
-                        Some((
-                            &self.path[c..],
-                            self.previous_part_is_path_separator_equivalent && idx == 1,
-                        ))
-                    }
-                } else {
-                    None
-                }
-            }
-            GlobPart::AnyFileChar => todo!(),
-            GlobPart::PathSeparator => {
-                if self.cursor.cur_cursor() == 0 {
-                    let Ok(Some(b)) = self.cursor.next_boundary(self.path, 0) else {
-                        return None;
-                    };
-                    if self.path.starts_with('/') {
-                        Some((&self.path[b..], true))
-                    } else if self.previous_part_is_path_separator_equivalent {
-                        Some((self.path, true))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            }
-            GlobPart::FileChar(chars) => {
-                let start = self.cursor.cur_cursor();
-                let Ok(Some(end)) = self.cursor.next_boundary(self.path, 0) else {
-                    return None;
-                };
-                let mut chars_in_path = self.path[start..end].chars();
-                let c = chars_in_path.next()?;
-                if chars_in_path.next().is_some() {
-                    return None;
-                }
-                chars.contains(&c).then(|| (&self.path[end..], false))
-            }
-            GlobPart::File(name) => {
-                if self.cursor.cur_cursor() == 0 && self.path.starts_with(name) {
-                    let Ok(Some(_)) = self.cursor.next_boundary(self.path, 0) else {
-                        return None;
-                    };
-                    Some((&self.path[name.len()..], false))
-                } else {
-                    None
-                }
-            }
-            GlobPart::Alternatives(alternatives) => loop {
-                if let Some(glob_iterator) = &mut self.glob_iterator {
-                    if let Some((path, is_path_separator_equivalent)) = glob_iterator.next() {
-                        return Some((path, is_path_separator_equivalent));
-                    } else {
-                        self.index += 1;
-                        self.glob_iterator = None;
-                    }
-                } else if let Some(alternative) = alternatives.get(self.index) {
-                    self.glob_iterator = Some(Box::new(alternative.iter_matches(
-                        self.path,
-                        self.previous_part_is_path_separator_equivalent,
-                        self.match_in_directory,
-                    )));
-                } else {
-                    return None;
-                }
-            },
-        }
+        Ok(Glob {
+            glob: input.to_string(),
+            regex,
+            directory_match_regex,
+        })
     }
 }
 
@@ -411,19 +96,575 @@ impl TryFrom<&str> for Glob {
 impl Glob {
     #[turbo_tasks::function]
     pub fn new(glob: RcStr) -> Result<Vc<Self>> {
-        Ok(Self::cell(Glob::try_from(glob.as_str())?))
+        Ok(Self::cell(Glob::parse(glob.as_str())?))
     }
 
     #[turbo_tasks::function]
     pub async fn alternatives(globs: Vec<Vc<Glob>>) -> Result<Vc<Self>> {
-        if globs.len() == 1 {
-            return Ok(globs.into_iter().next().unwrap());
+        match globs.len() {
+            0 => Ok(Glob::new("".into())),
+            1 => Ok(globs.into_iter().next().unwrap()),
+            _ => {
+                // Composing the Regexes with a RegexSet would be more efficient since we wouldn't
+                // need to recompile them.
+                let mut new_glob = String::new();
+                new_glob.push('{');
+                for (index, glob) in globs.iter().enumerate() {
+                    if index > 0 {
+                        new_glob.push(',');
+                    }
+                    new_glob.push_str(&glob.await?.glob);
+                }
+                new_glob.push('}');
+                Ok(Glob::new(new_glob.into()))
+            }
         }
-        Ok(Self::cell(Glob {
-            expression: vec![GlobPart::Alternatives(
-                globs.into_iter().map(|g| g.owned()).try_join().await?,
-            )],
-        }))
+    }
+}
+
+fn new_regex(pattern: &str) -> Regex {
+    RegexBuilder::new(pattern)
+        .dot_matches_new_line(true)
+        .build()
+        .expect("A successfully parsed glob should produce a valid regex")
+}
+
+/// The parsing and construction algorithms are based on the the `globset` crate.
+/// After discussing upstreaming our usecase with the authors of `globset`, we decided that a fork
+/// was appropriate given our divergent usecases. See discussion https://github.com/BurntSushi/ripgrep/issues/3049
+/// The original code is dual licensed under the MIT license and the Unlicense.
+/// Copyright (c) 2015 Andrew Gallant
+///
+/// Here it is heavily modified to:
+/// - Eliminate various configuration options we don't need
+/// - Eliminate the more complex GlobSet matcher strategies. We don't anticipate needing to compose
+///   thousands of globs like ripgrep and so don't need the performance optimizations that come with
+///   that.
+/// - Add the can_skip_directory method (this is what was rejected by upstream), this allows us to
+///   check if a directory is a valid prefix of a path that would match the glob.
+/// - Add support for nested alternations, a minor detail (this was also sent upstream in https://github.com/BurntSushi/ripgrep/pull/3048)
+/// - And generally simplify representations.
+///
+/// Still some of the cleverest ideas in the original code were in the parsing and construction and
+/// those are mostly preserved.
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+struct Tokens(Vec<Token>);
+impl std::ops::Deref for Tokens {
+    type Target = Vec<Token>;
+    fn deref(&self) -> &Vec<Token> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Tokens {
+    fn deref_mut(&mut self) -> &mut Vec<Token> {
+        &mut self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Token {
+    Literal(char),
+    /// Any Single non path separator Character
+    Any,
+    /// Any
+    ZeroOrMore,
+    /// A `**` at the beginning of the pattern
+    RecursivePrefix,
+    // A `/**` at the end of the pattern
+    RecursiveSuffix,
+    // A `**` in the middle of a pattern
+    RecursiveZeroOrMore,
+    Class {
+        negated: bool,
+        ranges: Vec<(char, char)>,
+    },
+    Alternates(Vec<Tokens>),
+}
+
+impl Tokens {
+    /// Convert this pattern to a string that is guaranteed to be a valid
+    /// regular expression and will represent the matching semantics of this
+    /// glob pattern and the options given.
+    fn to_regex(&self) -> String {
+        let mut re = String::new();
+        re.push_str("(?-u)^");
+        // Special case. If the entire glob is just `**`, then it should match
+        // everything.
+        if self.len() == 1 && self[0] == Token::RecursivePrefix {
+            re.push_str(".*$");
+            return re;
+        }
+        Tokens::tokens_to_regex(self, &mut re);
+        re.push('$');
+        re
+    }
+
+    fn tokens_to_regex(tokens: &[Token], re: &mut String) {
+        for tok in tokens.iter() {
+            match *tok {
+                Token::Literal(c) => {
+                    re.push_str(&char_to_escaped_literal(c));
+                }
+                Token::Any => {
+                    re.push_str("[^/]");
+                }
+                Token::ZeroOrMore => {
+                    re.push_str("[^/]*");
+                }
+                Token::RecursivePrefix => {
+                    re.push_str("(?:/?|.*/)");
+                }
+                Token::RecursiveSuffix => {
+                    re.push_str("/.*");
+                }
+                Token::RecursiveZeroOrMore => {
+                    re.push_str("(?:/|/.*/)");
+                }
+                Token::Class {
+                    negated,
+                    ref ranges,
+                } => {
+                    re.push('[');
+                    if negated {
+                        re.push('^');
+                    }
+                    for r in ranges {
+                        if r.0 == r.1 {
+                            // Not strictly necessary, but nicer to look at.
+                            re.push_str(&char_to_escaped_literal(r.0));
+                        } else {
+                            re.push_str(&char_to_escaped_literal(r.0));
+                            re.push('-');
+                            re.push_str(&char_to_escaped_literal(r.1));
+                        }
+                    }
+                    re.push(']');
+                }
+                Token::Alternates(ref patterns) => {
+                    let mut parts = vec![];
+                    for pat in patterns {
+                        let mut altre = String::new();
+                        Tokens::tokens_to_regex(pat, &mut altre);
+                        if !altre.is_empty() {
+                            parts.push(altre);
+                        }
+                    }
+
+                    // It is possible to have an empty set in which case the
+                    // resulting alternation '()' would be an error.
+                    if !parts.is_empty() {
+                        re.push_str("(?:");
+                        re.push_str(&parts.join("|"));
+                        re.push(')');
+                    }
+                }
+            }
+        }
+    }
+
+    /// Convert this pattern to a string that is guaranteed to be a valid
+    /// regular expression and will represent the matching semantics of this
+    /// glob pattern when used to check if a directory path might contain files that match this
+    /// glob.
+    /// This means we care about matching prefixes that are bounded by `/` characters.
+    /// The basic strategy is to add 'early exits' to the regex at `/` boundaries.
+    /// e.g. `foo/bar/baz` -> `foo(?:/bar(?:/baz(?:/.*)?)?)?`
+    /// that way 'foo' will match but foo/baz will not
+    fn to_directory_match_regex(&self) -> String {
+        let mut re = String::new();
+        re.push_str("(?-u)");
+        re.push('^');
+        // Special case. If the entire glob is just `**`, then it should match
+        // everything.
+        if self.len() == 1 && self[0] == Token::RecursivePrefix {
+            re.push_str(".*");
+            re.push('$');
+            return re;
+        }
+        Tokens::tokens_to_directory_match_regex(self, &mut re);
+        re.push('$');
+        re
+    }
+
+    fn tokens_to_directory_match_regex(tokens: &[Token], re: &mut String) {
+        let mut open_optional_suffixes: usize = 0;
+        for tok in tokens.iter() {
+            match *tok {
+                Token::Literal(c) => {
+                    if c == '/' {
+                        re.push_str("(?:");
+                        open_optional_suffixes += 1;
+                    }
+                    re.push_str(&char_to_escaped_literal(c));
+                }
+                Token::Any => {
+                    re.push_str("[^/]");
+                }
+                Token::ZeroOrMore => {
+                    re.push_str("[^/]*");
+                }
+                Token::RecursiveZeroOrMore | Token::RecursivePrefix => {
+                    re.push_str(".*");
+                    // A match like this will match all directories, so we don't need to examine the
+                    // rest of the tokens.
+                    break;
+                }
+                Token::RecursiveSuffix => {
+                    re.push_str("(?:/.*)?");
+                    break;
+                }
+
+                Token::Class {
+                    negated,
+                    ref ranges,
+                } => {
+                    // handle this as an alternation if it matches a `/`
+                    let matches_slash = if negated {
+                        // If all of the ranges exclude `/`, then the negation includes it.
+                        !ranges.iter().all(|r| r.0 > '/' || r.1 < '/')
+                    } else {
+                        // If any of the ranges include `/`, then the class includes it.
+                        ranges.iter().any(|r| r.0 <= '/' && r.1 >= '/')
+                    };
+                    // If the class matches then a valid directory match is the prefix starting here
+                    // so make the rest optional.
+                    if matches_slash {
+                        re.push_str("(?:");
+                        open_optional_suffixes += 1;
+                    }
+                    re.push('[');
+                    if negated {
+                        re.push('^');
+                    }
+                    for r in ranges {
+                        if r.0 == r.1 {
+                            // Not strictly necessary, but nicer to look at.
+                            re.push_str(&char_to_escaped_literal(r.0));
+                        } else {
+                            re.push_str(&char_to_escaped_literal(r.0));
+                            re.push('-');
+                            re.push_str(&char_to_escaped_literal(r.1));
+                        }
+                    }
+                    re.push(']');
+                }
+                Token::Alternates(ref patterns) => {
+                    let mut parts = Vec::with_capacity(patterns.len());
+                    for pat in patterns {
+                        let mut altre = String::new();
+                        Tokens::tokens_to_directory_match_regex(pat, &mut altre);
+                        if !altre.is_empty() {
+                            parts.push(altre);
+                        }
+                    }
+
+                    // It is possible to have an empty set in which case the
+                    // resulting alternation '()' would be an error.
+                    if !parts.is_empty() {
+                        re.push_str("(?:");
+                        re.push_str(&parts.join("|"));
+                        re.push(')');
+                    }
+                }
+            }
+        }
+        // close all the optional suffixes
+        for _ in 0..open_optional_suffixes {
+            re.push_str(")?")
+        }
+    }
+}
+
+/// Convert a Unicode scalar value to an escaped string suitable for use as
+/// a literal in a non-Unicode regex.
+fn char_to_escaped_literal(c: char) -> String {
+    let mut buf = [0; 4];
+    return regex::escape(c.encode_utf8(&mut buf));
+}
+
+/// The kind of error that can occur when parsing a glob pattern.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ErrorKind {
+    /// Occurs when a character class (e.g., `[abc]`) is not closed.
+    UnclosedClass,
+    /// Occurs when a range in a character (e.g., `[a-z]`) is invalid. For
+    /// example, if the range starts with a lexicographically larger character
+    /// than it ends with.
+    InvalidRange(char, char),
+    /// Occurs when a `}` is found without a matching `{`.
+    UnopenedAlternates,
+    /// Occurs when a `{` is found without a matching `}`.
+    UnclosedAlternates,
+    /// Occurs when an unescaped '\' is found at the end of a glob.
+    DanglingEscape,
+}
+
+impl ErrorKind {
+    fn description(&self, pos: usize) -> String {
+        let str: &'static str = match *self {
+            ErrorKind::UnclosedClass => "unclosed character class; missing ']'",
+            ErrorKind::InvalidRange(_, _) => "invalid character range",
+            ErrorKind::UnopenedAlternates => {
+                "unopened alternate group; missing '{' (maybe escape '}' with '[}]'?)"
+            }
+            ErrorKind::UnclosedAlternates => {
+                "unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)"
+            }
+            ErrorKind::DanglingEscape => "dangling '\\'",
+        };
+        format!("{str} @{pos}")
+    }
+}
+
+struct Parser<'a> {
+    glob: &'a str,
+    // Stores the offsets of where each set of nested alternates started.
+    alternates_stack: Vec<usize>,
+    // The current set of alternate branches being parsed.
+    // Guaranteed to be non-empty.
+    branches: Vec<Tokens>,
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+    // position in terms of characters, not bytes.
+    char_pos: usize,
+    prev: Option<char>,
+    cur: Option<char>,
+}
+fn is_separator(c: char) -> bool {
+    c == '/'
+}
+impl<'a> Parser<'a> {
+    fn new(glob: &'a str) -> Self {
+        Parser {
+            glob,
+            alternates_stack: vec![],
+            branches: vec![Tokens::default()],
+            chars: glob.chars().peekable(),
+            char_pos: 0,
+            prev: None,
+            cur: None,
+        }
+    }
+    fn error(&self, kind: ErrorKind) -> Error {
+        Error::msg(kind.description(self.char_pos))
+            .context(format!("Parsing glob pattern: {}", self.glob))
+    }
+
+    // Parsing consumes the parser
+    fn parse(mut self) -> Result<Tokens, Error> {
+        while let Some(c) = self.bump() {
+            match c {
+                '?' => self.push_token(Token::Any),
+                '*' => self.parse_star(),
+                '[' => self.parse_class()?,
+                '{' => self.push_alternate(),
+                '}' => self.pop_alternate()?,
+                ',' => self.parse_comma(),
+                '\\' => self.parse_backslash()?,
+                c => self.push_token(Token::Literal(c)),
+            }
+        }
+        if !self.alternates_stack.is_empty() {
+            return Err(self.error(ErrorKind::UnclosedAlternates));
+        }
+        debug_assert!(self.branches.len() == 1);
+        return Ok(self.branches.pop().unwrap());
+    }
+
+    fn push_alternate(&mut self) {
+        self.alternates_stack.push(self.branches.len());
+        self.branches.push(Tokens::default());
+    }
+
+    fn pop_alternate(&mut self) -> Result<(), Error> {
+        let Some(start) = self.alternates_stack.pop() else {
+            return Err(self.error(ErrorKind::UnopenedAlternates));
+        };
+        let alts = self.branches.split_off(start);
+        self.push_token(Token::Alternates(alts));
+        Ok(())
+    }
+
+    fn push_token(&mut self, tok: Token) {
+        self.branches.last_mut().unwrap().push(tok);
+    }
+
+    // Panics if there are no tokens to pop.
+    fn pop_token_unchecked(&mut self) -> Token {
+        self.branches.last_mut().unwrap().pop().unwrap()
+    }
+
+    fn have_tokens(&self) -> bool {
+        !self.branches.last().unwrap().is_empty()
+    }
+
+    fn parse_comma(&mut self) {
+        // If we aren't inside a group alternation, then don't
+        // treat commas specially. Otherwise, we need to start
+        // a new alternate.
+        if self.alternates_stack.is_empty() {
+            self.push_token(Token::Literal(','))
+        } else {
+            self.branches.push(Tokens::default())
+        }
+    }
+
+    fn parse_backslash(&mut self) -> Result<(), Error> {
+        match self.bump() {
+            None => Err(self.error(ErrorKind::DanglingEscape)),
+            Some(c) => {
+                self.push_token(Token::Literal(c));
+                Ok(())
+            }
+        }
+    }
+
+    fn parse_star(&mut self) {
+        let prev = self.prev;
+        if self.peek() != Some('*') {
+            self.push_token(Token::ZeroOrMore);
+            return;
+        }
+        assert!(self.bump() == Some('*'));
+        if !self.have_tokens() {
+            if !self.peek().is_none_or(is_separator) {
+                self.push_token(Token::ZeroOrMore);
+                self.push_token(Token::ZeroOrMore);
+            } else {
+                self.push_token(Token::RecursivePrefix);
+                assert!(self.bump().is_none_or(is_separator));
+            }
+            return;
+        }
+
+        if !prev.map(is_separator).unwrap_or(false)
+            && (self.branches.len() <= 1 || (prev != Some(',') && prev != Some('{')))
+        {
+            self.push_token(Token::ZeroOrMore);
+            self.push_token(Token::ZeroOrMore);
+            return;
+        }
+        let is_suffix = match self.peek() {
+            None => {
+                assert!(self.bump().is_none());
+                true
+            }
+            Some(',') | Some('}') if self.branches.len() >= 2 => true,
+            Some(c) if is_separator(c) => {
+                assert!(self.bump().map(is_separator).unwrap_or(false));
+                false
+            }
+            _ => {
+                self.push_token(Token::ZeroOrMore);
+                self.push_token(Token::ZeroOrMore);
+                return;
+            }
+        };
+        match self.pop_token_unchecked() {
+            Token::RecursivePrefix => {
+                self.push_token(Token::RecursivePrefix);
+            }
+            Token::RecursiveSuffix => {
+                self.push_token(Token::RecursiveSuffix);
+            }
+            _ => {
+                if is_suffix {
+                    self.push_token(Token::RecursiveSuffix);
+                } else {
+                    self.push_token(Token::RecursiveZeroOrMore);
+                }
+            }
+        }
+    }
+
+    fn parse_class(&mut self) -> Result<(), Error> {
+        fn add_to_last_range(r: &mut (char, char), add: char) -> Option<ErrorKind> {
+            r.1 = add;
+            if r.1 < r.0 {
+                Some(ErrorKind::InvalidRange(r.0, r.1))
+            } else {
+                None
+            }
+        }
+        let mut ranges = vec![];
+        let negated = match self.chars.peek() {
+            Some(&'!') | Some(&'^') => {
+                let bump = self.bump();
+                assert!(bump == Some('!') || bump == Some('^'));
+                true
+            }
+            _ => false,
+        };
+        let mut first = true;
+        let mut in_range = false;
+        loop {
+            let c = match self.bump() {
+                Some(c) => c,
+                // The only way to successfully break this loop is to observe
+                // a ']'.
+                None => return Err(self.error(ErrorKind::UnclosedClass)),
+            };
+            match c {
+                ']' => {
+                    if first {
+                        ranges.push((']', ']'));
+                    } else {
+                        break;
+                    }
+                }
+                '-' => {
+                    if first {
+                        ranges.push(('-', '-'));
+                    } else if in_range {
+                        // invariant: in_range is only set when there is
+                        // already at least one character seen.
+                        let r = ranges.last_mut().unwrap();
+                        if let Some(kind) = add_to_last_range(r, '-') {
+                            return Err(self.error(kind));
+                        }
+                        in_range = false;
+                    } else {
+                        assert!(!ranges.is_empty());
+                        in_range = true;
+                    }
+                }
+                c => {
+                    if in_range {
+                        // invariant: in_range is only set when there is
+                        // already at least one character seen.
+                        if let Some(kind) = add_to_last_range(ranges.last_mut().unwrap(), '-') {
+                            return Err(self.error(kind));
+                        }
+                    } else {
+                        ranges.push((c, c));
+                    }
+                    in_range = false;
+                }
+            }
+            first = false;
+        }
+        if in_range {
+            // Means that the last character in the class was a '-', so add
+            // it as a literal.
+            ranges.push(('-', '-'));
+        }
+        self.push_token(Token::Class { negated, ranges });
+        Ok(())
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        self.prev = self.cur;
+        self.cur = self.chars.next();
+        if self.cur.is_some() {
+            self.char_pos += 1;
+        }
+        self.cur
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        self.chars.peek().copied()
     }
 }
 
@@ -437,20 +678,16 @@ mod tests {
     #[case::file("file.js", "file.js")]
     #[case::dir_and_file("../public/äöüščří.png", "../public/äöüščří.png")]
     #[case::dir_and_file("dir/file.js", "dir/file.js")]
-    #[case::dir_and_file_partial("dir/file.js", "dir/")]
     #[case::file_braces("file.{ts,js}", "file.js")]
     #[case::dir_and_file_braces("dir/file.{ts,js}", "dir/file.js")]
     #[case::dir_and_file_dir_braces("{dir,other}/file.{ts,js}", "dir/file.js")]
     #[case::star("*.js", "file.js")]
     #[case::dir_star("dir/*.js", "dir/file.js")]
-    #[case::dir_star_partial("dir/*.js", "dir/")]
     #[case::globstar("**/*.js", "file.js")]
     #[case::globstar("**/*.js", "dir/file.js")]
     #[case::globstar("**/*.js", "dir/sub/file.js")]
     #[case::globstar("**/**/*.js", "file.js")]
     #[case::globstar("**/**/*.js", "dir/sub/file.js")]
-    #[case::globstar_partial("**/**/*.js", "dir/sub/")]
-    #[case::globstar_partial("**/**/*.js", "dir/")]
     #[case::globstar_in_dir("dir/**/sub/file.js", "dir/sub/file.js")]
     #[case::globstar_in_dir("dir/**/sub/file.js", "dir/a/sub/file.js")]
     #[case::globstar_in_dir("dir/**/sub/file.js", "dir/a/b/sub/file.js")]
@@ -458,10 +695,6 @@ mod tests {
         "**/next/dist/**/*.shared-runtime.js",
         "next/dist/shared/lib/app-router-context.shared-runtime.js"
     )]
-    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b/sub/")]
-    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b/")]
-    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/")]
-    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/")]
     #[case::star_dir(
         "**/*/next/dist/server/next.js",
         "node_modules/next/dist/server/next.js"
@@ -503,13 +736,13 @@ mod tests {
     #[case::alternatives_nested2("{a,b/c,d/e/{f,g/h}}", "b/c")]
     #[case::alternatives_nested3("{a,b/c,d/e/{f,g/h}}", "d/e/f")]
     #[case::alternatives_nested4("{a,b/c,d/e/{f,g/h}}", "d/e/g/h")]
-    // #[case::alternatives_chars("[abc]", "b")]
+    #[case::alternatives_chars("[abc]", "b")]
     fn glob_match(#[case] glob: &str, #[case] path: &str) {
         let glob = Glob::parse(glob).unwrap();
 
         println!("{glob:?} {path}");
 
-        assert!(glob.execute(path));
+        assert!(glob.matches(path));
     }
 
     #[rstest]
@@ -524,5 +757,23 @@ mod tests {
         println!("{glob:?} {path}");
 
         assert!(!glob.execute(path));
+    }
+
+    #[rstest]
+    #[case::dir_and_file_partial("dir/file.js", "dir")]
+    #[case::dir_star_partial("dir/*.js", "dir")]
+    #[case::globstar_partial("**/**/*.js", "dir/sub")]
+    #[case::globstar_partial("**/**/*.js", "dir")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b/sub")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir")]
+    #[case::alternatives_chars("[abc]", "b")]
+    fn glob_can_skip_directory(#[case] glob: &str, #[case] path: &str) {
+        let glob = Glob::parse(glob).unwrap();
+
+        println!("{glob:?} {path}");
+
+        assert!(!glob.can_skip_directory(path));
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -1,8 +1,10 @@
-use anyhow::{Error, Result};
+use anyhow::Result;
 use regex::bytes::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
+
+use crate::globset::parse;
 
 // Examples:
 // - file.js = File(file.js)
@@ -68,9 +70,9 @@ impl Glob {
     }
 
     pub fn parse(input: &str) -> Result<Glob> {
-        let tokens: Tokens = Parser::new(input).parse()?;
-        let regex = new_regex(tokens.to_regex().as_str());
-        let directory_match_regex = new_regex(tokens.to_directory_match_regex().as_str());
+        let (glob_re, directory_match_re) = parse(input)?;
+        let regex = new_regex(glob_re.as_str());
+        let directory_match_regex = new_regex(directory_match_re.as_str());
 
         Ok(Glob {
             glob: input.to_string(),
@@ -101,8 +103,6 @@ impl Glob {
             0 => Ok(Glob::new("".into())),
             1 => Ok(globs.into_iter().next().unwrap()),
             _ => {
-                // Composing the Regexes with a RegexSet would be more efficient since we wouldn't
-                // need to recompile them.
                 let mut new_glob = String::new();
                 new_glob.push('{');
                 for (index, glob) in globs.iter().enumerate() {
@@ -123,516 +123,6 @@ fn new_regex(pattern: &str) -> Regex {
         .dot_matches_new_line(true)
         .build()
         .expect("A successfully parsed glob should produce a valid regex")
-}
-
-/// The parsing and construction algorithms are based on the the `globset` crate.
-/// After discussing upstreaming our usecase with the authors of `globset`, we decided that a fork
-/// was appropriate given our divergent usecases. See discussion https://github.com/BurntSushi/ripgrep/issues/3049
-/// The original code is dual licensed under the MIT license and the Unlicense.
-/// Copyright (c) 2015 Andrew Gallant
-///
-/// Here it is heavily modified to:
-/// - Eliminate various configuration options we don't need
-/// - Eliminate the more complex GlobSet matcher strategies. We don't anticipate needing to compose
-///   thousands of globs like ripgrep and so don't need the performance optimizations that come with
-///   that.
-/// - Add the can_skip_directory method (this is what was rejected by upstream), this allows us to
-///   check if a directory is a valid prefix of a path that would match the glob.
-/// - Add support for nested alternations, a minor detail (this was also sent upstream in https://github.com/BurntSushi/ripgrep/pull/3048)
-/// - And generally simplify representations.
-///
-/// Still some of the cleverest ideas in the original code were in the parsing and construction and
-/// those are mostly preserved.
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[repr(transparent)]
-struct Tokens(Vec<Token>);
-impl std::ops::Deref for Tokens {
-    type Target = Vec<Token>;
-    fn deref(&self) -> &Vec<Token> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Tokens {
-    fn deref_mut(&mut self) -> &mut Vec<Token> {
-        &mut self.0
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum Token {
-    Literal(char),
-    /// Any Single non path separator Character
-    Any,
-    /// Any
-    ZeroOrMore,
-    /// A `**` at the beginning of the pattern
-    RecursivePrefix,
-    // A `/**` at the end of the pattern
-    RecursiveSuffix,
-    // A `**` in the middle of a pattern
-    RecursiveZeroOrMore,
-    Class {
-        negated: bool,
-        ranges: Vec<(char, char)>,
-    },
-    Alternates(Vec<Tokens>),
-}
-
-impl Tokens {
-    /// Convert this pattern to a string that is guaranteed to be a valid
-    /// regular expression and will represent the matching semantics of this
-    /// glob pattern and the options given.
-    fn to_regex(&self) -> String {
-        self.to_regex_impl(Tokens::tokens_to_regex)
-    }
-
-    /// Convert this pattern to a string that is guaranteed to be a valid
-    /// regular expression and will represent the matching semantics of this
-    /// glob pattern when used to check if a directory path might contain files that match this
-    /// glob.
-    /// This means we care about matching prefixes that are bounded by `/` characters.
-    /// The basic strategy is to add 'early exits' to the regex at `/` boundaries.
-    /// e.g. `foo/bar/baz` -> `foo(?:/bar(?:/baz(?:/.*)?)?)?`
-    /// that way 'foo' will match but foo/baz will not
-    fn to_directory_match_regex(&self) -> String {
-        self.to_regex_impl(Tokens::tokens_to_directory_match_regex)
-    }
-
-    fn to_regex_impl(&self, tokens_to_regex_fn: fn(&[Token], &mut String)) -> String {
-        let mut re = String::new();
-        re.push_str("(?-u)^");
-        // Special case. If the entire glob is just `**`, then it should match
-        // everything.
-        if self.len() == 1 && self[0] == Token::RecursivePrefix {
-            re.push_str(".*$");
-            return re;
-        }
-        tokens_to_regex_fn(self, &mut re);
-        re.push('$');
-        re
-    }
-
-    fn tokens_to_regex(tokens: &[Token], re: &mut String) {
-        for tok in tokens.iter() {
-            match *tok {
-                Token::Literal(c) => {
-                    re.push_str(&char_to_escaped_literal(c));
-                }
-                Token::Any => {
-                    re.push_str("[^/]");
-                }
-                Token::ZeroOrMore => {
-                    re.push_str("[^/]*");
-                }
-                Token::RecursivePrefix => {
-                    re.push_str("(?:/?|.*/)");
-                }
-                Token::RecursiveSuffix => {
-                    re.push_str("/.*");
-                }
-                Token::RecursiveZeroOrMore => {
-                    re.push_str("(?:/|/.*/)");
-                }
-                Token::Class {
-                    negated,
-                    ref ranges,
-                } => {
-                    build_char_class(re, negated, ranges);
-                }
-                Token::Alternates(ref patterns) => {
-                    build_alternates(re, patterns, Tokens::tokens_to_regex);
-                }
-            }
-        }
-    }
-
-    fn tokens_to_directory_match_regex(tokens: &[Token], re: &mut String) {
-        let mut open_optional_suffixes: usize = 0;
-        for tok in tokens.iter() {
-            match *tok {
-                Token::Literal(c) => {
-                    if c == '/' {
-                        re.push_str("(?:");
-                        open_optional_suffixes += 1;
-                    }
-                    re.push_str(&char_to_escaped_literal(c));
-                }
-                Token::Any => {
-                    re.push_str("[^/]");
-                }
-                Token::ZeroOrMore => {
-                    re.push_str("[^/]*");
-                }
-                Token::RecursivePrefix => {
-                    re.push_str(".*");
-                    // A match like this will match all directories, so we don't need to examine the
-                    // rest of the tokens.
-                    break;
-                }
-                Token::RecursiveZeroOrMore | Token::RecursiveSuffix => {
-                    re.push_str("(?:/.*)?");
-                    break;
-                }
-
-                Token::Class {
-                    negated,
-                    ref ranges,
-                } => {
-                    // handle this as an alternation if it matches a `/`
-                    let matches_slash = if negated {
-                        // If all of the ranges exclude `/`, then the negation includes it.
-                        !ranges.iter().all(|r| r.0 > '/' || r.1 < '/')
-                    } else {
-                        // If any of the ranges include `/`, then the class includes it.
-                        ranges.iter().any(|r| r.0 <= '/' && r.1 >= '/')
-                    };
-                    // If the class matches then a valid directory match is the prefix starting here
-                    // so make the rest optional.
-                    if matches_slash {
-                        re.push_str("(?:");
-                        open_optional_suffixes += 1;
-                    }
-                    build_char_class(re, negated, ranges);
-                }
-                Token::Alternates(ref patterns) => {
-                    build_alternates(re, patterns, Tokens::tokens_to_directory_match_regex);
-                }
-            }
-        }
-        // close all the optional suffixes
-        for _ in 0..open_optional_suffixes {
-            re.push_str(")?")
-        }
-    }
-}
-
-fn build_alternates(re: &mut String, patterns: &Vec<Tokens>, branch_fn: fn(&[Token], &mut String)) {
-    let mut parts = Vec::with_capacity(patterns.len());
-    for pat in patterns {
-        let mut altre = String::new();
-        branch_fn(pat, &mut altre);
-        if !altre.is_empty() {
-            parts.push(altre);
-        }
-    }
-
-    // It is possible to have an empty set in which case the
-    // resulting alternation '()' would be an error.
-    if !parts.is_empty() {
-        re.push_str("(?:");
-        re.push_str(&parts.join("|"));
-        re.push(')');
-    }
-}
-
-fn build_char_class(re: &mut String, negated: bool, ranges: &Vec<(char, char)>) {
-    re.push('[');
-    if negated {
-        re.push('^');
-    }
-    for r in ranges {
-        if r.0 == r.1 {
-            // Not strictly necessary, but nicer to look at.
-            re.push_str(&char_to_escaped_literal(r.0));
-        } else {
-            re.push_str(&char_to_escaped_literal(r.0));
-            re.push('-');
-            re.push_str(&char_to_escaped_literal(r.1));
-        }
-    }
-    re.push(']');
-}
-
-/// Convert a Unicode scalar value to an escaped string suitable for use as
-/// a literal in a non-Unicode regex.
-fn char_to_escaped_literal(c: char) -> String {
-    let mut buf = [0; 4];
-    return regex::escape(c.encode_utf8(&mut buf));
-}
-
-/// The kind of error that can occur when parsing a glob pattern.
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum ErrorKind {
-    /// Occurs when a character class (e.g., `[abc]`) is not closed.
-    UnclosedClass,
-    /// Occurs when a range in a character (e.g., `[a-z]`) is invalid. For
-    /// example, if the range starts with a lexicographically larger character
-    /// than it ends with.
-    InvalidRange(char, char),
-    /// Occurs when a `}` is found without a matching `{`.
-    UnopenedAlternates,
-    /// Occurs when a `{` is found without a matching `}`.
-    UnclosedAlternates,
-    /// Occurs when an unescaped '\' is found at the end of a glob.
-    DanglingEscape,
-}
-
-impl ErrorKind {
-    fn description(&self, pos: usize) -> String {
-        let str: &'static str = match *self {
-            ErrorKind::UnclosedClass => "unclosed character class; missing ']'",
-            ErrorKind::InvalidRange(_, _) => "invalid character range",
-            ErrorKind::UnopenedAlternates => {
-                "unopened alternate group; missing '{' (maybe escape '}' with '[}]'?)"
-            }
-            ErrorKind::UnclosedAlternates => {
-                "unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)"
-            }
-            ErrorKind::DanglingEscape => "dangling '\\'",
-        };
-        format!("{str} @{pos}")
-    }
-}
-
-struct Parser<'a> {
-    glob: &'a str,
-    // Stores the offsets of where each set of nested alternates started.
-    alternates_stack: Vec<usize>,
-    // The current set of alternate branches being parsed.
-    // Guaranteed to be non-empty.
-    branches: Vec<Tokens>,
-    chars: std::iter::Peekable<std::str::Chars<'a>>,
-    // position in terms of characters, not bytes.
-    char_pos: usize,
-    prev: Option<char>,
-    cur: Option<char>,
-}
-fn is_separator(c: char) -> bool {
-    c == '/'
-}
-impl<'a> Parser<'a> {
-    fn new(glob: &'a str) -> Self {
-        Parser {
-            glob,
-            alternates_stack: vec![],
-            branches: vec![Tokens::default()],
-            chars: glob.chars().peekable(),
-            char_pos: 0,
-            prev: None,
-            cur: None,
-        }
-    }
-    fn error(&self, kind: ErrorKind) -> Error {
-        Error::msg(kind.description(self.char_pos))
-            .context(format!("Parsing glob pattern: {}", self.glob))
-    }
-
-    // Parsing consumes the parser
-    fn parse(mut self) -> Result<Tokens, Error> {
-        while let Some(c) = self.bump() {
-            match c {
-                '?' => self.push_token(Token::Any),
-                '*' => self.parse_star(),
-                '[' => self.parse_class()?,
-                '{' => self.push_alternate(),
-                '}' => self.pop_alternate()?,
-                ',' => self.parse_comma(),
-                '\\' => self.parse_backslash()?,
-                c => self.push_token(Token::Literal(c)),
-            }
-        }
-        if !self.alternates_stack.is_empty() {
-            return Err(self.error(ErrorKind::UnclosedAlternates));
-        }
-        debug_assert!(self.branches.len() == 1);
-        return Ok(self.branches.pop().unwrap());
-    }
-
-    fn push_alternate(&mut self) {
-        self.alternates_stack.push(self.branches.len());
-        self.branches.push(Tokens::default());
-    }
-
-    fn pop_alternate(&mut self) -> Result<(), Error> {
-        let Some(start) = self.alternates_stack.pop() else {
-            return Err(self.error(ErrorKind::UnopenedAlternates));
-        };
-        let alts = self.branches.split_off(start);
-        self.push_token(Token::Alternates(alts));
-        Ok(())
-    }
-
-    fn push_token(&mut self, tok: Token) {
-        self.branches.last_mut().unwrap().push(tok);
-    }
-
-    // Panics if there are no tokens to pop.
-    fn pop_token_unchecked(&mut self) -> Token {
-        self.branches.last_mut().unwrap().pop().unwrap()
-    }
-
-    fn have_tokens(&self) -> bool {
-        !self.branches.last().unwrap().is_empty()
-    }
-
-    fn parse_comma(&mut self) {
-        // If we aren't inside a group alternation, then don't
-        // treat commas specially. Otherwise, we need to start
-        // a new alternate.
-        if self.alternates_stack.is_empty() {
-            self.push_token(Token::Literal(','))
-        } else {
-            self.branches.push(Tokens::default())
-        }
-    }
-
-    fn parse_backslash(&mut self) -> Result<(), Error> {
-        match self.bump() {
-            None => Err(self.error(ErrorKind::DanglingEscape)),
-            Some(c) => {
-                self.push_token(Token::Literal(c));
-                Ok(())
-            }
-        }
-    }
-
-    fn parse_star(&mut self) {
-        let prev = self.prev;
-        if self.peek() != Some('*') {
-            self.push_token(Token::ZeroOrMore);
-            return;
-        }
-        assert!(self.bump() == Some('*'));
-        if !self.have_tokens() {
-            if !self.peek().is_none_or(is_separator) {
-                self.push_token(Token::ZeroOrMore);
-                self.push_token(Token::ZeroOrMore);
-            } else {
-                self.push_token(Token::RecursivePrefix);
-                assert!(self.bump().is_none_or(is_separator));
-            }
-            return;
-        }
-
-        if !prev.map(is_separator).unwrap_or(false)
-            && (self.branches.len() <= 1 || (prev != Some(',') && prev != Some('{')))
-        {
-            self.push_token(Token::ZeroOrMore);
-            self.push_token(Token::ZeroOrMore);
-            return;
-        }
-        let is_suffix = match self.peek() {
-            None => {
-                assert!(self.bump().is_none());
-                true
-            }
-            Some(',') | Some('}') if self.branches.len() >= 2 => true,
-            Some(c) if is_separator(c) => {
-                assert!(self.bump().map(is_separator).unwrap_or(false));
-                false
-            }
-            _ => {
-                self.push_token(Token::ZeroOrMore);
-                self.push_token(Token::ZeroOrMore);
-                return;
-            }
-        };
-        match self.pop_token_unchecked() {
-            Token::RecursivePrefix => {
-                self.push_token(Token::RecursivePrefix);
-            }
-            Token::RecursiveSuffix => {
-                self.push_token(Token::RecursiveSuffix);
-            }
-            _ => {
-                if is_suffix {
-                    self.push_token(Token::RecursiveSuffix);
-                } else {
-                    self.push_token(Token::RecursiveZeroOrMore);
-                }
-            }
-        }
-    }
-
-    fn parse_class(&mut self) -> Result<(), Error> {
-        fn add_to_last_range(r: &mut (char, char), add: char) -> Option<ErrorKind> {
-            r.1 = add;
-            if r.1 < r.0 {
-                Some(ErrorKind::InvalidRange(r.0, r.1))
-            } else {
-                None
-            }
-        }
-        let mut ranges = vec![];
-        let negated = match self.chars.peek() {
-            Some(&'!') | Some(&'^') => {
-                let bump = self.bump();
-                assert!(bump == Some('!') || bump == Some('^'));
-                true
-            }
-            _ => false,
-        };
-        let mut first = true;
-        let mut in_range = false;
-        loop {
-            let c = match self.bump() {
-                Some(c) => c,
-                // The only way to successfully break this loop is to observe
-                // a ']'.
-                None => return Err(self.error(ErrorKind::UnclosedClass)),
-            };
-            match c {
-                ']' => {
-                    if first {
-                        ranges.push((']', ']'));
-                    } else {
-                        break;
-                    }
-                }
-                '-' => {
-                    if first {
-                        ranges.push(('-', '-'));
-                    } else if in_range {
-                        // invariant: in_range is only set when there is
-                        // already at least one character seen.
-                        let r = ranges.last_mut().unwrap();
-                        if let Some(kind) = add_to_last_range(r, '-') {
-                            return Err(self.error(kind));
-                        }
-                        in_range = false;
-                    } else {
-                        assert!(!ranges.is_empty());
-                        in_range = true;
-                    }
-                }
-                c => {
-                    if in_range {
-                        // invariant: in_range is only set when there is
-                        // already at least one character seen.
-                        if let Some(kind) = add_to_last_range(ranges.last_mut().unwrap(), '-') {
-                            return Err(self.error(kind));
-                        }
-                    } else {
-                        ranges.push((c, c));
-                    }
-                    in_range = false;
-                }
-            }
-            first = false;
-        }
-        if in_range {
-            // Means that the last character in the class was a '-', so add
-            // it as a literal.
-            ranges.push(('-', '-'));
-        }
-        self.push_token(Token::Class { negated, ranges });
-        Ok(())
-    }
-
-    fn bump(&mut self) -> Option<char> {
-        self.prev = self.cur;
-        self.cur = self.chars.next();
-        if self.cur.is_some() {
-            self.char_pos += 1;
-        }
-        self.cur
-    }
-
-    fn peek(&mut self) -> Option<char> {
-        self.chars.peek().copied()
-    }
 }
 
 #[cfg(test)]
@@ -729,13 +219,14 @@ mod tests {
     #[rstest]
     #[case::dir_and_file_partial("dir/file.js", "dir")]
     #[case::dir_star_partial("dir/*.js", "dir")]
-    #[case::globstar_partial("**/**/*.js", "dir/sub")]
     #[case::globstar_partial("**/**/*.js", "dir")]
-    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b/sub")]
-    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b")]
-    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a")]
+    #[case::globstar_partial("**/**/*.js", "dir/sub")]
+    #[case::globstar_partial("**/**/*.js", "dir/sub/file.js")] // This demonstrates some ambiguity in naming. `file.js` might be a directory name.
     #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir")]
-    #[case::alternatives_chars("[abc]", "b")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b/sub")]
+    #[case::globstar_in_dir_partial("dir/**/sub/file.js", "dir/a/b/sub/file.js")]
     fn glob_can_match_directory(#[case] glob: &str, #[case] path: &str) {
         let glob = Glob::parse(glob).unwrap();
 
@@ -743,38 +234,14 @@ mod tests {
 
         assert!(glob.can_match_in_directory(path));
     }
-
     #[rstest]
-    #[case::literal("dir/file.js", "dir/file\\.js", "dir(?:/file\\.js)?")]
-    #[case::literal("a/b/c/file.js", "a/b/c/file\\.js", "a(?:/b(?:/c(?:/file\\.js)?)?)?")]
-    #[case::globstar("**/file.js", "(?:/?|.*/)file\\.js", ".*")]
-    #[case::globstar("/**/file.js", "(?:/|/.*/)file\\.js", "(?:/.*)?")] // this one is a little silly since it does match the empty string
-    #[case::globstar("a/**/file.js", "a(?:/|/.*/)file\\.js", "a(?:/.*)?")]
-    #[case::globstar("a/**", "a/.*", "a(?:/.*)?")]
-    #[case::alternates("{a,b,c}/d/**", "(?:a|b|c)/d/.*", "(?:a|b|c)(?:/d(?:/.*)?)?")]
-    #[case::nested_alternates(
-        "{a,b,c/{e,f,g}}/h/**",
-        "(?:a|b|c/(?:e|f|g))/h/.*",
-        "(?:a|b|c(?:/(?:e|f|g))?)(?:/h(?:/.*)?)?"
-    )]
-    #[case::classes("[abc]/d/**", "[abc]/d/.*", "[abc](?:/d(?:/.*)?)?")]
-    fn glob_regex_mapping(
-        #[case] glob: &str,
-        #[case] glob_regex: &str,
-        #[case] directory_match_regex: &str,
-    ) {
+    #[case::dir_and_file_partial("dir/file.js", "dir/file.js")] // even if there was a dir, named `file.js` we know the glob wasn't intended to match it.
+    #[case::alternatives_chars("[abc]", "b")]
+    fn glob_not_can_match_directory(#[case] glob: &str, #[case] path: &str) {
         let glob = Glob::parse(glob).unwrap();
-        // All our regexes come with a fixed prefix and suffix, just assert and drop them
-        fn strip_overhead(s: String) -> String {
-            assert!(s.starts_with("(?-u)^"));
-            assert!(s.ends_with("$"));
-            s["(?-u)^".len()..s.len() - 1].to_string()
-        }
 
-        assert_eq!(glob_regex, strip_overhead(glob.regex.to_string()));
-        assert_eq!(
-            directory_match_regex,
-            strip_overhead(glob.directory_match_regex.to_string())
-        );
+        println!("{glob:?} {path}");
+
+        assert!(!glob.can_match_in_directory(path));
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -53,7 +53,7 @@ impl TryFrom<GlobForm> for Glob {
 
 impl Glob {
     pub fn execute(&self, path: &str) -> bool {
-        self.regex.is_match(path.as_bytes())
+        self.matches(path)
     }
 
     // Returns true if the glob matches the given path.

--- a/turbopack/crates/turbo-tasks-fs/src/globset.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/globset.rs
@@ -1,0 +1,653 @@
+/// The parsing and construction algorithms here are based on the the `globset` crate.
+/// After discussing upstreaming our usecase with the authors of `globset`, we decided that a
+/// fork was appropriate given our divergent usecases. See discussion https://github.com/BurntSushi/ripgrep/issues/3049
+/// The original code had the following license:
+/// ```
+/// The MIT License (MIT)
+///
+/// Copyright (c) 2015 Andrew Gallant
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// ```
+///
+/// Here it has been heavily modified to:
+/// - Eliminate various configuration options we don't need
+/// - Eliminate the more complex `GlobSet` matcher strategies. We don't anticipate needing to
+///   compose thousands of globs like ripgrep does and so don't need the performance
+///   optimizations that come with that.
+/// - Add the can_match_directory regex (this is what was rejected by upstream), this allows us
+///   to check if a directory is a valid prefix of a path that would match the glob.
+/// - Add support for nested alternations, a minor detail (this was also sent upstream in https://github.com/BurntSushi/ripgrep/pull/3048)
+/// - Add a number of comments to clarify the code.
+///
+/// Still some of the cleverest ideas in the original code were in the parsing and construction
+/// of regexes and those are mostly preserved.
+use anyhow::Error;
+
+/// The parsed tokens of a glob pattern.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
+struct Tokens(Vec<Token>);
+
+impl std::ops::Deref for Tokens {
+    type Target = Vec<Token>;
+    fn deref(&self) -> &Vec<Token> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Tokens {
+    fn deref_mut(&mut self) -> &mut Vec<Token> {
+        &mut self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Token {
+    Literal(char),
+    /// Any Single non path separator character
+    Any,
+    /// Any number of non path separator characters
+    ZeroOrMore,
+    /// A `**` at the beginning of the pattern
+    RecursivePrefix,
+    // A `/**` at the end of the pattern
+    RecursiveSuffix,
+    // A `**` in the middle of a pattern
+    RecursiveZeroOrMore,
+    Class {
+        negated: bool,
+        ranges: Vec<(char, char)>,
+        // This is just precomputed since it is used in two places.
+        matches_slash: bool,
+    },
+    Alternates(Vec<Tokens>),
+}
+
+impl Tokens {
+    /// Convert this pattern to a string that is guaranteed to be a valid
+    /// regular expression and will represent the matching semantics of this
+    /// glob pattern and the options given.
+    fn to_regex(&self) -> String {
+        self.to_regex_impl(Self::tokens_to_regex)
+    }
+
+    /// Convert this pattern to a string that is guaranteed to be a valid
+    /// regular expression and will represent the matching semantics of this
+    /// glob pattern when used to check if a directory path might contain files that match this
+    /// glob.
+    /// This means we care about matching prefixes that are bounded by `/` characters.
+    /// The basic strategy is to add 'early exits' to the regex at `/` boundaries.
+    /// e.g. `foo/bar/baz` -> `foo(?:/bar(?:/baz(?:/.*)?)?)?`
+    /// that way 'foo' will match but foo/baz will not
+    fn to_directory_match_regex(&self) -> String {
+        self.to_regex_impl(Self::tokens_to_directory_match_regex)
+    }
+
+    fn to_regex_impl(&self, tokens_to_regex_fn: fn(&[Token], &mut String)) -> String {
+        let mut re = String::new();
+        // Our patterns are always anchored to the beginning and end of the string and we care not
+        // for unicode correctness.  Paths do not require this and if the caller does they can
+        // simply take care to pass us valid utf8 themselves.
+        re.push_str("(?-u)^");
+        // Special case. If the entire glob is just `**`, then it should match
+        // everything.
+        if self.len() == 1 && self[0] == Token::RecursivePrefix {
+            re.push_str(".*$");
+            return re;
+        }
+        tokens_to_regex_fn(self, &mut re);
+        re.push('$');
+        re
+    }
+
+    fn tokens_to_regex(tokens: &[Token], re: &mut String) {
+        for tok in tokens.iter() {
+            match *tok {
+                Token::Literal(c) => {
+                    re.push_str(&char_to_escaped_literal(c));
+                }
+                Token::Any => {
+                    re.push_str("[^/]");
+                }
+                Token::ZeroOrMore => {
+                    re.push_str("[^/]*");
+                }
+                Token::RecursivePrefix => {
+                    re.push_str("(?:/?|.*/)");
+                }
+                Token::RecursiveSuffix => {
+                    re.push_str("/.*");
+                }
+                Token::RecursiveZeroOrMore => {
+                    re.push_str("(?:/|/.*/)");
+                }
+                Token::Class {
+                    negated,
+                    ref ranges,
+                    matches_slash: _,
+                } => {
+                    build_char_class(re, negated, ranges);
+                }
+                Token::Alternates(ref patterns) => {
+                    build_alternates(re, patterns, Self::tokens_to_regex);
+                }
+            }
+        }
+    }
+
+    fn tokens_to_directory_match_regex(tokens: &[Token], re: &mut String) {
+        Self::tokens_to_directory_match_regex_inner(tokens, re, true)
+    }
+    fn tokens_to_directory_match_regex_inner(mut tokens: &[Token], re: &mut String, at_end: bool) {
+        // If this branch is in a suffix position, then we need to try to trim any trailing filename
+        // patterns. We do this by scanning
+        if at_end {
+            // first trim any trailing literal filename matches
+            // e.g. foo/file.js -> foo/
+            // globs match filenames so any trailing literal should not match a directory name.
+            while let Some(tok) = tokens.last() {
+                match tok {
+                    Token::Literal(c) => {
+                        tokens = &tokens[..tokens.len() - 1];
+                        if *c == '/' {
+                            // This is a directory separator, so we can stop trimming after this
+                            break;
+                        }
+                    }
+                    Token::Class {
+                        negated: _,
+                        ranges: _,
+                        matches_slash,
+                    } => {
+                        if !*matches_slash {
+                            // This is a non-slash literal or class that doesn't match a slash
+                            // so we can trim it.
+                            tokens = &tokens[..tokens.len() - 1];
+                        } else {
+                            break;
+                        }
+                    }
+                    Token::ZeroOrMore | Token::Any => {
+                        tokens = &tokens[..tokens.len() - 1];
+                    }
+                    Token::Alternates(_)
+                    | Token::RecursiveZeroOrMore
+                    | Token::RecursiveSuffix
+                    | Token::RecursivePrefix => {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut open_optional_suffixes: usize = 0;
+        for (index, tok) in tokens.iter().enumerate() {
+            match *tok {
+                Token::Literal(c) => {
+                    if c == '/' {
+                        re.push_str("(?:");
+                        open_optional_suffixes += 1;
+                    }
+                    re.push_str(&char_to_escaped_literal(c));
+                }
+                Token::Any => {
+                    re.push_str("[^/]");
+                }
+                Token::ZeroOrMore => {
+                    re.push_str("[^/]*");
+                }
+                Token::RecursivePrefix => {
+                    re.push_str(".*");
+                    // A match like this will match all directories, so we don't need to examine the
+                    // rest of the tokens.
+                    break;
+                }
+                Token::RecursiveZeroOrMore | Token::RecursiveSuffix => {
+                    re.push_str("(?:/.*)?");
+                    break;
+                }
+
+                Token::Class {
+                    negated,
+                    ref ranges,
+                    matches_slash,
+                } => {
+                    // If the class matches then a valid directory match is the prefix starting here
+                    // so make the rest optional.
+                    if matches_slash {
+                        re.push_str("(?:");
+                        open_optional_suffixes += 1;
+                    }
+                    build_char_class(re, negated, ranges);
+                }
+                Token::Alternates(ref patterns) => {
+                    build_alternates(
+                        re,
+                        patterns,
+                        if index + 1 == tokens.len() {
+                            Self::tokens_to_directory_match_regex
+                        } else {
+                            fn tokens_to_directory_match_regex_middle(
+                                tokens: &[Token],
+                                re: &mut String,
+                            ) {
+                                Tokens::tokens_to_directory_match_regex_inner(tokens, re, false)
+                            }
+                            tokens_to_directory_match_regex_middle
+                        },
+                    );
+                }
+            }
+        }
+        // close all the optional suffixes
+        for _ in 0..open_optional_suffixes {
+            re.push_str(")?")
+        }
+    }
+}
+
+fn build_alternates(re: &mut String, patterns: &Vec<Tokens>, branch_fn: fn(&[Token], &mut String)) {
+    let mut parts = Vec::with_capacity(patterns.len());
+    for pat in patterns {
+        let mut altre = String::new();
+        branch_fn(pat, &mut altre);
+        if !altre.is_empty() {
+            parts.push(altre);
+        }
+    }
+
+    // It is possible to have an empty set in which case the
+    // resulting alternation '()' would be an error.
+    if !parts.is_empty() {
+        re.push_str("(?:");
+        re.push_str(&parts.join("|"));
+        re.push(')');
+    }
+}
+
+fn build_char_class(re: &mut String, negated: bool, ranges: &Vec<(char, char)>) {
+    re.push('[');
+    if negated {
+        re.push('^');
+    }
+    for r in ranges {
+        if r.0 == r.1 {
+            // Not strictly necessary, but nicer to look at.
+            re.push_str(&char_to_escaped_literal(r.0));
+        } else {
+            re.push_str(&char_to_escaped_literal(r.0));
+            re.push('-');
+            re.push_str(&char_to_escaped_literal(r.1));
+        }
+    }
+    re.push(']');
+}
+
+/// Convert a Unicode scalar value to an escaped string suitable for use as
+/// a literal in a non-Unicode regex.
+fn char_to_escaped_literal(c: char) -> String {
+    let mut buf = [0; 4];
+    return regex::escape(c.encode_utf8(&mut buf));
+}
+
+/// The kind of error that can occur when parsing a glob pattern.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ErrorKind {
+    /// Occurs when a character class (e.g., `[abc]`) is not closed.
+    UnclosedClass,
+    /// Occurs when a range in a character (e.g., `[a-z]`) is invalid. For
+    /// example, if the range starts with a lexicographically larger character
+    /// than it ends with.
+    InvalidRange(char, char),
+    /// Occurs when a `}` is found without a matching `{`.
+    UnopenedAlternates,
+    /// Occurs when a `{` is found without a matching `}`.
+    UnclosedAlternates,
+    /// Occurs when an unescaped '\' is found at the end of a glob.
+    DanglingEscape,
+}
+
+impl ErrorKind {
+    fn description(&self, pos: usize) -> String {
+        let str: &'static str = match *self {
+            ErrorKind::UnclosedClass => "unclosed character class; missing ']'",
+            ErrorKind::InvalidRange(_, _) => "invalid character range",
+            ErrorKind::UnopenedAlternates => {
+                "unopened alternate group; missing '{' (maybe escape '}' with '[}]'?)"
+            }
+            ErrorKind::UnclosedAlternates => {
+                "unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)"
+            }
+            ErrorKind::DanglingEscape => "dangling '\\'",
+        };
+        format!("{str} @{pos}")
+    }
+}
+
+// Parse the glob and return a tuple of the regex and the directory match regex
+// The regex is guaranteed to be valid and will match the same semantics as the glob.
+// The directory match regex is guaranteed to be valid and will match the same
+// semantics as the glob when used to check if a directory path might contain files that match
+// this glob. This means we care about matching prefixes that are bounded by `/` characters.
+pub(crate) fn parse(glob: &str) -> Result<(String, String), Error> {
+    let tokens = Parser::new(glob).parse()?;
+    Ok((tokens.to_regex(), tokens.to_directory_match_regex()))
+}
+
+struct Parser<'a> {
+    glob: &'a str,
+    // Stores the offsets of where each set of nested alternates started.
+    alternates_stack: Vec<usize>,
+    // The current set of alternate branches being parsed.
+    // Guaranteed to be non-empty.
+    branches: Vec<Tokens>,
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+    // position in terms of characters, not bytes.
+    char_pos: usize,
+    prev: Option<char>,
+    cur: Option<char>,
+}
+fn is_separator(c: char) -> bool {
+    c == '/'
+}
+impl<'a> Parser<'a> {
+    fn new(glob: &'a str) -> Self {
+        Parser {
+            glob,
+            alternates_stack: vec![],
+            branches: vec![Tokens::default()],
+            chars: glob.chars().peekable(),
+            char_pos: 0,
+            prev: None,
+            cur: None,
+        }
+    }
+    fn error(&self, kind: ErrorKind) -> Error {
+        Error::msg(kind.description(self.char_pos))
+            .context(format!("Parsing glob pattern: {}", self.glob))
+    }
+
+    // Parsing consumes the parser
+    fn parse(mut self) -> Result<Tokens, Error> {
+        while let Some(c) = self.bump() {
+            match c {
+                '?' => self.push_token(Token::Any),
+                '*' => self.parse_star(),
+                '[' => self.parse_class()?,
+                '{' => self.push_alternate(),
+                '}' => self.pop_alternate()?,
+                ',' => self.parse_comma(),
+                '\\' => self.parse_backslash()?,
+                c => self.push_token(Token::Literal(c)),
+            }
+        }
+        if !self.alternates_stack.is_empty() {
+            return Err(self.error(ErrorKind::UnclosedAlternates));
+        }
+        debug_assert!(self.branches.len() == 1);
+        return Ok(self.branches.pop().unwrap());
+    }
+
+    fn push_alternate(&mut self) {
+        self.alternates_stack.push(self.branches.len());
+        self.branches.push(Tokens::default());
+    }
+
+    fn pop_alternate(&mut self) -> Result<(), Error> {
+        let Some(start) = self.alternates_stack.pop() else {
+            return Err(self.error(ErrorKind::UnopenedAlternates));
+        };
+        let alts = self.branches.split_off(start);
+        self.push_token(Token::Alternates(alts));
+        Ok(())
+    }
+
+    fn push_token(&mut self, tok: Token) {
+        self.branches.last_mut().unwrap().push(tok);
+    }
+
+    // Panics if there are no tokens to pop.
+    fn pop_token_unchecked(&mut self) -> Token {
+        self.branches.last_mut().unwrap().pop().unwrap()
+    }
+
+    fn have_tokens(&self) -> bool {
+        !self.branches.last().unwrap().is_empty()
+    }
+
+    fn parse_comma(&mut self) {
+        // If we aren't inside a group alternation, then don't
+        // treat commas specially. Otherwise, we need to start
+        // a new alternate.
+        if self.alternates_stack.is_empty() {
+            self.push_token(Token::Literal(','))
+        } else {
+            self.branches.push(Tokens::default())
+        }
+    }
+
+    fn parse_backslash(&mut self) -> Result<(), Error> {
+        match self.bump() {
+            None => Err(self.error(ErrorKind::DanglingEscape)),
+            Some(c) => {
+                self.push_token(Token::Literal(c));
+                Ok(())
+            }
+        }
+    }
+
+    fn parse_star(&mut self) {
+        // A trivial isolated '*'
+        if self.peek() != Some('*') {
+            self.push_token(Token::ZeroOrMore);
+            return;
+        }
+        let prev = self.prev;
+        // consume the next '*'
+        assert!(self.bump() == Some('*'));
+        // Are we at the very beginning of a branch?
+        if !self.have_tokens() {
+            // Are we at the end of the glob or a separator?
+            if !self.peek().is_none_or(is_separator) {
+                // Just push two zero or mores.
+                // This is for something like '**foo/...`
+                // See https://git-scm.com/docs/gitignore#_pattern_format for where this comes from
+                self.push_token(Token::ZeroOrMore);
+            } else {
+                // this is just `**/....`
+                self.push_token(Token::RecursivePrefix);
+                assert!(self.bump().is_none_or(is_separator));
+            }
+            return;
+        }
+
+        // Are we at the beginning or not following a `/`?
+        if !prev.map(is_separator).unwrap_or(false) {
+            // same as the above, this is just an odd `a**/` pattern
+            self.push_token(Token::ZeroOrMore);
+            return;
+        }
+        debug_assert!(prev == Some('/'));
+        let is_suffix = match self.peek() {
+            None => {
+                assert!(self.bump().is_none());
+                true
+            }
+            Some(',') | Some('}') if !self.alternates_stack.is_empty() => true,
+            Some(c) if is_separator(c) => {
+                assert!(self.bump().map(is_separator).unwrap_or(false));
+                false
+            }
+            _ => {
+                self.push_token(Token::ZeroOrMore);
+                return;
+            }
+        };
+        // we don't need to check because we already checked 'have_tokens' above.
+        match self.pop_token_unchecked() {
+            // This is for `/**/**` which is kind of silly, just skip the second occurence
+            Token::RecursivePrefix => {
+                self.push_token(Token::RecursivePrefix);
+            }
+            Token::RecursiveSuffix => {
+                self.push_token(Token::RecursiveSuffix);
+            }
+            t => {
+                // merge with the prior '/' token
+                debug_assert!(Token::Literal('/') == t, "unexpected token {t:?}");
+                if is_suffix {
+                    // This is a `/**` at the end of a pattern.
+                    self.push_token(Token::RecursiveSuffix);
+                } else {
+                    // This is a `/**/` in the middle of a pattern.
+                    self.push_token(Token::RecursiveZeroOrMore);
+                }
+            }
+        }
+    }
+
+    fn parse_class(&mut self) -> Result<(), Error> {
+        fn add_to_last_range(r: &mut (char, char), add: char) -> Option<ErrorKind> {
+            r.1 = add;
+            if r.1 < r.0 {
+                Some(ErrorKind::InvalidRange(r.0, r.1))
+            } else {
+                None
+            }
+        }
+        let mut ranges = vec![];
+        let negated = match self.chars.peek() {
+            Some(&'!') | Some(&'^') => {
+                let bump = self.bump();
+                assert!(bump == Some('!') || bump == Some('^'));
+                true
+            }
+            _ => false,
+        };
+        let mut first = true;
+        let mut in_range = false;
+        loop {
+            let c = match self.bump() {
+                Some(c) => c,
+                // The only way to successfully break this loop is to observe
+                // a ']'.
+                None => return Err(self.error(ErrorKind::UnclosedClass)),
+            };
+            match c {
+                ']' => {
+                    if first {
+                        ranges.push((']', ']'));
+                    } else {
+                        break;
+                    }
+                }
+                '-' => {
+                    if first {
+                        ranges.push(('-', '-'));
+                    } else if in_range {
+                        // invariant: in_range is only set when there is
+                        // already at least one character seen.
+                        let r = ranges.last_mut().unwrap();
+                        if let Some(kind) = add_to_last_range(r, '-') {
+                            return Err(self.error(kind));
+                        }
+                        in_range = false;
+                    } else {
+                        assert!(!ranges.is_empty());
+                        in_range = true;
+                    }
+                }
+                c => {
+                    if in_range {
+                        // invariant: in_range is only set when there is
+                        // already at least one character seen.
+                        if let Some(kind) = add_to_last_range(ranges.last_mut().unwrap(), '-') {
+                            return Err(self.error(kind));
+                        }
+                    } else {
+                        ranges.push((c, c));
+                    }
+                    in_range = false;
+                }
+            }
+            first = false;
+        }
+        if in_range {
+            // Means that the last character in the class was a '-', so add
+            // it as a literal.
+            ranges.push(('-', '-'));
+        }
+        // handle this as an alternation if it matches a `/`
+        let matches_slash = if negated {
+            // If all of the ranges exclude `/`, then the negation includes it.
+            !ranges.iter().all(|r| r.0 > '/' || r.1 < '/')
+        } else {
+            // If any of the ranges include `/`, then the class includes it.
+            ranges.iter().any(|r| r.0 <= '/' && r.1 >= '/')
+        };
+
+        self.push_token(Token::Class {
+            negated,
+            ranges,
+            matches_slash,
+        });
+        Ok(())
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        self.prev = self.cur;
+        self.cur = self.chars.next();
+        if self.cur.is_some() {
+            self.char_pos += 1;
+        }
+        self.cur
+    }
+
+    fn peek(&mut self) -> Option<char> {
+        self.chars.peek().copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::*;
+
+    use super::parse;
+
+    #[rstest]
+    #[case::literal("dir/file.js", "dir/file\\.js", "dir")]
+    #[case::literal("a/b/c/file.js", "a/b/c/file\\.js", "a(?:/b(?:/c)?)?")]
+    #[case::globstar("**/file.js", "(?:/?|.*/)file\\.js", ".*")]
+    #[case::globstar("/**/file.js", "(?:/|/.*/)file\\.js", "(?:/.*)?")] // this one is a little silly since it does match the empty string
+    #[case::globstar("a/**/file.js", "a(?:/|/.*/)file\\.js", "a(?:/.*)?")]
+    #[case::globstar("a/**", "a/.*", "a(?:/.*)?")]
+    #[case::alternates("{a,b,c}/d/**", "(?:a|b|c)/d/.*", "(?:a|b|c)(?:/d(?:/.*)?)?")]
+    #[case::nested_alternates(
+        "{a,b,c/{e,f,g}}/h/**",
+        "(?:a|b|c/(?:e|f|g))/h/.*",
+        "(?:a|b|c(?:/)?)(?:/h(?:/.*)?)?"
+    )]
+    #[case::classes("[abc]/d/**", "[abc]/d/.*", "[abc](?:/d(?:/.*)?)?")]
+    fn glob_regex_mapping(
+        #[case] glob: &str,
+        #[case] glob_regex: &str,
+        #[case] directory_match_regex: &str,
+    ) {
+        let (glob_re, directory_match_re) = parse(glob).unwrap();
+        // All our regexes come with a fixed prefix and suffix, just assert and drop them
+        fn strip_overhead(s: String) -> String {
+            assert!(s.starts_with("(?-u)^"));
+            assert!(s.ends_with("$"));
+            s["(?-u)^".len()..s.len() - 1].to_string()
+        }
+
+        assert_eq!(glob_regex, strip_overhead(glob_re));
+        assert_eq!(directory_match_regex, strip_overhead(directory_match_re));
+    }
+}

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod attach;
 pub mod embed;
 pub mod glob;
+mod globset;
 pub mod invalidation;
 mod invalidator_map;
 pub mod json;

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -83,7 +83,7 @@ async fn track_glob_internal(
 
                 match resolve_symlink_safely(entry).await? {
                     DirectoryEntry::Directory(path) => {
-                        if glob_value.match_in_directory(&entry_path) {
+                        if !glob_value.can_skip_directory(&entry_path) {
                             completions.push(track_glob_inner(
                                 entry_path,
                                 *path,

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -93,13 +93,21 @@ async fn track_glob_internal(
                         }
                     }
                     DirectoryEntry::File(path) => {
-                        if glob_value.execute(&entry_path) {
+                        if {
+                            let this = &glob_value;
+                            let path: &str = &entry_path;
+                            this.matches(path)
+                        } {
                             reads.push(fs.read(*path))
                         }
                     }
                     DirectoryEntry::Symlink(_) => panic!("we already resolved symlinks"),
                     DirectoryEntry::Other(path) => {
-                        if glob_value.execute(&entry_path) {
+                        if {
+                            let this = &glob_value;
+                            let path: &str = &entry_path;
+                            this.matches(path)
+                        } {
                             types.push(path.get_type())
                         }
                     }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -83,7 +83,7 @@ async fn track_glob_internal(
 
                 match resolve_symlink_safely(entry).await? {
                     DirectoryEntry::Directory(path) => {
-                        if !glob_value.can_skip_directory(&entry_path) {
+                        if glob_value.can_match_in_directory(&entry_path) {
                             completions.push(track_glob_inner(
                                 entry_path,
                                 *path,
@@ -93,21 +93,13 @@ async fn track_glob_internal(
                         }
                     }
                     DirectoryEntry::File(path) => {
-                        if {
-                            let this = &glob_value;
-                            let path: &str = &entry_path;
-                            this.matches(path)
-                        } {
+                        if glob_value.matches(&entry_path) {
                             reads.push(fs.read(*path))
                         }
                     }
-                    DirectoryEntry::Symlink(_) => panic!("we already resolved symlinks"),
+                    DirectoryEntry::Symlink(_) => unreachable!("we already resolved symlinks"),
                     DirectoryEntry::Other(path) => {
-                        if {
-                            let this = &glob_value;
-                            let path: &str = &entry_path;
-                            this.matches(path)
-                        } {
+                        if glob_value.matches(&entry_path) {
                             types.push(path.get_type())
                         }
                     }

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -557,7 +557,7 @@ impl ResolvedMap {
         for (root, glob, mapping) in self.by_glob.iter() {
             let root = root.await?;
             if let Some(path) = root.get_path_to(&resolved) {
-                if glob.await?.execute(path) {
+                if glob.await?.matches(path) {
                     return Ok(import_mapping_to_result(
                         *mapping.convert().await?,
                         lookup_path,

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -31,7 +31,7 @@ impl AfterResolvePluginCondition {
         let path = fs_path.await?;
 
         if let Some(path) = root.get_path_to(&path) {
-            if glob.execute(path) {
+            if glob.matches(path) {
                 return Ok(Vc::cell(true));
             }
         }
@@ -66,7 +66,7 @@ impl BeforeResolvePluginCondition {
     pub async fn matches(&self, request: Vc<Request>) -> Result<Vc<bool>> {
         Ok(Vc::cell(match self {
             BeforeResolvePluginCondition::Request(glob) => match request.await?.request() {
-                Some(request) => glob.await?.execute(request.as_str()),
+                Some(request) => glob.await?.matches(request.as_str()),
                 None => false,
             },
             BeforeResolvePluginCondition::Modules(modules) => {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -164,7 +164,7 @@ pub async fn is_marked_as_side_effect_free(
     path: Vc<FileSystemPath>,
     side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<bool>> {
-    if side_effect_free_packages.await?.execute(&path.await?.path) {
+    if side_effect_free_packages.await?.matches(&path.await?.path) {
         return Ok(Vc::cell(true));
     }
 
@@ -181,7 +181,7 @@ pub async fn is_marked_as_side_effect_free(
                     .get_relative_path_to(&*path.await?)
                 {
                     let rel_path = rel_path.strip_prefix("./").unwrap_or(&rel_path);
-                    return Ok(Vc::cell(!glob.await?.execute(rel_path)));
+                    return Ok(Vc::cell(!glob.await?.matches(rel_path)));
                 }
             }
         }

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -148,9 +148,9 @@ impl RuleCondition {
                     }
                     RuleCondition::ResourcePathGlob { glob, base } => {
                         return Ok(if let Some(rel_path) = base.get_relative_path_to(path) {
-                            glob.execute(&rel_path)
+                            glob.matches(&rel_path)
                         } else {
-                            glob.execute(&path.path)
+                            glob.matches(&path.path)
                         });
                     }
                     RuleCondition::ResourceBasePathGlob(glob) => {
@@ -158,7 +158,7 @@ impl RuleCondition {
                             .path
                             .rsplit_once('/')
                             .map_or(path.path.as_str(), |(_, b)| b);
-                        return Ok(glob.execute(basename));
+                        return Ok(glob.matches(basename));
                     }
                     RuleCondition::ResourcePathRegex(_) => {
                         bail!("ResourcePathRegex not implemented yet");


### PR DESCRIPTION
## What 
After discussion with [upstream](https://github.com/BurntSushi/ripgrep/issues/3049) it was determined that upstreaming a function like `can_skip_directory` wasn't aligned. It turns out the needs of ripgrep and ours are somewhat divergent.  Instead they encouraged me to just fork and modify which is what we do here.

This copies the glob->regex translation logic and drops much of the other functionality that is optimized for large sets of globs.   Then I have added our `can_skip_directory` function following a similar pattern.

## Why

This approach allows us to easily support for character ranges (e.g. `[A-Za-z0-9_-]`) and improves performance.  I also suspect that this will be easier to maintain as debugging the generated regular expressions should be quite straightforward.

## Alternatives

We could just adopt globset directly as proposed in #79116 however we would lose the ability to skip directories during traversal which can reduce the cost of setting up turbotasks dependencies and directory watchers.  The other alternative that i pursued was a direct NFA implementation (see #78976).  This would be more memory efficient than regular expressions since both queries can share the same NFA, but the regex crate is much faster and better maintained.  If memory overhead becomes a concern we can configure the regexes to use less, however, i suspect many of our generated regexes will be quite simple and thus generate small automata.

Closes PACK-4401
Fixes #72196
