### PR TITLE
chore(turbo-tasks-backend): Fix build with `--features turbo-tasks-backend/lmdb`

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
@@ -137,6 +137,10 @@ impl<'a, B: SerialWriteBatch<'a>> SerialWriteBatch<'a> for FreshDbOptimizationWr
     fn delete(&mut self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.delete(key_space, key)
     }
+
+    fn flush(&mut self, key_space: KeySpace) -> Result<()> {
+        self.write_batch.flush(key_space)
+    }
 }
 
 impl<'a, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a>
@@ -148,5 +152,9 @@ impl<'a, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a>
 
     fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.delete(key_space, key)
+    }
+
+    unsafe fn flush(&self, key_space: KeySpace) -> Result<()> {
+        unsafe { self.write_batch.flush(key_space) }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
@@ -189,4 +189,9 @@ impl<'a> SerialWriteBatch<'a> for LmbdWriteBatch<'a> {
         )?;
         Ok(())
     }
+
+    fn flush(&mut self, _key_space: KeySpace) -> Result<()> {
+        // this is an unimplemented optimization, this LMDB implemenation is only used in testing
+        Ok(())
+    }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 use thread_local::ThreadLocal;
 
 use crate::database::{
-    key_value_database::KeyValueDatabase,
+    key_value_database::{KeySpace, KeyValueDatabase},
     write_batch::{
         BaseWriteBatch, ConcurrentWriteBatch, SerialWriteBatch, WriteBatch, WriteBuffer,
     },
@@ -88,7 +88,7 @@ impl<T: KeyValueDatabase + 'static> KeyValueDatabase for ReadTransactionCache<T>
     fn get<'l, 'db: 'l>(
         &'l self,
         transaction: &'l Self::ReadTransaction<'db>,
-        key_space: super::key_value_database::KeySpace,
+        key_space: KeySpace,
         key: &[u8],
     ) -> anyhow::Result<Option<Self::ValueBuffer<'l>>> {
         self.database
@@ -168,11 +168,7 @@ impl<'a, T: KeyValueDatabase + 'static, B: BaseWriteBatch<'a>> BaseWriteBatch<'a
         Self: 'l,
         'a: 'l;
 
-    fn get<'l>(
-        &'l self,
-        key_space: super::key_value_database::KeySpace,
-        key: &[u8],
-    ) -> Result<Option<Self::ValueBuffer<'l>>>
+    fn get<'l>(&'l self, key_space: KeySpace, key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
     where
         'a: 'l,
     {
@@ -185,37 +181,32 @@ impl<'a, T: KeyValueDatabase, B: SerialWriteBatch<'a>> SerialWriteBatch<'a>
 {
     fn put(
         &mut self,
-        key_space: super::key_value_database::KeySpace,
+        key_space: KeySpace,
         key: WriteBuffer<'_>,
         value: WriteBuffer<'_>,
     ) -> Result<()> {
         self.write_batch.put(key_space, key, value)
     }
-    fn delete(
-        &mut self,
-        key_space: super::key_value_database::KeySpace,
-        key: WriteBuffer<'_>,
-    ) -> Result<()> {
+    fn delete(&mut self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.delete(key_space, key)
+    }
+
+    fn flush(&mut self, key_space: KeySpace) -> Result<()> {
+        self.write_batch.flush(key_space)
     }
 }
 
 impl<'a, T: KeyValueDatabase, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a>
     for ReadTransactionCacheWriteBatch<'a, T, B>
 {
-    fn put(
-        &self,
-        key_space: super::key_value_database::KeySpace,
-        key: WriteBuffer<'_>,
-        value: WriteBuffer<'_>,
-    ) -> Result<()> {
+    fn put(&self, key_space: KeySpace, key: WriteBuffer<'_>, value: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.put(key_space, key, value)
     }
-    fn delete(
-        &self,
-        key_space: super::key_value_database::KeySpace,
-        key: WriteBuffer<'_>,
-    ) -> Result<()> {
+    fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.write_batch.delete(key_space, key)
+    }
+
+    unsafe fn flush(&self, key_space: KeySpace) -> Result<()> {
+        unsafe { self.write_batch.flush(key_space) }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Borrow,
     fs::{self, File},
-    hash::BuildHasherDefault,
     io::{BufWriter, Read, Write},
     mem::transmute,
     path::PathBuf,
@@ -10,7 +9,7 @@ use std::{
 
 use anyhow::{Ok, Result};
 use byteorder::WriteBytesExt;
-use rustc_hash::{FxHashMap, FxHasher};
+use rustc_hash::FxHashMap;
 use turbo_tasks::FxDashMap;
 
 use crate::database::{
@@ -290,6 +289,10 @@ impl<'a, B: SerialWriteBatch<'a>> SerialWriteBatch<'a> for StartupCacheWriteBatc
         }
         self.batch.delete(key_space, key)
     }
+
+    fn flush(&mut self, key_space: KeySpace) -> Result<()> {
+        self.batch.flush(key_space)
+    }
 }
 
 impl<'a, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a> for StartupCacheWriteBatch<'a, B> {
@@ -307,6 +310,10 @@ impl<'a, B: ConcurrentWriteBatch<'a>> ConcurrentWriteBatch<'a> for StartupCacheW
             cache.insert(key.to_vec(), None);
         }
         self.batch.delete(key_space, key)
+    }
+
+    unsafe fn flush(&self, key_space: KeySpace) -> Result<()> {
+        unsafe { self.batch.flush(key_space) }
     }
 }
 


### PR DESCRIPTION
This had bit-rotted. Sounds like we do want to keep it around for sanity checking things from time-to-time.

Tested with:

```
cargo check --features turbo-tasks-backend/lmdb
```

Closes PACK-4711