### PR TITLE
[sync-react] Base PR on target ref of workflow

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -518,7 +518,7 @@ Or run this command again without the --no-install flag to do both automatically
       owner: repoOwner,
       repo: repoName,
       head: branchName,
-      base: 'canary',
+      base: process.env.GITHUB_REF || 'canary',
       draft: false,
       title: prTitle,
       body: prDescription,


### PR DESCRIPTION
This will allow us to run the sync workflow on other branches (e.g. temporary branches while the sync is blocked or backport branches).

It already works today to run it on other branches but the created PRs were targeting the wrong branch and merging without special attention would've been a mistake.

The workflow runs by default on `canary` so nothing should change in the default case.

## Test plan

- [x] Run workflow on this branch. The created PR should target this branch instead of `canary`: https://github.com/vercel/next.js/actions/runs/15169189590/job/42654808993 -> https://github.com/vercel/next.js/pull/79467