### PR TITLE
Docs: Drop innacurate override information for dynamicParams

### DIFF
--- a/docs/01-app/05-api-reference/03-file-conventions/route-segment-config.mdx
+++ b/docs/01-app/05-api-reference/03-file-conventions/route-segment-config.mdx
@@ -87,7 +87,6 @@ export const dynamicParams = true // true | false,
 > - This option replaces the `fallback: true | false | blocking` option of `getStaticPaths` in the `pages` directory.
 > - To statically render all paths the first time they're visited, you'll need to return an empty array in `generateStaticParams` or utilize `export const dynamic = 'force-static'`.
 > - When `dynamicParams = true`, the segment uses [Streaming Server Rendering](/docs/app/building-your-application/routing/loading-ui-and-streaming#streaming-with-suspense).
-> - If the `dynamic = 'error'` and `dynamic = 'force-static'` are used, it'll change the default of `dynamicParams` to `false`.
 
 ### `revalidate`
 


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4725/docs-dynamic-dynamicparams

As far as I have been able to gather, `dynamicParams` always defaults to `true`. 