### PR TITLE
docs: --verbose option in dev mode is not yet supported

### DIFF
--- a/docs/01-app/02-guides/local-development.mdx
+++ b/docs/01-app/02-guides/local-development.mdx
@@ -137,11 +137,19 @@ The experimental `serverComponentsHmrCache` option allows you to cache `fetch` r
 
 ### Detailed fetch logging
 
-Use this command to see more detailed information about what's happening during development:
+Use this flag in your `next.config.js` file, to see more detailed information about what's happening during development:
 
-```bash
-next dev --verbose
+```js
+module.exports = {
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+}
 ```
+
+[Learn more about fetch logging](/docs/app/api-reference/config/next-config-js/logging).
 
 ## Turbopack tracing
 

--- a/docs/01-app/02-guides/local-development.mdx
+++ b/docs/01-app/02-guides/local-development.mdx
@@ -137,7 +137,7 @@ The experimental `serverComponentsHmrCache` option allows you to cache `fetch` r
 
 ### Detailed fetch logging
 
-Use this flag in your `next.config.js` file, to see more detailed information about what's happening during development:
+Use the `logging.fetches` option in your `next.config.js` file, to see more detailed information about what's happening during development:
 
 ```js
 module.exports = {


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4677/remove-reference-to-next-dev-verbose
Fixes: https://github.com/vercel/next.js/issues/79337

For now, `--verbose` is not supported for `next dev`.
