### PR TITLE
Update tailwind-css.mdx to remove `postcss` installation command

### DIFF
--- a/docs/01-app/02-guides/tailwind-css.mdx
+++ b/docs/01-app/02-guides/tailwind-css.mdx
@@ -13,7 +13,7 @@ description: Style your Next.js Application using Tailwind CSS.
 Install the necessary Tailwind CSS packages:
 
 ```bash filename="Terminal"
-npm install -D tailwindcss @tailwindcss/postcss postcss
+npm install -D tailwindcss @tailwindcss/postcss
 ```
 
 > **Good to know**: If you're using the `create-next-app` CLI to create your project, Next.js will prompt if you'd like to install Tailwind and automatically configure the project.


### PR DESCRIPTION

Remove the `postcss` installation command, as it is unnecessary — `@tailwindcss/postcss` already includes the required PostCSS setup.