### PR TITLE
[release-new] move "add label to pr" workflow from publish to trigger

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -612,13 +612,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
-      # Add label to verify the PR is created from this workflow.
-      - name: Add label to PR
-        if: steps.changesets.outputs.pullRequestNumber
-        run: 'gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "created-by: CI"'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Send a Slack notification of the publish status
         run: pnpm tsx scripts/release/slack.ts
         env:

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -107,10 +107,17 @@ jobs:
       - run: pnpm run build
 
       - name: Create Release Pull Request
-        id: version-packages
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm ci:version
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
+
+      # Add label to verify the PR is created from this workflow.
+      - name: Add label to PR
+        if: steps.changesets.outputs.pullRequestNumber
+        run: 'gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "created-by: CI"'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It _does work_  but it is more natural to put the "add a label to pr" workflow after the "create pr" workflow.