### PR TITLE
Add warning for large static exports

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -17,6 +17,7 @@ import { formatAmpMessages } from '../build/output/index'
 import type { AmpPageStatus } from '../build/output/index'
 import * as Log from '../build/output/log'
 import {
+  OUTPUT_EXPORT_PAGE_COUNT_WARNING_THRESHOLD,
   RSC_SEGMENT_SUFFIX,
   RSC_SEGMENTS_DIR_SUFFIX,
   RSC_SUFFIX,
@@ -467,6 +468,28 @@ async function exportAppImpl(
 
   if (filteredPaths.length === 0) {
     return null
+  }
+
+  if (
+    nextConfig.output === 'export' &&
+    filteredPaths.length > OUTPUT_EXPORT_PAGE_COUNT_WARNING_THRESHOLD
+  ) {
+    Log.warn(
+      yellow(
+        `Attempting to statically export ${filteredPaths.length} pages with 'output: "export"'. ` +
+          `Generating over ${OUTPUT_EXPORT_PAGE_COUNT_WARNING_THRESHOLD} pages this way can lead to build issues due to Node.js limitations.`
+      ) +
+        `\n` +
+        yellow(
+          `For improved scalability with Next.js, consider removing 'output: "export"' and using ` +
+            bold(`Incremental Static Regeneration (ISR)`) +
+            ` with a compatible host (e.g., Vercel).`
+        ) +
+        `\n` +
+        yellow(
+          `Learn more: https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration`
+        )
+    )
   }
 
   if (prerenderManifest && !options.buildExport) {

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -487,7 +487,7 @@ async function exportAppImpl(
         ) +
         `\n` +
         yellow(
-          `Learn more: https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration`
+          `Learn more: https://nextjs.org/docs/app/guides/incremental-static-regeneration`
         )
     )
   }

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -31,6 +31,10 @@ export const NEXT_CACHE_TAG_MAX_LENGTH = 256
 export const NEXT_CACHE_SOFT_TAG_MAX_LENGTH = 1024
 export const NEXT_CACHE_IMPLICIT_TAG_ID = '_N_T_'
 
+// Threshold for warning when 'output: "export"' is used with a large number of pages,
+// as it may lead to build issues like maximum call stack size exceeded.
+export const OUTPUT_EXPORT_PAGE_COUNT_WARNING_THRESHOLD = 15000
+
 // in seconds
 export const CACHE_ONE_YEAR = 31536000
 


### PR DESCRIPTION
### Adding a feature (Developer Experience Improvement)

-   **Implements an existing feature request or RFC:** N/A. This PR introduces a proactive warning to improve developer experience based on observed user issues.
-   **Related issues/discussions are linked using `fixes #number`:**
    * Provides context for issues like #80032 where users encounter `RangeError: Maximum call stack size exceeded` with `output: 'export'` and large page counts.
    * Similar issues have been observed in community discussions:
    * [generateStaticParams not working with large dataset (1.4 Million records)](https://www.reddit.com/r/nextjs/comments/1izajy2/generatestaticparams_not_working_with_large/)
    * [10 thousand pages on build time with ISR (related discussion on build limits)](https://www.reddit.com/r/nextjs/comments/14c36e6/10_thousand_pages_on_build_time_with_isr/)
-   **e2e tests added:** N/A for this type of warning. Manual verification was performed by temporarily lowering the threshold to confirm the warning triggers as expected.
-   **Documentation added:** N/A. This change adds a build-time warning, not a new user-facing feature requiring docs. The warning itself links to existing ISR documentation.
-   **Telemetry added:** N/A for this warning.
-   **Errors have a helpful link attached:** The warning message includes a link to the App Router ISR documentation.

---

### What?

This PR introduces a build-time warning when using `output: 'export'` in `next.config.js` if the number of pages to be statically exported exceeds a defined threshold (defaulting to 15,000 pages via the `OUTPUT_EXPORT_PAGE_COUNT_WARNING_THRESHOLD` constant).

The warning message is:

⚠ Attempting to statically export {X} pages with 'output: "export"'. Generating over {Y} pages this way can lead to build issues due to Node.js limitations.
For improved scalability with Next.js, consider removing 'output: "export"' and using Incremental Static Regeneration (ISR) with a compatible host (e.g., Vercel).
Learn more: https://nextjs.org/docs/app/guides/incremental-static-regeneration

![new warning](https://github.com/user-attachments/assets/ff7fad50-4745-4501-bc63-ce7bb9587f33)


### Why?

Users attempting to statically export a very large number of pages (e.g., 100,000+) with `output: 'export'` frequently encounter `RangeError: Maximum call stack size exceeded` during the "Collecting page data" phase of the build. This can be a frustrating and confusing experience.

This warning aims to:
1.  Proactively alert users to this potential build limitation *before* a crash occurs.
2.  Guide them towards Next.js's idiomatic solution for handling large sites that require static serving (Incremental Static Regeneration, ISR), which necessitates a compatible hosting environment.
3.  Manage expectations regarding the scalability of the `output: 'export'` mode for extremely high page volumes on purely static hosts.

This improves the developer experience by providing timely feedback and actionable advice.

### How?

1.  A new constant `OUTPUT_EXPORT_PAGE_COUNT_WARNING_THRESHOLD` (default: 15,000) is added to `packages/next/src/lib/constants.ts`.
2.  In `packages/next/src/export/index.ts`, within the `exportAppImpl` function, after the `filteredPaths` (list of pages to be exported) is determined:
    *   A check is performed: if `nextConfig.output === 'export'` and `filteredPaths.length` is greater than `OUTPUT_EXPORT_PAGE_COUNT_WARNING_THRESHOLD`.
    *   If true, `Log.warn` is used to display the informative message, styled with `picocolors`.

The threshold is a heuristic and can be adjusted based on maintainer feedback. The warning is intended to be minimally intrusive for users with smaller sites while providing guidance for those pushing the limits of this specific export mode.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
