### PR TITLE
docs: Rename CSS snippet to blog.module.css

### DIFF
--- a/docs/01-app/01-getting-started/06-css.mdx
+++ b/docs/01-app/01-getting-started/06-css.mdx
@@ -28,7 +28,7 @@ CSS Modules locally scope CSS by generating unique class names. This allows you 
 
 To start using CSS Modules, create a new file with the extension `.module.css` and import it into any component inside the `app` directory:
 
-```css filename="app/blog/styles.module.css"
+```css filename="app/blog/blog.module.css"
 .blog {
   padding: 24px;
 }


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4702/getting-started-css