### PR TITLE
[dynamicIO] use RSC dynamicness to control partial vs complete PPR result

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3182,7 +3182,6 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
       }
 
-      let clientIsDynamic = false
       let dynamicValidation = createDynamicValidationState()
 
       const prerender = require('react-dom/static.edge')
@@ -3209,8 +3208,6 @@ async function prerenderToStream(
                     isPrerenderInterruptedError(err) ||
                     finalClientController.signal.aborted
                   ) {
-                    clientIsDynamic = true
-
                     const componentStack: string | undefined = (
                       errorInfo as any
                     ).componentStack
@@ -3274,7 +3271,12 @@ async function prerenderToStream(
         fallbackRouteParams
       )
 
-      if (serverIsDynamic || clientIsDynamic) {
+      if (serverIsDynamic) {
+        // Dynamic case
+        // We will always need to perform a "resume" render of some kind when this route is accessed
+        // because the RSC data itself is dynamic. We determine if there are any HTML holes or not
+        // but generally this is a "partial" prerender in that there will be a per-request compute
+        // concatenated to the static shell.
         if (postponed != null) {
           // Dynamic HTML case
           metadata.postponed = await getDynamicHTMLPostponedState(
@@ -3308,6 +3310,8 @@ async function prerenderToStream(
         }
       } else {
         // Static case
+        // We will not perform resumption per request. The result can be served statically to the requestor
+        // and if there was anything dynamic it will be marked as
         if (workStore.forceDynamic) {
           throw new StaticGenBailoutError(
             'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'


### PR DESCRIPTION
Historically anything dynamic in a prerender would result in a partially static shell that resumes at runtime. With this change now partial shells are only possible when RSC is dynamic. If your client prerender has any IO but your RSC tree was entirely prerenderable then Next.js will produce a complete static result and not perform a resume at runtime. This simplifies how you reason about what will and wil not make a static page. It also means that anything dynamic in the client layer will only render in browser.