### PR TITLE
Run `tsc` in watch mode during `pnpm dev`

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2835,9 +2835,11 @@ export async function build(task, opts) {
 }
 
 export async function generate_types(task, opts) {
-  await execa.command('pnpm run types', {
-    stdio: 'inherit',
-  })
+  await execa(
+    'pnpm',
+    ['run', 'types', ...(opts.dev ? ['--watch', '--preserveWatchOutput'] : [])],
+    { stdio: 'inherit' }
+  )
 }
 
 export async function check_error_codes(task, opts) {


### PR DESCRIPTION
Now that `tsc` can be run repeatedly without erroring, we can run it in watch mode during `pnpm dev` to ensure that type errors are always up-to-date while developing. Previously, we had to restart `pnpm dev`, like animals.