### PR TITLE
chore(ci): Add large benchmark

### DIFF
--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -49,3 +49,28 @@ jobs:
         with:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
+
+  benchmark-large:
+    name: Benchmark Rust Crates (large)
+    # If the task is triggered manually, we want to run the large benchmarks
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-rust
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed@2.10.1
+
+      - name: Build the benchmark target(s)
+        run: cargo codspeed build -p turbopack -p turbopack-bench
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
### What?

Configure a large benchmark for turbopack.

### Why?

We may want to run a full benchmark for some PRs.



Closes PACK-4707