### PR TITLE
[Segment Cache] Fix: Ensure server references can be prerendered

### DIFF
--- a/.changeset/spotty-hotels-train.md
+++ b/.changeset/spotty-hotels-train.md
@@ -1,0 +1,5 @@
+---
+"next": patch
+---
+
+[Segment Cache] Fix: Ensure server references can be prerendered

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -99,7 +99,10 @@ import { makeGetServerInsertedHTML } from './make-get-server-inserted-html'
 import { walkTreeWithFlightRouterState } from './walk-tree-with-flight-router-state'
 import { createComponentTree, getRootParams } from './create-component-tree'
 import { getAssetQueryString } from './get-asset-query-string'
-import { setReferenceManifestsSingleton } from './encryption-utils'
+import {
+  getServerModuleMap,
+  setReferenceManifestsSingleton,
+} from './encryption-utils'
 import {
   DynamicState,
   type PostponedState,
@@ -3872,7 +3875,7 @@ async function collectSegmentData(
     moduleMap: isEdgeRuntime
       ? clientReferenceManifest.edgeRscModuleMapping
       : clientReferenceManifest.rscModuleMapping,
-    serverModuleMap: null,
+    serverModuleMap: getServerModuleMap(),
   }
 
   const staleTime = prerenderStore.stale

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -199,9 +199,7 @@ async function PrefetchTreeData({
     buildId,
     seedData,
     fallbackRouteParams,
-    fullPageDataBuffer,
     clientModules,
-    serverConsumerManifest,
     ROOT_SEGMENT_KEY,
     segmentTasks
   )
@@ -229,9 +227,7 @@ function collectSegmentDataImpl(
   buildId: string,
   seedData: CacheNodeSeedData | null,
   fallbackRouteParams: FallbackRouteParams | null,
-  fullPageDataBuffer: Buffer,
   clientModules: ManifestNode,
-  serverConsumerManifest: any,
   key: string,
   segmentTasks: Array<Promise<[string, Buffer]>>
 ): TreePrefetch {
@@ -262,9 +258,7 @@ function collectSegmentDataImpl(
       buildId,
       childSeedData,
       fallbackRouteParams,
-      fullPageDataBuffer,
       clientModules,
-      serverConsumerManifest,
       childKey,
       segmentTasks
     )

--- a/test/e2e/app-dir/segment-cache/basic/app/with-server-action/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/with-server-action/page.tsx
@@ -1,0 +1,19 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function FullyStaticStart() {
+  return (
+    <>
+      <p>
+        This is a regression test case to ensure that prerendered segments that
+        include server actions do not throw an error when navigating to them.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/with-server-action/target-page">
+            Target
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/with-server-action/target-page/action.ts
+++ b/test/e2e/app-dir/segment-cache/basic/app/with-server-action/target-page/action.ts
@@ -1,0 +1,5 @@
+'use server'
+
+export async function action() {
+  console.log('Action!')
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/with-server-action/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/with-server-action/target-page/page.tsx
@@ -1,0 +1,9 @@
+import { action } from './action'
+
+export default function Target() {
+  return (
+    <form id="target-page" action={action}>
+      Target
+    </form>
+  )
+}


### PR DESCRIPTION
When `experimental.clientSegmentCache` is enabled and a segment that references a server action is prefetched, we currently throw a client-side error during the subsequent navigation:

```
Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).
```

This happens because, during prerendering of the per-segment prefetch data, we did not provide a `serverModuleMap`. React needs this map (via `createFromReadableStream` in `PrefetchTreeData`) to correctly map server references back to their original server implementations. This mapping allows React to re-encode server references during the subsequent `prerender` call within `renderSegmentPrefetch`. (See also facebook/react#31300.)