### PR TITLE
build: Update `swc_core` to `v26.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3009,7 +3009,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -5699,7 +5699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.100",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -772,10 +772,10 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.4.5",
  "swc",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms 19.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms",
+ "swc_ecma_visit",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -3009,7 +3009,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4399,9 +4399,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5699,7 +5699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -6047,9 +6047,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6175,9 +6175,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -7297,10 +7297,10 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -7317,7 +7317,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_compat",
@@ -7325,12 +7325,12 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 11.0.0",
+ "swc_ecma_ast",
  "swc_ecma_minifier",
- "swc_ecma_parser 14.0.0",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -7373,23 +7373,23 @@ dependencies = [
  "serde_json",
  "sourcemap",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_codegen 13.0.0",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser 14.0.0",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
- "swc_ecma_transforms 19.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_transforms",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -7460,33 +7460,6 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53ebedaccf5e469fa3be2f54e432d9592c659a69eead0cc1b06f41f051e9d89"
-dependencies = [
- "anyhow",
- "ast_node",
- "better_scoped_tls",
- "cfg-if",
- "either",
- "from_variant",
- "new_debug_unreachable",
- "num-bigint",
- "once_cell",
- "rustc-hash 2.1.1",
- "serde",
- "siphasher",
- "swc_allocator",
- "swc_atoms",
- "swc_eq_ignore_macros",
- "swc_visit",
- "tracing",
- "unicode-width",
- "url",
-]
-
-[[package]]
-name = "swc_common"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209e700a12f0fccd72db3bac7a751e631ef777d543c9e86247e9366b11e30a27"
@@ -7537,13 +7510,13 @@ dependencies = [
  "sourcemap",
  "swc_allocator",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_codegen 13.0.0",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_minifier",
- "swc_ecma_parser 14.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_parser",
+ "swc_ecma_visit",
  "swc_timer",
 ]
 
@@ -7588,24 +7561,24 @@ dependencies = [
  "swc",
  "swc_allocator",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_codegen 13.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser 14.0.0",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_nodejs_common",
  "swc_plugin_proxy",
  "swc_plugin_runner",
@@ -7622,7 +7595,7 @@ dependencies = [
  "is-macro",
  "string_enum",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
 ]
 
 [[package]]
@@ -7636,7 +7609,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -7665,7 +7638,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7680,7 +7653,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7695,7 +7668,7 @@ dependencies = [
  "lexical",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
 ]
 
@@ -7711,7 +7684,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7728,7 +7701,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
  "swc_css_visit",
 ]
@@ -7741,29 +7714,9 @@ checksum = "acf01ce7c4f3d05f82ee58692daaa0df8bee5c8115842df36780bc3ce74faa41"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_css_ast",
  "swc_visit",
-]
-
-[[package]]
-name = "swc_ecma_ast"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca03c581bf83773f6502eb9cce6807a0400556f981dbf2f6f85b5b098322df80"
-dependencies = [
- "bitflags 2.9.0",
- "is-macro",
- "num-bigint",
- "once_cell",
- "phf",
- "rustc-hash 2.1.1",
- "scoped-tls",
- "string_enum",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_visit",
- "unicode-id-start",
 ]
 
 [[package]]
@@ -7786,32 +7739,9 @@ dependencies = [
  "shrink-to-fit",
  "string_enum",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_visit",
  "unicode-id-start",
-]
-
-[[package]]
-name = "swc_ecma_codegen"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa6c4eadc7cfb153b74ac0e7b4ab7b08f26be5b5678541da9bd582430848ffe"
-dependencies = [
- "ascii",
- "compact_str",
- "memchr",
- "num-bigint",
- "once_cell",
- "regex",
- "rustc-hash 2.1.1",
- "serde",
- "sourcemap",
- "swc_allocator",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "swc_ecma_codegen_macros",
- "tracing",
 ]
 
 [[package]]
@@ -7831,8 +7761,8 @@ dependencies = [
  "sourcemap",
  "swc_allocator",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -7857,12 +7787,12 @@ checksum = "842e35f35bb7732f35b885c906e93183817d76e167234ab45948bf7cfc856804"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -7873,10 +7803,10 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5d027ec8260c28031723a13d30f12793f0f1cdb1f64133c4da32891e5058e8"
 dependencies = [
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
 ]
 
@@ -7894,15 +7824,15 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 11.0.0",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -7914,12 +7844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f53fcada063eba1c278e829a8b9ec024408c5bad526171b0cb96c77bf9c533b"
 dependencies = [
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -7932,12 +7862,12 @@ checksum = "5d9a8e0589b8933b4e2de95a787b33e6ef91371c5a85f9d73c5870ac546fc6b7"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -7950,13 +7880,13 @@ checksum = "eb69df2828e6d00ca815d66fd1e609e64683abf705dcc46b195fbc7353cabe89"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -7968,11 +7898,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71abfad6a3a6093098f46e68e026d132ca15906fed912b0912f561a1cbd67f5"
 dependencies = [
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -7985,12 +7915,12 @@ checksum = "73b226871c16b8f4e3914c1dff2e8c93626fbc6a6bfeb3fb598f941d04890e20"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_compat_es2022",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8002,11 +7932,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f79df9e55b7c3fd29e4116fc6ef1e0155c86fe64fa6a91d357469501d574ef2"
 dependencies = [
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8019,14 +7949,14 @@ checksum = "6a7749e111ac8251708d6067dc20d0a9399dd7d8e3cd75a18d309830575064d1"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8037,11 +7967,11 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecfb2f4d16cd2459bdae7a12a0c3258bb53d63d97c0bbff50dade9c3f324c634"
 dependencies = [
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8054,35 +7984,10 @@ checksum = "1db3a2e81be5e12bf58f53a9217791e695bb79e43e6e9e0b63be602c048f0451"
 dependencies = [
  "phf",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
-]
-
-[[package]]
-name = "swc_ecma_lexer"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256ee9bd0c6928d71d635c7c5044d9125af37070ebd13ab16498303046b9e5d3"
-dependencies = [
- "arrayvec 0.7.4",
- "bitflags 2.9.0",
- "either",
- "new_debug_unreachable",
- "num-bigint",
- "num-traits",
- "phf",
- "rustc-hash 2.1.1",
- "serde",
- "smallvec",
- "smartstring",
- "stacker",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "tracing",
- "typed-arena",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8104,8 +8009,8 @@ dependencies = [
  "smartstring",
  "stacker",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "tracing",
  "typed-arena",
 ]
@@ -8124,11 +8029,11 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8149,7 +8054,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "tracing",
 ]
 
@@ -8177,44 +8082,18 @@ dependencies = [
  "serde_json",
  "swc_allocator",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_codegen 13.0.0",
- "swc_ecma_parser 14.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
  "swc_ecma_usage_analyzer",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a88f88646bf3efd7a614aec888c21b5a23bb8e63d7fbcf2df9fcf1a2c952d7"
-dependencies = [
- "arrayvec 0.7.4",
- "bitflags 2.9.0",
- "either",
- "new_debug_unreachable",
- "num-bigint",
- "num-traits",
- "phf",
- "rustc-hash 2.1.1",
- "serde",
- "smallvec",
- "smartstring",
- "stacker",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "swc_ecma_lexer 13.0.0",
- "tracing",
- "typed-arena",
 ]
 
 [[package]]
@@ -8236,9 +8115,9 @@ dependencies = [
  "smartstring",
  "stacker",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_lexer 14.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_lexer",
  "tracing",
  "typed-arena",
 ]
@@ -8261,11 +8140,11 @@ dependencies = [
  "st-map",
  "string_enum",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms 19.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8279,9 +8158,9 @@ dependencies = [
  "quote",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_parser 14.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_macros_common",
  "syn 2.0.100",
 ]
@@ -8301,62 +8180,23 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c77766fcc5e49fa8470de8369676bca55371ca58602fa81d49795c0452f4c1"
-dependencies = [
- "par-core",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "swc_ecma_transforms_base 14.0.0",
- "swc_ecma_utils 14.0.0",
- "swc_ecma_visit 10.0.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms"
 version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f91c0e075315f1e745f65888e135ff05e3d16b6c6393c70dc9fb2c944b40fe"
 dependencies = [
  "par-core",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
-]
-
-[[package]]
-name = "swc_ecma_transforms_base"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206283c6813ea714ea7f73ba1a14d0af833c5c7a080a3d6f0999495c2b3fe3ad"
-dependencies = [
- "better_scoped_tls",
- "bitflags 2.9.0",
- "indexmap 2.7.1",
- "once_cell",
- "par-core",
- "phf",
- "rustc-hash 2.1.1",
- "serde",
- "smallvec",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "swc_ecma_parser 13.0.0",
- "swc_ecma_utils 14.0.0",
- "swc_ecma_visit 10.0.0",
- "tracing",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8376,11 +8216,11 @@ dependencies = [
  "serde",
  "smallvec",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_parser 14.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -8391,11 +8231,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c30a47eb83be77705a16103918db015a409a45e158a490697d8419a6f92151a"
 dependencies = [
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8413,9 +8253,9 @@ dependencies = [
  "serde",
  "smallvec",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 11.0.0",
+ "swc_ecma_ast",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -8427,11 +8267,11 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8465,14 +8305,14 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 11.0.0",
+ "swc_ecma_ast",
  "swc_ecma_loader",
- "swc_ecma_parser 14.0.0",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -8491,13 +8331,13 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde_json",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_parser 14.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -8512,13 +8352,13 @@ dependencies = [
  "serde",
  "smallvec",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8538,14 +8378,14 @@ dependencies = [
  "string_enum",
  "swc_allocator",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_config",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_parser 14.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8563,14 +8403,14 @@ dependencies = [
  "sha2",
  "sourcemap",
  "swc_allocator",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_codegen 13.0.0",
- "swc_ecma_parser 14.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
  "swc_ecma_testing",
- "swc_ecma_transforms_base 15.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tempfile",
  "testing",
 ]
@@ -8586,12 +8426,12 @@ dependencies = [
  "ryu-js",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_transforms_base 15.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8604,33 +8444,12 @@ dependencies = [
  "indexmap 2.7.1",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_utils"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a273fc67f40746fe7c24894ff470531b5b75b17b0f40531ded7cb08610b66f"
-dependencies = [
- "indexmap 2.7.1",
- "num_cpus",
- "once_cell",
- "par-core",
- "par-iter",
- "rustc-hash 2.1.1",
- "ryu-js",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "swc_ecma_visit 10.0.0",
- "tracing",
- "unicode-id",
 ]
 
 [[package]]
@@ -8648,26 +8467,11 @@ dependencies = [
  "rustc-hash 2.1.1",
  "ryu-js",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
  "tracing",
  "unicode-id",
-]
-
-[[package]]
-name = "swc_ecma_visit"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035bb30e8f9e077b94a2b403f5056faaf0d8417b5190b4bcf0be62768342eab2"
-dependencies = [
- "new_debug_unreachable",
- "num-bigint",
- "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "swc_visit",
- "tracing",
 ]
 
 [[package]]
@@ -8680,17 +8484,17 @@ dependencies = [
  "num-bigint",
  "serde",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_visit",
  "tracing",
 ]
 
 [[package]]
 name = "swc_emotion"
-version = "0.89.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1a1ba26f59bf0461a1fede71c16ca2f95c6e46bb930e2863bc84cb222cbf79"
+checksum = "f04683db00e12df8b824066ab8c62867827e9436514a88bade6e624f871791f0"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8701,12 +8505,12 @@ dependencies = [
  "serde",
  "sourcemap",
  "swc_atoms",
- "swc_common 10.0.0",
- "swc_ecma_ast 10.0.0",
- "swc_ecma_codegen 12.0.0",
- "swc_ecma_transforms 18.0.0",
- "swc_ecma_utils 14.0.0",
- "swc_ecma_visit 10.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_transforms",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8735,7 +8539,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "swc_common 11.0.0",
+ "swc_common",
 ]
 
 [[package]]
@@ -8758,7 +8562,7 @@ dependencies = [
  "dashmap 5.5.3",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 11.0.0",
+ "swc_common",
 ]
 
 [[package]]
@@ -8797,8 +8601,8 @@ dependencies = [
  "rancor",
  "rkyv 0.8.9",
  "rustc-hash 2.1.1",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8818,8 +8622,8 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
  "swc_plugin_proxy",
  "swc_transform_common",
  "tokio",
@@ -8843,10 +8647,10 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -8881,7 +8685,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_common 11.0.0",
+ "swc_common",
 ]
 
 [[package]]
@@ -8894,10 +8698,10 @@ dependencies = [
  "petgraph 0.7.1",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common 11.0.0",
- "swc_ecma_ast 11.0.0",
- "swc_ecma_utils 15.0.0",
- "swc_ecma_visit 11.0.0",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "thiserror 1.0.69",
 ]
 
@@ -9092,7 +8896,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_common 11.0.0",
+ "swc_common",
  "swc_error_reporters",
  "testing_macros",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4d1ac485a2bed201ccf331ead87d97e1b33b239130b094a2226a7aa270b276"
+checksum = "c23c0cf9351aa158baee33c9dea1870a0f21393375cf00b2a6170ad7f477aa1b"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -772,10 +772,10 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.4.5",
  "swc",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms 19.0.0",
+ "swc_ecma_visit 11.0.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "mdxjs"
 version = "1.0.2"
-source = "git+https://github.com/kdy1/mdxjs-rs?branch=swc-core-25#b82ccfe50e3d3cff0819ae3ad6e026c69318e7b1"
+source = "git+https://github.com/kdy1/mdxjs-rs?branch=swc-core-26#d56c9e7f378496f4e838fb11a2644a38762fa86e"
 dependencies = [
  "markdown",
  "rustc-hash 2.1.1",
@@ -4388,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.85.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe193e65e83c580cfc8d7c6530a853a8b0443206d652625fcee266644f4b9082"
+checksum = "bba76aa13e6547ba9d916c24db54e054dc12de089b77d5c93ba76a8402071c94"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -4399,9 +4399,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
@@ -6040,16 +6040,16 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b176c3d2f5bb36112bef54754648389ad6647ce0a19a5e1a16a66b82cc978b8b"
+checksum = "ba0afc9ca3b8533c7f16fc01430d22c30d3ad730718bd83a8f84084132a5e6c7"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
@@ -6168,16 +6168,16 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef3bc7f88475475cc7079f92189c1eb3c650210a0dd8c4851532bde7992b3d1"
+checksum = "6fefe25b383a78fa2299d9c32eb231b49c054e119add0c0eba650024c0e09097"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
@@ -7287,9 +7287,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb50f5a791b70b725d8b2308676bc50876502952e62afab8dd444b5ac15c270"
+checksum = "1c4c07c72c3ac59d20689b5acf92b2c5fef06592c38a57bd547f69fb2722dbb6"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -7297,18 +7297,18 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.89.0"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b07a8f51fa6a4658a025ad7080729715f71a7eb136048ed347fa97af2009b3"
+checksum = "fe5c84bf9de7925aed8427c6b9bbcfac0796385e4457af901c8c6786d7cbb861"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -7317,7 +7317,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_compat",
@@ -7325,12 +7325,12 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 14.0.0",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -7349,9 +7349,9 @@ checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
 
 [[package]]
 name = "swc"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0faaca65307dd2162d5e27a1bc16b4884235e5a714f33846d08660fb3c9b61d7"
+checksum = "707e7a089761c5f4661765cc38b689d795d67bb0810782cdece3997cd03a6e94"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7373,23 +7373,23 @@ dependencies = [
  "serde_json",
  "sourcemap",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_codegen 13.0.0",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_parser 14.0.0",
  "swc_ecma_preset_env",
- "swc_ecma_transforms",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms 19.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -7467,6 +7467,33 @@ dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
+ "cfg-if",
+ "either",
+ "from_variant",
+ "new_debug_unreachable",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash 2.1.1",
+ "serde",
+ "siphasher",
+ "swc_allocator",
+ "swc_atoms",
+ "swc_eq_ignore_macros",
+ "swc_visit",
+ "tracing",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "swc_common"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209e700a12f0fccd72db3bac7a751e631ef777d543c9e86247e9366b11e30a27"
+dependencies = [
+ "anyhow",
+ "ast_node",
+ "better_scoped_tls",
  "bytecheck 0.8.0",
  "cfg-if",
  "either",
@@ -7494,9 +7521,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "21.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde317abee9dacf6641db282ffd4447c735d37c172577f41a254d1930c551367"
+checksum = "3aef98ee955eac3339cb3a8152c64746196bd14919b41afdf2cc410c06e6cfee"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7510,13 +7537,13 @@ dependencies = [
  "sourcemap",
  "swc_allocator",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_codegen 13.0.0",
  "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_visit",
+ "swc_ecma_parser 14.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_timer",
 ]
 
@@ -7553,32 +7580,32 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fef1dbff000a009f955919fe16ac5ee20641fa7018aaa71d7230f5debe8991"
+checksum = "b2b200c261818e6bae1b208ce476e54156dfa914d7adf70c9372ebf9b2e31ceb"
 dependencies = [
  "binding_macros",
  "swc",
  "swc_allocator",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_codegen 13.0.0",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_parser 14.0.0",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_nodejs_common",
  "swc_plugin_proxy",
  "swc_plugin_runner",
@@ -7588,28 +7615,28 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2e5c7bac48a1c715147b7f2aa218cdbbb2557dcd96902cd9ae61b9a6f49f2f"
+checksum = "a434516e60c9ceebcd288c5b22f6d6d4051403e11691a97a2c6729b74d8a9aba"
 dependencies = [
  "is-macro",
  "string_enum",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
 ]
 
 [[package]]
 name = "swc_css_codegen"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8423f3d64a4ff2904a9e5e646563dc1c3cc33d16113450d296b3fc33d00260"
+checksum = "838abcc39836584f28b413370575636286ea36cbaa00b748f787a3a68868e0c8"
 dependencies = [
  "auto_impl",
  "bitflags 2.9.0",
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -7629,16 +7656,16 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2daa1254805271bd110bdb59297bd8c8ad954ded2db0aa5a685e46539bd78d6"
+checksum = "ba75455f1f1e3539cf6baa999b2338b1366849ad50fd6a8f6db129109bec4eb9"
 dependencies = [
  "bitflags 2.9.0",
  "once_cell",
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7646,14 +7673,14 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c190c30cbafe0a5fa73c758f49d1bddfcc91ececbea21e0c3881526688513b"
+checksum = "10f809a4dff6a164664ff1553ec7ef891a69241c26a9ec788f0e59053542c9fc"
 dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7661,22 +7688,22 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc13c51d125d8311f535c16ca7900955e08cc21282310ec8a28373fe37404d53"
+checksum = "76c5f791bcaedb06018e1f6a5c6f8a45e03149be6cc72f291dae8782d90a3654"
 dependencies = [
  "lexical",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
 ]
 
 [[package]]
 name = "swc_css_prefixer"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19384972d97ca8b2256ebae54504144ee30615393456bb32898f0548bb3505c"
+checksum = "3dae7345db04cfe794e26a86e64aa82d9decad0fc9bc9897a7b7243355aa7b43"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -7684,7 +7711,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7692,29 +7719,29 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64de223005cc0d92eea793712ac4e9168577219adf0c38350209f484a5ab2e6"
+checksum = "c62b1d0dc15f9f09405f90f76cfb89900a5eaeb53486e91cdad1e8df25a1ee3d"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
  "swc_css_visit",
 ]
 
 [[package]]
 name = "swc_css_visit"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7995105f54a55711879f12ac595ce320dbcf539f696c14464a3b26bceca4ecfa"
+checksum = "acf01ce7c4f3d05f82ee58692daaa0df8bee5c8115842df36780bc3ce74faa41"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_css_ast",
  "swc_visit",
 ]
@@ -7724,6 +7751,26 @@ name = "swc_ecma_ast"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca03c581bf83773f6502eb9cce6807a0400556f981dbf2f6f85b5b098322df80"
+dependencies = [
+ "bitflags 2.9.0",
+ "is-macro",
+ "num-bigint",
+ "once_cell",
+ "phf",
+ "rustc-hash 2.1.1",
+ "scoped-tls",
+ "string_enum",
+ "swc_atoms",
+ "swc_common 10.0.0",
+ "swc_visit",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2313360a518a37c4b9ee50030d189222927a3af902903cc70c50f6929e402dc"
 dependencies = [
  "bitflags 2.9.0",
  "bytecheck 0.8.0",
@@ -7739,7 +7786,7 @@ dependencies = [
  "shrink-to-fit",
  "string_enum",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_visit",
  "unicode-id-start",
 ]
@@ -7761,8 +7808,31 @@ dependencies = [
  "sourcemap",
  "swc_allocator",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4eba460f872946ce9892fca7878b810fc3f259a5fd0dfca5e6357babdd07bb"
+dependencies = [
+ "ascii",
+ "compact_str",
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "regex",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sourcemap",
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -7781,40 +7851,40 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc0972813548db39a05fedf5ead846e74296bada067ee276c9ab0b66f0a127c"
+checksum = "842e35f35bb7732f35b885c906e93183817d76e167234ab45948bf7cfc856804"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd9cce533424d8d1f7a9a29fb5889aa986b9710fa991db92fa086443d980dbf"
+checksum = "ed5d027ec8260c28031723a13d30f12793f0f1cdb1f64133c4da32891e5058e8"
 dependencies = [
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7913c4368e0489e759b5fcf753b666da22e62c5d0b0dfc84d17ec2007c576ba"
+checksum = "073fd6f4f2fe6e5929056fab53d1ce188818b81b7008904bc7f932efa3348717"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -7824,170 +7894,170 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904033d1bb157d0c98ecc1fa3033e81b067adcb12a54ba437e47344bb2d9539b"
+checksum = "6f53fcada063eba1c278e829a8b9ec024408c5bad526171b0cb96c77bf9c533b"
 dependencies = [
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a27d8ecbf0b16417e44fa979cb2847679b6f12a48f81defc520a9558e92ebc"
+checksum = "5d9a8e0589b8933b4e2de95a787b33e6ef91371c5a85f9d73c5870ac546fc6b7"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f223933b2ceccd541ecbaa25369aaff8999ae431a56cb83a363a95abc163ba"
+checksum = "eb69df2828e6d00ca815d66fd1e609e64683abf705dcc46b195fbc7353cabe89"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edef2a29fa559fba37f3b1ab4ae0791d8f715c94850d78988a32af1278347cd3"
+checksum = "a71abfad6a3a6093098f46e68e026d132ca15906fed912b0912f561a1cbd67f5"
 dependencies = [
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd786103b7c18617a4308c89179df0f90a9f9f455fe4cedaf85a1cfd3ff0bf6"
+checksum = "73b226871c16b8f4e3914c1dff2e8c93626fbc6a6bfeb3fb598f941d04890e20"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_compat_es2022",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41713e150ba35137c870d746705774994ad51a57871b94b104f219ca3796fed4"
+checksum = "2f79df9e55b7c3fd29e4116fc6ef1e0155c86fe64fa6a91d357469501d574ef2"
 dependencies = [
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28d04789fe0570be1c28d3d6370d532ba5bf2c1aa7c349e5512981b688815a6"
+checksum = "6a7749e111ac8251708d6067dc20d0a9399dd7d8e3cd75a18d309830575064d1"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473af5a24b3683938e933d39ac370d8f82dcb3fdd3f588614706185d2bf12bcf"
+checksum = "ecfb2f4d16cd2459bdae7a12a0c3258bb53d63d97c0bbff50dade9c3f324c634"
 dependencies = [
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63c840e1a16615e785bdb656d7bd16c0fcea8489464e723b37ae46301536f8b"
+checksum = "1db3a2e81be5e12bf58f53a9217791e695bb79e43e6e9e0b63be602c048f0451"
 dependencies = [
  "phf",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
@@ -8009,17 +8079,42 @@ dependencies = [
  "smartstring",
  "stacker",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_lexer"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602a6a5190cbb4adc134bdf9a525b845912a86039130c2b476ff20123b1aacd5"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bitflags 2.9.0",
+ "either",
+ "new_debug_unreachable",
+ "num-bigint",
+ "num-traits",
+ "phf",
+ "rustc-hash 2.1.1",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "tracing",
  "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_lints"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdef224d9ad9a20cfaaf14abec264d877e3cbcb408e557d4be1e0962d25f915"
+checksum = "daf720184ed1f84a61a34df1c9d73be0931a8184a7ed6af67ad8f5f1bbec3881"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -8029,18 +8124,18 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_loader"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f5ea60d0f25a7abdc02ef025d773d3ac979a50b3446dd65ea745ef226d2259"
+checksum = "209c6a8a5ca19c9b24daf598debb4f2fa57bf21a3bd76046d9791b7f2a0b0c93"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -8054,15 +8149,15 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310cab11b33c3228975595acf6df886a71bb8180c8aae1bceae403abbd225ef"
+checksum = "438b4432fbb66f88260e32981819dcc24b6312da0f154866cfc0c616d0a6fae9"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8082,16 +8177,16 @@ dependencies = [
  "serde_json",
  "swc_allocator",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_codegen 13.0.0",
+ "swc_ecma_parser 14.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_optimization",
  "swc_ecma_usage_analyzer",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_timer",
  "tracing",
 ]
@@ -8115,18 +8210,44 @@ dependencies = [
  "smartstring",
  "stacker",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_lexer",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "swc_ecma_lexer 13.0.0",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebfd62dc0ffe6b80bedcd049f1c949133de6d524d12d2edbb0b6fb64896cefb"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bitflags 2.9.0",
+ "either",
+ "new_debug_unreachable",
+ "num-bigint",
+ "num-traits",
+ "phf",
+ "rustc-hash 2.1.1",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_lexer 14.0.0",
  "tracing",
  "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f2bb9ff805848ec72a03c4966f91d32cce122f3a9b777646c438cbab333e31"
+checksum = "e8f94ea6dfa4daf55a08e210cbc213b5758b6bc92a929a3af75f478c8b0253cf"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -8140,36 +8261,36 @@ dependencies = [
  "st-map",
  "string_enum",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms 19.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ef3fa4e146eff07845cd58216c73b044ea577222227974150673b4f58a4353"
+checksum = "3f755b824a30c6b70dba267077f4e2471d2a6e440623dc8e399ff27f59759a5a"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_parser 14.0.0",
  "swc_macros_common",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "swc_ecma_testing"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e67b2f453ea0e526056e97a4267e984c590cf03c91ca5d473d2b598c635082"
+checksum = "bfca232a0a2e743c963185665bc6fb6f92b1422449aba17ccd836ff4aa02858d"
 dependencies = [
  "anyhow",
  "hex",
@@ -8186,17 +8307,32 @@ checksum = "86c77766fcc5e49fa8470de8369676bca55371ca58602fa81d49795c0452f4c1"
 dependencies = [
  "par-core",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "swc_ecma_transforms_base 14.0.0",
+ "swc_ecma_utils 14.0.0",
+ "swc_ecma_visit 10.0.0",
+]
+
+[[package]]
+name = "swc_ecma_transforms"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f91c0e075315f1e745f65888e135ff05e3d16b6c6393c70dc9fb2c944b40fe"
+dependencies = [
+ "par-core",
+ "swc_atoms",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
@@ -8211,38 +8347,62 @@ dependencies = [
  "once_cell",
  "par-core",
  "phf",
+ "rustc-hash 2.1.1",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "swc_ecma_parser 13.0.0",
+ "swc_ecma_utils 14.0.0",
+ "swc_ecma_visit 10.0.0",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c539bb05b93a7df2865b98289d865e63e02bb97b43795fc6d480058b5271c0e8"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags 2.9.0",
+ "indexmap 2.7.1",
+ "once_cell",
+ "par-core",
+ "phf",
  "rayon",
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_parser 14.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7665503a3c1dcecd12da1cf6fc15b77efd8a7e962bc109dc657780d5f395f8d9"
+checksum = "1c30a47eb83be77705a16103918db015a409a45e158a490697d8419a6f92151a"
 dependencies = [
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d90c36d0756a6d2cfada472487a796f0cd23acdd1f80df35763497563b6282c"
+checksum = "4ab71af00c78903335fc2ac0ad4308e6729b6be60e47393a36357fb20ffbb612"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.7.1",
@@ -8253,9 +8413,9 @@ dependencies = [
  "serde",
  "smallvec",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -8267,11 +8427,11 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8290,9 +8450,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0924a56c73464aa546c8961f2c8f07d7ef629a4fd7d330452d63cfa4ac33ac"
+checksum = "bc169d2f3e52ab9619aff70b97b6f9db7b96feec8112454df3dd7d134f34078a"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -8305,22 +8465,22 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 11.0.0",
  "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 14.0.0",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb5dc5b05c68214134c6d72ba4409a48110f6cfa930bea91a3941cb991d6faf"
+checksum = "1e184bf675c5c9111e1b155e49fc267bc2971b732ac22d80887cc46973a782b7"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.7.1",
@@ -8331,41 +8491,41 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde_json",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_parser 14.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38564c381fb4bb1317be9dd7d7c465fd372fd9589ae38453b1a8e8355f6f277b"
+checksum = "f21a20e2231143fe4aacecf2f1957c80bca8096ebe52f27e6e5624a49a2a385d"
 dependencies = [
  "either",
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c795f11596f149dbe79579773d13d463bd6ab4e456495c360e60463f3e279f68"
+checksum = "a3f141582d19aa9679ecfc811bc72cb8ef24290bc1e53ba208445ff5d5745f2b"
 dependencies = [
  "base64 0.22.1",
  "dashmap 5.5.3",
@@ -8378,21 +8538,21 @@ dependencies = [
  "string_enum",
  "swc_allocator",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_parser 14.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f9e73a690d3e5bcbe211f22815cd2a0c884e542d709d632323e1cda7a699a5"
+checksum = "297e4f7638cfc0d6088ad637ec717b9ffbf7555a913963344cd1f3ce2864a660"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8403,51 +8563,51 @@ dependencies = [
  "sha2",
  "sourcemap",
  "swc_allocator",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_codegen 13.0.0",
+ "swc_ecma_parser 14.0.0",
  "swc_ecma_testing",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 15.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "tempfile",
  "testing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6845e968569f670fab573332245634bd00256814707173cc0fb6365af476ac"
+checksum = "5af18b9b3f38cf775b9dcf46f0fdbde542d6559e5759799263ef0f76563fcd9b"
 dependencies = [
  "once_cell",
  "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_transforms_base 15.0.0",
  "swc_ecma_transforms_react",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
 ]
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2edb37d49d187b687d45e93c7cf853fece54ec0fd3adc224c550b904345ddfc4"
+checksum = "4b1f2dccff9c6cde3f72a86babcc34b1213e0cef8c6e2f1a1da75eca7f5bbe73"
 dependencies = [
  "bitflags 2.9.0",
  "indexmap 2.7.1",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "swc_timer",
  "tracing",
 ]
@@ -8463,13 +8623,34 @@ dependencies = [
  "once_cell",
  "par-core",
  "par-iter",
+ "rustc-hash 2.1.1",
+ "ryu-js",
+ "swc_atoms",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "swc_ecma_visit 10.0.0",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1764198783b3dda9604ab31cd16e2418b120169b8ac404bb13a4d8031faadf82"
+dependencies = [
+ "indexmap 2.7.1",
+ "num_cpus",
+ "once_cell",
+ "par-core",
+ "par-iter",
  "rayon",
  "rustc-hash 2.1.1",
  "ryu-js",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_visit 11.0.0",
  "tracing",
  "unicode-id",
 ]
@@ -8482,10 +8663,25 @@ checksum = "035bb30e8f9e077b94a2b403f5056faaf0d8417b5190b4bcf0be62768342eab2"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
+ "swc_atoms",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8227d1d2d76a9ccfd190ec06bb4a4720bf3edb9f954c69816b2bca5f5aa43887"
+dependencies = [
+ "new_debug_unreachable",
+ "num-bigint",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_visit",
  "tracing",
 ]
@@ -8505,12 +8701,12 @@ dependencies = [
  "serde",
  "sourcemap",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_transforms",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 10.0.0",
+ "swc_ecma_ast 10.0.0",
+ "swc_ecma_codegen 12.0.0",
+ "swc_ecma_transforms 18.0.0",
+ "swc_ecma_utils 14.0.0",
+ "swc_ecma_visit 10.0.0",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8528,9 +8724,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c0fb3ceae263cc1d3fff8d00813409d5416ab8d2c047ecc1d4d6b44b118353"
+checksum = "572075b92eef780f9a13b99abcb4fbf8e6272abeed27b361632b5e3a2e8de70d"
 dependencies = [
  "anyhow",
  "miette",
@@ -8539,7 +8735,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "swc_common",
+ "swc_common 11.0.0",
 ]
 
 [[package]]
@@ -8555,14 +8751,14 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a9523aa3d6d0205b11da3a756ebe69f828f8b0264a4a850ece565bccd0b10c"
+checksum = "c75011be56778fa9d67fce20853b9a00f46484bfaef230e8098c08ad9caf8dc7"
 dependencies = [
  "dashmap 5.5.3",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
+ "swc_common 11.0.0",
 ]
 
 [[package]]
@@ -8592,26 +8788,26 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc484423fef3772ad4d7e63075d5e6384cce4d205fe44e20cc2366501732dc0"
+checksum = "ab1281343dca1fe02aa027e2dfdf77067e62506e77b651e3e9c1a4e3fa8bccf6"
 dependencies = [
  "better_scoped_tls",
  "bytecheck 0.8.0",
  "rancor",
  "rkyv 0.8.9",
  "rustc-hash 2.1.1",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_plugin_runner"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f20a682157c971162957c76f71b9d83f77312f79ee61f7876964c6cf018fe42"
+checksum = "4802311e7168c171b047c28335603e8969e62ba4d75c0c607b53e77fbcb1a9aa"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8622,8 +8818,8 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
  "swc_plugin_proxy",
  "swc_transform_common",
  "tokio",
@@ -8638,19 +8834,19 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd7f450c1fc39c5909b8aae6cda9a000dafa441c8f60a8cf93e25706e728002"
+checksum = "72fc243dfd853923676b3886c11b3e97b496fc580efd5e6d536539b7a8199a40"
 dependencies = [
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "tracing",
 ]
 
@@ -8676,32 +8872,32 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff8ea3abcae914d0caf6adece374bb0e55aa96d74dbc7dd2ddf6ad4535cd3ba"
+checksum = "3be97f7341c59045d8ecbd5579acad8063e545d10304db086846b9dcf985c56e"
 dependencies = [
  "better_scoped_tls",
  "once_cell",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_common",
+ "swc_common 11.0.0",
 ]
 
 [[package]]
 name = "swc_typescript"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef615742050fb93f9a6c0b3019eac212fb2498e82b16646bb30b463b9a030fa9"
+checksum = "89986d94714c9751f81509eb7b69074c580790825a7abad9baf9361bc6483ab3"
 dependencies = [
  "bitflags 2.9.0",
  "petgraph 0.7.1",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_common 11.0.0",
+ "swc_ecma_ast 11.0.0",
+ "swc_ecma_utils 15.0.0",
+ "swc_ecma_visit 11.0.0",
  "thiserror 1.0.69",
 ]
 
@@ -8883,9 +9079,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06bc54f1ba952d312b84bbccacf8b3155dcb590b71f452e680ea66b07a0416c"
+checksum = "4afa5efbee09e27d4fa6f7d3278e351ab1feaf8d253eea84bc69975fb6da418e"
 dependencies = [
  "ansi_term",
  "cargo_metadata 0.18.1",
@@ -8896,7 +9092,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_common",
+ "swc_common 11.0.0",
  "swc_error_reporters",
  "testing_macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,7 +310,7 @@ mdxjs = "1.0.1"
 modularize_imports = { version = "0.86.0" }
 styled_components = { version = "0.114.0" }
 styled_jsx = { version = "0.90.0" }
-swc_emotion = { version = "0.89.0" }
+swc_emotion = { version = "0.90.0" }
 swc_relay = { version = "0.60.0" }
 
 # General Deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,21 +297,21 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "25.0.0", features = [
+swc_core = { version = "26.0.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "11.0.0" }
+testing = { version = "12.0.0" }
 
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.18.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "1.0.1"
-modularize_imports = { version = "0.85.0" }
-styled_components = { version = "0.113.0" }
-styled_jsx = { version = "0.89.0" }
+modularize_imports = { version = "0.86.0" }
+styled_components = { version = "0.114.0" }
+styled_jsx = { version = "0.90.0" }
 swc_emotion = { version = "0.89.0" }
-swc_relay = { version = "0.59.0" }
+swc_relay = { version = "0.60.0" }
 
 # General Deps
 chromiumoxide = { version = "0.5.4", features = [
@@ -430,4 +430,4 @@ vergen-gitcl = { git = "https://github.com/bgw/vergen.git", branch = "bgw/no-opt
 webbrowser = "0.8.7"
 
 [patch.crates-io]
-mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-25" }
+mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-26" }

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -32,8 +32,8 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
-react_remove_properties = "0.39.0"
-remove_console = "0.40.0"
+react_remove_properties = "0.40.0"
+remove_console = "0.41.0"
 itertools = { workspace = true }
 auto-hash-map = { workspace = true }
 percent-encoding = "2.3.1"

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -62,8 +62,8 @@ turbopack-ecmascript-plugins = { workspace = true, optional = true }
 turbo-rcstr = { workspace = true }
 urlencoding = { workspace = true }
 
-react_remove_properties = "0.39.0"
-remove_console = "0.40.0"
+react_remove_properties = "0.40.0"
+remove_console = "0.41.0"
 preset_env_base = "3.0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
### What?

Update swc_core to v26

### Why?

https://github.com/swc-project/swc/pull/10399 made the parser 7% faster

### How?


Closes PACK-4641