### PR TITLE
[repo] add `github.vscode-github-actions` to vscode extensions recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,6 +13,9 @@
     // PR management / Reviewing
     "github.vscode-pull-request-github",
 
+    // CI
+    "github.vscode-github-actions",
+
     // Showing todo comments
     "gruntfuggly.todo-tree",
 


### PR DESCRIPTION
There was an invalid YAML syntax in the GH Action introduced from [here](https://github.com/vercel/next.js/pull/79409/files#diff-8812abff9ed11e2e98d5066031a3181c6d44b28aea00f0d369532d5cb254650fR621) which broke the [build and deploy](https://github.com/vercel/next.js/actions/runs/15213390449/attempts/3) CI before.

This was due to Prettier not catching this invalid syntax.

https://github.com/user-attachments/assets/cd234022-a1f1-4ccf-84c1-5e5a9f38e236

It would be good if we could added a test layer for the CI as well. This GH Action extension provided its own good linter, allowing us to run CI from the IDE. I think it's good to put in the recommendations.

| Before | After |
|--------|--------|
| ![CleanShot 2025-05-25 at 12 45 08@2x](https://github.com/user-attachments/assets/60698baf-66a7-4c83-a600-ffd4d19e22bc) | ![CleanShot 2025-05-25 at 12 44 56@2x](https://github.com/user-attachments/assets/e9e69add-a23a-489d-b995-a52bd52790cd) |