### PR TITLE
Do not cache fetches with `'no-store'` in `"use cache"` during SSG

### DIFF
--- a/.changeset/pretty-suns-watch.md
+++ b/.changeset/pretty-suns-watch.md
@@ -1,0 +1,5 @@
+---
+"next": patch
+---
+
+Do not cache fetches with 'no-store' in "use cache" during SSG

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -246,7 +246,8 @@ export function createPatchedFetcher(
         }
         // RequestInit doesn't keep extra fields e.g. next so it's
         // only available if init is used separate
-        let currentFetchRevalidate = getNextField('revalidate')
+        const originalFetchRevalidate = getNextField('revalidate')
+        let currentFetchRevalidate = originalFetchRevalidate
         const tags: string[] = validateTags(
           getNextField('tags') || [],
           `fetch ${input.toString()}`
@@ -339,11 +340,8 @@ export function createPatchedFetcher(
         ) {
           currentFetchRevalidate = false
         } else if (
-          // if we are inside of "use cache"/"unstable_cache"
-          // we shouldn't set the revalidate to 0 as it's overridden
-          // by the cache context
-          workUnitStore?.type !== 'cache' &&
-          (hasExplicitFetchCacheOptOut || noFetchConfigAndForceDynamic)
+          hasExplicitFetchCacheOptOut ||
+          noFetchConfigAndForceDynamic
         ) {
           currentFetchRevalidate = 0
         }
@@ -531,8 +529,9 @@ export function createPatchedFetcher(
           }
 
           // We only want to set the revalidate store's revalidate time if it
-          // was explicitly set for the fetch call, i.e. currentFetchRevalidate.
-          if (revalidateStore && currentFetchRevalidate === finalRevalidate) {
+          // was explicitly set for the fetch call, i.e.
+          // originalFetchRevalidate.
+          if (revalidateStore && originalFetchRevalidate === finalRevalidate) {
             revalidateStore.revalidate = finalRevalidate
           }
         }

--- a/test/e2e/app-dir/use-cache/app/cache-fetch-no-store/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-fetch-no-store/page.tsx
@@ -3,9 +3,10 @@ import React from 'react'
 async function getData() {
   'use cache'
 
-  return fetch('https://next-data-api-endpoint.vercel.app/api/random', {
-    cache: 'no-store',
-  }).then((res) => res.text())
+  return fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?no-store',
+    { cache: 'no-store' }
+  ).then((res) => res.text())
 }
 
 export default async function Page() {

--- a/test/e2e/app-dir/use-cache/incremental-cache-handler.js
+++ b/test/e2e/app-dir/use-cache/incremental-cache-handler.js
@@ -1,0 +1,13 @@
+const {
+  default: FileSystemCache,
+} = require('next/dist/server/lib/incremental-cache/file-system-cache')
+
+module.exports = class IncrementalCacheHandler extends FileSystemCache {
+  async set(key, data, ctx) {
+    if (ctx.fetchCache) {
+      console.log('cache-handler set fetch cache', ctx.fetchUrl)
+    }
+
+    return super.set(key, data, ctx)
+  }
+}

--- a/test/e2e/app-dir/use-cache/next.config.js
+++ b/test/e2e/app-dir/use-cache/next.config.js
@@ -16,6 +16,7 @@ const nextConfig = {
       custom: require.resolve('next/dist/server/lib/cache-handlers/default'),
     },
   },
+  cacheHandler: require.resolve('./incremental-cache-handler'),
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -637,6 +637,28 @@ describe('use-cache', () => {
     expect(await browser.elementByCss('#random').text()).toBe(initialValue)
   })
 
+  if (isNextStart) {
+    // TODO: This is an SSG optimization to share fetch responses during SSG
+    // (see #68546). Decide whether we want to keep this feature in the context
+    // of "use cache". Alternatively, instead of de-opting entirely, we might
+    // want a similar optimization using a build-specific default "use cache"
+    // cache handler that utilizes the file system, instead of piggybacking on
+    // the incremental cache handler for inner fetches.
+    it('should store a fetch response without no-store in the incremental cache handler during build', async () => {
+      expect(next.cliOutput).toContain(
+        'cache-handler set fetch cache https://next-data-api-endpoint.vercel.app/api/random'
+      )
+    })
+
+    // The no-store fetch cache option opts the response out of the SSG
+    // optimization to share fetch responses within an export worker.
+    it('should not store a fetch response with no-store in the incremental cache handler during build', async () => {
+      expect(next.cliOutput).not.toContain(
+        'cache-handler set fetch cache https://next-data-api-endpoint.vercel.app/api/random?no-store'
+      )
+    })
+  }
+
   it('should override fetch with cookies/auth in use cache properly', async () => {
     const browser = await next.browser('/cache-fetch-auth-header')
 


### PR DESCRIPTION
As of #68546, we're disabling the auto no-cache behavior that we introduced with Next 15 during static site generation (SSG). This improves the build speed by deduping fetches within an export worker. For now, this also applies to inner
fetches in `"use cache"`, which are otherwise not cached in the incremental cache handler. However, as stated in #68546, if a fetch opts out of caching (e.g. by setting `cache: 'no-store'`), it should also opt out of this SSG optimization. The opt-out did not work inside of `"use cache"` though, which this PR now fixes.

Related PRs:

- #71754
- #72105