### PR TITLE
Enable repeated `tsc` runs in `packages/next` without having to build first

### DIFF
--- a/packages/next/src/client/image-component.tsx
+++ b/packages/next/src/client/image-component.tsx
@@ -29,7 +29,7 @@ import { ImageConfigContext } from '../shared/lib/image-config-context.shared-ru
 import { warnOnce } from '../shared/lib/utils/warn-once'
 import { RouterContext } from '../shared/lib/router-context.shared-runtime'
 
-// @ts-ignore - This is replaced by webpack alias
+// This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
 import { useMergedRef } from './use-merged-ref'
 

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -4,7 +4,7 @@ import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 import { getImgProps } from './get-img-props'
 import { Image } from '../../client/image-component'
 
-// @ts-ignore - This is replaced by webpack alias
+// This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
 
 /**

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -8,12 +8,29 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "target": "ES2018",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "paths": {
+      // Required absolute paths.
+      // We rewrite these here so that they aren't also input files which would fail tsc with
+      // "Cannot write file ... because it would overwrite input file."
+      // Also has the benefit of enabling auto-completion before build.
+      "next/dist/client/app-find-source-map-url": [
+        "./src/client/app-find-source-map-url.ts"
+      ],
+      "next/dist/client/app-call-server": ["./src/client/app-call-server.ts"],
+      "next/dist/compiled/@edge-runtime/ponyfill": [
+        "./src/compiled/@edge-runtime/ponyfill"
+      ],
+      "next/dist/compiled/@vercel/og/satori": [
+        "./src/compiled/@vercel/og/satori"
+      ],
+      "next/dist/shared/lib/image-loader": ["./src/shared/lib/image-loader.ts"]
+    }
   },
   // When changing `exclude`, also update
   // `tsconfig.build.json`.
   "exclude": [
-    "dist",
+    "./dist/**/*",
     "./*.d.ts",
     "future/*.d.ts",
     "image-types/global.d.ts",

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -21,15 +21,6 @@ declare module 'next/dist/compiled/react-server-dom-turbopack/client.browser'
 declare module 'next/dist/compiled/react-server-dom-turbopack/server.browser'
 declare module 'next/dist/compiled/react-server-dom-turbopack/server.edge'
 declare module 'next/dist/compiled/react-server-dom-turbopack/static.edge'
-declare module 'next/dist/client/app-call-server' {
-  export function callServer(
-    actionId: string,
-    actionArgs: unknown[]
-  ): Promise<unknown>
-}
-declare module 'next/dist/client/app-find-source-map-url' {
-  export function findSourceMapURL(filename: string): string | null
-}
 declare module 'next/dist/compiled/react-dom/server'
 declare module 'next/dist/compiled/react-dom/server.edge'
 declare module 'next/dist/compiled/browserslist'


### PR DESCRIPTION
Makes it quicker to iterate over type issues.

Previously a repeated `pnpm types` failed with multiple `Cannot write file ... because it would overwrite input file.`. Now `pnpm types --watch` just works.

We also now no longer have to repeat types in `compiled.internal.d.ts` and the actual `.ts` impl. The only repetition is in module paths in `tsconfig` which is less error prone due to having the strings that should match right next to each other.

