### PR TITLE
fix(test/e2e): Increase timeout of flaky basepath test

### DIFF
--- a/test/e2e/basepath/router-events.test.ts
+++ b/test/e2e/basepath/router-events.test.ts
@@ -124,7 +124,7 @@ describe('basePath', () => {
             { shallow: false },
           ],
         ])
-      })
+      }, 10_000)
     } finally {
       await browser.close()
     }


### PR DESCRIPTION
Reducing this timeout from the default of 3000ms to 2500ms makes the failure reproduce 100% of the time for me. Increasing it, I'm unable to reproduce the issue.

Tested with:

```
pnpm test-dev-turbo test/e2e/basepath/router-events.test.ts 'should use urls with basepath in router events for failed route change'
```

This appears fail sometimes with turbopack, but never with webpack. For some reason, webpack is faster at building these error pages? There's a few redirects that have to happen here, and if you get unlucky, those redirects might not finish within 3 seconds on a cold turbopack session.

Closes PACK-4652