### PR TITLE
[testmode] Fix types of `wrapRequestHandler`

### DIFF
--- a/packages/next/src/experimental/testmode/server-edge.ts
+++ b/packages/next/src/experimental/testmode/server-edge.ts
@@ -5,8 +5,8 @@ export function interceptTestApis(): () => void {
   return interceptFetch(global.fetch)
 }
 
-export function wrapRequestHandler<T>(
-  handler: (req: Request, fn: () => T) => T
-): (req: Request, fn: () => T) => T {
+export function wrapRequestHandler<T, TRequest extends Request>(
+  handler: (req: TRequest, fn: () => T) => T
+): (req: TRequest, fn: () => T) => T {
   return (req, fn) => withRequestContext(req, reader, () => handler(req, fn))
 }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -634,7 +634,7 @@ export async function initialize(opts: {
   if (config.experimental.testProxy) {
     // Intercept fetch and other testmode apis.
     const { wrapRequestHandlerWorker, interceptTestApis } =
-      require('next/dist/experimental/testmode/server') as typeof import('next/src/experimental/testmode/server')
+      require('next/dist/experimental/testmode/server') as typeof import('../../experimental/testmode/server')
     requestHandler = wrapRequestHandlerWorker(requestHandler)
     interceptTestApis()
     // We treat the intercepted fetch as "original" fetch that should be reset to during HMR.

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -345,9 +345,8 @@ export default class NextNodeServer extends BaseServer<
     // Intercept fetch and other testmode apis.
     if (this.serverOptions.experimentalTestProxy) {
       process.env.NEXT_PRIVATE_TEST_PROXY = 'true'
-      const {
-        interceptTestApis,
-      } = require('next/dist/experimental/testmode/server')
+      const { interceptTestApis } =
+        require('next/dist/experimental/testmode/server') as typeof import('../experimental/testmode/server')
       interceptTestApis()
     }
 
@@ -1250,9 +1249,8 @@ export default class NextNodeServer extends BaseServer<
   public getRequestHandler(): NodeRequestHandler {
     const handler = this.makeRequestHandler()
     if (this.serverOptions.experimentalTestProxy) {
-      const {
-        wrapRequestHandlerNode,
-      } = require('next/dist/experimental/testmode/server')
+      const { wrapRequestHandlerNode } =
+        require('next/dist/experimental/testmode/server') as typeof import('../experimental/testmode/server')
       return wrapRequestHandlerNode(handler)
     }
     return handler

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -87,10 +87,8 @@ function ensureTestApisIntercepted() {
   if (!testApisIntercepted) {
     testApisIntercepted = true
     if (process.env.NEXT_PRIVATE_TEST_PROXY === 'true') {
-      const {
-        interceptTestApis,
-        wrapRequestHandler,
-      } = require('next/dist/experimental/testmode/server-edge')
+      const { interceptTestApis, wrapRequestHandler } =
+        require('next/dist/experimental/testmode/server-edge') as typeof import('../../experimental/testmode/server-edge')
       interceptTestApis()
       propagator = wrapRequestHandler(propagator)
     }


### PR DESCRIPTION
Was previously shadowed because we used an uncast `require` which results in `any`.

Fixes
```
Argument of type '<T>(request: NextRequestHint, fn: () => T) => T' is not assignable to parameter of type '(req: Request, fn: () => T) => T'.
  Types of parameters 'request' and 'req' are incompatible.
    Type 'Request' is missing the following properties from type 'NextRequestHint': sourcePage, fetchMetrics, request, respondWith, and 6 more.ts(2345)
``` 