### PR TITLE
fix(turbopack): Allow google font fetch errors to propagate when in production

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -161,7 +161,7 @@ pub async fn get_client_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_client_import_map =
-        get_next_client_import_map(*project_path, ty, next_config, execution_context)
+        get_next_client_import_map(*project_path, ty, next_config, mode, execution_context)
             .to_resolved()
             .await?;
     let next_client_fallback_import_map = get_next_client_fallback_import_map(ty)

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -110,7 +110,7 @@ pub async fn get_edge_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_edge_import_map =
-        get_next_edge_import_map(*project_path, ty, next_config, execution_context)
+        get_next_edge_import_map(*project_path, ty, next_config, mode, execution_context)
             .to_resolved()
             .await?;
 

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -93,6 +93,7 @@ pub async fn get_next_client_import_map(
     project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ClientContextType>,
     next_config: Vc<NextConfig>,
+    next_mode: Vc<NextMode>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
@@ -102,6 +103,7 @@ pub async fn get_next_client_import_map(
         project_path,
         execution_context,
         next_config,
+        next_mode,
         false,
     )
     .await?;
@@ -289,6 +291,7 @@ pub async fn get_next_server_import_map(
     project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ServerContextType>,
     next_config: Vc<NextConfig>,
+    next_mode: Vc<NextMode>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
@@ -298,6 +301,7 @@ pub async fn get_next_server_import_map(
         project_path,
         execution_context,
         next_config,
+        next_mode,
         false,
     )
     .await?;
@@ -384,6 +388,7 @@ pub async fn get_next_edge_import_map(
     project_path: ResolvedVc<FileSystemPath>,
     ty: Value<ServerContextType>,
     next_config: Vc<NextConfig>,
+    next_mode: Vc<NextMode>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
@@ -435,6 +440,7 @@ pub async fn get_next_edge_import_map(
         project_path,
         execution_context,
         next_config,
+        next_mode,
         true,
     )
     .await?;
@@ -845,6 +851,7 @@ async fn insert_next_shared_aliases(
     project_path: ResolvedVc<FileSystemPath>,
     execution_context: Vc<ExecutionContext>,
     next_config: Vc<NextConfig>,
+    next_mode: Vc<NextMode>,
     is_runtime_edge: bool,
 ) -> Result<()> {
     let package_root = next_js_fs().root().to_resolved().await?;
@@ -892,7 +899,7 @@ async fn insert_next_shared_aliases(
     import_map.insert_alias(
         AliasPattern::exact("@vercel/turbopack-next/internal/font/google/cssmodule.module.css"),
         ImportMapping::Dynamic(ResolvedVc::upcast(
-            NextFontGoogleCssModuleReplacer::new(*project_path, execution_context)
+            NextFontGoogleCssModuleReplacer::new(*project_path, execution_context, next_mode)
                 .to_resolved()
                 .await?,
         ))

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -134,7 +134,7 @@ pub async fn get_server_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_server_import_map =
-        get_next_server_import_map(*project_path, ty, next_config, execution_context)
+        get_next_server_import_map(*project_path, ty, next_config, mode, execution_context)
             .to_resolved()
             .await?;
     let foreign_code_context_condition =

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -7745,8 +7745,8 @@
     "runtimeError": false
   },
   "test/e2e/next-font/google-fetch-error.test.ts": {
-    "passed": [],
-    "failed": ["next/font/google fetch error should error when not in dev"],
+    "passed": ["next/font/google fetch error should error when not in dev"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## Fail Google Fonts in Production Builds When Fetch Fails

### What?
This PR changes the behavior of Google Fonts in Next.js to properly fail production builds when font fetching fails, while still allowing development to continue with fallback fonts.

### Why?
Previously, font fetch failures were only logged as warnings but didn't stop production builds. This could lead to production deployments with missing fonts, creating a poor user experience. Development mode should be more forgiving to allow work to continue offline.

### How?
- Added `is_dev_mode()` method to the `ChunkingContext` trait to determine the current environment
- Modified the Google font fetching logic to:
  - In development: Show a warning and use fallback fonts when fetching fails
  - In production: Throw an error that fails the build when fetching fails
- Passed the execution context to the font file replacer to access the chunking context

This ensures that production builds will fail fast when font resources can't be fetched, while development builds can continue with appropriate fallbacks.

Fixes #PACK-4667

### Future Hopes

I would hope to eventually expose an enum for the build mode rather than just a boolean flag like I have here. I started going down that path for this PR, but it was expanding the scope significantly of what would have to be done, so I have left it as a bool to fix this problem.