### PR TITLE
Turbopack: more deterministic manifest order

### DIFF
--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
-use rustc_hash::FxHashSet;
 use tracing::Instrument;
 use turbo_tasks::{
-    ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
+    FxIndexSet, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal},
 };
 use turbo_tasks_fs::{FileSystemPath, rebase};
@@ -113,7 +112,7 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
             .completed()?
             .into_inner()
             .into_postorder_topological()
-            .collect::<FxHashSet<_>>()
+            .collect::<FxIndexSet<_>>()
             .into_iter()
             .collect(),
     ))


### PR DESCRIPTION
Fix non-deterministic next font manifest order:

![Bildschirmfoto 2025-05-30 um 15.41.12.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sjZSbv6AFeuDg7Gb9rma/e2de4601-a90e-41db-ac4c-7fde7ffec146.png)


Closes PACK-4721