### PR TITLE
Docs: Remove non breaking space

### DIFF
--- a/docs/01-app/05-api-reference/04-functions/connection.mdx
+++ b/docs/01-app/05-api-reference/04-functions/connection.mdx
@@ -54,5 +54,5 @@ function connection(): Promise<void>
 
 | Version      | Changes                  |
 | ------------ | ------------------------ |
-| `v15.0.0`    | `connection` stabilized. |
-| `v15.0.0-RC` | `connection` introduced. |
+| `v15.0.0`    | `connection` stabilized. |
+| `v15.0.0-RC` | `connection` introduced. |


### PR DESCRIPTION
For some reason a non breaking space, ASCII 160 had been used instead of a regular space. 