### PR TITLE
docs: Fix flag for taint

### DIFF
--- a/docs/01-app/05-api-reference/05-config/01-next-config-js/taint.mdx
+++ b/docs/01-app/05-api-reference/05-config/01-next-config-js/taint.mdx
@@ -18,7 +18,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   experimental: {
-    ppr: 'incremental',
+    taint: true,
   },
 }
 
@@ -29,7 +29,7 @@ export default nextConfig
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    ppr: 'incremental',
+    taint: true,
   },
 }
 


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4668/document-the-experimentaltaint-option-in-nextconfigts

Flag value was incorrect.