### PR TITLE
Fix typo in static-exports.mdx

### DIFF
--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to create an static export of your Next.js application
+title: How to create a static export of your Next.js application
 nav_title: Static Exports
 description: Next.js enables starting as a static site or Single-Page Application (SPA), then later optionally upgrading to use features that require a server.
 ---


### PR DESCRIPTION
### What?

There was a typo in the title for the Static Exports guide.

