### PR TITLE
fix(eslint-plugin): respect custom pageExtensions in no-html-link-for…

### DIFF
--- a/test/unit/eslint-plugin-next/utils/url.test.ts
+++ b/test/unit/eslint-plugin-next/utils/url.test.ts
@@ -1,0 +1,53 @@
+import path from 'path'
+
+describe('getPageExtensions()', () => {
+  const originalCwd = process.cwd
+
+  afterEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    process.cwd = originalCwd
+  })
+
+  it('returns default extensions when next.config.js is not found', () => {
+    jest.isolateModules(() => {
+      const getPageExtensions =
+        require('../../../../packages/eslint-plugin-next/src/utils/url').getPageExtensions
+
+      expect(getPageExtensions()).toEqual(['js', 'jsx', 'ts', 'tsx'])
+    })
+  })
+
+  it('returns custom extensions from next.config.js', () => {
+    jest.doMock(
+      path.resolve(process.cwd(), 'next.config.js'),
+      () => ({ pageExtensions: ['md', 'mdx'] }),
+      { virtual: true }
+    )
+
+    jest.isolateModules(() => {
+      const getPageExtensions =
+        require('../../../../packages/eslint-plugin-next/src/utils/url').getPageExtensions
+
+      expect(getPageExtensions()).toEqual(['md', 'mdx'])
+    })
+  })
+
+  it('falls back to default when pageExtensions is not an array', () => {
+    jest.doMock(
+      path.resolve(process.cwd(), 'next.config.js'),
+      () => ({ pageExtensions: 'invalid' }),
+      { virtual: true }
+    )
+
+    jest.isolateModules(() => {
+      const getPageExtensions =
+        require('../../../../packages/eslint-plugin-next/src/utils/url').getPageExtensions
+
+      expect(getPageExtensions()).toEqual(['js', 'jsx', 'ts', 'tsx'])
+    })
+  })
+})

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/about.page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <div>About Page</div>
+}

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/details.other.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/details.other.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <a href="/details.other">Details</a>
+    </div>
+  )
+}

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/list/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/list/about.page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <div>About Page</div>
+}

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/next.config.js
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  reactStrictMode: true,
+  pageExtensions: ['page.tsx', 'other.jsx'],
+}


### PR DESCRIPTION
## What?

Fixes a bug in the ESLint rule `@next/next/no-html-link-for-pages`, where it did not recognize internal pages using custom `pageExtensions` defined in `next.config.js`.

## Why?

When users configure custom extensions (e.g., `page.tsx`, `mdx`), the rule still relied on a hardcoded default list (`['js', 'jsx', 'ts', 'tsx']`). This led to false positives by incorrectly flagging valid internal links as invalid.

This PR aligns the rule behavior with how Next.js resolves routes — respecting the developer’s intended page structure.

## How?

- Introduced a `getPageExtensions()` utility in `eslint-plugin-next` to dynamically load and normalize `pageExtensions` from `next.config.js`
- Designed `getPageExtensions()` as a **self-contained closure** to:
  - Resolve and memoize config parsing once (avoiding repeated file system reads)
  - Cleanly encapsulate fallback logic and default handling
  - Allow internal utils like `parseUrlForPages` and `parseUrlForAppDir` to call it without receiving external params
- Updated the ESLint rule to use this utility internally
- Added unit tests to verify behavior when:
  - `next.config.js` is missing → uses default
  - Valid custom extensions → returned and applied
  - Invalid config (non-array) → safely falls back
- **Refactored `getRegexPatterns()`** to receive page extensions from `getPageExtensions()`, ensuring:
  - `ext` and `index` patterns are correctly built from actual user config
  - Shared regex logic is cleanly encapsulated in a single place
  - All downstream consumers use a consistent pattern set

## Benefits of the Closure Design

By using `getPageExtensions()` as a lazy, memoized closure:
- There's **no need to manually pass extensions through multiple internal layers**
- **Consistency is guaranteed** across all internal utility functions
- We reduce **boilerplate and cognitive overhead** while improving testability
- `getRegexPatterns()` now cleanly depends on a single canonical source for extensions

## Additional Context

This change complements the fix in [#68770](https://github.com/vercel/next.js/pull/68770), which resolved structural matching issues for App Router, but did not handle `pageExtensions` in `pages/` linting.

It also supersedes partial or outdated approaches in:
- [#54474](https://github.com/vercel/next.js/pull/54474)
- [#68099](https://github.com/vercel/next.js/pull/68099)

## Fixes

Fixes [#53473](https://github.com/vercel/next.js/issues/53473)
