### PR TITLE
[turbopack] Fix a buggy serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9509,6 +9509,7 @@ dependencies = [
  "regex",
  "regress",
  "serde",
+ "serde_json",
  "turbo-tasks",
  "turbo-tasks-build",
 ]

--- a/turbopack/crates/turbo-esregex/Cargo.toml
+++ b/turbopack/crates/turbo-esregex/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 regex = { workspace = true }
 regress = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 turbo-tasks = { workspace = true }
 
 [build-dependencies]

--- a/turbopack/crates/turbo-esregex/src/lib.rs
+++ b/turbopack/crates/turbo-esregex/src/lib.rs
@@ -43,7 +43,7 @@ impl TryFrom<RegexForm> for EsRegex {
     type Error = anyhow::Error;
 
     fn try_from(value: RegexForm) -> std::result::Result<Self, Self::Error> {
-        EsRegex::new(&value.pattern, &value.pattern)
+        EsRegex::new(&value.pattern, &value.flags)
     }
 }
 
@@ -128,6 +128,14 @@ impl EsRegex {
 #[cfg(test)]
 mod tests {
     use super::{EsRegex, EsRegexImpl};
+
+    #[test]
+    fn round_trip_serialize() {
+        let regex = EsRegex::new("[a-z]", "i").unwrap();
+        let serialized = serde_json::to_string(&regex).unwrap();
+        let parsed = serde_json::from_str::<EsRegex>(&serialized).unwrap();
+        assert_eq!(regex, parsed);
+    }
 
     #[test]
     fn es_regex_matches_simple() {

--- a/turbopack/crates/turbo-esregex/src/lib.rs
+++ b/turbopack/crates/turbo-esregex/src/lib.rs
@@ -87,7 +87,7 @@ impl EsRegex {
                 'u' => applied_flags.push('u'),
                 // sticky search: not relevant for the regex itself
                 'y' => {}
-                _ => bail!("unsupported flag `{}` in regex", flag),
+                _ => bail!("unsupported flag `{flag}` in regex: `{pattern}` with flags: `{flags}`"),
             }
         }
 


### PR DESCRIPTION
Because regexes aren't naively serializable, we use a simple alternate representation and then just re-parse them when deserializing.  A trivial bug was introduced in #78251  that has broken deserialization.  Fix that and add a unit test.

My only defense for such a silly mistake is that this was my first PR 🤦‍♂️



Closes PACK-4660