### PR TITLE
flag no-async-client-components for named exports too

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
+++ b/packages/eslint-plugin-next/src/rules/no-async-client-component.ts
@@ -33,7 +33,11 @@ export = defineRule({
             isClientComponent = true
           }
 
-          if (block.type === 'ExportDefaultDeclaration' && isClientComponent) {
+          const isExported =
+            block.type === 'ExportNamedDeclaration' ||
+            block.type === 'ExportDefaultDeclaration'
+
+          if (isExported && isClientComponent) {
             // export default async function MyComponent() {...}
             if (
               block.declaration?.type === 'FunctionDeclaration' &&


### PR DESCRIPTION
### Adding a feature

Fixes #77243

Currently, only default exports will be reported as errors against this lint rule, but named client components can still be exported and imported and break the spirit of this rule.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #77243
