### PR TITLE
docs: Fix XSS vulnerability in JSON-LD guide example

### DIFF
--- a/docs/01-app/02-guides/json-ld.mdx
+++ b/docs/01-app/02-guides/json-ld.mdx
@@ -9,10 +9,15 @@ description: Learn how to add JSON-LD to your Next.js application to describe yo
 Our current recommendation for JSON-LD is to render structured data as a `<script>` tag in your `layout.js` or `page.js` components. For example:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
+function escapeJsonForScript(obj: any): string {
+  return JSON.stringify(obj).replace(/</g, '\\u003c').replace(/>/g, '\\u003e')
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   const product = await getProduct(id)
-
+  
+  // Ensure product data is properly sanitized before use
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Product',
@@ -20,13 +25,13 @@ export default async function Page({ params }) {
     image: product.image,
     description: product.description,
   }
-
+  
   return (
     <section>
       {/* Add JSON-LD to your page */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonForScript(jsonLd) }}
       />
       {/* ... */}
     </section>
@@ -35,10 +40,15 @@ export default async function Page({ params }) {
 ```
 
 ```jsx filename="app/products/[id]/page.js" switcher
+function escapeJsonForScript(obj) {
+  return JSON.stringify(obj).replace(/</g, '\\u003c').replace(/>/g, '\\u003e')
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   const product = await getProduct(id)
-
+  
+  // Ensure product data is properly sanitized before use
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Product',
@@ -46,19 +56,21 @@ export default async function Page({ params }) {
     image: product.image,
     description: product.description,
   }
-
+  
   return (
     <section>
       {/* Add JSON-LD to your page */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonForScript(jsonLd) }}
       />
       {/* ... */}
     </section>
   )
 }
 ```
+
+> **Security Note**: When using `dangerouslySetInnerHTML` with JSON-LD, it's important to escape HTML characters to prevent XSS attacks. The `escapeJsonForScript` function above replaces `<` and `>` characters with their Unicode escape sequences to prevent script injection. Always ensure that any user-generated content is properly sanitized before including it in JSON-LD structured data.
 
 You can validate and test your structured data with the [Rich Results Test](https://search.google.com/test/rich-results) for Google or the generic [Schema Markup Validator](https://validator.schema.org/).
 


### PR DESCRIPTION
## Problem
The JSON-LD documentation example uses `dangerouslySetInnerHTML` with `JSON.stringify()` without proper escaping, creating an XSS vulnerability. Malicious content in product data (e.g., `product.name` containing `</script><script>alert(1);</script>`) could break out of the script tag and execute arbitrary JavaScript.

## Solution
- Added `escapeJsonForScript()` helper function that escapes `<` and `>` characters using Unicode escape sequences
- Added security warning in documentation explaining the XSS risk
- Added comment reminding developers to sanitize user data
- Maintained example simplicity while making it secure

## Security Impact
This change prevents potential XSS attacks that could occur when user-controlled data is included in JSON-LD structured data without proper escaping.

## Testing
- [ ] Verified the escaped JSON is still valid JSON-LD
- [ ] Confirmed malicious payloads are properly escaped
- [ ] Documentation renders correctly

Fixes: XSS vulnerability in JSON-LD documentation example