### PR TITLE
chore(ci): Configure automated benchmark for turbopack

### DIFF
--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -30,9 +30,6 @@ jobs:
   benchmark-small:
     name: Benchmark Rust Crates (small)
     runs-on: ubuntu-22.04
-    # Limit the number of concurrent jobs to 1
-    concurrency:
-      group: ${{ github.workflow }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -36,10 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -1,6 +1,7 @@
 name: Turbopack Benchmark
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - canary
@@ -44,7 +45,7 @@ jobs:
           tool: cargo-codspeed@2.10.1
 
       - name: Build the benchmark target(s)
-        run: cargo codspeed build
+        run: cargo codspeed build -p turbo-rcstr -p turbopack-ecmascript
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -7,11 +7,13 @@ on:
       - canary
     paths:
       - '**/crates/**'
+      - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
     types: ['opened', 'reopened', 'synchronize']
     paths:
       - '**/crates/**'
+      - '**/Cargo.toml'
       - '**/Cargo.lock'
 
 concurrency:

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -4,8 +4,14 @@ on:
   push:
     branches:
       - canary
+    paths:
+      - '**/crates/**'
+      - '**/Cargo.lock'
   pull_request:
     types: ['opened', 'reopened', 'synchronize']
+    paths:
+      - '**/crates/**'
+      - '**/Cargo.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -1,13 +1,11 @@
-name: Benchmark
+name: Turbopack Benchmark
 
 on:
   push:
     branches:
       - canary
-    paths:
-      - '**/crates/**'
   pull_request:
-    types: ['labeled']
+    types: ['opened', 'reopened', 'synchronize']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -20,33 +18,12 @@ env:
   RUST_LOG: 'off'
 
 jobs:
-  list-crates:
-    name: List crates to benchmark
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
-    if: ${{ github.event.label.name == 'benchmark' }}
-    outputs:
-      crates: ${{ steps.list-crates.outputs.crates }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: List crates
-        id: list-crates
-        run: echo "crates=$(./scripts/cargo/bench/list-crates-with-bench.sh)" >> $GITHUB_OUTPUT
-
-  benchmark-crate:
-    name: Benchmark ${{ matrix.crate }}
+  benchmark-small:
+    name: Benchmark Rust Crates (small)
     runs-on: ubuntu-22.04
-    needs: list-crates
     # Limit the number of concurrent jobs to 1
     concurrency:
       group: ${{ github.workflow }}
-    strategy:
-      matrix:
-        crate: ${{fromJson(needs.list-crates.outputs.crates)}}
     steps:
       - uses: actions/checkout@v4
 
@@ -58,10 +35,10 @@ jobs:
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-codspeed@2.8.1
+          tool: cargo-codspeed@2.10.1
 
       - name: Build the benchmark target(s)
-        run: cargo codspeed build -p ${{ matrix.crate }}
+        run: cargo codspeed build
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "codspeed"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c"
+dependencies = [
+ "colored",
+ "libc",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c23d880a28a2aab52d38ca8481dd7a3187157d0a952196b6db1db3c8499725"
+dependencies = [
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "futures",
+ "tokio",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a2f7365e347f4f22a67e9ea689bf7bc89900a354e22e26cf8a531a42c8fbb"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1379,16 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "combine"
@@ -1613,34 +1678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "futures",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "tokio",
- "walkdir",
 ]
 
 [[package]]
@@ -2996,7 +3033,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -9519,7 +9556,7 @@ version = "0.1.0"
 name = "turbo-rcstr"
 version = "0.1.0"
 dependencies = [
- "criterion",
+ "codspeed-criterion-compat",
  "new_debug_unreachable",
  "serde",
  "shrink-to-fit",
@@ -9598,7 +9635,7 @@ dependencies = [
  "auto-hash-map",
  "bitfield",
  "byteorder",
- "criterion",
+ "codspeed-criterion-compat",
  "dashmap 6.1.0",
  "either",
  "hashbrown 0.14.5",
@@ -9696,8 +9733,8 @@ dependencies = [
  "auto-hash-map",
  "bitflags 1.3.2",
  "bytes",
+ "codspeed-criterion-compat",
  "concurrent-queue",
- "criterion",
  "dashmap 6.1.0",
  "dunce",
  "futures",
@@ -9818,7 +9855,7 @@ name = "turbopack"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "criterion",
+ "codspeed-criterion-compat",
  "difference",
  "futures",
  "indexmap 2.7.1",
@@ -9859,7 +9896,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chromiumoxide",
- "criterion",
+ "codspeed-criterion-compat",
  "futures",
  "nix 0.26.4",
  "once_cell",
@@ -9910,8 +9947,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "codspeed-criterion-compat",
  "console-subscriber",
- "criterion",
  "dunce",
  "futures",
  "mime",
@@ -10088,7 +10125,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "criterion",
+ "codspeed-criterion-compat",
  "data-encoding",
  "either",
  "indexmap 2.7.1",
@@ -10669,9 +10706,14 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "v_frame"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,7 @@ concurrent-queue = "2.5.0"
 console = "0.15.5"
 console-subscriber = "0.4.1"
 const_format = "0.2.30"
-criterion = "0.5.1"
+criterion = { package = "codspeed-criterion-compat", version = "2.10.1" }
 crossbeam-channel = "0.5.8"
 dashmap = "6.1.0"
 data-encoding = "2.3.3"

--- a/turbopack/crates/turbo-tasks-macros/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros/Cargo.toml
@@ -19,5 +19,5 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
-syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
+syn = { workspace = true, features = ["full", "extra-traits", "visit", "visit-mut"] }
 turbo-tasks-macros-shared = { workspace = true }


### PR DESCRIPTION
### What?

This PR configures an automated benchmark for turbopack. We can run small benchmarks for all turbopack PRs, and I'll add more benchmarks with follow-up PRs.


### Why?

We need a way to track performance consistently.

Closes PACK-3212

Closes PACK-4705
