### PR TITLE
fix: remove redundant performance.measure usage

### DIFF
--- a/packages/next/src/lib/require-instrumentation-client.ts
+++ b/packages/next/src/lib/require-instrumentation-client.ts
@@ -9,13 +9,7 @@ if (process.env.NODE_ENV === 'development') {
   const startTime = performance.now()
   module.exports = require('private-next-instrumentation-client')
   const endTime = performance.now()
-
   const duration = endTime - startTime
-  performance.measure(measureName, {
-    start: startTime,
-    end: endTime,
-    detail: 'Client instrumentation initialization',
-  })
 
   // Using 16ms threshold as it represents one frame (1000ms/60fps)
   // This helps identify if the instrumentation hook initialization


### PR DESCRIPTION
`performance.measure` here is causing problems but I also do not see the point of keeping it, so this PR deletes it.

Closes NDX-1050
Fixes https://github.com/vercel/next.js/issues/79188
