### PR TITLE
Always show warning if fetch cache limit hit

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -571,11 +571,12 @@ export class IncrementalCache implements IncrementalCacheType {
       !this.hasCustomCacheHandler &&
       itemSize > 2 * 1024 * 1024
     ) {
+      const warningText = `Failed to set Next.js data cache for ${ctx.fetchUrl || pathname}, items over 2MB can not be cached (${itemSize} bytes)`
+
       if (this.dev) {
-        throw new Error(
-          `Failed to set Next.js data cache, items over 2MB can not be cached (${itemSize} bytes)`
-        )
+        throw new Error(warningText)
       }
+      console.warn(warningText)
       return
     }
 

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -4346,8 +4346,8 @@ describe('app-dir static/dynamic handling', () => {
           expect(
             next.cliOutput.substring(cliOutputStart).match(/Load data/g).length
           ).toBe(2)
-          expect(next.cliOutput.substring(cliOutputStart)).toContain(
-            'Error: Failed to set Next.js data cache, items over 2MB can not be cached'
+          expect(stripAnsi(next.cliOutput.substring(cliOutputStart))).toMatch(
+            /Failed to set Next.js data cache for http:\/\/localhost:.*?\/api\/large-data, items over 2MB can not be cached/
           )
           return 'success'
         }, 'success')
@@ -4376,8 +4376,8 @@ describe('app-dir static/dynamic handling', () => {
           return 'success'
         }, 'success')
 
-        expect(next.cliOutput.substring(cliOutputStart)).not.toContain(
-          'Error: Failed to set Next.js data cache, items over 2MB can not be cached'
+        expect(next.cliOutput.substring(cliOutputStart)).not.toMatch(
+          /Failed to set Next.js data cache for http:\/\/localhost:.*?\/api\/large-data, items over 2MB can not be cached/
         )
       })
     }


### PR DESCRIPTION
We previously weren't showing any indication when we weren't setting to the runtime cache in production due to the size limit being hit which can make debugging cache misses very tricky so this ensures we always show the warning not just in dev mode. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1747675632042719?thread_ts=1746633220.634939&cid=C02K2HCH5V4)