### PR TITLE
[release-old] use `backport` NPM dist tag instead of `stable` for backports

### DIFF
--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -52,8 +52,8 @@ const cwd = process.cwd()
         // is a backport release. Since NPM sets the 'latest' tag by default
         // during publishing, when users install `next@latest`, they might
         // get the backported version instead of the actual "latest" version.
-        // Therefore, we explicitly set the tag as 'stable' for backports.
-        tag = 'stable'
+        // Therefore, we explicitly set the tag as 'backport' for backports.
+        tag = 'backport'
       }
     }
   } catch (error) {
@@ -61,9 +61,7 @@ const cwd = process.cwd()
     throw error
   }
 
-  console.log(
-    `Publishing ${isCanary ? 'canary' : isReleaseCandidate ? 'rc' : 'stable'}`
-  )
+  console.log(`Publishing as "${tag}" dist tag...`)
 
   if (!process.env.NPM_TOKEN) {
     console.log('No NPM_TOKEN, exiting...')


### PR DESCRIPTION
PR https://github.com/vercel/next.js/pull/79596 introduced setting `stable` dist tag for backports, but due to https://github.com/vercel/next.js/pull/79538#pullrequestreview-2866854431, 

> This sounds like something users would use. However, it might point to 14.x when 15.x exists and we would certainly want people to use 14.x. It's also weird that 14.x would have a `stable` tag but not 15.x.
> 
> That's why `backport` makes more sense since it's less specific and not common vernacular when talking about release characteristics (e.g. "experimental", "nightly", "stable", "unstable" etc.).
> 
> The tag could actually just be "internal-backport" and ideally we'd remove it right after publish. The goal here isn't to come up with a useful tag for backports. We just want to work around NPM requiring a tag during publish.

better to use another dist tag: i.e.,`backport`.