### PR TITLE
perf(turbopack): Use owned instance of `Code` for `minify()`

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -117,7 +117,7 @@ impl Rope {
         self.data.to_bytes(self.length)
     }
 
-    pub fn into_bytes(self) -> Cow<'static, [u8]> {
+    pub fn into_bytes(self) -> Bytes {
         self.data.into_bytes(self.length)
     }
 }
@@ -540,9 +540,9 @@ impl InnerRope {
         }
     }
 
-    fn into_bytes(mut self, len: usize) -> Cow<'static, [u8]> {
+    fn into_bytes(mut self, len: usize) -> Bytes {
         if self.0.is_empty() {
-            return Cow::Borrowed(EMPTY_BUF);
+            return Bytes::default();
         } else if self.0.len() == 1 {
             let data = Arc::try_unwrap(self.0);
             match data {
@@ -559,7 +559,7 @@ impl InnerRope {
         let mut buf = Vec::with_capacity(len);
         read.read_to_end(&mut buf)
             .expect("read of rope cannot fail");
-        Cow::Owned(buf)
+        buf.into()
     }
 }
 
@@ -636,7 +636,7 @@ impl RopeElem {
         }
     }
 
-    fn into_bytes(self, len: usize) -> Cow<'static, [u8]> {
+    fn into_bytes(self, len: usize) -> Bytes {
         match self {
             Local(bytes) => bytes,
             Shared(inner) => inner.into_bytes(len),

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -128,7 +128,7 @@ impl EcmascriptBrowserChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(&code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle)?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -194,7 +194,7 @@ impl EcmascriptBrowserEvaluateChunk {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(&code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle)?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -34,6 +34,11 @@ impl Code {
     pub fn has_source_map(&self) -> bool {
         !self.mappings.is_empty()
     }
+
+    /// Take the source code out of the Code.
+    pub fn into_source_code(self) -> Rope {
+        self.code
+    }
 }
 
 /// CodeBuilder provides a mutable container to append source code.

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -36,7 +36,7 @@ pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Resu
         .then(|| code.generate_source_map_ref())
         .transpose()?;
 
-    let source_code = code.into_source_code().into_bytes().into_owned();
+    let source_code = code.into_source_code().into_bytes().into();
     let source_code = String::from_utf8(source_code)?;
 
     let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -31,17 +31,17 @@ use turbopack_core::{
 use crate::parse::generate_js_source_map;
 
 #[instrument(level = Level::INFO, skip_all)]
-pub fn minify(code: &Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
+pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
     let source_maps = source_maps
         .then(|| code.generate_source_map_ref())
         .transpose()?;
 
+    let source_code = code.into_source_code().into_bytes().into_owned();
+    let source_code = String::from_utf8(source_code)?;
+
     let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));
     let (src, mut src_map_buf) = {
-        let fm = cm.new_source_file(
-            FileName::Anon.into(),
-            code.source_code().to_str()?.into_owned(),
-        );
+        let fm = cm.new_source_file(FileName::Anon.into(), source_code);
 
         let lexer = Lexer::new(
             Syntax::default(),
@@ -57,10 +57,7 @@ pub fn minify(code: &Code, source_maps: bool, mangle: Option<MangleType>) -> Res
                     Ok(program) => program,
                     Err(err) => {
                         err.into_diagnostic(handler).emit();
-                        bail!(
-                            "failed to parse source code\n{}",
-                            code.source_code().to_str()?
-                        )
+                        bail!("failed to parse source code\n{}", fm.src)
                     }
                 };
                 let comments = SingleThreadedComments::default();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -78,7 +78,7 @@ impl EcmascriptBuildNodeChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(&code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle)?;
         }
 
         Ok(code.cell())


### PR DESCRIPTION
### What?

Add `Rope::into_string()` that takes the owned instance of `self` and avoids an extra allocation.

### Why?

We don't need to go through `Read` + `Clone` interface in these cases. We construct the `Code` instance, and pass it right away to the `minify` without cloning so we can even use `String`.

### How?



Closes PACK-4741