### PR TITLE
perf(turbopack): Use sourcemap with perf patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7162,8 +7162,7 @@ dependencies = [
 [[package]]
 name = "sourcemap"
 version = "9.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdee719193ae5c919a3ee43f64c2c0dd87f9b9a451d67918a2a5ec2e3c70561c"
+source = "git+https://github.com/getsentry/rust-sourcemap?branch=master#24a07e376a634c7823ada1b55326454ba7fc921d"
 dependencies = [
  "base64-simd 0.8.0",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,3 +431,5 @@ webbrowser = "0.8.7"
 
 [patch.crates-io]
 mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-26" }
+# Use unreleased version of sourcemap, in the name of performance
+sourcemap = { git = "https://github.com/getsentry/rust-sourcemap", branch = "master" }


### PR DESCRIPTION
### What?

Use latest version of `sourcemap` crate

### Why?

In the name of the performance!

Applies
 - https://github.com/getsentry/rust-sourcemap/pull/122
 - https://github.com/getsentry/rust-sourcemap/pull/124


Closes PACK-4659