### PR TITLE
[release-new] fix: release pr commit contains `(#number)` at last

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -55,7 +55,7 @@ jobs:
           then
             echo "__NEW_RELEASE=true" >> $GITHUB_ENV
             echo "value=production" >> $GITHUB_OUTPUT
-          elif [[ $RELEASE_CHECK = "legacy-release" ]];
+          elif [[ $RELEASE_CHECK = v* ]];
           then
             echo "value=production" >> $GITHUB_OUTPUT
           elif [ '${{ github.ref }}' == 'refs/heads/canary' ]

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,8 +19,9 @@ env:
   #
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
   MACOSX_DEPLOYMENT_TARGET: 11.0
-  # This will become "true" if the latest commit is
-  # "Version Packages" or "Version Pacakges \((canary|rc)\)"
+  # This will become "true" if the latest commit (merged release PR) is either:
+  # - "Version Packages (#<number>)"
+  # - "Version Pacakges (canary/rc) (#<number>)"
   # set from scripts/check-is-release.js
   __NEW_RELEASE: 'false'
 
@@ -50,10 +51,11 @@ jobs:
         run: |
           # TODO: Remove the new release check once the new release workflow is fully replaced.
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-          if [[ $RELEASE_CHECK =~ ^Version\ Packages(\ \((canary|rc)\))?$ ]];
+          if [[ $RELEASE_CHECK = "new-release" ]];
           then
             echo "__NEW_RELEASE=true" >> $GITHUB_ENV
-          elif [[ $RELEASE_CHECK = v* ]];
+            echo "value=production" >> $GITHUB_OUTPUT
+          elif [[ $RELEASE_CHECK = "legacy-release" ]];
           then
             echo "value=production" >> $GITHUB_OUTPUT
           elif [ '${{ github.ref }}' == 'refs/heads/canary' ]

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -51,11 +51,11 @@ jobs:
         run: |
           # TODO: Remove the new release check once the new release workflow is fully replaced.
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-          if [[ $RELEASE_CHECK = "new-release" ]];
+          if [[ $RELEASE_CHECK == 'new-release' ]];
           then
             echo "__NEW_RELEASE=true" >> $GITHUB_ENV
             echo "value=production" >> $GITHUB_OUTPUT
-          elif [[ $RELEASE_CHECK = v* ]];
+          elif [[ $RELEASE_CHECK == v* ]];
           then
             echo "value=production" >> $GITHUB_OUTPUT
           elif [ '${{ github.ref }}' == 'refs/heads/canary' ]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,8 @@ jobs:
       - name: check for release
         id: is-release
         run: |
-          if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) = v* ]];
+          RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
+          if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = "legacy-release" ]];
             then
               echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
         id: is-release
         run: |
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-          if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = "legacy-release" ]];
+          if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = v* ]];
             then
               echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
         id: is-release
         run: |
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-          if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = v* ]];
+          if [[ $RELEASE_CHECK == "new-release" || $RELEASE_CHECK == v* ]];
             then
               echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
             else

--- a/scripts/check-is-release.js
+++ b/scripts/check-is-release.js
@@ -13,13 +13,13 @@ const checkIsRelease = async () => {
 
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
-  const newPublishMsgRegex = /^Version Packages( \((canary|rc)\))?$/
+  const newPublishMsgRegex = /^Version Packages( \((canary|rc)\))?( \(#\d+\))?$/
 
   if (publishMsgRegex.test(versionString)) {
-    console.log(versionString)
+    console.log('legacy-release')
     process.exit(0)
   } else if (newPublishMsgRegex.test(commitMsg)) {
-    console.log(commitMsg)
+    console.log('new-release')
     process.exit(0)
   } else {
     console.log('not publish commit', { commitId, commitMsg, versionString })

--- a/scripts/check-is-release.js
+++ b/scripts/check-is-release.js
@@ -16,7 +16,7 @@ const checkIsRelease = async () => {
   const newPublishMsgRegex = /^Version Packages( \((canary|rc)\))?( \(#\d+\))?$/
 
   if (publishMsgRegex.test(versionString)) {
-    console.log('legacy-release')
+    console.log(versionString)
     process.exit(0)
   } else if (newPublishMsgRegex.test(commitMsg)) {
     console.log('new-release')

--- a/scripts/check-is-release.js
+++ b/scripts/check-is-release.js
@@ -14,11 +14,14 @@ const checkIsRelease = async () => {
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
   const newPublishMsgRegex = /^Version Packages( \((canary|rc)\))?( \(#\d+\))?$/
+  // When the "Version Packages" PR is merged, it may contain "\n"
+  // in the message when co-authored, so split and get the first one.
+  const newPublishPrMessage = commitMsg.split('\n')[0]
 
   if (publishMsgRegex.test(versionString)) {
     console.log(versionString)
     process.exit(0)
-  } else if (newPublishMsgRegex.test(commitMsg)) {
+  } else if (newPublishMsgRegex.test(newPublishPrMessage)) {
     console.log('new-release')
     process.exit(0)
   } else {

--- a/scripts/release-stats.sh
+++ b/scripts/release-stats.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = v* ]];
+if [[ $RELEASE_CHECK == "new-release" || $RELEASE_CHECK == v* ]];
   then
     echo "Publish occurred, running release stats..."
   else

--- a/scripts/release-stats.sh
+++ b/scripts/release-stats.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
-if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = "legacy-release" ]];
+if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = v* ]];
   then
     echo "Publish occurred, running release stats..."
   else

--- a/scripts/release-stats.sh
+++ b/scripts/release-stats.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) = v* ]];
+RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
+if [[ $RELEASE_CHECK = "new-release" || $RELEASE_CHECK = "legacy-release" ]];
   then
     echo "Publish occurred, running release stats..."
   else


### PR DESCRIPTION
When the "Version Packages" PR is merged, the created commit is the format of "Version Packages (#number)". Therefore, the check-is-release.js script won't match the current regex. Also, I modified the workflows that use the `check-is-release.js` to consider the new release as a release workflow as well.