### PR TITLE
[Segment Cache] Fix: Skew during dynamic prefetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ coverage
 # test output
 test/**/out/*
 test/**/next-env.d.ts
+test/**/.next*
 .DS_Store
 /e2e-tests
 test/tmp/**

--- a/test/e2e/app-dir/segment-cache/deployment-skew/app/dynamic-page/page.jsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/app/dynamic-page/page.jsx
@@ -1,0 +1,6 @@
+import { connection } from 'next/server'
+
+export default async function TargetPage() {
+  await connection()
+  return <div id="build-id">Build ID: {process.env.NEXT_PUBLIC_BUILD_ID}</div>
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/app/layout.jsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children, params }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/app/page.jsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/app/page.jsx
@@ -1,0 +1,28 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <ul>
+      <li>
+        <LinkAccordion href="/dynamic-page">
+          Dynamic page, same deployment
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/dynamic-page?deployment=2">
+          Dynamic page, different deployment
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/static-page">
+          Static page, same deployment
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/static-page?deployment=2">
+          Static page, different deployment
+        </LinkAccordion>
+      </li>
+    </ul>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/app/static-page/page.jsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/app/static-page/page.jsx
@@ -1,0 +1,3 @@
+export default function TargetPage() {
+  return <div id="build-id">Build ID: {process.env.NEXT_PUBLIC_BUILD_ID}</div>
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/build.mjs
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/build.mjs
@@ -1,0 +1,3 @@
+import { build } from './servers.mjs'
+
+build()

--- a/test/e2e/app-dir/segment-cache/deployment-skew/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: boolean
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
@@ -1,0 +1,105 @@
+import type * as Playwright from 'playwright'
+import webdriver from 'next-webdriver'
+import { createRouterAct } from '../router-act'
+import { findPort } from 'next-test-utils'
+import { isNextDeploy, isNextDev } from 'e2e-utils'
+import { build, start } from './servers.mjs'
+
+describe('segment cache (deployment skew)', () => {
+  if (isNextDev || isNextDeploy) {
+    test('should not run during dev or deploy test runs', () => {})
+    return
+  }
+
+  // To debug these tests locally, first build the app:
+  //   node build.mjs
+  //
+  // Then start:
+  //   node start.mjs
+  //
+  // This will build two versions of the same app on different ports, then
+  // start a proxy server that rewrites incoming requests to one or the other
+  // based on the request information.
+
+  let cleanup: () => Promise<void>
+  let port: number
+
+  beforeAll(async () => {
+    build()
+    const proxyPort = (port = await findPort())
+    const nextPort1 = await findPort()
+    const nextPort2 = await findPort()
+    cleanup = await start(proxyPort, nextPort1, nextPort2)
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  it(
+    'does not crash when prefetching a dynamic, non-PPR page ' +
+      'on a different deployment',
+    async () => {
+      // Reproduces a bug that occurred when prefetching a dynamic page
+      // from a different deployment, when PPR is disabled. Once PPR is the
+      // default, it's OK to rewrite this to use the latest APIs.
+      let act
+      const browser = await webdriver(port, '/', {
+        beforePageLoad(p: Playwright.Page) {
+          act = createRouterAct(p)
+        },
+      })
+
+      // Initiate a prefetch of link to a different deployment
+      await act(async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="/dynamic-page?deployment=2"]'
+        )
+        await checkbox.click()
+      })
+
+      // Navigate to the target page
+      const link = await browser.elementByCss(
+        'a[href="/dynamic-page?deployment=2"]'
+      )
+      await link.click()
+
+      // Should have performed a full-page navigation to the new deployment.
+      const buildId = await browser.elementById('build-id')
+      expect(await buildId.text()).toBe('Build ID: 2')
+    },
+    60 * 1000
+  )
+
+  it(
+    'does not crash when prefetching a static page on a different deployment',
+    async () => {
+      // Same as the previous test, but for a static page
+      let act
+      const browser = await webdriver(port, '/', {
+        beforePageLoad(p: Playwright.Page) {
+          act = createRouterAct(p)
+        },
+      })
+
+      // Initiate a prefetch of link to a different deployment
+      await act(async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="/static-page?deployment=2"]'
+        )
+        await checkbox.click()
+      })
+
+      // Navigate to the target page
+      const link = await browser.elementByCss(
+        'a[href="/static-page?deployment=2"]'
+      )
+      await link.click()
+
+      // Should have performed a full-page navigation to the new deployment.
+      const buildId = await browser.elementById('build-id')
+      expect(await buildId.text()).toBe('Build ID: 2')
+    },
+    60 * 1000
+  )
+})

--- a/test/e2e/app-dir/segment-cache/deployment-skew/next.config.js
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/next.config.js
@@ -1,0 +1,21 @@
+const BUILD_ID = process.env.BUILD_ID
+if (!BUILD_ID) {
+  throw new Error('BUILD_ID is not set')
+}
+
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    clientSegmentCache: true,
+  },
+
+  distDir: '.next.' + BUILD_ID,
+
+  async generateBuildId() {
+    return BUILD_ID
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/deployment-skew/servers.mjs
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/servers.mjs
@@ -1,0 +1,102 @@
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+import { spawn, spawnSync } from 'child_process'
+import { createServer } from 'node:http'
+import httpProxy from 'http-proxy'
+import process from 'node:process'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+
+async function spawnNext(buildId, port) {
+  const child = spawn('pnpm', ['next', 'start', '-p', port, dir], {
+    env: {
+      ...process.env,
+      BUILD_ID: buildId,
+      NEXT_PUBLIC_BUILD_ID: buildId,
+    },
+    stdio: ['inherit', 'pipe', 'inherit'],
+  })
+
+  child.stdout.pipe(process.stdout)
+
+  // Wait until the server is listening.
+  return new Promise((resolve, reject) => {
+    child.stdout.on('data', (data) => {
+      if (data.toString().includes('Ready')) {
+        resolve(child)
+      }
+    })
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve(child)
+      } else {
+        reject(new Error(`Next.js server exited with code ${code}`))
+      }
+    })
+  })
+}
+
+export function buildNext(buildId) {
+  spawnSync('pnpm', ['next', 'build', dir], {
+    env: {
+      ...process.env,
+      BUILD_ID: buildId,
+      NEXT_PUBLIC_BUILD_ID: buildId,
+    },
+    stdio: 'inherit',
+  })
+}
+
+export function build() {
+  buildNext('1')
+  buildNext('2')
+}
+
+export async function start(
+  mainPort = 3000,
+  nextPort1 = mainPort + 1,
+  nextPort2 = mainPort + 2
+) {
+  // Start two different Next.js servers, one with BUILD_ID=1 and one
+  // with BUILD_ID=2
+  const [next1, next2] = await Promise.all([
+    spawnNext('1', nextPort1),
+    spawnNext('2', nextPort2),
+  ])
+
+  // Create a proxy server. If search params include `deployment=2`, proxy to
+  // to the second next server. Otherwise, proxy to the first.
+  const proxy = httpProxy.createProxyServer()
+  const server = createServer((req, res) => {
+    let port = nextPort1
+    if (req.url) {
+      const searchParams = new URL(req.url, 'http://localhost').searchParams
+      if (searchParams.get('deployment') === '2') {
+        port = nextPort2
+      }
+    }
+    proxy.web(req, res, { target: `http://localhost:${port}` })
+  })
+
+  const onTerminate = () => {
+    server.close()
+    next1.kill()
+    next2.kill()
+    process.exit(0)
+  }
+  process.on('SIGINT', onTerminate)
+  process.on('SIGTERM', onTerminate)
+
+  const cleanup = async () => {
+    next1.kill()
+    next2.kill()
+    await new Promise((resolve) => server.close(resolve))
+  }
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject)
+    server.listen(mainPort, () => {
+      resolve(cleanup)
+    })
+  })
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/start.mjs
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/start.mjs
@@ -1,0 +1,3 @@
+import { start } from './servers.mjs'
+
+await start()


### PR DESCRIPTION
Fixes a bug that occurred when prefetching a Link to a dynamic page on a different deployment. I didn't catch this earlier during dogfooding because the app we were testing it on was using skew protection. It also only applies to non-PPR/static routes.

This particular case happens when an app is redeployed on the server, but it can also happen when linking to a completely different Next app.