### PR TITLE
[build-sourcemaps] Increase stacktrace limit during prerender

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -355,6 +355,15 @@ export async function exportPages(
     options,
   } = input
 
+  if (nextConfig.experimental.enablePrerenderSourceMaps) {
+    try {
+      // Same as `next dev`
+      // Limiting the stack trace to a useful amount of frames is handled by ignore-listing.
+      // TODO: How high can we go without severely impacting CPU/memory?
+      Error.stackTraceLimit = 50
+    } catch {}
+  }
+
   // If the fetch cache was enabled, we need to create an incremental
   // cache instance for this page.
   const incrementalCache = await createIncrementalCache({


### PR DESCRIPTION
Gated behind `experimental.enablePrerenderSourceMaps`.

A low limit increases the likelihood of the stacktrace only including frames pointing into `node_modules` which we consider unhelpful and ignore-list.

We already increase it to 50 in `next dev` so we should do the same during prerender to avoid confusion.

I'll follow-up with checking the CPU/memory impact of increasing this limit. For debugging, it should really be +infinity. Limiting the stacktrace to something useful is handled by ignore-listing not an arbitrary number of frames. Especially in the terminal, it's annoying to limit it to N frames because you can't expand it later on when you look at the error in the terminal. Really, the terminal is just not a good debugging tool.