### PR TITLE
refactor(turbopack): Remove `PassFactory`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -679,7 +679,6 @@ impl EsmExports {
 
         Ok(CodeGeneration::new(
             vec![],
-            vec![],
             [dynamic_stmt
                 .map(|stmt| CodeGenerationHoistedStmt::new("__turbopack_dynamic__".into(), stmt))]
             .into_iter()


### PR DESCRIPTION
### What?

Remove `PassFactory`. Instead, merge it into `AstModifier`.

### Why?

`PassFactory` was a temporary solution required only for step-by-step refactoring. Now the refactoring is done, we don't need it anymore.

Closes PACK-4673