### PR TITLE
Implement handler interface for app-page

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1,6 +1,38 @@
 import type { LoaderTree } from '../../server/lib/app-dir-module'
-import { AppPageRouteModule } from '../../server/route-modules/app-page/module.compiled' with { 'turbopack-transition': 'next-ssr' }
+import type { ServerOnInstrumentationRequestError } from '../../server/app-render/types'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import {
+  AppPageRouteModule,
+  type AppPageRouteHandlerContext,
+} from '../../server/route-modules/app-page/module.compiled' with { 'turbopack-transition': 'next-ssr' }
+
 import { RouteKind } from '../../server/route-kind' with { 'turbopack-transition': 'next-server-utility' }
+
+import { getRevalidateReason } from '../../server/instrumentation/utils'
+import { getTracer, SpanKind, type Span } from '../../server/lib/trace/tracer'
+import { getRequestMeta } from '../../server/request-meta'
+import { BaseServerSpan } from '../../server/lib/trace/constants'
+import { interopDefault } from '../../server/app-render/interop-default'
+import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
+import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr'
+import { getFallbackRouteParams } from '../../server/request/fallback-params'
+import { setReferenceManifestsSingleton } from '../../server/app-render/encryption-utils'
+import {
+  isHtmlBotRequest,
+  shouldServeStreamingMetadata,
+} from '../../server/lib/streaming-metadata'
+import { createServerModuleMap } from '../../server/app-render/action-utils'
+import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
+import { getIsPossibleServerAction } from '../../server/lib/server-action-request-meta'
+import {
+  RouterServerContextSymbol,
+  routerServerGlobal,
+} from '../../server/lib/router-utils/router-server-context'
+import {
+  NEXT_ROUTER_PREFETCH_HEADER,
+  RSC_HEADER,
+} from '../../client/components/app-router-headers'
 
 // These are injected by the loader afterwards.
 
@@ -18,7 +50,9 @@ declare const pages: any
 
 export { tree, pages }
 
-export { default as GlobalError } from 'VAR_MODULE_GLOBAL_ERROR' with { 'turbopack-transition': 'next-server-utility' }
+import GlobalError from 'VAR_MODULE_GLOBAL_ERROR' with { 'turbopack-transition': 'next-server-utility' }
+
+export { GlobalError }
 
 // These are injected by the loader afterwards.
 declare const __next_app_require__: (id: string | number) => unknown
@@ -31,6 +65,9 @@ export const __next_app__ = {
   require: __next_app_require__,
   loadChunk: __next_app_load_chunk__,
 }
+
+import * as entryBase from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
+import { getBotType } from '../../shared/lib/router/utils/is-bot'
 
 export * from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
 
@@ -51,3 +88,432 @@ export const routeModule = new AppPageRouteModule({
   distDir: process.env.__NEXT_RELATIVE_DIST_DIR || '',
   projectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
 })
+
+export async function handler(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: {
+    waitUntil: (prom: Promise<void>) => void
+  }
+) {
+  let srcPage = 'VAR_DEFINITION_PAGE'
+
+  // turbopack doesn't normalize `/index` in the page name
+  // so we need to to process dynamic routes properly
+  // TODO: fix turbopack providing differing value from webpack
+  if (process.env.TURBOPACK) {
+    srcPage = srcPage.replace(/\/index$/, '') || '/'
+  } else if (srcPage === '/index') {
+    // we always normalize /index specifically
+    srcPage = '/'
+  }
+  const multiZoneDraftMode = process.env
+    .__NEXT_MULTI_ZONE_DRAFT_MODE as any as boolean
+
+  const postponed = getRequestMeta(req, 'postponed')
+
+  const prepareResult = await routeModule.prepare(req, res, {
+    srcPage,
+    multiZoneDraftMode,
+  })
+
+  if (!prepareResult) {
+    res.statusCode = 400
+    res.end('Bad Request')
+    ctx.waitUntil?.(Promise.resolve())
+    return null
+  }
+
+  const {
+    buildId,
+    query,
+    params,
+    parsedUrl,
+    pageIsDynamic,
+    buildManifest,
+    nextFontManifest,
+    serverFilesManifest,
+    reactLoadableManifest,
+    serverActionsManifest,
+    clientReferenceManifest,
+    subresourceIntegrityManifest,
+    prerenderManifest,
+    isDraftMode,
+    isOnDemandRevalidate,
+  } = prepareResult
+
+  const routerServerContext =
+    routerServerGlobal[RouterServerContextSymbol]?.[
+      process.env.__NEXT_RELATIVE_PROJECT_DIR || ''
+    ]
+
+  const onInstrumentationRequestError =
+    routeModule.instrumentationOnRequestError.bind(routeModule)
+
+  const onError: ServerOnInstrumentationRequestError = (
+    err,
+    _,
+    errorContext
+  ) => {
+    if (routerServerContext?.logErrorWithOriginalStack) {
+      routerServerContext.logErrorWithOriginalStack(err, 'app-dir')
+    } else {
+      console.error(err)
+    }
+    return onInstrumentationRequestError(
+      req,
+      err,
+      {
+        path: req.url || '/',
+        headers: req.headers,
+        method: req.method || 'GET',
+      },
+      errorContext
+    )
+  }
+
+  const nextConfig =
+    routerServerContext?.nextConfig || serverFilesManifest.config
+
+  const pathname = parsedUrl.pathname || '/'
+  const normalizedSrcPage = normalizeAppPath(srcPage)
+  let isIsr = Boolean(
+    prerenderManifest.dynamicRoutes[normalizedSrcPage] ||
+      prerenderManifest.routes[normalizedSrcPage] ||
+      prerenderManifest.routes[pathname]
+  )
+
+  const couldSupportPPR: boolean = checkIsAppPPREnabled(
+    nextConfig.experimental.ppr
+  )
+
+  // When enabled, this will allow the use of the `?__nextppronly` query to
+  // enable debugging of the static shell.
+  const hasDebugStaticShellQuery =
+    process.env.__NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING === '1' &&
+    typeof query.__nextppronly !== 'undefined' &&
+    couldSupportPPR
+
+  // When enabled, this will allow the use of the `?__nextppronly` query
+  // to enable debugging of the fallback shell.
+  const hasDebugFallbackShellQuery =
+    hasDebugStaticShellQuery && query.__nextppronly === 'fallback'
+
+  // This page supports PPR if it is marked as being `PARTIALLY_STATIC` in the
+  // prerender manifest and this is an app page.
+  const isRoutePPREnabled = Boolean(
+    couldSupportPPR &&
+      ((
+        prerenderManifest.routes[normalizedSrcPage] ??
+        prerenderManifest.routes[pathname] ??
+        prerenderManifest.dynamicRoutes[normalizedSrcPage]
+      )?.renderingMode === 'PARTIALLY_STATIC' ||
+        // Ideally we'd want to check the appConfig to see if this page has PPR
+        // enabled or not, but that would require plumbing the appConfig through
+        // to the server during development. We assume that the page supports it
+        // but only during development.
+        (hasDebugStaticShellQuery &&
+          (routeModule.isDev || routerServerContext?.experimentalTestProxy)))
+  )
+
+  const isDebugFallbackShell = hasDebugFallbackShellQuery && isRoutePPREnabled
+
+  const isDebugStaticShell: boolean =
+    hasDebugStaticShellQuery && isRoutePPREnabled
+
+  // We should enable debugging dynamic accesses when the static shell
+  // debugging has been enabled and we're also in development mode.
+  const isDebugDynamicAccesses =
+    isDebugStaticShell && routeModule.isDev === true
+
+  const isRSCRequest =
+    getRequestMeta(req, 'isRSCRequest') || Boolean(req.headers[RSC_HEADER])
+
+  const userAgent = req.headers['user-agent'] || ''
+  const botType = getBotType(userAgent)
+  const isHtmlBot = isHtmlBotRequest(req)
+  const shouldWaitOnAllReady = isHtmlBot && isRoutePPREnabled
+  let serveStreamingMetadata = shouldServeStreamingMetadata(
+    userAgent,
+    // @ts-expect-error update for readonly
+    nextConfig.htmlLimitedBots
+  )
+
+  if (isHtmlBot && isRoutePPREnabled) {
+    isIsr = false
+    serveStreamingMetadata = false
+  }
+
+  // If this is a dynamic route with PPR enabled and the default route
+  // matches were set, then we should pass the fallback route params to
+  // the renderer as this is a fallback revalidation request.
+  const fallbackRouteParams =
+    pageIsDynamic &&
+    isRoutePPREnabled &&
+    (getRequestMeta(req, 'renderFallbackShell') || isDebugFallbackShell)
+      ? getFallbackRouteParams(normalizedSrcPage)
+      : null
+
+  const ComponentMod = {
+    ...entryBase,
+    tree,
+    pages,
+    GlobalError,
+    handler,
+    routeModule,
+    __next_app__,
+  }
+
+  // Before rendering (which initializes component tree modules), we have to
+  // set the reference manifests to our global store so Server Action's
+  // encryption util can access to them at the top level of the page module.
+  if (serverActionsManifest && clientReferenceManifest) {
+    setReferenceManifestsSingleton({
+      page: srcPage,
+      clientReferenceManifest,
+      serverActionsManifest,
+      serverModuleMap: createServerModuleMap({
+        serverActionsManifest,
+      }),
+    })
+  }
+
+  const isPossibleServerAction = getIsPossibleServerAction(req)
+
+  /**
+   * If true, this indicates that the request being made is for an app
+   * prefetch request.
+   */
+  const isPrefetchRSCRequest =
+    getRequestMeta(req, 'isPrefetchRSCRequest') ??
+    Boolean(isRSCRequest && req.headers[NEXT_ROUTER_PREFETCH_HEADER])
+
+  // If PPR is enabled, and this is a RSC request (but not a prefetch), then
+  // we can use this fact to only generate the flight data for the request
+  // because we can't cache the HTML (as it's also dynamic).
+  const isDynamicRSCRequest =
+    isRoutePPREnabled && isRSCRequest && !isPrefetchRSCRequest
+
+  let supportsDynamicResponse: boolean =
+    // If we're in development, we always support dynamic HTML
+    routeModule.isDev === true ||
+    // If this is not SSG or does not have static paths, then it supports
+    // dynamic HTML.
+    !isIsr ||
+    // If this request has provided postponed data, it supports dynamic
+    // HTML.
+    typeof postponed === 'string' ||
+    // If this is a dynamic RSC request, then this render supports dynamic
+    // HTML (it's dynamic).
+    isDynamicRSCRequest
+
+  // This is a revalidation request if the request is for a static
+  // page and it is not being resumed from a postponed render and
+  // it is not a dynamic RSC request then it is a revalidation
+  // request.
+  const isRevalidate =
+    isIsr && !supportsDynamicResponse && !postponed && !isDynamicRSCRequest
+
+  const method = req.method || 'GET'
+  const tracer = getTracer()
+  const activeSpan = tracer.getActiveScopeSpan()
+
+  try {
+    const invokeRouteModule = async (span?: Span) => {
+      const context: AppPageRouteHandlerContext = {
+        query,
+        params,
+        page: normalizedSrcPage,
+        sharedContext: {
+          buildId,
+        },
+        serverComponentsHmrCache: getRequestMeta(
+          req,
+          'serverComponentsHmrCache'
+        ),
+        fallbackRouteParams,
+        renderOpts: {
+          App: () => null,
+          Document: () => null,
+          pageConfig: {},
+          ComponentMod,
+          Component: interopDefault(ComponentMod),
+
+          params,
+          routeModule,
+          page: srcPage,
+          postponed,
+          shouldWaitOnAllReady,
+          serveStreamingMetadata,
+          supportsDynamicResponse,
+          buildManifest,
+          nextFontManifest,
+          reactLoadableManifest,
+          subresourceIntegrityManifest,
+          serverActionsManifest,
+          clientReferenceManifest,
+          isPossibleServerAction,
+          isOnDemandRevalidate,
+          setIsrStatus: routerServerContext?.setIsrStatus,
+
+          dir: routeModule.projectDir,
+          isDraftMode,
+          isRevalidate,
+          botType,
+          assetPrefix: nextConfig.assetPrefix,
+          nextConfigOutput: nextConfig.output,
+          crossOrigin: nextConfig.crossOrigin,
+          trailingSlash: nextConfig.trailingSlash,
+          previewProps: prerenderManifest.preview,
+          deploymentId: nextConfig.deploymentId,
+          enableTainting: nextConfig.experimental.taint,
+          // @ts-expect-error fix issue with readonly regex object type
+          htmlLimitedBots: nextConfig.htmlLimitedBots,
+          reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
+
+          multiZoneDraftMode,
+          incrementalCache: getRequestMeta(req, 'incrementalCache'),
+          cacheLifeProfiles: nextConfig.experimental.cacheLife,
+          basePath: nextConfig.basePath,
+          // @ts-expect-error fix issue with readonly regex object type
+          serverActions: nextConfig.experimental.serverActions,
+
+          ...(isDebugStaticShell || isDebugDynamicAccesses
+            ? {
+                nextExport: true,
+                supportsDynamicResponse: false,
+                isStaticGeneration: true,
+                isRevalidate: true,
+                isDebugDynamicAccesses: isDebugDynamicAccesses,
+              }
+            : {}),
+
+          experimental: {
+            isRoutePPREnabled,
+            expireTime: nextConfig.expireTime,
+            staleTimes: nextConfig.experimental.staleTimes,
+            dynamicIO: Boolean(nextConfig.experimental.dynamicIO),
+            clientSegmentCache: Boolean(
+              nextConfig.experimental.clientSegmentCache
+            ),
+            dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
+            inlineCss: Boolean(nextConfig.experimental.inlineCss),
+            authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
+            clientTraceMetadata:
+              nextConfig.experimental.clientTraceMetadata || ([] as any),
+          },
+
+          waitUntil: ctx.waitUntil,
+          onClose: (cb) => {
+            res.on('close', cb)
+          },
+          onAfterTaskError: () => {},
+
+          onInstrumentationRequestError: onError,
+          err: getRequestMeta(req, 'invokeError'),
+          dev: routeModule.isDev,
+        },
+      }
+      const nextReq = new NodeNextRequest(req)
+      const nextRes = new NodeNextResponse(res)
+
+      // TODO: adapt for putting the RDC inside the postponed data
+      // If we're in dev, and this isn't a prefetch or a server action,
+      // we should seed the resume data cache.
+      if (process.env.NODE_ENV === 'development') {
+        if (
+          nextConfig.experimental.dynamicIO &&
+          !isPrefetchRSCRequest &&
+          !isPossibleServerAction
+        ) {
+          const warmup = await routeModule.warmup(nextReq, nextRes, context)
+
+          // If the warmup is successful, we should use the resume data
+          // cache from the warmup.
+          if (warmup.metadata.devRenderResumeDataCache) {
+            context.renderOpts.devRenderResumeDataCache =
+              warmup.metadata.devRenderResumeDataCache
+          }
+        }
+      }
+
+      return routeModule.render(nextReq, nextRes, context).finally(() => {
+        if (!span) return
+
+        span.setAttributes({
+          'http.status_code': res.statusCode,
+          'next.rsc': false,
+        })
+
+        const rootSpanAttributes = tracer.getRootSpanAttributes()
+        // We were unable to get attributes, probably OTEL is not enabled
+        if (!rootSpanAttributes) {
+          return
+        }
+
+        if (
+          rootSpanAttributes.get('next.span_type') !==
+          BaseServerSpan.handleRequest
+        ) {
+          console.warn(
+            `Unexpected root span type '${rootSpanAttributes.get(
+              'next.span_type'
+            )}'. Please report this Next.js issue https://github.com/vercel/next.js`
+          )
+          return
+        }
+
+        const route = rootSpanAttributes.get('next.route')
+        if (route) {
+          const name = `${method} ${route}`
+
+          span.setAttributes({
+            'next.route': route,
+            'http.route': route,
+            'next.span_name': name,
+          })
+          span.updateName(name)
+        } else {
+          span.updateName(`${method} ${req.url}`)
+        }
+      })
+    }
+
+    // TODO: activeSpan code path is for when wrapped by
+    // next-server can be removed when this is no longer used
+    if (activeSpan) {
+      return await invokeRouteModule(activeSpan)
+    } else {
+      return await tracer.withPropagatedContext(req.headers, () =>
+        tracer.trace(
+          BaseServerSpan.handleRequest,
+          {
+            spanName: `${method} ${req.url}`,
+            kind: SpanKind.SERVER,
+            attributes: {
+              'http.method': method,
+              'http.target': req.url,
+            },
+          },
+          invokeRouteModule
+        )
+      )
+    }
+  } catch (err) {
+    // if we aren't wrapped by base-server handle here
+    if (!activeSpan) {
+      await onError(err, req, {
+        routerKind: 'App Router',
+        routePath: srcPage,
+        routeType: 'render',
+        revalidateReason: getRevalidateReason({
+          isRevalidate,
+          isOnDemandRevalidate,
+        }),
+      })
+    }
+
+    // rethrow so that we can handle serving error page
+    throw err
+  }
+}

--- a/packages/next/src/build/templates/pages.ts
+++ b/packages/next/src/build/templates/pages.ts
@@ -245,6 +245,7 @@ export async function handler(
             locale,
             locales,
             defaultLocale,
+            setIsrStatus: routerServerContext?.setIsrStatus,
 
             isNextDataRequest:
               isNextDataRequest && (hasServerProps || hasStaticProps),

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2779,56 +2779,59 @@ export default abstract class Server<
             return null
           }
 
-          if (isPagesRouteModule(routeModule)) {
-            const request = isNodeNextRequest(req) ? req.originalRequest : req
+          const request = isNodeNextRequest(req) ? req.originalRequest : req
+          const response = isNodeNextResponse(res) ? res.originalResponse : res
 
-            const response = isNodeNextResponse(res)
-              ? res.originalResponse
-              : res
+          if (
+            components.ComponentMod.handler &&
+            process.env.NEXT_RUNTIME !== 'edge'
+          ) {
+            const parsedInitUrl = parseUrl(
+              getRequestMeta(req, 'initURL') || req.url
+            )
+            request.url =
+              req.url = `${parsedInitUrl.pathname}${parsedInitUrl.search || ''}`
 
-            if (
-              components.ComponentMod.handler &&
-              process.env.NEXT_RUNTIME !== 'edge'
-            ) {
-              const parsedInitUrl = parseUrl(
-                getRequestMeta(req, 'initURL') || req.url
-              )
-              request.url =
-                req.url = `${parsedInitUrl.pathname}${parsedInitUrl.search || ''}`
+            // propagate the request context for dev
+            setRequestMeta(request, getRequestMeta(req))
+            addRequestMeta(request, 'postponed', postponed)
+            addRequestMeta(request, 'projectDir', this.dir)
+            addRequestMeta(request, 'isIsrFallback', pagesFallback)
+            addRequestMeta(
+              request,
+              'renderFallbackShell',
+              Boolean(fallbackRouteParams)
+            )
+            addRequestMeta(request, 'query', query)
+            addRequestMeta(request, 'params', opts.params)
+            addRequestMeta(
+              request,
+              'ampValidator',
+              this.renderOpts.ampValidator
+            )
 
-              // propagate the request context for dev
-              setRequestMeta(request, getRequestMeta(req))
-              addRequestMeta(request, 'projectDir', this.dir)
-              addRequestMeta(request, 'isIsrFallback', pagesFallback)
-              addRequestMeta(request, 'query', query)
-              addRequestMeta(request, 'params', opts.params)
-              addRequestMeta(
-                request,
-                'ampValidator',
-                this.renderOpts.ampValidator
-              )
-
-              if (renderOpts.err) {
-                addRequestMeta(request, 'invokeError', renderOpts.err)
+            if (renderOpts.err) {
+              addRequestMeta(request, 'invokeError', renderOpts.err)
+            }
+            const handler: (
+              req: ServerRequest | IncomingMessage,
+              res: ServerResponse | HTTPServerResponse,
+              ctx: {
+                waitUntil: ReturnType<Server['getWaitUntil']>
               }
-              const handler: (
-                req: ServerRequest | IncomingMessage,
-                res: ServerResponse | HTTPServerResponse,
-                ctx: {
-                  waitUntil: ReturnType<Server['getWaitUntil']>
-                }
-              ) => Promise<RenderResult> = components.ComponentMod.handler
+            ) => Promise<RenderResult> = components.ComponentMod.handler
 
-              result = await handler(request, response, {
-                waitUntil: this.getWaitUntil(),
-              })
+            result = await handler(request, response, {
+              waitUntil: this.getWaitUntil(),
+            })
 
-              if (!result) {
-                throw new Error(
-                  `Invariant: missing result from invoking ${pathname} handler`
-                )
-              }
-            } else {
+            if (!result) {
+              throw new Error(
+                `Invariant: missing result from invoking ${pathname} handler`
+              )
+            }
+          } else {
+            if (isPagesRouteModule(routeModule)) {
               // Due to the way we pass data by mutating `renderOpts`, we can't extend
               // the object here but only updating its `clientReferenceManifest` and
               // `nextFontManifest` properties.
@@ -2875,48 +2878,48 @@ export default abstract class Server<
                 })
                 throw err
               }
-            }
-          } else {
-            const module = components.routeModule as AppPageRouteModule
+            } else {
+              const module = components.routeModule as AppPageRouteModule
 
-            // Due to the way we pass data by mutating `renderOpts`, we can't extend the
-            // object here but only updating its `nextFontManifest` field.
-            // https://github.com/vercel/next.js/blob/df7cbd904c3bd85f399d1ce90680c0ecf92d2752/packages/next/server/render.tsx#L947-L952
-            renderOpts.nextFontManifest = this.nextFontManifest
+              // Due to the way we pass data by mutating `renderOpts`, we can't extend the
+              // object here but only updating its `nextFontManifest` field.
+              // https://github.com/vercel/next.js/blob/df7cbd904c3bd85f399d1ce90680c0ecf92d2752/packages/next/server/render.tsx#L947-L952
+              renderOpts.nextFontManifest = this.nextFontManifest
 
-            const context: AppPageRouteHandlerContext = {
-              page: is404Page ? '/404' : pathname,
-              params: opts.params,
-              query,
-              fallbackRouteParams,
-              renderOpts,
-              serverComponentsHmrCache: this.getServerComponentsHmrCache(),
-              sharedContext: {
-                buildId: this.buildId,
-              },
-            }
-
-            // TODO: adapt for putting the RDC inside the postponed data
-            // If we're in dev, and this isn't a prefetch or a server action,
-            // we should seed the resume data cache.
-            if (
-              this.nextConfig.experimental.dynamicIO &&
-              this.renderOpts.dev &&
-              !isPrefetchRSCRequest &&
-              !isPossibleServerAction
-            ) {
-              const warmup = await module.warmup(req, res, context)
-
-              // If the warmup is successful, we should use the resume data
-              // cache from the warmup.
-              if (warmup.metadata.devRenderResumeDataCache) {
-                renderOpts.devRenderResumeDataCache =
-                  warmup.metadata.devRenderResumeDataCache
+              const context: AppPageRouteHandlerContext = {
+                page: is404Page ? '/404' : pathname,
+                params: opts.params,
+                query,
+                fallbackRouteParams,
+                renderOpts,
+                serverComponentsHmrCache: this.getServerComponentsHmrCache(),
+                sharedContext: {
+                  buildId: this.buildId,
+                },
               }
-            }
 
-            // Call the built-in render method on the module.
-            result = await module.render(req, res, context)
+              // TODO: adapt for putting the RDC inside the postponed data
+              // If we're in dev, and this isn't a prefetch or a server action,
+              // we should seed the resume data cache.
+              if (
+                this.nextConfig.experimental.dynamicIO &&
+                this.renderOpts.dev &&
+                !isPrefetchRSCRequest &&
+                !isPossibleServerAction
+              ) {
+                const warmup = await module.warmup(req, res, context)
+
+                // If the warmup is successful, we should use the resume data
+                // cache from the warmup.
+                if (warmup.metadata.devRenderResumeDataCache) {
+                  renderOpts.devRenderResumeDataCache =
+                    warmup.metadata.devRenderResumeDataCache
+                }
+              }
+
+              // Call the built-in render method on the module.
+              result = await module.render(req, res, context)
+            }
           }
         } else {
           throw new Error('Invariant: Unknown route module type')
@@ -3205,7 +3208,7 @@ export default abstract class Server<
                 postponed: undefined,
                 pagesFallback: undefined,
                 fallbackRouteParams:
-                  // If we're in production of we're debugging the fallback
+                  // If we're in production or we're debugging the fallback
                   // shell then we should postpone when dynamic params are
                   // accessed.
                   isProduction || isDebugFallbackShell

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -676,6 +676,11 @@ export async function initialize(opts: {
     nextConfig: config,
     hostname: handlers.server.hostname,
     revalidate: handlers.server.revalidate.bind(handlers.server),
+    experimentalTestProxy: renderServerOpts.experimentalTestProxy,
+    logErrorWithOriginalStack: opts.dev
+      ? handlers.server.logErrorWithOriginalStack.bind(handlers.server)
+      : (err: unknown) => Log.error(err),
+    setIsrStatus: devBundlerService?.setIsrStatus.bind(devBundlerService),
   }
 
   const logError = async (

--- a/packages/next/src/server/lib/router-utils/block-cross-site.ts
+++ b/packages/next/src/server/lib/router-utils/block-cross-site.ts
@@ -1,5 +1,5 @@
 import type { Duplex } from 'stream'
-import type { IncomingMessage, ServerResponse } from 'webpack-dev-server'
+import type { IncomingMessage, ServerResponse } from 'node:http'
 import { parseUrl } from '../../../lib/url'
 import { warnOnce } from '../../../build/output/log'
 import { isCsrfOriginAllowed } from '../../app-render/csrf-protection'

--- a/packages/next/src/server/lib/router-utils/router-server-context.ts
+++ b/packages/next/src/server/lib/router-utils/router-server-context.ts
@@ -25,6 +25,12 @@ export type RouterServerContext = Record<
     nextConfig?: NextConfigComplete
     // whether running in custom server mode
     isCustomServer?: boolean
+    // whether test proxy is enabled
+    experimentalTestProxy?: boolean
+    // allow dev server to log with original stack
+    logErrorWithOriginalStack?: (err: unknown, type: string) => void
+    // allow setting ISR status in dev
+    setIsrStatus?: (key: string, value: boolean | null) => void
   }
 >
 

--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -20,7 +20,9 @@ export function shouldServeStreamingMetadata(
 
 // When the request UA is a html-limited bot, we should do a dynamic render.
 // In this case, postpone state is not sent.
-export function isHtmlBotRequest(req: BaseNextRequest): boolean {
+export function isHtmlBotRequest(req: {
+  headers: BaseNextRequest['headers']
+}): boolean {
   const ua = req.headers['user-agent'] || ''
   const botType = getBotType(ua)
 

--- a/packages/next/src/server/load-manifest.external.ts
+++ b/packages/next/src/server/load-manifest.external.ts
@@ -115,6 +115,7 @@ export function loadManifestFromRelativePath<T extends object>({
   cache,
   skipParse,
   handleMissing,
+  useEval,
 }: {
   projectDir: string
   distDir: string
@@ -123,14 +124,19 @@ export function loadManifestFromRelativePath<T extends object>({
   cache?: Map<string, unknown>
   skipParse?: boolean
   handleMissing?: boolean
+  useEval?: boolean
 }): DeepReadonly<T> {
   try {
-    return loadManifest<T>(
-      join(/* turbopackIgnore: true */ projectDir, distDir, manifest),
-      shouldCache,
-      cache,
-      skipParse
+    const manifestPath = join(
+      /* turbopackIgnore: true */ projectDir,
+      distDir,
+      manifest
     )
+
+    if (useEval) {
+      return evalManifest<T>(manifestPath, shouldCache, cache)
+    }
+    return loadManifest<T>(manifestPath, shouldCache, cache, skipParse)
   } catch (err) {
     if (handleMissing) {
       // TODO: should this be undefined

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -86,6 +86,8 @@ interface NextWrapperServer {
     ...args: Parameters<NextNodeServer['revalidate']>
   ): ReturnType<NextNodeServer['revalidate']>
 
+  logErrorWithOriginalStack(err: unknown, type: string): void
+
   render(
     ...args: Parameters<NextNodeServer['render']>
   ): ReturnType<NextNodeServer['render']>
@@ -162,6 +164,14 @@ export class NextServer implements NextWrapperServer {
   logError(...args: Parameters<NextWrapperServer['logError']>) {
     if (this.server) {
       this.server.logError(...args)
+    }
+  }
+
+  async logErrorWithOriginalStack(err: unknown, type: string) {
+    const server = await this.getServer()
+    // this is only available on dev server
+    if ((server as any).logErrorWithOriginalStack) {
+      return (server as any).logErrorWithOriginalStack(err, type)
     }
   }
 
@@ -450,6 +460,10 @@ class NextCustomServer implements NextWrapperServer {
 
   logError(...args: Parameters<NextWrapperServer['logError']>) {
     this.server.logError(...args)
+  }
+
+  logErrorWithOriginalStack(err: unknown, type: string) {
+    return this.server.logErrorWithOriginalStack(err, type)
   }
 
   async revalidate(...args: Parameters<NextWrapperServer['revalidate']>) {

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -58,6 +58,13 @@ export class AppPageRouteModule extends RouteModule<
   AppPageRouteDefinition,
   AppPageUserlandModule
 > {
+  constructor(
+    options: RouteModuleOptions<AppPageRouteDefinition, AppPageUserlandModule>
+  ) {
+    super(options)
+    this.isAppRouter = true
+  }
+
   public render(
     req: BaseNextRequest,
     res: BaseNextResponse,

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -13,11 +13,14 @@ import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import {
   BUILD_ID_FILE,
   BUILD_MANIFEST,
+  CLIENT_REFERENCE_MANIFEST,
   NEXT_FONT_MANIFEST,
   PRERENDER_MANIFEST,
   REACT_LOADABLE_MANIFEST,
   ROUTES_MANIFEST,
   SERVER_FILES_MANIFEST,
+  SERVER_REFERENCE_MANIFEST,
+  SUBRESOURCE_INTEGRITY_MANIFEST,
 } from '../../shared/lib/constants'
 import { parseReqUrl } from '../../lib/url'
 import {
@@ -38,6 +41,7 @@ import { normalizeDataPath } from '../../shared/lib/page-path/normalize-data-pat
 import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
 import { addRequestMeta, getRequestMeta } from '../request-meta'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
+import { isStaticMetadataRoute } from '../../lib/metadata/is-metadata-route'
 
 /**
  * RouteModuleOptions is the options that are passed to the route module, other
@@ -93,6 +97,7 @@ export abstract class RouteModule<
   public isDev: boolean
   public distDir: string
   public projectDir: string
+  public isAppRouter?: boolean
 
   constructor({
     userland,
@@ -140,6 +145,9 @@ export abstract class RouteModule<
         buildManifest,
         reactLoadableManifest,
         nextFontManifest,
+        clientReferenceManifest,
+        serverActionsManifest,
+        subresourceIntegrityManifest,
         serverFilesManifest,
         buildId,
       ] = await Promise.all([
@@ -162,7 +170,7 @@ export abstract class RouteModule<
           projectDir,
           distDir: this.distDir,
           manifest: process.env.TURBOPACK
-            ? `server/pages${normalizedPagePath}/${REACT_LOADABLE_MANIFEST}`
+            ? `server/${this.isAppRouter ? 'app' : 'pages'}${normalizedPagePath}/${REACT_LOADABLE_MANIFEST}`
             : REACT_LOADABLE_MANIFEST,
           handleMissing: true,
         }),
@@ -170,6 +178,32 @@ export abstract class RouteModule<
           projectDir,
           distDir: this.distDir,
           manifest: `server/${NEXT_FONT_MANIFEST}.json`,
+        }),
+        this.isAppRouter && !isStaticMetadataRoute(srcPage)
+          ? loadManifestFromRelativePath({
+              distDir: this.distDir,
+              projectDir,
+              useEval: true,
+              handleMissing: true,
+              manifest: `server/app${srcPage.replace(/%5F/g, '_') + '_' + CLIENT_REFERENCE_MANIFEST}.js`,
+              shouldCache: !this.isDev,
+            })
+          : undefined,
+        this.isAppRouter
+          ? loadManifestFromRelativePath<any>({
+              distDir: this.distDir,
+              projectDir,
+              manifest: `server/${SERVER_REFERENCE_MANIFEST}.json`,
+              handleMissing: true,
+              shouldCache: !this.isDev,
+            })
+          : {},
+        loadManifestFromRelativePath<Record<string, string>>({
+          projectDir,
+          distDir: this.distDir,
+          manifest: `server/${SUBRESOURCE_INTEGRITY_MANIFEST}.json`,
+          handleMissing: true,
+          shouldCache: !this.isDev,
         }),
         this.isDev
           ? ({} as any)
@@ -196,6 +230,10 @@ export abstract class RouteModule<
         prerenderManifest,
         serverFilesManifest,
         reactLoadableManifest,
+        clientReferenceManifest: (clientReferenceManifest as any)
+          ?.__RSC_MANIFEST?.[srcPage.replace(/%5F/g, '_')],
+        serverActionsManifest,
+        subresourceIntegrityManifest,
       }
     }
     throw new Error('Invariant: loadManifests called for edge runtime')
@@ -223,6 +261,7 @@ export abstract class RouteModule<
         params?: ParsedUrlQuery
         parsedUrl: UrlWithParsedQuery
         previewData: PreviewData
+        pageIsDynamic: boolean
         isDraftMode: boolean
         isNextDataRequest: boolean
         buildManifest: DeepReadonly<BuildManifest>
@@ -231,6 +270,11 @@ export abstract class RouteModule<
         reactLoadableManifest: DeepReadonly<ReactLoadableManifest>
         routesManifest: DeepReadonly<DevRoutesManifest>
         prerenderManifest: DeepReadonly<PrerenderManifest>
+        // we can't pull in the client reference type or it causes issues with
+        // our pre-compiled types
+        clientReferenceManifest?: any
+        serverActionsManifest?: any
+        subresourceIntegrityManifest?: DeepReadonly<Record<string, string>>
         isOnDemandRevalidate: boolean
         revalidateOnlyGenerated: boolean
       }
@@ -339,11 +383,16 @@ export abstract class RouteModule<
 
       // attempt parsing from pathname
       if (!params && serverUtils.dynamicRouteMatcher) {
-        const paramsResult = serverUtils.dynamicRouteMatcher(
+        const paramsMatch = serverUtils.dynamicRouteMatcher(
           normalizeDataPath(localeResult?.pathname || parsedUrl.pathname || '/')
         )
-        if (paramsResult) {
-          params = paramsResult
+        const paramsResult = serverUtils.normalizeDynamicRouteParams(
+          paramsMatch || {},
+          true
+        )
+
+        if (paramsResult.hasValidParams) {
+          params = paramsResult.params
         }
       }
 
@@ -361,14 +410,34 @@ export abstract class RouteModule<
       }
 
       const routeParamKeys = new Set<string>()
-      const combinedParamKeys = [...rewriteParamKeys, ...routeParamKeys]
+      const combinedParamKeys = [...routeParamKeys]
+
+      for (const key of rewriteParamKeys) {
+        // We only want to filter rewrite param keys from the URL
+        // if they are matches from the URL e.g. the key/value matches
+        // before and after applying the rewrites /:path for /hello and
+        // { path: 'hello' } but not for { path: 'another' } and /hello
+        // TODO: we should prefix rewrite param keys the same as we do
+        // for dynamic routes so we can identify them properly
+        const originalValue = Array.isArray(originalQuery[key])
+          ? originalQuery[key].join('')
+          : originalQuery[key]
+
+        const queryValue = Array.isArray(query[key])
+          ? query[key].join('')
+          : query[key]
+
+        if (!(key in originalQuery) || originalValue === queryValue) {
+          combinedParamKeys.push(key)
+        }
+      }
 
       serverUtils.normalizeCdnUrl(req, combinedParamKeys)
       serverUtils.normalizeQueryParams(query, routeParamKeys)
       serverUtils.filterInternalQuery(originalQuery, combinedParamKeys)
 
       if (pageIsDynamic) {
-        const result = serverUtils.normalizeDynamicRouteParams(query, true)
+        const queryResult = serverUtils.normalizeDynamicRouteParams(query, true)
 
         req.url = serverUtils.interpolateDynamicPath(
           req.url || '/',
@@ -384,13 +453,28 @@ export abstract class RouteModule<
         )
 
         // try pulling from query if valid
-        if (result.hasValidParams) {
-          params = Object.assign({}, result.params, params)
+        if (!params) {
+          if (queryResult.hasValidParams) {
+            params = Object.assign({}, queryResult.params)
 
-          // If we pulled from query remove it so it's
-          // only in params
-          for (const key in params) {
-            delete query[key]
+            // If we pulled from query remove it so it's
+            // only in params
+            for (const key in serverUtils.defaultRouteMatches) {
+              delete query[key]
+            }
+          } else {
+            // use final params from URL matching
+            const paramsMatch = serverUtils.dynamicRouteMatcher?.(
+              normalizeDataPath(
+                localeResult?.pathname || parsedUrl.pathname || '/'
+              )
+            )
+            // we don't normalize these as they are allowed to be
+            // the literal slug matches here e.g. /blog/[slug]
+            // actually being requested
+            if (paramsMatch) {
+              params = Object.assign({}, paramsMatch)
+            }
           }
         }
       }
@@ -433,9 +517,12 @@ export abstract class RouteModule<
         defaultLocale,
         isDraftMode,
         previewData,
+        pageIsDynamic,
         isOnDemandRevalidate,
         revalidateOnlyGenerated,
         ...manifests,
+        serverActionsManifest: manifests.serverActionsManifest,
+        clientReferenceManifest: manifests.clientReferenceManifest,
       }
     }
   }

--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -105,7 +105,9 @@ export function interpolateDynamicPath(
       paramValue = ''
     }
 
-    pathname = pathname.replaceAll(builtParam, paramValue)
+    if (paramValue || optional) {
+      pathname = pathname.replaceAll(builtParam, paramValue)
+    }
   }
 
   return pathname

--- a/test/e2e/on-request-error/isr/instrumentation.js
+++ b/test/e2e/on-request-error/isr/instrumentation.js
@@ -1,12 +1,11 @@
 import fs from 'fs'
-import fsp from 'fs/promises'
 import path from 'path'
 
 const dir = path.dirname(new URL(import.meta.url).pathname)
 const logPath = path.join(dir, 'output-log.json')
 
 export async function register() {
-  await fsp.writeFile(logPath, '{}', 'utf8')
+  fs.writeFileSync(logPath, '{}', 'utf8')
 }
 
 // Since only Node.js runtime support ISR, we can just write the error state to a file here.
@@ -19,7 +18,7 @@ export async function onRequestError(err, request, context) {
   }
 
   const json = fs.existsSync(logPath)
-    ? JSON.parse(await fsp.readFile(logPath, 'utf8'))
+    ? JSON.parse(fs.readFileSync(logPath, 'utf8'))
     : {}
 
   json[payload.message] = payload
@@ -27,5 +26,5 @@ export async function onRequestError(err, request, context) {
   console.log(
     `[instrumentation] write-log:${payload.message} ${payload.context.revalidateReason}`
   )
-  await fsp.writeFile(logPath, JSON.stringify(json, null, 2), 'utf8')
+  fs.writeFileSync(logPath, JSON.stringify(json, null, 2), 'utf8')
 }

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -1266,7 +1266,7 @@ describe('required server files', () => {
     )
 
     const json = await res.json()
-    expect(json.query).toEqual({ another: 'value', rest: ['index'] })
+    expect(json.query).toEqual({ another: 'value' })
     expect(json.url).toBe('/api/optional/index?another=value')
   })
 

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -17729,7 +17729,6 @@
   },
   "test/integration/server-side-dev-errors/test/index.test.js": {
     "passed": [
-      "server-side dev errors should show server-side error for dynamic api route correctly",
       "server-side dev errors should show server-side error for dynamic gssp page correctly",
       "server-side dev errors should show server-side error for gsp page correctly",
       "server-side dev errors should show server-side error for gssp page correctly",
@@ -17739,7 +17738,8 @@
       "server-side dev errors should show server-side error for uncaught rejection correctly"
     ],
     "failed": [
-      "server-side dev errors should show server-side error for api route correctly"
+      "server-side dev errors should show server-side error for api route correctly",
+      "server-side dev errors should show server-side error for dynamic api route correctly"
     ],
     "pending": [],
     "flakey": [],

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -21205,12 +21205,12 @@
   },
   "test/integration/server-side-dev-errors/test/index.test.js": {
     "passed": [
-      "server-side dev errors should show server-side error for api route correctly",
       "server-side dev errors should show server-side error for dynamic gssp page correctly",
       "server-side dev errors should show server-side error for gsp page correctly",
       "server-side dev errors should show server-side error for gssp page correctly"
     ],
     "failed": [
+      "server-side dev errors should show server-side error for api route correctly",
       "server-side dev errors should show server-side error for dynamic api route correctly",
       "server-side dev errors should show server-side error for uncaught empty exception correctly",
       "server-side dev errors should show server-side error for uncaught empty rejection correctly",


### PR DESCRIPTION
Continuation of https://github.com/vercel/next.js/pull/78166 this implements the handler interface for app router pages, This does not move the response handling inside of the handler yet as that will be in a follow-up PR to keep the changes isolated. This still returns the RenderResult for the base-server to continue to handle.

Validated against deploy tests https://github.com/vercel/vercel/pull/13389 and https://github.com/vercel/next.js/actions/runs/15358616431/job/43222466204