### PR TITLE
report build-and-deploy failures only after retries

### DIFF
--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -21,7 +21,6 @@ jobs:
       ${{ 
         github.event.workflow_run.conclusion == 'failure' &&
         github.repository == 'vercel/next.js' &&
-        github.event.workflow.name != 'build-and-deploy' &&
         github.event.workflow_run.run_attempt < 3
       }}
     runs-on: ubuntu-latest
@@ -43,7 +42,7 @@ jobs:
     if: >-
       ${{ 
         github.event.workflow_run.conclusion == 'failure' &&
-        (github.event.workflow_run.run_attempt >= 3 || github.event.workflow.name == 'build-and-deploy') &&
+        github.event.workflow_run.run_attempt >= 3 &&
         !github.event.workflow_run.head_repository.fork
       }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
In #75749 we made a single failure for `build-and-deploy` alert. However as seen there can be transient failures ([ex1](https://github.com/vercel/next.js/actions/runs/15218556449/job/42809569102), [ex2](https://github.com/vercel/next.js/actions/runs/15198747807/job/42748740308))

This updates the logic to treat both workflows the same, and alert after 3 retries. 