### PR TITLE
Enable preview builds for forks

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -532,7 +532,7 @@ jobs:
           path: crates/wasm
 
       - name: Create tarballs
-        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ runner.temp }}/preview-tarballs"
+        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.workflow_sha }}" "${{ runner.temp }}/preview-tarballs"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@v4

--- a/scripts/create-preview-tarballs.js
+++ b/scripts/create-preview-tarballs.js
@@ -6,7 +6,8 @@ const path = require('node:path')
 
 async function main() {
   const [
-    commitSha,
+    githubSha,
+    githubWorkflowSha,
     tarballDirectory = path.join(os.tmpdir(), 'vercel-nextjs-preview-tarballs'),
   ] = process.argv.slice(2)
   const repoRoot = path.resolve(__dirname, '..')
@@ -14,7 +15,7 @@ async function main() {
   await fs.mkdir(tarballDirectory, { recursive: true })
 
   const [{ stdout: shortSha }, { stdout: dateString }] = await Promise.all([
-    execa('git', ['rev-parse', '--short', commitSha]),
+    execa('git', ['rev-parse', '--short', githubSha]),
     // Source: https://github.com/facebook/react/blob/767f52237cf7892ad07726f21e3e8bacfc8af839/scripts/release/utils.js#L114
     execa(`git`, [
       'show',
@@ -22,7 +23,7 @@ async function main() {
       '--no-show-signature',
       '--format=%cd',
       '--date=format:%Y%m%d',
-      commitSha,
+      githubSha,
     ]),
   ])
 
@@ -97,16 +98,18 @@ async function main() {
   ])
   const packages = JSON.parse(lernaListJson.stdout)
   const packagesByVersion = new Map()
+  // vercel-packages finds GH artifacts via the head SHA because that's the only
+  // API GitHub offers.
   for (const packageInfo of packages) {
     packagesByVersion.set(
       packageInfo.name,
-      `https://vercel-packages.vercel.app/next/commits/${commitSha}/${packageInfo.name}`
+      `https://vercel-packages.vercel.app/next/commits/${githubWorkflowSha}/${packageInfo.name}`
     )
   }
   for (const nextSwcPackageName of nextSwcPackageNames) {
     packagesByVersion.set(
       nextSwcPackageName,
-      `https://vercel-packages.vercel.app/next/commits/${commitSha}/${nextSwcPackageName}`
+      `https://vercel-packages.vercel.app/next/commits/${githubWorkflowSha}/${nextSwcPackageName}`
     )
   }
 


### PR DESCRIPTION
GitHub only has an API to find artifacts by head sha. However, on forks, we run on the merge commit (GitHub default). So the endpoint on vercel-packages needs the head sha even though the artifact will be built on a different commit.

The `version` field will be always the correct thing. The mismatching commit for forked PRs is a necessary evil until we either always run CI/CD on head commits or GitHub adds an API to find workflows by merge commit.

docs: https://github.com/vercel/vercel-packages/pull/46

## Test plan

- [x] https://vercel-packages.vercel.app/next/prs/79648/next references dependencies that exist