### PR TITLE
Revert "Removes onNavigate from transition scope"

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -271,28 +271,30 @@ function linkClicked(
 
   e.preventDefault()
 
-  if (onNavigate) {
-    let isDefaultPrevented = false
+  const navigate = () => {
+    if (onNavigate) {
+      let isDefaultPrevented = false
 
-    onNavigate({
-      preventDefault: () => {
-        isDefaultPrevented = true
-      },
-    })
+      onNavigate({
+        preventDefault: () => {
+          isDefaultPrevented = true
+        },
+      })
 
-    if (isDefaultPrevented) {
-      return
+      if (isDefaultPrevented) {
+        return
+      }
     }
-  }
 
-  React.startTransition(() => {
     dispatchNavigateAction(
       as || href,
       replace ? 'replace' : 'push',
       scroll ?? true,
       linkInstanceRef.current
     )
-  })
+  }
+
+  React.startTransition(navigate)
 }
 
 function formatStringOrUrl(urlObjOrString: UrlObject | string): string {


### PR DESCRIPTION
Reverts vercel/next.js#78605

Revert back to the default state being inside a transition scope. For any state change inside transition, users can use useOptimistic.