### PR TITLE
[dynamicIO] Use filled Resume Data Cache for final-phase prerenders

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -365,9 +365,9 @@ export async function handler(
 
           // If the warmup is successful, we should use the resume data
           // cache from the warmup.
-          if (warmup.metadata.devRenderResumeDataCache) {
-            context.renderOpts.devRenderResumeDataCache =
-              warmup.metadata.devRenderResumeDataCache
+          if (warmup.metadata.renderResumeDataCache) {
+            context.renderOpts.renderResumeDataCache =
+              warmup.metadata.renderResumeDataCache
           }
         }
       }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -655,6 +655,9 @@ async function exportAppImpl(
         // all the entries that the fallback shell also needs. We don't need to
         // merge them per page.
         renderResumeDataCachesByPage[page] = result.renderResumeDataCache
+        // Remove the RDC string from the result so that it can be garbage
+        // collected, when there are more results for the same page.
+        result.renderResumeDataCache = undefined
       }
     }
 

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -29,6 +29,7 @@ import { AfterRunner } from '../../server/after/run-with-after'
 import type { RequestLifecycleOpts } from '../../server/base-server'
 import type { AppSharedContext } from '../../server/app-render/app-render'
 import type { MultiFileWriter } from '../../lib/multi-file-writer'
+import { stringifyResumeDataCache } from '../../server/resume-data-cache/resume-data-cache'
 
 /**
  * Renders & exports a page associated with the /app directory
@@ -92,6 +93,7 @@ export async function exportAppPage(
       fetchTags,
       fetchMetrics,
       segmentData,
+      renderResumeDataCache,
     } = metadata
 
     // Ensure we don't postpone without having PPR enabled.
@@ -220,6 +222,9 @@ export async function exportAppPage(
       hasPostponed: Boolean(postponed),
       cacheControl,
       fetchMetrics,
+      renderResumeDataCache: renderResumeDataCache
+        ? await stringifyResumeDataCache(renderResumeDataCache)
+        : undefined,
     }
   } catch (err) {
     if (!isDynamicUsageError(err)) {

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -12,6 +12,7 @@ import type {
 } from '../build/turborepo-access-trace'
 import type { FetchMetrics } from '../server/base-http'
 import type { RouteMetadata } from './routes/types'
+import type { RenderResumeDataCache } from '../server/resume-data-cache/resume-data-cache'
 
 export interface AmpValidation {
   page: string
@@ -40,6 +41,7 @@ export interface ExportPagesInput {
   cacheHandler: string | undefined
   fetchCacheKeyPrefix: string | undefined
   options: ExportAppOptions
+  renderResumeDataCachesByPage: Record<string, string> | undefined
 }
 
 export interface ExportPageInput {
@@ -62,6 +64,7 @@ export interface ExportPageInput {
   nextConfigOutput?: NextConfigComplete['output']
   enableExperimentalReact?: boolean
   sriEnabled: boolean
+  renderResumeDataCache: RenderResumeDataCache | undefined
 }
 
 export type ExportRouteResult =
@@ -73,6 +76,7 @@ export type ExportRouteResult =
       hasEmptyStaticShell?: boolean
       hasPostponed?: boolean
       fetchMetrics?: FetchMetrics
+      renderResumeDataCache?: string
     }
   | {
       error: boolean

--- a/packages/next/src/server/app-render/postponed-state.ts
+++ b/packages/next/src/server/app-render/postponed-state.ts
@@ -62,14 +62,14 @@ export type PostponedState =
 export async function getDynamicHTMLPostponedState(
   data: object,
   fallbackRouteParams: FallbackRouteParams | null,
-  prerenderResumeDataCache: PrerenderResumeDataCache
+  resumeDataCache: PrerenderResumeDataCache | RenderResumeDataCache
 ): Promise<string> {
   if (!fallbackRouteParams || fallbackRouteParams.size === 0) {
     const postponedString = JSON.stringify(data)
 
     // Serialized as `<postponedString.length>:<postponedString><renderResumeDataCache>`
     return `${postponedString.length}:${postponedString}${await stringifyResumeDataCache(
-      createRenderResumeDataCache(prerenderResumeDataCache)
+      createRenderResumeDataCache(resumeDataCache)
     )}`
   }
 
@@ -81,13 +81,13 @@ export async function getDynamicHTMLPostponedState(
   const postponedString = `${replacementsString.length}${replacementsString}${dataString}`
 
   // Serialized as `<postponedString.length>:<postponedString><renderResumeDataCache>`
-  return `${postponedString.length}:${postponedString}${await stringifyResumeDataCache(prerenderResumeDataCache)}`
+  return `${postponedString.length}:${postponedString}${await stringifyResumeDataCache(resumeDataCache)}`
 }
 
 export async function getDynamicDataPostponedState(
-  prerenderResumeDataCache: PrerenderResumeDataCache
+  resumeDataCache: PrerenderResumeDataCache | RenderResumeDataCache
 ): Promise<string> {
-  return `4:null${await stringifyResumeDataCache(createRenderResumeDataCache(prerenderResumeDataCache))}`
+  return `4:null${await stringifyResumeDataCache(createRenderResumeDataCache(resumeDataCache))}`
 }
 
 export function parsePostponedState(

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -250,10 +250,11 @@ export interface RenderOptsPartial {
   shouldWaitOnAllReady?: boolean
 
   /**
-   * The resume data cache that was generated for this partially prerendered
-   * page during dev warmup.
+   * A prefilled resume data cache. This was either generated for this page
+   * during dev warmup, or when a page with defined params was previously
+   * prerendered, and now its matching optional fallback shell is prerendered.
    */
-  devRenderResumeDataCache?: RenderResumeDataCache
+  renderResumeDataCache?: RenderResumeDataCache
 
   /**
    * When true, the page will be rendered using the static rendering to detect

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -280,21 +280,24 @@ export function getPrerenderResumeDataCache(
 export function getRenderResumeDataCache(
   workUnitStore: WorkUnitStore
 ): RenderResumeDataCache | null {
-  if (
-    workUnitStore.type !== 'prerender-legacy' &&
-    workUnitStore.type !== 'cache' &&
-    workUnitStore.type !== 'unstable-cache'
-  ) {
-    if (workUnitStore.type === 'request') {
+  switch (workUnitStore.type) {
+    case 'request':
       return workUnitStore.renderResumeDataCache
-    }
-
-    // We return the mutable resume data cache here as an immutable version of
-    // the cache as it can also be used for reading.
-    return workUnitStore.prerenderResumeDataCache
+    case 'prerender':
+    case 'prerender-client':
+      if (workUnitStore.renderResumeDataCache) {
+        // If we are in a prerender, we might have a render resume data cache
+        // that is used to read from prefilled caches.
+        return workUnitStore.renderResumeDataCache
+      }
+    // fallthrough
+    case 'prerender-ppr':
+      // Otherwise we return the mutable resume data cache here as an immutable
+      // version of the cache as it can also be used for reading.
+      return workUnitStore.prerenderResumeDataCache
+    default:
+      return null
   }
-
-  return null
 }
 
 export function getHmrRefreshHash(

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -116,9 +116,17 @@ export interface PrerenderStoreModern extends CommonWorkUnitStore {
   tags: null | string[]
 
   /**
-   * The resume data cache for this prerender.
+   * A mutable resume data cache for this prerender.
    */
   prerenderResumeDataCache: PrerenderResumeDataCache | null
+
+  /**
+   * An immutable resume data cache for this prerender. This may be provided
+   * instead of the `prerenderResumeDataCache` if the prerender is not supposed
+   * to fill caches, and only read from prefilled caches, e.g. when prerendering
+   * an optional fallback shell.
+   */
+  renderResumeDataCache: RenderResumeDataCache | null
 
   /**
    * The HMR refresh hash is only provided in dev mode. It is needed for the dev

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2774,9 +2774,9 @@ export default abstract class Server<
 
                 // If the warmup is successful, we should use the resume data
                 // cache from the warmup.
-                if (warmup.metadata.devRenderResumeDataCache) {
-                  renderOpts.devRenderResumeDataCache =
-                    warmup.metadata.devRenderResumeDataCache
+                if (warmup.metadata.renderResumeDataCache) {
+                  renderOpts.renderResumeDataCache =
+                    warmup.metadata.renderResumeDataCache
                 }
               }
 

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -38,10 +38,12 @@ export type AppPageRenderResultMetadata = {
   segmentData?: Map<string, Buffer>
 
   /**
-   * In development, the cache is warmed up before the render. This is attached
-   * to the metadata so that it can be used during the render.
+   * In development, the resume data cache is warmed up before the render. This
+   * is attached to the metadata so that it can be used during the render. When
+   * prerendering, the filled resume data cache is also attached to the metadata
+   * so that it can be used when prerendering matching fallback shells.
    */
-  devRenderResumeDataCache?: RenderResumeDataCache
+  renderResumeDataCache?: RenderResumeDataCache
 }
 
 export type PagesRenderResultMetadata = {

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.ts
@@ -157,10 +157,14 @@ export function createPrerenderResumeDataCache(): PrerenderResumeDataCache {
  * 1. An existing prerender cache instance
  * 2. A serialized cache string
  *
+ * @param renderResumeDataCache - A RenderResumeDataCache instance to be used directly
  * @param prerenderResumeDataCache - A PrerenderResumeDataCache instance to convert to immutable
  * @param persistedCache - A serialized cache string to parse
  * @returns An immutable RenderResumeDataCache instance
  */
+export function createRenderResumeDataCache(
+  renderResumeDataCache: RenderResumeDataCache
+): RenderResumeDataCache
 export function createRenderResumeDataCache(
   prerenderResumeDataCache: PrerenderResumeDataCache
 ): RenderResumeDataCache
@@ -168,20 +172,23 @@ export function createRenderResumeDataCache(
   persistedCache: string
 ): RenderResumeDataCache
 export function createRenderResumeDataCache(
-  prerenderResumeDataCacheOrPersistedCache: PrerenderResumeDataCache | string
+  resumeDataCacheOrPersistedCache:
+    | RenderResumeDataCache
+    | PrerenderResumeDataCache
+    | string
 ): RenderResumeDataCache {
   if (process.env.NEXT_RUNTIME === 'edge') {
     throw new InvariantError(
       '`createRenderResumeDataCache` should not be called in edge runtime.'
     )
   } else {
-    if (typeof prerenderResumeDataCacheOrPersistedCache !== 'string') {
-      // If the cache is already a prerender cache, we can return it directly,
-      // we're just performing a type change.
-      return prerenderResumeDataCacheOrPersistedCache
+    if (typeof resumeDataCacheOrPersistedCache !== 'string') {
+      // If the cache is already a prerender or render cache, we can return it
+      // directly. For the former, we're just performing a type change.
+      return resumeDataCacheOrPersistedCache
     }
 
-    if (prerenderResumeDataCacheOrPersistedCache === 'null') {
+    if (resumeDataCacheOrPersistedCache === 'null') {
       return {
         cache: new Map(),
         fetch: new Map(),
@@ -197,7 +204,7 @@ export function createRenderResumeDataCache(
 
     const json: ResumeStoreSerialized = JSON.parse(
       inflateSync(
-        Buffer.from(prerenderResumeDataCacheOrPersistedCache, 'base64')
+        Buffer.from(resumeDataCacheOrPersistedCache, 'base64')
       ).toString('utf-8')
     )
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -395,7 +395,9 @@ export class AppRouteRouteModule extends RouteModule<
               expire: INFINITE_CACHE,
               stale: INFINITE_CACHE,
               tags: [...implicitTags.tags],
+              // TODO: Shouldn't we provide an RDC here?
               prerenderResumeDataCache: null,
+              renderResumeDataCache: null,
               hmrRefreshHash: undefined,
             })
 
@@ -483,7 +485,9 @@ export class AppRouteRouteModule extends RouteModule<
             expire: INFINITE_CACHE,
             stale: INFINITE_CACHE,
             tags: [...implicitTags.tags],
+            // TODO: Shouldn't we provide an RDC here?
             prerenderResumeDataCache: null,
+            renderResumeDataCache: null,
             hmrRefreshHash: undefined,
           })
 

--- a/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-suspense/layout.jsx
+++ b/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-suspense/layout.jsx
@@ -7,8 +7,8 @@ export default async function Layout({ children }) {
   return (
     <html>
       <body>
-        <div id="layout">
-          Layout: {new Date().toISOString()} ({getSentinelValue()})
+        <div id="root-layout">
+          Root Layout: {new Date().toISOString()} ({getSentinelValue()})
         </div>
         <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
       </body>

--- a/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-suspense/params-in-page/[slug]/layout.tsx
+++ b/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-suspense/params-in-page/[slug]/layout.tsx
@@ -1,0 +1,19 @@
+'use cache'
+
+import { getSentinelValue } from '../../../sentinel'
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <p>This layout is explicitly not reading params.</p>
+      <div id="layout">
+        Layout: {new Date().toISOString()} ({getSentinelValue()})
+      </div>
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/fallback-shells/app/with-cached-io/without-suspense/layout.jsx
+++ b/test/e2e/app-dir/fallback-shells/app/with-cached-io/without-suspense/layout.jsx
@@ -6,8 +6,8 @@ export default async function Layout({ children }) {
   return (
     <html>
       <body>
-        <div id="layout">
-          Layout: {new Date().toISOString()} ({getSentinelValue()})
+        <div id="root-layout">
+          Root Layout: {new Date().toISOString()} ({getSentinelValue()})
         </div>
         {children}
       </body>

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -55,9 +55,8 @@ describe('fallback-shells', () => {
             '/with-cached-io/with-suspense/params-in-page/foo'
           )
 
-          const layoutDateRouteShell = $(
-            '[data-testid="layout-buildtime"]'
-          ).text()
+          const selector = `[data-testid="layout-${isNextDev ? 'runtime' : 'buildtime'}"]`
+          const layoutDateRouteShell = $(selector).text()
 
           // Sanity check that we've selected the correct element.
           expect(layoutDateRouteShell).toStartWith('Layout:')
@@ -67,9 +66,7 @@ describe('fallback-shells', () => {
             '/with-cached-io/with-suspense/params-in-page/bar'
           )
 
-          const layoutDateFallbackShell = $(
-            '[data-testid="layout-buildtime"]'
-          ).text()
+          const layoutDateFallbackShell = $(selector).text()
 
           expect(layoutDateFallbackShell).toBe(layoutDateRouteShell)
         })

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -49,27 +49,31 @@ describe('fallback-shells', () => {
           }
         })
 
-        it('shares a cached layout between a prerendered route shell and the fallback shell', async () => {
-          // `/foo` was prerendered
-          let $ = await next.render$(
-            '/with-cached-io/with-suspense/params-in-page/foo'
-          )
+        // TODO: Activate for deploy tests once background revalidation for
+        // prerendered pages is not triggered anymore on the first visit.
+        if (!isNextDeploy) {
+          it('shares a cached layout between a prerendered route shell and the fallback shell', async () => {
+            // `/foo` was prerendered
+            let $ = await next.render$(
+              '/with-cached-io/with-suspense/params-in-page/foo'
+            )
 
-          const selector = `[data-testid="layout-${isNextDev ? 'runtime' : 'buildtime'}"]`
-          const layoutDateRouteShell = $(selector).text()
+            const selector = `[data-testid="layout-${isNextDev ? 'runtime' : 'buildtime'}"]`
+            const layoutDateRouteShell = $(selector).text()
 
-          // Sanity check that we've selected the correct element.
-          expect(layoutDateRouteShell).toStartWith('Layout:')
+            // Sanity check that we've selected the correct element.
+            expect(layoutDateRouteShell).toStartWith('Layout:')
 
-          // `/bar` was not prerendered, so the fallback shell is used
-          $ = await next.render$(
-            '/with-cached-io/with-suspense/params-in-page/bar'
-          )
+            // `/bar` was not prerendered, so the fallback shell is used
+            $ = await next.render$(
+              '/with-cached-io/with-suspense/params-in-page/bar'
+            )
 
-          const layoutDateFallbackShell = $(selector).text()
+            const layoutDateFallbackShell = $(selector).text()
 
-          expect(layoutDateFallbackShell).toBe(layoutDateRouteShell)
-        })
+            expect(layoutDateFallbackShell).toBe(layoutDateRouteShell)
+          })
+        }
       })
 
       describe('and the params accessed in cached non-page function', () => {

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -48,6 +48,31 @@ describe('fallback-shells', () => {
             expect(headers['x-nextjs-postponed']).toBe('1')
           }
         })
+
+        it('shares a cached layout between a prerendered route shell and the fallback shell', async () => {
+          // `/foo` was prerendered
+          let $ = await next.render$(
+            '/with-cached-io/with-suspense/params-in-page/foo'
+          )
+
+          const layoutDateRouteShell = $(
+            '[data-testid="layout-buildtime"]'
+          ).text()
+
+          // Sanity check that we've selected the correct element.
+          expect(layoutDateRouteShell).toStartWith('Layout:')
+
+          // `/bar` was not prerendered, so the fallback shell is used
+          $ = await next.render$(
+            '/with-cached-io/with-suspense/params-in-page/bar'
+          )
+
+          const layoutDateFallbackShell = $(
+            '[data-testid="layout-buildtime"]'
+          ).text()
+
+          expect(layoutDateFallbackShell).toBe(layoutDateRouteShell)
+        })
       })
 
       describe('and the params accessed in cached non-page function', () => {

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -52,7 +52,29 @@ describe('fallback-shells', () => {
         // TODO: Activate for deploy tests once background revalidation for
         // prerendered pages is not triggered anymore on the first visit.
         if (!isNextDeploy) {
-          it('shares a cached layout between a prerendered route shell and the fallback shell', async () => {
+          it('shares a cached parent layout between a prerendered route shell and the fallback shell', async () => {
+            // `/foo` was prerendered
+            let $ = await next.render$(
+              '/with-cached-io/with-suspense/params-in-page/foo'
+            )
+
+            const selector = `[data-testid="root-layout-${isNextDev ? 'runtime' : 'buildtime'}"]`
+            const layoutDateRouteShell = $(selector).text()
+
+            // Sanity check that we've selected the correct element.
+            expect(layoutDateRouteShell).toStartWith('Root Layout:')
+
+            // `/bar` was not prerendered, so the fallback shell is used
+            $ = await next.render$(
+              '/with-cached-io/with-suspense/params-in-page/bar'
+            )
+
+            const layoutDateFallbackShell = $(selector).text()
+
+            expect(layoutDateFallbackShell).toBe(layoutDateRouteShell)
+          })
+
+          it('shares a cached layout with unused dynamic params between a prerendered route shell and the fallback shell', async () => {
             // `/foo` was prerendered
             let $ = await next.render$(
               '/with-cached-io/with-suspense/params-in-page/foo'


### PR DESCRIPTION
When a route with dynamic params is prerendered using defined params from `generateStaticParams`, the filled Resume Data Cache is now used for the final-phase prerender of the matching optional fallback shell.

This ensures that the fallback shell can reuse existing cache entries, which partially mitigates the performance hit we accepted by splitting up the prerendering into two phases.

Furthermore, it will allow us to short-circuit fallback params access in `"use cache"` functions. Instead of having to wait for the timeout error, we will be able to regard cache misses (excluding cached pages and layouts, whose params access is already handled swiftly) to be caused by including the params in the cache key, if `allowEmptyFallbackShell` is `true`.