### PR TITLE
[dev-tools] assert types for dev overlay entries

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -220,7 +220,9 @@ export async function fetchServerResponse(
     // In dev, the Webpack runtime is minimal for each page.
     // We need to ensure the Webpack runtime is updated before executing client-side JS of the new page.
     if (process.env.NODE_ENV !== 'production' && !process.env.TURBOPACK) {
-      await require('../react-dev-overlay/app/hot-reloader-client').waitForWebpackRuntimeHotUpdate()
+      await (
+        require('../react-dev-overlay/app/hot-reloader-client') as typeof import('../react-dev-overlay/app/hot-reloader-client')
+      ).waitForWebpackRuntimeHotUpdate()
     }
 
     // Handle the `fetch` readable stream that can be unwrapped by `React.use`.

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -48,6 +48,7 @@ import {
 import { onRecoverableError } from './react-client-callbacks/on-recoverable-error'
 import tracer from './tracing/tracer'
 import { isNextRouterError } from './components/is-next-router-error'
+import type { PagesDevOverlayType } from './components/react-dev-overlay/pages/pages-dev-overlay'
 
 /// <reference types="react-dom/experimental" />
 
@@ -179,9 +180,9 @@ class Container extends React.Component<{
     if (process.env.NODE_ENV === 'production') {
       return this.props.children
     } else {
-      const {
-        PagesDevOverlay,
-      }: typeof import('./components/react-dev-overlay/pages/pages-dev-overlay') = require('./components/react-dev-overlay/pages/pages-dev-overlay')
+      const PagesDevOverlay =
+        require('./components/react-dev-overlay/pages/pages-dev-overlay')
+          .PagesDevOverlay as PagesDevOverlayType
       return <PagesDevOverlay>{this.props.children}</PagesDevOverlay>
     }
   }

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -48,7 +48,6 @@ import {
 import { onRecoverableError } from './react-client-callbacks/on-recoverable-error'
 import tracer from './tracing/tracer'
 import { isNextRouterError } from './components/is-next-router-error'
-import type { PagesDevOverlayType } from './components/react-dev-overlay/pages/pages-dev-overlay'
 
 /// <reference types="react-dom/experimental" />
 
@@ -182,7 +181,7 @@ class Container extends React.Component<{
     } else {
       const PagesDevOverlay =
         require('./components/react-dev-overlay/pages/pages-dev-overlay')
-          .PagesDevOverlay as PagesDevOverlayType
+          .PagesDevOverlay as typeof import('./components/react-dev-overlay/pages/pages-dev-overlay').PagesDevOverlay
       return <PagesDevOverlay>{this.props.children}</PagesDevOverlay>
     }
   }


### PR DESCRIPTION
This PR asserted correct types to DevOverlay entries with `require()` calls.

https://github.com/vercel/next.js/blob/bcb38e4a4866cfa7a62fe988e47de84e8486e1a0/packages/next/src/build/templates/pages.ts#L166-L172 is omitted because is removing at https://github.com/vercel/next.js/pull/79641.