### PR TITLE
Turbopack build: Skip test that is not relevant for Turbopack

### DIFF
--- a/test/integration/invalid-document-image-import/test/index.test.js
+++ b/test/integration/invalid-document-image-import/test/index.test.js
@@ -7,43 +7,46 @@ jest.setTimeout(1000 * 60 * 2)
 const appDir = join(__dirname, '../')
 const nextConfig = new File(join(appDir, 'next.config.js'))
 
-describe('Invalid static image import in _document', () => {
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-    'production mode',
-    () => {
-      afterAll(() => nextConfig.restore())
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'Invalid static image import in _document',
+  () => {
+    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+      'production mode',
+      () => {
+        afterAll(() => nextConfig.restore())
 
-      it('Should fail to build when no next.config.js', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
+        it('Should fail to build when no next.config.js', async () => {
+          const { code, stderr } = await nextBuild(appDir, [], {
+            stderr: true,
+          })
+          expect(code).not.toBe(0)
+          expect(stderr).toContain('Failed to compile')
+          expect(stderr).toMatch(
+            /Images.*cannot.*be imported within.*pages[\\/]_document\.js/
+          )
+          expect(stderr).toMatch(/Location:.*pages[\\/]_document\.js/)
         })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toMatch(
-          /Images.*cannot.*be imported within.*pages[\\/]_document\.js/
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]_document\.js/)
-      })
 
-      it('Should fail to build when disableStaticImages in next.config.js', async () => {
-        nextConfig.write(`
+        it('Should fail to build when disableStaticImages in next.config.js', async () => {
+          nextConfig.write(`
       module.exports = {
         images: {
           disableStaticImages: true
         }
       }
     `)
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
+          const { code, stderr } = await nextBuild(appDir, [], {
+            stderr: true,
+          })
+          expect(code).not.toBe(0)
+          expect(stderr).toMatch(
+            /You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file/
+          )
+          expect(stderr).not.toMatch(
+            /Images.*cannot.*be imported within.*pages[\\/]_document\.js/
+          )
         })
-        expect(code).not.toBe(0)
-        expect(stderr).toMatch(
-          /You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file/
-        )
-        expect(stderr).not.toMatch(
-          /Images.*cannot.*be imported within.*pages[\\/]_document\.js/
-        )
-      })
-    }
-  )
-})
+      }
+    )
+  }
+)

--- a/test/integration/invalid-document-image-import/test/index.test.js
+++ b/test/integration/invalid-document-image-import/test/index.test.js
@@ -7,7 +7,7 @@ jest.setTimeout(1000 * 60 * 2)
 const appDir = join(__dirname, '../')
 const nextConfig = new File(join(appDir, 'next.config.js'))
 
-;(process.env.TURBOPACK ? describe.skip : describe)(
+;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'Invalid static image import in _document',
   () => {
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15233,11 +15233,11 @@
   },
   "test/integration/invalid-document-image-import/test/index.test.js": {
     "passed": [],
-    "failed": [
+    "failed": [],
+    "pending": [
       "Invalid static image import in _document production mode Should fail to build when disableStaticImages in next.config.js",
       "Invalid static image import in _document production mode Should fail to build when no next.config.js"
     ],
-    "pending": [],
     "flakey": [],
     "runtimeError": false
   },


### PR DESCRIPTION
## What?

Turbopack doesn't fail in this case as it can process server-side assets regardless of if they're also in the client layer. That's something we couldn't do with webpack.

Closes PACK-4642