### PR TITLE
Update flakey empty-project test

### DIFF
--- a/test/integration/empty-project/test/index.test.js
+++ b/test/integration/empty-project/test/index.test.js
@@ -13,7 +13,8 @@ describe('Empty Project', () => {
     context.server = await launchApp(join(__dirname, '../'), context.appPort)
   })
 
-  const fetch = (p, q) => fetchViaHTTP(context.appPort, p, q, { timeout: 5000 })
+  const fetch = (p, q) =>
+    fetchViaHTTP(context.appPort, p, q, { timeout: 10_000 })
 
   it('Should not time out and return 404', async () => {
     const res = await fetch('/')


### PR DESCRIPTION
This test case has been flaking quite a bit so this increases the fetch timeout delay as we mainly want to ensure the correct content is rendered and it works not the duration. 