### PR TITLE
Turbopack Build: Fix dynamic-missing-gsp test

### DIFF
--- a/test/integration/app-dir-export/test/dynamic-missing-gsp-prod.test.ts
+++ b/test/integration/app-dir-export/test/dynamic-missing-gsp-prod.test.ts
@@ -10,7 +10,7 @@ describe('app dir - with output export - dynamic missing gsp prod', () => {
           dynamicPage: 'undefined',
           generateStaticParamsOpt: 'set noop',
           expectedErrMsg:
-            'Page "/another/[slug]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.',
+            /Page ".*\/another\/\[slug\].*" is missing "generateStaticParams\(\)" so it cannot be used with "output: export" config\./,
         })
       })
 
@@ -20,7 +20,7 @@ describe('app dir - with output export - dynamic missing gsp prod', () => {
           dynamicPage: 'undefined',
           generateStaticParamsOpt: 'set client',
           expectedErrMsg:
-            'Page "/another/[slug]/page" cannot use both "use client" and export function "generateStaticParams()".',
+            /Page ".*\/another\/\[slug\]\/page.*" cannot use both "use client" and export function "generateStaticParams\(\)"\./,
         })
       })
     }

--- a/test/integration/app-dir-export/test/utils.ts
+++ b/test/integration/app-dir-export/test/utils.ts
@@ -117,7 +117,7 @@ export async function runTests({
   dynamicParams?: string
   dynamicApiRoute?: string
   generateStaticParamsOpt?: 'set noop' | 'set client'
-  expectedErrMsg?: string
+  expectedErrMsg?: string | RegExp
 }) {
   if (trailingSlash !== undefined) {
     nextConfig.replace(
@@ -125,17 +125,18 @@ export async function runTests({
       `trailingSlash: ${trailingSlash},`
     )
   }
+
   if (dynamicPage !== undefined) {
     slugPage.replace(
-      `const dynamic = 'force-static'`,
-      `const dynamic = ${dynamicPage}`
+      `export const dynamic = 'force-static'`,
+      dynamicPage === 'undefined' ? '' : `export const dynamic = ${dynamicPage}`
     )
   }
 
   if (dynamicApiRoute !== undefined) {
     apiJson.replace(
-      `const dynamic = 'force-static'`,
-      `const dynamic = ${dynamicApiRoute}`
+      `export const dynamic = 'force-static'`,
+      `export const dynamic = ${dynamicApiRoute}`
     )
   }
 
@@ -179,7 +180,11 @@ export async function runTests({
         await assertHasRedbox(browser)
         const header = await getRedboxHeader(browser)
         const source = await getRedboxSource(browser)
-        expect(`${header}\n${source}`).toContain(expectedErrMsg)
+        if (expectedErrMsg instanceof RegExp) {
+          expect(`${header}\n${source}`).toContain(expectedErrMsg)
+        } else {
+          expect(`${header}\n${source}`).toContain(expectedErrMsg)
+        }
       } else {
         await check(() => result.stderr, /error/i)
       }

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -9305,11 +9305,10 @@
   },
   "test/integration/app-dir-export/test/dynamic-missing-gsp-prod.test.ts": {
     "passed": [
-      "app dir - with output export - dynamic missing gsp prod production mode should error when dynamic route is missing generateStaticParams"
-    ],
-    "failed": [
+      "app dir - with output export - dynamic missing gsp prod production mode should error when dynamic route is missing generateStaticParams",
       "app dir - with output export - dynamic missing gsp prod production mode should error when client component has generateStaticParams"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Fixes the test by changing the path it checks, both webpack and turbopack versions are okay, the Turbopack version is better though holding the full path root to page.js file.

Also fixed the test to not add `export const dynamic = undefined` as that is checked in Turbopack as it's not a valid string. This is also a better error.

Closes PACK-4654