### PR TITLE
Update script location used in `pnpm unpack-next`

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -56,13 +56,13 @@ see **[Developing Using Your Local Version of Next.js](./developing-using-local-
 Since Turbopack doesn't support symlinks when pointing outside of the workspace directory, it can be difficult to develop against a local Next.js version. Neither `pnpm link` nor `file:` imports quite cut it. An alternative is to pack the Next.js version you want to test into a tarball and add it to the pnpm overrides of your test application. The following script will do it for you:
 
 ```bash
-pnpm pack-next --release && pnpm unpack-next path/to/project
+pnpm pack-next --tar && pnpm unpack-next path/to/project
 ```
 
 Or without running the build:
 
 ```bash
-pnpm pack-next --no-build --release && pnpm unpack-next path/to/project
+pnpm pack-next --no-js-build --tar && pnpm unpack-next path/to/project
 ```
 
 Without going through a tarball (only works if you've added the overrides from `pack-next`):
@@ -74,21 +74,19 @@ pnpm patch-next path/to/project
 Supports the same arguments:
 
 ```bash
-pnpm patch-next --no-build --release path/to/project
+pnpm patch-next --no-js-build path/to/project
 ```
 
 ### Explanation of the scripts
 
 ```bash
 # Generate a tarball of the Next.js version you want to test
-$ pnpm pack-next
+$ pnpm pack-next --tar
 
-# If you need to build in release mode:
-$ pnpm pack-next --release
 # You can also pass any cargo argument to the script
 
 # To skip the `pnpm i` and `pnpm build` steps in next.js (e. g. if you are running `pnpm dev`)
-$ pnpm pack-next --no-build
+$ pnpm pack-next --no-js-build
 ```
 
 Afterwards, you'll need to unpack the tarball into your test project. You can either manually edit the `package.json` to point to the new tarballs (see the stdout from `pack-next` script), or you can automatically unpack it with:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "sync-react": "node ./scripts/sync-react.js",
     "update-google-fonts": "node ./scripts/update-google-fonts.js",
     "patch-next": "node scripts/patch-next.cjs",
-    "unpack-next": "tsx scripts/unpack-next.cjs",
+    "unpack-next": "tsx scripts/unpack-next.ts",
     "swc-build-native": "tsx scripts/build-native.ts",
     "swc-build-wasm": "tsx scripts/build-wasm.cjs",
     "build-turbopack-cli": "cargo build -p turbopack-cli --release",


### PR DESCRIPTION
Fixes "pack-next" + "unpack-next" workflows and updates docs.

Follow-up to https://github.com/vercel/next.js/pull/77538 and https://github.com/vercel/next.js/issues/77536