### PR TITLE
Turbopack: add test for reexport cycles

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
@@ -1,0 +1,1 @@
+export { a } from './b.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/b.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/b.js
@@ -1,0 +1,1 @@
+export { a } from './a.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js
@@ -1,0 +1,13 @@
+// TODO this test has not the expected behavior yet. But it's still here to check if the compilation doesn't crash or hang.
+
+it('should error on reexport cycles', async () => {
+  await import('./a')
+  // TODO this is not working yet. We need to throw an SyntaxError in that case.
+  // await expect(import('./a')).rejects.toThrowError('')
+})
+
+it('should error on self reexport cycle', async () => {
+  await import('./self')
+  // TODO this is not working yet. We need to throw an SyntaxError in that case.
+  // await expect(import('./self')).rejects.toThrowError('')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/self.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/self.js
@@ -1,0 +1,1 @@
+export { a } from './self.js'


### PR DESCRIPTION
### What?

Add a test case to make sure the compilation doesn't hang on reexport cycles

Closes PACK-4713