### PR TITLE
[release] fix: shouldn't publish from release prs

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -611,6 +611,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm ci:publish
+          # TODO: Remove once we're certain of this workflow.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
           if [[ $RELEASE_CHECK == 'new-release' ]];
           then
             echo "__NEW_RELEASE=true" >> $GITHUB_ENV
-            echo "value=production" >> $GITHUB_OUTPUT
+            echo "value=production-new" >> $GITHUB_OUTPUT
           elif [[ $RELEASE_CHECK == v* ]];
           then
             echo "value=production" >> $GITHUB_OUTPUT
@@ -542,7 +542,7 @@ jobs:
           path: ${{ runner.temp }}/preview-tarballs/*
 
   publishRelease:
-    if: ${{ needs.deploy-target.outputs.value == 'production' && github.event_name == 'push' && (github.ref == 'refs/heads/canary' || github.ref == 'refs/heads/release/dry-run') }}
+    if: ${{ needs.deploy-target.outputs.value == 'production' }}
     name: Potentially publish release
     runs-on: ubuntu-latest
     needs:
@@ -597,17 +597,75 @@ jobs:
       - run: npm i -g npm@10.4.0 # need latest version for provenance (pinning to avoid bugs)
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: ./scripts/publish-native.js
-      # Legacy release process
       - run: ./scripts/publish-release.js
-        if: ${{ env.__NEW_RELEASE == 'false' }}
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
-      # New release process
+      - name: Upload npm log artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-publish-logs
+          path: /home/runner/.npm/_logs/*
+
+  publishReleaseNew:
+    if: ${{ needs.deploy-target.outputs.value == 'production-new' && github.event_name == 'push' && (github.ref == 'refs/heads/canary' || github.ref == 'refs/heads/release/dry-run') }}
+    name: Potentially publish release
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-target
+      - build
+      - build-wasm
+      - build-native
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          check-latest: true
+      - name: Setup corepack
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
+
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - uses: actions/cache@v4
+        timeout-minutes: 5
+        id: restore-build
+        with:
+          path: ./*
+          # Cache includes repo checkout which is required for later scripts
+          fail-on-cache-miss: true
+          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ github.sha }}-${{ github.run_number }}
+            ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: next-swc-binaries-*
+          merge-multiple: true
+          path: packages/next-swc/native
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wasm-binaries-*
+          merge-multiple: true
+          path: crates/wasm
+
+      - run: npm i -g npm@10.4.0 # need latest version for provenance (pinning to avoid bugs)
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run: ./scripts/publish-native.js
+
       - name: Publish to NPM
         id: changesets
-        # TODO: Change to IS_RELEASE condition when new release becomes stable.
-        if: ${{ env.__NEW_RELEASE == 'true' }}
         uses: changesets/action@v1
         with:
           publish: pnpm ci:publish
@@ -618,8 +676,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Send a Slack notification of the publish status
-        # TODO: Change to IS_RELEASE condition when new release becomes stable.
-        if: ${{ env.__NEW_RELEASE == 'true' && (steps.changesets.outputs.published == 'true' || steps.changesets.outputs.published == 'false') }}
+        if: ${{ steps.changesets.outputs.published == 'true' || steps.changesets.outputs.published == 'false' }}
         run: pnpm tsx scripts/release/slack.ts
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
@@ -709,7 +766,7 @@ jobs:
       - 'x64'
       - 'metal'
     timeout-minutes: 25
-    needs: [publishRelease]
+    needs: [publishRelease, publishReleaseNew]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -44,7 +44,6 @@ jobs:
         # 'staging' for canary branch since that will eventually be published i.e. become the production build.
         id: deploy-target
         run: |
-          # TODO: Remove the new release check once the new release workflow is fully replaced.
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
           if [[ $RELEASE_CHECK == 'new-release' ]];
           then
@@ -597,6 +596,7 @@ jobs:
 
       - name: Upload npm log artifact
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: npm-publish-logs
           path: /home/runner/.npm/_logs/*
@@ -680,6 +680,7 @@ jobs:
 
       - name: Upload npm log artifact
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: npm-publish-logs
           path: /home/runner/.npm/_logs/*

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,11 +19,6 @@ env:
   #
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
   MACOSX_DEPLOYMENT_TARGET: 11.0
-  # This will become "true" if the latest commit (merged release PR) is either:
-  # - "Version Packages (#<number>)"
-  # - "Version Pacakges (canary/rc) (#<number>)"
-  # set from scripts/check-is-release.js
-  __NEW_RELEASE: 'false'
 
 jobs:
   deploy-target:
@@ -53,7 +48,6 @@ jobs:
           RELEASE_CHECK=$(node ./scripts/check-is-release.js 2> /dev/null || :)
           if [[ $RELEASE_CHECK == 'new-release' ]];
           then
-            echo "__NEW_RELEASE=true" >> $GITHUB_ENV
             echo "value=production-new" >> $GITHUB_OUTPUT
           elif [[ $RELEASE_CHECK == v* ]];
           then
@@ -484,7 +478,7 @@ jobs:
           path: crates/wasm/pkg-*
 
   deploy-tarball:
-    if: ${{ needs.deploy-target.outputs.value != 'production' }}
+    if: ${{ needs.deploy-target.outputs.value != 'production' && needs.deploy-target.outputs.value != 'production-new' }}
     name: Deploy preview tarball
     runs-on: ubuntu-latest
     needs:
@@ -737,13 +731,13 @@ jobs:
       - name: Install Vercel CLI
         run: npm i -g vercel@latest
       - name: Deploy preview examples
-        if: ${{ needs.deploy-target.outputs.value != 'production' }}
+        if: ${{ needs.deploy-target.outputs.value != 'production' && needs.deploy-target.outputs.value != 'production-new' }}
         run: ./scripts/deploy-examples.sh
         env:
           VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
           DEPLOY_ENVIRONMENT: preview
       - name: Deploy production examples
-        if: ${{ needs.deploy-target.outputs.value == 'production' }}
+        if: ${{ needs.deploy-target.outputs.value == 'production' || needs.deploy-target.outputs.value == 'production-new' }}
         run: ./scripts/deploy-examples.sh
         env:
           VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -542,7 +542,7 @@ jobs:
           path: ${{ runner.temp }}/preview-tarballs/*
 
   publishRelease:
-    if: ${{ needs.deploy-target.outputs.value == 'production' }}
+    if: ${{ needs.deploy-target.outputs.value == 'production' && github.event_name == 'push' && (github.ref == 'refs/heads/canary' || github.ref == 'refs/heads/release/dry-run') }}
     name: Potentially publish release
     runs-on: ubuntu-latest
     needs:
@@ -626,7 +626,6 @@ jobs:
           WORKFLOW_ACTOR: ${{ github.actor }}
 
       - name: Upload npm log artifact
-        if: steps.changesets.outputs.published == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: npm-publish-logs

--- a/scripts/release/publish-npm.ts
+++ b/scripts/release/publish-npm.ts
@@ -99,7 +99,8 @@ async function publishNpm() {
     })
 
     const packagePath = join(packagesDir, packageDir.name)
-    const args = ['publish', packagePath, '--tag', tag]
+    // TODO: Prevent from accidentally publishing
+    const args = ['publish', packagePath, '--tag', tag, '--dry-run']
 
     console.log(
       `Running command: "pnpm ${args.join(' ')}" for ${pkgJson.name}@${pkgJson.version}`


### PR DESCRIPTION
### Why?

While I was testing the new workflow on `release/dry-run`, the publish accidentally happened since the `publishRelease` job was running on the `pull_request` target as well. This resulted in **running the old workflow to publish**.

This PR splits the old and new workflow, which should've always been from the beginning. Set workflows of the new release as dry by default. I will come up with a way to ensure everything is working before triggering ANY workflow.