### PR TITLE
Make sure bundle analyzer does not trigger warning with turbopack

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,23 +1,25 @@
 module.exports =
   ({ enabled = true, logLevel, openAnalyzer, analyzerMode } = {}) =>
   (nextConfig = {}) => {
+    if (!enabled) {
+      return nextConfig
+    }
+
     return Object.assign({}, nextConfig, {
       webpack(config, options) {
-        if (enabled) {
-          const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
-          config.plugins.push(
-            new BundleAnalyzerPlugin({
-              analyzerMode: analyzerMode || 'static',
-              logLevel,
-              openAnalyzer,
-              reportFilename: !options.nextRuntime
-                ? `./analyze/client.html`
-                : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
-                    options.nextRuntime
-                  }.html`,
-            })
-          )
-        }
+        const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+        config.plugins.push(
+          new BundleAnalyzerPlugin({
+            analyzerMode: analyzerMode || 'static',
+            logLevel,
+            openAnalyzer,
+            reportFilename: !options.nextRuntime
+              ? `./analyze/client.html`
+              : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
+                  options.nextRuntime
+                }.html`,
+          })
+        )
 
         if (typeof nextConfig.webpack === 'function') {
           return nextConfig.webpack(config, options)


### PR DESCRIPTION
### What?

Add a guard to return earlier to prevent `webpack` assignment to the config.

### Why?

Next produces the warning if running with `--turbopack` and config has `webpack` configuration.