### PR TITLE
fix: Revert bugfix for conflicting assets

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -223,7 +223,7 @@ export class ClientReferenceManifestPlugin {
   }
 
   apply(compiler: webpack.Compiler) {
-    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
       compilation.hooks.processAssets.tap(
         {
           name: PLUGIN_NAME,

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -781,7 +781,7 @@ export default class MiddlewarePlugin {
   }
 
   public apply(compiler: webpack.Compiler) {
-    compiler.hooks.thisCompilation.tap(NAME, (compilation, params) => {
+    compiler.hooks.compilation.tap(NAME, (compilation, params) => {
       const { hooks } = params.normalModuleFactory
       /**
        * This is the static code analysis phase.

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -650,7 +650,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
   }
 
   apply(compiler: webpack.Compiler) {
-    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
       const compilationSpan =
         getCompilationSpan(compilation) || getCompilationSpan(compiler)!
       const traceEntrypointsPluginSpan = compilationSpan.traceChild(

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -1003,7 +1003,7 @@ export class NextTypesPlugin {
       }
     }
 
-    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
       compilation.hooks.processAssets.tapAsync(
         {
           name: PLUGIN_NAME,

--- a/packages/next/src/build/webpack/plugins/profiling-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/profiling-plugin.ts
@@ -91,7 +91,7 @@ export class ProfilingPlugin {
   traceTopLevelHooks(compiler: any) {
     this.traceHookPair(
       'webpack-compilation',
-      compiler.hooks.thisCompilation,
+      compiler.hooks.compilation,
       compiler.hooks.afterCompile,
       {
         parentSpan: () =>
@@ -146,7 +146,7 @@ export class ProfilingPlugin {
       },
     })
 
-    compiler.hooks.thisCompilation.tap(
+    compiler.hooks.compilation.tap(
       { name: pluginName, stage: -Infinity },
       (compilation: any) => {
         compilation.hooks.buildModule.tap(pluginName, (module: any) => {


### PR DESCRIPTION
### What?

Revert https://github.com/vercel/next.js/pull/78011

cc @Karibash

### Why?

Because it caused a regression like https://github.com/vercel/next.js/issues/79938

### How?

Closes https://github.com/vercel/next.js/issues/79938

Closes PACK-4715