### PR TITLE
fix(napi): Update generated types, add alias for RcStr

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -12,6 +12,7 @@ export type NapiRouteHas = {
   value?: string
   readonly __tag: unique symbol
 }
+export type RcStr = string
 
 export function lightningCssTransform(args: object): Promise<unknown>
 export function lightningCssTransformStyleAttribute(
@@ -76,13 +77,13 @@ export declare function endpointClientChangedSubscribe(
   func: (...args: any[]) => any
 ): { __napiType: 'RootTask' }
 export interface NapiEnvVar {
-  name: string
-  value: string
+  name: RcStr
+  value: RcStr
 }
 export interface NapiDraftModeOptions {
-  previewModeId: string
-  previewModeEncryptionKey: string
-  previewModeSigningKey: string
+  previewModeId: RcStr
+  previewModeEncryptionKey: RcStr
+  previewModeSigningKey: RcStr
 }
 export interface NapiWatchOptions {
   /** Whether to watch the filesystem for file changes. */
@@ -98,20 +99,20 @@ export interface NapiProjectOptions {
    * A root path from which all files must be nested under. Trying to access
    * a file outside this root will fail. Think of this as a chroot.
    */
-  rootPath: string
+  rootPath: RcStr
   /** A path inside the root_path which contains the app/pages directories. */
-  projectPath: string
+  projectPath: RcStr
   /**
    * next.config's distDir. Project initialization occurs eariler than
    * deserializing next.config, so passing it as separate option.
    */
-  distDir: string
+  distDir: RcStr
   /** Filesystem watcher options. */
   watch: NapiWatchOptions
   /** The contents of next.config.js, serialized to JSON. */
-  nextConfig: string
+  nextConfig: RcStr
   /** The contents of ts/config read by load-jsconfig, serialized to JSON. */
-  jsConfig: string
+  jsConfig: RcStr
   /** A map of environment variables to use when compiling code. */
   env: Array<NapiEnvVar>
   /**
@@ -122,13 +123,13 @@ export interface NapiProjectOptions {
   /** The mode in which Next.js is running. */
   dev: boolean
   /** The server actions encryption key. */
-  encryptionKey: string
+  encryptionKey: RcStr
   /** The build id. */
-  buildId: string
+  buildId: RcStr
   /** Options for draft mode. */
   previewProps: NapiDraftModeOptions
   /** The browserslist query to use for targeting browsers. */
-  browserslistQuery: string
+  browserslistQuery: RcStr
   /**
    * When the code is minified, this opts out of the default mangling of
    * local names for variables, functions etc., which can be useful for
@@ -142,20 +143,20 @@ export interface NapiPartialProjectOptions {
    * A root path from which all files must be nested under. Trying to access
    * a file outside this root will fail. Think of this as a chroot.
    */
-  rootPath?: string
+  rootPath?: RcStr
   /** A path inside the root_path which contains the app/pages directories. */
-  projectPath?: string
+  projectPath?: RcStr
   /**
    * next.config's distDir. Project initialization occurs eariler than
    * deserializing next.config, so passing it as separate option.
    */
-  distDir?: string | undefined | null
+  distDir?: RcStr | undefined | null
   /** Filesystem watcher options. */
   watch?: NapiWatchOptions
   /** The contents of next.config.js, serialized to JSON. */
-  nextConfig?: string
+  nextConfig?: RcStr
   /** The contents of ts/config read by load-jsconfig, serialized to JSON. */
-  jsConfig?: string
+  jsConfig?: RcStr
   /** A map of environment variables to use when compiling code. */
   env?: Array<NapiEnvVar>
   /**
@@ -166,13 +167,13 @@ export interface NapiPartialProjectOptions {
   /** The mode in which Next.js is running. */
   dev?: boolean
   /** The server actions encryption key. */
-  encryptionKey?: string
+  encryptionKey?: RcStr
   /** The build id. */
-  buildId?: string
+  buildId?: RcStr
   /** Options for draft mode. */
   previewProps?: NapiDraftModeOptions
   /** The browserslist query to use for targeting browsers. */
-  browserslistQuery?: string
+  browserslistQuery?: RcStr
   /**
    * When the code is minified, this opts out of the default mangling of
    * local names for variables, functions etc., which can be useful for
@@ -222,7 +223,7 @@ export declare function projectShutdown(project: {
 }): Promise<void>
 export interface AppPageNapiRoute {
   /** The relative path from project_path to the route file */
-  originalName?: string
+  originalName?: RcStr
   htmlEndpoint?: ExternalObject<ExternalEndpoint>
   rscEndpoint?: ExternalObject<ExternalEndpoint>
 }
@@ -230,7 +231,7 @@ export interface NapiRoute {
   /** The router path */
   pathname: string
   /** The relative path from project_path to the route file */
-  originalName?: string
+  originalName?: RcStr
   /** The type of route, eg a Page or App */
   type: string
   pages?: Array<AppPageNapiRoute>
@@ -264,11 +265,11 @@ export declare function projectEntrypointsSubscribe(
 ): { __napiType: 'RootTask' }
 export declare function projectHmrEvents(
   project: { __napiType: 'Project' },
-  identifier: string,
+  identifier: RcStr,
   func: (...args: any[]) => any
 ): { __napiType: 'RootTask' }
 export interface HmrIdentifiers {
-  identifiers: Array<string>
+  identifiers: Array<RcStr>
 }
 export declare function projectHmrIdentifiersSubscribe(
   project: { __napiType: 'Project' },
@@ -310,10 +311,10 @@ export interface StackFrame {
   isServer: boolean
   isInternal?: boolean
   originalFile?: string
-  file: string
+  file: RcStr
   line?: number
   column?: number
-  methodName?: string
+  methodName?: RcStr
 }
 export declare function projectTraceSource(
   project: { __napiType: 'Project' },
@@ -322,15 +323,15 @@ export declare function projectTraceSource(
 ): Promise<StackFrame | null>
 export declare function projectGetSourceForAsset(
   project: { __napiType: 'Project' },
-  filePath: string
+  filePath: RcStr
 ): Promise<string | null>
 export declare function projectGetSourceMap(
   project: { __napiType: 'Project' },
-  filePath: string
+  filePath: RcStr
 ): Promise<string | null>
 export declare function projectGetSourceMapSync(
   project: { __napiType: 'Project' },
-  filePath: string
+  filePath: RcStr
 ): string | null
 export declare function rootTaskDispose(rootTask: {
   __napiType: 'RootTask'


### PR DESCRIPTION
We have some annoying caching issues with napi, which led me to miss this in https://github.com/vercel/next.js/pull/79806.

You can force a rebuild of the types with:

```
rm /tmp/*.napi_type_def.tmp
cargo clean
pnpm swc-build-native
```

Closes PACK-4710