### PR TITLE
[release] use `backport` NPM dist tag for backports

### DIFF
--- a/scripts/release/publish-npm.ts
+++ b/scripts/release/publish-npm.ts
@@ -43,7 +43,7 @@ async function getTag({
   // If the current version is less than the latest,
   // it means this is a backport release. Since NPM
   // sets the 'latest' tag by default during publishing,
-  // when users install next@latest, they might get the
+  // when users install `next@latest`, they might get the
   // backported version instead of the actual "latest"
   // version. Hence, we explicitly set the tag as
   // 'stable' for backports.

--- a/scripts/release/publish-npm.ts
+++ b/scripts/release/publish-npm.ts
@@ -40,6 +40,17 @@ async function getTag({
     )
   }
 
+  // If the current version is less than the latest,
+  // it means this is a backport release. Since NPM
+  // sets the 'latest' tag by default during publishing,
+  // when users install next@latest, they might get the
+  // backported version instead of the actual "latest"
+  // version. Hence, we explicitly set the tag as
+  // 'stable' for backports.
+  if (semver.lt(version, latest)) {
+    return 'stable'
+  }
+
   return 'latest'
 }
 

--- a/scripts/release/publish-npm.ts
+++ b/scripts/release/publish-npm.ts
@@ -15,9 +15,11 @@ async function fetchTagsFromRegistry(packageName: string) {
 async function getTag({
   name,
   version,
+  latest,
 }: {
   name: string
   version: string
+  latest: string
 }): Promise<string> {
   const preConfigPath = join(process.cwd(), '.changeset', 'pre.json')
 
@@ -93,6 +95,7 @@ async function publishNpm() {
     const tag = await getTag({
       name: pkgJson.name,
       version: pkgJson.version,
+      latest: tags.latest,
     })
 
     const packagePath = join(packagesDir, packageDir.name)


### PR DESCRIPTION
### Why?

When backport releases are published, they are marked as `latest` dist tag, which makes `next@latest` not the "latest."

x-ref: [slack thread](https://vercel.slack.com/archives/C04LGE5SYEB/p1747984846615469)

### How?

Use `stable` dist tag for backports.