### PR TITLE
Enforce consistency between packages in preview builds

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -530,7 +530,7 @@ jobs:
           path: crates/wasm
 
       - name: Create tarballs
-        run: GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }} node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ runner.temp }}/preview-tarballs"
+        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ runner.temp }}/preview-tarballs"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@v4

--- a/scripts/create-preview-tarballs.js
+++ b/scripts/create-preview-tarballs.js
@@ -82,7 +82,7 @@ async function main() {
         }
       )
       // tarball name is printed as the last line of npm-pack
-      const tarballName = stdout.trim().split('\n').pop() || ''
+      const tarballName = stdout.trim().split('\n').pop()
       console.info(`Created tarball ${path.join(packDestination, tarballName)}`)
 
       nextSwcPackageNames.add(manifest.name)
@@ -97,21 +97,16 @@ async function main() {
   ])
   const packages = JSON.parse(lernaListJson.stdout)
   const packagesByVersion = new Map()
-  const PR_NUMBER = process.env.GH_PR_NUMBER
-  const basePackageUrl = PR_NUMBER
-    ? `https://vercel-packages.vercel.app/next/prs/${PR_NUMBER}/`
-    : `https://vercel-packages.vercel.app/next/commits/${commitSha}/`
-
   for (const packageInfo of packages) {
     packagesByVersion.set(
       packageInfo.name,
-      `${basePackageUrl}${packageInfo.name}`
+      `https://vercel-packages.vercel.app/next/commits/${commitSha}/${packageInfo.name}`
     )
   }
   for (const nextSwcPackageName of nextSwcPackageNames) {
     packagesByVersion.set(
       nextSwcPackageName,
-      `${basePackageUrl}${nextSwcPackageName}`
+      `https://vercel-packages.vercel.app/next/commits/${commitSha}/${nextSwcPackageName}`
     )
   }
 
@@ -169,7 +164,7 @@ async function main() {
       }
     )
     // tarball name is printed as the last line of npm-pack
-    const tarballName = stdout.trim().split('\n').pop() || ''
+    const tarballName = stdout.trim().split('\n').pop()
     console.info(`Created tarball ${path.join(packDestination, tarballName)}`)
   }
 


### PR DESCRIPTION
Resolves https://github.com/vercel/next.js/pull/78737#discussion_r2071788535 by reverting all the changes to `scripts/create-preview-tarballs.js` from that PR.

Preview builds should be consistent. For a given commit, a package should depend on the exact same commit not a later commit. Otherwise we produce hard to debug issues and make it impossible to reproduce preview builds.


Since we always create tarballs for all packages, we can always assume that package A can depend on package B of the same commit. Once we no longer build all packages, we have to change the versioning strategy. But then we would fetch the previously built commit not the latest (which is what linking to a PR does).

For example, https://github.com/vercel/front/actions/runs/15238358866/job/42855229181 should've been the preview build from a commit but referenced the preview build of a PR.
