### PR TITLE
Fix defunct ESLint overrides

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -126,7 +126,7 @@
       }
     },
     {
-      "files": ["packages/**/*.tsx?"],
+      "files": ["packages/**/*.ts", "packages/**/*.tsx"],
       "rules": {
         "jsdoc/no-types": "error",
         "jsdoc/no-undefined-types": "error"

--- a/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
@@ -52,7 +52,7 @@ export default class EvalSourceMapDevToolPlugin {
   shouldIgnorePath: (modulePath: string) => boolean
 
   /**
-   * @param {SourceMapDevToolPluginOptions|string} inputOptions Options object
+   * @param inputOptions Options object
    */
   constructor(inputOptions: EvalSourceMapDevToolPluginOptions) {
     let options: EvalSourceMapDevToolPluginOptions
@@ -197,9 +197,7 @@ export default class EvalSourceMapDevToolPlugin {
               sourceMap.sourcesContent = undefined
             }
             sourceMap.sourceRoot = options.sourceRoot || ''
-            const moduleId =
-              /** @type {ModuleId} */
-              chunkGraph.getModuleId(m)
+            const moduleId = chunkGraph.getModuleId(m)
             if (moduleId) {
               sourceMap.file =
                 typeof moduleId === 'number' ? `${moduleId}.js` : moduleId

--- a/packages/next/src/client/components/react-dev-overlay/ui/utils/merge-refs.ts
+++ b/packages/next/src/client/components/react-dev-overlay/ui/utils/merge-refs.ts
@@ -9,8 +9,8 @@ import type * as React from 'react'
  * <div ref={mergeRefs(ref1, ref2, ref3)} />
  * ```
  *
- * @param {(React.Ref<T> | undefined)[]} inputRefs Array of refs
- * @returns {React.Ref<T> | React.RefCallback<T>} Merged refs
+ * @param inputRefs Array of refs
+ * @returns Merged refs
  */
 export default function mergeRefs<T>(
   ...inputRefs: (React.Ref<T> | undefined)[]

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -49,7 +49,7 @@ export const getExtensionRegexString = (
  * @param appDirRelativePath the relative file path to app/
  * @param pageExtensions the js extensions, such as ['js', 'jsx', 'ts', 'tsx']
  * @param strictlyMatchExtensions if it's true, match the file with page extension, otherwise match the file with default corresponding extension
- * @returns {boolean} if the file is a metadata route file
+ * @returns if the file is a metadata route file
  */
 export function isMetadataRouteFile(
   appDirRelativePath: string,

--- a/packages/next/src/server/lib/to-route.ts
+++ b/packages/next/src/server/lib/to-route.ts
@@ -2,8 +2,8 @@
  * This transforms a URL pathname into a route. It removes any trailing slashes
  * and the `/index` suffix.
  *
- * @param {string} pathname - The URL path that needs to be optimized.
- * @returns {string} - The route
+ * @param pathname - The URL path that needs to be optimized.
+ * @returns - The route
  *
  * @example
  * // returns '/example'


### PR DESCRIPTION
The patterns in ESLint's `overrides[].files` isn't exactly like the globs you're used to e.g. `"packages/**/*.tsx?"` does not work as expected. Need to explode that into `"packages/**/*.ts", "packages/**/*.tsx"`.

Other changes are a consequence of applying the rules that were previously configured but not applied.