### PR TITLE
Turbopack: avoid negative uppers and follower and use retry loop instead

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -2438,8 +2438,8 @@ fn retry_loop(mut f: impl FnMut() -> ControlFlow<()>) -> Result<()> {
         }
         yield_now();
         if let Some(t) = time {
-            if t.elapsed() > Duration::from_secs(2) {
-                bail!("Retry loop timed out, probably do to an graph invariant violation");
+            if t.elapsed() > Duration::from_secs(60) {
+                bail!("Retry loop timed out, probably due to an graph invariant violation");
             }
         } else {
             time = Some(Instant::now());

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1287,7 +1287,7 @@ impl AggregationUpdateQueue {
                 // For performance reasons this should stay `Meta` and not `All`
                 TaskDataCategory::Meta,
             );
-            let mut removed_uppers = Vec::new();
+            let mut removed_uppers = SmallVec::new();
             swap_retain(&mut upper_ids, |&mut upper_id| {
                 let mut keep_upper = false;
                 let mut follower_in_upper = false;
@@ -1344,7 +1344,7 @@ impl AggregationUpdateQueue {
                 if !followers.is_empty() {
                     self.push(
                         InnerOfUppersLostFollowersJob {
-                            upper_ids: upper_ids.clone(),
+                            upper_ids: removed_uppers.clone(),
                             lost_follower_ids: followers,
                         }
                         .into(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1287,6 +1287,7 @@ impl AggregationUpdateQueue {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("lost follower (n uppers)", uppers = upper_ids.len()).entered();
 
+        // see documentation of `retry_loop` for more information why this is needed
         let result = retry_loop(|| {
             let mut follower = ctx.task(
                 lost_follower_id,
@@ -1455,6 +1456,7 @@ impl AggregationUpdateQueue {
         )
         .entered();
 
+        // see documentation of `retry_loop` for more information why this is needed
         let result = retry_loop(|| {
             swap_retain(&mut lost_follower_ids, |&mut lost_follower_id| {
                 let mut follower = ctx.task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1429,9 +1429,9 @@ impl AggregationUpdateQueue {
             retry += 1;
             if retry > MAX_RETRIES {
                 panic!(
-                    "inner_of_uppers_lost_follower is not able to remove follower {:?} from {:?} \
-                     as they don't exist as upper or follower edges",
-                    lost_follower_id, upper_ids
+                    "inner_of_uppers_lost_follower is not able to remove follower \
+                     {lost_follower_id:?} from {upper_ids:?} as they don't exist as upper or \
+                     follower edges"
                 );
             }
             self.push(AggregationUpdateJob::InnerOfUppersLostFollower {
@@ -1590,9 +1590,9 @@ impl AggregationUpdateQueue {
             retry += 1;
             if retry > MAX_RETRIES {
                 panic!(
-                    "inner_of_upper_lost_followers is not able to remove followers {:?} from {:?} \
-                     as they don't exist as upper or follower edges",
-                    lost_follower_ids, upper_id
+                    "inner_of_upper_lost_followers is not able to remove followers \
+                     {lost_follower_ids:?} from {upper_id:?} as they don't exist as upper or \
+                     follower edges"
                 )
             }
             self.push(AggregationUpdateJob::InnerOfUpperLostFollowers {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -98,6 +98,7 @@ impl Operation for CleanupOldEdgesOperation {
                                     queue.push(AggregationUpdateJob::InnerOfUpperLostFollowers {
                                         upper_id: task_id,
                                         lost_follower_ids: children,
+                                        retry: 0,
                                     });
                                 } else {
                                     let upper_ids = get_uppers(&task);


### PR DESCRIPTION
### Why?

Multiple graph modifications can happen concurrently. Each modification only locks one or two tasks in the graph at a single step, but a full graph modification could affect many tasks in graph. So modifications are executed step by step only affecting a maximum of two tasks on each step.

Because of this operation mode modifications bubble through the graph and multiple modifications can bubble through the graph concurrently, even at different speeds.

One important case is that an "add" modification could be partially applied, while a "remove" modification for the same item is triggered. This "remove" modification could be faster and would try to remove items from tasks where they have not been added yet (as the "add" modification is still in progress).

To account for this problem we used to allow negative counts on each item, so the "remove" modification would temporarily cause negative item counts until the "add" modification returns the count to zero.

But some decisions (e. g. if a upper or follower should be removed) are based on the values of these counts, so this approach doesn't work correctly in some rare race condition edge cases. So this change uses a different approach.

### What?

We want to avoid negative counts, so when the "remove" modification tries to remove an non-existent item, it should wait for the "add" modification to catch up before continuing. There are two cases here: Either the "add" modification is done by a different thread, or it's done by the same thread and is in the queue. The first case is handled by a busy loop yielding. The second case is handled by re-enqueuing the job at the end of the queue.

There is a limit of 10s for retries after that we panic. This allows to detect invalid graph scenarios and points out bugs in the graph implementation. Let's hope we never see this panic. In the old implementation this problem was silently ignored: Count got negative, but that was just accepted and has let to weird side effects (like errors/collectibles not disappearing or hanging compilation).

Closes PACK-4648