### PR TITLE
[dev-tools] refactor: dev-indicator server state to dev-tools server state

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -43,7 +43,7 @@ import { useUntrackedPathname } from '../../navigation-untracked'
 import { getComponentStack, getOwnerStack } from '../../errors/stitched-error'
 import { handleDevBuildIndicatorHmrEvents } from '../../../dev/dev-build-indicator/internal/handle-dev-build-indicator-hmr-events'
 import type { GlobalErrorComponent } from '../../global-error'
-import type { DevIndicatorServerState } from '../../../../server/dev/dev-indicator-server-state'
+import type { DevToolsServerState } from '../../../../server/dev/dev-tools-server-state'
 import reportHmrLatency from '../utils/report-hmr-latency'
 import { TurbopackHmr } from '../utils/turbopack-hot-reloader-common'
 import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../app-router-headers'
@@ -56,7 +56,7 @@ export interface Dispatcher {
   onBeforeRefresh(): void
   onRefresh(): void
   onStaticIndicator(status: boolean): void
-  onDevIndicator(devIndicator: DevIndicatorServerState): void
+  onDevIndicator(devIndicator: DevToolsServerState['devIndicator']): void
 }
 
 let mostRecentCompilationHash: any = null

--- a/packages/next/src/client/components/react-dev-overlay/pages/client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/client.ts
@@ -18,7 +18,7 @@ import {
 } from '../shared'
 import type { VersionInfo } from '../../../../server/dev/parse-version-info'
 import { getComponentStack, getOwnerStack } from '../../errors/stitched-error'
-import type { DevIndicatorServerState } from '../../../../server/dev/dev-indicator-server-state'
+import type { DevToolsServerState } from '../../../../server/dev/dev-tools-server-state'
 
 let isRegistered = false
 
@@ -126,8 +126,10 @@ export function onStaticIndicator(isStatic: boolean) {
   Bus.emit({ type: ACTION_STATIC_INDICATOR, staticIndicator: isStatic })
 }
 
-export function onDevIndicator(devIndicatorsState: DevIndicatorServerState) {
-  Bus.emit({ type: ACTION_DEV_INDICATOR, devIndicator: devIndicatorsState })
+export function onDevIndicator(
+  devIndicator: DevToolsServerState['devIndicator']
+) {
+  Bus.emit({ type: ACTION_DEV_INDICATOR, devIndicator })
 }
 
 export { getErrorByType } from '../utils/get-error-by-type'

--- a/packages/next/src/client/components/react-dev-overlay/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/shared.ts
@@ -5,7 +5,7 @@ import type { VersionInfo } from '../../../server/dev/parse-version-info'
 import type { SupportedErrorEvent } from './ui/container/runtime-error/render-error'
 import type { ComponentStackFrame } from './utils/parse-component-stack'
 import type { DebugInfo } from './types'
-import type { DevIndicatorServerState } from '../../../server/dev/dev-indicator-server-state'
+import type { DevToolsServerState } from '../../../server/dev/dev-tools-server-state'
 import type { HMR_ACTION_TYPES } from '../../../server/dev/hot-reloader-types'
 import { getOwnerStack } from '../errors/stitched-error'
 
@@ -87,7 +87,7 @@ interface VersionInfoAction {
 
 interface DevIndicatorAction {
   type: typeof ACTION_DEV_INDICATOR
-  devIndicator: DevIndicatorServerState
+  devIndicator: DevToolsServerState['devIndicator']
 }
 
 export type BusEvent =

--- a/packages/next/src/server/dev/dev-indicator-middleware.ts
+++ b/packages/next/src/server/dev/dev-indicator-middleware.ts
@@ -1,7 +1,7 @@
 import type { ServerResponse, IncomingMessage } from 'http'
 import { middlewareResponse } from '../../client/components/react-dev-overlay/server/middleware-response'
 import * as Log from '../../build/output/log'
-import { devIndicatorServerState } from './dev-indicator-server-state'
+import { devToolsServerState } from './dev-tools-server-state'
 
 const DISABLE_DEV_INDICATOR_PREFIX = '/__nextjs_disable_dev_indicator'
 
@@ -27,7 +27,8 @@ export function getDisableDevIndicatorMiddleware() {
         return middlewareResponse.methodNotAllowed(res)
       }
 
-      devIndicatorServerState.disabledUntil = Date.now() + COOLDOWN_TIME_MS
+      devToolsServerState.devIndicator.disabledUntil =
+        Date.now() + COOLDOWN_TIME_MS
 
       return middlewareResponse.noContent(res)
     } catch (err) {

--- a/packages/next/src/server/dev/dev-indicator-server-state.ts
+++ b/packages/next/src/server/dev/dev-indicator-server-state.ts
@@ -1,5 +1,0 @@
-export type DevIndicatorServerState = typeof devIndicatorServerState
-
-export const devIndicatorServerState = {
-  disabledUntil: 0,
-}

--- a/packages/next/src/server/dev/dev-tools-server-state.ts
+++ b/packages/next/src/server/dev/dev-tools-server-state.ts
@@ -1,0 +1,5 @@
+export type DevToolsServerState = typeof devToolsServerState
+
+export const devToolsServerState = {
+  devIndicator: { disabledUntil: 0 },
+}

--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -27,7 +27,7 @@ import { isMiddlewareFilename } from '../../build/utils'
 import type { VersionInfo } from './parse-version-info'
 import type { HMR_ACTION_TYPES } from './hot-reloader-types'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
-import { devIndicatorServerState } from './dev-indicator-server-state'
+import { devToolsServerState } from './dev-tools-server-state'
 
 function isMiddlewareStats(stats: webpack.Stats) {
   for (const key of stats.compilation.entrypoints.keys()) {
@@ -203,8 +203,8 @@ export class WebpackHotMiddleware {
       const stats = statsToJson(syncStats)
       const middlewareStats = statsToJson(this.middlewareLatestStats?.stats)
 
-      if (devIndicatorServerState.disabledUntil < Date.now()) {
-        devIndicatorServerState.disabledUntil = 0
+      if (devToolsServerState.devIndicator.disabledUntil < Date.now()) {
+        devToolsServerState.devIndicator.disabledUntil = 0
       }
 
       this.publish({
@@ -219,7 +219,7 @@ export class WebpackHotMiddleware {
         debug: {
           devtoolsFrontendUrl: this.devtoolsFrontendUrl,
         },
-        devIndicator: devIndicatorServerState,
+        devIndicator: devToolsServerState.devIndicator,
       })
     }
   }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -95,7 +95,7 @@ import {
   type TopLevelIssuesMap,
 } from '../../shared/lib/turbopack/utils'
 import { getDevOverlayFontMiddleware } from '../../client/components/react-dev-overlay/font/get-dev-overlay-font-middleware'
-import { devIndicatorServerState } from './dev-indicator-server-state'
+import { devToolsServerState } from './dev-tools-server-state'
 import { getDisableDevIndicatorMiddleware } from './dev-indicator-middleware'
 import { getRestartDevServerMiddleware } from '../../client/components/react-dev-overlay/server/restart-dev-server-middleware'
 // import { getSupportedBrowsers } from '../../build/utils'
@@ -839,8 +839,8 @@ export async function createHotReloaderTurbopack(
           }
         }
 
-        if (devIndicatorServerState.disabledUntil < Date.now()) {
-          devIndicatorServerState.disabledUntil = 0
+        if (devToolsServerState.devIndicator.disabledUntil < Date.now()) {
+          devToolsServerState.devIndicator.disabledUntil = 0
         }
 
         ;(async function () {
@@ -855,7 +855,7 @@ export async function createHotReloaderTurbopack(
             debug: {
               devtoolsFrontendUrl,
             },
-            devIndicator: devIndicatorServerState,
+            devIndicator: devToolsServerState.devIndicator,
           }
 
           sendToClient(client, sync)

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -7,7 +7,7 @@ import type { RouteDefinition } from '../route-definitions/route-definition'
 import type { Project, Update as TurbopackUpdate } from '../../build/swc/types'
 import type { VersionInfo } from './parse-version-info'
 import type { DebugInfo } from '../../client/components/react-dev-overlay/types'
-import type { DevIndicatorServerState } from './dev-indicator-server-state'
+import type { DevToolsServerState } from './dev-tools-server-state'
 
 export const enum HMR_ACTIONS_SENT_TO_BROWSER {
   ADDED_PAGE = 'addedPage',
@@ -57,7 +57,7 @@ export interface SyncAction {
   versionInfo: VersionInfo
   updatedModules?: ReadonlyArray<string>
   debug?: DebugInfo
-  devIndicator: DevIndicatorServerState
+  devIndicator: DevToolsServerState['devIndicator']
 }
 interface BuiltAction {
   action: HMR_ACTIONS_SENT_TO_BROWSER.BUILT
@@ -121,7 +121,7 @@ export interface AppIsrManifestAction {
 
 export interface DevIndicatorAction {
   action: HMR_ACTIONS_SENT_TO_BROWSER.DEV_INDICATOR
-  devIndicator: DevIndicatorServerState
+  devIndicator: DevToolsServerState
 }
 
 export type HMR_ACTION_TYPES =


### PR DESCRIPTION
### Why?

Since there are upcoming DevTools server states, we will merge the existing ones into one. The DevIndicator is the existing one, so I converted it to the DevTools server state.