### PR TITLE
Use relative sources in `require()` instead of `next/dist/` if possible

### DIFF
--- a/packages/next/src/build/webpack/loaders/lightningcss-loader/src/loader.ts
+++ b/packages/next/src/build/webpack/loaders/lightningcss-loader/src/loader.ts
@@ -305,7 +305,8 @@ export async function LightningCssLoader(
       ),
     })
   }
-  const { loadBindings } = require('next/dist/build/swc')
+  const { loadBindings } =
+    require('../../../../../build/swc') as typeof import('../../../../../build/swc')
 
   const transform =
     implementation?.transformCss ??

--- a/packages/next/src/build/webpack/loaders/lightningcss-loader/src/minify.ts
+++ b/packages/next/src/build/webpack/loaders/lightningcss-loader/src/minify.ts
@@ -66,7 +66,8 @@ export class LightningCssMinifyPlugin {
     } = compilation.compiler
 
     if (!this.transform) {
-      const { loadBindings } = require('next/dist/build/swc')
+      const { loadBindings } =
+        require('../../../../../build/swc') as typeof import('../../../../../build/swc')
       this.transform = (await loadBindings()).css.lightning.transform
     }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1370,7 +1370,8 @@ export default async function loadConfig(
     }
 
     if (userConfig.experimental?.useLightningcss) {
-      const { loadBindings } = require('next/dist/build/swc')
+      const { loadBindings } =
+        require('../build/swc') as typeof import('../build/swc')
       const isLightningSupported = (await loadBindings())?.css?.lightning
 
       if (!isLightningSupported) {


### PR DESCRIPTION
Makes it easier to get types for those previously untyped `require` calls.