### PR TITLE
[dynamicIO] Only report client sync IO errors if they are above a Suspense boundary

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -132,6 +132,7 @@ import {
   createDynamicValidationState,
   trackAllowedDynamicAccess,
   throwIfDisallowedDynamic,
+  PreludeState,
   consumeDynamicAccess,
   type DynamicAccess,
 } from './dynamic-rendering'
@@ -2611,7 +2612,8 @@ async function spawnDynamicValidationInDev(
                     trackAllowedDynamicAccess(
                       workStore.route,
                       componentStack,
-                      dynamicValidation
+                      dynamicValidation,
+                      clientDynamicTracking
                     )
                   }
                   return
@@ -2629,16 +2631,14 @@ async function spawnDynamicValidationInDev(
       )
 
     const { preludeIsEmpty } = await processPrelude(unprocessedPrelude)
-
     resolveValidation(
       <LogSafely
         fn={throwIfDisallowedDynamic.bind(
           null,
           workStore,
-          preludeIsEmpty,
+          preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
           dynamicValidation,
-          serverDynamicTracking,
-          clientDynamicTracking
+          serverDynamicTracking
         )}
       />
     )
@@ -2646,14 +2646,12 @@ async function spawnDynamicValidationInDev(
     // Even if the root errors we still want to report any dynamic IO errors
     // that were discovered before the root errored.
 
-    const preludeIsEmpty = true
     let loggingFunction = throwIfDisallowedDynamic.bind(
       null,
       workStore,
-      preludeIsEmpty,
+      PreludeState.Errored,
       dynamicValidation,
-      serverDynamicTracking,
-      clientDynamicTracking
+      serverDynamicTracking
     )
 
     if (process.env.NEXT_DEBUG_BUILD || process.env.__NEXT_VERBOSE_LOGGING) {
@@ -3222,7 +3220,8 @@ async function prerenderToStream(
                       trackAllowedDynamicAccess(
                         workStore.route,
                         componentStack,
-                        dynamicValidation
+                        dynamicValidation,
+                        clientDynamicTracking
                       )
                     }
                     return
@@ -3253,10 +3252,9 @@ async function prerenderToStream(
       if (!allowEmptyStaticShell) {
         throwIfDisallowedDynamic(
           workStore,
-          preludeIsEmpty,
+          preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
           dynamicValidation,
-          serverDynamicTracking,
-          clientDynamicTracking
+          serverDynamicTracking
         )
       }
 

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -1,40 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-const stackStart = /\s+at /
-
-function createExpectError(cliOutput: string) {
-  let cliIndex = 0
-  return function expectError(
-    containing: string,
-    withStackContaining?: string
-  ) {
-    const initialCliIndex = cliIndex
-    let lines = cliOutput.slice(cliIndex).split('\n')
-
-    let i = 0
-    while (i < lines.length) {
-      let line = lines[i++] + '\n'
-      cliIndex += line.length
-      if (line.includes(containing)) {
-        if (typeof withStackContaining !== 'string') {
-          return
-        } else {
-          while (i < lines.length) {
-            let stackLine = lines[i++] + '\n'
-            if (!stackStart.test(stackLine)) {
-              expect(stackLine).toContain(withStackContaining)
-            }
-            if (stackLine.includes(withStackContaining)) {
-              return
-            }
-          }
-        }
-      }
-    }
-
-    expect(cliOutput.slice(initialCliIndex)).toContain(containing)
-  }
-}
+import { createExpectError } from './utils'
 
 function runTests(options: { withMinification: boolean }) {
   const { withMinification } = options

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -1,0 +1,179 @@
+import { nextTestSetup } from 'e2e-utils'
+
+import { createExpectError } from './utils'
+
+function runTests(options: { withMinification: boolean }) {
+  const { withMinification } = options
+  describe(`Dynamic IO Errors - ${withMinification ? 'With Minification' : 'Without Minification'}`, () => {
+    describe('Error Attribution with Sync IO - Guarded RSC with guarded Client sync IO', () => {
+      const { next, isNextDev, skipped } = nextTestSetup({
+        files:
+          __dirname +
+          '/fixtures/sync-attribution/guarded-async-guarded-clientsync',
+        skipStart: true,
+        skipDeployment: true,
+      })
+
+      if (skipped) {
+        return
+      }
+
+      if (isNextDev) {
+        it('does not run in dev', () => {})
+        return
+      }
+
+      beforeEach(async () => {
+        if (!withMinification) {
+          await next.patchFile('next.config.js', (content) =>
+            content.replace(
+              'serverMinification: true,',
+              'serverMinification: false,'
+            )
+          )
+        }
+      })
+
+      it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
+        try {
+          await next.start()
+        } catch {
+          throw new Error('expected build not to fail')
+        }
+        expect(next.cliOutput).toContain('◐ / ')
+      })
+    })
+    describe('Error Attribution with Sync IO - Guarded RSC with unguarded Client sync IO', () => {
+      const { next, isNextDev, skipped } = nextTestSetup({
+        files:
+          __dirname +
+          '/fixtures/sync-attribution/guarded-async-unguarded-clientsync',
+        skipStart: true,
+        skipDeployment: true,
+      })
+
+      if (skipped) {
+        return
+      }
+
+      if (isNextDev) {
+        it('does not run in dev', () => {})
+        return
+      }
+
+      beforeEach(async () => {
+        if (!withMinification) {
+          await next.patchFile('next.config.js', (content) =>
+            content.replace(
+              'serverMinification: true,',
+              'serverMinification: false,'
+            )
+          )
+        }
+      })
+
+      it('should error the build with a reason related to sync IO access', async () => {
+        try {
+          await next.start()
+        } catch {
+          // we expect the build to fail
+        }
+        const expectError = createExpectError(next.cliOutput)
+
+        expectError(
+          'Error: Route "/" used `new Date()` instead of using `performance` or without explicitly calling `await connection()` beforehand.'
+        )
+        expectError('Error occurred prerendering page "/"')
+      })
+    })
+    describe('Error Attribution with Sync IO - Unguarded RSC with guarded Client sync IO', () => {
+      const { next, isNextDev, skipped } = nextTestSetup({
+        files:
+          __dirname +
+          '/fixtures/sync-attribution/unguarded-async-guarded-clientsync',
+        skipStart: true,
+        skipDeployment: true,
+      })
+
+      if (skipped) {
+        return
+      }
+
+      if (isNextDev) {
+        it('does not run in dev', () => {})
+        return
+      }
+
+      beforeEach(async () => {
+        if (!withMinification) {
+          await next.patchFile('next.config.js', (content) =>
+            content.replace(
+              'serverMinification: true,',
+              'serverMinification: false,'
+            )
+          )
+        }
+      })
+
+      it('should error the build with a reason related dynamic data', async () => {
+        try {
+          await next.start()
+        } catch {
+          // we expect the build to fail
+        }
+        const expectError = createExpectError(next.cliOutput)
+
+        expectError(
+          'Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it.'
+        )
+        expectError('Error occurred prerendering page "/"')
+      })
+    })
+    describe('Error Attribution with Sync IO - unguarded RSC with unguarded Client sync IO', () => {
+      const { next, isNextDev, skipped } = nextTestSetup({
+        files:
+          __dirname +
+          '/fixtures/sync-attribution/unguarded-async-unguarded-clientsync',
+        skipStart: true,
+        skipDeployment: true,
+      })
+
+      if (skipped) {
+        return
+      }
+
+      if (isNextDev) {
+        it('does not run in dev', () => {})
+        return
+      }
+
+      beforeEach(async () => {
+        if (!withMinification) {
+          await next.patchFile('next.config.js', (content) =>
+            content.replace(
+              'serverMinification: true,',
+              'serverMinification: false,'
+            )
+          )
+        }
+      })
+
+      it('should error the build with a reason related to sync IO access', async () => {
+        try {
+          await next.start()
+        } catch {
+          // we expect the build to fail
+        }
+        const expectError = createExpectError(next.cliOutput)
+
+        expectError(
+          'Error: Route "/" used `new Date()` instead of using `performance` or without explicitly calling `await connection()` beforehand.'
+        )
+        expectError('Error occurred prerendering page "/"')
+      })
+    })
+  })
+}
+
+runTests({ withMinification: true })
+runTests({ withMinification: false })

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -1,40 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-const stackStart = /\s+at /
-
-function createExpectError(cliOutput: string) {
-  let cliIndex = 0
-  return function expectError(
-    containing: string,
-    withStackContaining?: string
-  ) {
-    const initialCliIndex = cliIndex
-    let lines = cliOutput.slice(cliIndex).split('\n')
-
-    let i = 0
-    while (i < lines.length) {
-      let line = lines[i++] + '\n'
-      cliIndex += line.length
-      if (line.includes(containing)) {
-        if (typeof withStackContaining !== 'string') {
-          return
-        } else {
-          while (i < lines.length) {
-            let stackLine = lines[i++] + '\n'
-            if (!stackStart.test(stackLine)) {
-              expect(stackLine).toContain(withStackContaining)
-            }
-            if (stackLine.includes(withStackContaining)) {
-              return
-            }
-          }
-        }
-      }
-    }
-
-    expect(cliOutput.slice(initialCliIndex)).toContain(containing)
-  }
-}
+import { createExpectError } from './utils'
 
 function runTests(options: { withMinification: boolean }) {
   const { withMinification } = options
@@ -114,7 +80,11 @@ function runTests(options: { withMinification: boolean }) {
         }
         const expectError = createExpectError(next.cliOutput)
 
-        expectError('Route "/" used `searchParams.foo`')
+        // TODO we need to figure out a way to improve this error message. This is the rare case where the sync IO is escaping out of it's parent Suspense because something is rendering too slowly in the root. At the moment we don't have a way of discriminating between this and something like Request data access in the server.
+        // expectError('Route "/" used `searchParams.foo`')
+        expectError(
+          'Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it.'
+        )
         expectError('Error occurred prerendering page "/"')
         expectError('exiting the build.')
       })

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -1,40 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-const stackStart = /\s+at /
-
-function createExpectError(cliOutput: string) {
-  let cliIndex = 0
-  return function expectError(
-    containing: string,
-    withStackContaining?: string
-  ): Array<string> {
-    const initialCliIndex = cliIndex
-    let lines = cliOutput.slice(cliIndex).split('\n')
-
-    let i = 0
-    while (i < lines.length) {
-      let line = lines[i++] + '\n'
-      cliIndex += line.length
-      if (line.includes(containing)) {
-        if (typeof withStackContaining !== 'string') {
-          return
-        } else {
-          while (i < lines.length) {
-            let stackLine = lines[i++] + '\n'
-            if (!stackStart.test(stackLine)) {
-              expect(stackLine).toContain(withStackContaining)
-            }
-            if (stackLine.includes(withStackContaining)) {
-              return
-            }
-          }
-        }
-      }
-    }
-
-    expect(cliOutput.slice(initialCliIndex)).toContain(containing)
-  }
-}
+import { createExpectError } from './utils'
 
 function runTests(options: { withMinification: boolean }) {
   const isTurbopack = !!process.env.IS_TURBOPACK_TEST

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/client.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function SyncIO() {
+  // This is a sync IO access that should not cause an error
+  const data = new Date().toISOString()
+
+  return (
+    <main>
+      <h1>Sync IO Access</h1>
+      <p suppressHydrationWarning>Current date and time: {data}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/page.tsx
@@ -1,0 +1,42 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+import { SyncIO } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <section>
+        <p>
+          In this test we have two components. One reads `new Date()`
+          synchronously in a client component render. The other awaits cookies
+          in a Server Component.
+        </p>
+        <p>
+          In this version both components are wrapped in Suspense. We expect
+          that this page will prerender with fallbacks around both components
+        </p>
+      </section>
+      <section>
+        <Suspense fallback="">
+          <SyncIO />
+        </Suspense>
+      </section>
+      <section>
+        <Suspense fallback="">
+          <RequestData />
+        </Suspense>
+      </section>
+    </main>
+  )
+}
+
+async function RequestData() {
+  ;(await cookies()).get('foo')
+  return (
+    <div>
+      <h2>Request Data Access</h2>
+      <p>This component accesses request data without a Suspense boundary.</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+    serverMinification: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/app/client.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/app/client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function SyncIO() {
+  // This is a sync IO access that should not cause an error
+  const data = new Date().toISOString()
+
+  return (
+    <main>
+      <h1>Sync IO Access</h1>
+      <p suppressHydrationWarning>Current date and time: {data}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/app/page.tsx
@@ -1,0 +1,41 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+import { SyncIO } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <section>
+        <p>
+          In this test we have two components. One reads `new Date()`
+          synchronously in a client component render. The other awaits cookies
+          in a Server Component.
+        </p>
+        <p>
+          In this version the client component is not wrapped in a Suspense
+          boundary. We expect this to be a build failure with the reason
+          pointing to the line where `new Date()` was called.
+        </p>
+      </section>
+      <section>
+        <SyncIO />
+      </section>
+      <section>
+        <Suspense fallback="">
+          <RequestData />
+        </Suspense>
+      </section>
+    </main>
+  )
+}
+
+async function RequestData() {
+  ;(await cookies()).get('foo')
+  return (
+    <div>
+      <h2>Request Data Access</h2>
+      <p>This component accesses request data without a Suspense boundary.</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+    serverMinification: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/app/client.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/app/client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function SyncIO() {
+  // This is a sync IO access that should not cause an error
+  const data = new Date().toISOString()
+
+  return (
+    <main>
+      <h1>Sync IO Access</h1>
+      <p suppressHydrationWarning>Current date and time: {data}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/app/page.tsx
@@ -1,0 +1,41 @@
+import { cookies } from 'next/headers'
+
+import { SyncIO } from './client'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  return (
+    <main>
+      <section>
+        <p>
+          In this test we have two components. One reads `new Date()`
+          synchronously in a client component render. The other awaits cookies
+          in a Server Component.
+        </p>
+        <p>
+          In this version the server component is not wrapped in a Suspense
+          boundary. We expect the build to error with the reason referencing
+          some dynamic data access. It should not mention `new Date()`.
+        </p>
+      </section>
+      <section>
+        <Suspense fallback={<p>Loading...</p>}>
+          <SyncIO />
+        </Suspense>
+      </section>
+      <section>
+        <RequestData />
+      </section>
+    </main>
+  )
+}
+
+async function RequestData() {
+  ;(await cookies()).get('foo')
+  return (
+    <div>
+      <h2>Request Data Access</h2>
+      <p>This component accesses request data without a Suspense boundary.</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+    serverMinification: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/app/client.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/app/client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function SyncIO() {
+  // This is a sync IO access that should not cause an error
+  const data = new Date().toISOString()
+
+  return (
+    <main>
+      <h1>Sync IO Access</h1>
+      <p suppressHydrationWarning>Current date and time: {data}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/app/page.tsx
@@ -1,0 +1,39 @@
+import { cookies } from 'next/headers'
+
+import { SyncIO } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <section>
+        <p>
+          In this test we have two components. One reads `new Date()`
+          synchronously in a client component render. The other awaits cookies
+          in a Server Component.
+        </p>
+        <p>
+          In this version neither component is wrapped in a Suspense boundary.
+          There are no defined semantics about which reason is more "valid" than
+          another but with the current implementation we report the `new Date()`
+          reason when failing the build.
+        </p>
+      </section>
+      <section>
+        <SyncIO />
+      </section>
+      <section>
+        <RequestData />
+      </section>
+    </main>
+  )
+}
+
+async function RequestData() {
+  ;(await cookies()).get('foo')
+  return (
+    <div>
+      <h2>Request Data Access</h2>
+      <p>This component accesses request data without a Suspense boundary.</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+    serverMinification: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/app/page.tsx
@@ -71,8 +71,8 @@ function LongRunningComponent() {
 function ShortRunningComponent() {
   return (
     <div>
-      This component runs quickly (in a microtask). It should be finished before
-      the sync searchParams access happens.
+      This component renders synchronously. It should be finished before sync IO
+      is accessed in the other component.
     </div>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/app/page.tsx
@@ -69,8 +69,8 @@ function LongRunningComponent() {
 function ShortRunningComponent() {
   return (
     <div>
-      This component runs quickly (in a microtask). It should be finished before
-      the sync searchParams access happens.
+      This component renders synchronously. It should be finished before sync IO
+      is accessed in the other component.
     </div>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/utils.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/utils.ts
@@ -1,0 +1,35 @@
+const stackStart = /\s+at /
+
+export function createExpectError(cliOutput: string) {
+  let cliIndex = 0
+  return function expectError(
+    containing: string,
+    withStackContaining?: string
+  ): void {
+    const initialCliIndex = cliIndex
+    let lines = cliOutput.slice(cliIndex).split('\n')
+
+    let i = 0
+    while (i < lines.length) {
+      let line = lines[i++] + '\n'
+      cliIndex += line.length
+      if (line.includes(containing)) {
+        if (typeof withStackContaining !== 'string') {
+          return
+        } else {
+          while (i < lines.length) {
+            let stackLine = lines[i++] + '\n'
+            if (!stackStart.test(stackLine)) {
+              expect(stackLine).toContain(withStackContaining)
+            }
+            if (stackLine.includes(withStackContaining)) {
+              return
+            }
+          }
+        }
+      }
+    }
+
+    expect(cliOutput.slice(initialCliIndex)).toContain(containing)
+  }
+}


### PR DESCRIPTION
Currently if the client has any sync IO during prerenders and no shell is produced dynamicIO will assume that the sync IO in the client is the cause. This is often incorrect because you might abort the prerender in a component inside a Suspense boundary but still have some reference to Request data that came from RSC that is not in a Suspense boundary. This misleads the user into thinking the sync IO is the problem when in fact it is a misplaced boundary around something else entirely.

This is a tricky one to solve and it may be that this doesn't fully cover all the cases it should. The technique is to abort on sync IO before stashing the sync IO error. All of the pending render tasks React has stashed away will abort and use normal processing ot decide if they violate the rules. Namely this is where messages like "A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary" come from. Then the sync IO error is stashed. If any more (one more to be exact) render tasks abort after this we know that this task was the one that was currently rendering when the sync IO happened. If this is the case we include the sync IO error in the list of dynamic errors rather than the generic reason and only if it has no Suspense ancestor.

This fix is probably incomplete. For instance if you perform syncIO inside `queueMicrotask` then all of the render tasks will be aborted and we'll have no way to attribute it to any particular component stack and thus cannot know if it was inside or outside of a Suspense boundary. This will be solved (if possible) in a follow up change.