### PR TITLE
Turbopack Build: Fix middleware rewrite test

### DIFF
--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -24,15 +24,19 @@ describe('Middleware Rewrite', () => {
 
   function tests() {
     it('should handle catch-all rewrite correctly', async () => {
-      const browser = await next.browser('/', { waitHydration: false })
+      let requests: string[] = []
+
+      const browser = await next.browser('/', {
+        waitHydration: false,
+        beforePageLoad(page) {
+          page.on('request', (request) => {
+            const url = new URL(request.url())
+            requests.push(url.pathname)
+          })
+        },
+      })
 
       if (!(global as any).isNextDev) {
-        let requests = []
-
-        browser.on('request', (req) => {
-          requests.push(new URL(req.url()).pathname)
-        })
-
         browser.elementByCss('#to-article-rewrite').moveTo()
 
         await retry(async () => {

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -7574,9 +7574,10 @@
       "Middleware Rewrite should rewrite to the external url for incoming data request externally rewritten",
       "Middleware Rewrite should rewrite when not using localhost",
       "Middleware Rewrite should rewrite without hard navigation",
-      "Middleware Rewrite support colons in path"
+      "Middleware Rewrite support colons in path",
+      "Middleware Rewrite should handle catch-all rewrite correctly"
     ],
-    "failed": ["Middleware Rewrite should handle catch-all rewrite correctly"],
+    "failed": [],
     "pending": [
       "Middleware Rewrite includes the locale in rewrites by default"
     ],


### PR DESCRIPTION
## What?

The reason this test fails seems to be that the `browser.on('request'` gets registered too late and the requests are not tracked because of that. Seems it can flake with webpack too. Switched to `beforePageLoad` to register it always. That switch makes the test consistently pass with Turbopack too.

Closes PACK-4695