### PR TITLE
perf(turbopack): Compress `Rope`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,12 +1089,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -3033,7 +3034,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -3688,9 +3689,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -4141,6 +4142,25 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -9742,11 +9762,13 @@ dependencies = [
  "concurrent-queue",
  "dashmap 6.1.0",
  "dunce",
+ "either",
  "futures",
  "futures-retry",
  "include_dir",
  "indexmap 2.7.1",
  "jsonc-parser 0.21.0",
+ "lz4",
  "mime",
  "notify",
  "parking_lot",

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -32,6 +32,7 @@ bytes = { workspace = true }
 concurrent-queue = { workspace = true }
 dashmap = { workspace = true }
 dunce = { workspace = true }
+either = { workspace = true }
 futures = { workspace = true }
 futures-retry = { workspace = true }
 include_dir = { version = "0.7.2", features = ["nightly"] }
@@ -56,6 +57,7 @@ turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 unicode-segmentation = { workspace = true }
 urlencoding = { workspace = true }
+lz4 = "1.28.1"
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }


### PR DESCRIPTION
### What?

Compress `Rope` using `lz4`. We split `Local` to `Static` and `Compressed`, and apply compression only to the owned vector (`Vec<T>`).

### Why?

To reduce memory usage.

---


I'll wait for downstack PRs and benchmarks