### PR TITLE
[dev-overlay] Move Redbox open/close into dispatcher

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/app-dev-overlay.tsx
@@ -1,7 +1,11 @@
-import type { OverlayState } from '../shared'
+import {
+  ACTION_ERROR_OVERLAY_OPEN,
+  type OverlayDispatch,
+  type OverlayState,
+} from '../shared'
 import type { GlobalErrorComponent } from '../../global-error'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect } from 'react'
 import { AppDevOverlayErrorBoundary } from './app-dev-overlay-error-boundary'
 import { FontStyles } from '../font/font-styles'
 import { DevOverlay } from '../ui/dev-overlay'
@@ -70,17 +74,18 @@ function ReplaySsrOnlyErrors({
 
 export function AppDevOverlay({
   state,
+  dispatch,
   globalError,
   children,
 }: {
   state: OverlayState
+  dispatch: OverlayDispatch
   globalError: [GlobalErrorComponent, React.ReactNode]
   children: React.ReactNode
 }) {
-  const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(false)
   const openOverlay = useCallback(() => {
-    setIsErrorOverlayOpen(true)
-  }, [])
+    dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
+  }, [dispatch])
 
   return (
     <>
@@ -94,11 +99,7 @@ export function AppDevOverlay({
       <>
         {/* Fonts can only be loaded outside the Shadow DOM. */}
         <FontStyles />
-        <DevOverlay
-          state={state}
-          isErrorOverlayOpen={isErrorOverlayOpen}
-          setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-        />
+        <DevOverlay state={state} dispatch={dispatch} />
       </>
     </>
   )

--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -624,7 +624,7 @@ export default function HotReload({
   ])
 
   return (
-    <AppDevOverlay state={state} globalError={globalError}>
+    <AppDevOverlay state={state} dispatch={dispatch} globalError={globalError}>
       {children}
     </AppDevOverlay>
   )

--- a/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
@@ -30,5 +30,6 @@ export const usePagesDevOverlay = () => {
   return {
     state,
     onComponentError,
+    dispatch,
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/pages/pages-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/pages-dev-overlay.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { PagesDevOverlayErrorBoundary } from './pages-dev-overlay-error-boundary'
 import { usePagesDevOverlay } from './hooks'
 import { FontStyles } from '../font/font-styles'
@@ -13,9 +12,7 @@ interface PagesDevOverlayProps {
 }
 
 export function PagesDevOverlay({ children }: PagesDevOverlayProps) {
-  const { state, onComponentError } = usePagesDevOverlay()
-
-  const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(true)
+  const { state, dispatch, onComponentError } = usePagesDevOverlay()
 
   return (
     <>
@@ -25,11 +22,7 @@ export function PagesDevOverlay({ children }: PagesDevOverlayProps) {
 
       {/* Fonts can only be loaded outside the Shadow DOM. */}
       <FontStyles />
-      <DevOverlay
-        state={state}
-        isErrorOverlayOpen={isErrorOverlayOpen}
-        setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-      />
+      <DevOverlay state={state} dispatch={dispatch} />
     </>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -56,13 +56,14 @@ const state: OverlayState = {
   notFound: false,
   staticIndicator: true,
   debugInfo: { devtoolsFrontendUrl: undefined },
+  isErrorOverlayOpen: false,
 }
 
 export const StaticRoute: Story = {
   args: {
     errorCount: 0,
     state,
-    setIsErrorOverlayOpen: () => {},
+    dispatch: () => {},
   },
 }
 
@@ -73,7 +74,7 @@ export const DynamicRoute: Story = {
       ...state,
       staticIndicator: false,
     },
-    setIsErrorOverlayOpen: () => {},
+    dispatch: () => {},
   },
 }
 
@@ -81,7 +82,7 @@ export const SingleError: Story = {
   args: {
     errorCount: 1,
     state,
-    setIsErrorOverlayOpen: () => {},
+    dispatch: () => {},
   },
 }
 
@@ -89,6 +90,6 @@ export const MultipleErrors: Story = {
   args: {
     errorCount: 3,
     state,
-    setIsErrorOverlayOpen: () => {},
+    dispatch: () => {},
   },
 }

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -1,5 +1,11 @@
 import type { CSSProperties, Dispatch, SetStateAction } from 'react'
-import { STORAGE_KEY_POSITION, type OverlayState } from '../../../../shared'
+import {
+  ACTION_ERROR_OVERLAY_OPEN,
+  ACTION_ERROR_OVERLAY_TOGGLE,
+  STORAGE_KEY_POSITION,
+  type OverlayDispatch,
+  type OverlayState,
+} from '../../../../shared'
 
 import { useState, useEffect, useRef, createContext, useContext } from 'react'
 import { Toast } from '../../toast'
@@ -30,15 +36,13 @@ export function DevToolsIndicator({
   state,
   errorCount,
   isBuildError,
-  setIsErrorOverlayOpen,
   ...props
 }: {
   state: OverlayState
+  dispatch: OverlayDispatch
   errorCount: number
   isBuildError: boolean
-  setIsErrorOverlayOpen: (
-    isErrorOverlayOpen: boolean | ((prev: boolean) => boolean)
-  ) => void
+
   scale: DevToolsScale
   setScale: (value: DevToolsScale) => void
 }) {
@@ -57,7 +61,6 @@ export function DevToolsIndicator({
           method: 'POST',
         })
       }}
-      setIsErrorOverlayOpen={setIsErrorOverlayOpen}
       isTurbopack={!!process.env.TURBOPACK}
       disabled={state.disableDevIndicator || !isDevToolsIndicatorVisible}
       isBuildError={isBuildError}
@@ -96,7 +99,7 @@ function DevToolsPopover({
   isTurbopack,
   isBuildError,
   hide,
-  setIsErrorOverlayOpen,
+  dispatch,
   scale,
   setScale,
 }: {
@@ -108,9 +111,7 @@ function DevToolsPopover({
   isTurbopack: boolean
   isBuildError: boolean
   hide: () => void
-  setIsErrorOverlayOpen: (
-    isOverlayOpen: boolean | ((prev: boolean) => boolean)
-  ) => void
+  dispatch: OverlayDispatch
   scale: DevToolsScale
   setScale: (value: DevToolsScale) => void
 }) {
@@ -210,12 +211,12 @@ function DevToolsPopover({
   function openErrorOverlay() {
     setOpen(null)
     if (issueCount > 0) {
-      setIsErrorOverlayOpen(true)
+      dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
     }
   }
 
   function toggleErrorOverlay() {
-    setIsErrorOverlayOpen((prev) => !prev)
+    dispatch({ type: ACTION_ERROR_OVERLAY_TOGGLE })
   }
 
   function openRootMenu() {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay/error-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay/error-overlay.tsx
@@ -1,4 +1,8 @@
-import type { OverlayState } from '../../../../shared'
+import {
+  ACTION_ERROR_OVERLAY_CLOSE,
+  type OverlayDispatch,
+  type OverlayState,
+} from '../../../../shared'
 
 import { Suspense } from 'react'
 import { BuildError } from '../../../container/build-error'
@@ -18,21 +22,19 @@ export interface ErrorBaseProps {
 
 export function ErrorOverlay({
   state,
+  dispatch,
   runtimeErrors,
-  isErrorOverlayOpen,
-  setIsErrorOverlayOpen,
   errorCount,
 }: {
   state: OverlayState
+  dispatch: OverlayDispatch
   runtimeErrors: ReadyRuntimeError[]
-  isErrorOverlayOpen: boolean
-  setIsErrorOverlayOpen: (value: boolean) => void
   errorCount: number
 }) {
   const isTurbopack = !!process.env.TURBOPACK
 
   // This hook lets us do an exit animation before unmounting the component
-  const { mounted, rendered } = useDelayedRender(isErrorOverlayOpen, {
+  const { mounted, rendered } = useDelayedRender(state.isErrorOverlayOpen, {
     exitDelay: transitionDurationMs,
   })
 
@@ -74,7 +76,7 @@ export function ErrorOverlay({
       debugInfo={state.debugInfo}
       runtimeErrors={runtimeErrors}
       onClose={() => {
-        setIsErrorOverlayOpen(false)
+        dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
       }}
     />
   )

--- a/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.stories.tsx
@@ -1,12 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import type { OverlayState } from '../shared'
+import type { BusEvent, OverlayState } from '../shared'
 
 // @ts-expect-error
 import imgApp from './app.png'
 
-import { useState } from 'react'
+import { useReducer } from 'react'
 import { DevOverlay } from './dev-overlay'
-import { ACTION_UNHANDLED_ERROR } from '../shared'
+import {
+  ACTION_ERROR_OVERLAY_CLOSE,
+  ACTION_ERROR_OVERLAY_OPEN,
+  ACTION_ERROR_OVERLAY_TOGGLE,
+  ACTION_UNHANDLED_ERROR,
+} from '../shared'
 
 const meta: Meta<typeof DevOverlay> = {
   component: DevOverlay,
@@ -18,7 +23,7 @@ const meta: Meta<typeof DevOverlay> = {
 export default meta
 type Story = StoryObj<typeof DevOverlay>
 
-const state: OverlayState = {
+const initialState: OverlayState = {
   nextId: 0,
   routerType: 'app',
   buildError: null,
@@ -81,11 +86,32 @@ const state: OverlayState = {
     installed: '15.2.0',
     staleness: 'fresh',
   },
+  isErrorOverlayOpen: true,
+}
+
+function useOverlayReducer() {
+  return useReducer<OverlayState, [BusEvent]>((state, action): OverlayState => {
+    switch (action.type) {
+      case ACTION_ERROR_OVERLAY_CLOSE: {
+        return { ...state, isErrorOverlayOpen: false }
+      }
+      case ACTION_ERROR_OVERLAY_OPEN: {
+        return { ...state, isErrorOverlayOpen: true }
+      }
+      case ACTION_ERROR_OVERLAY_TOGGLE: {
+        return { ...state, isErrorOverlayOpen: !state.isErrorOverlayOpen }
+      }
+      default: {
+        return state
+      }
+    }
+    return state
+  }, initialState)
 }
 
 export const Default: Story = {
   render: function DevOverlayStory() {
-    const [isErrorOverlayOpen, setIsErrorOverlayOpen] = useState(true)
+    const [state, dispatch] = useOverlayReducer()
     return (
       <>
         <img
@@ -96,11 +122,7 @@ export const Default: Story = {
             objectFit: 'contain',
           }}
         />
-        <DevOverlay
-          state={state}
-          isErrorOverlayOpen={isErrorOverlayOpen}
-          setIsErrorOverlayOpen={setIsErrorOverlayOpen}
-        />
+        <DevOverlay state={state} dispatch={dispatch} />
       </>
     )
   },

--- a/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.tsx
@@ -1,4 +1,4 @@
-import type { OverlayState } from '../shared'
+import type { OverlayDispatch, OverlayState } from '../shared'
 
 import { ShadowPortal } from './components/shadow-portal'
 import { Base } from './styles/base'
@@ -13,14 +13,10 @@ import { useDevToolsScale } from './components/errors/dev-tools-indicator/dev-to
 
 export function DevOverlay({
   state,
-  isErrorOverlayOpen,
-  setIsErrorOverlayOpen,
+  dispatch,
 }: {
   state: OverlayState
-  isErrorOverlayOpen: boolean
-  setIsErrorOverlayOpen: (
-    isErrorOverlayOpen: boolean | ((prev: boolean) => boolean)
-  ) => void
+  dispatch: OverlayDispatch
 }) {
   const [scale, setScale] = useDevToolsScale()
   return (
@@ -41,18 +37,17 @@ export function DevOverlay({
                   scale={scale}
                   setScale={setScale}
                   state={state}
+                  dispatch={dispatch}
                   errorCount={totalErrorCount}
                   isBuildError={isBuildError}
-                  setIsErrorOverlayOpen={setIsErrorOverlayOpen}
                 />
               )}
 
               <ErrorOverlay
                 state={state}
+                dispatch={dispatch}
                 runtimeErrors={runtimeErrors}
                 errorCount={totalErrorCount}
-                isErrorOverlayOpen={isErrorOverlayOpen}
-                setIsErrorOverlayOpen={setIsErrorOverlayOpen}
               />
             </>
           )

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -209,7 +209,7 @@ describe('Error overlay for hydration errors in App router', () => {
        {
          "componentStack": "...
            <HotReload assetPrefix="" globalError={[...]}>
-             <AppDevOverlay state={{nextId:1, ...}} globalError={[...]}>
+             <AppDevOverlay state={{nextId:1, ...}} dispatch={function bound dispatchReducerAction} globalError={[...]}>
                <AppDevOverlayErrorBoundary globalError={[...]} onError={function}>
                  <ReplaySsrOnlyErrors>
                  <DevRootHTTPAccessFallbackBoundary>
@@ -245,7 +245,7 @@ describe('Error overlay for hydration errors in App router', () => {
        {
          "componentStack": "...
            <HotReload assetPrefix="" globalError={[...]}>
-             <AppDevOverlay state={{nextId:1, ...}} globalError={[...]}>
+             <AppDevOverlay state={{nextId:1, ...}} dispatch={function bound dispatchReducerAction} globalError={[...]}>
                <AppDevOverlayErrorBoundary globalError={[...]} onError={function}>
                  <ReplaySsrOnlyErrors>
                  <DevRootHTTPAccessFallbackBoundary>
@@ -1045,7 +1045,7 @@ describe('Error overlay for hydration errors in App router', () => {
        {
          "componentStack": "...
          <HotReload assetPrefix="" globalError={[...]}>
-           <AppDevOverlay state={{nextId:1, ...}} globalError={[...]}>
+           <AppDevOverlay state={{nextId:1, ...}} dispatch={function bound dispatchReducerAction} globalError={[...]}>
              <AppDevOverlayErrorBoundary globalError={[...]} onError={function}>
                <ReplaySsrOnlyErrors>
                <DevRootHTTPAccessFallbackBoundary>


### PR DESCRIPTION
The dispatcher will later be the bridge between user code and the dev overlay so it should house all logic that communicates with the Dev Overlay frontend.