### PR TITLE
Update test E2E deploy workflow to accept version

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -6,6 +6,11 @@ on:
     types: [published]
   # allow triggering manually as well
   workflow_dispatch:
+    inputs:
+      nextVersion:
+        description: canary or custom tarball URL
+        default: canary
+        type: string
 
 env:
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
@@ -54,7 +59,7 @@ jobs:
       matrix:
         group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
     with:
-      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-${{ matrix.group }}'


### PR DESCRIPTION
This allows us to run the E2E deploy tests against a custom tarball or version without triggering a canary release. 