### PR TITLE
perf(turbopack): Use `rayon` for CPU-heavy tasks

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2027,7 +2027,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     }
 
                     let this = self.clone();
-                    let snapshot = turbo_tasks::spawn_blocking(move || this.snapshot()).await;
+                    let snapshot = turbo_tasks::spawn_blocking_rayon(move || this.snapshot()).await;
                     if let Some((snapshot_start, new_data)) = snapshot {
                         last_snapshot = snapshot_start;
                         if new_data {

--- a/turbopack/crates/turbo-tasks-fs/src/retry.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/retry.rs
@@ -29,7 +29,7 @@ where
 {
     let path = path.as_ref().to_owned();
 
-    turbo_tasks::spawn_blocking(move || {
+    turbo_tasks::spawn_blocking_tokio(move || {
         let mut attempt = 1;
 
         loop {

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -108,8 +108,8 @@ pub use manager::{
     CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
     TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
     dynamic_call, emit, mark_finished, mark_root, mark_session_dependent, mark_stateful,
-    prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, turbo_tasks_scope,
+    prevent_gc, run_once, run_once_with_reason, spawn_blocking_rayon, spawn_blocking_tokio,
+    spawn_thread, trait_call, turbo_tasks, turbo_tasks_scope,
 };
 pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1759,7 +1759,9 @@ pub fn emit<T: VcValueTrait + ?Sized>(collectible: ResolvedVc<T>) {
     })
 }
 
-pub async fn spawn_blocking<T: Send + 'static>(func: impl FnOnce() -> T + Send + 'static) -> T {
+pub async fn spawn_blocking_tokio<T: Send + 'static>(
+    func: impl FnOnce() -> T + Send + 'static,
+) -> T {
     let turbo_tasks = turbo_tasks();
     let span = Span::current();
     let (result, duration, alloc_info) = tokio::task::spawn_blocking(|| {
@@ -1771,6 +1773,27 @@ pub async fn spawn_blocking<T: Send + 'static>(func: impl FnOnce() -> T + Send +
     })
     .await
     .unwrap();
+    capture_future::add_duration(duration);
+    capture_future::add_allocation_info(alloc_info);
+    result
+}
+
+pub async fn spawn_blocking_rayon<T: Send + 'static>(
+    func: impl FnOnce() -> T + Send + 'static,
+) -> T {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let turbo_tasks = turbo_tasks();
+    let span = Span::current();
+    rayon::spawn(|| {
+        let _guard = span.entered();
+        let start = Instant::now();
+        let start_allocations = TurboMalloc::allocation_counters();
+        let r = turbo_tasks_scope(turbo_tasks, func);
+        let _ = tx.send((r, start.elapsed(), start_allocations.until_now()));
+    });
+
+    let (result, duration, alloc_info) = rx.await.unwrap();
     capture_future::add_duration(duration);
     capture_future::add_allocation_info(alloc_info);
     result

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -128,7 +128,7 @@ impl EcmascriptBrowserChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -187,7 +187,7 @@ impl EcmascriptBrowserEvaluateChunk {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -23,6 +23,7 @@ use swc_core::{
     },
 };
 use tracing::{Level, instrument};
+use turbo_tasks::spawn_blocking_rayon;
 use turbopack_core::{
     chunk::MangleType,
     code_builder::{Code, CodeBuilder},
@@ -31,121 +32,124 @@ use turbopack_core::{
 use crate::parse::generate_js_source_map;
 
 #[instrument(level = Level::INFO, skip_all)]
-pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
-    let source_maps = source_maps
-        .then(|| code.generate_source_map_ref())
-        .transpose()?;
+pub async fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
+    spawn_blocking_rayon(move || {
+        let source_maps = source_maps
+            .then(|| code.generate_source_map_ref())
+            .transpose()?;
 
-    let source_code = code.into_source_code().into_bytes().into();
-    let source_code = String::from_utf8(source_code)?;
+        let source_code = code.into_source_code().into_bytes().into();
+        let source_code = String::from_utf8(source_code)?;
 
-    let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));
-    let (src, mut src_map_buf) = {
-        let fm = cm.new_source_file(FileName::Anon.into(), source_code);
+        let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));
+        let (src, mut src_map_buf) = {
+            let fm = cm.new_source_file(FileName::Anon.into(), source_code);
 
-        let lexer = Lexer::new(
-            Syntax::default(),
-            EsVersion::latest(),
-            StringInput::from(&*fm),
-            None,
-        );
-        let mut parser = Parser::new_from(lexer);
+            let lexer = Lexer::new(
+                Syntax::default(),
+                EsVersion::latest(),
+                StringInput::from(&*fm),
+                None,
+            );
+            let mut parser = Parser::new_from(lexer);
 
-        let program = try_with_handler(cm.clone(), Default::default(), |handler| {
-            GLOBALS.set(&Default::default(), || {
-                let program = match parser.parse_program() {
-                    Ok(program) => program,
-                    Err(err) => {
-                        err.into_diagnostic(handler).emit();
-                        bail!("failed to parse source code\n{}", fm.src)
-                    }
-                };
-                let comments = SingleThreadedComments::default();
-                let unresolved_mark = Mark::new();
-                let top_level_mark = Mark::new();
+            let program = try_with_handler(cm.clone(), Default::default(), |handler| {
+                GLOBALS.set(&Default::default(), || {
+                    let program = match parser.parse_program() {
+                        Ok(program) => program,
+                        Err(err) => {
+                            err.into_diagnostic(handler).emit();
+                            bail!("failed to parse source code\n{}", fm.src)
+                        }
+                    };
+                    let comments = SingleThreadedComments::default();
+                    let unresolved_mark = Mark::new();
+                    let top_level_mark = Mark::new();
 
-                let program = program.apply(paren_remover(Some(&comments)));
+                    let program = program.apply(paren_remover(Some(&comments)));
 
-                let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
-                    unresolved_mark,
-                    top_level_mark,
-                    false,
-                ));
-
-                program = swc_core::ecma::minifier::optimize(
-                    program,
-                    cm.clone(),
-                    Some(&comments),
-                    None,
-                    &MinifyOptions {
-                        compress: Some(CompressOptions {
-                            // Only run 2 passes, this is a tradeoff between performance and
-                            // compression size. Default is 3 passes.
-                            passes: 2,
-                            keep_classnames: mangle.is_none(),
-                            keep_fnames: mangle.is_none(),
-                            ..Default::default()
-                        }),
-                        mangle: mangle.map(|mangle| {
-                            let reserved = vec!["AbortSignal".into()];
-                            match mangle {
-                                MangleType::OptimalSize => MangleOptions {
-                                    reserved,
-                                    ..Default::default()
-                                },
-                                MangleType::Deterministic => MangleOptions {
-                                    reserved,
-                                    disable_char_freq: true,
-                                    ..Default::default()
-                                },
-                            }
-                        }),
-                        ..Default::default()
-                    },
-                    &ExtraOptions {
-                        top_level_mark,
+                    let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
                         unresolved_mark,
-                        mangle_name_cache: None,
-                    },
-                );
-
-                if mangle.is_none() {
-                    program.mutate(hygiene_with_config(hygiene::Config {
                         top_level_mark,
-                        ..Default::default()
-                    }));
-                }
+                        false,
+                    ));
 
-                Ok(program.apply(ecma::transforms::base::fixer::fixer(Some(
-                    &comments as &dyn Comments,
-                ))))
+                    program = swc_core::ecma::minifier::optimize(
+                        program,
+                        cm.clone(),
+                        Some(&comments),
+                        None,
+                        &MinifyOptions {
+                            compress: Some(CompressOptions {
+                                // Only run 2 passes, this is a tradeoff between performance and
+                                // compression size. Default is 3 passes.
+                                passes: 2,
+                                keep_classnames: mangle.is_none(),
+                                keep_fnames: mangle.is_none(),
+                                ..Default::default()
+                            }),
+                            mangle: mangle.map(|mangle| {
+                                let reserved = vec!["AbortSignal".into()];
+                                match mangle {
+                                    MangleType::OptimalSize => MangleOptions {
+                                        reserved,
+                                        ..Default::default()
+                                    },
+                                    MangleType::Deterministic => MangleOptions {
+                                        reserved,
+                                        disable_char_freq: true,
+                                        ..Default::default()
+                                    },
+                                }
+                            }),
+                            ..Default::default()
+                        },
+                        &ExtraOptions {
+                            top_level_mark,
+                            unresolved_mark,
+                            mangle_name_cache: None,
+                        },
+                    );
+
+                    if mangle.is_none() {
+                        program.mutate(hygiene_with_config(hygiene::Config {
+                            top_level_mark,
+                            ..Default::default()
+                        }));
+                    }
+
+                    Ok(program.apply(ecma::transforms::base::fixer::fixer(Some(
+                        &comments as &dyn Comments,
+                    ))))
+                })
             })
-        })
-        .map_err(|e| e.to_pretty_error())?;
+            .map_err(|e| e.to_pretty_error())?;
 
-        print_program(cm.clone(), program, source_maps.is_some())?
-    };
+            print_program(cm.clone(), program, source_maps.is_some())?
+        };
 
-    let mut builder = CodeBuilder::new(source_maps.is_some());
-    if let Some(original_map) = source_maps.as_ref() {
-        src_map_buf.shrink_to_fit();
-        builder.push_source(
-            &src.into(),
-            Some(generate_js_source_map(
-                &*cm,
-                src_map_buf,
-                Some(original_map),
-                true,
-                // We do not inline source contents.
-                // We provide a synthesized value to `cm.new_source_file` above, so it cannot be
-                // the value user expect anyway.
-                false,
-            )?),
-        );
-    } else {
-        builder.push_source(&src.into(), None);
-    }
-    Ok(builder.build())
+        let mut builder = CodeBuilder::new(source_maps.is_some());
+        if let Some(original_map) = source_maps.as_ref() {
+            src_map_buf.shrink_to_fit();
+            builder.push_source(
+                &src.into(),
+                Some(generate_js_source_map(
+                    &*cm,
+                    src_map_buf,
+                    Some(original_map),
+                    true,
+                    // We do not inline source contents.
+                    // We provide a synthesized value to `cm.new_source_file` above, so it cannot
+                    // be the value user expect anyway.
+                    false,
+                )?),
+            );
+        } else {
+            builder.push_source(&src.into(), None);
+        }
+        Ok(builder.build())
+    })
+    .await
 }
 
 // From https://github.com/swc-project/swc/blob/11efd4e7c5e8081f8af141099d3459c3534c1e1d/crates/swc/src/lib.rs#L523-L560

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -78,7 +78,7 @@ impl EcmascriptBuildNodeChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())


### PR DESCRIPTION
### What?

Distinguish blocking tasks into IO-heavy and CPU-heavy, and use `rayon` for CPU-heavy tasks.

### Why?

 - `spawn_blocking` from `tokio` has overhead that's not justifiable for CPU-heavy tasks.



Closes PACK-4908