### PR TITLE
add .github directory to CNA isFolderEmpty allow list

### DIFF
--- a/packages/create-next-app/helpers/is-folder-empty.ts
+++ b/packages/create-next-app/helpers/is-folder-empty.ts
@@ -25,6 +25,7 @@ export function isFolderEmpty(root: string, name: string): boolean {
     'yarn-error.log',
     'yarnrc.yml',
     '.yarn',
+    '.github',
   ]
 
   const conflicts = readdirSync(root).filter(


### PR DESCRIPTION
I'm sorry I just now read that you should open a discussion first, I already created a new issue for this as well as a reproduction, let me know if I should go back, close my issue and then open a discussion instead

the suggested feature, is about adding .github to the allowed directories and files list for the CNA "isFolderEmpty" function

fixes: https://github.com/vercel/next.js/issues/79550


