### PR TITLE
Fix watchmode for `taskr` tasks

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2835,11 +2835,21 @@ export async function build(task, opts) {
 }
 
 export async function generate_types(task, opts) {
-  await execa(
+  const watchmode = opts.dev
+  const typesPromise = execa(
     'pnpm',
-    ['run', 'types', ...(opts.dev ? ['--watch', '--preserveWatchOutput'] : [])],
+    [
+      'run',
+      'types',
+      ...(watchmode ? ['--watch', '--preserveWatchOutput'] : []),
+    ],
     { stdio: 'inherit' }
   )
+  // In watch-mode the process never completes i.e. the Promise never resolve.
+  // But taskr needs to know that it can start watching the files for the task it has to manually restart.
+  if (!watchmode) {
+    await typesPromise
+  }
 }
 
 export async function check_error_codes(task, opts) {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/79785

`tsc` watchmode will leave the process hanging which means `taskr` never started watching the other tasks it has to manually restart. Since we never re-triggered `client`, the next-server runtime inputs never changed thus preventing a rebuild of the next-server runtime.