### PR TITLE
[CNA] default to node v22 types in CNA templates

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -226,7 +226,7 @@ export const installTemplate = async ({
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
       typescript: "^5",
-      "@types/node": "^20",
+      "@types/node": "^22",
       "@types/react": "^19",
       "@types/react-dom": "^19",
     };


### PR DESCRIPTION
the current CNA templates have `@types/node@20` in `devDependencies`. this PR updates that to use node v22 types. node v22 has been the LTS version for quite a while, and should be supported on all hosting platforms.