### PR TITLE
fix(next-swc): Fix specificity issue of `styled-jsx` in lightningcss mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7277,9 +7277,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.90.2"
+version = "0.90.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad543134d46a26fc674ff59809eac1da01e244067500ce003478f2d2623e0b10"
+checksum = "49ff886a0a4e71062203c04c3a0a053db7751dce0074e922571b07f2721b7d65"
 dependencies = [
  "anyhow",
  "lightningcss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "1.0.1"
 modularize_imports = { version = "0.86.0" }
 styled_components = { version = "0.114.0" }
-styled_jsx = { version = "0.90.2" }
+styled_jsx = { version = "0.90.3" }
 swc_emotion = { version = "0.90.0" }
 swc_relay = { version = "0.60.0" }
 


### PR DESCRIPTION
### What?

Update the `styled-jsx` SWC plugin to the latest

### Why?

Apply https://github.com/swc-project/plugins/pull/464

x-ref: https://vercel.slack.com/archives/C08GMHRF7NC/p1748451540079049?thread_ts=1741381916.437039&cid=C08GMHRF7NC



Closes PACK-4708