### PR TITLE
[dynamicIO] Split up static generation into two phases

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -735,7 +735,7 @@ const staticWorkerExposedMethods = [
   'getDefinedNamedExports',
   'exportPages',
 ] as const
-type StaticWorker = typeof import('./worker') & Worker
+export type StaticWorker = typeof import('./worker') & Worker
 export function createStaticWorker(
   config: NextConfigComplete,
   options: {

--- a/packages/next/src/build/static-paths/types.ts
+++ b/packages/next/src/build/static-paths/types.ts
@@ -34,6 +34,6 @@ type FallbackPrerenderedRoute = {
 export type PrerenderedRoute = StaticPrerenderedRoute | FallbackPrerenderedRoute
 
 export type StaticPathsResult = {
-  fallbackMode: FallbackMode
-  prerenderedRoutes: PrerenderedRoute[]
+  fallbackMode: FallbackMode | undefined
+  prerenderedRoutes: PrerenderedRoute[] | undefined
 }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -624,22 +624,19 @@ async function exportAppImpl(
 
   for (const exportPaths of exportPathsByPage.values()) {
     if (renderOpts.experimental.dynamicIO) {
-      const withFallbackRouteParams: ExportPathEntry[] = []
-      const withoutFallbackRouteParams: ExportPathEntry[] = []
+      const allowEmptyStaticShellExportPaths: ExportPathEntry[] = []
+      const otherExportPaths: ExportPathEntry[] = []
 
       for (const exportPath of exportPaths) {
-        if (
-          exportPath._fallbackRouteParams &&
-          exportPath._fallbackRouteParams.length > 0
-        ) {
-          withFallbackRouteParams.push(exportPath)
+        if (exportPath._allowEmptyStaticShell) {
+          allowEmptyStaticShellExportPaths.push(exportPath)
         } else {
-          withoutFallbackRouteParams.push(exportPath)
+          otherExportPaths.push(exportPath)
         }
       }
 
-      initialPhaseExportPaths.push(...withoutFallbackRouteParams)
-      finalPhaseExportPaths.push(...withFallbackRouteParams)
+      initialPhaseExportPaths.push(...otherExportPaths)
+      finalPhaseExportPaths.push(...allowEmptyStaticShellExportPaths)
     } else {
       initialPhaseExportPaths.push(...exportPaths)
     }

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -21,12 +21,13 @@ export interface AmpValidation {
   }
 }
 
-type PathMap = ExportPathMap[keyof ExportPathMap]
+export type ExportPathEntry = ExportPathMap[keyof ExportPathMap] & {
+  path: string
+}
 
 export interface ExportPagesInput {
   buildId: string
-  paths: string[]
-  exportPathMap: ExportPathMap
+  exportPaths: ExportPathEntry[]
   parentSpanId: number
   dir: string
   distDir: string
@@ -43,8 +44,7 @@ export interface ExportPagesInput {
 
 export interface ExportPageInput {
   buildId: string
-  path: string
-  pathMap: PathMap
+  exportPath: ExportPathEntry
   distDir: string
   outDir: string
   pagesDataDir: string
@@ -86,6 +86,7 @@ export type ExportPageResult = ExportRouteResult & {
 export type ExportPagesResult = {
   result: ExportPageResult | undefined
   path: string
+  page: string
   pageKey: string
 }[]
 

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -75,7 +75,7 @@ export async function loadStaticPaths({
   buildId: string
   authInterrupts: boolean
   sriEnabled: boolean
-}): Promise<Partial<StaticPathsResult>> {
+}): Promise<StaticPathsResult> {
   // this needs to be initialized before loadComponents otherwise
   // "use cache" could be missing it's cache handlers
   await createIncrementalCache({

--- a/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
+++ b/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
@@ -14,8 +14,6 @@ describe('build-output-tree-view', () => {
     beforeAll(() => next.build())
 
     it('should show info about prerendered and dynamic routes in a tree view', async () => {
-      // TODO: Fix double-listing of the /ppr/[slug] fallback.
-
       expect(getTreeView(next.cliOutput)).toMatchInlineSnapshot(`
        "Route (app)                      Size  First Load JS  Revalidate  Expire
        ┌ ○ /_not-found                N/A kB         N/A kB
@@ -26,7 +24,6 @@ describe('build-output-tree-view', () => {
        ├ ○ /cache-life-hours          N/A kB         N/A kB          1h      1d
        ├ ƒ /dynamic                   N/A kB         N/A kB
        ├ ◐ /ppr/[slug]                N/A kB         N/A kB          1w     30d
-       ├   ├ /ppr/[slug]                                             1w     30d
        ├   ├ /ppr/[slug]                                             1w     30d
        ├   ├ /ppr/days                                               1d      1w
        ├   └ /ppr/weeks                                              1w     30d


### PR DESCRIPTION
When `experimental.dynamicIO` is enabled, we're now prerendering fallback shells for routes that have some entries defined in `generateStaticParams` in a second phase, after the more specific route are prerendered.

This will allow us to offer better error messages when those fallback prerenders timeout due to accessing params inside of `"use cache"`. In the future, we might even be able to avoid waiting for a timeout in this case, if we share the resume data cache between the two prerender phases. This would also reduce most of the build performance cost we're adding with this PR temporarily (when the feature flag is enabled). [^1]

We're also fixing a bug with this PR, where PPR shells for routes with dynamic params were listed twice in the build output.

[^1]: Note that `fetch` responses are already cached and shared between the two phases.