### PR TITLE
[backport]: properly gate segmentCache branch in base-server

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3095,15 +3095,13 @@ export default abstract class Server<
       // is disabled.
       res.statusCode = 204
 
-      if (isRoutePPREnabled) {
-        // Set a header to indicate that PPR is enabled for this route. This
-        // lets the client distinguish between a regular cache miss and a cache
-        // miss due to PPR being disabled.
-        // NOTE: Theoretically, when PPR is enabled, there should *never* be
-        // a cache miss because we should generate a fallback route. So this
-        // is mostly defensive.
-        res.setHeader(NEXT_DID_POSTPONE_HEADER, '1')
-      }
+      // Set a header to indicate that PPR is enabled for this route. This
+      // lets the client distinguish between a regular cache miss and a cache
+      // miss due to PPR being disabled.
+      // NOTE: Theoretically, when PPR is enabled, there should *never* be
+      // a cache miss because we should generate a fallback route. So this
+      // is mostly defensive.
+      res.setHeader(NEXT_DID_POSTPONE_HEADER, '1')
       return {
         type: 'rsc',
         body: RenderResult.fromStatic(''),

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3105,7 +3105,7 @@ export default abstract class Server<
       return {
         type: 'rsc',
         body: RenderResult.fromStatic(''),
-        revalidate: 0,
+        revalidate: cacheEntry?.revalidate,
       }
     }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3095,11 +3095,6 @@ export default abstract class Server<
       // is disabled.
       res.statusCode = 204
 
-      res.setHeader(
-        'Cache-Control',
-        'private, no-cache, no-store, max-age=0, must-revalidate'
-      )
-
       if (isRoutePPREnabled) {
         // Set a header to indicate that PPR is enabled for this route. This
         // lets the client distinguish between a regular cache miss and a cache
@@ -3112,7 +3107,7 @@ export default abstract class Server<
       return {
         type: 'rsc',
         body: RenderResult.fromStatic(''),
-        revalidate: cacheEntry?.revalidate,
+        revalidate: 0,
       }
     }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3054,7 +3054,11 @@ export default abstract class Server<
       }
     )
 
-    if (isPrefetchRSCRequest && typeof segmentPrefetchHeader === 'string') {
+    if (
+      isRoutePPREnabled &&
+      isPrefetchRSCRequest &&
+      typeof segmentPrefetchHeader === 'string'
+    ) {
       // This is a prefetch request issued by the client Segment Cache. These
       // should never reach the application layer (lambda). We should either
       // respond from the cache (HIT) or respond with 204 No Content (MISS).
@@ -3090,6 +3094,12 @@ export default abstract class Server<
       // segment), we should *always* respond with a tree, even if PPR
       // is disabled.
       res.statusCode = 204
+
+      res.setHeader(
+        'Cache-Control',
+        'private, no-cache, no-store, max-age=0, must-revalidate'
+      )
+
       if (isRoutePPREnabled) {
         // Set a header to indicate that PPR is enabled for this route. This
         // lets the client distinguish between a regular cache miss and a cache

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('segment cache (incremental opt in)', () => {
+// Backport Note: This test is skipped as it's only currently usable in the experimental release channel.
+describe.skip('segment cache (incremental opt in)', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,

--- a/test/e2e/pages-performance-mark/pages/_document.js
+++ b/test/e2e/pages-performance-mark/pages/_document.js
@@ -4,7 +4,6 @@ export default function Document() {
   return (
     <Html>
       <Head />
-      <Head />
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
In 15.1, this branch should be a no-op when PPR is not enabled, because `collectSegmentData` is [gated](https://github.com/vercel/next.js/blob/69afa37323610c9bbfbecd22f0194f2f299d5a6c/packages/next/src/server/app-render/app-render.tsx#L4008) on `isRoutePPREnabled`. 

This also sets a no-store cache header when we respond with a 204 to align with intended behavior. 