### PR TITLE
[dev-overlay] Remove unnecessary code from /pages dev error boundary

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/pages/pages-dev-overlay-error-boundary.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/pages-dev-overlay-error-boundary.tsx
@@ -15,10 +15,6 @@ export class PagesDevOverlayErrorBoundary extends React.PureComponent<
     return { error }
   }
 
-  componentDidCatch(error: Error) {
-    this.setState({ error })
-  }
-
   // Explicit type is needed to avoid the generated `.d.ts` having a wide return type that could be specific to the `@types/react` version.
   render(): React.ReactNode {
     // The component has to be unmounted or else it would continue to error

--- a/packages/next/src/client/components/react-dev-overlay/pages/pages-dev-overlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/pages-dev-overlay.tsx
@@ -17,9 +17,7 @@ export function PagesDevOverlay({ children }: PagesDevOverlayProps) {
 
   return (
     <>
-      <PagesDevOverlayErrorBoundary>
-        {children ?? null}
-      </PagesDevOverlayErrorBoundary>
+      <PagesDevOverlayErrorBoundary>{children}</PagesDevOverlayErrorBoundary>
 
       {/* Fonts can only be loaded outside the Shadow DOM. */}
       <FontStyles />


### PR DESCRIPTION
No longer needed in React 18+