### PR TITLE
segment cache: cache misses should not be cached

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3421,10 +3421,11 @@ export default abstract class Server<
       // don't bother to respond with 404, because these requests are only
       // issued as part of a prefetch.
       res.statusCode = 204
+
       return {
         type: 'rsc',
         body: RenderResult.fromStatic(''),
-        cacheControl: cacheEntry?.cacheControl,
+        cacheControl: { revalidate: 0, expire: undefined },
       }
     }
 


### PR DESCRIPTION
When the `clientSegmentCache` flag is enabled, and there's a cache miss on the segment data, we respond with a 204. This technically signals a cache miss (404), and thus should not be cached, as it might change in a subsequent request. 