### PR TITLE
Turbopack Build: Fix next/dynamic test

### DIFF
--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -6,16 +6,16 @@ use std::{
 use pathdiff::diff_paths;
 use swc_core::{
     atoms::Atom,
-    common::{errors::HANDLER, FileName, Span, DUMMY_SP},
+    common::{DUMMY_SP, FileName, Span, errors::HANDLER},
     ecma::{
         ast::{
-            op, ArrayLit, ArrowExpr, BinExpr, BlockStmt, BlockStmtOrExpr, Bool, CallExpr, Callee,
-            Expr, ExprOrSpread, ExprStmt, Id, Ident, IdentName, ImportDecl, ImportNamedSpecifier,
+            ArrayLit, ArrowExpr, BinExpr, BlockStmt, BlockStmtOrExpr, Bool, CallExpr, Callee, Expr,
+            ExprOrSpread, ExprStmt, Id, Ident, IdentName, ImportDecl, ImportNamedSpecifier,
             ImportSpecifier, KeyValueProp, Lit, ModuleDecl, ModuleItem, ObjectLit, Pass, Prop,
-            PropName, PropOrSpread, Stmt, Str, Tpl, UnaryExpr, UnaryOp,
+            PropName, PropOrSpread, Stmt, Str, Tpl, UnaryExpr, UnaryOp, op,
         },
-        utils::{private_ident, quote_ident, ExprFactory},
-        visit::{fold_pass, Fold, FoldWith, VisitMut, VisitMutWith},
+        utils::{ExprFactory, private_ident, quote_ident},
+        visit::{Fold, FoldWith, VisitMut, VisitMutWith, fold_pass},
     },
     quote,
 };
@@ -256,7 +256,12 @@ impl Fold for NextDynamicPatcher {
                                     specifier: dynamically_imported_specifier.clone(),
                                 });
 
-                                module_id_options(Expr::Ident(id_ident))
+                                // Turn into string here to ensure that it matches the
+                                // react-loadable-manifest `id` property which is a string too.
+                                // These are used during hydration in Pages Router.
+                                module_id_options(
+                                    quote!("String($id)" as Expr, id: Ident = id_ident),
+                                )
                             }
                         },
                     }));

--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -6,16 +6,16 @@ use std::{
 use pathdiff::diff_paths;
 use swc_core::{
     atoms::Atom,
-    common::{DUMMY_SP, FileName, Span, errors::HANDLER},
+    common::{errors::HANDLER, FileName, Span, DUMMY_SP},
     ecma::{
         ast::{
-            ArrayLit, ArrowExpr, BinExpr, BlockStmt, BlockStmtOrExpr, Bool, CallExpr, Callee, Expr,
-            ExprOrSpread, ExprStmt, Id, Ident, IdentName, ImportDecl, ImportNamedSpecifier,
+            op, ArrayLit, ArrowExpr, BinExpr, BlockStmt, BlockStmtOrExpr, Bool, CallExpr, Callee,
+            Expr, ExprOrSpread, ExprStmt, Id, Ident, IdentName, ImportDecl, ImportNamedSpecifier,
             ImportSpecifier, KeyValueProp, Lit, ModuleDecl, ModuleItem, ObjectLit, Pass, Prop,
-            PropName, PropOrSpread, Stmt, Str, Tpl, UnaryExpr, UnaryOp, op,
+            PropName, PropOrSpread, Stmt, Str, Tpl, UnaryExpr, UnaryOp,
         },
-        utils::{ExprFactory, private_ident, quote_ident},
-        visit::{Fold, FoldWith, VisitMut, VisitMutWith, fold_pass},
+        utils::{private_ident, quote_ident, ExprFactory},
+        visit::{fold_pass, Fold, FoldWith, VisitMut, VisitMutWith},
     },
     quote,
 };

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15648,10 +15648,11 @@
     "runtimeError": false
   },
   "test/integration/next-dynamic/test/index.test.js": {
-    "passed": ["next/dynamic production mode should render server value"],
-    "failed": [
+    "passed": [
+      "next/dynamic production mode should render server value",
       "next/dynamic production mode should render dynamic server rendered values on client mount"
     ],
+    "failed": [],
     "pending": [
       "next/dynamic development mode should render dynamic server rendered values on client mount",
       "next/dynamic development mode should render server value"


### PR DESCRIPTION
## What?

Took some digging to find the root cause of this test failing. Turns out the `loadableGenerated.modules` property held an integer while react-loadable-manifest.json held a string.

In this place the `dynamicId` sent from server -> browser are checked using `includes()`: https://github.com/vercel/next.js/blob/da25bd72437e1f2c1ccccd0bd49c30ea602d0c9f/packages/next/src/shared/lib/loadable.shared-runtime.tsx#L103

But since the array it's checking holds strings and the id is an integer it results in `false` which means the initializer is not called, resulting in the module not being loaded before hydration starts, even though it is needed.

This PR solves the mismatch, making both values a string. That also matches development behavior.

Fixes PACK-4514