### PR TITLE
misc: remove leftover `clientInstrumentationHook` type

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -684,15 +684,6 @@ export interface ExperimentalConfig {
   }
 
   /**
-   * Enables the client instrumentation hook.
-   * Loads the instrumentation-client.ts file from the project root
-   * and executes it on the client side before hydration.
-   *
-   * Note: Use with caution as this can negatively impact page loading performance.
-   */
-  clientInstrumentationHook?: boolean
-
-  /**
    * Enables using the global-not-found.js file in the app directory
    *
    */


### PR DESCRIPTION
Remaining of https://github.com/vercel/next.js/pull/77649