### PR TITLE
perf(turbopack): Use `Cow` instead of `Bytes` for `Rope`

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -663,11 +663,14 @@ impl RopeReader {
                 Some(b) => b,
             };
 
-            let amount = min(bytes.get_ref().len(), remaining);
+            let pos = bytes.position() as usize;
+            let len = bytes.get_ref().len() - pos;
 
-            buf.put_slice(&bytes.get_ref()[0..amount]);
+            let amount = min(len, remaining);
 
-            if amount < bytes.get_ref().len() {
+            buf.put_slice(&bytes.get_ref()[pos..pos + amount]);
+
+            if amount < len {
                 bytes.advance(amount);
                 self.stack.push(StackElem::Local(bytes))
             }
@@ -745,7 +748,7 @@ impl BufRead for RopeReader {
 
     fn consume(&mut self, amt: usize) {
         if let Some(StackElem::Local(b)) = self.stack.last_mut() {
-            if amt == b.get_ref().len() {
+            if amt == b.get_ref().len() - b.position() as usize {
                 self.stack.pop();
             } else {
                 // Consume some amount of bytes from the current Bytes instance, ensuring

--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -743,7 +743,7 @@ impl BufRead for RopeReader {
             unreachable!()
         };
 
-        Ok(bytes.get_ref())
+        Ok(&bytes.get_ref()[bytes.position() as usize..])
     }
 
     fn consume(&mut self, amt: usize) {

--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -45,7 +45,7 @@ pub struct Rope {
 struct InnerRope(Arc<[RopeElem]>);
 
 /// Differentiates the types of stored bytes in a rope.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 enum RopeElem {
     /// Local bytes are owned directly by this rope.
     Local(Cow<'static, [u8]>),

--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -321,7 +321,7 @@ impl Uncommitted {
         }
     }
 
-    /// Converts the current uncommitted bytes into a Bytes, resetting our
+    /// Converts the current uncommitted bytes into a `Cow<'static, [u8]>`, resetting our
     /// representation to None.
     fn finish(&mut self) -> Option<Cow<'static, [u8]>> {
         match mem::take(self) {

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -190,7 +190,7 @@ pub async fn process_request_with_content_source(
                         hyper::header::HeaderValue::try_from(content.len().to_string())?,
                     );
 
-                    response.body(hyper::Body::wrap_stream(content.read()))?
+                    response.body(hyper::Body::wrap_stream(ReaderStream::new(content.read())))?
                 };
 
                 return Ok((response, side_effects));


### PR DESCRIPTION
### What?

Use `Cow` for the `Rope` type.

### Why?

`Bytes` copies the underlying byte array in many cases. I think that's because it's a very dynamic type...


Closes PACK-4726