### PR TITLE
fix(next-swc): Fix react compiler usefulness detector

### DIFF
--- a/crates/next-custom-transforms/src/react_compiler.rs
+++ b/crates/next-custom-transforms/src/react_compiler.rs
@@ -54,7 +54,7 @@ impl Visit for Finder {
     fn visit_fn_expr(&mut self, node: &FnExpr) {
         let old = self.is_interested;
 
-        self.is_interested = node.ident.as_ref().is_some_and(|ident| {
+        self.is_interested |= node.ident.as_ref().is_some_and(|ident| {
             ident.sym.starts_with("use") || ident.sym.starts_with(|c: char| c.is_ascii_uppercase())
         });
 

--- a/crates/next-custom-transforms/src/react_compiler.rs
+++ b/crates/next-custom-transforms/src/react_compiler.rs
@@ -38,6 +38,18 @@ impl Visit for Finder {
         if self.found {
             return;
         }
+        if matches!(
+            node,
+            Expr::JSXMember(..)
+                | Expr::JSXNamespacedName(..)
+                | Expr::JSXEmpty(..)
+                | Expr::JSXElement(..)
+                | Expr::JSXFragment(..)
+        ) {
+            self.found = true;
+            return;
+        }
+
         node.visit_children_with(self);
     }
 


### PR DESCRIPTION
### What?

Fix usefulness detector for the React Compiler

### Why?

JSX was also target of the React Compiler

### How?

Closes https://github.com/vercel/next.js/issues/79385

Closes PACK-4650