### PR TITLE
[test] Use NEXT_TEST_CI when forking test in CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,7 @@
         "jest/no-export": "off",
         "jest/no-standalone-expect": [
           "error",
-          { "additionalTestBlockFunctions": ["retry"] }
+          { "additionalTestBlockFunctions": ["retry", "itCI", "itHeaded"] }
         ]
       }
     },

--- a/run-tests.js
+++ b/run-tests.js
@@ -480,7 +480,7 @@ ${ENDGROUP}`)
         // tested when enabled
         CI: '',
         // But some tests need to fork based on machine? CI? behavior differences
-        // Only use read this in tests.
+        // Only use this in tests.
         // For implementation forks, use `process.env.CI` instead
         NEXT_TEST_CI: process.env.CI,
 

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -640,7 +640,7 @@ describe('next.rs api', () => {
     let currentContent = await next.readFile(file)
     let nextContent = pagesIndexCode('hello world2')
 
-    const count = process.env.CI ? 300 : 1000
+    const count = process.env.NEXT_TEST_CI ? 300 : 1000
     for (let i = 0; i < count; i++) {
       await next.patchFile(file, nextContent)
       const content = currentContent

--- a/test/development/experimental-https-server/https-server.generated-key.test.ts
+++ b/test/development/experimental-https-server/https-server.generated-key.test.ts
@@ -8,11 +8,11 @@ describe('experimental-https-server (generated certificate)', () => {
     startCommand: `pnpm next ${
       shouldRunTurboDevTest() ? 'dev --turbo' : 'dev'
     } --experimental-https`,
-    skipStart: !process.env.CI,
+    skipStart: !process.env.NEXT_TEST_CI,
   })
   if (skipped) return
 
-  if (!process.env.CI) {
+  if (!process.env.NEXT_TEST_CI) {
     console.warn('only runs on CI as it requires administrator privileges')
     it('only runs on CI as it requires administrator privileges', () => {})
     return

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -26,6 +26,8 @@ const browserConfigWithFixedTime = {
   },
 }
 
+const itHeaded = process.env.HEADLESS ? it.skip : it
+
 describe('app dir - prefetching', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
@@ -91,12 +93,7 @@ describe('app dir - prefetching', () => {
     )
   })
 
-  it('should not suppress prefetches after navigating back', async () => {
-    if (!process.env.CI && process.env.HEADLESS) {
-      console.warn('This test can only run in headed mode. Skipping...')
-      return
-    }
-
+  itHeaded('should not suppress prefetches after navigating back', async () => {
     // Force headed mode, as bfcache is not available in headless mode.
     const browser = await next.browser('/', { headless: false })
 

--- a/test/e2e/app-dir/next-image/next-image-https.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-https.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('app dir - next-image (with https)', () => {
+// TODO: Test didn't (or maybe) never ran in CI but it should.
+describe.skip('app dir - next-image (with https)', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -8,12 +9,6 @@ describe('app dir - next-image (with https)', () => {
   })
 
   if (skipped) {
-    return
-  }
-
-  if (!process.env.CI) {
-    console.warn('only runs on CI as it requires administrator privileges')
-    it('only runs on CI as it requires administrator privileges', () => {})
     return
   }
 

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -6,6 +6,7 @@ import {
   killApp,
   launchApp,
   nextBuild,
+  retry,
   runNextCommand,
   runNextCommandDev,
 } from 'next-test-utils'
@@ -17,6 +18,8 @@ import stripAnsi from 'strip-ansi'
 
 const dirBasic = join(__dirname, '../basic')
 const dirDuplicateSass = join(__dirname, '../duplicate-sass')
+
+const itCI = process.env.NEXT_TEST_CI ? it : it.skip
 
 const runAndCaptureOutput = async ({ port }) => {
   let stdout = ''
@@ -738,16 +741,8 @@ describe('CLI Usage', () => {
       }
     })
 
-    // only runs on CI as it requires administrator privileges
-    test('--experimental-https', async () => {
-      if (!process.env.CI) {
-        console.warn(
-          '--experimental-https only runs on CI as it requires administrator privileges'
-        )
-
-        return
-      }
-
+    itCI('--experimental-https', async () => {
+      // only runs on CI as it requires administrator privileges
       const port = await findPort()
       let output = ''
       const app = await runNextCommandDev(
@@ -760,9 +755,11 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, /Network:\s*http:\/\/\[::\]:(\d+)/)
-        await check(() => output, /https:\/\/localhost:(\d+)/)
-        await check(() => output, /Certificates created in/)
+        await retry(() => {
+          expect(output).toMatch(/Network:\s*https:\/\//)
+        })
+        expect(output).toMatch(/Local:\s*https:\/\/localhost:(\d+)/)
+        expect(output).toContain('Certificates created in')
       } finally {
         await killApp(app)
       }

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -73,13 +73,13 @@ export class NextDevInstance extends NextInstance {
 
         this.childProcess.stdout!.on('data', (chunk) => {
           const msg = chunk.toString()
-          if (!process.env.CI) process.stdout.write(chunk)
+          process.stdout.write(chunk)
           this._cliOutput += msg
           this.emit('stdout', [msg])
         })
         this.childProcess.stderr!.on('data', (chunk) => {
           const msg = chunk.toString()
-          if (!process.env.CI) process.stderr.write(chunk)
+          process.stderr.write(chunk)
           this._cliOutput += msg
           this.emit('stderr', [msg])
         })

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -26,13 +26,13 @@ export class NextStartInstance extends NextInstance {
   private handleStdio = (childProcess) => {
     childProcess.stdout.on('data', (chunk) => {
       const msg = chunk.toString()
-      if (!process.env.CI) process.stdout.write(chunk)
+      process.stdout.write(chunk)
       this._cliOutput += msg
       this.emit('stdout', [msg])
     })
     childProcess.stderr.on('data', (chunk) => {
       const msg = chunk.toString()
-      if (!process.env.CI) process.stderr.write(chunk)
+      process.stderr.write(chunk)
       this._cliOutput += msg
       this.emit('stderr', [msg])
     })

--- a/test/production/bfcache-routing/index.test.ts
+++ b/test/production/bfcache-routing/index.test.ts
@@ -8,6 +8,8 @@ import {
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
+const itHeaded = process.env.HEADLESS ? it.skip : it
+
 describe('bfcache-routing', () => {
   let port: number
   let app: Server
@@ -25,59 +27,60 @@ describe('bfcache-routing', () => {
     stopApp(app)
   })
 
-  it('should not suspend indefinitely when page is restored from bfcache after an mpa navigation', async () => {
-    // bfcache is not currently supported by CDP, so we need to run this particular test in headed mode
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=1317959
-    if (!process.env.CI && process.env.HEADLESS) {
-      console.warn('This test can only run in headed mode. Skipping...')
-      return
+  itHeaded(
+    'should not suspend indefinitely when page is restored from bfcache after an mpa navigation',
+    async () => {
+      // bfcache is not currently supported by CDP, so we need to run this particular test in headed mode
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1317959
+
+      const browser = await webdriver(port, '/index.html', { headless: false })
+
+      // we overwrite the typical waitUntil: 'load' option here as the event is never being triggered if we hit the bfcache
+      const bfOptions = { waitUntil: 'commit' as const }
+
+      await browser.elementByCss('a[href="https://example.vercel.sh"]').click()
+      await browser.waitForCondition(
+        'window.location.origin === "https://example.vercel.sh"'
+      )
+
+      await browser.back(bfOptions)
+
+      await browser.waitForCondition(
+        'window.location.origin.includes("localhost")'
+      )
+
+      let html = await browser.eval<string>(
+        'document.documentElement.innerHTML'
+      )
+
+      expect(html).toContain('BFCache Test')
+
+      await browser.eval(`document.querySelector('button').click()`)
+
+      // we should still be on the test page
+      html = await browser.eval<string>('document.documentElement.innerHTML')
+      expect(html).toContain('BFCache Test')
+
+      await browser.forward(bfOptions)
+      await browser.back(bfOptions)
+
+      await browser.waitForCondition(
+        'window.location.origin.includes("localhost")'
+      )
+
+      // we should be back on the test page with no errors
+      html = await browser.eval<string>('document.documentElement.innerHTML')
+      expect(html).toContain('BFCache Test')
+
+      // After restoring from bfcache, a subsequent mpa navigation to the same URL should work
+      // We trigger the click via `eval` because when restoring from bfcache, our internal
+      // 'waitForElementByCss' method doesn't think the element is attached to the DOM.
+      await browser.eval(
+        `document.querySelector('a[href="https://example.vercel.sh"]').click()`
+      )
+      await browser.waitForCondition(
+        'window.location.origin === "https://example.vercel.sh"'
+      )
     }
-
-    const browser = await webdriver(port, '/index.html', { headless: false })
-
-    // we overwrite the typical waitUntil: 'load' option here as the event is never being triggered if we hit the bfcache
-    const bfOptions = { waitUntil: 'commit' as const }
-
-    await browser.elementByCss('a[href="https://example.vercel.sh"]').click()
-    await browser.waitForCondition(
-      'window.location.origin === "https://example.vercel.sh"'
-    )
-
-    await browser.back(bfOptions)
-
-    await browser.waitForCondition(
-      'window.location.origin.includes("localhost")'
-    )
-
-    let html = await browser.eval<string>('document.documentElement.innerHTML')
-
-    expect(html).toContain('BFCache Test')
-
-    await browser.eval(`document.querySelector('button').click()`)
-
-    // we should still be on the test page
-    html = await browser.eval<string>('document.documentElement.innerHTML')
-    expect(html).toContain('BFCache Test')
-
-    await browser.forward(bfOptions)
-    await browser.back(bfOptions)
-
-    await browser.waitForCondition(
-      'window.location.origin.includes("localhost")'
-    )
-
-    // we should be back on the test page with no errors
-    html = await browser.eval<string>('document.documentElement.innerHTML')
-    expect(html).toContain('BFCache Test')
-
-    // After restoring from bfcache, a subsequent mpa navigation to the same URL should work
-    // We trigger the click via `eval` because when restoring from bfcache, our internal
-    // 'waitForElementByCss' method doesn't think the element is attached to the DOM.
-    await browser.eval(
-      `document.querySelector('a[href="https://example.vercel.sh"]').click()`
-    )
-    await browser.waitForCondition(
-      'window.location.origin === "https://example.vercel.sh"'
-    )
-  })
+  )
 })


### PR DESCRIPTION
[`CI` is intentionally unset in `run-tests.js`](https://github.com/vercel/next.js/pull/50436) for 2 years now so `!process.env.CI` in tests was always true.

`NEXT_TEST_CI` can be used instead to fork tests.
I removed `!process.env.CI` checks where the current behavior makes sense to keep.
If it was obviously a mistake, I replaced it with `NEXT_TEST_CI`.

`test/e2e/app-dir/next-image/next-image-https.test.ts` does not currently work in CI so I skipped it for now (see https://github.com/vercel/next.js/actions/runs/15105098699/job/42452376688?pr=79354).