### PR TITLE
chore(ci): Run turbopack benchmark from custom runners

### DIFF
--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   benchmark-tiny:
     name: Benchmark Rust Crates (tiny)
-    runs-on: ubuntu-22.04
+    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
     steps:
       - uses: actions/checkout@v4
 
@@ -55,7 +55,7 @@ jobs:
 
   benchmark-small-apps:
     name: Benchmark Rust Crates (small apps)
-    runs-on: ubuntu-22.04
+    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
     steps:
       - uses: actions/checkout@v4
 
@@ -94,7 +94,7 @@ jobs:
     name: Benchmark Rust Crates (large)
     # If the task is triggered manually, we want to run the large benchmarks
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-22.04
+    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### What?

User the custom runner for turbopack benchmarks

### Why?

Turbopack is very parallel so it's better to use custom runners which has more CPU cores.



Closes PACK-4725