### PR TITLE
chore(ci): Make turbopack benchmark less flaky

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10157,6 +10157,7 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
+ "turbo-tasks-malloc",
  "turbo-tasks-testing",
  "turbopack-core",
  "turbopack-resolve",

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use turbopack_cli::{
     arguments::{BuildArguments, CommonArguments},
     register,
@@ -47,44 +47,47 @@ fn bench_small_apps(c: &mut Criterion) {
     let mut g = c.benchmark_group("turbopack/build/apps");
 
     for app in apps {
-        g.bench_function(app.file_name().unwrap_or_default().to_string_lossy(), |b| {
-            let apps_dir = apps_dir.clone();
-            let app = app.clone();
-
-            b.iter(move || {
-                let mut rt = tokio::runtime::Builder::new_multi_thread();
-                rt.enable_all().on_thread_stop(|| {
-                    TurboMalloc::thread_stop();
-                });
-                let rt = rt.build().unwrap();
-
+        g.bench_function(
+            BenchmarkId::new("build", app.file_name().unwrap().to_string_lossy()),
+            |b| {
                 let apps_dir = apps_dir.clone();
                 let app = app.clone();
 
-                let app_name = app.file_name().unwrap().to_string_lossy().to_string();
+                b.iter(move || {
+                    let mut rt = tokio::runtime::Builder::new_multi_thread();
+                    rt.enable_all().on_thread_stop(|| {
+                        TurboMalloc::thread_stop();
+                    });
+                    let rt = rt.build().unwrap();
 
-                rt.block_on(async move {
-                    //
-                    turbopack_cli::build::build(&BuildArguments {
-                        common: CommonArguments {
-                            entries: Some(vec![format!("{app_name}/index.tsx")]),
-                            dir: Some(app.clone()),
-                            root: Some(apps_dir),
-                            log_level: None,
-                            show_all: false,
-                            log_detail: false,
-                            full_stats: false,
-                            target: None,
-                        },
-                        no_sourcemap: false,
-                        no_minify: false,
-                        force_memory_cleanup: true,
+                    let apps_dir = apps_dir.clone();
+                    let app = app.clone();
+
+                    let app_name = app.file_name().unwrap().to_string_lossy().to_string();
+
+                    rt.block_on(async move {
+                        //
+                        turbopack_cli::build::build(&BuildArguments {
+                            common: CommonArguments {
+                                entries: Some(vec![format!("{app_name}/index.tsx")]),
+                                dir: Some(app.clone()),
+                                root: Some(apps_dir),
+                                log_level: None,
+                                show_all: false,
+                                log_detail: false,
+                                full_stats: false,
+                                target: None,
+                            },
+                            no_sourcemap: false,
+                            no_minify: false,
+                            force_memory_cleanup: true,
+                        })
+                        .await
                     })
-                    .await
-                })
-                .unwrap();
-            });
-        });
+                    .unwrap();
+                });
+            },
+        );
     }
 }
 

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -47,7 +47,7 @@ fn bench_small_apps(c: &mut Criterion) {
     let mut g = c.benchmark_group("turbopack/build/apps");
 
     for app in apps {
-        g.bench_function(app.to_string_lossy().to_string(), |b| {
+        g.bench_function(app.file_name().unwrap_or_default().to_string_lossy(), |b| {
             let apps_dir = apps_dir.clone();
             let app = app.clone();
 

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(codspeed), allow(unused))]
 
+extern crate turbo_tasks_malloc;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -77,6 +77,7 @@ par-core = { workspace = true, features = ["rayon"] }
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 turbo-tasks-backend = { workspace = true }
+turbo-tasks-malloc = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 
 [build-dependencies]

--- a/turbopack/crates/turbopack-ecmascript/benches/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/mod.rs
@@ -1,3 +1,5 @@
+extern crate turbo_tasks_malloc;
+
 use criterion::{criterion_group, criterion_main};
 
 mod analyzer;


### PR DESCRIPTION
### What?

Use mimalloc in the benchmark

### Why?

I know it's a bit ridiculous, but using mimalloc stabilizes the benchmark. At least, it was the case for SWC.

Closes PACK-4720