### PR TITLE
fix(hmr): avoid showing NaNms when startMsSinceEpoch is null

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -150,7 +150,7 @@ function tryApplyUpdatesWebpack(
   if (!isUpdateAvailable() || !canApplyUpdates()) {
     resolvePendingHotUpdateWebpack()
     dispatcher.onBuildOk()
-    reportHmrLatency(sendMessage, [], webpackStartMsSinceEpoch!, Date.now())
+    reportHmrLatency(sendMessage, [], webpackStartMsSinceEpoch, Date.now())
     return
   }
 
@@ -181,7 +181,7 @@ function tryApplyUpdatesWebpack(
     reportHmrLatency(
       sendMessage,
       updatedModules,
-      webpackStartMsSinceEpoch!,
+      webpackStartMsSinceEpoch,
       Date.now()
     )
 

--- a/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/report-hmr-latency.ts
@@ -18,12 +18,17 @@ declare global {
 export default function reportHmrLatency(
   sendMessage: (message: string) => void,
   updatedModules: ReadonlyArray<string | number>,
-  startMsSinceEpoch: number,
+  startMsSinceEpoch: number | null,
   endMsSinceEpoch: number,
   hasUpdate: boolean = true
 ) {
-  const latencyMs = endMsSinceEpoch - startMsSinceEpoch
-  console.log(`[Fast Refresh] done in ${latencyMs}ms`)
+  if (startMsSinceEpoch === null) {
+    return;
+  }
+  const latencyMs = endMsSinceEpoch - startMsSinceEpoch;
+  if (!isNaN(latencyMs)) {
+    console.log(`[Fast Refresh] done in ${latencyMs}ms`);
+  }
   if (!hasUpdate) {
     return
   }


### PR DESCRIPTION
### What?
Fixes an issue where the log message displays `[Fast Refresh] done in NaNms`.
![Screenshot](https://github.com/user-attachments/assets/8f7ba1f3-b279-4c69-8518-19ef5b47bf79)
### Why?
This happens because `startMsSinceEpoch` can be `null`, but it was being force-cast with a non-null assertion (`!`), leading to invalid latency calculation.
### How?
Improved the type safety by explicitly checking:
- That `startMsSinceEpoch` is defined
- That the computed `latencyMs` is a valid number
