### PR TITLE
refactor(turbopack): Do not use `Result` for `Rope#read`

### DIFF
--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -29,7 +29,7 @@ async fn hash_file_content(path: Vc<FileSystemPath>) -> Result<u64> {
 
     Ok(match &*original_file_content {
         FileContent::Content(content) => {
-            let content = content.content().to_bytes()?;
+            let content = content.content().to_bytes();
             hash_xxh3_hash64(&*content)
         }
         FileContent::NotFound => {

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -117,7 +117,7 @@ async fn get_base64_file_content(path: Vc<FileSystemPath>) -> Result<String> {
 
     Ok(match &*original_file_content {
         FileContent::Content(content) => {
-            let content = content.content().to_bytes()?;
+            let content = content.content().to_bytes();
             Base64Display::new(&content, &STANDARD).to_string()
         }
         FileContent::NotFound => {

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -108,7 +108,7 @@ async fn get_font_adjustment(
         FileContent::Content(file) => file.content(),
     };
 
-    let font_file_binary = font_file_rope.to_bytes()?;
+    let font_file_binary = font_file_rope.to_bytes();
     let scope = allsorts::binary::read::ReadScope::new(&font_file_binary);
     let mut font = Font::new(scope.read::<FontData>()?.table_provider(0)?)?.context(format!(
         "Unable to read font metrics from font file at {}",

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -101,7 +101,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
             };
 
             Ok(Some((
-                SwcPluginModule::new(name, file.content().to_bytes()?.to_vec()).resolved_cell(),
+                SwcPluginModule::new(name, file.content().to_bytes().to_vec()).resolved_cell(),
                 config.clone(),
             )))
         })

--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -114,7 +114,7 @@ impl Rope {
     }
 
     /// Returns a slice of all bytes
-    pub fn to_bytes(&self) -> Result<Cow<'_, [u8]>> {
+    pub fn to_bytes(&self) -> Cow<'_, [u8]> {
         self.data.to_bytes(self.length)
     }
 }
@@ -362,8 +362,7 @@ impl Serialize for Rope {
     /// deserialization won't deduplicate and share the Arcs (being the only
     /// possible owner of a individual "shared" data doesn't make sense).
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::Error;
-        let bytes = self.to_bytes().map_err(Error::custom)?;
+        let bytes = self.to_bytes();
         match bytes {
             Cow::Borrowed(b) => serde_bytes::Bytes::new(b).serialize(serializer),
             Cow::Owned(b) => ByteBuf::from(b).serialize(serializer),
@@ -523,16 +522,17 @@ impl InnerRope {
     }
 
     /// Returns a slice of all bytes.
-    fn to_bytes(&self, len: usize) -> Result<Cow<'_, [u8]>> {
+    fn to_bytes(&self, len: usize) -> Cow<'_, [u8]> {
         match &self[..] {
-            [] => Ok(Cow::Borrowed(EMPTY_BUF)),
+            [] => Cow::Borrowed(EMPTY_BUF),
             [Shared(inner)] => inner.to_bytes(len),
-            [Local(bytes)] => Ok(Cow::Borrowed(bytes)),
+            [Local(bytes)] => Cow::Borrowed(bytes),
             _ => {
                 let mut read = RopeReader::new(self, 0);
                 let mut buf = Vec::with_capacity(len);
-                read.read_to_end(&mut buf)?;
-                Ok(Cow::Owned(buf))
+                read.read_to_end(&mut buf)
+                    .expect("rope reader should not fail");
+                buf.into()
             }
         }
     }
@@ -1045,7 +1045,7 @@ mod test {
     #[test]
     fn test_to_bytes() -> Result<()> {
         let rope = Rope::from("abc");
-        assert_eq!(rope.to_bytes()?, Cow::Borrowed::<[u8]>(&[0x61, 0x62, 0x63]));
+        assert_eq!(rope.to_bytes(), Cow::Borrowed::<[u8]>(&[0x61, 0x62, 0x63]));
         Ok(())
     }
 }

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -347,7 +347,7 @@ pub async fn get_meta_data(
     let FileContent::Content(content) = &*content.await? else {
         bail!("Input image not found");
     };
-    let bytes = content.content().to_bytes()?;
+    let bytes = content.content().to_bytes();
     let path_resolved = ident.path().to_resolved().await?;
     let path = path_resolved.await?;
     let extension = path.extension_ref();
@@ -430,7 +430,7 @@ pub async fn optimize(
     let FileContent::Content(content) = &*content.await? else {
         return Ok(FileContent::NotFound.cell());
     };
-    let bytes = content.content().to_bytes()?;
+    let bytes = content.content().to_bytes();
     let path = ident.path().to_resolved().await?;
 
     let Some((image, format)) = load_image(path, &bytes, ident.path().await?.extension_ref())

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -230,7 +230,7 @@ impl WebpackLoadersProcessedAsset {
                 "binary".to_string(),
                 JsonValue::from(
                     base64::engine::general_purpose::STANDARD
-                        .encode(file_content.content().to_bytes().unwrap()),
+                        .encode(file_content.content().to_bytes()),
                 ),
             )))),
         };

--- a/turbopack/crates/turbopack-wasm/src/analysis.rs
+++ b/turbopack/crates/turbopack-wasm/src/analysis.rs
@@ -29,7 +29,7 @@ pub(crate) async fn analyze(source: Vc<WebAssemblySource>) -> Result<Vc<WebAssem
         return Ok(analysis.cell());
     };
 
-    let mut bytes = &*file.content().to_bytes()?;
+    let mut bytes = &*file.content().to_bytes();
 
     let mut parser = Parser::new(0);
     loop {

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -76,7 +76,7 @@ impl Asset for WebAssemblySource {
             return Ok(AssetContent::file(FileContent::NotFound.cell()));
         };
 
-        let bytes = file.content().to_bytes()?;
+        let bytes = file.content().to_bytes();
         let parsed = wat::parse_bytes(&bytes)?;
 
         Ok(AssetContent::file(File::from(&*parsed).into()))


### PR DESCRIPTION
### What?

Use `Cow<'_, [u8]>` instead of `Result<Cow<'_, [u8]>>`. 

### Why?

`RopeReader` never fails.



Closes PACK-4732