### PR TITLE
remove unique metadata prop from initial RSC payload

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -521,7 +521,6 @@ async function generateDynamicRSCPayload(
             />
             {/* Adding requestId as react key to make metadata remount for each render */}
             <ViewportTree key={getFlightViewportKey(requestId)} />
-            {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
             <MetadataTree key={getFlightMetadataKey(requestId)} />
           </React.Fragment>
         ),
@@ -862,8 +861,7 @@ async function getRSCPayload(
         statusCode={ctx.res.statusCode}
         isPossibleServerAction={ctx.isPossibleServerAction}
       />
-      <ViewportTree key={getFlightViewportKey(ctx.requestId)} />
-      {/* Not add requestId as react key to ensure segment prefetch could result consistently if nothing changed */}
+      <ViewportTree />
       <MetadataTree />
     </React.Fragment>
   )
@@ -931,7 +929,6 @@ async function getErrorRSCPayload(
       ViewportBoundary,
     },
     url,
-    requestId,
     workStore,
   } = ctx
 
@@ -950,9 +947,6 @@ async function getErrorRSCPayload(
     serveStreamingMetadata: serveStreamingMetadata,
   })
 
-  // {/* Adding requestId as react key to make metadata remount for each render */}
-  const metadata = <MetadataTree key={getFlightMetadataKey(requestId)} />
-
   const initialHead = (
     <React.Fragment key={flightDataPathHeadKey}>
       <NonIndex
@@ -960,12 +954,11 @@ async function getErrorRSCPayload(
         statusCode={ctx.res.statusCode}
         isPossibleServerAction={ctx.isPossibleServerAction}
       />
-      {/* Adding requestId as react key to make metadata remount for each render */}
-      <ViewportTree key={getFlightViewportKey(requestId)} />
+      <ViewportTree />
       {process.env.NODE_ENV === 'development' && (
         <meta name="next-error" content="not-found" />
       )}
-      {metadata}
+      <MetadataTree />
     </React.Fragment>
   )
 


### PR DESCRIPTION
This value is used as a key to re-mount `head` on subsequent client navigations, but as far as I can tell, it's not needed for the initial RSC payload that seeds these pages. 

In its current form, these random IDs get serialized as part of the RSC payload, leading to non-deterministic HTML outputs. 

Fixes #77810