### PR TITLE
[release-new] prevent release race condition from scheduled releases

### DIFF
--- a/.github/workflows/force_merge_canary_release_pr.yml
+++ b/.github/workflows/force_merge_canary_release_pr.yml
@@ -11,10 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     # Validate the login, PR title, and the label to ensure the PR is
     # from the release PR and prevent spoofing.
+    # If it has "Freeze: Scheduled Release" label, it means that this
+    # release PR was triggered manually, assuming we might want to review it.
     if: |
       github.event.pull_request.user.login == 'vercel-release-bot' &&
       github.event.pull_request.title == 'Version Packages (canary)' &&
-      contains(github.event.pull_request.labels.*.name, 'created-by: CI')
+      contains(github.event.pull_request.labels.*.name, 'created-by: CI') &&
+      !contains(github.event.pull_request.labels.*.name, 'Freeze: Scheduled Release')
     steps:
       - name: Bypass required status checks and merge PR
         run: gh pr merge --admin --squash "$PR_URL"

--- a/.github/workflows/force_merge_canary_release_pr.yml
+++ b/.github/workflows/force_merge_canary_release_pr.yml
@@ -1,6 +1,9 @@
 name: Force Merge Canary Release PR
 
-on: pull_request
+on:
+  pull_request:
+    # "labeled" since the labels are added after PR being opened.
+    types: [opened, synchronize, labeled]
 
 permissions:
   # To bypass and merge PR
@@ -13,7 +16,7 @@ jobs:
     # from the release PR and prevent spoofing.
     # If it has "Freeze: Scheduled Release" label, it means that this
     # release PR was triggered manually, assuming we might want to review it.
-    if: |
+    if: >-
       github.event.pull_request.user.login == 'vercel-release-bot' &&
       github.event.pull_request.title == 'Version Packages (canary)' &&
       contains(github.event.pull_request.labels.*.name, 'created-by: CI') &&

--- a/.github/workflows/force_merge_canary_release_pr.yml
+++ b/.github/workflows/force_merge_canary_release_pr.yml
@@ -3,7 +3,7 @@ name: Force Merge Canary Release PR
 on:
   pull_request:
     # "labeled" since the labels are added after PR being opened.
-    types: [opened, synchronize, labeled]
+    types: [labeled]
 
 permissions:
   # To bypass and merge PR

--- a/.github/workflows/force_merge_canary_release_pr.yml
+++ b/.github/workflows/force_merge_canary_release_pr.yml
@@ -23,4 +23,4 @@ jobs:
         run: gh pr merge --admin --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.RELEASE_BOT_GITHUB_TOKEN}}

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -66,6 +66,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
+      - name: Check for existing Freeze Release PR
+        run: |
+          FREEZE_PR=$(gh pr list --label "Freeze: Release" --state open --json number --jq '.[0].number // empty')
+          if [ ! -z "$FREEZE_PR" ]; then
+            echo 'Found existing PR #$FREEZE_PR with "Freeze: Release" label. Skipping workflow...'
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+
       - name: Get commit of the latest tag
         run: echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 $(git describe --tags --abbrev=0))" >> $GITHUB_ENV
 
@@ -115,9 +125,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
 
-      # Add label to verify the PR is created from this workflow.
+      # Add "created-by: CI" label to verify the PR is created from this workflow.
+      # Add "Freeze: Release" label to freeze the next release process to prevent race condition from cron jobs.
       - name: Add label to PR
         if: steps.changesets.outputs.pullRequestNumber
-        run: 'gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "created-by: CI"'
+        run: |
+          gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "created-by: CI"
+          if [ "${{ github.event.inputs.releaseType }}" != "canary" ]; then
+            gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "Freeze: Release"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           FREEZE_PR=$(gh pr list --label "Freeze: Scheduled Release" --state open --json number --jq '.[0].number // empty')
           if [ ! -z "$FREEZE_PR" ]; then
-            echo "Found existing PR #$FREEZE_PR with 'Freeze: Scheduled Release' label. Skipping scheduled release..."
+            echo "Found existing PR with 'Freeze: Scheduled Release' label. Skipping scheduled release..."
+            echo "PR: https://github.com/${{ github.repository }}/pull/$FREEZE_PR"
             exit 1
           fi
         env:

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -66,13 +66,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
-      - name: Check for existing Freeze Scheduled Release PR
+      - name: Check for existing Freeze Scheduled Release PR and skip if exists
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          FREEZE_PR=$(gh pr list --label "Freeze: Scheduled Release" --state open --json number --jq '.[0].number // empty')
-          if [ ! -z "$FREEZE_PR" ]; then
+          # Check if there is an open pull request labeled "Freeze: Scheduled Release"
+          freeze_pr_number=$(gh pr list \
+            --label "Freeze: Scheduled Release" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          # If there is an open PR with the "Freeze: Scheduled Release" label, skip scheduled release.
+          if [ -n "$freeze_pr_number" ]; then
             echo "Found existing PR with 'Freeze: Scheduled Release' label. Skipping scheduled release..."
-            echo "PR: https://github.com/${{ github.repository }}/pull/$FREEZE_PR"
+            echo "PR: https://github.com/${{ github.repository }}/pull/$freeze_pr_number"
             exit 1
           fi
         env:

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -66,11 +66,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
-      - name: Check for existing Freeze Release PR
+      - name: Check for existing Freeze Scheduled Release PR
+        if: ${{ github.event_name == 'schedule' }}
         run: |
-          FREEZE_PR=$(gh pr list --label "Freeze: Release" --state open --json number --jq '.[0].number // empty')
+          FREEZE_PR=$(gh pr list --label "Freeze: Scheduled Release" --state open --json number --jq '.[0].number // empty')
           if [ ! -z "$FREEZE_PR" ]; then
-            echo 'Found existing PR #$FREEZE_PR with "Freeze: Release" label. Skipping workflow...'
+            echo "Found existing PR #$FREEZE_PR with 'Freeze: Scheduled Release' label. Skipping scheduled release..."
             exit 1
           fi
         env:
@@ -126,13 +127,14 @@ jobs:
           RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
 
       # Add "created-by: CI" label to verify the PR is created from this workflow.
-      # Add "Freeze: Release" label to freeze the next release process to prevent race condition from cron jobs.
+      # If this workflow is manually triggered, add "Freeze: Scheduled Release" label
+      # to freeze the next scheduled release to prevent race condition from cron jobs.
       - name: Add label to PR
         if: steps.changesets.outputs.pullRequestNumber
         run: |
           gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "created-by: CI"
-          if [ "${{ github.event.inputs.releaseType }}" != "canary" ]; then
-            gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "Freeze: Release"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "Freeze: Scheduled Release"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -138,4 +138,4 @@ jobs:
             gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label "Freeze: Scheduled Release"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
### Why?

When we manually trigger a release, we don't expect the cron jobs to overtake our process and cause conflicts. Therefore, add the "Freeze: Scheduled Release" label to the release PR created by the manually triggered workflow.

Also, it prevents force-merging the canary release PR.