### PR TITLE
[dev-overlay] Parse stacks in reducer not during dispatch

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -20,7 +20,6 @@ import {
   reportInvalidHmrMessage,
   useErrorOverlayReducer,
 } from '../shared'
-import { parseStack } from '../utils/parse-stack'
 import { AppDevOverlay } from './app-dev-overlay'
 import { useErrorHandler } from '../../errors/use-error-handler'
 import { RuntimeErrorHandler } from '../../errors/runtime-error-handler'
@@ -30,7 +29,6 @@ import {
   useWebsocket,
   useWebsocketPing,
 } from '../utils/use-websocket'
-import { parseComponentStack } from '../utils/parse-component-stack'
 import type { VersionInfo } from '../../../../server/dev/parse-version-info'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../../../server/dev/hot-reloader-types'
 import type {
@@ -40,7 +38,6 @@ import type {
 import { REACT_REFRESH_FULL_RELOAD_FROM_ERROR } from '../shared'
 import type { DebugInfo } from '../types'
 import { useUntrackedPathname } from '../../navigation-untracked'
-import { getComponentStack, getOwnerStack } from '../../errors/stitched-error'
 import { handleDevBuildIndicatorHmrEvents } from '../../../dev/dev-build-indicator/internal/handle-dev-build-indicator-hmr-events'
 import type { GlobalErrorComponent } from '../../global-error'
 import type { DevIndicatorServerState } from '../../../../server/dev/dev-indicator-server-state'
@@ -514,26 +511,15 @@ export default function HotReload({
         })
       },
       onUnhandledError(error) {
-        // Component stack is added to the error in use-error-handler in case there was a hydration error
-        const componentStack = getComponentStack(error)
-        const ownerStack = getOwnerStack(error)
-
         dispatch({
           type: ACTION_UNHANDLED_ERROR,
           reason: error,
-          frames: parseStack((error.stack || '') + (ownerStack || '')),
-          componentStackFrames:
-            typeof componentStack === 'string'
-              ? parseComponentStack(componentStack)
-              : undefined,
         })
       },
       onUnhandledRejection(error) {
-        const ownerStack = getOwnerStack(error)
         dispatch({
           type: ACTION_UNHANDLED_REJECTION,
           reason: error,
-          frames: parseStack((error.stack || '') + (ownerStack || '')),
         })
       },
     }

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/render-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/runtime-error/render-error.tsx
@@ -1,18 +1,18 @@
-import type {
-  OverlayState,
-  UnhandledErrorAction,
-  UnhandledRejectionAction,
-} from '../../../shared'
+import type { OverlayState } from '../../../shared'
 
 import { useMemo, useState, useEffect } from 'react'
 import {
   getErrorByType,
   type ReadyRuntimeError,
 } from '../../../utils/get-error-by-type'
+import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
+import type { ComponentStackFrame } from '../../../utils/parse-component-stack'
 
 export type SupportedErrorEvent = {
   id: number
-  event: UnhandledErrorAction | UnhandledRejectionAction
+  error: Error
+  frames: StackFrame[]
+  componentStackFrames?: ComponentStackFrame[]
 }
 
 type Props = {

--- a/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/dev-overlay.stories.tsx
@@ -10,7 +10,6 @@ import {
   ACTION_ERROR_OVERLAY_CLOSE,
   ACTION_ERROR_OVERLAY_OPEN,
   ACTION_ERROR_OVERLAY_TOGGLE,
-  ACTION_UNHANDLED_ERROR,
 } from '../shared'
 
 const meta: Meta<typeof DevOverlay> = {
@@ -32,50 +31,41 @@ const initialState: OverlayState = {
   errors: [
     {
       id: 1,
-      event: {
-        type: ACTION_UNHANDLED_ERROR,
-        reason: Object.assign(new Error('First error message'), {
-          __NEXT_ERROR_CODE: 'E001',
-        }),
-        componentStackFrames: [
-          {
-            file: 'app/page.tsx',
-            component: 'Home',
-            lineNumber: 10,
-            column: 5,
-            canOpenInEditor: true,
-          },
-        ],
-        frames: [
-          {
-            file: 'app/page.tsx',
-            methodName: 'Home',
-            arguments: [],
-            lineNumber: 10,
-            column: 5,
-          },
-        ],
-      },
+      error: Object.assign(new Error('First error message'), {
+        __NEXT_ERROR_CODE: 'E001',
+      }),
+      componentStackFrames: [
+        {
+          file: 'app/page.tsx',
+          component: 'Home',
+          lineNumber: 10,
+          column: 5,
+          canOpenInEditor: true,
+        },
+      ],
+      frames: [
+        {
+          file: 'app/page.tsx',
+          methodName: 'Home',
+          arguments: [],
+          lineNumber: 10,
+          column: 5,
+        },
+      ],
     },
     {
       id: 2,
-      event: {
-        type: ACTION_UNHANDLED_ERROR,
-        reason: Object.assign(new Error('Second error message'), {
-          __NEXT_ERROR_CODE: 'E002',
-        }),
-        frames: [],
-      },
+      error: Object.assign(new Error('Second error message'), {
+        __NEXT_ERROR_CODE: 'E002',
+      }),
+      frames: [],
     },
     {
       id: 3,
-      event: {
-        type: ACTION_UNHANDLED_ERROR,
-        reason: Object.assign(new Error('Third error message'), {
-          __NEXT_ERROR_CODE: 'E003',
-        }),
-        frames: [],
-      },
+      error: Object.assign(new Error('Third error message'), {
+        __NEXT_ERROR_CODE: 'E003',
+      }),
+      frames: [],
     },
   ],
   refreshState: { type: 'idle' },

--- a/packages/next/src/client/components/react-dev-overlay/utils/get-error-by-type.ts
+++ b/packages/next/src/client/components/react-dev-overlay/utils/get-error-by-type.ts
@@ -1,4 +1,3 @@
-import { ACTION_UNHANDLED_ERROR, ACTION_UNHANDLED_REJECTION } from '../shared'
 import type { SupportedErrorEvent } from '../ui/container/runtime-error/render-error'
 import { getOriginalStackFrames } from './stack-frame'
 import type { OriginalStackFrame } from './stack-frame'
@@ -37,58 +36,46 @@ export const useFrames = (error: ReadyRuntimeError): OriginalStackFrame[] => {
 }
 
 export async function getErrorByType(
-  ev: SupportedErrorEvent,
+  event: SupportedErrorEvent,
   isAppDir: boolean
 ): Promise<ReadyRuntimeError> {
-  const { id, event } = ev
-  switch (event.type) {
-    case ACTION_UNHANDLED_ERROR:
-    case ACTION_UNHANDLED_REJECTION: {
-      const baseError = {
-        id,
-        runtime: true,
-        error: event.reason,
-      } as const
+  const baseError = {
+    id: event.id,
+    runtime: true,
+    error: event.error,
+  } as const
 
-      if ('use' in React) {
-        const readyRuntimeError: ReadyRuntimeError = {
-          ...baseError,
-          // createMemoizedPromise dedups calls to getOriginalStackFrames
-          frames: createMemoizedPromise(async () => {
-            return await getOriginalStackFrames(
-              event.frames,
-              getErrorSource(event.reason),
-              isAppDir
-            )
-          }),
-        }
-        if (event.type === ACTION_UNHANDLED_ERROR) {
-          readyRuntimeError.componentStackFrames = event.componentStackFrames
-        }
-        return readyRuntimeError
-      } else {
-        const readyRuntimeError: ReadyRuntimeError = {
-          ...baseError,
-          // createMemoizedPromise dedups calls to getOriginalStackFrames
-          frames: await getOriginalStackFrames(
-            event.frames,
-            getErrorSource(event.reason),
-            isAppDir
-          ),
-        }
-        if (event.type === ACTION_UNHANDLED_ERROR) {
-          readyRuntimeError.componentStackFrames = event.componentStackFrames
-        }
-        return readyRuntimeError
-      }
+  if ('use' in React) {
+    const readyRuntimeError: ReadyRuntimeError = {
+      ...baseError,
+      // createMemoizedPromise dedups calls to getOriginalStackFrames
+      frames: createMemoizedPromise(async () => {
+        return await getOriginalStackFrames(
+          event.frames,
+          getErrorSource(event.error),
+          isAppDir
+        )
+      }),
     }
-    default: {
-      break
+    if (event.componentStackFrames !== undefined) {
+      readyRuntimeError.componentStackFrames = event.componentStackFrames
     }
+    return readyRuntimeError
+  } else {
+    const readyRuntimeError: ReadyRuntimeError = {
+      ...baseError,
+      // createMemoizedPromise dedups calls to getOriginalStackFrames
+      frames: await getOriginalStackFrames(
+        event.frames,
+        getErrorSource(event.error),
+        isAppDir
+      ),
+    }
+    if (event.componentStackFrames !== undefined) {
+      readyRuntimeError.componentStackFrames = event.componentStackFrames
+    }
+    return readyRuntimeError
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _: never = event
-  throw new Error('type system invariant violation')
 }
 
 function createMemoizedPromise<T>(


### PR DESCRIPTION
In the reducer we'll later inject the implementation of `get*Stack`. The reducer will live in a different module than `stitched-errors` so we need to make sure `get*Stack` is a singleton. Dependency injection makes this easier to achieve.

`getOwnerStack` will be injected in a follow-up