### PR TITLE
[release-new] fix: slack notification only if is a publish workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -606,6 +606,7 @@ jobs:
       # New release process
       - name: Publish to NPM
         id: changesets
+        # TODO: Change to IS_RELEASE condition when new release becomes stable.
         if: ${{ env.__NEW_RELEASE == 'true' }}
         uses: changesets/action@v1
         with:
@@ -615,6 +616,9 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Send a Slack notification of the publish status
+        # TODO: Change to IS_RELEASE condition when new release becomes stable. We always
+        # want Slack notification if is a release.
+        if: ${{ env.__NEW_RELEASE == 'true' && steps.changesets.outputs.published != '' }}
         run: pnpm tsx scripts/release/slack.ts
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -616,9 +616,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Send a Slack notification of the publish status
-        # TODO: Change to IS_RELEASE condition when new release becomes stable. We always
-        # want Slack notification if is a release.
-        if: ${{ env.__NEW_RELEASE == 'true' && steps.changesets.outputs.published != '' }}
+        # TODO: Change to IS_RELEASE condition when new release becomes stable.
+        if: ${{ env.__NEW_RELEASE == 'true' && (steps.changesets.outputs.published == 'true' || steps.changesets.outputs.published == 'false') }}
         run: pnpm tsx scripts/release/slack.ts
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
The Slack notification workflow didn't have if condition, so it was notified on every `build_and_deploy` job.

x-ref: [slack thread](https://vercel.slack.com/archives/C0668R2391V/p1748475689878939)