### PR TITLE
Turbopack Build: Fix next-font test

### DIFF
--- a/test/e2e/next-font/app/pages/with-fonts.js
+++ b/test/e2e/next-font/app/pages/with-fonts.js
@@ -1,5 +1,6 @@
 import CompWithFonts from '../components/CompWithFonts'
-import { openSans } from './_app'
+import { Open_Sans } from 'next/font/google'
+const openSans = Open_Sans({ variable: '--open-sans', subsets: ['latin'] })
 
 export default function WithFonts() {
   return (

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -7767,15 +7767,14 @@
       "next/font import values page with font",
       "next/font import values page with local fonts",
       "next/font preload page with fonts",
-      "next/font should not have deprecation warning"
-    ],
-    "failed": [
+      "next/font should not have deprecation warning",
       "next/font preload font without preloadable subsets",
       "next/font preload font without size adjust",
       "next/font preload google fonts with multiple weights/styles",
       "next/font preload page with local fonts",
       "next/font preload page without fonts"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

When importing `_app` from another entrypoint it causes the font files imported to be included in _app. This is an edge case so changing the test as it doesn't check for that. Creating a separate issue to dig into this further later.

Closes PACK-4733