### PR TITLE
RSC caching redirect behavior fix via Vary header

### DIFF
--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -15,6 +15,8 @@ export const NEXT_HMR_REFRESH_HEADER = 'Next-HMR-Refresh' as const
 export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
 export const NEXT_URL = 'Next-Url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
+export const RSC_VARY_HEADER_VALUE =
+  'RSC, Next-Router-State-Tree, Next-Url, Accept-Encoding' as const
 
 export const FLIGHT_HEADERS = [
   RSC_HEADER,

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -85,6 +85,14 @@ export async function sendRenderResult({
     )
   }
 
+  // Add vary header for RSC responses to prevent CDN caching
+  if (type === 'rsc') {
+    res.setHeader(
+      'Vary',
+      'RSC, Next-Router-State-Tree, Next-Url, Accept-Encoding'
+    )
+  }
+
   if (payload) {
     res.setHeader('Content-Length', Buffer.byteLength(payload))
   }

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -6,7 +6,10 @@ import { isResSent } from '../shared/lib/utils'
 import { generateETag } from './lib/etag'
 import fresh from 'next/dist/compiled/fresh'
 import { getCacheControlHeader } from './lib/cache-control'
-import { RSC_CONTENT_TYPE_HEADER } from '../client/components/app-router-headers'
+import {
+  RSC_CONTENT_TYPE_HEADER,
+  RSC_VARY_HEADER_VALUE,
+} from '../client/components/app-router-headers'
 
 export function sendEtagResponse(
   req: IncomingMessage,
@@ -87,10 +90,7 @@ export async function sendRenderResult({
 
   // Add vary header for RSC responses to prevent CDN caching
   if (type === 'rsc') {
-    res.setHeader(
-      'Vary',
-      'RSC, Next-Router-State-Tree, Next-Url, Accept-Encoding'
-    )
+    res.setHeader('Vary', RSC_VARY_HEADER_VALUE)
   }
 
   if (payload) {

--- a/test/e2e/app-dir/rsc-response-middleware-no-cache/app/layout.tsx
+++ b/test/e2e/app-dir/rsc-response-middleware-no-cache/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rsc-response-middleware-no-cache/app/page.tsx
+++ b/test/e2e/app-dir/rsc-response-middleware-no-cache/app/page.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link prefetch={false} href="/p2">
+        Page 2
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-response-middleware-no-cache/middleware.ts
+++ b/test/e2e/app-dir/rsc-response-middleware-no-cache/middleware.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  const url = request.nextUrl
+
+  if (url.pathname === '/p2') {
+    url.pathname = '/'
+    return NextResponse.redirect(url, 307)
+  }
+}

--- a/test/e2e/app-dir/rsc-response-middleware-no-cache/next.config.js
+++ b/test/e2e/app-dir/rsc-response-middleware-no-cache/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/rsc-response-middleware-no-cache/rsc-response-middleware-no-cache.test.ts
+++ b/test/e2e/app-dir/rsc-response-middleware-no-cache/rsc-response-middleware-no-cache.test.ts
@@ -1,0 +1,53 @@
+import { nextTestSetup } from 'e2e-utils'
+import { waitFor } from 'next-test-utils'
+import { RSC_CONTENT_TYPE_HEADER } from 'next/dist/client/components/app-router-headers'
+
+describe('rsc-response-middleware-no-cache', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not contain RSC as one of the values in the Vary header for non-RSC requests', async () => {
+    const browser = await next.browser('/')
+
+    const rscRequestsVaryHeaderValues: string[] = []
+    browser.on('response', (res) => {
+      const headers = res.headers()
+      if (headers['content-type'] === RSC_CONTENT_TYPE_HEADER) {
+        rscRequestsVaryHeaderValues.push(headers['vary'])
+      }
+    })
+
+    // no RSC requests on home page
+    expect(rscRequestsVaryHeaderValues.length).toBe(0)
+    // rscRequestsVaryHeaderValues should not contain RSC as a substring
+    expect(
+      rscRequestsVaryHeaderValues.every((value) => !value.includes('RSC'))
+    ).toBe(true)
+  })
+
+  it('should contain RSC as one of the values in the Vary header for RSC requests', async () => {
+    const browser = await next.browser('/')
+
+    const rscRequestsVaryHeaderValues: string[] = []
+    browser.on('response', (res) => {
+      const headers = res.headers()
+      if (headers['content-type'] === RSC_CONTENT_TYPE_HEADER) {
+        rscRequestsVaryHeaderValues.push(headers['vary'])
+      }
+    })
+
+    // Click redirect link
+    const link = await browser.elementByCss('a')
+    await link.click()
+
+    await waitFor(1000)
+
+    // The rewrite source url should contain the rsc query
+    expect(rscRequestsVaryHeaderValues.length).toBeGreaterThan(0)
+    // rscRequestsVaryHeaderValues should contain RSC as a substring
+    expect(
+      rscRequestsVaryHeaderValues.some((value) => value.includes('RSC'))
+    ).toBe(true)
+  })
+})

--- a/test/e2e/app-dir/rsc-response-middleware-no-cache/rsc-response-middleware-no-cache.test.ts
+++ b/test/e2e/app-dir/rsc-response-middleware-no-cache/rsc-response-middleware-no-cache.test.ts
@@ -1,13 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
-import { RSC_CONTENT_TYPE_HEADER } from 'next/dist/client/components/app-router-headers'
+import {
+  RSC_CONTENT_TYPE_HEADER,
+  RSC_VARY_HEADER_VALUE,
+} from 'next/dist/client/components/app-router-headers'
 
 describe('rsc-response-middleware-no-cache', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should not contain RSC as one of the values in the Vary header for non-RSC requests', async () => {
+  it('should not contain "RSC, Next-Router-State-Tree, Next-Url, Accept-Encoding" as the Vary header value for non-RSC requests', async () => {
     const browser = await next.browser('/')
 
     const rscRequestsVaryHeaderValues: string[] = []
@@ -20,13 +23,14 @@ describe('rsc-response-middleware-no-cache', () => {
 
     // no RSC requests on home page
     expect(rscRequestsVaryHeaderValues.length).toBe(0)
-    // rscRequestsVaryHeaderValues should not contain RSC as a substring
     expect(
-      rscRequestsVaryHeaderValues.every((value) => !value.includes('RSC'))
+      rscRequestsVaryHeaderValues.every(
+        (value) => value !== RSC_VARY_HEADER_VALUE
+      )
     ).toBe(true)
   })
 
-  it('should contain RSC as one of the values in the Vary header for RSC requests', async () => {
+  it('should contain "RSC, Next-Router-State-Tree, Next-Url, Accept-Encoding" as the Vary header value for RSC requests', async () => {
     const browser = await next.browser('/')
 
     const rscRequestsVaryHeaderValues: string[] = []
@@ -43,11 +47,13 @@ describe('rsc-response-middleware-no-cache', () => {
 
     await waitFor(1000)
 
+    console.log('sadjakd', rscRequestsVaryHeaderValues)
     // The rewrite source url should contain the rsc query
     expect(rscRequestsVaryHeaderValues.length).toBeGreaterThan(0)
-    // rscRequestsVaryHeaderValues should contain RSC as a substring
     expect(
-      rscRequestsVaryHeaderValues.some((value) => value.includes('RSC'))
+      rscRequestsVaryHeaderValues.every(
+        (value) => value === RSC_VARY_HEADER_VALUE
+      )
     ).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes #79346

When RSC response is received by the browser for a page, the CDN can cache it and the payload is shown to the user as-is if they close and re-open the tab. This behavior is fixed by adding a `Vary` header to the response and setting it to the value `RSC, Next-Router-State-Tree, Next-Url, Accept-Encoding` so that the response is not cached by the CDN when the user closes and opens the tab again.

Demo:

https://github.com/user-attachments/assets/e77db909-cf65-4fcd-b331-83edb7333155

