### PR TITLE
test: fix more Runtime/Recoverable Error flakiness in HMR

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1279,11 +1279,12 @@ describe('ReactRefreshLogBox app', () => {
     )
     const { session, browser } = sandbox
 
-    await expect(browser).toDisplayRedbox(`
+    await expect(browser).toDisplayRedbox(
+      `
      {
        "description": "Server component error",
        "environmentLabel": "Server",
-       "label": "Runtime Error",
+       "label": "<FIXME-excluded-label>",
        "source": "app/page.js (2:9) @ Page
      > 2 |   throw new Error('Server component error')
          |         ^",
@@ -1291,7 +1292,11 @@ describe('ReactRefreshLogBox app', () => {
          "Page app/page.js (2:9)",
        ],
      }
-    `)
+    `,
+
+      // FIXME: `label` is flaking between "Runtime Error" and "Recoverable Error"
+      { label: false }
+    )
 
     // Remove error
     await session.patch(
@@ -1318,11 +1323,12 @@ describe('ReactRefreshLogBox app', () => {
       `
     )
 
-    await expect(browser).toDisplayRedbox(`
+    await expect(browser).toDisplayRedbox(
+      `
      {
        "description": "Server component error!",
        "environmentLabel": "Server",
-       "label": "Runtime Error",
+       "label": "<FIXME-excluded-label>",
        "source": "app/page.js (2:9) @ Page
      > 2 |   throw new Error('Server component error!')
          |         ^",
@@ -1330,7 +1336,11 @@ describe('ReactRefreshLogBox app', () => {
          "Page app/page.js (2:9)",
        ],
      }
-    `)
+    `,
+
+      // FIXME: `label` is flaking between "Runtime Error" and "Recoverable Error"
+      { label: false }
+    )
   })
 
   test('Import trace when module not found in layout', async () => {

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -37,7 +37,10 @@ declare global {
        *
        * @param inlineSnapshot - The snapshot to compare against.
        */
-      toDisplayRedbox(inlineSnapshot?: string): Promise<void>
+      toDisplayRedbox(
+        inlineSnapshot?: string,
+        opts?: ErrorSnapshotOptions
+      ): Promise<void>
 
       /**
        * Inline snapshot matcher for a Redbox that's collapsed by default.
@@ -57,9 +60,16 @@ declare global {
        *
        * @param inlineSnapshot - The snapshot to compare against.
        */
-      toDisplayCollapsedRedbox(inlineSnapshot?: string): Promise<void>
+      toDisplayCollapsedRedbox(
+        inlineSnapshot?: string,
+        opts?: ErrorSnapshotOptions
+      ): Promise<void>
     }
   }
+}
+
+interface ErrorSnapshotOptions {
+  label?: boolean
 }
 
 interface ErrorSnapshot {
@@ -73,11 +83,12 @@ interface ErrorSnapshot {
 
 async function createErrorSnapshot(
   browser: Playwright,
-  next: NextInstance | null
+  next: NextInstance | null,
+  { label: includeLabel = true }: ErrorSnapshotOptions = {}
 ): Promise<ErrorSnapshot> {
   const [label, environmentLabel, description, source, stack, componentStack] =
     await Promise.all([
-      getRedboxLabel(browser),
+      includeLabel ? getRedboxLabel(browser) : null,
       getRedboxEnvironmentLabel(browser),
       getRedboxDescription(browser),
       getRedboxSource(browser),
@@ -155,7 +166,7 @@ async function createErrorSnapshot(
 
   const snapshot: ErrorSnapshot = {
     environmentLabel,
-    label,
+    label: label ?? '<FIXME-excluded-label>',
     description:
       description !== null && next !== null
         ? description.replace(next.testDir, '<FIXME-project-root>')
@@ -182,13 +193,14 @@ type RedboxSnapshot = ErrorSnapshot | ErrorSnapshot[]
 
 async function createRedboxSnapshot(
   browser: Playwright,
-  next: NextInstance | null
+  next: NextInstance | null,
+  opts?: ErrorSnapshotOptions
 ): Promise<RedboxSnapshot> {
   const errorTally = await getRedboxTotalErrorCount(browser)
   const errorSnapshots: ErrorSnapshot[] = []
 
   for (let errorIndex = 0; errorIndex < errorTally; errorIndex++) {
-    const errorSnapshot = await createErrorSnapshot(browser, next)
+    const errorSnapshot = await createErrorSnapshot(browser, next, opts)
     errorSnapshots.push(errorSnapshot)
 
     if (errorIndex < errorTally - 1) {
@@ -214,7 +226,8 @@ expect.extend({
   async toDisplayRedbox(
     this: MatcherContext,
     browserOrContext: Playwright | { browser: Playwright; next: NextInstance },
-    expectedRedboxSnapshot?: string
+    expectedRedboxSnapshot?: string,
+    opts?: ErrorSnapshotOptions
   ) {
     let browser: Playwright
     let next: NextInstance | null
@@ -250,7 +263,7 @@ expect.extend({
       }
     }
 
-    const redbox = await createRedboxSnapshot(browser, next)
+    const redbox = await createRedboxSnapshot(browser, next, opts)
 
     // argument length is relevant.
     // Jest will update absent snapshots but fail if you specify a snapshot even if undefined.
@@ -263,7 +276,8 @@ expect.extend({
   async toDisplayCollapsedRedbox(
     this: MatcherContext,
     browserOrContext: Playwright | { browser: Playwright; next: NextInstance },
-    expectedRedboxSnapshot?: string
+    expectedRedboxSnapshot?: string,
+    opts?: ErrorSnapshotOptions
   ) {
     let browser: Playwright
     let next: NextInstance | null
@@ -306,7 +320,7 @@ expect.extend({
       }
     }
 
-    const redbox = await createRedboxSnapshot(browser, next)
+    const redbox = await createRedboxSnapshot(browser, next, opts)
 
     // argument length is relevant.
     // Jest will update absent snapshots but fail if you specify a snapshot even if undefined.


### PR DESCRIPTION
Follow-up to #79254, there's one more test flaking with the same issue.

I pulled the label-ignoring logic out into

```ts
expect(browser).toDisplayRedbox('...', { label: false })
```

so that it's easy to find these later when we fix the underlying issue.