### PR TITLE
Fix build and deploy workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -618,7 +618,7 @@ jobs:
         if: steps.changesets.outputs.pullRequestNumber
         run: 'gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "created-by: CI"'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send a Slack notification of the publish status
         run: pnpm tsx scripts/release/slack.ts


### PR DESCRIPTION
Fix syntax error introduced in https://github.com/vercel/next.js/pull/79409 

This error is hidden on the workflows page unfortunately so isn't seen on the PR itself

https://github.com/vercel/next.js/actions/runs/15216527935?pr=79563