### PR TITLE
Turbopack: split meta data and AQMF into separate files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9491,6 +9491,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "either",
  "jiff",
  "lzzzz",
  "memmap2 0.9.5",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT"
 
 [features]
+default = []
 verify_sst_content = []
 strict_checks = []
 stats = ["quick_cache/stats"]
@@ -12,6 +13,7 @@ print_stats = ["stats"]
 
 [dependencies]
 anyhow = { workspace = true }
+either = { workspace = true }
 pot = "3.0.0"
 byteorder = "1.5.0"
 jiff = "0.2.10"

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -36,7 +36,7 @@ Therefore there are there value types:
 A meta file can contain metadata about multiple SST files. The metadata is stored in a single file to avoid having too many small files.
 
 - Header
-  - 4 bytes magic number and version
+  - 4 bytes magic number (0xFE4ADA4A)
   - 4 bytes key family
   - 4 bytes count of obsolete SST files
   - foreach obsolete SST file

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -38,6 +38,9 @@ A meta file can contain metadata about multiple SST files. The metadata is store
 - Header
   - 4 bytes magic number and version
   - 4 bytes key family
+  - 4 bytes count of obsolete SST files
+  - foreach obsolete SST file
+    - 4 bytes sequence number of the obsolete SST file
   - 4 bytes count of described SST files
   - foreach described SST file
     - 4 bytes sequence number of the SST file

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -21,7 +21,7 @@ pub trait Compactable {
     fn range(&self) -> Range;
 
     /// Returns the size of the compactable.
-    fn size(&self) -> usize;
+    fn size(&self) -> u64;
 }
 
 fn is_overlapping(a: &Range, b: &Range) -> bool {
@@ -65,7 +65,7 @@ pub struct CompactConfig {
     pub max_merge: usize,
 
     /// The maximum size of all files to merge at once.
-    pub max_merge_size: usize,
+    pub max_merge_size: u64,
 }
 
 /// For a list of compactables, computes merge and move jobs that are expected to perform best.
@@ -228,7 +228,7 @@ mod tests {
 
     struct TestCompactable {
         range: Range,
-        size: usize,
+        size: u64,
     }
 
     impl Compactable for TestCompactable {
@@ -236,7 +236,7 @@ mod tests {
             self.range
         }
 
-        fn size(&self) -> usize {
+        fn size(&self) -> u64 {
             self.size
         }
     }
@@ -244,7 +244,7 @@ mod tests {
     fn compact<const N: usize>(
         ranges: [(u64, u64); N],
         max_merge: usize,
-        max_merge_size: usize,
+        max_merge_size: u64,
     ) -> CompactionJobs {
         let compactables = ranges
             .iter()
@@ -277,7 +277,7 @@ mod tests {
                 (30, 40),
             ],
             3,
-            usize::MAX,
+            u64::MAX,
         );
         assert_eq!(merge_jobs, vec![vec![0, 1, 2], vec![4, 5, 6]]);
         assert_eq!(move_jobs, vec![3, 8]);
@@ -341,7 +341,7 @@ mod tests {
                 let config = CompactConfig {
                     max_merge: 4,
                     min_merge: 2,
-                    max_merge_size: usize::MAX,
+                    max_merge_size: u64::MAX,
                 };
                 let jobs = get_compaction_jobs(&containers, &config);
                 if !jobs.is_empty() {
@@ -387,8 +387,8 @@ mod tests {
             (self.keys[0], *self.keys.last().unwrap())
         }
 
-        fn size(&self) -> usize {
-            self.keys.len()
+        fn size(&self) -> u64 {
+            self.keys.len() as u64
         }
     }
 

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -18,6 +18,7 @@ use lzzzz::lz4::decompress;
 use memmap2::Mmap;
 use parking_lot::{Mutex, RwLock};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use rustc_hash::FxHashSet;
 use tracing::Span;
 
 use crate::{
@@ -32,12 +33,14 @@ use crate::{
         VALUE_BLOCK_CACHE_SIZE,
     },
     key::{StoreKey, hash_key},
-    lookup_entry::LookupEntry,
+    lookup_entry::{LookupEntry, LookupValue},
     merge_iter::MergeIter,
-    static_sorted_file::{
-        AqmfCache, BlockCache, LookupResult, StaticSortedFile, StaticSortedFileRange,
+    meta_file::{
+        ApplySstFilterResult, AqmfCache, MetaFile, MetaLookupResult, StaticSortedFileRange,
     },
-    static_sorted_file_builder::StaticSortedFileBuilder,
+    meta_file_builder::MetaFileBuilder,
+    static_sorted_file::{BlockCache, SstLookupResult},
+    static_sorted_file_builder::{StaticSortedFileBuilder, StaticSortedFileBuilderMetaResult},
     write_batch::{FinishResult, WriteBatch},
 };
 
@@ -79,12 +82,14 @@ impl CacheStatistics {
 #[cfg(feature = "stats")]
 #[derive(Debug)]
 pub struct Statistics {
+    pub meta_files: usize,
     pub sst_files: usize,
     pub key_block_cache: CacheStatistics,
     pub value_block_cache: CacheStatistics,
     pub aqmf_cache: CacheStatistics,
     pub hits: u64,
     pub misses: u64,
+    pub miss_family: u64,
     pub miss_range: u64,
     pub miss_aqmf: u64,
     pub miss_key: u64,
@@ -96,6 +101,7 @@ struct TrackedStats {
     hits_deleted: std::sync::atomic::AtomicU64,
     hits_small: std::sync::atomic::AtomicU64,
     hits_blob: std::sync::atomic::AtomicU64,
+    miss_family: std::sync::atomic::AtomicU64,
     miss_range: std::sync::atomic::AtomicU64,
     miss_aqmf: std::sync::atomic::AtomicU64,
     miss_key: std::sync::atomic::AtomicU64,
@@ -128,8 +134,8 @@ pub struct TurboPersistence {
 
 /// The inner state of the database.
 struct Inner {
-    /// The list of SST files in the database in order.
-    static_sorted_files: Vec<StaticSortedFile>,
+    /// The list of meta files in the database. This is used to derive the SST files.
+    meta_files: Vec<MetaFile>,
     /// The current sequence number for the database.
     current_sequence_number: u32,
 }
@@ -143,7 +149,7 @@ impl TurboPersistence {
         let mut db = Self {
             path,
             inner: RwLock::new(Inner {
-                static_sorted_files: Vec::new(),
+                meta_files: Vec::new(),
                 current_sequence_number: 0,
             }),
             idle_write_batch: Mutex::new(None),
@@ -217,7 +223,7 @@ impl TurboPersistence {
 
     /// Loads an existing database directory and performs cleanup if necessary.
     fn load_directory(&mut self, entries: ReadDir) -> Result<bool> {
-        let mut sst_files = Vec::new();
+        let mut meta_files = Vec::new();
         let mut current_file = match File::open(self.path.join("CURRENT")) {
             Ok(file) => file,
             Err(e) => {
@@ -249,8 +255,8 @@ impl TurboPersistence {
                     fs::remove_file(&path)?;
                 } else {
                     match ext {
-                        "sst" => {
-                            sst_files.push(seq);
+                        "meta" => {
+                            meta_files.push(seq);
                         }
                         "del" => {
                             let mut content = &*fs::read(&path)?;
@@ -259,8 +265,9 @@ impl TurboPersistence {
                                 let seq = content.read_u32::<BE>()?;
                                 deleted_files.insert(seq);
                                 let sst_file = self.path.join(format!("{seq:08}.sst"));
+                                let meta_file = self.path.join(format!("{seq:08}.meta"));
                                 let blob_file = self.path.join(format!("{seq:08}.blob"));
-                                for path in [sst_file, blob_file] {
+                                for path in [sst_file, blob_file, meta_file] {
                                     if fs::exists(&path)? {
                                         fs::remove_file(path)?;
                                         no_existing_files = false;
@@ -271,8 +278,8 @@ impl TurboPersistence {
                                 fs::remove_file(&path)?;
                             }
                         }
-                        "blob" => {
-                            // ignore blobs, they are read when needed
+                        "blob" | "sst" => {
+                            // ignore blobs and sst, they are read when needed
                         }
                         _ => {
                             if !path
@@ -304,41 +311,31 @@ impl TurboPersistence {
             }
         }
 
-        sst_files.retain(|seq| !deleted_files.contains(seq));
-        sst_files.sort_unstable();
-        let sst_files = sst_files
-            .into_iter()
-            .map(|seq| self.open_sst(seq))
-            .collect::<Result<Vec<StaticSortedFile>>>()?;
-        #[cfg(feature = "print_stats")]
-        {
-            for sst in sst_files.iter() {
-                let crate::static_sorted_file::StaticSortedFileRange {
-                    family,
-                    min_hash,
-                    max_hash,
-                } = sst.range()?;
-                println!(
-                    "SST {}  {} {:016x} - {:016x}  {:016x}",
-                    sst.sequence_number(),
-                    family,
-                    min_hash,
-                    max_hash,
-                    max_hash - min_hash
-                );
-            }
-        }
+        meta_files.retain(|seq| !deleted_files.contains(seq));
+        meta_files.sort_unstable();
+        let span = Span::current();
+        let mut meta_files = meta_files
+            .into_par_iter()
+            .with_min_len(1)
+            .map(|seq| {
+                let _span = span.enter();
+                let meta_file = MetaFile::open(&self.path, seq)?;
+                Ok(meta_file)
+            })
+            .collect::<Result<Vec<MetaFile>>>()?;
+
+        let mut open_sst_seq_numbers = FxHashSet::default();
+        meta_files.retain_mut(|meta_file| {
+            !matches!(
+                meta_file.apply_sst_filter(|seq| open_sst_seq_numbers.insert(seq)),
+                ApplySstFilterResult::Empty
+            )
+        });
+
         let inner = self.inner.get_mut();
-        inner.static_sorted_files = sst_files;
+        inner.meta_files = meta_files;
         inner.current_sequence_number = current;
         Ok(true)
-    }
-
-    /// Opens a single SST file. This memory maps the file, but doesn't read it yet.
-    fn open_sst(&self, seq: u32) -> Result<StaticSortedFile> {
-        let path = self.path.join(format!("{seq:08}.sst"));
-        StaticSortedFile::open(seq, path)
-            .with_context(|| format!("Unable to open sst file {seq:08}.sst"))
     }
 
     /// Reads and decompresses a blob file. This is not backed by any cache.
@@ -367,7 +364,7 @@ impl TurboPersistence {
 
     /// Returns true if the database is empty.
     pub fn is_empty(&self) -> bool {
-        self.inner.read().static_sorted_files.is_empty()
+        self.inner.read().meta_files.is_empty()
     }
 
     /// Starts a new WriteBatch for the database. Only a single write operation is allowed at a
@@ -415,10 +412,20 @@ impl TurboPersistence {
     ) -> Result<()> {
         let FinishResult {
             sequence_number,
+            new_meta_files,
             new_sst_files,
             new_blob_files,
+            keys_written,
         } = write_batch.finish()?;
-        self.commit(new_sst_files, new_blob_files, vec![], sequence_number)?;
+        self.commit(
+            new_meta_files,
+            new_sst_files,
+            new_blob_files,
+            vec![],
+            vec![],
+            sequence_number,
+            keys_written,
+        )?;
         self.active_write_operation.store(false, Ordering::Release);
         self.idle_write_batch.lock().replace((
             TypeId::of::<WriteBatch<K, FAMILIES>>(),
@@ -431,61 +438,102 @@ impl TurboPersistence {
     /// new files.
     fn commit(
         &self,
+        mut new_meta_files: Vec<(u32, File)>,
         mut new_sst_files: Vec<(u32, File)>,
-        new_blob_files: Vec<(u32, File)>,
-        mut indicies_to_delete: Vec<usize>,
+        mut new_blob_files: Vec<(u32, File)>,
+        mut sst_seq_numbers_to_delete: Vec<u32>,
+        mut blob_seq_numbers_to_delete: Vec<u32>,
         mut seq: u32,
+        keys_written: u64,
     ) -> Result<(), anyhow::Error> {
         let time = Timestamp::now();
 
-        new_sst_files.sort_unstable_by_key(|(seq, _)| *seq);
+        new_meta_files.sort_unstable_by_key(|(seq, _)| *seq);
 
-        let mut new_sst_files = new_sst_files
-            .into_iter()
+        let mut new_sst_seq_numbers = FxHashSet::default();
+        let mut new_meta_files = new_meta_files
+            .into_par_iter()
+            .with_min_len(1)
             .map(|(seq, file)| {
                 file.sync_all()?;
-                self.open_sst(seq)
+                let meta_file = MetaFile::open(&self.path, seq)?;
+                Ok(meta_file)
             })
             .collect::<Result<Vec<_>>>()?;
 
+        for meta_file in new_meta_files.iter_mut() {
+            let result = meta_file.apply_sst_filter(|seq| new_sst_seq_numbers.insert(seq));
+            debug_assert_eq!(result, ApplySstFilterResult::Unmodified);
+        }
+
+        for (_, file) in new_sst_files.iter() {
+            file.sync_all()?;
+        }
         for (_, file) in new_blob_files.iter() {
             file.sync_all()?;
         }
 
-        let new_sst_info = new_sst_files
+        let new_meta_info = new_meta_files
             .iter()
-            .map(|sst| {
-                let seq = sst.sequence_number();
-                let range = sst.range()?;
-                let size = sst.size();
-                Ok((seq, range.family, range.min_hash, range.max_hash, size))
+            .map(|meta| {
+                let ssts = meta
+                    .entries()
+                    .iter()
+                    .map(|entry| {
+                        let seq = entry.sequence_number();
+                        let range = entry.range();
+                        let size = entry.size();
+                        (seq, range.min_hash, range.max_hash, size)
+                    })
+                    .collect::<Vec<_>>();
+                (meta.sequence_number(), meta.family(), ssts)
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Vec<_>>();
 
-        if !indicies_to_delete.is_empty() {
-            seq += 1;
-        }
-
-        let removed_ssts;
+        let has_delete_file;
+        let mut meta_seq_numbers_to_delete = Vec::new();
 
         {
             let mut inner = self.inner.write();
+            inner.meta_files.retain_mut(|meta| {
+                if matches!(
+                    meta.apply_sst_filter(|seq| !new_sst_seq_numbers.contains(&seq)),
+                    ApplySstFilterResult::Empty
+                ) {
+                    meta_seq_numbers_to_delete.push(meta.sequence_number());
+                    false
+                } else {
+                    true
+                }
+            });
+            has_delete_file = !sst_seq_numbers_to_delete.is_empty()
+                || !blob_seq_numbers_to_delete.is_empty()
+                || !meta_seq_numbers_to_delete.is_empty();
+            if has_delete_file {
+                seq += 1;
+            }
             inner.current_sequence_number = seq;
-            indicies_to_delete.sort_unstable();
-            removed_ssts = remove_indicies(&mut inner.static_sorted_files, &indicies_to_delete);
-            inner.static_sorted_files.append(&mut new_sst_files);
+            inner.meta_files.append(&mut new_meta_files);
         }
 
-        let mut removed_ssts = removed_ssts
-            .into_iter()
-            .map(|sst| sst.sequence_number())
-            .collect::<Vec<_>>();
-        removed_ssts.sort_unstable();
-
-        if !indicies_to_delete.is_empty() {
+        if has_delete_file {
+            sst_seq_numbers_to_delete.sort_unstable();
+            meta_seq_numbers_to_delete.sort_unstable();
+            blob_seq_numbers_to_delete.sort_unstable();
             // Write *.del file, marking the selected files as to delete
-            let mut buf = Vec::with_capacity(removed_ssts.len() * 4);
-            for seq in removed_ssts.iter() {
+            let mut buf = Vec::with_capacity(
+                (sst_seq_numbers_to_delete.len()
+                    + meta_seq_numbers_to_delete.len()
+                    + blob_seq_numbers_to_delete.len())
+                    * 4,
+            );
+            for seq in sst_seq_numbers_to_delete.iter() {
+                buf.write_u32::<BE>(*seq)?;
+            }
+            for seq in meta_seq_numbers_to_delete.iter() {
+                buf.write_u32::<BE>(*seq)?;
+            }
+            for seq in blob_seq_numbers_to_delete.iter() {
                 buf.write_u32::<BE>(*seq)?;
             }
             let mut file = File::create(self.path.join(format!("{seq:08}.del")))?;
@@ -501,31 +549,47 @@ impl TurboPersistence {
         current_file.write_u32::<BE>(seq)?;
         current_file.sync_all()?;
 
-        for seq in removed_ssts {
+        for seq in sst_seq_numbers_to_delete.iter() {
             fs::remove_file(self.path.join(format!("{seq:08}.sst")))?;
+        }
+        for seq in meta_seq_numbers_to_delete.iter() {
+            fs::remove_file(self.path.join(format!("{seq:08}.meta")))?;
+        }
+        for seq in blob_seq_numbers_to_delete.iter() {
+            fs::remove_file(self.path.join(format!("{seq:08}.blob")))?;
         }
 
         {
             let mut log = self.open_log()?;
             writeln!(log, "Time {time}")?;
             let span = time.until(Timestamp::now())?;
-            writeln!(log, "Commit {seq:08} {span:#}")?;
-            for (index, family, min, max, size) in new_sst_info.iter() {
-                writeln!(
-                    log,
-                    "{:08} SST family:{} {:016x}-{:016x} {} MiB",
-                    index,
-                    family,
-                    min,
-                    max,
-                    size / 1024 / 1024
-                )?;
+            writeln!(log, "Commit {seq:08} {keys_written} keys in {span:#}")?;
+            for (seq, family, ssts) in new_meta_info {
+                writeln!(log, "{seq:08} META family:{family}",)?;
+                for (seq, min, max, size) in ssts {
+                    writeln!(
+                        log,
+                        "  {seq:08} SST  {min:016x}-{max:016x} {} MiB",
+                        size / 1024 / 1024
+                    )?;
+                }
             }
+            new_sst_files.sort_unstable_by_key(|(seq, _)| *seq);
+            for (seq, _) in new_sst_files.iter() {
+                writeln!(log, "{seq:08} NEW SST")?;
+            }
+            new_blob_files.sort_unstable_by_key(|(seq, _)| *seq);
             for (seq, _) in new_blob_files.iter() {
-                writeln!(log, "{seq:08} BLOB")?;
+                writeln!(log, "{seq:08} NEW BLOB")?;
             }
-            for index in indicies_to_delete.iter() {
-                writeln!(log, "{index:08} DELETED")?;
+            for seq in sst_seq_numbers_to_delete.iter() {
+                writeln!(log, "{seq:08} SST DELETED")?;
+            }
+            for seq in meta_seq_numbers_to_delete.iter() {
+                writeln!(log, "{seq:08} META DELETED")?;
+            }
+            for seq in blob_seq_numbers_to_delete.iter() {
+                writeln!(log, "{seq:08} BLOB DELETED")?;
             }
         }
 
@@ -535,7 +599,7 @@ impl TurboPersistence {
     /// Runs a full compaction on the database. This will rewrite all SST files, removing all
     /// duplicate keys and separating all key ranges into unique files.
     pub fn full_compact(&self) -> Result<()> {
-        self.compact(0.0, usize::MAX, usize::MAX)?;
+        self.compact(0.0, usize::MAX, u64::MAX)?;
         Ok(())
     }
 
@@ -547,7 +611,7 @@ impl TurboPersistence {
         &self,
         max_coverage: f32,
         max_merge_sequence: usize,
-        max_merge_size: usize,
+        max_merge_size: u64,
     ) -> Result<()> {
         let _span = tracing::info_span!("compact database").entered();
         if self
@@ -562,29 +626,38 @@ impl TurboPersistence {
         }
 
         let mut sequence_number;
+        let mut new_meta_files = Vec::new();
         let mut new_sst_files = Vec::new();
-        let mut indicies_to_delete = Vec::new();
+        let mut sst_seq_numbers_to_delete = Vec::new();
+        let mut blob_seq_numbers_to_delete = Vec::new();
+        let mut keys_written = 0;
 
         {
             let inner = self.inner.read();
             sequence_number = AtomicU32::new(inner.current_sequence_number);
             self.compact_internal(
-                &inner.static_sorted_files,
+                &inner.meta_files,
                 &sequence_number,
+                &mut new_meta_files,
                 &mut new_sst_files,
-                &mut indicies_to_delete,
+                &mut sst_seq_numbers_to_delete,
+                &mut blob_seq_numbers_to_delete,
+                &mut keys_written,
                 max_coverage,
                 max_merge_sequence,
                 max_merge_size,
             )?;
         }
 
-        if !new_sst_files.is_empty() {
+        if !new_meta_files.is_empty() {
             self.commit(
+                new_meta_files,
                 new_sst_files,
                 Vec::new(),
-                indicies_to_delete,
+                sst_seq_numbers_to_delete,
+                blob_seq_numbers_to_delete,
                 *sequence_number.get_mut(),
+                keys_written,
             )?;
         }
 
@@ -596,22 +669,27 @@ impl TurboPersistence {
     /// Internal function to perform a compaction.
     fn compact_internal(
         &self,
-        static_sorted_files: &[StaticSortedFile],
+        meta_files: &[MetaFile],
         sequence_number: &AtomicU32,
+        new_meta_files: &mut Vec<(u32, File)>,
         new_sst_files: &mut Vec<(u32, File)>,
-        indicies_to_delete: &mut Vec<usize>,
+        sst_seq_numbers_to_delete: &mut Vec<u32>,
+        blob_seq_numbers_to_delete: &mut Vec<u32>,
+        keys_written: &mut u64,
         max_coverage: f32,
         max_merge_sequence: usize,
-        max_merge_size: usize,
+        max_merge_size: u64,
     ) -> Result<()> {
-        if static_sorted_files.is_empty() {
+        if meta_files.is_empty() {
             return Ok(());
         }
 
         struct SstWithRange {
-            index: usize,
+            meta_index: usize,
+            index_in_meta: u32,
+            seq: u32,
             range: StaticSortedFileRange,
-            size: usize,
+            size: u64,
         }
 
         impl Compactable for SstWithRange {
@@ -619,20 +697,25 @@ impl TurboPersistence {
                 (self.range.min_hash, self.range.max_hash)
             }
 
-            fn size(&self) -> usize {
+            fn size(&self) -> u64 {
                 self.size
             }
         }
 
-        let ssts_with_ranges = static_sorted_files
+        let ssts_with_ranges = meta_files
             .iter()
             .enumerate()
-            .flat_map(|(index, sst)| {
-                sst.range().ok().map(|range| SstWithRange {
-                    index,
-                    range,
-                    size: sst.size(),
-                })
+            .flat_map(|(meta_index, meta)| {
+                meta.entries()
+                    .iter()
+                    .enumerate()
+                    .map(move |(index_in_meta, entry)| SstWithRange {
+                        meta_index,
+                        index_in_meta: index_in_meta as u32,
+                        seq: entry.sequence_number(),
+                        range: entry.range(),
+                        size: entry.size(),
+                    })
             })
             .collect::<Vec<_>>();
 
@@ -661,10 +744,11 @@ impl TurboPersistence {
             .with_min_len(1)
             .enumerate()
             .map(|(family, ssts_with_ranges)| {
+                let family = family as u32;
                 let _span = span.clone().entered();
                 let coverage = total_coverage(&ssts_with_ranges, (0, u64::MAX));
                 if coverage <= max_coverage {
-                    return Ok((Vec::new(), Vec::new()));
+                    return Ok((None, Vec::new(), Vec::new(), Vec::new(), 0));
                 }
 
                 let CompactionJobs {
@@ -689,29 +773,22 @@ impl TurboPersistence {
                     for job in merge_jobs.iter() {
                         writeln!(log, "  merge")?;
                         for i in job.iter() {
-                            let index = ssts_with_ranges[*i].index;
+                            let seq = ssts_with_ranges[*i].seq;
                             let (min, max) = ssts_with_ranges[*i].range();
-                            writeln!(log, "    {index:08} {min:016x}-{max:016x}")?;
-                        }
-                    }
-                    if !move_jobs.is_empty() {
-                        writeln!(log, "  move")?;
-                        for i in move_jobs.iter() {
-                            let index = ssts_with_ranges[*i].index;
-                            let (min, max) = ssts_with_ranges[*i].range();
-                            writeln!(log, "    {index:08} {min:016x}-{max:016x}")?;
+                            writeln!(log, "    {seq:08} {min:016x}-{max:016x}")?;
                         }
                     }
                     drop(guard);
                 }
 
-                // Later we will remove the merged and moved files
-                let indicies_to_delete = merge_jobs
+                // Later we will remove the merged files
+                let sst_seq_numbers_to_delete = merge_jobs
                     .iter()
                     .flat_map(|l| l.iter().copied())
-                    .chain(move_jobs.iter().copied())
-                    .map(|index| ssts_with_ranges[index].index)
+                    .map(|index| ssts_with_ranges[index].seq)
                     .collect::<Vec<_>>();
+
+                let meta_file_builder = Mutex::new(MetaFileBuilder::new(family));
 
                 // Merge SST files
                 let span = tracing::trace_span!("merge files");
@@ -721,21 +798,23 @@ impl TurboPersistence {
                     .map(|indicies| {
                         let _span = span.clone().entered();
                         fn create_sst_file(
-                            family: u32,
                             entries: &[LookupEntry],
                             total_key_size: usize,
                             total_value_size: usize,
                             path: &Path,
                             seq: u32,
+                            meta_file_builder: &Mutex<MetaFileBuilder>,
                         ) -> Result<(u32, File)> {
                             let _span = tracing::trace_span!("write merged sst file").entered();
                             let builder = StaticSortedFileBuilder::new(
-                                family,
                                 entries,
                                 total_key_size,
                                 total_value_size,
                             )?;
-                            Ok((seq, builder.write(&path.join(format!("{seq:08}.sst")))?))
+                            let (meta, file) =
+                                builder.write(&path.join(format!("{seq:08}.sst")))?;
+                            meta_file_builder.lock().add(seq, meta);
+                            Ok((seq, file))
                         }
 
                         let mut new_sst_files = Vec::new();
@@ -744,13 +823,21 @@ impl TurboPersistence {
                         let iters = indicies
                             .iter()
                             .map(|&index| {
-                                let index = ssts_with_ranges[index].index;
-                                let sst = &static_sorted_files[index];
-                                sst.iter(key_block_cache, value_block_cache)
+                                let meta_index = ssts_with_ranges[index].meta_index;
+                                let index_in_meta = ssts_with_ranges[index].index_in_meta;
+                                let meta = &meta_files[meta_index];
+                                meta.entry(index_in_meta)
+                                    .sst(&self.path)?
+                                    .iter(key_block_cache, value_block_cache)
                             })
                             .collect::<Result<Vec<_>>>()?;
 
                         let iter = MergeIter::new(iters.into_iter())?;
+
+                        // TODO figure out how to delete blobs when they are no longer referenced
+                        let blob_seq_numbers_to_delete: Vec<u32> = Vec::new();
+
+                        let mut keys_written = 0;
 
                         let mut total_key_size = 0;
                         let mut total_value_size = 0;
@@ -787,13 +874,14 @@ impl TurboPersistence {
                                             let seq =
                                                 sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
 
+                                            keys_written += entries.len() as u64;
                                             new_sst_files.push(create_sst_file(
-                                                family as u32,
                                                 &entries,
                                                 selected_total_key_size,
                                                 selected_total_value_size,
                                                 path,
                                                 seq,
+                                                &meta_file_builder,
                                             )?);
 
                                             entries.clear();
@@ -817,13 +905,14 @@ impl TurboPersistence {
                         if last_entries.is_empty() && !entries.is_empty() {
                             let seq = sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
 
+                            keys_written += entries.len() as u64;
                             new_sst_files.push(create_sst_file(
-                                family as u32,
                                 &entries,
                                 total_key_size,
                                 total_value_size,
                                 path,
                                 seq,
+                                &meta_file_builder,
                             )?);
                         } else
                         // If we have two sets of entries left, merge them and
@@ -840,63 +929,101 @@ impl TurboPersistence {
                             let seq1 = sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
                             let seq2 = sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
 
+                            keys_written += part1.len() as u64;
                             new_sst_files.push(create_sst_file(
-                                family as u32,
                                 part1,
                                 // We don't know the exact sizes so we estimate them
                                 last_entries_total_sizes.0 / 2,
                                 last_entries_total_sizes.1 / 2,
                                 path,
                                 seq1,
+                                &meta_file_builder,
                             )?);
 
+                            keys_written += part2.len() as u64;
                             new_sst_files.push(create_sst_file(
-                                family as u32,
                                 part2,
                                 last_entries_total_sizes.0 / 2,
                                 last_entries_total_sizes.1 / 2,
                                 path,
                                 seq2,
+                                &meta_file_builder,
                             )?);
                         }
-                        Ok(new_sst_files)
+                        Ok((new_sst_files, blob_seq_numbers_to_delete, keys_written))
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                let move_jobs = move_jobs
-                    .into_iter()
-                    .map(|index| {
-                        let seq = sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
-                        (index, seq)
-                    })
-                    .collect::<Vec<_>>();
+                let mut meta_file_builder = meta_file_builder.into_inner();
 
                 // Move SST files
-                let span = tracing::trace_span!("move files");
-                let mut new_sst_files = move_jobs
-                    .into_par_iter()
-                    .with_min_len(1)
-                    .map(|(index, seq)| {
-                        let _span = span.clone().entered();
-                        let index = ssts_with_ranges[index].index;
-                        let sst = &static_sorted_files[index];
-                        let src_path = self.path.join(format!("{:08}.sst", sst.sequence_number()));
-                        let dst_path = self.path.join(format!("{seq:08}.sst"));
-                        if fs::hard_link(&src_path, &dst_path).is_err() {
-                            fs::copy(src_path, &dst_path)?;
-                        }
-                        Ok((seq, File::open(dst_path)?))
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+                let span = tracing::trace_span!("query moved sst files").entered();
+                for index in move_jobs {
+                    let meta_index = ssts_with_ranges[index].meta_index;
+                    let index_in_meta = ssts_with_ranges[index].index_in_meta;
+                    let meta_file = &meta_files[meta_index];
+                    let entry = meta_file.entry(index_in_meta);
+                    let aqmf = entry.aqmf(meta_file.aqmf_data()).to_vec();
+                    let meta = StaticSortedFileBuilderMetaResult {
+                        min_hash: entry.min_hash(),
+                        max_hash: entry.max_hash(),
+                        aqmf,
+                        key_compression_dictionary_length: entry
+                            .key_compression_dictionary_length(),
+                        value_compression_dictionary_length: entry
+                            .value_compression_dictionary_length(),
+                        block_count: entry.block_count(),
+                        size: entry.size(),
+                        entries: 0,
+                    };
+                    meta_file_builder.add(entry.sequence_number(), meta);
+                }
+                drop(span);
 
-                new_sst_files.extend(merge_result.into_iter().flatten());
-                Ok((new_sst_files, indicies_to_delete))
+                let span = tracing::trace_span!("write meta file").entered();
+                let seq = sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
+                let meta_file =
+                    meta_file_builder.write(&self.path.join(format!("{seq:08}.meta")))?;
+                drop(span);
+
+                let mut new_sst_files =
+                    Vec::with_capacity(merge_result.iter().map(|(v, _, _)| v.len()).sum());
+                let mut blob_seq_numbers_to_delete =
+                    Vec::with_capacity(merge_result.iter().map(|(_, v, _)| v.len()).sum());
+                let mut keys_written = 0;
+                for (
+                    merged_new_sst_files,
+                    merged_blob_seq_numbers_to_delete,
+                    merged_keys_written,
+                ) in merge_result
+                {
+                    new_sst_files.extend(merged_new_sst_files);
+                    blob_seq_numbers_to_delete.extend(merged_blob_seq_numbers_to_delete);
+                    keys_written += merged_keys_written;
+                }
+                Ok((
+                    Some((seq, meta_file)),
+                    new_sst_files,
+                    sst_seq_numbers_to_delete,
+                    blob_seq_numbers_to_delete,
+                    keys_written,
+                ))
             })
             .collect::<Result<Vec<_>>>()?;
 
-        for (mut inner_new_sst_files, mut inner_indicies_to_delete) in result {
+        for (
+            inner_new_meta_file,
+            mut inner_new_sst_files,
+            mut inner_sst_seq_numbers_to_delete,
+            mut inner_blob_seq_numbers_to_delete,
+            inner_keys_written,
+        ) in result
+        {
+            new_meta_files.extend(inner_new_meta_file);
             new_sst_files.append(&mut inner_new_sst_files);
-            indicies_to_delete.append(&mut inner_indicies_to_delete);
+            sst_seq_numbers_to_delete.append(&mut inner_sst_seq_numbers_to_delete);
+            blob_seq_numbers_to_delete.append(&mut inner_blob_seq_numbers_to_delete);
+            *keys_written += inner_keys_written;
         }
 
         Ok(())
@@ -907,8 +1034,8 @@ impl TurboPersistence {
     pub fn get<K: QueryKey>(&self, family: usize, key: &K) -> Result<Option<ArcSlice<u8>>> {
         let hash = hash_key(key);
         let inner = self.inner.read();
-        for sst in inner.static_sorted_files.iter().rev() {
-            match sst.lookup(
+        for meta in inner.meta_files.iter().rev() {
+            match meta.lookup(
                 family as u32,
                 hash,
                 key,
@@ -916,34 +1043,42 @@ impl TurboPersistence {
                 &self.key_block_cache,
                 &self.value_block_cache,
             )? {
-                LookupResult::Deleted => {
+                MetaLookupResult::FamilyMiss => {
                     #[cfg(feature = "stats")]
-                    self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
-                    return Ok(None);
+                    self.stats.miss_family.fetch_add(1, Ordering::Relaxed);
                 }
-                LookupResult::Slice { value } => {
-                    #[cfg(feature = "stats")]
-                    self.stats.hits_small.fetch_add(1, Ordering::Relaxed);
-                    return Ok(Some(value));
-                }
-                LookupResult::Blob { sequence_number } => {
-                    #[cfg(feature = "stats")]
-                    self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
-                    let blob = self.read_blob(sequence_number)?;
-                    return Ok(Some(blob));
-                }
-                LookupResult::RangeMiss => {
+                MetaLookupResult::RangeMiss => {
                     #[cfg(feature = "stats")]
                     self.stats.miss_range.fetch_add(1, Ordering::Relaxed);
                 }
-                LookupResult::QuickFilterMiss => {
+                MetaLookupResult::QuickFilterMiss => {
                     #[cfg(feature = "stats")]
                     self.stats.miss_aqmf.fetch_add(1, Ordering::Relaxed);
                 }
-                LookupResult::KeyMiss => {
-                    #[cfg(feature = "stats")]
-                    self.stats.miss_key.fetch_add(1, Ordering::Relaxed);
-                }
+                MetaLookupResult::SstLookup(result) => match result {
+                    SstLookupResult::Found(result) => match result {
+                        LookupValue::Deleted => {
+                            #[cfg(feature = "stats")]
+                            self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
+                            return Ok(None);
+                        }
+                        LookupValue::Slice { value } => {
+                            #[cfg(feature = "stats")]
+                            self.stats.hits_small.fetch_add(1, Ordering::Relaxed);
+                            return Ok(Some(value));
+                        }
+                        LookupValue::Blob { sequence_number } => {
+                            #[cfg(feature = "stats")]
+                            self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
+                            let blob = self.read_blob(sequence_number)?;
+                            return Ok(Some(blob));
+                        }
+                    },
+                    SstLookupResult::NotFound => {
+                        #[cfg(feature = "stats")]
+                        self.stats.miss_key.fetch_add(1, Ordering::Relaxed);
+                    }
+                },
             }
         }
         #[cfg(feature = "stats")]
@@ -956,7 +1091,8 @@ impl TurboPersistence {
     pub fn statistics(&self) -> Statistics {
         let inner = self.inner.read();
         Statistics {
-            sst_files: inner.static_sorted_files.len(),
+            meta_files: inner.meta_files.len(),
+            sst_files: inner.meta_files.iter().map(|m| m.entries().len()).sum(),
             key_block_cache: CacheStatistics::new(&self.key_block_cache),
             value_block_cache: CacheStatistics::new(&self.value_block_cache),
             aqmf_cache: CacheStatistics::new(&self.aqmf_cache),
@@ -964,6 +1100,7 @@ impl TurboPersistence {
                 + self.stats.hits_small.load(Ordering::Relaxed)
                 + self.stats.hits_blob.load(Ordering::Relaxed),
             misses: self.stats.miss_global.load(Ordering::Relaxed),
+            miss_family: self.stats.miss_family.load(Ordering::Relaxed),
             miss_range: self.stats.miss_range.load(Ordering::Relaxed),
             miss_aqmf: self.stats.miss_aqmf.load(Ordering::Relaxed),
             miss_key: self.stats.miss_key.load(Ordering::Relaxed),
@@ -975,67 +1112,5 @@ impl TurboPersistence {
         #[cfg(feature = "print_stats")]
         println!("{:#?}", self.statistics());
         Ok(())
-    }
-}
-
-/// Helper method to remove certain indicies from a list while keeping the order.
-/// This is similar to the `remove` method on Vec, but it allows to remove multiple indicies at
-/// once. It returns the removed elements in unspecified order.
-///
-/// Note: The `sorted_indicies` list needs to be sorted.
-fn remove_indicies<T>(list: &mut Vec<T>, sorted_indicies: &[usize]) -> Vec<T> {
-    let mut r = 0;
-    let mut w = 0;
-    let mut i = 0;
-    while r < list.len() {
-        if i < sorted_indicies.len() {
-            let idx = sorted_indicies[i];
-            if r != idx {
-                list.swap(w, r);
-                w += 1;
-                r += 1;
-            } else {
-                r += 1;
-                i += 1;
-            }
-        } else {
-            list.swap(w, r);
-            w += 1;
-            r += 1;
-        }
-    }
-    list.split_off(w)
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::db::remove_indicies;
-
-    #[test]
-    fn test_remove_indicies() {
-        let mut list = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let sorted_indicies = vec![1, 3, 5, 7];
-        let removed = remove_indicies(&mut list, &sorted_indicies);
-        assert_eq!(list, vec![1, 3, 5, 7, 9]);
-        assert!(removed.contains(&2));
-        assert!(removed.contains(&4));
-        assert!(removed.contains(&6));
-        assert!(removed.contains(&8));
-        assert_eq!(removed.len(), 4);
-    }
-
-    #[test]
-    fn test_remove_indicies2() {
-        let mut list = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let sorted_indicies = vec![0, 1, 2, 6, 7, 8];
-        let removed = remove_indicies(&mut list, &sorted_indicies);
-        assert_eq!(list, vec![4, 5, 6]);
-        assert!(removed.contains(&1));
-        assert!(removed.contains(&2));
-        assert!(removed.contains(&3));
-        assert!(removed.contains(&7));
-        assert!(removed.contains(&8));
-        assert!(removed.contains(&9));
-        assert_eq!(removed.len(), 6);
     }
 }

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -19,6 +19,7 @@ mod write_batch;
 
 mod meta_file;
 mod meta_file_builder;
+mod sst_filter;
 #[cfg(test)]
 mod tests;
 mod value_buf;

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(new_zeroed_alloc)]
 #![feature(get_mut_unchecked)]
 #![feature(sync_unsafe_cell)]
+#![feature(iter_collect_into)]
 
 mod arc_slice;
 mod collector;
@@ -16,6 +17,8 @@ mod static_sorted_file;
 mod static_sorted_file_builder;
 mod write_batch;
 
+mod meta_file;
+mod meta_file_builder;
 #[cfg(test)]
 mod tests;
 mod value_buf;

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -1,0 +1,297 @@
+use std::{
+    fs::File,
+    hash::BuildHasherDefault,
+    io::{BufReader, Seek},
+    path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
+};
+
+use anyhow::{Context, Result, bail};
+use byteorder::{BE, ReadBytesExt};
+use memmap2::{Mmap, MmapOptions};
+use quick_cache::sync::GuardResult;
+use rustc_hash::FxHasher;
+
+use crate::{
+    QueryKey,
+    static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
+};
+
+#[derive(Clone, Default)]
+pub struct AqmfWeighter;
+
+impl quick_cache::Weighter<u32, Arc<qfilter::Filter>> for AqmfWeighter {
+    fn weight(&self, _key: &u32, filter: &Arc<qfilter::Filter>) -> u64 {
+        filter.capacity() + 1
+    }
+}
+
+pub type AqmfCache =
+    quick_cache::sync::Cache<u32, Arc<qfilter::Filter>, AqmfWeighter, BuildHasherDefault<FxHasher>>;
+
+pub struct MetaEntry {
+    /// The metadata for the static sorted file.
+    sst_data: StaticSortedFileMetaData,
+    /// The key family of the SST file.
+    family: u32,
+    /// The minimum hash value of the keys in the SST file.
+    min_hash: u64,
+    /// The maximum hash value of the keys in the SST file.
+    max_hash: u64,
+    /// The size of the SST file in bytes.
+    size: u64,
+    /// The offset of the start of the AQMF data in the meta file relative to the end of the
+    /// header.
+    start_of_aqmf_data_offset: u32,
+    /// The offset of the end of the AQMF data in the the meta file relative to the end of the
+    /// header.
+    end_of_aqmf_data_offset: u32,
+    /// The AQMF filter of this file. This is only used if the range is very large. Smaller ranges
+    /// use the AQMF cache instead.
+    aqmf: OnceLock<qfilter::Filter>,
+    /// The static sorted file that is lazily loaded
+    sst: OnceLock<StaticSortedFile>,
+}
+
+impl MetaEntry {
+    pub fn sequence_number(&self) -> u32 {
+        self.sst_data.sequence_number
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn aqmf<'l>(&self, aqmf_data: &'l [u8]) -> &'l [u8] {
+        aqmf_data
+            .get(self.start_of_aqmf_data_offset as usize..self.end_of_aqmf_data_offset as usize)
+            .expect("AQMF data out of bounds")
+    }
+
+    pub fn sst(&self, db_path: &Path) -> Result<&StaticSortedFile> {
+        self.sst
+            .get_or_try_init(|| StaticSortedFile::open(db_path, self.sst_data.clone()))
+    }
+
+    /// Returns the key family and hash range of this file.
+    pub fn range(&self) -> StaticSortedFileRange {
+        StaticSortedFileRange {
+            family: self.family,
+            min_hash: self.min_hash,
+            max_hash: self.max_hash,
+        }
+    }
+
+    pub fn min_hash(&self) -> u64 {
+        self.min_hash
+    }
+
+    pub fn max_hash(&self) -> u64 {
+        self.max_hash
+    }
+
+    pub fn key_compression_dictionary_length(&self) -> u16 {
+        self.sst_data.key_compression_dictionary_length
+    }
+
+    pub fn value_compression_dictionary_length(&self) -> u16 {
+        self.sst_data.value_compression_dictionary_length
+    }
+
+    pub fn block_count(&self) -> u16 {
+        self.sst_data.block_count
+    }
+}
+
+/// The result of a lookup operation.
+pub enum MetaLookupResult {
+    /// The key was not found because it is from a different key family.
+    FamilyMiss,
+    /// The key was not found because it is out of the range of this SST file. But it was the
+    /// correct key family.
+    RangeMiss,
+    /// The key was not found because it was not in the AQMF filter. But it was in the range.
+    QuickFilterMiss,
+    /// The key was looked up in the SST file. It was in the AQMF filter.
+    SstLookup(SstLookupResult),
+}
+
+/// The key family and hash range of an SST file.
+#[derive(Clone, Copy)]
+pub struct StaticSortedFileRange {
+    pub family: u32,
+    pub min_hash: u64,
+    pub max_hash: u64,
+}
+
+pub struct MetaFile {
+    /// The database path
+    db_path: PathBuf,
+    /// The sequence number of this file.
+    sequence_number: u32,
+    /// The key family of the SST files in this meta file.
+    family: u32,
+    /// The entries of the file.
+    entries: Vec<MetaEntry>,
+    /// The memory mapped file.
+    mmap: Mmap,
+}
+
+impl MetaFile {
+    /// Opens a meta file at the given path. This memory maps the file, but does not read it yet.
+    /// It's lazy read on demand.
+    pub fn open(db_path: &Path, sequence_number: u32) -> Result<Self> {
+        let filename = format!("{sequence_number:08}.meta");
+        let path = db_path.join(&filename);
+        Self::open_internal(db_path.to_path_buf(), sequence_number, &path)
+            .with_context(|| format!("Unable to open meta file {filename}"))
+    }
+
+    fn open_internal(db_path: PathBuf, sequence_number: u32, path: &Path) -> Result<Self> {
+        let mut file = BufReader::new(File::open(path)?);
+        let magic = file.read_u32::<BE>()?;
+        if magic != 0x53535401 {
+            bail!("Invalid magic number or version");
+        }
+        let family = file.read_u32::<BE>()?;
+        let count = file.read_u32::<BE>()?;
+        let mut entries = Vec::with_capacity(count as usize);
+        let mut start_of_aqmf_data_offset = 0;
+        for _ in 0..count {
+            let entry = MetaEntry {
+                sst_data: StaticSortedFileMetaData {
+                    sequence_number: file.read_u32::<BE>()?,
+                    key_compression_dictionary_length: file.read_u16::<BE>()?,
+                    value_compression_dictionary_length: file.read_u16::<BE>()?,
+                    block_count: file.read_u16::<BE>()?,
+                },
+                family,
+                min_hash: file.read_u64::<BE>()?,
+                max_hash: file.read_u64::<BE>()?,
+                size: file.read_u64::<BE>()?,
+                start_of_aqmf_data_offset,
+                end_of_aqmf_data_offset: file.read_u32::<BE>()?,
+                aqmf: OnceLock::new(),
+                sst: OnceLock::new(),
+            };
+            start_of_aqmf_data_offset = entry.end_of_aqmf_data_offset;
+            entries.push(entry);
+        }
+        let offset = file.stream_position()?;
+        let file = file.into_inner();
+        let mut options = MmapOptions::new();
+        options.offset(offset);
+        let mmap = unsafe { options.map(&file)? };
+        mmap.advise(memmap2::Advice::Random)?;
+        let file = Self {
+            db_path,
+            sequence_number,
+            family,
+            entries,
+            mmap,
+        };
+        Ok(file)
+    }
+
+    pub fn sequence_number(&self) -> u32 {
+        self.sequence_number
+    }
+
+    pub fn family(&self) -> u32 {
+        self.family
+    }
+
+    pub fn entries(&self) -> &[MetaEntry] {
+        &self.entries
+    }
+
+    pub fn entry(&self, index: u32) -> &MetaEntry {
+        let index = index as usize;
+        &self.entries[index]
+    }
+
+    pub fn aqmf_data(&self) -> &[u8] {
+        &self.mmap
+    }
+
+    pub fn apply_sst_filter(
+        &mut self,
+        mut sst_filter: impl FnMut(u32) -> bool,
+    ) -> ApplySstFilterResult {
+        let old_len = self.entries.len();
+        self.entries
+            .retain(|entry| sst_filter(entry.sst_data.sequence_number));
+        if old_len == self.entries.len() {
+            return ApplySstFilterResult::Unmodified;
+        }
+
+        if self.entries.is_empty() {
+            ApplySstFilterResult::Empty
+        } else {
+            ApplySstFilterResult::Reduced
+        }
+    }
+
+    pub fn lookup<K: QueryKey>(
+        &self,
+        key_family: u32,
+        key_hash: u64,
+        key: &K,
+        aqmf_cache: &AqmfCache,
+        key_block_cache: &BlockCache,
+        value_block_cache: &BlockCache,
+    ) -> Result<MetaLookupResult> {
+        if key_family != self.family {
+            return Ok(MetaLookupResult::FamilyMiss);
+        }
+        let mut miss_result = MetaLookupResult::RangeMiss;
+        for entry in self.entries.iter() {
+            if key_hash < entry.min_hash || key_hash > entry.max_hash {
+                continue;
+            }
+            let use_aqmf_cache = entry.max_hash - entry.min_hash < 1 << 60;
+            if use_aqmf_cache {
+                let aqmf = match aqmf_cache.get_value_or_guard(&entry.sequence_number(), None) {
+                    GuardResult::Value(aqmf) => aqmf,
+                    GuardResult::Guard(guard) => {
+                        let aqmf = entry.aqmf(self.aqmf_data());
+                        let aqmf: Arc<qfilter::Filter> = Arc::new(pot::from_slice(aqmf)?);
+                        let _ = guard.insert(aqmf.clone());
+                        aqmf
+                    }
+                    GuardResult::Timeout => unreachable!(),
+                };
+                if !aqmf.contains_fingerprint(key_hash) {
+                    miss_result = MetaLookupResult::QuickFilterMiss;
+                    continue;
+                }
+            } else {
+                let aqmf = entry.aqmf.get_or_try_init(|| {
+                    let aqmf = entry.aqmf(self.aqmf_data());
+                    anyhow::Ok(pot::from_slice(aqmf)?)
+                })?;
+                if !aqmf.contains_fingerprint(key_hash) {
+                    miss_result = MetaLookupResult::QuickFilterMiss;
+                    continue;
+                }
+            };
+            let result = entry.sst(&self.db_path)?.lookup(
+                key_hash,
+                key,
+                key_block_cache,
+                value_block_cache,
+            )?;
+            if !matches!(result, SstLookupResult::NotFound) {
+                return Ok(MetaLookupResult::SstLookup(result));
+            }
+        }
+        Ok(miss_result)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplySstFilterResult {
+    Unmodified,
+    Reduced,
+    Empty,
+}

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -152,8 +152,8 @@ impl MetaFile {
     fn open_internal(db_path: PathBuf, sequence_number: u32, path: &Path) -> Result<Self> {
         let mut file = BufReader::new(File::open(path)?);
         let magic = file.read_u32::<BE>()?;
-        if magic != 0x53535401 {
-            bail!("Invalid magic number or version");
+        if magic != 0xFE4ADA4A {
+            bail!("Invalid magic number");
         }
         let family = file.read_u32::<BE>()?;
         let obsolete_count = file.read_u32::<BE>()?;

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -190,6 +190,7 @@ impl MetaFile {
         let mut options = MmapOptions::new();
         options.offset(offset);
         let mmap = unsafe { options.map(&file)? };
+        #[cfg(unix)]
         mmap.advise(memmap2::Advice::Random)?;
         let file = Self {
             db_path,

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -6,12 +6,12 @@ use std::{
 
 use byteorder::{BE, WriteBytesExt};
 
-use crate::static_sorted_file_builder::StaticSortedFileBuilderMetaResult;
+use crate::static_sorted_file_builder::StaticSortedFileBuilderMeta;
 
 pub struct MetaFileBuilder {
     family: u32,
     /// Entries in the meta file, tuples of (sequence_number, StaticSortedFileBuilderMetaResult)
-    entries: Vec<(u32, StaticSortedFileBuilderMetaResult)>,
+    entries: Vec<(u32, StaticSortedFileBuilderMeta)>,
     /// Obsolete SST files, represented by their sequence numbers
     obsolete_sst_files: Vec<u32>,
 }
@@ -25,7 +25,7 @@ impl MetaFileBuilder {
         }
     }
 
-    pub fn add(&mut self, sequence_number: u32, sst: StaticSortedFileBuilderMetaResult) {
+    pub fn add(&mut self, sequence_number: u32, sst: StaticSortedFileBuilderMeta) {
         self.entries.push((sequence_number, sst));
     }
 
@@ -36,7 +36,7 @@ impl MetaFileBuilder {
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn write(&self, file: &Path) -> io::Result<File> {
         let mut file = BufWriter::new(File::create(file)?);
-        file.write_u32::<BE>(0x53535401)?; // Magic number
+        file.write_u32::<BE>(0xFE4ADA4A)?; // Magic number
         file.write_u32::<BE>(self.family)?;
 
         file.write_u32::<BE>(self.obsolete_sst_files.len() as u32)?;

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -1,0 +1,54 @@
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::Path,
+};
+
+use byteorder::{BE, WriteBytesExt};
+
+use crate::static_sorted_file_builder::StaticSortedFileBuilderMetaResult;
+
+pub struct MetaFileBuilder {
+    family: u32,
+    /// Entries in the meta file, tuples of (sequence_number, StaticSortedFileBuilderMetaResult)
+    entries: Vec<(u32, StaticSortedFileBuilderMetaResult)>,
+}
+
+impl MetaFileBuilder {
+    pub fn new(family: u32) -> Self {
+        Self {
+            family,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, sequence_number: u32, sst: StaticSortedFileBuilderMetaResult) {
+        self.entries.push((sequence_number, sst));
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub fn write(&self, file: &Path) -> io::Result<File> {
+        let mut file = BufWriter::new(File::create(file)?);
+        file.write_u32::<BE>(0x53535401)?; // Magic number
+        file.write_u32::<BE>(self.family)?;
+        file.write_u32::<BE>(self.entries.len() as u32)?;
+
+        let mut aqmf_offset = 0;
+        for (sequence_number, sst) in &self.entries {
+            file.write_u32::<BE>(*sequence_number)?;
+            file.write_u16::<BE>(sst.key_compression_dictionary_length)?;
+            file.write_u16::<BE>(sst.value_compression_dictionary_length)?;
+            file.write_u16::<BE>(sst.block_count)?;
+            file.write_u64::<BE>(sst.min_hash)?;
+            file.write_u64::<BE>(sst.max_hash)?;
+            file.write_u64::<BE>(sst.size)?;
+            aqmf_offset += sst.aqmf.len();
+            file.write_u32::<BE>(aqmf_offset as u32)?;
+        }
+
+        for (_, sst) in &self.entries {
+            file.write_all(&sst.aqmf)?;
+        }
+        Ok(file.into_inner()?)
+    }
+}

--- a/turbopack/crates/turbo-persistence/src/sst_filter.rs
+++ b/turbopack/crates/turbo-persistence/src/sst_filter.rs
@@ -1,0 +1,69 @@
+use std::collections::hash_map::Entry;
+
+use rustc_hash::FxHashMap;
+
+use crate::meta_file::MetaFile;
+
+enum SstState {
+    Active,
+    UnusedObsolete,
+    Obsolete,
+}
+
+pub struct SstFilter(FxHashMap<u32, SstState>);
+
+impl SstFilter {
+    pub fn new() -> Self {
+        Self(FxHashMap::default())
+    }
+
+    /// Phase 1: Apply the filter to the meta file and update the state in the filter.
+    pub fn apply_filter(&mut self, meta: &mut MetaFile) {
+        meta.retain_entries(|seq| match self.0.entry(seq) {
+            Entry::Occupied(mut e) => {
+                let state = e.get_mut();
+                match state {
+                    SstState::Active => false,
+                    SstState::UnusedObsolete => {
+                        *state = SstState::Obsolete;
+                        false
+                    }
+                    SstState::Obsolete => false,
+                }
+            }
+            Entry::Vacant(e) => {
+                e.insert(SstState::Active);
+                true
+            }
+        });
+        for seq in meta.obsolete_sst_files() {
+            self.0.entry(*seq).or_insert(SstState::UnusedObsolete);
+        }
+    }
+
+    /// Phase 2: Check if the meta file can be removed based on the filter state after phase 1.
+    /// Updates the filter state for the next meta file. Returns true if the meta file can be
+    /// removed.
+    pub fn apply_and_get_remove(&mut self, meta: &MetaFile) -> bool {
+        let mut used = false;
+        for seq in meta.obsolete_sst_files() {
+            match self.0.entry(*seq) {
+                Entry::Occupied(e) => match e.get() {
+                    SstState::Active => {}
+                    SstState::UnusedObsolete => {
+                        e.remove();
+                    }
+                    SstState::Obsolete => {
+                        e.remove();
+                        used = true;
+                    }
+                },
+                Entry::Vacant(e) => {
+                    e.insert(SstState::UnusedObsolete);
+                }
+            }
+        }
+
+        !used && !meta.has_active_entries()
+    }
+}

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -6,7 +6,6 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::Arc,
-    usize,
 };
 
 use anyhow::{Context, Result, bail};

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -6,6 +6,7 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::Arc,
+    usize,
 };
 
 use anyhow::{Context, Result, bail};
@@ -75,17 +76,19 @@ pub struct StaticSortedFileMetaData {
 
 impl StaticSortedFileMetaData {
     pub fn block_offsets_start(&self) -> usize {
-        self.key_compression_dictionary_length as usize
-            + self.value_compression_dictionary_length as usize
+        let k: usize = self.key_compression_dictionary_length.into();
+        let v: usize = self.value_compression_dictionary_length.into();
+        k + v
     }
 
     pub fn blocks_start(&self) -> usize {
-        self.block_offsets_start() + self.block_count as usize * 4
+        let bc: usize = self.block_count.into();
+        self.block_offsets_start() + bc * size_of::<u32>()
     }
 
     pub fn key_compression_dictionary_range(&self) -> Range<usize> {
         let start = 0;
-        let end = self.key_compression_dictionary_length as usize;
+        let end: usize = self.key_compression_dictionary_length.into();
         start..end
     }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -118,6 +118,8 @@ impl StaticSortedFile {
 
     fn open_internal(path: PathBuf, meta: StaticSortedFileMetaData) -> Result<Self> {
         let mmap = unsafe { Mmap::map(&File::open(&path)?)? };
+        #[cfg(unix)]
+        mmap.advise(memmap2::Advice::Random)?;
         let file = Self { meta, mmap };
         Ok(file)
     }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -3,11 +3,12 @@ use std::{
     fs::File,
     hash::BuildHasherDefault,
     mem::{MaybeUninit, transmute},
-    path::PathBuf,
-    sync::{Arc, OnceLock},
+    ops::Range,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use byteorder::{BE, ReadBytesExt};
 use lzzzz::lz4::decompress_with_dict;
 use memmap2::Mmap;
@@ -35,73 +36,16 @@ pub const KEY_BLOCK_ENTRY_TYPE_DELETED: u8 = 2;
 pub const KEY_BLOCK_ENTRY_TYPE_MEDIUM: u8 = 3;
 
 /// The result of a lookup operation.
-pub enum LookupResult {
-    /// The key was deleted.
-    Deleted,
-    /// The key was found and the value is a slice.
-    Slice { value: ArcSlice<u8> },
-    /// The key was found and the value is a blob.
-    Blob { sequence_number: u32 },
-    /// The key was not found because it is out of the range of this SST file.
-    RangeMiss,
-    /// The key was not found because it was not in the AQMF filter. But it was in the range.
-    QuickFilterMiss,
-    /// The key was not found. But it was in the range and the AQMF filter.
-    KeyMiss,
+pub enum SstLookupResult {
+    /// The key was found.
+    Found(LookupValue),
+    /// The key was not found.
+    NotFound,
 }
 
-impl From<LookupValue> for LookupResult {
+impl From<LookupValue> for SstLookupResult {
     fn from(value: LookupValue) -> Self {
-        match value {
-            LookupValue::Deleted => LookupResult::Deleted,
-            LookupValue::Slice { value } => LookupResult::Slice { value },
-            LookupValue::Blob { sequence_number } => LookupResult::Blob { sequence_number },
-        }
-    }
-}
-
-/// A byte range in the SST file.
-struct LocationInFile {
-    start: usize,
-    end: usize,
-}
-
-/// The read and parsed header of an SST file.
-struct Header {
-    /// The key family stored in this file.
-    family: u32,
-    /// The minimum hash value in this file.
-    min_hash: u64,
-    /// The maximum hash value in this file.
-    max_hash: u64,
-    /// The location of the AQMF filter in the file.
-    aqmf: LocationInFile,
-    /// The location of the key compression dictionary in the file.
-    key_compression_dictionary: LocationInFile,
-    /// The location of the value compression dictionary in the file.
-    value_compression_dictionary: LocationInFile,
-    /// The byte offset where the block offsets start.
-    block_offsets_start: usize,
-    /// The byte offset where the blocks start.
-    blocks_start: usize,
-    /// The number of blocks in this file.
-    block_count: u16,
-}
-
-/// The key family and hash range of an SST file.
-#[derive(Clone, Copy)]
-pub struct StaticSortedFileRange {
-    pub family: u32,
-    pub min_hash: u64,
-    pub max_hash: u64,
-}
-
-#[derive(Clone, Default)]
-pub struct AqmfWeighter;
-
-impl quick_cache::Weighter<u32, Arc<qfilter::Filter>> for AqmfWeighter {
-    fn weight(&self, _key: &u32, filter: &Arc<qfilter::Filter>) -> u64 {
-        filter.capacity() + 1
+        SstLookupResult::Found(value)
     }
 }
 
@@ -114,105 +58,66 @@ impl quick_cache::Weighter<(u32, u16), ArcSlice<u8>> for BlockWeighter {
     }
 }
 
-pub type AqmfCache =
-    quick_cache::sync::Cache<u32, Arc<qfilter::Filter>, AqmfWeighter, BuildHasherDefault<FxHasher>>;
 pub type BlockCache =
     quick_cache::sync::Cache<(u32, u16), ArcSlice<u8>, BlockWeighter, BuildHasherDefault<FxHasher>>;
 
+#[derive(Clone, Debug)]
+pub struct StaticSortedFileMetaData {
+    /// The sequence number of this file.
+    pub sequence_number: u32,
+    /// The length of the key compression dictionary.
+    pub key_compression_dictionary_length: u16,
+    /// The length of the value compression dictionary.
+    pub value_compression_dictionary_length: u16,
+    /// The number of blocks in the SST file.
+    pub block_count: u16,
+}
+
+impl StaticSortedFileMetaData {
+    pub fn block_offsets_start(&self) -> usize {
+        self.key_compression_dictionary_length as usize
+            + self.value_compression_dictionary_length as usize
+    }
+
+    pub fn blocks_start(&self) -> usize {
+        self.block_offsets_start() + self.block_count as usize * 4
+    }
+
+    pub fn key_compression_dictionary_range(&self) -> Range<usize> {
+        let start = 0;
+        let end = self.key_compression_dictionary_length as usize;
+        start..end
+    }
+
+    pub fn value_compression_dictionary_range(&self) -> Range<usize> {
+        let start = self.key_compression_dictionary_length as usize;
+        let end = start + self.value_compression_dictionary_length as usize;
+        start..end
+    }
+}
+
 /// A memory mapped SST file.
 pub struct StaticSortedFile {
-    /// The sequence number of this file.
-    sequence_number: u32,
+    /// The meta file of this file.
+    meta: StaticSortedFileMetaData,
     /// The memory mapped file.
     mmap: Mmap,
-    /// The parsed header of this file.
-    header: OnceLock<Header>,
-    /// The AQMF filter of this file. This is only used if the range is very large. Smaller ranges
-    /// use the AQMF cache instead.
-    aqmf: OnceLock<qfilter::Filter>,
 }
 
 impl StaticSortedFile {
-    /// The sequence number of this file.
-    pub fn sequence_number(&self) -> u32 {
-        self.sequence_number
-    }
-
-    /// The size of this file in bytes.
-    pub fn size(&self) -> usize {
-        self.mmap.len()
-    }
-
     /// Opens an SST file at the given path. This memory maps the file, but does not read it yet.
     /// It's lazy read on demand.
-    pub fn open(sequence_number: u32, path: PathBuf) -> Result<Self> {
+    pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
+        let filename = format!("{:08}.sst", meta.sequence_number);
+        let path = db_path.join(&filename);
+        Self::open_internal(path, meta)
+            .with_context(|| format!("Unable to open static sorted file {filename}"))
+    }
+
+    fn open_internal(path: PathBuf, meta: StaticSortedFileMetaData) -> Result<Self> {
         let mmap = unsafe { Mmap::map(&File::open(&path)?)? };
-        let file = Self {
-            sequence_number,
-            mmap,
-            header: OnceLock::new(),
-            aqmf: OnceLock::new(),
-        };
+        let file = Self { meta, mmap };
         Ok(file)
-    }
-
-    /// Reads and parses the header of this file if it hasn't been read yet.
-    fn header(&self) -> Result<&Header> {
-        self.header.get_or_try_init(|| {
-            let mut file = &*self.mmap;
-            let magic = file.read_u32::<BE>()?;
-            if magic != 0x53535401 {
-                bail!("Invalid magic number or version");
-            }
-            let family = file.read_u32::<BE>()?;
-            let min_hash = file.read_u64::<BE>()?;
-            let max_hash = file.read_u64::<BE>()?;
-            let aqmf_length = file.read_u24::<BE>()? as usize;
-            let key_compression_dictionary_length = file.read_u16::<BE>()? as usize;
-            let value_compression_dictionary_length = file.read_u16::<BE>()? as usize;
-            let block_count = file.read_u16::<BE>()?;
-            const HEADER_SIZE: usize = 33;
-            let mut current_offset = HEADER_SIZE;
-            let aqmf = LocationInFile {
-                start: current_offset,
-                end: current_offset + aqmf_length,
-            };
-            current_offset += aqmf_length;
-            let key_compression_dictionary = LocationInFile {
-                start: current_offset,
-                end: current_offset + key_compression_dictionary_length,
-            };
-            current_offset += key_compression_dictionary_length;
-            let value_compression_dictionary = LocationInFile {
-                start: current_offset,
-                end: current_offset + value_compression_dictionary_length,
-            };
-            current_offset += value_compression_dictionary_length;
-            let block_offsets_start = current_offset;
-            let blocks_start = block_offsets_start + block_count as usize * 4;
-
-            Ok(Header {
-                family,
-                min_hash,
-                max_hash,
-                aqmf,
-                key_compression_dictionary,
-                value_compression_dictionary,
-                block_offsets_start,
-                blocks_start,
-                block_count,
-            })
-        })
-    }
-
-    /// Returns the key family and hash range of this file.
-    pub fn range(&self) -> Result<StaticSortedFileRange> {
-        let header = self.header()?;
-        Ok(StaticSortedFileRange {
-            family: header.family,
-            min_hash: header.min_hash,
-            max_hash: header.max_hash,
-        })
     }
 
     /// Iterate over all entries in this file in sorted order.
@@ -221,61 +126,28 @@ impl StaticSortedFile {
         key_block_cache: &'l BlockCache,
         value_block_cache: &'l BlockCache,
     ) -> Result<StaticSortedFileIter<'l>> {
-        let header = self.header()?;
         let mut iter = StaticSortedFileIter {
             this: self,
             key_block_cache,
             value_block_cache,
-            header,
             stack: Vec::new(),
             current_key_block: None,
         };
-        iter.enter_block(header.block_count - 1)?;
+        iter.enter_block(self.meta.block_count - 1)?;
         Ok(iter)
     }
 
     /// Looks up a key in this file.
     pub fn lookup<K: QueryKey>(
         &self,
-        key_family: u32,
         key_hash: u64,
         key: &K,
-        aqmf_cache: &AqmfCache,
         key_block_cache: &BlockCache,
         value_block_cache: &BlockCache,
-    ) -> Result<LookupResult> {
-        let header = self.header()?;
-        if key_family != header.family || key_hash < header.min_hash || key_hash > header.max_hash {
-            return Ok(LookupResult::RangeMiss);
-        }
-
-        let use_aqmf_cache = header.max_hash - header.min_hash < 1 << 62;
-        if use_aqmf_cache {
-            let aqmf = match aqmf_cache.get_value_or_guard(&self.sequence_number, None) {
-                GuardResult::Value(aqmf) => aqmf,
-                GuardResult::Guard(guard) => {
-                    let aqmf = &self.mmap[header.aqmf.start..header.aqmf.end];
-                    let aqmf: Arc<qfilter::Filter> = Arc::new(pot::from_slice(aqmf)?);
-                    let _ = guard.insert(aqmf.clone());
-                    aqmf
-                }
-                GuardResult::Timeout => unreachable!(),
-            };
-            if !aqmf.contains_fingerprint(key_hash) {
-                return Ok(LookupResult::QuickFilterMiss);
-            }
-        } else {
-            let aqmf = self.aqmf.get_or_try_init(|| {
-                let aqmf = &self.mmap[header.aqmf.start..header.aqmf.end];
-                anyhow::Ok(pot::from_slice(aqmf)?)
-            })?;
-            if !aqmf.contains_fingerprint(key_hash) {
-                return Ok(LookupResult::QuickFilterMiss);
-            }
-        }
-        let mut current_block = header.block_count - 1;
+    ) -> Result<SstLookupResult> {
+        let mut current_block = self.meta.block_count - 1;
         loop {
-            let block = self.get_key_block(header, current_block, key_block_cache)?;
+            let block = self.get_key_block(current_block, key_block_cache)?;
             let mut block = &block[..];
             let block_type = block.read_u8()?;
             match block_type {
@@ -283,7 +155,7 @@ impl StaticSortedFile {
                     current_block = self.lookup_index_block(block, key_hash)?;
                 }
                 BLOCK_TYPE_KEY => {
-                    return self.lookup_key_block(block, key_hash, key, header, value_block_cache);
+                    return self.lookup_key_block(block, key_hash, key, value_block_cache);
                 }
                 _ => {
                     bail!("Invalid block type");
@@ -344,9 +216,8 @@ impl StaticSortedFile {
         mut block: &[u8],
         key_hash: u64,
         key: &K,
-        header: &Header,
         value_block_cache: &BlockCache,
-    ) -> Result<LookupResult> {
+    ) -> Result<SstLookupResult> {
         let entry_count = block.read_u24::<BE>()? as usize;
         let offsets = &block[..entry_count * 4];
         let entries = &block[entry_count * 4..];
@@ -368,7 +239,7 @@ impl StaticSortedFile {
                 }
                 Ordering::Equal => {
                     return Ok(self
-                        .handle_key_match(ty, mid_val, header, value_block_cache)?
+                        .handle_key_match(ty, mid_val, value_block_cache)?
                         .into());
                 }
                 Ordering::Greater => {
@@ -376,7 +247,7 @@ impl StaticSortedFile {
                 }
             }
         }
-        Ok(LookupResult::KeyMiss)
+        Ok(SstLookupResult::NotFound)
     }
 
     /// Handles a key match by looking up the value.
@@ -384,7 +255,6 @@ impl StaticSortedFile {
         &self,
         ty: u8,
         mut val: &[u8],
-        header: &Header,
         value_block_cache: &BlockCache,
     ) -> Result<LookupValue> {
         Ok(match ty {
@@ -393,13 +263,13 @@ impl StaticSortedFile {
                 let size = val.read_u16::<BE>()? as usize;
                 let position = val.read_u32::<BE>()? as usize;
                 let value = self
-                    .get_value_block(header, block, value_block_cache)?
+                    .get_value_block(block, value_block_cache)?
                     .slice(position..position + size);
                 LookupValue::Slice { value }
             }
             KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
                 let block = val.read_u16::<BE>()?;
-                let value = self.read_value_block(header, block)?;
+                let value = self.read_value_block(block)?;
                 LookupValue::Slice { value }
             }
             KEY_BLOCK_ENTRY_TYPE_BLOB => {
@@ -416,15 +286,14 @@ impl StaticSortedFile {
     /// Gets a key block from the cache or reads it from the file.
     fn get_key_block(
         &self,
-        header: &Header,
         block: u16,
         key_block_cache: &BlockCache,
     ) -> Result<ArcSlice<u8>, anyhow::Error> {
         Ok(
-            match key_block_cache.get_value_or_guard(&(self.sequence_number, block), None) {
+            match key_block_cache.get_value_or_guard(&(self.meta.sequence_number, block), None) {
                 GuardResult::Value(block) => block,
                 GuardResult::Guard(guard) => {
-                    let block = self.read_key_block(header, block)?;
+                    let block = self.read_key_block(block)?;
                     let _ = guard.insert(block.clone());
                     block
                 }
@@ -434,65 +303,51 @@ impl StaticSortedFile {
     }
 
     /// Gets a value block from the cache or reads it from the file.
-    fn get_value_block(
-        &self,
-        header: &Header,
-        block: u16,
-        value_block_cache: &BlockCache,
-    ) -> Result<ArcSlice<u8>> {
-        let block = match value_block_cache.get_value_or_guard(&(self.sequence_number, block), None)
-        {
-            GuardResult::Value(block) => block,
-            GuardResult::Guard(guard) => {
-                let block = self.read_value_block(header, block)?;
-                let _ = guard.insert(block.clone());
-                block
-            }
-            GuardResult::Timeout => unreachable!(),
-        };
+    fn get_value_block(&self, block: u16, value_block_cache: &BlockCache) -> Result<ArcSlice<u8>> {
+        let block =
+            match value_block_cache.get_value_or_guard(&(self.meta.sequence_number, block), None) {
+                GuardResult::Value(block) => block,
+                GuardResult::Guard(guard) => {
+                    let block = self.read_value_block(block)?;
+                    let _ = guard.insert(block.clone());
+                    block
+                }
+                GuardResult::Timeout => unreachable!(),
+            };
         Ok(block)
     }
 
     /// Reads a key block from the file.
-    fn read_key_block(&self, header: &Header, block_index: u16) -> Result<ArcSlice<u8>> {
+    fn read_key_block(&self, block_index: u16) -> Result<ArcSlice<u8>> {
         self.read_block(
-            header,
             block_index,
-            &self.mmap
-                [header.key_compression_dictionary.start..header.key_compression_dictionary.end],
+            &self.mmap[self.meta.key_compression_dictionary_range()],
         )
     }
 
     /// Reads a value block from the file.
-    fn read_value_block(&self, header: &Header, block_index: u16) -> Result<ArcSlice<u8>> {
+    fn read_value_block(&self, block_index: u16) -> Result<ArcSlice<u8>> {
         self.read_block(
-            header,
             block_index,
-            &self.mmap[header.value_compression_dictionary.start
-                ..header.value_compression_dictionary.end],
+            &self.mmap[self.meta.value_compression_dictionary_range()],
         )
     }
 
     /// Reads a block from the file.
-    fn read_block(
-        &self,
-        header: &Header,
-        block_index: u16,
-        compression_dictionary: &[u8],
-    ) -> Result<ArcSlice<u8>> {
+    fn read_block(&self, block_index: u16, compression_dictionary: &[u8]) -> Result<ArcSlice<u8>> {
         #[cfg(feature = "strict_checks")]
-        if block_index >= header.block_count {
+        if block_index >= self.meta.block_count {
             bail!(
                 "Corrupted file seq:{} block:{} > number of blocks {} (block_offsets: {:x}, \
                  blocks: {:x})",
                 self.sequence_number,
                 block_index,
-                header.block_count,
-                header.block_offsets_start,
-                header.blocks_start
+                self.meta.block_count,
+                self.meta.block_offsets_start(),
+                self.meta.blocks_start()
             );
         }
-        let offset = header.block_offsets_start + block_index as usize * 4;
+        let offset = self.meta.block_offsets_start() + block_index as usize * 4;
         #[cfg(feature = "strict_checks")]
         if offset + 4 > self.mmap.len() {
             bail!(
@@ -502,17 +357,17 @@ impl StaticSortedFile {
                 block_index,
                 offset,
                 self.mmap.len(),
-                header.block_offsets_start,
-                header.blocks_start
+                self.meta.block_offsets_start(),
+                self.meta.blocks_start()
             );
         }
         let block_start = if block_index == 0 {
-            header.blocks_start
+            self.meta.blocks_start()
         } else {
-            header.blocks_start + (&self.mmap[offset - 4..offset]).read_u32::<BE>()? as usize
+            self.meta.blocks_start() + (&self.mmap[offset - 4..offset]).read_u32::<BE>()? as usize
         };
         let block_end =
-            header.blocks_start + (&self.mmap[offset..offset + 4]).read_u32::<BE>()? as usize;
+            self.meta.blocks_start() + (&self.mmap[offset..offset + 4]).read_u32::<BE>()? as usize;
         #[cfg(feature = "strict_checks")]
         if block_end > self.mmap.len() || block_start > self.mmap.len() {
             bail!(
@@ -523,8 +378,8 @@ impl StaticSortedFile {
                 block_start,
                 block_end,
                 self.mmap.len(),
-                header.block_offsets_start,
-                header.blocks_start
+                self.meta.block_offsets_start(),
+                self.meta.blocks_start()
             );
         }
         let uncompressed_length =
@@ -546,7 +401,6 @@ pub struct StaticSortedFileIter<'l> {
     this: &'l StaticSortedFile,
     key_block_cache: &'l BlockCache,
     value_block_cache: &'l BlockCache,
-    header: &'l Header,
 
     stack: Vec<CurrentIndexBlock>,
     current_key_block: Option<CurrentKeyBlock>,
@@ -576,9 +430,7 @@ impl Iterator for StaticSortedFileIter<'_> {
 impl StaticSortedFileIter<'_> {
     /// Enters a block at the given index.
     fn enter_block(&mut self, block_index: u16) -> Result<()> {
-        let block_arc = self
-            .this
-            .get_key_block(self.header, block_index, self.key_block_cache)?;
+        let block_arc = self.this.get_key_block(block_index, self.key_block_cache)?;
         let mut block = &*block_arc;
         let block_type = block.read_u8()?;
         match block_type {
@@ -623,9 +475,9 @@ impl StaticSortedFileIter<'_> {
             {
                 let GetKeyEntryResult { hash, key, ty, val } =
                     get_key_entry(&offsets, &entries, entry_count, index)?;
-                let value =
-                    self.this
-                        .handle_key_match(ty, val, self.header, self.value_block_cache)?;
+                let value = self
+                    .this
+                    .handle_key_match(ty, val, self.value_block_cache)?;
                 let entry = LookupEntry {
                     hash,
                     // Safety: The key is a valid slice of the entries.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -72,7 +72,7 @@ pub enum EntryValue<'l> {
 }
 
 #[derive(Debug, Clone)]
-pub struct StaticSortedFileBuilderMetaResult {
+pub struct StaticSortedFileBuilderMeta {
     /// The minimum hash of the keys in the SST file
     pub min_hash: u64,
     /// The maximum hash of the keys in the SST file
@@ -390,7 +390,7 @@ impl StaticSortedFileBuilder {
 
     /// Writes the SST file.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub fn write(self, file: &Path) -> io::Result<(StaticSortedFileBuilderMetaResult, File)> {
+    pub fn write(self, file: &Path) -> io::Result<(StaticSortedFileBuilderMeta, File)> {
         let mut file = BufWriter::new(File::create(file)?);
         // Write the key compression dictionary
         file.write_all(&self.key_compression_dictionary)?;
@@ -412,7 +412,7 @@ impl StaticSortedFileBuilder {
             // Compressed block
             file.write_all(&block)?;
         }
-        let meta = StaticSortedFileBuilderMetaResult {
+        let meta = StaticSortedFileBuilderMeta {
             min_hash: self.min_hash,
             max_hash: self.max_hash,
             aqmf: self.aqmf,

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::min,
     fs::File,
-    io::{self, BufWriter, Write},
+    io::{self, BufWriter, Seek, Write},
     path::Path,
 };
 
@@ -71,29 +71,48 @@ pub enum EntryValue<'l> {
     Deleted,
 }
 
+#[derive(Debug, Clone)]
+pub struct StaticSortedFileBuilderMetaResult {
+    /// The minimum hash of the keys in the SST file
+    pub min_hash: u64,
+    /// The maximum hash of the keys in the SST file
+    pub max_hash: u64,
+    /// The AQMF data
+    pub aqmf: Vec<u8>,
+    /// The key compression dictionary
+    pub key_compression_dictionary_length: u16,
+    /// The value compression dictionary
+    pub value_compression_dictionary_length: u16,
+    /// The number of blocks in the SST file
+    pub block_count: u16,
+    /// The file size of the SST file
+    pub size: u64,
+    /// The number of entries in the SST file
+    pub entries: u64,
+}
+
 #[derive(Debug, Default)]
 pub struct StaticSortedFileBuilder {
-    family: u32,
     aqmf: Vec<u8>,
     key_compression_dictionary: Vec<u8>,
     value_compression_dictionary: Vec<u8>,
     blocks: Vec<(u32, Vec<u8>)>,
     min_hash: u64,
     max_hash: u64,
+    entries: u64,
 }
 
 impl StaticSortedFileBuilder {
     pub fn new<E: Entry>(
-        family: u32,
         entries: &[E],
         total_key_size: usize,
         total_value_size: usize,
     ) -> Result<Self> {
         debug_assert!(entries.iter().map(|e| e.key_hash()).is_sorted());
         let mut builder = Self {
-            family,
             min_hash: entries.first().map(|e| e.key_hash()).unwrap_or(u64::MAX),
             max_hash: entries.last().map(|e| e.key_hash()).unwrap_or(0),
+            entries: entries.len() as u64,
             ..Default::default()
         };
         builder.compute_aqmf(entries);
@@ -113,6 +132,9 @@ impl StaticSortedFileBuilder {
                 .insert_fingerprint(false, entry.key_hash())
                 // This can't fail as we allocated enough capacity
                 .expect("AQMF insert failed");
+        }
+        for entry in entries {
+            debug_assert!(filter.contains_fingerprint(entry.key_hash()));
         }
         self.aqmf = pot::to_vec(&filter).expect("AQMF serialization failed");
     }
@@ -368,27 +390,8 @@ impl StaticSortedFileBuilder {
 
     /// Writes the SST file.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub fn write(&self, file: &Path) -> io::Result<File> {
+    pub fn write(self, file: &Path) -> io::Result<(StaticSortedFileBuilderMetaResult, File)> {
         let mut file = BufWriter::new(File::create(file)?);
-        // magic number and version
-        file.write_u32::<BE>(0x53535401)?;
-        // family
-        file.write_u32::<BE>(self.family)?;
-        // min hash
-        file.write_u64::<BE>(self.min_hash)?;
-        // max hash
-        file.write_u64::<BE>(self.max_hash)?;
-        // AQMF length
-        file.write_u24::<BE>(self.aqmf.len().try_into().unwrap())?;
-        // Key compression dictionary length
-        file.write_u16::<BE>(self.key_compression_dictionary.len().try_into().unwrap())?;
-        // Value compression dictionary length
-        file.write_u16::<BE>(self.value_compression_dictionary.len().try_into().unwrap())?;
-        // Number of blocks
-        file.write_u16::<BE>(self.blocks.len().try_into().unwrap())?;
-
-        // Write the AQMF
-        file.write_all(&self.aqmf)?;
         // Write the key compression dictionary
         file.write_all(&self.key_compression_dictionary)?;
         // Write the value compression dictionary
@@ -402,13 +405,32 @@ impl StaticSortedFileBuilder {
             offset += len;
             file.write_u32::<BE>(offset.try_into().unwrap())?;
         }
-        for (uncompressed_size, block) in &self.blocks {
+        let block_count = self.blocks.len().try_into().unwrap();
+        for (uncompressed_size, block) in self.blocks {
             // Uncompressed size
-            file.write_u32::<BE>(*uncompressed_size)?;
+            file.write_u32::<BE>(uncompressed_size)?;
             // Compressed block
-            file.write_all(block)?;
+            file.write_all(&block)?;
         }
-        Ok(file.into_inner()?)
+        let meta = StaticSortedFileBuilderMetaResult {
+            min_hash: self.min_hash,
+            max_hash: self.max_hash,
+            aqmf: self.aqmf,
+            key_compression_dictionary_length: self
+                .key_compression_dictionary
+                .len()
+                .try_into()
+                .unwrap(),
+            value_compression_dictionary_length: self
+                .value_compression_dictionary
+                .len()
+                .try_into()
+                .unwrap(),
+            block_count,
+            size: file.stream_position()?,
+            entries: self.entries,
+        };
+        Ok((meta, file.into_inner()?))
     }
 }
 

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -455,7 +455,7 @@ fn persist_changes() -> Result<()> {
     {
         let db = TurboPersistence::open(path.to_path_buf())?;
 
-        db.compact(1.0, 3, usize::MAX)?;
+        db.compact(1.0, 3, u64::MAX)?;
 
         check(&db, 1, 13)?;
         check(&db, 2, 22)?;

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -4,7 +4,7 @@ use std::{
     io::Write,
     mem::{replace, take},
     path::PathBuf,
-    sync::atomic::{AtomicU32, Ordering},
+    sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
 
 use anyhow::{Context, Result};
@@ -25,7 +25,8 @@ use crate::{
     collector_entry::CollectorEntry,
     constants::{MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
     key::StoreKey,
-    static_sorted_file_builder::StaticSortedFileBuilder,
+    meta_file_builder::MetaFileBuilder,
+    static_sorted_file_builder::{StaticSortedFileBuilder, StaticSortedFileBuilderMetaResult},
 };
 
 /// The thread local state of a `WriteBatch`. `FAMILIES` should fit within a `u32`.
@@ -49,9 +50,13 @@ const COLLECTOR_SHARD_SHIFT: usize =
 pub(crate) struct FinishResult {
     pub(crate) sequence_number: u32,
     /// Tuple of (sequence number, file).
+    pub(crate) new_meta_files: Vec<(u32, File)>,
+    /// Tuple of (sequence number, file).
     pub(crate) new_sst_files: Vec<(u32, File)>,
     /// Tuple of (sequence number, file).
     pub(crate) new_blob_files: Vec<(u32, File)>,
+    /// Number of keys written in this batch.
+    pub(crate) keys_written: u64,
 }
 
 enum GlobalCollectorState<K: StoreKey + Send> {
@@ -65,13 +70,15 @@ enum GlobalCollectorState<K: StoreKey + Send> {
 /// A write batch.
 pub struct WriteBatch<K: StoreKey + Send, const FAMILIES: usize> {
     /// The database path
-    path: PathBuf,
+    db_path: PathBuf,
     /// The current sequence number counter. Increased for every new SST file or blob file.
     current_sequence_number: AtomicU32,
     /// The thread local state.
     thread_locals: ThreadLocal<SyncUnsafeCell<ThreadLocalState<K, FAMILIES>>>,
     /// Collectors in use. The thread local collectors flush into these when they are full.
     collectors: [Mutex<GlobalCollectorState<K>>; FAMILIES],
+    /// Meta file builders for each family.
+    meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMetaResult)>>; FAMILIES],
     /// The list of new SST files that have been created.
     /// Tuple of (sequence number, file).
     new_sst_files: Mutex<Vec<(u32, File)>>,
@@ -88,11 +95,12 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
             assert!(FAMILIES <= usize_from_u32(u32::MAX));
         };
         Self {
-            path,
+            db_path: path,
             current_sequence_number: AtomicU32::new(current),
             thread_locals: ThreadLocal::new(),
             collectors: [(); FAMILIES]
                 .map(|_| Mutex::new(GlobalCollectorState::Unsharded(Collector::new()))),
+            meta_collectors: [(); FAMILIES].map(|_| Mutex::new(Vec::new())),
             new_sst_files: Mutex::new(Vec::new()),
             idle_collectors: Mutex::new(Vec::new()),
             idle_thread_local_collectors: Mutex::new(Vec::new()),
@@ -369,12 +377,42 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
             })?;
 
         shared_error.into_inner()?;
+
+        // Not we need to write the new meta files.
+        let new_meta_collectors = [(); FAMILIES].map(|_| Mutex::new(Vec::new()));
+        let meta_collectors = replace(&mut self.meta_collectors, new_meta_collectors);
+        let keys_written = AtomicU64::new(0);
+        let new_meta_files = meta_collectors
+            .into_par_iter()
+            .map(|mutex| mutex.into_inner())
+            .enumerate()
+            .filter(|(_, sst_files)| !sst_files.is_empty())
+            .map(|(family, sst_files)| {
+                let family = family as u32;
+                let mut entries = 0;
+                let mut builder = MetaFileBuilder::new(family);
+                for (seq, sst) in sst_files {
+                    entries += sst.entries;
+                    builder.add(seq, sst);
+                }
+                keys_written.fetch_add(entries, Ordering::Relaxed);
+                let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
+                let file = self.db_path.join(format!("{seq:08}.meta"));
+                let file = builder
+                    .write(&file)
+                    .with_context(|| format!("Unable to write meta file {seq:08}.meta"))?;
+                Ok((seq, file))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Finally we return the new files and sequence number.
         let seq = self.current_sequence_number.load(Ordering::SeqCst);
-        new_sst_files.sort_unstable_by_key(|(seq, _)| *seq);
         Ok(FinishResult {
             sequence_number: seq,
+            new_meta_files,
             new_sst_files,
             new_blob_files,
+            keys_written: keys_written.into_inner(),
         })
     }
 
@@ -388,7 +426,7 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
         lz4::compress_to_vec(value, &mut buffer, ACC_LEVEL_DEFAULT)
             .context("Compression of value for blob file failed")?;
 
-        let file = self.path.join(format!("{seq:08}.blob"));
+        let file = self.db_path.join(format!("{seq:08}.blob"));
         let mut file = File::create(&file).context("Unable to create blob file")?;
         file.write_all(&buffer)
             .context("Unable to write blob file")?;
@@ -407,11 +445,10 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
         let (entries, total_key_size, total_value_size) = collector_data;
         let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
 
-        let builder =
-            StaticSortedFileBuilder::new(family, entries, total_key_size, total_value_size)?;
+        let builder = StaticSortedFileBuilder::new(entries, total_key_size, total_value_size)?;
 
-        let path = self.path.join(format!("{seq:08}.sst"));
-        let file = builder
+        let path = self.db_path.join(format!("{seq:08}.sst"));
+        let (meta, file) = builder
             .write(&path)
             .with_context(|| format!("Unable to write SST file {seq:08}.sst"))?;
 
@@ -422,19 +459,23 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
             use crate::{
                 collector_entry::CollectorEntryValue,
                 key::hash_key,
-                static_sorted_file::{AqmfCache, BlockCache, LookupResult, StaticSortedFile},
+                lookup_entry::LookupValue,
+                static_sorted_file::{
+                    BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData,
+                },
                 static_sorted_file_builder::Entry,
             };
 
             file.sync_all()?;
-            let sst = StaticSortedFile::open(seq, path)?;
-            let cache1 = AqmfCache::with(
-                10,
-                u64::MAX,
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
+            let sst = StaticSortedFile::open(
+                &self.db_path,
+                StaticSortedFileMetaData {
+                    sequence_number: seq,
+                    key_compression_dictionary_length: meta.key_compression_dictionary_length,
+                    value_compression_dictionary_length: meta.value_compression_dictionary_length,
+                    block_count: meta.block_count,
+                },
+            )?;
             let cache2 = BlockCache::with(
                 10,
                 u64::MAX,
@@ -453,21 +494,14 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
             for entry in entries {
                 entry.write_key_to(&mut key_buf);
                 let result = sst
-                    .lookup(
-                        family,
-                        hash_key(&key_buf),
-                        &key_buf,
-                        &cache1,
-                        &cache2,
-                        &cache3,
-                    )
+                    .lookup(hash_key(&key_buf), &key_buf, &cache2, &cache3)
                     .expect("key found");
                 key_buf.clear();
                 match result {
-                    LookupResult::Deleted => {}
-                    LookupResult::Slice {
+                    SstLookupResult::Found(LookupValue::Deleted) => {}
+                    SstLookupResult::Found(LookupValue::Slice {
                         value: lookup_value,
-                    } => {
+                    }) => {
                         let expected_value_slice = match &entry.value {
                             CollectorEntryValue::Small { value } => &**value,
                             CollectorEntryValue::Medium { value } => &**value,
@@ -475,13 +509,15 @@ impl<K: StoreKey + Send + Sync, const FAMILIES: usize> WriteBatch<K, FAMILIES> {
                         };
                         assert_eq!(*lookup_value, *expected_value_slice);
                     }
-                    LookupResult::Blob { sequence_number: _ } => {}
-                    LookupResult::QuickFilterMiss => panic!("aqmf must include"),
-                    LookupResult::RangeMiss => panic!("Index must cover"),
-                    LookupResult::KeyMiss => panic!("All keys must exist"),
+                    SstLookupResult::Found(LookupValue::Blob { sequence_number: _ }) => {}
+                    SstLookupResult::NotFound => panic!("All keys must exist"),
                 }
             }
         }
+
+        self.meta_collectors[usize_from_u32(family)]
+            .lock()
+            .push((seq, meta));
 
         Ok((seq, file))
     }

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -26,7 +26,7 @@ use crate::{
     constants::{MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
     key::StoreKey,
     meta_file_builder::MetaFileBuilder,
-    static_sorted_file_builder::{StaticSortedFileBuilder, StaticSortedFileBuilderMetaResult},
+    static_sorted_file_builder::{StaticSortedFileBuilder, StaticSortedFileBuilderMeta},
 };
 
 /// The thread local state of a `WriteBatch`. `FAMILIES` should fit within a `u32`.
@@ -78,7 +78,7 @@ pub struct WriteBatch<K: StoreKey + Send, const FAMILIES: usize> {
     /// Collectors in use. The thread local collectors flush into these when they are full.
     collectors: [Mutex<GlobalCollectorState<K>>; FAMILIES],
     /// Meta file builders for each family.
-    meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMetaResult)>>; FAMILIES],
+    meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMeta)>>; FAMILIES],
     /// The list of new SST files that have been created.
     /// Tuple of (sequence number, file).
     new_sst_files: Mutex<Vec<(u32, File)>>,

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -15,7 +15,7 @@ use crate::database::{
 
 const COMPACT_MAX_COVERAGE: f32 = 20.0;
 const COMPACT_MAX_MERGE_SEQUENCE: usize = 64;
-const COMPACT_MAX_MERGE_SIZE: usize = 512 * 1024 * 1024; // 512 MiB
+const COMPACT_MAX_MERGE_SIZE: u64 = 512 * 1024 * 1024; // 512 MiB
 
 pub struct TurboKeyValueDatabase {
     db: Arc<TurboPersistence>,


### PR DESCRIPTION
### What?

Split the SST meta data and AQMF into a separate `*.meta` file. A single meta file can contain meta data and AQMFs of multiple SST files.

On database startup only the meta data files need to be read and SST files are lazily mmapped and read only when the AQM-Filter is successful. This ensures that only SST files with a high likelyhood need to be read at all.

Currently this has not much benefit as keys are randomly distributed in SST files, so all files need to be read anyway.
There is a small benefit after a bunch of incremental builds, when some SST files become unused as they have been overwritten.

In future we want to split keys into recently used and not recently used keys and place them in separate SST files. This ensures that less SST files need to be read. This change is a pre-requirement to that change.

Closes PACK-4703