### PR TITLE
Only share incremental cache for edge in next start

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -186,7 +186,10 @@ export async function adapter(
   }
 
   if (
-    !(globalThis as any).__incrementalCache &&
+    // If we are inside of the next start sandbox
+    // leverage the shared instance if not we need
+    // to create a fresh cache instance each time
+    !(globalThis as any).__incrementalCacheShared &&
     (params as any).IncrementalCache
   ) {
     ;(globalThis as any).__incrementalCache = new (

--- a/packages/next/src/server/web/sandbox/sandbox.ts
+++ b/packages/next/src/server/web/sandbox/sandbox.ts
@@ -77,6 +77,7 @@ export async function getRuntimeContext(
   })
 
   if (params.incrementalCache) {
+    runtime.context.globalThis.__incrementalCacheShared = true
     runtime.context.globalThis.__incrementalCache = params.incrementalCache
   }
 


### PR DESCRIPTION
When in minimal mode we should not try leveraging a shared `IncrementalCache` instance across invocations as we pass in request headers which are request specific. The only time we should share this instance is in `next start` mode where the sandbox needs to be able to access the filesystem-cache. 

x-ref: [slack thread](https://vercel.slack.com/archives/C07CGAA2RS6/p1747687927600699?thread_ts=1747142004.153739&cid=C07CGAA2RS6)