### PR TITLE
[turbopack] Create a macro rcstr! for constructing RcStr from string literals.

### DIFF
--- a/turbopack/crates/turbo-rcstr/benches/mod.rs
+++ b/turbopack/crates/turbo-rcstr/benches/mod.rs
@@ -1,5 +1,5 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 
 // map has a fast-path if the Arc is uniquely owned
 fn bench_map(c: &mut Criterion) {
@@ -30,9 +30,26 @@ fn bench_map(c: &mut Criterion) {
     }
 }
 
+/// Compare the performance of `from` and `rcstr!`
+fn bench_construct(c: &mut Criterion) {
+    let mut g = c.benchmark_group("Rcstr::construct");
+    g.bench_with_input("rcstr!/small", "small", |f, _| {
+        f.iter(|| rcstr!("hello"));
+    });
+    g.bench_with_input("rcstr!/large", "large", |f, _| {
+        f.iter(|| rcstr!("this is a long string that will take time to copy"));
+    });
+
+    g.bench_with_input("from/small", "small", |f, _| {
+        f.iter(|| RcStr::from("hello"));
+    });
+    g.bench_with_input("from/large", "large", |f, _| {
+        f.iter(|| RcStr::from("this is a long string that will take time to copy"));
+    });
+}
 criterion_group!(
   name = benches;
   config = Criterion::default();
-  targets = bench_map,
+  targets = bench_map,bench_construct,
 );
 criterion_main!(benches);

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -72,7 +72,7 @@ impl TaggedValue {
     }
 
     #[inline(always)]
-    pub fn new_tag(value: NonZeroU8) -> Self {
+    pub const fn new_tag(value: NonZeroU8) -> Self {
         let value = value.get() as RawTaggedValue;
         Self {
             value: unsafe { std::mem::transmute(value) },
@@ -129,7 +129,7 @@ impl TaggedValue {
     /// used when setting the untagged slice part of this value. If tag is
     /// zero and the slice is zeroed out, using this `TaggedValue` will be
     /// UB!
-    pub unsafe fn data_mut(&mut self) -> &mut [u8] {
+    pub const unsafe fn data_mut(&mut self) -> &mut [u8] {
         let x: *mut _ = &mut self.value;
         let mut data = x as *mut u8;
         // All except the lowest byte, which is first in little-endian, last in


### PR DESCRIPTION
## Add `rcstr!` macro for efficient string literal handling

### What?

This PR introduces a new `rcstr!` macro that creates `RcStr` instances from string literals, optimizing for inline storage when possible and using `LazyLock` for longer strings.

### Why?

The `rcstr!` macro provides several benefits:
- Allows compile-time evaluation of inline strings
- Caches longer strings using `LazyLock` to avoid repeated allocations


Closes PACK-4729