### PR TITLE
disallow unstable_rootParams in client components

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -640,7 +640,7 @@ impl ReactServerComponentValidator {
             invalid_client_imports: vec![Atom::from("server-only"), Atom::from("next/headers")],
 
             invalid_client_lib_apis_mapping: FxHashMap::from_iter([
-                ("next/server", vec!["after"]),
+                ("next/server", vec!["after", "unstable_rootParams"]),
                 (
                     "next/cache",
                     vec![

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/input.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/input.js
@@ -1,0 +1,13 @@
+// This is a comment.
+
+'use strict'
+
+/**
+ * This is a comment.
+ */
+
+import { unstable_rootParams } from 'next/server'
+
+export default function () {
+  return null
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/output.js
@@ -1,0 +1,8 @@
+// This is a comment.
+'use strict';
+/**
+ * This is a comment.
+ */ import { unstable_rootParams } from 'next/server';
+export default function() {
+    return null;
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/output.stderr
@@ -1,0 +1,9 @@
+  x You're importing a component that needs "unstable_rootParams". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/
+  | building-your-application/rendering/server-components
+  | 
+  | 
+   ,-[input.js:9:1]
+ 8 | 
+ 9 | import { unstable_rootParams } from 'next/server'
+   :          ^^^^^^^^^^^^^^^^^^^
+   `----


### PR DESCRIPTION
unstable_rootParams is a server component API and should not be allowed to be accessed from client components. This change adds a compiler error if this import is detected within the client module graph.