### PR TITLE
docs: Reference to statically imported images

### DIFF
--- a/docs/01-app/01-getting-started/04-images.mdx
+++ b/docs/01-app/01-getting-started/04-images.mdx
@@ -58,10 +58,8 @@ export default function Page() {
     <Image
       src="/profile.png"
       alt="Picture of the author"
-      // width={500} automatically provided
-      // height={500} automatically provided
-      // blurDataURL="data:..." automatically provided
-      // placeholder="blur" // Optional blur-up while loading
+      width={500}
+      height={500}
     />
   )
 }
@@ -75,6 +73,26 @@ export default function Page() {
     <Image
       src="/profile.png"
       alt="Picture of the author"
+      width={500}
+      height={500}
+    />
+  )
+}
+```
+
+### Statically imported images
+
+You can also import local images into a module. When doing so, Next.js will automatically determine the intrinsic [`width`](/docs/app/api-reference/components/image#width-and-height) and [`height`](/docs/app/api-reference/components/image#width-and-height) of your image based on the imported file. These values are used to determine the image ratio and prevent [Cumulative Layout Shift](https://web.dev/articles/cls) while your image is loading.
+
+```tsx filename="app/page.tsx" switcher
+import Image from 'next/image'
+import ProfileImage from './profile.png'
+
+export default function Page() {
+  return (
+    <Image
+      src={ProfileImage}
+      alt="Picture of the author"
       // width={500} automatically provided
       // height={500} automatically provided
       // blurDataURL="data:..." automatically provided
@@ -84,7 +102,25 @@ export default function Page() {
 }
 ```
 
-When using local images, Next.js will automatically determine the intrinsic [`width`](/docs/app/api-reference/components/image#width-and-height) and [`height`](/docs/app/api-reference/components/image#width-and-height) of your image based on the imported file. These values are used to determine the image ratio and prevent [Cumulative Layout Shift](https://web.dev/articles/cls) while your image is loading.
+```jsx filename="app/page.js" switcher
+import Image from 'next/image'
+import ProfileImage from './profile.png'
+
+export default function Page() {
+  return (
+    <Image
+      src={ProfileImage}
+      alt="Picture of the author"
+      // width={500} automatically provided
+      // height={500} automatically provided
+      // blurDataURL="data:..." automatically provided
+      // placeholder="blur" // Optional blur-up while loading
+    />
+  )
+}
+```
+
+In this case, Next.js expects the `app/profile.png` file to be available.
 
 ## Remote images
 

--- a/docs/01-app/01-getting-started/04-images.mdx
+++ b/docs/01-app/01-getting-started/04-images.mdx
@@ -82,7 +82,7 @@ export default function Page() {
 
 ### Statically imported images
 
-You can also import local images into a module. When doing so, Next.js will automatically determine the intrinsic [`width`](/docs/app/api-reference/components/image#width-and-height) and [`height`](/docs/app/api-reference/components/image#width-and-height) of your image based on the imported file. These values are used to determine the image ratio and prevent [Cumulative Layout Shift](https://web.dev/articles/cls) while your image is loading.
+You can also import and use local image files. Next.js will automatically determine the intrinsic [`width`](/docs/app/api-reference/components/image#width-and-height) and [`height`](/docs/app/api-reference/components/image#width-and-height) of your image based on the imported file. These values are used to determine the image ratio and prevent [Cumulative Layout Shift](https://web.dev/articles/cls) while your image is loading.
 
 ```tsx filename="app/page.tsx" switcher
 import Image from 'next/image'


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4730/docs-nextimage-local-images-broken-snippet
Fixes: #80023

Made the static image imports, into a sub section of local images, and referenced how their width/height is auto calculated.

- https://github.com/vercel/next.js/blob/fde4f7f2974d5870a74c196383af70df981de39e/packages/next/src/shared/lib/get-img-props.ts#L397-L398 here we copy the dimensions for statically imported images

There's also some tests that reference this usage:

- https://github.com/vercel/next.js/blob/00c52d1506638ed8a4e46ac97ad999454c4823d1/test/integration/next-image-new/base-path/pages/static-img.js#L23