### PR TITLE
[dynamicIO] reimplement dynamicIO validation on prerender

### DIFF
--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -23,7 +23,7 @@ describe('Dynamic IO Dev Errors', () => {
          "stack": [
            "Page app/error/page.tsx (2:23)",
            "JSON.parse <anonymous> (0:0)",
-           "<unknown> <anonymous> (0:0)",
+           "LogSafely <anonymous> (0:0)",
          ],
        }
       `)
@@ -49,7 +49,7 @@ describe('Dynamic IO Dev Errors', () => {
          "stack": [
            "Page app/error/page.tsx (2:23)",
            "JSON.parse <anonymous> (0:0)",
-           "<unknown> <anonymous> (0:0)",
+           "LogSafely <anonymous> (0:0)",
          ],
        }
       `)
@@ -111,7 +111,7 @@ describe('Dynamic IO Dev Errors', () => {
            "html <anonymous> (2:1)",
            "Root [Server] <anonymous> (2:1)",
            "JSON.parse <anonymous> (0:0)",
-           "<unknown> <anonymous> (0:0)",
+           "LogSafely <anonymous> (0:0)",
          ],
        }
       `)


### PR DESCRIPTION
This updates the dynamic validation implementation to more closely follow the pattern used in prerenders for dynamicIO + PPR. Now that PPR is the only way to use dynamicIO we only have one implementation and the validation should match it as much as possible.