### PR TITLE
[release] fix: `GITHUB_TOKEN` is needed to open release pr

### DIFF
--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -111,3 +111,5 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm ci:version
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
To open a "Version Packages" PR, the Action requires a `GITHUB_TOKEN` token.

Discovered while testing:

![CleanShot 2025-05-25 at 13 38 56@2x](https://github.com/user-attachments/assets/91d6b4b6-0f13-4cf1-85d7-fa309ca3aaa0)
