### PR TITLE
refactor(turbopack): Refactor usage of visitors

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -242,11 +242,18 @@ macro_rules! create_visitor {
             }
         }
 
-        (
-            $ast_path,
-            Box::new(Box::new(Visitor {
-                $name: move |$arg: &mut swc_core::ecma::ast::$ty| $b,
-            })) as Box<dyn $crate::code_gen::VisitorFactory>,
-        )
+        {
+            #[cfg(debug_assertions)]
+            if $ast_path.is_empty() {
+                unreachable!("if the path is empty, the visitor should be a root visitor");
+            }
+
+            (
+                $ast_path,
+                Box::new(Box::new(Visitor {
+                    $name: move |$arg: &mut swc_core::ecma::ast::$ty| $b,
+                })) as Box<dyn $crate::code_gen::VisitorFactory>,
+            )
+        }
     }};
 }

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -111,12 +111,14 @@ impl CodeGenerationHoistedStmt {
 }
 
 pub trait VisitorFactory: Send + Sync {
-    fn create<'a>(&'a self) -> Box<dyn VisitMut + Send + Sync + 'a>;
+    fn create<'a>(&'a self) -> Box<dyn AstModifier + 'a>;
 }
 
 pub trait PassFactory: Send + Sync {
     fn create<'a>(&'a self) -> Box<dyn Pass + Send + Sync + 'a>;
 }
+
+pub trait AstModifier: Send + Sync {}
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
 pub enum CodeGen {
@@ -229,12 +231,12 @@ macro_rules! create_visitor {
         impl<T: Fn(&mut swc_core::ecma::ast::$ty) + Send + Sync> $crate::code_gen::VisitorFactory
             for Box<Visitor<T>>
         {
-            fn create<'a>(&'a self) -> Box<dyn swc_core::ecma::visit::VisitMut + Send + Sync + 'a> {
+            fn create<'a>(&'a self) -> Box<dyn $crate::code_gen::AstModifier + 'a> {
                 Box::new(&**self)
             }
         }
 
-        impl<'a, T: Fn(&mut swc_core::ecma::ast::$ty) + Send + Sync> swc_core::ecma::visit::VisitMut
+        impl<'a, T: Fn(&mut swc_core::ecma::ast::$ty) + Send + Sync> $crate::code_gen::AstModifier
             for &'a Visitor<T>
         {
             fn $name(&mut self, $arg: &mut swc_core::ecma::ast::$ty) {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -679,6 +679,7 @@ impl EsmExports {
 
         Ok(CodeGeneration::new(
             vec![],
+            vec![],
             [dynamic_stmt
                 .map(|stmt| CodeGenerationHoistedStmt::new("__turbopack_dynamic__".into(), stmt))]
             .into_iter()


### PR DESCRIPTION
### What?

We are using `VisitMut`, which is very heavy, to apply simple operations. This PR refactors it to use a custom trait, which is very lightweight and has a proper signature.

### Why?

For a small performance improvement and a smaller binary. I'll refactor to remove  `VisitorFactory` completely because we don't need such indirection anymore. This is possible because `AstModifier` takes `&self`, unlike `&mut self` of `VisitMut`.

Closes PACK-4668