### PR TITLE
Turbopack Build: Fix conflicting page error

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -790,8 +790,8 @@ impl Issue for DuplicateParallelRouteIssue {
             format!(
                 "You cannot have two parallel pages that resolve to the same path. Please check \
                  {} and {}.",
-                this.previously_inserted_page.to_string(),
-                this.page.to_string()
+                this.previously_inserted_page,
+                this.page
             )
             .into(),
         )

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -790,8 +790,7 @@ impl Issue for DuplicateParallelRouteIssue {
             format!(
                 "You cannot have two parallel pages that resolve to the same path. Please check \
                  {} and {}.",
-                this.previously_inserted_page,
-                this.page
+                this.previously_inserted_page, this.page
             )
             .into(),
         )

--- a/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
+++ b/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('conflicting-page-segments', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -25,10 +25,11 @@ describe('conflicting-page-segments', () => {
     } else {
       await expect(next.start()).rejects.toThrow('next build failed')
 
-      await check(
-        () => next.cliOutput,
-        /You cannot have two parallel pages that resolve to the same path\. Please check \/\(group-a\)\/page and \/\(group-b\)\/page\./i
-      )
+      await retry(() => {
+        expect(next.cliOutput).toMatch(
+          /You cannot have two parallel pages that resolve to the same path\. Please check \/\(group-a\)(\/page)? and \/\(group-b\)(\/page)?\./i
+        )
+      })
     }
   })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1641,10 +1641,10 @@
     "runtimeError": false
   },
   "test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "conflicting-page-segments should throw an error when a route groups causes a conflict with a parallel segment"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Implements the missing part of the error to make the test pass.

Small difference between webpack/Turbopack is that Turbopack will spot the conflict earlier and because of that errors earlier too, making the path still correct but shorter, not a problem in my opinion.

Closes PACK-4691