### PR TITLE
[turbopack] Fix URL fragment and query handling in Turbopack

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -213,7 +213,7 @@ pub async fn to_rsc_context(
     // module.
     let source = FileSource::new_with_query(
         client_module.ident().path().root().join(entry_path.into()),
-        Vc::cell(entry_query.into()),
+        entry_query.into(),
     );
     let module = asset_context
         .process(

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -71,7 +71,11 @@ impl Transition for NextEcmascriptClientReferenceTransition {
                     .replace("next/dist/esm/", "next/dist/")
                     .into(),
             );
-            Vc::upcast(FileSource::new_with_query(path, *ident_ref.query))
+            Vc::upcast(FileSource::new_with_query_and_fragment(
+                path,
+                (*ident_ref.query.await?).clone(),
+                (*ident_ref.fragment.await?).clone(),
+            ))
         } else {
             source
         };

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -13,32 +13,33 @@ use crate::{
 /// references to other [Source]s.
 #[turbo_tasks::value]
 pub struct FileSource {
-    pub path: ResolvedVc<FileSystemPath>,
-    pub query: ResolvedVc<RcStr>,
+    path: ResolvedVc<FileSystemPath>,
+    query: RcStr,
+    fragment: RcStr,
+}
+
+impl FileSource {
+    pub fn new(path: Vc<FileSystemPath>) -> Vc<Self> {
+        FileSource::new_with_query_and_fragment(path, RcStr::default(), RcStr::default())
+    }
+    pub fn new_with_query(path: Vc<FileSystemPath>, query: RcStr) -> Vc<Self> {
+        FileSource::new_with_query_and_fragment(path, query, RcStr::default())
+    }
 }
 
 #[turbo_tasks::value_impl]
 impl FileSource {
     #[turbo_tasks::function]
-    pub fn new(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new_with_query_and_fragment(
+        path: ResolvedVc<FileSystemPath>,
+        query: RcStr,
+        fragment: RcStr,
+    ) -> Vc<Self> {
         Self::cell(FileSource {
             path,
-            query: ResolvedVc::cell(RcStr::default()),
+            query,
+            fragment,
         })
-    }
-
-    #[turbo_tasks::function]
-    pub async fn new_with_query(
-        path: ResolvedVc<FileSystemPath>,
-        query: ResolvedVc<RcStr>,
-    ) -> Result<Vc<Self>> {
-        if query.await?.is_empty() {
-            // Delegate to the other factory to ensure there is a single empty ResolvedVc<RcStr> for
-            // the FileSource type.
-            Ok(Self::new(*path))
-        } else {
-            Ok(Self::cell(FileSource { path, query }))
-        }
     }
 }
 
@@ -46,7 +47,14 @@ impl FileSource {
 impl Source for FileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(*self.path).with_query(*self.query)
+        let mut ident = AssetIdent::from_path(*self.path);
+        if !self.query.is_empty() {
+            ident = ident.with_query(Vc::cell(self.query.clone()));
+        }
+        if !self.fragment.is_empty() {
+            ident = ident.with_fragment(Vc::cell(self.fragment.clone()));
+        }
+        ident
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -33,6 +33,8 @@ impl FileSource {
         query: ResolvedVc<RcStr>,
     ) -> Result<Vc<Self>> {
         if query.await?.is_empty() {
+            // Delegate to the other factory to ensure there is a single empty ResolvedVc<RcStr> for
+            // the FileSource type.
             Ok(Self::new(*path))
         } else {
             Ok(Self::cell(FileSource { path, query }))

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -157,6 +157,13 @@ impl AssetIdent {
     }
 
     #[turbo_tasks::function]
+    pub fn with_fragment(&self, fragment: ResolvedVc<RcStr>) -> Vc<Self> {
+        let mut this = self.clone();
+        this.fragment = fragment;
+        Self::new(Value::new(this))
+    }
+
+    #[turbo_tasks::function]
     pub fn with_modifier(&self, modifier: ResolvedVc<RcStr>) -> Vc<Self> {
         let mut this = self.clone();
         this.add_modifier(modifier);

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -71,18 +71,18 @@ fn split_off_query_fragment(mut raw: &str) -> (Pattern, RcStr, RcStr) {
 
     let hash = match raw.as_bytes().iter().position(|&b| b == b'#') {
         Some(pos) => {
-            let hash = RcStr::from(&raw[pos..]);
-            raw = &raw[..pos];
-            hash
+            let (prefix, hash) = raw.split_at(pos);
+            raw = prefix;
+            RcStr::from(hash)
         }
         None => RcStr::default(),
     };
 
     let query = match raw.as_bytes().iter().position(|&b| b == b'?') {
         Some(pos) => {
-            let query = RcStr::from(&raw[pos..]);
-            raw = &raw[..pos];
-            query
+            let (prefix, query) = raw.split_at(pos);
+            raw = prefix;
+            RcStr::from(query)
         }
         None => RcStr::default(),
     };

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -194,7 +194,7 @@ impl CssChunk {
                 ServerFileSystem::new().root().to_resolved().await?
             },
             query: ResolvedVc::cell(RcStr::default()),
-            fragment: None,
+            fragment: ResolvedVc::cell(RcStr::default()),
             assets,
             modifiers: Vec::new(),
             parts: Vec::new(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -123,7 +123,7 @@ impl Chunk for EcmascriptChunk {
                 ServerFileSystem::new().root().to_resolved().await?
             },
             query: ResolvedVc::cell(RcStr::default()),
-            fragment: None,
+            fragment: ResolvedVc::cell(RcStr::default()),
             assets,
             modifiers: Vec::new(),
             parts: Vec::new(),


### PR DESCRIPTION
Fix URL fragment and query handling in Turbopack

## What?
This PR improves how URL fragments and query strings are handled in Turbopack by:

1. Standardizing the representation of fragments and queries in `AssetIdent`
2. Ensuring fragments and queries are either empty or include their prefix characters (`#` and `?`)
3. Fixing the URL parsing logic to correctly handle fragments that contain `?` character
4. Removing some ad-hoc workarounds for this issue in the `resolver` and `Assetident::to_string`

## Why?
The previous implementation had inconsistencies in how fragments and queries were represented which lead to a variety of confusing issues e.g. does `AssetIdent::to_string` need to add a `?` ?, well sometimes depending on how it was constructed.






Closes PACK-4723