### PR TITLE
Docs IA 2.0: Add i18n guides

### DIFF
--- a/docs/01-app/01-getting-started/11-error-handling.mdx
+++ b/docs/01-app/01-getting-started/11-error-handling.mdx
@@ -274,7 +274,7 @@ Errors will bubble up to the nearest parent error boundary. This allows for gran
 
 ### Global errors
 
-While less common, you can handle errors in the root layout using the [`global-error.js`](/docs/app/api-reference/file-conventions/error#global-error) file, located in the root app directory, even when leveraging [internationalization](/docs/app/building-your-application/routing/internationalization). Global error UI must define its own `<html>` and `<body>` tags, since it is replacing the root layout or template when active.
+While less common, you can handle errors in the root layout using the [`global-error.js`](/docs/app/api-reference/file-conventions/error#global-error) file, located in the root app directory, even when leveraging [internationalization](/docs/app/guides/internationalization). Global error UI must define its own `<html>` and `<body>` tags, since it is replacing the root layout or template when active.
 
 ```tsx filename="app/global-error.tsx" switcher
 'use client' // Error boundaries must be Client Components

--- a/docs/01-app/02-guides/internationalization.mdx
+++ b/docs/01-app/02-guides/internationalization.mdx
@@ -168,7 +168,7 @@ export default async function Page({ params }) {
 
 Because all layouts and pages in the `app/` directory default to [Server Components](/docs/app/getting-started/server-and-client-components), we do not need to worry about the size of the translation files affecting our client-side JavaScript bundle size. This code will **only run on the server**, and only the resulting HTML will be sent to the browser.
 
-## Static Generation
+## Static Rendering
 
 To generate static routes for a given set of locales, we can use `generateStaticParams` with any page or layout. This can be global, for example, in the root layout:
 

--- a/docs/01-app/02-guides/migrating/app-router-migration.mdx
+++ b/docs/01-app/02-guides/migrating/app-router-migration.mdx
@@ -470,7 +470,7 @@ export default function ExampleClientComponent() {
 In addition, the new `useRouter` hook has the following changes:
 
 - `isFallback` has been removed because `fallback` has [been replaced](#replacing-fallback).
-- The `locale`, `locales`, `defaultLocales`, `domainLocales` values have been removed because built-in i18n Next.js features are no longer necessary in the `app` directory. [Learn more about i18n](/docs/app/building-your-application/routing/internationalization).
+- The `locale`, `locales`, `defaultLocales`, `domainLocales` values have been removed because built-in i18n Next.js features are no longer necessary in the `app` directory. [Learn more about i18n](/docs/app/guides/internationalization).
 - `basePath` has been removed. The alternative will not be part of `useRouter`. It has not yet been implemented.
 - `asPath` has been removed because the concept of `as` has been removed from the new router.
 - `isReady` has been removed because it is no longer necessary. During [static rendering](/docs/app/getting-started/partial-prerendering#static-rendering), any component that uses the [`useSearchParams()`](/docs/app/api-reference/functions/use-search-params) hook will skip the prerendering step and instead be rendered on the client at runtime.

--- a/docs/01-app/02-guides/migrating/from-create-react-app.mdx
+++ b/docs/01-app/02-guides/migrating/from-create-react-app.mdx
@@ -39,7 +39,7 @@ Depending on your needs, Next.js allows you to choose your data fetching strateg
 
 ### Middleware
 
-[Next.js Middleware](/docs/app/building-your-application/routing/middleware) allows you to run code on the server before a request is completed. For instance, you can avoid a flash of unauthenticated content by redirecting a user to a login page in the middleware for authenticated-only pages. You can also use it for features like A/B testing, experimentation, and [internationalization](/docs/app/building-your-application/routing/internationalization).
+[Next.js Middleware](/docs/app/building-your-application/routing/middleware) allows you to run code on the server before a request is completed. For instance, you can avoid a flash of unauthenticated content by redirecting a user to a login page in the middleware for authenticated-only pages. You can also use it for features like A/B testing, experimentation, and [internationalization](/docs/app/guides/internationalization).
 
 ### Built-in Optimizations
 

--- a/docs/01-app/02-guides/migrating/from-vite.mdx
+++ b/docs/01-app/02-guides/migrating/from-vite.mdx
@@ -39,7 +39,7 @@ Depending on your needs, Next.js allows you to choose your data fetching strateg
 
 ### Middleware
 
-[Next.js Middleware](/docs/app/building-your-application/routing/middleware) allows you to run code on the server before a request is completed. This is especially useful to avoid having a flash of unauthenticated content when the user visits an authenticated-only page by redirecting the user to a login page. The middleware is also useful for experimentation and [internationalization](/docs/app/building-your-application/routing/internationalization).
+[Next.js Middleware](/docs/app/building-your-application/routing/middleware) allows you to run code on the server before a request is completed. This is especially useful to avoid having a flash of unauthenticated content when the user visits an authenticated-only page by redirecting the user to a login page. The middleware is also useful for experimentation and [internationalization](/docs/app/guides/internationalization).
 
 ### Built-in Optimizations
 

--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -301,7 +301,7 @@ export const dynamic = 'error'
 
 <PagesOnly>
 
-- [Internationalized Routing](/docs/pages/building-your-application/routing/internationalization)
+- [Internationalized Routing](/docs/pages/guides/internationalization)
 - [API Routes](/docs/pages/building-your-application/routing/api-routes)
 - [Rewrites](/docs/pages/api-reference/config/next-config-js/rewrites)
 - [Redirects](/docs/pages/api-reference/config/next-config-js/redirects)

--- a/docs/01-app/03-building-your-application/01-routing/05-error-handling.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/05-error-handling.mdx
@@ -227,7 +227,7 @@ Errors will bubble up to the nearest parent error boundary. This allows for gran
 
 ### Handling Global Errors
 
-While less common, you can handle errors in the root layout using `app/global-error.js`, located in the root app directory, even when leveraging [internationalization](/docs/app/building-your-application/routing/internationalization). Global error UI must define its own `<html>` and `<body>` tags, since it is replacing the root layout or template when active.
+While less common, you can handle errors in the root layout using `app/global-error.js`, located in the root app directory, even when leveraging [internationalization](/docs/app/guides/internationalization). Global error UI must define its own `<html>` and `<body>` tags, since it is replacing the root layout or template when active.
 
 ```tsx filename="app/global-error.tsx" switcher
 'use client' // Error boundaries must be Client Components

--- a/docs/01-app/05-api-reference/03-file-conventions/error.mdx
+++ b/docs/01-app/05-api-reference/03-file-conventions/error.mdx
@@ -153,7 +153,7 @@ export default function Error({ error, reset }) {
 
 ### Global Error
 
-While less common, you can handle errors in the root layout or template using `global-error.js`, located in the root app directory, even when leveraging [internationalization](/docs/app/building-your-application/routing/internationalization). Global error UI must define its own `<html>` and `<body>` tags. This file replaces the root layout or template when active.
+While less common, you can handle errors in the root layout or template using `global-error.js`, located in the root app directory, even when leveraging [internationalization](/docs/app/guides/internationalization). Global error UI must define its own `<html>` and `<body>` tags. This file replaces the root layout or template when active.
 
 ```tsx filename="app/global-error.tsx" switcher
 'use client' // Error boundaries must be Client Components

--- a/docs/01-app/05-api-reference/04-functions/next-request.mdx
+++ b/docs/01-app/05-api-reference/04-functions/next-request.mdx
@@ -92,7 +92,7 @@ The following options are available:
 | ----------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `basePath`        | `string`                  | The [base path](/docs/pages/api-reference/config/next-config-js/basePath) of the URL.                                                  |
 | `buildId`         | `string` \| `undefined`   | The build identifier of the Next.js application. Can be [customized](/docs/pages/api-reference/config/next-config-js/generateBuildId). |
-| `defaultLocale`   | `string` \| `undefined`   | The default locale for [internationalization](/docs/pages/building-your-application/routing/internationalization).                     |
+| `defaultLocale`   | `string` \| `undefined`   | The default locale for [internationalization](/docs/pages/guides/internationalization).                                                |
 | `domainLocale`    |                           |                                                                                                                                        |
 | - `defaultLocale` | `string`                  | The default locale within a domain.                                                                                                    |
 | - `domain`        | `string`                  | The domain associated with a specific locale.                                                                                          |
@@ -112,7 +112,7 @@ The following options are available:
 | `pathname`     | `string`                | The pathname of the URL.                                                                                                             |
 | `searchParams` | `Object`                | The search parameters of the URL.                                                                                                    |
 
-> **Note:** The internationalization properties from the Pages Router are not available for usage in the App Router. Learn more about [internationalization with the App Router](/docs/app/building-your-application/routing/internationalization).
+> **Note:** The internationalization properties from the Pages Router are not available for usage in the App Router. Learn more about [internationalization with the App Router](/docs/app/guides/internationalization).
 
 </AppOnly>
 

--- a/docs/01-app/05-api-reference/05-config/01-next-config-js/headers.mdx
+++ b/docs/01-app/05-api-reference/05-config/01-next-config-js/headers.mdx
@@ -320,13 +320,13 @@ module.exports = {
 
 <AppOnly>
 
-When leveraging [`i18n` support](/docs/app/building-your-application/routing/internationalization) with headers each `source` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the header. If `locale: false` is used you must prefix the `source` with a locale for it to be matched correctly.
+When leveraging [`i18n` support](/docs/app/guides/internationalization) with headers each `source` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the header. If `locale: false` is used you must prefix the `source` with a locale for it to be matched correctly.
 
 </AppOnly>
 
 <PagesOnly>
 
-When leveraging [`i18n` support](/docs/pages/building-your-application/routing/internationalization) with headers each `source` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the header. If `locale: false` is used you must prefix the `source` with a locale for it to be matched correctly.
+When leveraging [`i18n` support](/docs/pages/guides/internationalization) with headers each `source` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the header. If `locale: false` is used you must prefix the `source` with a locale for it to be matched correctly.
 
 </PagesOnly>
 

--- a/docs/01-app/05-api-reference/05-config/01-next-config-js/redirects.mdx
+++ b/docs/01-app/05-api-reference/05-config/01-next-config-js/redirects.mdx
@@ -250,13 +250,13 @@ module.exports = {
 
 <AppOnly>
 
-When leveraging [`i18n` support](/docs/app/building-your-application/routing/internationalization) with redirects each `source` and `destination` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the redirect. If `locale: false` is used you must prefix the `source` and `destination` with a locale for it to be matched correctly.
+When leveraging [`i18n` support](/docs/app/guides/internationalization) with redirects each `source` and `destination` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the redirect. If `locale: false` is used you must prefix the `source` and `destination` with a locale for it to be matched correctly.
 
 </AppOnly>
 
 <PagesOnly>
 
-When leveraging [`i18n` support](/docs/pages/building-your-application/routing/internationalization) with redirects each `source` and `destination` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the redirect. If `locale: false` is used you must prefix the `source` and `destination` with a locale for it to be matched correctly.
+When leveraging [`i18n` support](/docs/pages/guides/internationalization) with redirects each `source` and `destination` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the redirect. If `locale: false` is used you must prefix the `source` and `destination` with a locale for it to be matched correctly.
 
 </PagesOnly>
 

--- a/docs/01-app/05-api-reference/05-config/01-next-config-js/rewrites.mdx
+++ b/docs/01-app/05-api-reference/05-config/01-next-config-js/rewrites.mdx
@@ -415,7 +415,7 @@ module.exports = {
 
 ### Rewrites with i18n support
 
-When leveraging [`i18n` support](/docs/pages/building-your-application/routing/internationalization) with rewrites each `source` and `destination` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the rewrite. If `locale: false` is used you must prefix the `source` and `destination` with a locale for it to be matched correctly.
+When leveraging [`i18n` support](/docs/pages/guides/internationalization) with rewrites each `source` and `destination` is automatically prefixed to handle the configured `locales` unless you add `locale: false` to the rewrite. If `locale: false` is used you must prefix the `source` and `destination` with a locale for it to be matched correctly.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/02-pages/02-guides/internationalization.mdx
+++ b/docs/02-pages/02-guides/internationalization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Internationalization (i18n) Routing
+title: How to implement internationalization in Next.js
 nav_title: Internationalization
 description: Next.js has built-in support for internationalized routing and language detection. Learn more here.
 ---

--- a/docs/02-pages/04-api-reference/03-functions/get-static-paths.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/get-static-paths.mdx
@@ -102,7 +102,7 @@ The value for each `params` object must match the parameters used in the page na
 
 The `params` strings are **case-sensitive** and ideally should be normalized to ensure the paths are generated correctly. For example, if `WoRLD` is returned for a param it will only match if `WoRLD` is the actual path visited, not `world` or `World`.
 
-Separate of the `params` object a `locale` field can be returned when [i18n is configured](/docs/pages/building-your-application/routing/internationalization), which configures the locale for the path being generated.
+Separate of the `params` object a `locale` field can be returned when [i18n is configured](/docs/pages/guides/internationalization), which configures the locale for the path being generated.
 
 ### `fallback: false`
 

--- a/errors/export-no-i18n.mdx
+++ b/errors/export-no-i18n.mdx
@@ -15,4 +15,4 @@ In your `next.config.js` you defined `i18n`, along with `output: 'export'` (or y
 
 - [Deployment Documentation](/docs/pages/getting-started/deploying)
 - [`output: 'export'` Documentation](/docs/pages/guides/static-exports)
-- [Internationalized Routing](/docs/pages/building-your-application/routing/internationalization)
+- [Internationalized Routing](/docs/pages/guides/internationalization)

--- a/errors/invalid-i18n-config.mdx
+++ b/errors/invalid-i18n-config.mdx
@@ -43,4 +43,4 @@ module.exports = {
 
 ## Useful Links
 
-- [Internationalized Routing Documentation](/docs/pages/building-your-application/routing/internationalization)
+- [Internationalized Routing Documentation](/docs/pages/guides/internationalization)


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4682/guide-internationalization-i18n
Redirects: https://github.com/vercel/front/pull/45963