### PR TITLE
Turbopack Build: Skip edge stacktrace test

### DIFF
--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -14,33 +14,39 @@ describe('fetch failures have good stack traces in edge runtime', () => {
     return
   }
 
-  it('when awaiting `fetch` using an unknown domain, stack traces are preserved', async () => {
-    const outputIndex = next.cliOutput.length
-    const browser = await webdriver(next.url, '/api/unknown-domain')
+  // TODO: Failure is not specific to Turbopack, edge runtime errors don't have source maps applied.
+  ;(process.env.IS_TURBOPACK_TEST && isNextStart ? it.skip : it)(
+    'when awaiting `fetch` using an unknown domain, stack traces are preserved',
+    async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await webdriver(next.url, '/api/unknown-domain')
 
-    if (isNextStart) {
-      expect(next.cliOutput.slice(outputIndex)).toMatch(
-        /at.+\/pages\/api\/unknown-domain.js/
-      )
-    } else if (isNextDev) {
-      expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
-        '' +
-          '\n ⨯ Error [TypeError]: fetch failed' +
-          '\n    at anotherFetcher (src/fetcher.js:6:15)' +
-          '\n    at fetcher (src/fetcher.js:2:15)' +
-          '\n    at UnknownDomainEndpoint (pages/api/unknown-domain.js:6:16)' +
-          '\n  4 |' +
-          '\n  5 | async function anotherFetcher(...args) {' +
-          '\n> 6 |   return await fetch(...args)' +
-          '\n    |               ^' +
-          '\n  7 | }' +
-          '\n  8 |' +
-          // TODO(veil): Why double error?
-          '\n ⨯ Error [TypeError]: fetch failed'
-      )
+      if (isNextStart) {
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(next.cliOutput.slice(outputIndex)).toMatch(
+          /at.+\/pages\/api\/unknown-domain.js/
+        )
+      } else if (isNextDev) {
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
+          '' +
+            '\n ⨯ Error [TypeError]: fetch failed' +
+            '\n    at anotherFetcher (src/fetcher.js:6:15)' +
+            '\n    at fetcher (src/fetcher.js:2:15)' +
+            '\n    at UnknownDomainEndpoint (pages/api/unknown-domain.js:6:16)' +
+            '\n  4 |' +
+            '\n  5 | async function anotherFetcher(...args) {' +
+            '\n> 6 |   return await fetch(...args)' +
+            '\n    |               ^' +
+            '\n  7 | }' +
+            '\n  8 |' +
+            // TODO(veil): Why double error?
+            '\n ⨯ Error [TypeError]: fetch failed'
+        )
 
-      // TODO(veil): Why column off by one?
-      await expect(browser).toDisplayRedbox(`
+        // TODO(veil): Why column off by one?
+        // eslint-disable-next-line jest/no-standalone-expect
+        await expect(browser).toDisplayRedbox(`
        {
          "description": "fetch failed",
          "environmentLabel": null,
@@ -55,8 +61,9 @@ describe('fetch failures have good stack traces in edge runtime', () => {
          ],
        }
       `)
+      }
     }
-  })
+  )
 
   // TODO: It need to have source maps picked up by node.js
   it.skip('when returning `fetch` using an unknown domain, stack traces are preserved', async () => {

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -6621,11 +6621,10 @@
   },
   "test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts": {
     "passed": [],
-    "failed": [
-      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved"
-    ],
+    "failed": [],
     "pending": [
-      "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved"
+      "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved",
+      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved"
     ],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

This test is checking a specific path that is not actually sourcemapped when using webpack either. This won't fail for both webpack/Turbopack once edge runtime supports sourcemaps.

Closes PACK-4693