### PR TITLE
[turbopack] Simplify the definition of AssetIdent

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -37,7 +37,7 @@ use next_core::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc,
     fxindexmap, fxindexset, trace::TraceRawVcs,
@@ -438,7 +438,7 @@ impl AppProject {
             self.project().server_compile_time_info(),
             self.rsc_module_options_context(),
             self.rsc_resolve_options_context(),
-            Vc::cell("app-rsc".into()),
+            rcstr!("app-rsc"),
         ))
     }
 
@@ -453,7 +453,7 @@ impl AppProject {
             self.project().edge_compile_time_info(),
             self.edge_rsc_module_options_context(),
             self.edge_rsc_resolve_options_context(),
-            Vc::cell("app-edge-rsc".into()),
+            rcstr!("app-edge-rsc"),
         ))
     }
 
@@ -504,7 +504,7 @@ impl AppProject {
             self.project().server_compile_time_info(),
             self.route_module_options_context(),
             self.route_resolve_options_context(),
-            Vc::cell("app-route".into()),
+            rcstr!("app-route"),
         ))
     }
 
@@ -554,7 +554,7 @@ impl AppProject {
             self.project().edge_compile_time_info(),
             self.edge_route_module_options_context(),
             self.edge_route_resolve_options_context(),
-            Vc::cell("app-edge-route".into()),
+            rcstr!("app-edge-route"),
         ))
     }
 
@@ -581,7 +581,7 @@ impl AppProject {
             self.project().client_compile_time_info(),
             self.client_module_options_context(),
             self.client_resolve_options_context(),
-            Vc::cell("app-client".into()),
+            rcstr!("app-client"),
         ))
     }
 
@@ -664,7 +664,7 @@ impl AppProject {
             self.project().server_compile_time_info(),
             self.ssr_module_options_context(),
             self.ssr_resolve_options_context(),
-            Vc::cell("app-ssr".into()),
+            rcstr!("app-ssr"),
         ))
     }
 
@@ -684,7 +684,7 @@ impl AppProject {
             self.project().server_compile_time_info(),
             self.ssr_module_options_context(),
             self.ssr_resolve_options_context(),
-            Vc::cell("app-shared".into()),
+            rcstr!("app-shared"),
         ))
     }
 
@@ -724,7 +724,7 @@ impl AppProject {
             self.project().edge_compile_time_info(),
             self.edge_ssr_module_options_context(),
             self.edge_ssr_resolve_options_context(),
-            Vc::cell("app-edge-ssr".into()),
+            rcstr!("app-edge-ssr"),
         ))
     }
 
@@ -744,7 +744,7 @@ impl AppProject {
             self.project().edge_compile_time_info(),
             self.edge_ssr_module_options_context(),
             self.edge_ssr_resolve_options_context(),
-            Vc::cell("app-edge-shared".into()),
+            rcstr!("app-edge-shared"),
         ))
     }
 
@@ -1027,16 +1027,6 @@ pub fn app_entry_point_to_route(
     .cell()
 }
 
-#[turbo_tasks::function]
-fn client_shared_chunks_modifier() -> Vc<RcStr> {
-    Vc::cell("client-shared-chunks".into())
-}
-
-#[turbo_tasks::function]
-fn server_utils_modifier() -> Vc<RcStr> {
-    Vc::cell("server-utils".into())
-}
-
 #[turbo_tasks::value(transparent)]
 struct OutputAssetsWithAvailability((ResolvedVc<OutputAssets>, AvailabilityInfo));
 
@@ -1230,7 +1220,7 @@ impl AppEndpoint {
 
         let client_shared_chunk_group = get_app_client_shared_chunk_group(
             AssetIdent::from_path(project.project_path())
-                .with_modifier(client_shared_chunks_modifier()),
+                .with_modifier(rcstr!("client-shared-chunks")),
             this.app_project.client_runtime_entries(),
             *module_graphs.full,
             *client_chunking_context,
@@ -1785,7 +1775,7 @@ impl AppEndpoint {
                         let chunk_group = chunking_context
                             .chunk_group(
                                 AssetIdent::from_path(this.app_project.project().project_path())
-                                    .with_modifier(server_utils_modifier()),
+                                    .with_modifier(rcstr!("server-utils")),
                                 // TODO this should be ChunkGroup::Shared
                                 ChunkGroup::Entry(server_utils),
                                 module_graph,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -126,11 +126,14 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
         .iter_nodes()
         .map(|node| async move {
             let SingleModuleGraphModuleNode { module } = node;
-            let layer = match module.ident().await?.layer {
-                Some(l) => Some(l.await?),
-                None => None,
-            };
-            if layer.is_some_and(|layer| *layer == "app-client" || *layer == "client") {
+
+            if module
+                .ident()
+                .await?
+                .layer
+                .as_ref()
+                .is_some_and(|layer| *layer == "app-client" || *layer == "client")
+            {
                 if let Some(dynamic_entry_module) =
                     ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module)
                 {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -27,7 +27,7 @@ use next_core::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Value, ValueToString, Vc,
     fxindexmap, fxindexset, trace::TraceRawVcs,
@@ -84,11 +84,6 @@ use crate::{
 #[turbo_tasks::value]
 pub struct PagesProject {
     project: ResolvedVc<Project>,
-}
-
-#[turbo_tasks::function]
-fn client_layer() -> Vc<RcStr> {
-    Vc::cell("client".into())
 }
 
 #[turbo_tasks::value_impl]
@@ -373,7 +368,7 @@ impl PagesProject {
             self.project().client_compile_time_info(),
             self.client_module_options_context(),
             self.client_resolve_options_context(),
-            client_layer(),
+            rcstr!("client"),
         )
     }
 
@@ -384,7 +379,7 @@ impl PagesProject {
             self.project().server_compile_time_info(),
             self.ssr_module_options_context(),
             self.ssr_resolve_options_context(),
-            Vc::cell("ssr".into()),
+            rcstr!("ssr"),
         )
     }
 
@@ -397,7 +392,7 @@ impl PagesProject {
             self.project().server_compile_time_info(),
             self.api_module_options_context(),
             self.ssr_resolve_options_context(),
-            Vc::cell("api".into()),
+            rcstr!("api"),
         )
     }
 
@@ -408,7 +403,7 @@ impl PagesProject {
             self.project().server_compile_time_info(),
             self.ssr_data_module_options_context(),
             self.ssr_resolve_options_context(),
-            Vc::cell("ssr-data".into()),
+            rcstr!("ssr-data"),
         )
     }
 
@@ -419,7 +414,7 @@ impl PagesProject {
             self.project().edge_compile_time_info(),
             self.edge_ssr_module_options_context(),
             self.edge_ssr_resolve_options_context(),
-            Vc::cell("edge-ssr".into()),
+            rcstr!("edge-ssr"),
         )
     }
 
@@ -430,7 +425,7 @@ impl PagesProject {
             self.project().edge_compile_time_info(),
             self.edge_api_module_options_context(),
             self.edge_ssr_resolve_options_context(),
-            Vc::cell("edge-api".into()),
+            rcstr!("edge-api"),
         )
     }
 
@@ -441,7 +436,7 @@ impl PagesProject {
             self.project().edge_compile_time_info(),
             self.edge_ssr_data_module_options_context(),
             self.edge_ssr_resolve_options_context(),
-            Vc::cell("edge-ssr-data".into()),
+            rcstr!("edge-ssr-data"),
         )
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -22,7 +22,7 @@ use next_core::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Completions, FxIndexMap, IntoTraitRef, NonLocalValue, OperationValue, OperationVc,
     ReadRef, ResolvedVc, State, TaskInput, TransientInstance, TryFlatJoinIterExt, Value, Vc,
@@ -1308,7 +1308,7 @@ impl Project {
                 self.next_config(),
                 self.execution_context(),
             ),
-            Vc::cell("middleware-edge".into()),
+            rcstr!("middleware-edge"),
         )))
     }
 
@@ -1363,7 +1363,7 @@ impl Project {
                 self.next_config(),
                 self.execution_context(),
             ),
-            Vc::cell("middleware".into()),
+            rcstr!("middleware"),
         )))
     }
 
@@ -1475,7 +1475,7 @@ impl Project {
                 self.next_config(),
                 self.execution_context(),
             ),
-            Vc::cell("instrumentation".into()),
+            rcstr!("instrumentation"),
         )))
     }
 
@@ -1530,7 +1530,7 @@ impl Project {
                 self.next_config(),
                 self.execution_context(),
             ),
-            Vc::cell("instrumentation-edge".into()),
+            rcstr!("instrumentation-edge"),
         )))
     }
 

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -18,7 +18,7 @@ use swc_core::{
         utils::find_pat_ids,
     },
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{self, File, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
@@ -92,11 +92,6 @@ pub(crate) async fn create_server_actions_manifest(
     .cell())
 }
 
-#[turbo_tasks::function]
-fn server_actions_loader_modifier() -> Vc<RcStr> {
-    Vc::cell("server actions loader".into())
-}
-
 /// Builds the "action loader" entry point, which reexports every found action
 /// behind a lazy dynamic import.
 ///
@@ -132,7 +127,7 @@ pub(crate) async fn build_server_actions_loader(
     let path = project_path.join(format!(".next-internal/server/app{page_name}/actions.js").into());
     let file = File::from(contents.build());
     let source = VirtualSource::new_with_ident(
-        AssetIdent::from_path(path).with_modifier(server_actions_loader_modifier()),
+        AssetIdent::from_path(path).with_modifier(rcstr!("server actions loader")),
         AssetContent::file(file.into()),
     );
     let import_map = import_map.into_iter().map(|(k, v)| (v, k)).collect();
@@ -436,12 +431,8 @@ pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllMo
         .map(|node| {
             async move {
                 let SingleModuleGraphModuleNode { module } = node;
-                let layer = match module.ident().await?.layer {
-                    Some(l) => Some(l.await?),
-                    None => None,
-                };
                 // TODO: compare module contexts instead?
-                let layer = match layer {
+                let layer = match module.ident().await?.layer.as_ref() {
                     Some(layer) if *layer == "app-rsc" || *layer == "app-edge-rsc" => {
                         ActionLayer::Rsc
                     }

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{glob::Glob, rope::RopeBuilder};
 use turbopack_core::{
@@ -25,11 +25,6 @@ use turbopack_ecmascript::{
     utils::StringifyJs,
 };
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("hmr-entry".into())
-}
-
 #[turbo_tasks::value(shared)]
 pub struct HmrEntryModule {
     pub ident: ResolvedVc<AssetIdent>,
@@ -51,7 +46,7 @@ impl HmrEntryModule {
 impl Module for HmrEntryModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.ident.with_modifier(modifier())
+        self.ident.with_modifier(rcstr!("hmr-entry"))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{
     FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc,
 };
@@ -21,16 +21,6 @@ use crate::{
     },
     next_server_component::server_component_module::NextServerComponentModule,
 };
-
-#[turbo_tasks::function]
-pub fn client_modules_modifier() -> Vc<RcStr> {
-    Vc::cell("client modules".into())
-}
-
-#[turbo_tasks::function]
-pub fn ssr_modules_modifier() -> Vc<RcStr> {
-    Vc::cell("ssr modules".into())
-}
 
 #[turbo_tasks::value]
 pub struct ClientReferencesChunks {
@@ -224,7 +214,7 @@ pub async fn get_app_client_references_chunks(
                         .entered();
 
                         ssr_chunking_context.chunk_group(
-                            base_ident.with_modifier(ssr_modules_modifier()),
+                            base_ident.with_modifier(rcstr!("ssr modules")),
                             ChunkGroup::IsolatedMerged {
                                 parent: parent_chunk_group,
                                 merge_tag: ECMASCRIPT_CLIENT_REFERENCE_MERGE_TAG_SSR.clone(),
@@ -262,7 +252,7 @@ pub async fn get_app_client_references_chunks(
                     .entered();
 
                     Some(client_chunking_context.chunk_group(
-                        base_ident.with_modifier(client_modules_modifier()),
+                        base_ident.with_modifier(rcstr!("client modules")),
                         ChunkGroup::IsolatedMerged {
                             parent: parent_chunk_group,
                             merge_tag: ECMASCRIPT_CLIENT_REFERENCE_MERGE_TAG_CLIENT.clone(),

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -15,7 +15,7 @@ use crate::{
     next_client_reference::{
         ClientReferenceType,
         ecmascript_client_reference::ecmascript_client_reference_module::{
-            ECMASCRIPT_CLIENT_REFERENCE_MERGE_TAG_CLIENT, ECMASCRIPT_CLIENT_REFERENCE_MERGE_TAG_SSR,
+            ecmascript_client_reference_merge_tag, ecmascript_client_reference_merge_tag_ssr,
         },
         visit_client_reference::ClientReferenceGraphResult,
     },
@@ -217,7 +217,7 @@ pub async fn get_app_client_references_chunks(
                             base_ident.with_modifier(rcstr!("ssr modules")),
                             ChunkGroup::IsolatedMerged {
                                 parent: parent_chunk_group,
-                                merge_tag: ECMASCRIPT_CLIENT_REFERENCE_MERGE_TAG_SSR.clone(),
+                                merge_tag: ecmascript_client_reference_merge_tag_ssr(),
                                 entries: ssr_modules,
                             },
                             module_graph,
@@ -255,7 +255,7 @@ pub async fn get_app_client_references_chunks(
                         base_ident.with_modifier(rcstr!("client modules")),
                         ChunkGroup::IsolatedMerged {
                             parent: parent_chunk_group,
-                            merge_tag: ECMASCRIPT_CLIENT_REFERENCE_MERGE_TAG_CLIENT.clone(),
+                            merge_tag: ecmascript_client_reference_merge_tag(),
                             entries: client_modules,
                         },
                         module_graph,

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -105,11 +105,11 @@ pub async fn get_app_page_entry(
 
     result.concat(source_content);
 
-    let query = RcStr::from(qstring::QString::new(vec![("page", page.to_string())]).to_string());
+    let query = qstring::QString::new(vec![("page", page.to_string())]);
 
     let file = File::from(result.build());
     let source = VirtualSource::new_with_ident(
-        source.ident().with_query(query),
+        source.ident().with_query(RcStr::from(format!("?{query}"))),
         AssetContent::file(file.into()),
     );
 

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -105,13 +105,11 @@ pub async fn get_app_page_entry(
 
     result.concat(source_content);
 
-    let query = qstring::QString::new(vec![("page", page.to_string())]);
+    let query = RcStr::from(qstring::QString::new(vec![("page", page.to_string())]).to_string());
 
     let file = File::from(result.build());
     let source = VirtualSource::new_with_ident(
-        source
-            .ident()
-            .with_query(Vc::cell(format!("?{query}").into())),
+        source.ident().with_query(query),
         AssetContent::file(file.into()),
     );
 

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack::css::chunk::CssChunkPlaceable;
 use turbopack_core::{
@@ -31,18 +31,13 @@ impl CssClientReferenceModule {
     }
 }
 
-#[turbo_tasks::function]
-fn css_client_reference_modifier() -> Vc<RcStr> {
-    Vc::cell("css client reference".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Module for CssClientReferenceModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.client_module
             .ident()
-            .with_modifier(css_client_reference_modifier())
+            .with_modifier(rcstr!("css client reference"))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::{
@@ -35,11 +34,6 @@ impl NextEcmascriptClientReferenceTransition {
 
 #[turbo_tasks::value_impl]
 impl Transition for NextEcmascriptClientReferenceTransition {
-    #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
-        Vc::cell(layer)
-    }
-
     #[turbo_tasks::function]
     async fn process(
         self: Vc<Self>,

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -36,8 +36,8 @@ impl NextEcmascriptClientReferenceTransition {
 #[turbo_tasks::value_impl]
 impl Transition for NextEcmascriptClientReferenceTransition {
     #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: Vc<RcStr>) -> Vc<RcStr> {
-        layer
+    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
+        Vc::cell(layer)
     }
 
     #[turbo_tasks::function]
@@ -73,8 +73,8 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             );
             Vc::upcast(FileSource::new_with_query_and_fragment(
                 path,
-                (*ident_ref.query.await?).clone(),
-                (*ident_ref.fragment.await?).clone(),
+                ident_ref.query.clone(),
+                ident_ref.fragment.clone(),
             ))
         } else {
             source
@@ -122,7 +122,7 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             *module_asset_context.compile_time_info,
             *module_asset_context.module_options_context,
             *module_asset_context.resolve_options_context,
-            *module_asset_context.layer,
+            module_asset_context.layer.clone(),
         );
 
         Ok(ProcessResult::Module(ResolvedVc::upcast(

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 use indoc::formatdoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -21,11 +21,6 @@ use turbopack_ecmascript::{
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("next/dynamic entry".into())
-}
 
 /// A [`NextDynamicEntryModule`] is a marker asset used to indicate which
 /// dynamic assets should appear in the dynamic manifest.
@@ -51,7 +46,9 @@ fn dynamic_ref_description() -> Vc<RcStr> {
 impl Module for NextDynamicEntryModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.module.ident().with_modifier(modifier())
+        self.module
+            .ident()
+            .with_modifier(rcstr!("next/dynamic entry"))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -46,8 +46,8 @@ impl NextDynamicTransition {
 #[turbo_tasks::value_impl]
 impl Transition for NextDynamicTransition {
     #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: Vc<RcStr>) -> Vc<RcStr> {
-        layer
+    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
+        Vc::cell(layer)
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::{
@@ -45,11 +44,6 @@ impl NextDynamicTransition {
 
 #[turbo_tasks::value_impl]
 impl Transition for NextDynamicTransition {
-    #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
-        Vc::cell(layer)
-    }
-
     #[turbo_tasks::function]
     async fn process(
         self: Vc<Self>,

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -71,7 +71,7 @@ fn unsupported_module_source(root_path: Vc<FileSystemPath>, module: RcStr) -> Vc
     let content = AssetContent::file(File::from(code).into());
     VirtualSource::new_with_ident(
         AssetIdent::from_path(root_path)
-            .with_modifier(Vc::cell(format!("unsupported edge import {module}").into())),
+            .with_modifier(format!("unsupported edge import {module}").into()),
         content,
     )
 }

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -90,7 +90,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
         let Request::Module {
             module: _,
             path: _,
-            query: query_vc,
+            query,
             fragment: _,
         } = request
         else {
@@ -99,14 +99,13 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
         match request_key.as_str() {
             "next/font/local/target.css" => {
-                if !can_use_next_font(*this.root, **query_vc).await? {
+                if !can_use_next_font(*this.root, query).await? {
                     return Ok(ResolveResultOption::none());
                 }
 
-                let query = query_vc.await?.to_string();
-                let request_hash = get_request_hash(&query).await?;
+                let request_hash = get_request_hash(query.as_str());
                 let qstr = qstring::QString::from(query.as_str());
-                let options_vc = font_options_from_query_map(**query_vc);
+                let options_vc = font_options_from_query_map(query.clone());
 
                 let font_fallbacks = &*get_font_fallbacks(lookup_path, options_vc).await?;
                 let lookup_path = lookup_path.to_resolved().await?;
@@ -178,9 +177,8 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 )))
             }
             "@vercel/turbopack-next/internal/font/local/cssmodule.module.css" => {
-                let query = query_vc.await?.to_string();
-                let request_hash = get_request_hash(&query).await?;
-                let options = font_options_from_query_map(**query_vc);
+                let request_hash = get_request_hash(query);
+                let options = font_options_from_query_map(query.clone());
                 let css_virtual_path = lookup_path.join(
                     format!(
                         "/{}.module.css",
@@ -206,7 +204,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 };
 
                 let stylesheet = build_stylesheet(
-                    font_options_from_query_map(**query_vc),
+                    font_options_from_query_map(query.clone()),
                     fallback,
                     get_font_css_properties(options, fallback),
                 )
@@ -228,7 +226,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                     path,
                     preload,
                     has_size_adjust: size_adjust,
-                } = font_file_options_from_query_map(**query_vc).await?;
+                } = font_file_options_from_query_map(query).await?;
 
                 let (filename, ext) = split_extension(&path);
                 let ext = ext.with_context(|| format!("font {} needs an extension", &path))?;
@@ -294,8 +292,8 @@ async fn get_font_css_properties(
 }
 
 #[turbo_tasks::function]
-async fn font_options_from_query_map(query: Vc<RcStr>) -> Result<Vc<NextFontLocalOptions>> {
-    let query_map = qstring::QString::from(&**query.await?);
+fn font_options_from_query_map(query: RcStr) -> Result<Vc<NextFontLocalOptions>> {
+    let query_map = qstring::QString::from(query.as_str());
 
     if query_map.len() != 1 {
         bail!("next/font/local queries have exactly one entry");
@@ -309,10 +307,8 @@ async fn font_options_from_query_map(query: Vc<RcStr>) -> Result<Vc<NextFontLoca
         .map(|o| NextFontLocalOptions::new(Value::new(o)))
 }
 
-async fn font_file_options_from_query_map(
-    query: Vc<RcStr>,
-) -> Result<NextFontLocalFontFileOptions> {
-    let query_map = qstring::QString::from(&**query.await?);
+async fn font_file_options_from_query_map(query: &RcStr) -> Result<NextFontLocalFontFileOptions> {
+    let query_map = qstring::QString::from(query.as_str());
 
     if query_map.len() != 1 {
         bail!("next/font/local queries have exactly one entry");

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -24,7 +24,7 @@ pub(crate) struct FontCssProperties {
 /// and scoped font family names.
 pub(crate) fn get_request_hash(query: &str) -> u32 {
     let query = qstring::QString::from(query);
-    let mut to_hash = vec![];
+    let mut to_hash = Vec::with_capacity(query.len() * 2);
     for (k, v) in query {
         to_hash.push(k);
         to_hash.push(v);

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -22,7 +22,7 @@ pub(crate) struct FontCssProperties {
 /// A hash of the requested querymap derived from how the user invoked
 /// next/font. Used to uniquely identify font requests for generated filenames
 /// and scoped font family names.
-pub(crate) async fn get_request_hash(query: &str) -> Result<u32> {
+pub(crate) fn get_request_hash(query: &str) -> u32 {
     let query = qstring::QString::from(query);
     let mut to_hash = vec![];
     for (k, v) in query {
@@ -30,11 +30,9 @@ pub(crate) async fn get_request_hash(query: &str) -> Result<u32> {
         to_hash.push(v);
     }
 
-    Ok(
-        // Truncate the hash to u32. These hashes are ultimately displayed as 6- or 8-character
-        // hexadecimal values.
-        hash_xxh3_hash64(to_hash) as u32,
-    )
+    // Truncate the hash to u32. These hashes are ultimately displayed as 6- or 8-character
+    // hexadecimal values.
+    hash_xxh3_hash64(to_hash) as u32
 }
 
 #[turbo_tasks::value(shared)]
@@ -82,9 +80,9 @@ struct HasPath {
 
 pub(crate) async fn can_use_next_font(
     project_path: Vc<FileSystemPath>,
-    query: Vc<RcStr>,
+    query: &RcStr,
 ) -> Result<bool> {
-    let query_map = qstring::QString::from(&**query.await?);
+    let query_map = qstring::QString::from(query.as_str());
     let request: HasPath = parse_json_with_source_context(
         query_map
             .to_pairs()

--- a/crates/next-core/src/next_image/source_asset.rs
+++ b/crates/next-core/src/next_image/source_asset.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, rope::RopeBuilder};
 use turbopack_core::{
@@ -13,10 +13,6 @@ use turbopack_ecmascript::utils::StringifyJs;
 use turbopack_image::process::{BlurPlaceholderOptions, get_meta_data};
 
 use super::module::BlurPlaceholderMode;
-
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("structured image object".into())
-}
 
 #[turbo_tasks::function]
 fn blur_options() -> Vc<BlurPlaceholderOptions> {
@@ -41,7 +37,7 @@ impl Source for StructuredImageFileSource {
     fn ident(&self) -> Vc<AssetIdent> {
         self.image
             .ident()
-            .with_modifier(modifier())
+            .with_modifier(rcstr!("structured image object"))
             .rename_as("*.mjs".into())
     }
 }

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 use indoc::formatdoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -24,11 +24,6 @@ use turbopack_ecmascript::{
 };
 
 use super::server_component_reference::NextServerComponentModuleReference;
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("Next.js Server Component".into())
-}
 
 #[turbo_tasks::value(shared)]
 pub struct NextServerComponentModule {
@@ -52,7 +47,9 @@ impl NextServerComponentModule {
 impl Module for NextServerComponentModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.module.ident().with_modifier(modifier())
+        self.module
+            .ident()
+            .with_modifier(rcstr!("Next.js Server Component"))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server_component/server_component_transition.rs
+++ b/crates/next-core/src/next_server_component/server_component_transition.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::module::Module;
@@ -27,11 +26,6 @@ impl NextServerComponentTransition {
 
 #[turbo_tasks::value_impl]
 impl Transition for NextServerComponentTransition {
-    #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
-        Vc::cell(layer)
-    }
-
     #[turbo_tasks::function]
     async fn process_module(
         self: Vc<Self>,

--- a/crates/next-core/src/next_server_component/server_component_transition.rs
+++ b/crates/next-core/src/next_server_component/server_component_transition.rs
@@ -28,8 +28,8 @@ impl NextServerComponentTransition {
 #[turbo_tasks::value_impl]
 impl Transition for NextServerComponentTransition {
     #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: Vc<RcStr>) -> Vc<RcStr> {
-        layer
+    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
+        Vc::cell(layer)
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 use indoc::formatdoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -24,11 +24,6 @@ use turbopack_ecmascript::{
 };
 
 use super::server_utility_reference::NextServerUtilityModuleReference;
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("Next.js server utility".into())
-}
 
 #[turbo_tasks::value(shared)]
 pub struct NextServerUtilityModule {
@@ -52,7 +47,9 @@ impl NextServerUtilityModule {
 impl Module for NextServerUtilityModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.module.ident().with_modifier(modifier())
+        self.module
+            .ident()
+            .with_modifier(rcstr!("Next.js server utility"))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server_utility/server_utility_transition.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_transition.rs
@@ -28,8 +28,8 @@ impl NextServerUtilityTransition {
 #[turbo_tasks::value_impl]
 impl Transition for NextServerUtilityTransition {
     #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: Vc<RcStr>) -> Vc<RcStr> {
-        layer
+    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
+        Vc::cell(layer)
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server_utility/server_utility_transition.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_transition.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::module::Module;
@@ -27,11 +26,6 @@ impl NextServerUtilityTransition {
 
 #[turbo_tasks::value_impl]
 impl Transition for NextServerUtilityTransition {
-    #[turbo_tasks::function]
-    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
-        Vc::cell(layer)
-    }
-
     #[turbo_tasks::function]
     async fn process_module(
         self: Vc<Self>,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Upcast, Value, ValueToString, Vc,
     trace::TraceRawVcs,
@@ -550,12 +550,11 @@ impl ChunkingContext for BrowserChunkingContext {
                 match input_availability_info {
                     AvailabilityInfo::Root => {}
                     AvailabilityInfo::Untracked => {
-                        ident = ident.with_modifier(Vc::cell("untracked".into()));
+                        ident = ident.with_modifier(rcstr!("untracked"));
                     }
                     AvailabilityInfo::Complete { available_modules } => {
-                        ident = ident.with_modifier(Vc::cell(
-                            available_modules.hash().await?.to_string().into(),
-                        ));
+                        ident =
+                            ident.with_modifier(available_modules.hash().await?.to_string().into());
                     }
                 }
                 assets.push(

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -403,6 +403,10 @@ impl ChunkingContext for BrowserChunkingContext {
         ident: Vc<AssetIdent>,
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
+        debug_assert!(
+            extension.starts_with("."),
+            "`extension` should include the leading '.', got '{extension}'"
+        );
         let root_path = self.chunk_root_path;
         let name = match self.content_hashing {
             None => {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -50,7 +50,9 @@ impl EcmascriptBrowserChunk {
 
 impl EcmascriptBrowserChunk {
     fn ident_for_path(&self) -> Vc<AssetIdent> {
-        self.chunk.ident().with_modifier(modifier())
+        self.chunk
+            .ident()
+            .with_modifier(rcstr!("ecmascript dev chunk"))
     }
 }
 
@@ -72,11 +74,6 @@ impl OutputChunk for EcmascriptBrowserChunk {
         }
         .cell())
     }
-}
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript dev chunk".into())
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 use either::Either;
 use indoc::writedoc;
 use serde::Serialize;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
@@ -204,13 +204,13 @@ impl EcmascriptBrowserEvaluateChunk {
     async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.ident.owned().await?;
 
-        ident.add_modifier(modifier().to_resolved().await?);
+        ident.add_modifier(rcstr!("ecmascript browser evaluate chunk"));
 
         let evaluatable_assets = self.evaluatable_assets.await?;
         ident.modifiers.extend(
             evaluatable_assets
                 .iter()
-                .map(|entry| entry.ident().to_string().to_resolved())
+                .map(|entry| async move { Ok((*entry.ident().to_string().await?).clone()) })
                 .try_join()
                 .await?,
         );
@@ -219,7 +219,7 @@ impl EcmascriptBrowserEvaluateChunk {
             self.other_chunks
                 .await?
                 .iter()
-                .map(|chunk| chunk.path().to_string().to_resolved())
+                .map(|chunk| async move { Ok((*chunk.path().to_string().await?).clone()) })
                 .try_join()
                 .await?,
         );
@@ -244,11 +244,6 @@ impl ValueToString for EcmascriptBrowserEvaluateChunk {
     fn to_string(&self) -> Vc<RcStr> {
         Vc::cell("Ecmascript Browser Evaluate Chunk".into())
     }
-}
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript browser evaluate chunk".into())
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -68,38 +68,18 @@ impl ValueToString for EcmascriptDevChunkList {
     }
 }
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript dev chunk list".into())
-}
-
-#[turbo_tasks::function]
-fn dynamic_modifier() -> Vc<RcStr> {
-    Vc::cell("dynamic".into())
-}
-
-#[turbo_tasks::function]
-fn chunk_list_chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("chunk list chunk".into())
-}
-
-#[turbo_tasks::function]
-fn chunk_key() -> Vc<RcStr> {
-    Vc::cell("chunk".into())
-}
-
 #[turbo_tasks::value_impl]
 impl OutputAsset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
         let mut ident = this.ident.owned().await?;
-        ident.add_modifier(modifier().to_resolved().await?);
+        ident.add_modifier(rcstr!("ecmascript dev chunk list"));
 
         match this.source {
             EcmascriptDevChunkListSource::Entry => {}
             EcmascriptDevChunkListSource::Dynamic => {
-                ident.add_modifier(dynamic_modifier().to_resolved().await?);
+                ident.add_modifier(rcstr!("dynamic"));
             }
         }
 

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack::{
@@ -192,7 +192,7 @@ pub fn get_client_asset_context(
         compile_time_info,
         module_options_context,
         resolve_options_context,
-        Vc::cell("client".into()),
+        rcstr!("client"),
     ));
 
     asset_context

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -49,10 +49,10 @@ impl Source for FileSource {
     fn ident(&self) -> Vc<AssetIdent> {
         let mut ident = AssetIdent::from_path(*self.path);
         if !self.query.is_empty() {
-            ident = ident.with_query(Vc::cell(self.query.clone()));
+            ident = ident.with_query(self.query.clone());
         }
         if !self.fragment.is_empty() {
-            ident = ident.with_fragment(Vc::cell(self.fragment.clone()));
+            ident = ident.with_fragment(self.fragment.clone());
         }
         ident
     }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -34,14 +34,6 @@ pub struct AssetIdent {
 }
 
 impl AssetIdent {
-    pub fn query(&self) -> &RcStr {
-        &self.query
-    }
-
-    pub fn fragment(&self) -> &RcStr {
-        &self.fragment
-    }
-
     pub fn add_modifier(&mut self, modifier: RcStr) {
         self.modifiers.push(modifier);
     }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -34,6 +34,14 @@ pub struct AssetIdent {
 }
 
 impl AssetIdent {
+    pub fn query(&self) -> &RcStr {
+        &self.query
+    }
+
+    pub fn fragment(&self) -> &RcStr {
+        &self.fragment
+    }
+
     pub fn add_modifier(&mut self, modifier: RcStr) {
         self.modifiers.push(modifier);
     }
@@ -119,11 +127,11 @@ impl ValueToString for AssetIdent {
 impl AssetIdent {
     #[turbo_tasks::function]
     pub async fn new(ident: Value<AssetIdent>) -> Result<Vc<Self>> {
-        debug_+assert!(
+        debug_assert!(
             ident.query.is_empty() || ident.query.starts_with("?"),
             "query should be empty or start with a `?`"
         );
-        assert!(
+        debug_assert!(
             ident.fragment.is_empty() || ident.fragment.starts_with("#"),
             "query should be empty or start with a `?`"
         );
@@ -147,10 +155,6 @@ impl AssetIdent {
 
     #[turbo_tasks::function]
     pub fn with_query(&self, query: RcStr) -> Vc<Self> {
-        debug_assert!(
-            !query.starts_with("?"),
-            "query should not start with a `?`. one is added during formatting."
-        );
         let mut this = self.clone();
         this.query = query;
         Self::new(Value::new(this))
@@ -164,7 +168,7 @@ impl AssetIdent {
     }
 
     #[turbo_tasks::function]
-    pub fn with_modifier(&self, modifier: ResolvedVc<RcStr>) -> Vc<Self> {
+    pub fn with_modifier(&self, modifier: RcStr) -> Vc<Self> {
         let mut this = self.clone();
         this.add_modifier(modifier);
         Self::new(Value::new(this))
@@ -208,11 +212,6 @@ impl AssetIdent {
     #[turbo_tasks::function]
     pub fn path(&self) -> Vc<FileSystemPath> {
         *self.path
-    }
-
-    #[turbo_tasks::function]
-    pub fn query(&self) -> Vc<RcStr> {
-        Vc::cell(self.query.clone())
     }
 
     /// Computes a unique output asset name for the given asset identifier.

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -17,28 +17,28 @@ pub struct AssetIdent {
     pub path: ResolvedVc<FileSystemPath>,
     /// The query string of the asset this is either the empty string or a query string that starts
     /// with a `?` (e.g. `?foo=bar`)
-    pub query: ResolvedVc<RcStr>,
+    pub query: RcStr,
     /// The fragment of the asset, this is either the empty string or a fragment string that starts
     /// with a `#` (e.g. `#foo`)
-    pub fragment: ResolvedVc<RcStr>,
+    pub fragment: RcStr,
     /// The assets that are nested in this asset
-    pub assets: Vec<(ResolvedVc<RcStr>, ResolvedVc<AssetIdent>)>,
+    pub assets: Vec<(RcStr, ResolvedVc<AssetIdent>)>,
     /// The modifiers of this asset (e.g. `client chunks`)
-    pub modifiers: Vec<ResolvedVc<RcStr>>,
+    pub modifiers: Vec<RcStr>,
     /// The parts of the asset that are (ECMAScript) modules
     pub parts: Vec<ModulePart>,
     /// The asset layer the asset was created from.
-    pub layer: Option<ResolvedVc<RcStr>>,
+    pub layer: Option<RcStr>,
     /// The MIME content type, if this asset was created from a data URL.
     pub content_type: Option<RcStr>,
 }
 
 impl AssetIdent {
-    pub fn add_modifier(&mut self, modifier: ResolvedVc<RcStr>) {
+    pub fn add_modifier(&mut self, modifier: RcStr) {
         self.modifiers.push(modifier);
     }
 
-    pub fn add_asset(&mut self, key: ResolvedVc<RcStr>, asset: ResolvedVc<AssetIdent>) {
+    pub fn add_asset(&mut self, key: RcStr, asset: ResolvedVc<AssetIdent>) {
         self.assets.push((key, asset));
     }
 
@@ -60,9 +60,9 @@ impl ValueToString for AssetIdent {
         let mut s = self.path.to_string().owned().await?.into_owned();
 
         // The query string is either empty or non-empty starting with `?` so we can just concat
-        s.push_str(&self.query.await?);
+        s.push_str(&self.query);
         // ditto for fragment
-        s.push_str(&self.fragment.await?);
+        s.push_str(&self.fragment);
 
         if !self.assets.is_empty() {
             s.push_str(" {");
@@ -72,16 +72,15 @@ impl ValueToString for AssetIdent {
                     s.push(',');
                 }
 
-                let key_str = key.await?;
                 let asset_str = asset.to_string().await?;
-                write!(s, " {key_str} => {asset_str:?}")?;
+                write!(s, " {key} => {asset_str:?}")?;
             }
 
             s.push_str(" }");
         }
 
         if let Some(layer) = &self.layer {
-            write!(s, " [{}]", layer.await?)?;
+            write!(s, " [{layer}]")?;
         }
 
         if !self.modifiers.is_empty() {
@@ -92,7 +91,7 @@ impl ValueToString for AssetIdent {
                     s.push_str(", ");
                 }
 
-                s.push_str(&modifier.await?);
+                s.push_str(modifier);
             }
 
             s.push(')');
@@ -120,15 +119,12 @@ impl ValueToString for AssetIdent {
 impl AssetIdent {
     #[turbo_tasks::function]
     pub async fn new(ident: Value<AssetIdent>) -> Result<Vc<Self>> {
-        let query = &*ident.query.await?;
-        // TODO(lukesandberg); downgrade to debug_assert
-        assert!(
-            query.is_empty() || query.starts_with("?"),
+        debug_+assert!(
+            ident.query.is_empty() || ident.query.starts_with("?"),
             "query should be empty or start with a `?`"
         );
-        let fragment = &*ident.fragment.await?;
         assert!(
-            fragment.is_empty() || fragment.starts_with("#"),
+            ident.fragment.is_empty() || ident.fragment.starts_with("#"),
             "query should be empty or start with a `?`"
         );
         Ok(ident.into_value().cell())
@@ -139,8 +135,8 @@ impl AssetIdent {
     pub fn from_path(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
         Self::new(Value::new(AssetIdent {
             path,
-            query: ResolvedVc::cell(RcStr::default()),
-            fragment: ResolvedVc::cell(RcStr::default()),
+            query: RcStr::default(),
+            fragment: RcStr::default(),
             assets: Vec::new(),
             modifiers: Vec::new(),
             parts: Vec::new(),
@@ -150,14 +146,18 @@ impl AssetIdent {
     }
 
     #[turbo_tasks::function]
-    pub fn with_query(&self, query: ResolvedVc<RcStr>) -> Vc<Self> {
+    pub fn with_query(&self, query: RcStr) -> Vc<Self> {
+        debug_assert!(
+            !query.starts_with("?"),
+            "query should not start with a `?`. one is added during formatting."
+        );
         let mut this = self.clone();
         this.query = query;
         Self::new(Value::new(this))
     }
 
     #[turbo_tasks::function]
-    pub fn with_fragment(&self, fragment: ResolvedVc<RcStr>) -> Vc<Self> {
+    pub fn with_fragment(&self, fragment: RcStr) -> Vc<Self> {
         let mut this = self.clone();
         this.fragment = fragment;
         Self::new(Value::new(this))
@@ -185,7 +185,7 @@ impl AssetIdent {
     }
 
     #[turbo_tasks::function]
-    pub fn with_layer(&self, layer: ResolvedVc<RcStr>) -> Vc<Self> {
+    pub fn with_layer(&self, layer: RcStr) -> Vc<Self> {
         let mut this = self.clone();
         this.layer = Some(layer);
         Self::new(Value::new(this))
@@ -212,7 +212,7 @@ impl AssetIdent {
 
     #[turbo_tasks::function]
     pub fn query(&self) -> Vc<RcStr> {
-        *self.query
+        Vc::cell(self.query.clone())
     }
 
     /// Computes a unique output asset name for the given asset identifier.
@@ -262,13 +262,11 @@ impl AssetIdent {
             layer,
             content_type,
         } = self;
-        let query = query.await?;
         if !query.is_empty() {
             0_u8.deterministic_hash(&mut hasher);
             query.deterministic_hash(&mut hasher);
             has_hash = true;
         }
-        let fragment = fragment.await?;
         if !fragment.is_empty() {
             1_u8.deterministic_hash(&mut hasher);
             fragment.deterministic_hash(&mut hasher);
@@ -276,12 +274,11 @@ impl AssetIdent {
         }
         for (key, ident) in assets.iter() {
             2_u8.deterministic_hash(&mut hasher);
-            key.await?.deterministic_hash(&mut hasher);
+            key.deterministic_hash(&mut hasher);
             ident.to_string().await?.deterministic_hash(&mut hasher);
             has_hash = true;
         }
         for modifier in modifiers.iter() {
-            let modifier = modifier.await?;
             if let Some(default_modifier) = default_modifier {
                 if *modifier == default_modifier {
                     continue;
@@ -332,7 +329,7 @@ impl AssetIdent {
         }
         if let Some(layer) = layer {
             5_u8.deterministic_hash(&mut hasher);
-            layer.await?.deterministic_hash(&mut hasher);
+            layer.deterministic_hash(&mut hasher);
             has_hash = true;
         }
         if let Some(content_type) = content_type {

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -224,6 +224,10 @@ impl AssetIdent {
         context_path: Vc<FileSystemPath>,
         expected_extension: RcStr,
     ) -> Result<Vc<RcStr>> {
+        debug_assert!(
+            expected_extension.starts_with("."),
+            "the extension should include the leading '.', got '{expected_extension}'"
+        );
         // TODO(PACK-2140): restrict character set to A–Za–z0–9-_.~'()
         // to be compatible with all operating systems + URLs.
 

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -316,14 +316,48 @@ impl SingleModuleGraph {
         #[cfg(debug_assertions)]
         {
             let mut duplicates = Vec::new();
-            let mut set = FxHashSet::default();
+            let mut ident_to_module: FxHashMap<ReadRef<RcStr>, Vec<ResolvedVc<Box<dyn Module>>>> =
+                FxHashMap::default();
             for &module in modules.keys() {
                 let ident = module.ident().to_string().await?;
-                if !set.insert(ident.clone()) {
+                let modules = ident_to_module.entry(ident.clone()).or_default();
+                modules.push(module);
+                if modules.len() > 1 {
                     duplicates.push(ident);
                 }
             }
             if !duplicates.is_empty() {
+                let duplicates =
+                    duplicates
+                        .iter()
+                        .map(|i| {
+                            let modules = ident_to_module.get(i).unwrap();
+                            async move {
+                                Ok((
+                                    i,
+                                    modules
+                                        .iter()
+                                        .map(|m| async move {
+                                            Ok(
+                                                match ResolvedVc::try_sidecast::<
+                                                    Box<dyn ValueToString>,
+                                                >(
+                                                    *m
+                                                ) {
+                                                    Some(v) => {
+                                                        v.to_string().await?.to_owned().to_string()
+                                                    }
+                                                    None => format!("{m:?}"),
+                                                },
+                                            )
+                                        })
+                                        .try_join()
+                                        .await?,
+                                ))
+                            }
+                        })
+                        .try_join()
+                        .await?;
                 panic!("Duplicate module idents in graph: {duplicates:#?}");
             }
         }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2327,7 +2327,7 @@ async fn resolve_relative_request(
             }
             if !fragment.is_empty() {
                 // If the fragment is not empty, we need to strip it from the matched pattern
-                if let Some(matched_pattern) = matched_pattern.strip_suffix(fragment) {
+                if let Some(matched_pattern) = matched_pattern.strip_suffix(fragment.as_str()) {
                     results.push(
                         resolved(
                             RequestKey::new(matched_pattern.into()),

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -11,31 +11,31 @@ use super::pattern::Pattern;
 pub enum Request {
     Raw {
         path: Pattern,
-        query: ResolvedVc<RcStr>,
+        query: RcStr,
         force_in_lookup_dir: bool,
-        fragment: ResolvedVc<RcStr>,
+        fragment: RcStr,
     },
     Relative {
         path: Pattern,
-        query: ResolvedVc<RcStr>,
+        query: RcStr,
         force_in_lookup_dir: bool,
-        fragment: ResolvedVc<RcStr>,
+        fragment: RcStr,
     },
     Module {
         module: RcStr,
         path: Pattern,
-        query: ResolvedVc<RcStr>,
-        fragment: ResolvedVc<RcStr>,
+        query: RcStr,
+        fragment: RcStr,
     },
     ServerRelative {
         path: Pattern,
-        query: ResolvedVc<RcStr>,
-        fragment: ResolvedVc<RcStr>,
+        query: RcStr,
+        fragment: RcStr,
     },
     Windows {
         path: Pattern,
-        query: ResolvedVc<RcStr>,
-        fragment: ResolvedVc<RcStr>,
+        query: RcStr,
+        fragment: RcStr,
     },
     Empty,
     PackageInternal {
@@ -44,8 +44,8 @@ pub enum Request {
     Uri {
         protocol: RcStr,
         remainder: RcStr,
-        query: ResolvedVc<RcStr>,
-        fragment: ResolvedVc<RcStr>,
+        query: RcStr,
+        fragment: RcStr,
     },
     DataUri {
         media_type: RcStr,
@@ -160,8 +160,8 @@ impl Request {
             return Ok(Request::Uri {
                 protocol: "//".into(),
                 remainder: remainder.into(),
-                query: ResolvedVc::cell(RcStr::default()),
-                fragment: ResolvedVc::cell(RcStr::default()),
+                query: RcStr::default(),
+                fragment: RcStr::default(),
             });
         }
 
@@ -170,8 +170,8 @@ impl Request {
 
             return Ok(Request::ServerRelative {
                 path,
-                query: ResolvedVc::cell(query),
-                fragment: ResolvedVc::cell(fragment),
+                query,
+                fragment,
             });
         }
 
@@ -187,8 +187,8 @@ impl Request {
             return Ok(Request::Relative {
                 path,
                 force_in_lookup_dir: false,
-                query: ResolvedVc::cell(query),
-                fragment: ResolvedVc::cell(fragment),
+                query,
+                fragment,
             });
         }
 
@@ -197,8 +197,8 @@ impl Request {
 
             return Ok(Request::Windows {
                 path,
-                query: ResolvedVc::cell(query),
-                fragment: ResolvedVc::cell(fragment),
+                query,
+                fragment,
             });
         }
 
@@ -219,8 +219,8 @@ impl Request {
                 return Ok(Request::Uri {
                     protocol: protocol.as_str().into(),
                     remainder: remainder.as_str().into(),
-                    query: ResolvedVc::cell(RcStr::default()),
-                    fragment: ResolvedVc::cell(RcStr::default()),
+                    query: RcStr::default(),
+                    fragment: RcStr::default(),
                 });
             }
         }
@@ -234,8 +234,8 @@ impl Request {
             return Ok(Request::Module {
                 module: module.as_str().into(),
                 path,
-                query: ResolvedVc::cell(query),
-                fragment: ResolvedVc::cell(fragment),
+                query,
+                fragment,
             });
         }
 
@@ -319,30 +319,30 @@ impl Request {
     #[turbo_tasks::function]
     pub async fn raw(
         request: Value<Pattern>,
-        query: Vc<RcStr>,
-        fragment: Vc<RcStr>,
+        query: RcStr,
+        fragment: RcStr,
         force_in_lookup_dir: bool,
     ) -> Result<Vc<Self>> {
         Ok(Self::cell(Request::Raw {
             path: request.into_value(),
             force_in_lookup_dir,
-            query: query.to_resolved().await?,
-            fragment: fragment.to_resolved().await?,
+            query,
+            fragment,
         }))
     }
 
     #[turbo_tasks::function]
     pub async fn relative(
         request: Value<Pattern>,
-        query: Vc<RcStr>,
-        fragment: Vc<RcStr>,
+        query: RcStr,
+        fragment: RcStr,
         force_in_lookup_dir: bool,
     ) -> Result<Vc<Self>> {
         Ok(Self::cell(Request::Relative {
             path: request.into_value(),
             force_in_lookup_dir,
-            query: query.to_resolved().await?,
-            fragment: fragment.to_resolved().await?,
+            query,
+            fragment,
         }))
     }
 
@@ -350,14 +350,14 @@ impl Request {
     pub async fn module(
         module: RcStr,
         path: Value<Pattern>,
-        query: Vc<RcStr>,
-        fragment: Vc<RcStr>,
+        query: RcStr,
+        fragment: RcStr,
     ) -> Result<Vc<Self>> {
         Ok(Self::cell(Request::Module {
             module,
             path: path.into_value(),
-            query: query.to_resolved().await?,
-            fragment: fragment.to_resolved().await?,
+            query,
+            fragment,
         }))
     }
 
@@ -409,7 +409,7 @@ impl Request {
     }
 
     #[turbo_tasks::function]
-    pub async fn with_query(self: Vc<Self>, query: Vc<RcStr>) -> Result<Vc<Self>> {
+    pub async fn with_query(self: Vc<Self>, query: RcStr) -> Result<Vc<Self>> {
         Ok(match &*self.await? {
             Request::Raw {
                 path,
@@ -418,9 +418,9 @@ impl Request {
                 fragment,
             } => Request::Raw {
                 path: path.clone(),
-                query: query.to_resolved().await?,
+                query,
                 force_in_lookup_dir: *force_in_lookup_dir,
-                fragment: *fragment,
+                fragment: fragment.clone(),
             }
             .cell(),
             Request::Relative {
@@ -430,9 +430,9 @@ impl Request {
                 fragment,
             } => Request::Relative {
                 path: path.clone(),
-                query: query.to_resolved().await?,
+                query,
                 force_in_lookup_dir: *force_in_lookup_dir,
-                fragment: *fragment,
+                fragment: fragment.clone(),
             }
             .cell(),
             Request::Module {
@@ -443,8 +443,8 @@ impl Request {
             } => Request::Module {
                 module: module.clone(),
                 path: path.clone(),
-                query: query.to_resolved().await?,
-                fragment: *fragment,
+                query,
+                fragment: fragment.clone(),
             }
             .cell(),
             Request::ServerRelative {
@@ -453,8 +453,8 @@ impl Request {
                 fragment,
             } => Request::ServerRelative {
                 path: path.clone(),
-                query: query.to_resolved().await?,
-                fragment: *fragment,
+                query,
+                fragment: fragment.clone(),
             }
             .cell(),
             Request::Windows {
@@ -463,8 +463,8 @@ impl Request {
                 fragment,
             } => Request::Windows {
                 path: path.clone(),
-                query: query.to_resolved().await?,
-                fragment: *fragment,
+                query,
+                fragment: fragment.clone(),
             }
             .cell(),
             Request::Empty => self,
@@ -477,7 +477,7 @@ impl Request {
                 let requests = requests
                     .iter()
                     .copied()
-                    .map(|req| req.with_query(query))
+                    .map(|req| req.with_query(query.clone()))
                     .map(|v| async move { v.to_resolved().await })
                     .try_join()
                     .await?;
@@ -487,7 +487,7 @@ impl Request {
     }
 
     #[turbo_tasks::function]
-    pub async fn with_fragment(self: Vc<Self>, fragment: Vc<RcStr>) -> Result<Vc<Self>> {
+    pub async fn with_fragment(self: Vc<Self>, fragment: RcStr) -> Result<Vc<Self>> {
         Ok(match &*self.await? {
             Request::Raw {
                 path,
@@ -496,9 +496,9 @@ impl Request {
                 fragment: _,
             } => Request::Raw {
                 path: path.clone(),
-                query: *query,
+                query: query.clone(),
                 force_in_lookup_dir: *force_in_lookup_dir,
-                fragment: fragment.to_resolved().await?,
+                fragment,
             }
             .cell(),
             Request::Relative {
@@ -508,9 +508,9 @@ impl Request {
                 fragment: _,
             } => Request::Relative {
                 path: path.clone(),
-                query: *query,
+                query: query.clone(),
                 force_in_lookup_dir: *force_in_lookup_dir,
-                fragment: fragment.to_resolved().await?,
+                fragment,
             }
             .cell(),
             Request::Module {
@@ -521,8 +521,8 @@ impl Request {
             } => Request::Module {
                 module: module.clone(),
                 path: path.clone(),
-                query: *query,
-                fragment: fragment.to_resolved().await?,
+                query: query.clone(),
+                fragment,
             }
             .cell(),
             Request::ServerRelative {
@@ -531,8 +531,8 @@ impl Request {
                 fragment: _,
             } => Request::ServerRelative {
                 path: path.clone(),
-                query: *query,
-                fragment: fragment.to_resolved().await?,
+                query: query.clone(),
+                fragment,
             }
             .cell(),
             Request::Windows {
@@ -541,8 +541,8 @@ impl Request {
                 fragment: _,
             } => Request::Windows {
                 path: path.clone(),
-                query: *query,
-                fragment: fragment.to_resolved().await?,
+                query: query.clone(),
+                fragment,
             }
             .cell(),
             Request::Empty => self,
@@ -555,7 +555,7 @@ impl Request {
                 let requests = requests
                     .iter()
                     .copied()
-                    .map(|req| req.with_fragment(fragment))
+                    .map(|req| req.with_fragment(fragment.clone()))
                     .map(|v| async move { v.to_resolved().await })
                     .try_join()
                     .await?;
@@ -575,7 +575,12 @@ impl Request {
             } => {
                 let mut pat = Pattern::concat([path.clone(), suffix.into()]);
                 pat.normalize();
-                Self::raw(Value::new(pat), **query, **fragment, *force_in_lookup_dir)
+                Self::raw(
+                    Value::new(pat),
+                    query.clone(),
+                    fragment.clone(),
+                    *force_in_lookup_dir,
+                )
             }
             Request::Relative {
                 path,
@@ -585,7 +590,12 @@ impl Request {
             } => {
                 let mut pat = Pattern::concat([path.clone(), suffix.into()]);
                 pat.normalize();
-                Self::relative(Value::new(pat), **query, **fragment, *force_in_lookup_dir)
+                Self::relative(
+                    Value::new(pat),
+                    query.clone(),
+                    fragment.clone(),
+                    *force_in_lookup_dir,
+                )
             }
             Request::Module {
                 module,
@@ -595,7 +605,12 @@ impl Request {
             } => {
                 let mut pat = Pattern::concat([path.clone(), suffix.into()]);
                 pat.normalize();
-                Self::module(module.clone(), Value::new(pat), **query, **fragment)
+                Self::module(
+                    module.clone(),
+                    Value::new(pat),
+                    query.clone(),
+                    fragment.clone(),
+                )
             }
             Request::ServerRelative {
                 path,
@@ -606,8 +621,8 @@ impl Request {
                 pat.normalize();
                 Self::ServerRelative {
                     path: pat,
-                    query: *query,
-                    fragment: *fragment,
+                    query: query.clone(),
+                    fragment: fragment.clone(),
                 }
                 .cell()
             }
@@ -620,8 +635,8 @@ impl Request {
                 pat.normalize();
                 Self::Windows {
                     path: pat,
-                    query: *query,
-                    fragment: *fragment,
+                    query: query.clone(),
+                    fragment: fragment.clone(),
                 }
                 .cell()
             }
@@ -654,8 +669,8 @@ impl Request {
                 Self::Uri {
                     protocol: protocol.clone(),
                     remainder,
-                    query: *query,
-                    fragment: *fragment,
+                    query: query.clone(),
+                    fragment: fragment.clone(),
                 }
                 .cell()
             }
@@ -678,21 +693,21 @@ impl Request {
 
     #[turbo_tasks::function]
     pub fn query(&self) -> Vc<RcStr> {
-        match self {
-            Request::Raw { query, .. } => **query,
-            Request::Relative { query, .. } => **query,
-            Request::Module { query, .. } => **query,
-            Request::ServerRelative { query, .. } => **query,
-            Request::Windows { query, .. } => **query,
-            Request::Empty => Vc::<RcStr>::default(),
-            Request::PackageInternal { .. } => Vc::<RcStr>::default(),
-            Request::DataUri { .. } => Vc::<RcStr>::default(),
-            Request::Uri { .. } => Vc::<RcStr>::default(),
-            Request::Unknown { .. } => Vc::<RcStr>::default(),
-            Request::Dynamic => Vc::<RcStr>::default(),
+        Vc::cell(match self {
+            Request::Windows { query, .. }
+            | Request::ServerRelative { query, .. }
+            | Request::Module { query, .. }
+            | Request::Relative { query, .. }
+            | Request::Raw { query, .. } => query.clone(),
+            Request::Dynamic
+            | Request::Unknown { .. }
+            | Request::Uri { .. }
+            | Request::DataUri { .. }
+            | Request::PackageInternal { .. }
+            | Request::Empty => RcStr::default(),
             // TODO: is this correct, should we return the first one instead?
-            Request::Alternatives { .. } => Vc::<RcStr>::default(),
-        }
+            Request::Alternatives { .. } => RcStr::default(),
+        })
     }
 
     /// Turns the request into a pattern, similar to [Request::request()] but

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -317,48 +317,43 @@ impl Request {
     }
 
     #[turbo_tasks::function]
-    pub async fn raw(
+    pub fn raw(
         request: Value<Pattern>,
         query: RcStr,
         fragment: RcStr,
         force_in_lookup_dir: bool,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(Request::Raw {
+    ) -> Vc<Self> {
+        Self::cell(Request::Raw {
             path: request.into_value(),
             force_in_lookup_dir,
             query,
             fragment,
-        }))
+        })
     }
 
     #[turbo_tasks::function]
-    pub async fn relative(
+    pub fn relative(
         request: Value<Pattern>,
         query: RcStr,
         fragment: RcStr,
         force_in_lookup_dir: bool,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(Request::Relative {
+    ) -> Vc<Self> {
+        Self::cell(Request::Relative {
             path: request.into_value(),
             force_in_lookup_dir,
             query,
             fragment,
-        }))
+        })
     }
 
     #[turbo_tasks::function]
-    pub async fn module(
-        module: RcStr,
-        path: Value<Pattern>,
-        query: RcStr,
-        fragment: RcStr,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(Request::Module {
+    pub fn module(module: RcStr, path: Value<Pattern>, query: RcStr, fragment: RcStr) -> Vc<Self> {
+        Self::cell(Request::Module {
             module,
             path: path.into_value(),
             query,
             fragment,
-        }))
+        })
     }
 
     #[turbo_tasks::function]
@@ -416,37 +411,34 @@ impl Request {
                 query: _,
                 force_in_lookup_dir,
                 fragment,
-            } => Request::Raw {
-                path: path.clone(),
+            } => Request::raw(
+                Value::new(path.clone()),
                 query,
-                force_in_lookup_dir: *force_in_lookup_dir,
-                fragment: fragment.clone(),
-            }
-            .cell(),
+                fragment.clone(),
+                *force_in_lookup_dir,
+            ),
             Request::Relative {
                 path,
                 query: _,
                 force_in_lookup_dir,
                 fragment,
-            } => Request::Relative {
-                path: path.clone(),
+            } => Request::relative(
+                Value::new(path.clone()),
                 query,
-                force_in_lookup_dir: *force_in_lookup_dir,
-                fragment: fragment.clone(),
-            }
-            .cell(),
+                fragment.clone(),
+                *force_in_lookup_dir,
+            ),
             Request::Module {
                 module,
                 path,
                 query: _,
                 fragment,
-            } => Request::Module {
-                module: module.clone(),
-                path: path.clone(),
+            } => Request::module(
+                module.clone(),
+                Value::new(path.clone()),
                 query,
-                fragment: fragment.clone(),
-            }
-            .cell(),
+                fragment.clone(),
+            ),
             Request::ServerRelative {
                 path,
                 query: _,

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -110,9 +110,9 @@ impl Module for CssModuleAsset {
             .source
             .ident()
             .with_modifier(rcstr!("css"))
-            .with_layer((*self.asset_context.layer().await?).clone());
+            .with_layer(self.asset_context.layer().owned().await?);
         if let Some(import_context) = self.import_context {
-            ident = ident.with_modifier((*import_context.modifier().await?).clone())
+            ident = ident.with_modifier(import_context.modifier().owned().await?)
         }
         Ok(ident)
     }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -28,11 +28,6 @@ use crate::{
         compose::CssModuleComposeReference, import::ImportAssetReference, url::ReferencedAsset,
     },
 };
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("css".into())
-}
 
 #[turbo_tasks::value]
 #[derive(Clone)]
@@ -110,16 +105,16 @@ impl ProcessCss for CssModuleAsset {
 #[turbo_tasks::value_impl]
 impl Module for CssModuleAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self
             .source
             .ident()
-            .with_modifier(modifier())
-            .with_layer(self.asset_context.layer());
+            .with_modifier(rcstr!("css"))
+            .with_layer((*self.asset_context.layer().await?).clone());
         if let Some(import_context) = self.import_context {
-            ident = ident.with_modifier(import_context.modifier())
+            ident = ident.with_modifier((*import_context.modifier().await?).clone())
         }
-        ident
+        Ok(ident)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 
 use anyhow::{Result, bail};
 use swc_core::common::pass::Either;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueDefault, ValueToString,
     Vc,
@@ -175,12 +175,11 @@ impl CssChunk {
                 }
             }
         }
-        let chunk_item_key = &*chunk_item_key().await?;
         let assets = chunk_items
             .iter()
             .map(|chunk_item| async move {
                 Ok((
-                    chunk_item_key.clone(),
+                    rcstr!("chunk item"),
                     chunk_item.content_ident().to_resolved().await?,
                 ))
             })
@@ -315,11 +314,6 @@ impl OutputChunk for CssChunk {
     }
 }
 
-#[turbo_tasks::function]
-fn chunk_item_key() -> Vc<RcStr> {
-    Vc::cell("chunk item".into())
-}
-
 #[turbo_tasks::value_impl]
 impl OutputAsset for CssChunk {
     #[turbo_tasks::function]
@@ -329,7 +323,7 @@ impl OutputAsset for CssChunk {
         Ok(self
             .await?
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, ".css".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, rcstr!(".css")))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -161,7 +161,6 @@ impl CssChunk {
 
         // The included chunk items and the availability info describe the chunk
         // uniquely
-        let chunk_item_key = chunk_item_key().to_resolved().await?;
         for &chunk_item in chunk_items.iter() {
             if let Some((common_path_vc, common_path_ref)) = common_path.as_mut() {
                 let path = chunk_item.asset_ident().path().await?;
@@ -176,11 +175,12 @@ impl CssChunk {
                 }
             }
         }
+        let chunk_item_key = &*chunk_item_key().await?;
         let assets = chunk_items
             .iter()
             .map(|chunk_item| async move {
                 Ok((
-                    chunk_item_key,
+                    chunk_item_key.clone(),
                     chunk_item.content_ident().to_resolved().await?,
                 ))
             })
@@ -193,8 +193,8 @@ impl CssChunk {
             } else {
                 ServerFileSystem::new().root().to_resolved().await?
             },
-            query: ResolvedVc::cell(RcStr::default()),
-            fragment: ResolvedVc::cell(RcStr::default()),
+            query: RcStr::default(),
+            fragment: RcStr::default(),
             assets,
             modifiers: Vec::new(),
             parts: Vec::new(),

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
@@ -75,7 +75,7 @@ impl SingleItemCssChunk {
     #[turbo_tasks::function]
     pub(super) async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
         let item = self.item.asset_ident();
-        Ok(item.with_modifier(single_item_modifier()))
+        Ok(item.with_modifier(rcstr!("single item css chunk")))
     }
 }
 
@@ -91,11 +91,6 @@ impl Chunk for SingleItemCssChunk {
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }
-}
-
-#[turbo_tasks::function]
-fn single_item_modifier() -> Vc<RcStr> {
-    Vc::cell("single item css chunk".into())
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use indoc::formatdoc;
 use lightningcss::css_modules::CssModuleReference;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
@@ -35,11 +35,6 @@ use crate::{
     references::{compose::CssModuleComposeReference, internal::InternalCssAssetReference},
 };
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("css module".into())
-}
-
 #[turbo_tasks::value]
 #[derive(Clone)]
 pub struct ModuleCssAsset {
@@ -64,11 +59,12 @@ impl ModuleCssAsset {
 #[turbo_tasks::value_impl]
 impl Module for ModuleCssAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
             .ident()
-            .with_modifier(modifier())
-            .with_layer(self.asset_context.layer())
+            .with_modifier(rcstr!("css module"))
+            .with_layer((*self.asset_context.layer().await?).clone()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -64,7 +64,7 @@ impl Module for ModuleCssAsset {
             .source
             .ident()
             .with_modifier(rcstr!("css module"))
-            .with_layer((*self.asset_context.layer().await?).clone()))
+            .with_layer(self.asset_context.layer().owned().await?))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
@@ -1,3 +1,4 @@
+use turbo_rcstr::rcstr;
 use turbo_tasks::{Result, Vc};
 use turbopack::{
     ModuleAssetContext,
@@ -34,7 +35,7 @@ pub async fn get_runtime_asset_context(
         compile_time_info,
         module_options_context,
         Vc::default(),
-        Vc::cell("runtime".into()),
+        rcstr!("runtime"),
     ));
 
     Ok(asset_context)

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -168,9 +168,7 @@ impl ChunkItem for AsyncLoaderChunkItem {
     async fn content_ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
         let ident = self.module().ident();
 
-        Ok(ident.with_modifier(Vc::cell(
-            self.chunks_data().hash().await?.to_string().into(),
-        )))
+        Ok(ident.with_modifier(self.chunks_data().hash().await?.to_string().into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -43,7 +43,7 @@ impl AsyncLoaderModule {
 
     #[turbo_tasks::function]
     pub fn asset_ident_for(module: Vc<Box<dyn ChunkableModule>>) -> Vc<AssetIdent> {
-        module.ident().with_modifier(async_loader_modifier())
+        module.ident().with_modifier(rcstr!("async loader"))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -104,12 +104,12 @@ impl Chunk for EcmascriptChunk {
             }
         }
 
-        let chunk_item_key = chunk_item_key().to_resolved().await?;
+        let chunk_item_key = &*chunk_item_key().await?;
         let assets = chunk_items
             .iter()
             .map(|&chunk_item| async move {
                 Ok((
-                    chunk_item_key,
+                    chunk_item_key.clone(),
                     chunk_item.content_ident().to_resolved().await?,
                 ))
             })
@@ -122,8 +122,8 @@ impl Chunk for EcmascriptChunk {
             } else {
                 ServerFileSystem::new().root().to_resolved().await?
             },
-            query: ResolvedVc::cell(RcStr::default()),
-            fragment: ResolvedVc::cell(RcStr::default()),
+            query: RcStr::default(),
+            fragment: RcStr::default(),
             assets,
             modifiers: Vec::new(),
             parts: Vec::new(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod placeable;
 use std::fmt::Write;
 
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystem;
 use turbopack_core::{
@@ -66,16 +66,6 @@ impl EcmascriptChunk {
     }
 }
 
-#[turbo_tasks::function]
-fn chunk_item_key() -> Vc<RcStr> {
-    Vc::cell("chunk item".into())
-}
-
-#[turbo_tasks::function]
-fn availability_root_key() -> Vc<RcStr> {
-    Vc::cell("current_availability_root".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Chunk for EcmascriptChunk {
     #[turbo_tasks::function]
@@ -104,12 +94,11 @@ impl Chunk for EcmascriptChunk {
             }
         }
 
-        let chunk_item_key = &*chunk_item_key().await?;
         let assets = chunk_items
             .iter()
             .map(|&chunk_item| async move {
                 Ok((
-                    chunk_item_key.clone(),
+                    rcstr!("chunk item"),
                     chunk_item.content_ident().to_resolved().await?,
                 ))
             })

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -614,16 +614,14 @@ impl ValueToString for EcmascriptModuleAsset {
 impl Module for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let modifier = rcstr!("ecmascript");
-        let layer = (*self.asset_context.layer().await?).clone();
         let mut ident = self.source.ident().owned().await?;
         if let Some(inner_assets) = self.inner_assets {
             for (name, asset) in inner_assets.await?.iter() {
                 ident.add_asset(name.clone(), asset.ident().to_resolved().await?);
             }
         }
-        ident.add_modifier(modifier);
-        ident.layer = Some(layer);
+        ident.add_modifier(rcstr!("ecmascript"));
+        ident.layer = Some(self.asset_context.layer().owned().await?);
         Ok(AssetIdent::new(Value::new(ident)))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -602,15 +602,6 @@ impl EcmascriptModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptModuleAsset {
-    #[turbo_tasks::function]
-    async fn to_string(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        let this = &*self.await?;
-        Ok(Vc::cell(format!("{this:#?}").into()))
-    }
-}
-
-#[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -68,7 +68,7 @@ pub use transform::{
     CustomTransformer, EcmascriptInputTransform, EcmascriptInputTransforms, TransformContext,
     TransformPlugin, UnsupportedServerActionIssue,
 };
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Value,
     ValueToString, Vc, trace::TraceRawVcs,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -68,7 +68,7 @@ pub use transform::{
     CustomTransformer, EcmascriptInputTransform, EcmascriptInputTransforms, TransformContext,
     TransformPlugin, UnsupportedServerActionIssue,
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Value,
     ValueToString, Vc, trace::TraceRawVcs,
@@ -206,11 +206,6 @@ impl Display for EcmascriptModuleAssetType {
             EcmascriptModuleAssetType::TypescriptDeclaration => write!(f, "typescript declaration"),
         }
     }
-}
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript".into())
 }
 
 #[derive(Clone)]
@@ -607,27 +602,29 @@ impl EcmascriptModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
+impl ValueToString for EcmascriptModuleAsset {
+    #[turbo_tasks::function]
+    async fn to_string(self: Vc<Self>) -> Result<Vc<RcStr>> {
+        let this = &*self.await?;
+        Ok(Vc::cell(format!("{this:#?}").into()))
+    }
+}
+
+#[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        let modifier = rcstr!("ecmascript");
+        let layer = (*self.asset_context.layer().await?).clone();
+        let mut ident = self.source.ident().owned().await?;
         if let Some(inner_assets) = self.inner_assets {
-            let mut ident = self.source.ident().owned().await?;
             for (name, asset) in inner_assets.await?.iter() {
-                ident.add_asset(
-                    ResolvedVc::cell(name.to_string().into()),
-                    asset.ident().to_resolved().await?,
-                );
+                ident.add_asset(name.clone(), asset.ident().to_resolved().await?);
             }
-            ident.add_modifier(modifier().to_resolved().await?);
-            ident.layer = Some(self.asset_context.layer().to_resolved().await?);
-            Ok(AssetIdent::new(Value::new(ident)))
-        } else {
-            Ok(self
-                .source
-                .ident()
-                .with_modifier(modifier())
-                .with_layer(self.asset_context.layer()))
         }
+        ident.add_modifier(modifier);
+        ident.layer = Some(layer);
+        Ok(AssetIdent::new(Value::new(ident)))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -17,11 +17,6 @@ use turbopack_core::{
 
 use super::chunk_item::ManifestChunkItem;
 use crate::chunk::{EcmascriptChunkPlaceable, EcmascriptExports};
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("manifest chunk".into())
-}
 
 /// The manifest module is deferred until requested by the manifest loader
 /// item when the dynamic `import()` expression is reached.
@@ -104,8 +99,7 @@ impl ManifestAsyncModule {
     pub async fn content_ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.inner.ident();
         if let Some(available_modules) = self.availability_info.available_modules() {
-            ident =
-                ident.with_modifier(Vc::cell(available_modules.hash().await?.to_string().into()));
+            ident = ident.with_modifier(available_modules.hash().await?.to_string().into());
         }
         Ok(ident)
     }
@@ -120,7 +114,7 @@ fn manifest_chunk_reference_description() -> Vc<RcStr> {
 impl Module for ManifestAsyncModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.inner.ident().with_modifier(modifier())
+        self.inner.ident().with_modifier(rcstr!("manifest chunk"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -2,7 +2,7 @@ use std::io::Write as _;
 
 use anyhow::{Result, anyhow};
 use indoc::writedoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{
@@ -25,9 +25,8 @@ use crate::{
     utils::{StringifyJs, StringifyModuleId},
 };
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("loader".into())
+fn modifier() -> RcStr {
+    rcstr!("loader")
 }
 
 /// The manifest loader item is shipped in the same chunk that uses the dynamic

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -226,7 +226,7 @@ async fn parse_internal(
                         fs_path_vc,
                         fs_path,
                         ident,
-                        source.ident().query().owned().await?,
+                        source.ident().await?.query.clone(),
                         file_path_hash,
                         source,
                         ty,

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, io::Write};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{FileContent, FileSystem, VirtualFileSystem, glob::Glob, rope::RopeBuilder};
 use turbopack_core::{
@@ -26,11 +26,6 @@ use crate::{
     },
     utils::StringifyJs,
 };
-
-#[turbo_tasks::function]
-fn layer() -> Vc<RcStr> {
-    Vc::cell("external".into())
-}
 
 #[derive(
     Copy,
@@ -126,9 +121,9 @@ impl Module for CachedExternalModule {
         let fs = VirtualFileSystem::new_with_name("externals".into());
 
         AssetIdent::from_path(fs.root().join(self.request.clone()))
-            .with_layer(layer())
-            .with_modifier(Vc::cell(self.request.clone()))
-            .with_modifier(Vc::cell(self.external_type.to_string().into()))
+            .with_layer(rcstr!("external"))
+            .with_modifier(self.request.clone())
+            .with_modifier(self.external_type.to_string().into())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -373,16 +373,13 @@ pub struct RequireContextAsset {
     include_subdirs: bool,
 }
 
-#[turbo_tasks::function]
-fn modifier(dir: RcStr, include_subdirs: bool) -> Vc<RcStr> {
-    Vc::cell(
-        format!(
-            "require.context {}/{}",
-            dir,
-            if include_subdirs { "**" } else { "*" },
-        )
-        .into(),
+fn modifier(dir: &RcStr, include_subdirs: bool) -> RcStr {
+    format!(
+        "require.context {}/{}",
+        dir,
+        if include_subdirs { "**" } else { "*" },
     )
+    .into()
 }
 
 #[turbo_tasks::value_impl]
@@ -391,7 +388,7 @@ impl Module for RequireContextAsset {
     fn ident(&self) -> Vc<AssetIdent> {
         self.source
             .ident()
-            .with_modifier(modifier(self.dir.clone(), self.include_subdirs))
+            .with_modifier(modifier(&self.dir, self.include_subdirs))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -132,8 +132,8 @@ impl ModuleReference for TsReferenceTypeAssetReference {
             Request::module(
                 self.module.clone(),
                 Value::new(RcStr::default().into()),
-                Vc::<RcStr>::default(),
-                Vc::<RcStr>::default(),
+                RcStr::default(),
+                RcStr::default(),
             ),
         )
     }

--- a/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{
@@ -29,13 +29,10 @@ impl TextContentFileSource {
 impl Source for TextContentFileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        lazy_static::lazy_static! {
-            static ref MODIFIER: RcStr = "text content".into();
-        }
         self.source
             .ident()
-            .with_modifier(MODIFIER.clone())
-            .rename_as("*.mjs".into())
+            .with_modifier(rcstr!("text content"))
+            .rename_as(rcstr!("*.mjs"))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
@@ -10,11 +10,6 @@ use turbopack_core::{
 
 use crate::utils::StringifyJs;
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("text content".into())
-}
-
 /// A source asset that exports the string content of an asset as the default
 /// export of a JS module.
 #[turbo_tasks::value]
@@ -34,9 +29,12 @@ impl TextContentFileSource {
 impl Source for TextContentFileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
+        lazy_static::lazy_static! {
+            static ref MODIFIER: RcStr = "text content".into();
+        }
         self.source
             .ident()
-            .with_modifier(modifier())
+            .with_modifier(MODIFIER.clone())
             .rename_as("*.mjs".into())
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
@@ -57,11 +57,11 @@ impl Module for SideEffectsModule {
         ident.parts.push(self.part.clone());
 
         ident.add_asset(
-            RcStr::from("resolved"),
+            rcstr!("resolved"),
             self.resolved_as.ident().to_resolved().await?,
         );
 
-        ident.add_modifier(RcStr::from("side effects"));
+        ident.add_modifier(rcstr!("side effects"));
 
         for (i, side_effect) in self.side_effects.iter().enumerate() {
             ident.add_asset(
@@ -84,7 +84,7 @@ impl Module for SideEffectsModule {
                     Ok(ResolvedVc::upcast(
                         SingleChunkableModuleReference::new(
                             *ResolvedVc::upcast(*side_effect),
-                            Vc::cell(RcStr::from("side effect")),
+                            Vc::cell(rcstr!("side effect")),
                         )
                         .to_resolved()
                         .await?,
@@ -97,7 +97,7 @@ impl Module for SideEffectsModule {
         references.push(ResolvedVc::upcast(
             SingleChunkableModuleReference::new(
                 *ResolvedVc::upcast(self.resolved_as),
-                Vc::cell(RcStr::from("resolved as")),
+                Vc::cell(rcstr!("resolved as")),
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -57,15 +57,15 @@ impl Module for SideEffectsModule {
         ident.parts.push(self.part.clone());
 
         ident.add_asset(
-            ResolvedVc::cell(RcStr::from("resolved")),
+            RcStr::from("resolved"),
             self.resolved_as.ident().to_resolved().await?,
         );
 
-        ident.add_modifier(ResolvedVc::cell(RcStr::from("side effects")));
+        ident.add_modifier(RcStr::from("side effects"));
 
         for (i, side_effect) in self.side_effects.iter().enumerate() {
             ident.add_asset(
-                ResolvedVc::cell(RcStr::from(format!("side effect {i}"))),
+                RcStr::from(format!("side effect {i}")),
                 side_effect.ident().to_resolved().await?,
             );
         }

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -165,8 +165,8 @@ impl Module for TsConfigModuleAsset {
                         Request::module(
                             name,
                             Value::new(RcStr::default().into()),
-                            Vc::<RcStr>::default(),
-                            Vc::<RcStr>::default(),
+                            RcStr::default(),
+                            RcStr::default(),
                         ),
                     )
                     .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use swc_core::ecma::ast::Lit;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -24,11 +24,6 @@ use crate::EcmascriptInputTransforms;
 
 pub mod parse;
 pub(crate) mod references;
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("webpack".into())
-}
 
 #[turbo_tasks::value]
 pub struct WebpackModuleAsset {
@@ -57,7 +52,7 @@ impl WebpackModuleAsset {
 impl Module for WebpackModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().with_modifier(modifier())
+        self.source.ident().with_modifier(rcstr!("webpack"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbopack_core::{
     chunk::{
@@ -30,19 +30,13 @@ pub struct WorkerLoaderChunkItem {
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
-#[turbo_tasks::function]
-pub fn worker_modifier() -> Vc<RcStr> {
-    Vc::cell("worker".into())
-}
-
 #[turbo_tasks::value_impl]
 impl WorkerLoaderChunkItem {
     #[turbo_tasks::function]
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
         let module = self.module.await?;
-
         Ok(self.chunking_context.evaluated_chunk_group_assets(
-            module.inner.ident().with_modifier(worker_modifier()),
+            module.inner.ident().with_modifier(rcstr!("worker")),
             ChunkGroup::Isolated(ResolvedVc::upcast(module.inner)),
             *self.module_graph,
             Value::new(AvailabilityInfo::Root),

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -35,6 +35,7 @@ impl WorkerLoaderChunkItem {
     #[turbo_tasks::function]
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
         let module = self.module.await?;
+
         Ok(self.chunking_context.evaluated_chunk_group_assets(
             module.inner.ident().with_modifier(rcstr!("worker")),
             ChunkGroup::Isolated(ResolvedVc::upcast(module.inner)),

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -15,11 +15,6 @@ use turbopack_core::{
 };
 
 use super::chunk_item::WorkerLoaderChunkItem;
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("worker loader".into())
-}
 
 /// The WorkerLoaderModule is a module that creates a separate root chunk group for the given module
 /// and exports a URL to pass to the worker constructor.
@@ -37,7 +32,7 @@ impl WorkerLoaderModule {
 
     #[turbo_tasks::function]
     pub fn asset_ident_for(module: Vc<Box<dyn ChunkableModule>>) -> Vc<AssetIdent> {
-        module.ident().with_modifier(modifier())
+        module.ident().with_modifier(rcstr!("worker loader"))
     }
 }
 

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -12,7 +12,7 @@
 use std::fmt::Write;
 
 use anyhow::{Error, Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileJsonContent, glob::Glob};
 use turbopack_core::{
@@ -31,11 +31,6 @@ use turbopack_ecmascript::{
     runtime_functions::TURBOPACK_EXPORT_VALUE,
 };
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("json".into())
-}
-
 #[turbo_tasks::value]
 pub struct JsonModuleAsset {
     source: ResolvedVc<Box<dyn Source>>,
@@ -53,7 +48,7 @@ impl JsonModuleAsset {
 impl Module for JsonModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().with_modifier(modifier())
+        self.source.ident().with_modifier(rcstr!("json"))
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -266,7 +266,7 @@ impl WebpackLoadersProcessedAsset {
                 ResolvedVc::cell(content),
                 // We need to pass the query string to the loader
                 ResolvedVc::cell(resource_path.to_string().into()),
-                ResolvedVc::cell(this.source.ident().query().await?.to_string().into()),
+                ResolvedVc::cell(this.source.ident().await?.query.to_string().into()),
                 ResolvedVc::cell(json!(*loaders)),
                 ResolvedVc::cell(transform.source_maps.into()),
             ],

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -56,9 +56,8 @@ impl ValueToString for EcmascriptBuildNodeChunk {
     }
 }
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript build node chunk".into())
+fn modifier() -> RcStr {
+    rcstr!("ecmascript build node chunk")
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -408,8 +408,8 @@ pub async fn type_resolve(
         Some(Request::module(
             format!("@types/{m}").into(),
             Value::new(p.clone()),
-            Vc::<RcStr>::default(),
-            Vc::<RcStr>::default(),
+            RcStr::default(),
+            RcStr::default(),
         ))
     } else {
         None

--- a/turbopack/crates/turbopack-static/src/css.rs
+++ b/turbopack/crates/turbopack-static/src/css.rs
@@ -1,4 +1,4 @@
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -11,11 +11,6 @@ use turbopack_core::{
 use turbopack_css::embed::CssEmbed;
 
 use crate::output_asset::StaticOutputAsset;
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("static in css".into())
-}
 
 #[turbo_tasks::value]
 #[derive(Clone)]
@@ -43,7 +38,7 @@ impl StaticUrlCssModule {
 impl Module for StaticUrlCssModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().with_modifier(modifier())
+        self.source.ident().with_modifier(rcstr!("static in css"))
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -20,11 +20,6 @@ use turbopack_ecmascript::{
 };
 
 use crate::output_asset::StaticOutputAsset;
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("static in ecmascript".into())
-}
 
 #[turbo_tasks::value]
 #[derive(Clone)]
@@ -52,7 +47,9 @@ impl StaticUrlJsModule {
 impl Module for StaticUrlJsModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().with_modifier(modifier())
+        self.source
+            .ident()
+            .with_modifier(rcstr!("static in ecmascript"))
     }
 }
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use dunce::canonicalize;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, NonLocalValue, OperationVc, ResolvedVc, TryJoinIterExt, TurboTasks, Value, Vc,
     apply_effects, debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
@@ -404,7 +404,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
             ..Default::default()
         }
         .cell(),
-        Vc::cell("test".into()),
+        rcstr!("test"),
     ));
 
     let chunking_context = NodeJsChunkingContext::builder(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -10,7 +10,7 @@ use dunce::canonicalize;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde_json::json;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     ReadConsistency, ReadRef, ResolvedVc, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc,
     apply_effects,
@@ -335,7 +335,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             ..Default::default()
         }
         .cell(),
-        Vc::cell("test".into()),
+        rcstr!("test"),
     ));
 
     let runtime_entries = maybe_load_env(asset_context, *project_path)

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -63,9 +63,9 @@ impl WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     async fn loader_as_module(self: Vc<Self>) -> Result<Vc<Box<dyn Module>>> {
         let this = self.await?;
-        let query = &*this.source.ident().query().await?;
+        let query = &this.source.ident().await?.query;
 
-        let loader_source = if query == "module" {
+        let loader_source = if query == "?module" {
             compiling_loader_source(*this.source)
         } else {
             instantiating_loader_source(*this.source)

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -126,7 +126,7 @@ impl Module for WebAssemblyModuleAsset {
             .source
             .ident()
             .with_modifier(rcstr!("wasm module"))
-            .with_layer((*self.asset_context.layer().await?).clone()))
+            .with_layer(self.asset_context.layer().owned().await?))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Value, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -33,11 +33,6 @@ use crate::{
     source::WebAssemblySource,
 };
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("wasm module".into())
-}
-
 /// Creates a javascript loader which instantiates the WebAssembly source and
 /// re-exports its exports.
 #[turbo_tasks::value]
@@ -70,7 +65,7 @@ impl WebAssemblyModuleAsset {
         let this = self.await?;
         let query = &*this.source.ident().query().await?;
 
-        let loader_source = if query == "?module" {
+        let loader_source = if query == "module" {
             compiling_loader_source(*this.source)
         } else {
             instantiating_loader_source(*this.source)
@@ -126,11 +121,12 @@ impl WebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl Module for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
             .ident()
-            .with_modifier(modifier())
-            .with_layer(self.asset_context.layer())
+            .with_modifier(rcstr!("wasm module"))
+            .with_layer((*self.asset_context.layer().await?).clone()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -10,11 +10,6 @@ use turbopack_core::{
 };
 
 use crate::source::WebAssemblySource;
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("wasm".into())
-}
 
 /// Emits the [WebAssemblySource] at a chunk path determined by the
 /// [ChunkingContext].
@@ -43,10 +38,11 @@ impl OutputAsset for WebAssemblyAsset {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let ident = this.source.ident().with_modifier(modifier());
+        let wasm = rcstr!("wasm");
+        let ident = this.source.ident().with_modifier(wasm.clone());
         Ok(this
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, ".wasm".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, wasm))
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -38,11 +38,10 @@ impl OutputAsset for WebAssemblyAsset {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let wasm = rcstr!("wasm");
-        let ident = this.source.ident().with_modifier(wasm.clone());
+        let ident = this.source.ident().with_modifier(rcstr!("wasm"));
         Ok(this
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, wasm))
+            .chunk_path(Some(Vc::upcast(self)), ident, rcstr!(".wasm")))
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -21,11 +21,6 @@ use turbopack_ecmascript::{
 };
 
 use crate::{output_asset::WebAssemblyAsset, source::WebAssemblySource};
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("wasm raw".into())
-}
 
 /// Exports the relative path to the WebAssembly file without loading it.
 #[turbo_tasks::value]
@@ -57,11 +52,12 @@ impl RawWebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl Module for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
             .ident()
-            .with_modifier(modifier())
-            .with_layer(self.asset_context.layer())
+            .with_modifier(rcstr!("wasm raw"))
+            .with_layer((*self.asset_context.layer().await?).clone()))
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -57,7 +57,7 @@ impl Module for RawWebAssemblyModuleAsset {
             .source
             .ident()
             .with_modifier(rcstr!("wasm raw"))
-            .with_layer((*self.asset_context.layer().await?).clone()))
+            .with_layer(self.asset_context.layer().owned().await?))
     }
 }
 
@@ -81,10 +81,7 @@ impl ChunkableModule for RawWebAssemblyModuleAsset {
             RawModuleChunkItem {
                 module: self,
                 chunking_context,
-                wasm_asset: self
-                    .wasm_asset(Vc::upcast(*chunking_context))
-                    .to_resolved()
-                    .await?,
+                wasm_asset: self.wasm_asset(*chunking_context).to_resolved().await?,
             }
             .cell(),
         ))

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
@@ -56,7 +57,7 @@ impl Source for WebAssemblySource {
             WebAssemblySourceType::Text => self
                 .source
                 .ident()
-                .with_path(self.source.ident().path().append("_.wasm".into())),
+                .with_path(self.source.ident().path().append(rcstr!("_.wasm"))),
         }
     }
 }

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -2,7 +2,7 @@ use std::{fs, path::PathBuf};
 
 use criterion::{Bencher, BenchmarkId, Criterion};
 use regex::Regex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ReadConsistency, ResolvedVc, TurboTasks, Value, Vc, apply_effects};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, NullFileSystem};
@@ -113,7 +113,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                         ..Default::default()
                     }
                     .cell(),
-                    Vc::cell("node_file_trace".into()),
+                    rcstr!("node_file_trace"),
                 );
                 let module = module_asset_context
                     .process(Vc::upcast(source), Value::new(ReferenceType::Undefined))

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::Result;
 use tokio::{spawn, time::sleep};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ReadConsistency, TurboTasks, UpdateInfo, Value, Vc, util::FormatDuration};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
                     ..Default::default()
                 }
                 .cell(),
-                Vc::cell("default".into()),
+                rcstr!("default"),
             );
             let module = module_asset_context
                 .process(

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -115,6 +115,6 @@ pub async fn node_evaluate_asset_context(
         }
         .cell(),
         resolve_options_context,
-        Vc::cell(layer),
+        layer,
     )))
 }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -25,7 +25,7 @@ use ecmascript::{
 use graph::{AggregatedGraph, AggregatedGraphNodeContent, aggregate};
 use module_options::{ModuleOptions, ModuleOptionsContext, ModuleRuleEffect, ModuleType};
 use tracing::{Instrument, field::Empty};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexSet, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 pub use turbopack_core::condition;
@@ -135,10 +135,10 @@ async fn apply_module_type(
                 builder = builder.with_inner_assets(inner_assets);
             }
 
+            let module = builder.build().to_resolved().await?;
             if runtime_code {
-                ResolvedVc::upcast(builder.build().to_resolved().await?)
+                ResolvedVc::upcast(module)
             } else {
-                let module = builder.build().resolve().await?;
                 if matches!(&part, Some(ModulePart::Evaluation)) {
                     // Skip the evaluation part if the module is marked as side effect free.
                     let side_effect_free_packages = module_asset_context
@@ -158,7 +158,7 @@ async fn apply_module_type(
                 match options.tree_shaking_mode {
                     Some(TreeShakingMode::ModuleFragments) => {
                         Vc::upcast(EcmascriptModulePartAsset::select_part(
-                            module,
+                            *module,
                             part.unwrap_or(ModulePart::facade()),
                         ))
                     }
@@ -168,11 +168,11 @@ async fn apply_module_type(
                                 ModulePart::Evaluation => {
                                     if *module.get_exports().needs_facade().await? {
                                         Vc::upcast(EcmascriptModuleFacadeModule::new(
-                                            Vc::upcast(module),
+                                            Vc::upcast(*module),
                                             part,
                                         ))
                                     } else {
-                                        Vc::upcast(module)
+                                        Vc::upcast(*module)
                                     }
                                 }
                                 ModulePart::Export(_) => {
@@ -185,7 +185,7 @@ async fn apply_module_type(
                                         apply_reexport_tree_shaking(
                                             Vc::upcast(
                                                 EcmascriptModuleFacadeModule::new(
-                                                    Vc::upcast(module),
+                                                    Vc::upcast(*module),
                                                     ModulePart::exports(),
                                                 )
                                                 .resolve()
@@ -196,7 +196,7 @@ async fn apply_module_type(
                                         )
                                     } else {
                                         apply_reexport_tree_shaking(
-                                            Vc::upcast(module.resolve().await?),
+                                            Vc::upcast(*module),
                                             part,
                                             side_effect_free_packages,
                                         )
@@ -210,14 +210,14 @@ async fn apply_module_type(
                             }
                         } else if *module.get_exports().needs_facade().await? {
                             Vc::upcast(EcmascriptModuleFacadeModule::new(
-                                Vc::upcast(module),
+                                Vc::upcast(*module),
                                 ModulePart::facade(),
                             ))
                         } else {
-                            Vc::upcast(module)
+                            Vc::upcast(*module)
                         }
                     }
-                    None => Vc::upcast(module),
+                    None => Vc::upcast(*module),
                 }
                 .to_resolved()
                 .await?
@@ -309,7 +309,7 @@ pub struct ModuleAssetContext {
     pub compile_time_info: ResolvedVc<CompileTimeInfo>,
     pub module_options_context: ResolvedVc<ModuleOptionsContext>,
     pub resolve_options_context: ResolvedVc<ResolveOptionsContext>,
-    pub layer: ResolvedVc<RcStr>,
+    pub layer: RcStr,
     transition: Option<ResolvedVc<Box<dyn Transition>>>,
     /// Whether to replace external resolutions with CachedExternalModules. Used with
     /// ModuleOptionsContext.enable_externals_tracing to handle transitive external dependencies.
@@ -324,7 +324,7 @@ impl ModuleAssetContext {
         compile_time_info: ResolvedVc<CompileTimeInfo>,
         module_options_context: ResolvedVc<ModuleOptionsContext>,
         resolve_options_context: ResolvedVc<ResolveOptionsContext>,
-        layer: ResolvedVc<RcStr>,
+        layer: RcStr,
     ) -> Vc<Self> {
         Self::cell(ModuleAssetContext {
             transitions,
@@ -343,7 +343,7 @@ impl ModuleAssetContext {
         compile_time_info: ResolvedVc<CompileTimeInfo>,
         module_options_context: ResolvedVc<ModuleOptionsContext>,
         resolve_options_context: ResolvedVc<ResolveOptionsContext>,
-        layer: ResolvedVc<RcStr>,
+        layer: RcStr,
         transition: ResolvedVc<Box<dyn Transition>>,
     ) -> Vc<Self> {
         Self::cell(ModuleAssetContext {
@@ -363,7 +363,7 @@ impl ModuleAssetContext {
         compile_time_info: ResolvedVc<CompileTimeInfo>,
         module_options_context: ResolvedVc<ModuleOptionsContext>,
         resolve_options_context: ResolvedVc<ResolveOptionsContext>,
-        layer: ResolvedVc<RcStr>,
+        layer: RcStr,
     ) -> Vc<Self> {
         Self::cell(ModuleAssetContext {
             transitions,
@@ -411,7 +411,7 @@ impl ModuleAssetContext {
             *this.compile_time_info,
             *this.module_options_context,
             resolve_options_context,
-            *this.layer,
+            this.layer.clone(),
         ))
     }
 }
@@ -461,8 +461,7 @@ async fn process_default(
     if !span.is_disabled() {
         // Need to use record, otherwise future is not Send for some reason.
         let module_asset_context_ref = module_asset_context.await?;
-        let layer = module_asset_context_ref.layer.await?;
-        span.record("layer", &**layer);
+        span.record("layer", module_asset_context_ref.layer.as_str());
     }
     process_default_internal(
         module_asset_context,
@@ -684,7 +683,7 @@ async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleA
         }
         .cell(),
         resolve_options.cell(),
-        Vc::cell("externals-tracing".into()),
+        rcstr!("externals-tracing"),
     ))
 }
 
@@ -697,7 +696,7 @@ impl AssetContext for ModuleAssetContext {
 
     #[turbo_tasks::function]
     fn layer(&self) -> Vc<RcStr> {
-        *self.layer
+        Vc::cell(self.layer.clone())
     }
 
     #[turbo_tasks::function]
@@ -907,7 +906,7 @@ impl AssetContext for ModuleAssetContext {
                     *self.compile_time_info,
                     *self.module_options_context,
                     *self.resolve_options_context,
-                    *self.layer,
+                    self.layer.clone(),
                     *transition,
                 ))
             } else {
@@ -917,7 +916,7 @@ impl AssetContext for ModuleAssetContext {
                     *self.compile_time_info,
                     *self.module_options_context,
                     *self.resolve_options_context,
-                    *self.layer,
+                    self.layer.clone(),
                 ))
             },
         )

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -34,11 +34,6 @@ pub trait Transition {
         compile_time_info
     }
 
-    /// Apply modifications to the layer
-    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
-        Vc::cell(layer)
-    }
-
     /// Apply modifications/wrapping to the module options context
     fn process_module_options_context(
         self: Vc<Self>,
@@ -84,16 +79,14 @@ pub trait Transition {
             self.process_module_options_context(*module_asset_context.module_options_context);
         let resolve_options_context =
             self.process_resolve_options_context(*module_asset_context.resolve_options_context);
-        let layer = self
-            .process_layer(module_asset_context.layer.clone())
-            .await?;
+        let layer = module_asset_context.layer.clone();
         let transition_options = self.process_transition_options(*module_asset_context.transitions);
         let module_asset_context = ModuleAssetContext::new(
             transition_options,
             compile_time_info,
             module_options_context,
             resolve_options_context,
-            (*layer).clone(),
+            layer,
         );
         Ok(module_asset_context)
     }

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -35,8 +35,8 @@ pub trait Transition {
     }
 
     /// Apply modifications to the layer
-    fn process_layer(self: Vc<Self>, layer: Vc<RcStr>) -> Vc<RcStr> {
-        layer
+    fn process_layer(self: Vc<Self>, layer: RcStr) -> Vc<RcStr> {
+        Vc::cell(layer)
     }
 
     /// Apply modifications/wrapping to the module options context
@@ -84,14 +84,16 @@ pub trait Transition {
             self.process_module_options_context(*module_asset_context.module_options_context);
         let resolve_options_context =
             self.process_resolve_options_context(*module_asset_context.resolve_options_context);
-        let layer = self.process_layer(*module_asset_context.layer);
+        let layer = self
+            .process_layer(module_asset_context.layer.clone())
+            .await?;
         let transition_options = self.process_transition_options(*module_asset_context.transitions);
         let module_asset_context = ModuleAssetContext::new(
             transition_options,
             compile_time_info,
             module_options_context,
             resolve_options_context,
-            layer,
+            (*layer).clone(),
         );
         Ok(module_asset_context)
     }

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -27,7 +27,7 @@ use rstest_reuse::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::{process::Command, time::timeout};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     ResolvedVc, TurboTasks, Value, ValueToString, Vc, apply_effects, backend::Backend,
     trace::TraceRawVcs,
@@ -365,7 +365,7 @@ async fn node_file_trace_operation(
             ..Default::default()
         }
         .cell(),
-        Vc::cell("test".into()),
+        rcstr!("test"),
     );
     let module = module_asset_context
         .process(Vc::upcast(source), Value::new(ReferenceType::Undefined))


### PR DESCRIPTION
Replace the `ResolvedVc<RcStr>` uses inside of `AssetIdent` with `RcStr` directly

## Why

This simplifies construction and usage and provides more reasonably equality semantics.  In principle, storing `ResolvedVc` would enable finer grained invalidations.  e.g. if only the `query` changed and a task only depended upon the `modifiers` then that task wouldn't get invalidated.  However, the entire `Assetident` is often consumed monolithically already.  For example, it is when producing output chunks and constructing the modulegraph (via the `to_string` function).  So modeling it more monolitically seems appropriate.

Additionally, by accepting `RcStr` values as _values_ instead of `cells` we clarify equality semantics.  So we should expect to get _more_ cache hits from `AssetIdent::new`.   In principle this may make equality slower, but it is very rare that any of the RcStr instances involved are more than a handful of bytes, so this shouldn't be much of a concern.

This makes the type slightly smaller, now it is `120 bytes` instead of `144 bytes`, which should help with performance a bit since there are many thousands of these in a build.

## What

This was mostly done by just replacing the types and chasing build errors backwards to remove the `ResolvedVc` values at the source.  This allowed me to replace many tiny turbotask functions with the `rcstr!` macro and remove many calls to `cell`.

## Performance

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/AwJ29EfoPcPdLSwCZxAz/70962bb3-5a5a-4762-9580-a38141f84c1c.png)

Testing `vercel-site` reveals a small improvement in MaxRSS which is expected due to 1. eliminating a bunch of turbotask cells, and 2 reducing the size of `AssetIdent`

Closes PACK-4736