### PR TITLE
[ppr] Narrow condition for fallback shell generation at runtime

### DIFF
--- a/.changeset/giant-bushes-sink.md
+++ b/.changeset/giant-bushes-sink.md
@@ -1,0 +1,5 @@
+---
+'next': patch
+---
+
+Resolved bug where hitting the parameterized path directly would cause a fallback shell generation instead of just rendering the route with the parameterized placeholders.

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -153,9 +153,9 @@ export interface RequestMeta {
   middlewareInvoke?: boolean
 
   /**
-   * Whether the default route matches were set on the request during routing.
+   * Whether the request should render the fallback shell or not.
    */
-  didSetDefaultRouteMatches?: boolean
+  renderFallbackShell?: boolean
 
   /**
    * Whether the request is for the custom error page.

--- a/test/e2e/app-dir/empty-fallback-shells/empty-fallback-shells.test.ts
+++ b/test/e2e/app-dir/empty-fallback-shells/empty-fallback-shells.test.ts
@@ -118,6 +118,23 @@ describe('empty-fallback-shells', () => {
             expect(res.headers.get('x-nextjs-postponed')).not.toBe('1')
           }
         })
+
+        it('does not render a fallback shell when using a params placeholder', async () => {
+          // This should trigger a blocking prerender of the route shell.
+          const res = await next.fetch(
+            '/with-cached-io/without-suspense/params-in-page/[slug]'
+          )
+
+          expect(res.status).toBe(200)
+
+          const html = await res.text()
+
+          // This should render the encoded param in the route shell, and not
+          // interpret the param as a fallback param, and subsequently try to
+          // render the fallback shell instead, which would fail because of the
+          // missing parent suspense boundary.
+          expect(html).toContain('page-%5Bslug%5D')
+        })
       })
 
       describe('and the params accessed in a cached non-page function', () => {

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -355,6 +355,7 @@ describe('required server files app router', () => {
         'x-matched-path': '/postpone/isr/[slug]',
         // We don't include the `x-now-route-matches` header because we want to
         // test that the fallback route params are correctly set.
+        'x-now-route-matches': '',
       },
     })
 


### PR DESCRIPTION
This addresses a bug where a fallback shell was generated at runtime when it was not expected to do so. This was an issue with how the `x-now-route-matches` header was parsed and was incorrectly assuming that a falsy header was the same as comparing it to a string. This correctly only generates the fallback shell if the header is present and was an empty string as was sent by Vercel.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
