### PR TITLE
Model prerender store as separate server and client scopes

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -690,5 +690,7 @@
   "689": "The \\`compiler.defineServer\\` option is configured to replace the \\`%s\\` variable. This variable is either part of a Next.js built-in or is already configured.",
   "690": "Invariant: loadManifests called for edge runtime",
   "691": "Accessed fallback \\`params\\` during prerendering.",
-  "692": "Expected clientReferenceManifest to be defined."
+  "692": "Expected clientReferenceManifest to be defined.",
+  "693": "%s must not be used within a client component. Next.js should be preventing %s from being included in client components statically, but did not in this case.",
+  "694": "createPrerenderPathname was called inside a client component scope."
 }

--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -12,6 +12,7 @@ export function bailoutToClientRendering(reason: string): void | never {
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':
+      case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy':
         throw new BailoutToCSRError(reason)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1223,7 +1223,9 @@ async function renderToHTMLOrFlightImpl(
       const workUnitStore = workUnitAsyncStorage.getStore()
       return !!(
         workUnitStore &&
-        (workUnitStore.type === 'prerender' || workUnitStore.type === 'cache')
+        (workUnitStore.type === 'prerender' ||
+          workUnitStore.type === 'prerender-client' ||
+          workUnitStore.type === 'cache')
       )
     }
 
@@ -2398,7 +2400,7 @@ async function spawnDynamicValidationInDev(
   if (initialServerResult) {
     const initialClientController = new AbortController()
     const initialClientPrerenderStore: PrerenderStore = {
-      type: 'prerender',
+      type: 'prerender-client',
       phase: 'render',
       rootParams,
       implicitTags,
@@ -2546,7 +2548,7 @@ async function spawnDynamicValidationInDev(
   )
   const finalClientController = new AbortController()
   const finalClientPrerenderStore: PrerenderStore = {
-    type: 'prerender',
+    type: 'prerender-client',
     phase: 'render',
     rootParams,
     implicitTags,
@@ -2997,7 +2999,7 @@ async function prerenderToStream(
       if (initialServerResult) {
         const initialClientController = new AbortController()
         const initialClientPrerenderStore: PrerenderStore = {
-          type: 'prerender',
+          type: 'prerender-client',
           phase: 'render',
           rootParams,
           implicitTags,
@@ -3153,7 +3155,7 @@ async function prerenderToStream(
       )
       const finalClientController = new AbortController()
       const finalClientPrerenderStore: PrerenderStore = {
-        type: 'prerender',
+        type: 'prerender-client',
         phase: 'render',
         rootParams,
         implicitTags,

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -237,8 +237,10 @@ export function trackDynamicDataInDynamicRender(
       // forbidden inside a cache scope.
       return
     }
+    // TODO: it makes no sense to have these work unit store types during a dev render.
     if (
       workUnitStore.type === 'prerender' ||
+      workUnitStore.type === 'prerender-client' ||
       workUnitStore.type === 'prerender-legacy'
     ) {
       workUnitStore.revalidate = 0
@@ -578,7 +580,7 @@ export function useDynamicRouteParams(expression: string) {
     const workUnitStore = workUnitAsyncStorage.getStore()
     if (workUnitStore) {
       // We're prerendering with dynamicIO or PPR or both
-      if (workUnitStore.type === 'prerender') {
+      if (workUnitStore.type === 'prerender-client') {
         // We are in a prerender with dynamicIO semantics
         // We are going to hang here and never resolve. This will cause the currently
         // rendering component to effectively be a dynamic hole

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -79,7 +79,10 @@ export interface RequestStore extends CommonWorkUnitStore {
  * to fill all caches.
  */
 export interface PrerenderStoreModern extends CommonWorkUnitStore {
-  type: 'prerender'
+  // In the future the prerender-client variant will get it's own type.
+  // prerender represents the RSC scope of the prerender.
+  // prerender-client represents the HTML scope of the prerender.
+  type: 'prerender' | 'prerender-client'
 
   /**
    * This signal is aborted when the React render is complete. (i.e. it is the same signal passed to react)
@@ -221,6 +224,7 @@ export function getExpectedRequestStore(
       return workUnitStore
 
     case 'prerender':
+    case 'prerender-client':
     case 'prerender-ppr':
     case 'prerender-legacy':
       // This should not happen because we should have checked it already.
@@ -255,6 +259,8 @@ export function getPrerenderResumeDataCache(
 ): PrerenderResumeDataCache | null {
   if (
     workUnitStore.type === 'prerender' ||
+    // TODO eliminate fetch caching in client scope and stop exposing this data cache during SSR
+    workUnitStore.type === 'prerender-client' ||
     workUnitStore.type === 'prerender-ppr'
   ) {
     return workUnitStore.prerenderResumeDataCache

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -256,6 +256,8 @@ export function createPatchedFetcher(
           workUnitStore &&
           (workUnitStore.type === 'cache' ||
             workUnitStore.type === 'prerender' ||
+            // TODO: stop accumulating tags in client prerender
+            workUnitStore.type === 'prerender-client' ||
             workUnitStore.type === 'prerender-ppr' ||
             workUnitStore.type === 'prerender-legacy')
             ? workUnitStore
@@ -405,7 +407,11 @@ export function createPatchedFetcher(
         if (
           hasNoExplicitCacheConfig &&
           workUnitStore !== undefined &&
-          workUnitStore.type === 'prerender'
+          (workUnitStore.type === 'prerender' ||
+            // While we don't want to do caching in the client scope
+            // we know the fetch will be dynamic for dynamicIO so we
+            // may as well avoid the call here
+            workUnitStore.type === 'prerender-client')
         ) {
           // If we have no cache config, and we're in Dynamic I/O prerendering, it'll be a dynamic call.
           // We don't have to issue that dynamic call.
@@ -500,22 +506,28 @@ export function createPatchedFetcher(
           // If we were setting the revalidate value to 0, we should try to
           // postpone instead first.
           if (finalRevalidate === 0) {
-            if (workUnitStore && workUnitStore.type === 'prerender') {
-              if (cacheSignal) {
-                cacheSignal.endRead()
-                cacheSignal = null
+            if (workUnitStore) {
+              switch (workUnitStore.type) {
+                case 'prerender':
+                case 'prerender-client':
+                  if (cacheSignal) {
+                    cacheSignal.endRead()
+                    cacheSignal = null
+                  }
+                  return makeHangingPromise<Response>(
+                    workUnitStore.renderSignal,
+                    'fetch()'
+                  )
+                default:
+                // fallthrough
               }
-              return makeHangingPromise<Response>(
-                workUnitStore.renderSignal,
-                'fetch()'
-              )
-            } else {
-              markCurrentScopeAsDynamic(
-                workStore,
-                workUnitStore,
-                `revalidate: 0 fetch ${input} ${workStore.route}`
-              )
             }
+
+            markCurrentScopeAsDynamic(
+              workStore,
+              workUnitStore,
+              `revalidate: 0 fetch ${input} ${workStore.route}`
+            )
           }
 
           // We only want to set the revalidate store's revalidate time if it
@@ -633,7 +645,11 @@ export function createPatchedFetcher(
                     ? CACHE_ONE_YEAR
                     : finalRevalidate
 
-                if (workUnitStore && workUnitStore.type === 'prerender') {
+                if (
+                  workUnitStore &&
+                  (workUnitStore.type === 'prerender' ||
+                    workUnitStore.type === 'prerender-client')
+                ) {
                   // We are prerendering at build time or revalidate time with dynamicIO so we need to
                   // buffer the response so we can guarantee it can be read in a microtask
                   const bodyBuffer = await res.arrayBuffer()
@@ -780,7 +796,11 @@ export function createPatchedFetcher(
               // We sometimes use the cache to dedupe fetches that do not specify a cache configuration
               // In these cases we want to make sure we still exclude them from prerenders if dynamicIO is on
               // so we introduce an artificial Task boundary here.
-              if (workUnitStore && workUnitStore.type === 'prerender') {
+              if (
+                workUnitStore &&
+                (workUnitStore.type === 'prerender' ||
+                  workUnitStore.type === 'prerender-client')
+              ) {
                 await waitAtLeastOneReactRenderTask()
               }
             }
@@ -863,22 +883,27 @@ export function createPatchedFetcher(
 
           if (cache === 'no-store') {
             // If enabled, we should bail out of static generation.
-            if (workUnitStore && workUnitStore.type === 'prerender') {
-              if (cacheSignal) {
-                cacheSignal.endRead()
-                cacheSignal = null
+            if (workUnitStore) {
+              switch (workUnitStore.type) {
+                case 'prerender':
+                case 'prerender-client':
+                  if (cacheSignal) {
+                    cacheSignal.endRead()
+                    cacheSignal = null
+                  }
+                  return makeHangingPromise<Response>(
+                    workUnitStore.renderSignal,
+                    'fetch()'
+                  )
+                default:
+                // fallthrough
               }
-              return makeHangingPromise<Response>(
-                workUnitStore.renderSignal,
-                'fetch()'
-              )
-            } else {
-              markCurrentScopeAsDynamic(
-                workStore,
-                workUnitStore,
-                `no-store fetch ${input} ${workStore.route}`
-              )
             }
+            markCurrentScopeAsDynamic(
+              workStore,
+              workUnitStore,
+              `no-store fetch ${input} ${workStore.route}`
+            )
           }
 
           const hasNextConfig = 'next' in init
@@ -890,18 +915,23 @@ export function createPatchedFetcher(
           ) {
             if (next.revalidate === 0) {
               // If enabled, we should bail out of static generation.
-              if (workUnitStore && workUnitStore.type === 'prerender') {
-                return makeHangingPromise<Response>(
-                  workUnitStore.renderSignal,
-                  'fetch()'
-                )
-              } else {
-                markCurrentScopeAsDynamic(
-                  workStore,
-                  workUnitStore,
-                  `revalidate: 0 fetch ${input} ${workStore.route}`
-                )
+              if (workUnitStore) {
+                switch (workUnitStore.type) {
+                  case 'prerender':
+                  case 'prerender-client':
+                    return makeHangingPromise<Response>(
+                      workUnitStore.renderSignal,
+                      'fetch()'
+                    )
+                  default:
+                  // fallthrough
+                }
               }
+              markCurrentScopeAsDynamic(
+                workStore,
+                workUnitStore,
+                `revalidate: 0 fetch ${input} ${workStore.route}`
+              )
             }
 
             if (!workStore.forceStatic || next.revalidate !== 0) {

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -11,7 +11,10 @@ type ApiType = 'time' | 'random' | 'crypto'
 export function io(expression: string, type: ApiType) {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
-    if (workUnitStore.type === 'prerender') {
+    if (
+      workUnitStore.type === 'prerender' ||
+      workUnitStore.type === 'prerender-client'
+    ) {
       const prerenderSignal = workUnitStore.controller.signal
       if (prerenderSignal.aborted === false) {
         // If the prerender signal is already aborted we don't need to construct any stacks

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -53,7 +53,10 @@ export function connection(): Promise<void> {
     }
 
     if (workUnitStore) {
-      if (workUnitStore.type === 'prerender') {
+      if (
+        workUnitStore.type === 'prerender' ||
+        workUnitStore.type === 'prerender-client'
+      ) {
         // dynamicIO Prerender
         // We return a promise that never resolves to allow the prender to stall at this point
         return makeHangingPromise(workUnitStore.renderSignal, '`connection()`')

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -23,6 +23,7 @@ import { makeHangingPromise } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { scheduleImmediate } from '../../lib/scheduler'
 import { isRequestAPICallableInsideAfter } from './utils'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 /**
  * In this version of Next.js `cookies()` returns a Promise however you can still reference the properties of the underlying cookies object
@@ -89,32 +90,42 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
     }
 
     if (workUnitStore) {
-      if (workUnitStore.type === 'prerender') {
-        // dynamicIO Prerender
-        // We don't track dynamic access here because access will be tracked when you access
-        // one of the properties of the cookies object.
-        return makeDynamicallyTrackedExoticCookies(
-          workStore.route,
-          workUnitStore
-        )
-      } else if (workUnitStore.type === 'prerender-ppr') {
-        // PPR Prerender (no dynamicIO)
-        // We are prerendering with PPR. We need track dynamic access here eagerly
-        // to keep continuity with how cookies has worked in PPR without dynamicIO.
-        postponeWithTracking(
-          workStore.route,
-          callingExpression,
-          workUnitStore.dynamicTracking
-        )
-      } else if (workUnitStore.type === 'prerender-legacy') {
-        // Legacy Prerender
-        // We track dynamic access here so we don't need to wrap the cookies in
-        // individual property access tracking.
-        throwToInterruptStaticGeneration(
-          callingExpression,
-          workStore,
-          workUnitStore
-        )
+      switch (workUnitStore.type) {
+        case 'prerender':
+          // dynamicIO Prerender
+          // We don't track dynamic access here because access will be tracked when you access
+          // one of the properties of the cookies object.
+          return makeDynamicallyTrackedExoticCookies(
+            workStore.route,
+            workUnitStore
+          )
+        case 'prerender-client':
+          const exportName = '`cookies`'
+          throw new InvariantError(
+            `${exportName} must not be used within a client component. Next.js should be preventing ${exportName} from being included in client components statically, but did not in this case.`
+          )
+        case 'prerender-ppr':
+          // PPR Prerender (no dynamicIO)
+          // We are prerendering with PPR. We need track dynamic access here eagerly
+          // to keep continuity with how cookies has worked in PPR without dynamicIO.
+          postponeWithTracking(
+            workStore.route,
+            callingExpression,
+            workUnitStore.dynamicTracking
+          )
+          break
+        case 'prerender-legacy':
+          // Legacy Prerender
+          // We track dynamic access here so we don't need to wrap the cookies in
+          // individual property access tracking.
+          throwToInterruptStaticGeneration(
+            callingExpression,
+            workStore,
+            workUnitStore
+          )
+          break
+        default:
+        // fallthrough
       }
     }
     // We fall through to the dynamic context below but we still track dynamic access

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -18,6 +18,7 @@ import {
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { DynamicServerError } from '../../client/components/hooks-server-context'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 /**
  * In this version of Next.js `draftMode()` returns a Promise however you can still reference the properties of the underlying draftMode object
@@ -75,6 +76,7 @@ export function draftMode(): Promise<DraftMode> {
     // Otherwise, we fall through to providing an empty draft mode.
     // eslint-disable-next-line no-fallthrough
     case 'prerender':
+    case 'prerender-client':
     case 'prerender-ppr':
     case 'prerender-legacy':
       // Return empty draft mode
@@ -268,41 +270,50 @@ function trackDynamicDraftMode(expression: string) {
     }
 
     if (workUnitStore) {
-      if (workUnitStore.type === 'prerender') {
-        // dynamicIO Prerender
-        const error = new Error(
-          `Route ${store.route} used ${expression} without first calling \`await connection()\`. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-headers`
-        )
-        abortAndThrowOnSynchronousRequestDataAccess(
-          store.route,
-          expression,
-          error,
-          workUnitStore
-        )
-      } else if (workUnitStore.type === 'prerender-ppr') {
-        // PPR Prerender
-        postponeWithTracking(
-          store.route,
-          expression,
-          workUnitStore.dynamicTracking
-        )
-      } else if (workUnitStore.type === 'prerender-legacy') {
-        // legacy Prerender
-        workUnitStore.revalidate = 0
+      switch (workUnitStore.type) {
+        case 'prerender':
+          // dynamicIO Prerender
+          const error = new Error(
+            `Route ${store.route} used ${expression} without first calling \`await connection()\`. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-headers`
+          )
+          abortAndThrowOnSynchronousRequestDataAccess(
+            store.route,
+            expression,
+            error,
+            workUnitStore
+          )
+          break
+        case 'prerender-client':
+          const exportName = '`draftMode`'
+          throw new InvariantError(
+            `${exportName} must not be used within a client component. Next.js should be preventing ${exportName} from being included in client components statically, but did not in this case.`
+          )
+        case 'prerender-ppr':
+          // PPR Prerender
+          postponeWithTracking(
+            store.route,
+            expression,
+            workUnitStore.dynamicTracking
+          )
+          break
+        case 'prerender-legacy':
+          // legacy Prerender
+          workUnitStore.revalidate = 0
 
-        const err = new DynamicServerError(
-          `Route ${store.route} couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
-        )
-        store.dynamicUsageDescription = expression
-        store.dynamicUsageStack = err.stack
+          const err = new DynamicServerError(
+            `Route ${store.route} couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+          )
+          store.dynamicUsageDescription = expression
+          store.dynamicUsageStack = err.stack
 
-        throw err
-      } else if (
-        process.env.NODE_ENV === 'development' &&
-        workUnitStore &&
-        workUnitStore.type === 'request'
-      ) {
-        workUnitStore.usedDynamic = true
+          throw err
+        case 'request':
+          if (process.env.NODE_ENV === 'development') {
+            workUnitStore.usedDynamic = true
+          }
+          break
+        default:
+        // fallthrough
       }
     }
   }

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -20,6 +20,7 @@ import { makeHangingPromise } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { scheduleImmediate } from '../../lib/scheduler'
 import { isRequestAPICallableInsideAfter } from './utils'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 /**
  * In this version of Next.js `headers()` returns a Promise however you can still reference the properties of the underlying Headers instance
@@ -93,30 +94,40 @@ export function headers(): Promise<ReadonlyHeaders> {
     }
 
     if (workUnitStore) {
-      if (workUnitStore.type === 'prerender') {
-        // dynamicIO Prerender
-        // We don't track dynamic access here because access will be tracked when you access
-        // one of the properties of the headers object.
-        return makeDynamicallyTrackedExoticHeaders(
-          workStore.route,
-          workUnitStore
-        )
-      } else if (workUnitStore.type === 'prerender-ppr') {
-        // PPR Prerender (no dynamicIO)
-        // We are prerendering with PPR. We need track dynamic access here eagerly
-        // to keep continuity with how headers has worked in PPR without dynamicIO.
-        // TODO consider switching the semantic to throw on property access instead
-        postponeWithTracking(
-          workStore.route,
-          'headers',
-          workUnitStore.dynamicTracking
-        )
-      } else if (workUnitStore.type === 'prerender-legacy') {
-        // Legacy Prerender
-        // We are in a legacy static generation mode while prerendering
-        // We track dynamic access here so we don't need to wrap the headers in
-        // individual property access tracking.
-        throwToInterruptStaticGeneration('headers', workStore, workUnitStore)
+      switch (workUnitStore.type) {
+        case 'prerender':
+          // dynamicIO Prerender
+          // We don't track dynamic access here because access will be tracked when you access
+          // one of the properties of the headers object.
+          return makeDynamicallyTrackedExoticHeaders(
+            workStore.route,
+            workUnitStore
+          )
+        case 'prerender-client':
+          const exportName = '`headers`'
+          throw new InvariantError(
+            `${exportName} must not be used within a client component. Next.js should be preventing ${exportName} from being included in client components statically, but did not in this case.`
+          )
+        case 'prerender-ppr':
+          // PPR Prerender (no dynamicIO)
+          // We are prerendering with PPR. We need track dynamic access here eagerly
+          // to keep continuity with how headers has worked in PPR without dynamicIO.
+          // TODO consider switching the semantic to throw on property access instead
+          postponeWithTracking(
+            workStore.route,
+            'headers',
+            workUnitStore.dynamicTracking
+          )
+          break
+        case 'prerender-legacy':
+          // Legacy Prerender
+          // We are in a legacy static generation mode while prerendering
+          // We track dynamic access here so we don't need to wrap the headers in
+          // individual property access tracking.
+          throwToInterruptStaticGeneration('headers', workStore, workUnitStore)
+          break
+        default:
+        // fallthrough
       }
     }
     // We fall through to the dynamic context below but we still track dynamic access

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -10,6 +10,7 @@ import {
   type PrerenderStore,
 } from '../app-render/work-unit-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 export function createServerPathnameForMetadata(
   underlyingPathname: string,
@@ -19,6 +20,7 @@ export function createServerPathnameForMetadata(
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':
+      case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy': {
         return createPrerenderPathname(
@@ -46,6 +48,10 @@ function createPrerenderPathname(
         return makeHangingPromise<string>(
           prerenderStore.renderSignal,
           '`pathname`'
+        )
+      case 'prerender-client':
+        throw new InvariantError(
+          'createPrerenderPathname was called inside a client component scope.'
         )
       case 'prerender-ppr':
         return makeErroringPathname(workStore, prerenderStore.dynamicTracking)

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -1132,7 +1132,7 @@ function createDynamicIOError(route: string) {
   )
 }
 
-export function trackDynamic(
+function trackDynamic(
   store: WorkStore,
   workUnitStore: undefined | WorkUnitStore,
   expression: string

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -30,10 +30,16 @@ export function unstable_noStore() {
     return
   } else {
     store.isUnstableNoStore = true
-    if (workUnitStore && workUnitStore.type === 'prerender') {
-      // unstable_noStore() is a noop in Dynamic I/O.
-    } else {
-      markCurrentScopeAsDynamic(store, workUnitStore, callingExpression)
+    if (workUnitStore) {
+      switch (workUnitStore.type) {
+        case 'prerender':
+        case 'prerender-client':
+          // unstable_noStore() is a noop in Dynamic I/O.
+          return
+        default:
+        // fallthrough
+      }
     }
+    markCurrentScopeAsDynamic(store, workUnitStore, callingExpression)
   }
 }


### PR DESCRIPTION
When we adopted the architecture of WorkUnitStore the idea was that code could be running in only one scope at a time. The point was to limit accidental leakage of incorrect data into a scope, for instance by carrying request data into a cache function where it would poison the cache entry that reads from it. However the model of these stores did not discriminate between rendering for RSC and rendering for the client. There are many APIs that are only available in RSC and that should not work when performing an HTML render on the server but without discriminating between the render type it is impossible to make such differentiations at runtime and we must rely on other means to prevent incorrect usage of APIs in the wrong scope.

This change forks the prerender store (dynamicIO) into a server ('prerender') and client ('prerender-client') type. At the moment they still share all the same store properties but in later updates I will be removing all the unnecessary properties from the client version of this store.