### PR TITLE
Fix --tag argument in publish-release

### DIFF
--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -86,7 +86,8 @@ const cwd = process.cwd()
           '--access',
           'public',
           '--ignore-scripts',
-          ['--tag', tag],
+          '--tag',
+          tag,
         ],
         { stdio: 'pipe' }
       )


### PR DESCRIPTION
Somehow `@ts-check` didn't catch this array not being spread anymore. 