### PR TITLE
Typecheck `require()` calls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -127,7 +127,9 @@
     },
     {
       "files": ["packages/**/*.ts", "packages/**/*.tsx"],
+      "plugins": ["@next/eslint-plugin-internal"],
       "rules": {
+        "@next/internal/typechecked-require": "error",
         "jsdoc/no-types": "error",
         "jsdoc/no-undefined-types": "error"
       }

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const customJestConfig = {
     '<rootDir>',
     '<rootDir>/../packages/next/src/',
     '<rootDir>/../packages/next-codemod/',
+    '<rootDir>/../packages/eslint-plugin-internal/',
     '<rootDir>/../packages/font/src/',
   ],
   modulePathIgnorePatterns: ['/\\.next/'],

--- a/packages/eslint-plugin-internal/package.json
+++ b/packages/eslint-plugin-internal/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@next/eslint-plugin-internal",
+  "private": true,
+  "version": "0.0.0",
+  "description": "ESLint plugin for working on Next.js.",
+  "exports": {
+    ".": "./src/eslint-plugin-internal.js"
+  },
+  "license": "MIT",
+  "repository": {
+    "url": "vercel/next.js",
+    "directory": "packages/eslint-plugin-internal"
+  },
+  "dependencies": {},
+  "peerDependencies": {
+    "eslint": "9.12.0"
+  },
+  "devDependencies": {
+    "eslint": "9.12.0"
+  }
+}

--- a/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
+++ b/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
@@ -1,0 +1,7 @@
+const typecheckedRequire = require('./eslint-typechecked-require')
+
+module.exports = {
+  rules: {
+    'typechecked-require': typecheckedRequire,
+  },
+}

--- a/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
+++ b/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
@@ -1,0 +1,109 @@
+/**
+ * ESLint rule: typechecked-require
+ * Ensures every require(source) call is cast to typeof import(source)
+ * Source: https://v0.dev/chat/eslint-cast-imports-CDvQ3iWC1Mo
+ */
+
+module.exports = {
+  name: 'typechecked-require',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Enforce require() calls to be cast as typeof import(). ' +
+        'Rule can be disabled for require(cjs) or for files not distributed in next/dist/esm.',
+      category: 'TypeScript',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missingCast: '`require(source)` must be cast as `typeof import(source)`',
+      mismatchedSource:
+        'Source in `require(source)` must match source in `import(source)`.\n' +
+        'Require: "{{requireSource}}"\n' +
+        ' Import: "{{importSource}}"',
+    },
+  },
+
+  create(context) {
+    function checkRequireCall(node) {
+      // Check if this is a require() call
+      if (
+        node.type !== 'CallExpression' ||
+        node.callee.type !== 'Identifier' ||
+        node.callee.name !== 'require' ||
+        node.arguments.length !== 1 ||
+        node.arguments[0].type !== 'Literal'
+      ) {
+        return
+      }
+
+      const requireSource = node.arguments[0].value
+      const parent = node.parent
+
+      // Check if the require is wrapped in a TypeScript assertion
+      if (parent && parent.type === 'TSAsExpression') {
+        const typeAnnotation = parent.typeAnnotation
+
+        // Check if it's a typeof import() expression
+        if (
+          typeAnnotation.type === 'TSTypeQuery' &&
+          typeAnnotation.exprName.type === 'TSImportType'
+        ) {
+          const importType = typeAnnotation.exprName
+
+          // Check if the import source matches the require source
+          if (
+            importType.argument &&
+            importType.argument.type === 'TSLiteralType' &&
+            importType.argument.literal.type === 'Literal'
+          ) {
+            const importSource = importType.argument.literal.value
+
+            if (requireSource !== importSource) {
+              context.report({
+                node,
+                messageId: 'mismatchedSource',
+                data: {
+                  requireSource,
+                  importSource,
+                },
+                fix(fixer) {
+                  // importSource as source of truth since that's what's typechecked
+                  // and will be changed by automated refactors.
+                  const newCast = `(require('${importSource}') as typeof import('${importSource}'))`
+                  return fixer.replaceText(parent, newCast)
+                },
+              })
+            }
+          }
+        } else {
+          // Has assertion but not the correct type
+          context.report({
+            node: parent,
+            messageId: 'missingCast',
+            fix(fixer) {
+              const newCast = `(require('${requireSource}') as typeof import('${requireSource}'))`
+              return fixer.replaceText(parent, newCast)
+            },
+          })
+        }
+      } else {
+        // No TypeScript assertion at all
+        context.report({
+          node,
+          messageId: 'missingCast',
+          fix(fixer) {
+            const newCast = `(require('${requireSource}') as typeof import('${requireSource}'))`
+            return fixer.replaceText(node, newCast)
+          },
+        })
+      }
+    }
+
+    return {
+      CallExpression: checkRequireCall,
+    }
+  },
+}

--- a/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
+++ b/packages/eslint-plugin-internal/src/eslint-typechecked-require.js
@@ -42,6 +42,11 @@ module.exports = {
       const requireSource = node.arguments[0].value
       const parent = node.parent
 
+      // json is fine because we have resolveJsonModule disabled in our TS project
+      if (requireSource.endsWith('.json')) {
+        return
+      }
+
       // Check if the require is wrapped in a TypeScript assertion
       if (parent && parent.type === 'TSAsExpression') {
         const typeAnnotation = parent.typeAnnotation

--- a/packages/eslint-plugin-internal/src/eslint-typechecked-require.test.js
+++ b/packages/eslint-plugin-internal/src/eslint-typechecked-require.test.js
@@ -122,6 +122,11 @@ describe('require-cast-to-import ESLint rule', () => {
         code: `const module = require()`,
         filename: 'test.ts',
       },
+
+      {
+        code: `const config = require('./config.json')`,
+        filename: 'test.ts',
+      },
     ],
 
     invalid: [
@@ -287,14 +292,6 @@ describe('require-cast-to-import ESLint rule', () => {
         filename: 'test.ts',
         errors: [{ messageId: 'missingCast' }],
         output: `const util = (require('../../../../utils/deep/nested') as typeof import('../../../../utils/deep/nested'))`,
-      },
-
-      // ❌ File extensions in require
-      {
-        code: `const config = require('./config.json')`,
-        filename: 'test.ts',
-        errors: [{ messageId: 'missingCast' }],
-        output: `const config = (require('./config.json') as typeof import('./config.json'))`,
       },
 
       // ❌ Multiple violations in one file

--- a/packages/eslint-plugin-internal/src/eslint-typechecked-require.test.js
+++ b/packages/eslint-plugin-internal/src/eslint-typechecked-require.test.js
@@ -1,0 +1,374 @@
+const { RuleTester } = require('eslint')
+const rule = require('./eslint-typechecked-require')
+
+// ESLint v9 flat config format
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+  },
+})
+
+describe('require-cast-to-import ESLint rule', () => {
+  ruleTester.run('require-cast-to-import', rule, {
+    valid: [
+      // ✅ Correct usage - basic modules
+      {
+        code: `const fs = require('fs') as typeof import('fs')`,
+        filename: 'test.ts',
+      },
+      {
+        code: `const path = require('path') as typeof import('path')`,
+        filename: 'test.ts',
+      },
+      {
+        code: `const express = require('express') as typeof import('express')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Correct usage - scoped packages
+      {
+        code: `const lodash = require('@types/lodash') as typeof import('@types/lodash')`,
+        filename: 'test.ts',
+      },
+      {
+        code: `const react = require('@types/react') as typeof import('@types/react')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Correct usage - relative imports
+      {
+        code: `const utils = require('./utils') as typeof import('./utils')`,
+        filename: 'test.ts',
+      },
+      {
+        code: `const config = require('../config/database') as typeof import('../config/database')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Correct usage - complex paths
+      {
+        code: `const helper = require('../../shared/helpers/string-utils') as typeof import('../../shared/helpers/string-utils')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Multiple requires in one statement
+      {
+        code: `const fs = require('fs') as typeof import('fs'), path = require('path') as typeof import('path')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Require in different contexts
+      {
+        code: `
+          function loadModule() {
+            return require('dynamic-module') as typeof import('dynamic-module')
+          }
+        `,
+        filename: 'test.ts',
+      },
+
+      // ✅ Correct usage - destructuring with cast
+      {
+        code: `const { readFile } = require('fs') as typeof import('fs')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Non-require calls should be ignored
+      {
+        code: `const result = someFunction('fs')`,
+        filename: 'test.ts',
+      },
+      {
+        code: `import fs from 'fs'`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Template literals (dynamic requires)
+      {
+        code: `const module = require(\`\${moduleName}\`)`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Variable requires
+      {
+        code: `const module = require(moduleName)`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Expression requires
+      {
+        code: `const module = require('prefix' + suffix)`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Method called require
+      {
+        code: `obj.require('something')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ Multiple arguments
+      {
+        code: `const module = require('fs', 'extra')`,
+        filename: 'test.ts',
+      },
+
+      // ✅ No arguments
+      {
+        code: `const module = require()`,
+        filename: 'test.ts',
+      },
+    ],
+
+    invalid: [
+      // ❌ Missing cast entirely
+      {
+        code: `const fs = require('fs')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'fs' },
+          },
+        ],
+        output: `const fs = (require('fs') as typeof import('fs'))`,
+      },
+      // ❌ Ensure member access is propagated correctly
+      {
+        code: `const readFile = require('fs').readFile`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'fs' },
+          },
+        ],
+        output: `const readFile = (require('fs') as typeof import('fs')).readFile`,
+      },
+      {
+        code: `const path = require('path')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'path' },
+          },
+        ],
+        output: `const path = (require('path') as typeof import('path'))`,
+      },
+
+      // ❌ Destructuring without cast
+      {
+        code: `const { readFile } = require('fs')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'fs' },
+          },
+        ],
+        output: `const { readFile } = (require('fs') as typeof import('fs'))`,
+      },
+
+      // ❌ Wrong cast type - using 'any'
+      {
+        code: `const lodash = require('lodash') as any`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'lodash' },
+          },
+        ],
+        output: `const lodash = (require('lodash') as typeof import('lodash'))`,
+      },
+
+      // ❌ Wrong cast type - using specific interface
+      {
+        code: `const express = require('express') as Express`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'express' },
+          },
+        ],
+        output: `const express = (require('express') as typeof import('express'))`,
+      },
+
+      // ❌ Mismatched sources
+      {
+        code: `const fs = require('fs') as typeof import('path')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'mismatchedSource',
+            data: { requireSource: 'fs', importSource: 'path' },
+          },
+        ],
+        output: `const fs = (require('path') as typeof import('path'))`,
+      },
+      {
+        code: `const lodash = require('lodash') as typeof import('underscore')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'mismatchedSource',
+            data: { requireSource: 'lodash', importSource: 'underscore' },
+          },
+        ],
+        output: `const lodash = (require('underscore') as typeof import('underscore'))`,
+      },
+
+      // ❌ Scoped packages - missing cast
+      {
+        code: `const types = require('@types/node')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: '@types/node' },
+          },
+        ],
+        output: `const types = (require('@types/node') as typeof import('@types/node'))`,
+      },
+      {
+        code: `const pkg = require('@babel/core')`,
+        filename: 'test.ts',
+        errors: [{ messageId: 'missingCast' }],
+        output: `const pkg = (require('@babel/core') as typeof import('@babel/core'))`,
+      },
+
+      // ❌ Packages with special characters
+      {
+        code: `const vue = require('vue3')`,
+        filename: 'test.ts',
+        errors: [{ messageId: 'missingCast' }],
+        output: `const vue = (require('vue3') as typeof import('vue3'))`,
+      },
+      {
+        code: `const parser = require('html-parser')`,
+        filename: 'test.ts',
+        errors: [{ messageId: 'missingCast' }],
+        output: `const parser = (require('html-parser') as typeof import('html-parser'))`,
+      },
+
+      // ❌ Relative imports - missing cast
+      {
+        code: `const utils = require('./utils')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: './utils' },
+          },
+        ],
+        output: `const utils = (require('./utils') as typeof import('./utils'))`,
+      },
+      {
+        code: `const config = require('../config')`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: '../config' },
+          },
+        ],
+        output: `const config = (require('../config') as typeof import('../config'))`,
+      },
+
+      // ❌ Complex relative paths
+      {
+        code: `const util = require('../../../../utils/deep/nested')`,
+        filename: 'test.ts',
+        errors: [{ messageId: 'missingCast' }],
+        output: `const util = (require('../../../../utils/deep/nested') as typeof import('../../../../utils/deep/nested'))`,
+      },
+
+      // ❌ File extensions in require
+      {
+        code: `const config = require('./config.json')`,
+        filename: 'test.ts',
+        errors: [{ messageId: 'missingCast' }],
+        output: `const config = (require('./config.json') as typeof import('./config.json'))`,
+      },
+
+      // ❌ Multiple violations in one file
+      {
+        code: `
+          const fs = require('fs')
+          const path = require('path') as any
+          const lodash = require('lodash') as typeof import('underscore')
+        `,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'fs' },
+          },
+          {
+            messageId: 'missingCast',
+            data: { source: 'path' },
+          },
+          {
+            messageId: 'mismatchedSource',
+            data: { requireSource: 'lodash', importSource: 'underscore' },
+          },
+        ],
+        output: `
+          const fs = (require('fs') as typeof import('fs'))
+          const path = (require('path') as typeof import('path'))
+          const lodash = (require('underscore') as typeof import('underscore'))
+        `,
+      },
+
+      // ❌ Require in function context
+      {
+        code: `
+          function loadDynamicModule() {
+            const module = require('dynamic-lib')
+            return module
+          }
+        `,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'dynamic-lib' },
+          },
+        ],
+        output: `
+          function loadDynamicModule() {
+            const module = (require('dynamic-lib') as typeof import('dynamic-lib'))
+            return module
+          }
+        `,
+      },
+
+      // ❌ Require in conditional
+      {
+        code: `
+          if (condition) {
+            const optional = require('optional-dep')
+          }
+        `,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingCast',
+            data: { source: 'optional-dep' },
+          },
+        ],
+        output: `
+          if (condition) {
+            const optional = (require('optional-dep') as typeof import('optional-dep'))
+          }
+        `,
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -31,27 +31,48 @@ const coreWebVitalsRules = {
 
 const plugin = {
   rules: {
-    'google-font-display': require('./rules/google-font-display'),
-    'google-font-preconnect': require('./rules/google-font-preconnect'),
-    'inline-script-id': require('./rules/inline-script-id'),
-    'next-script-for-ga': require('./rules/next-script-for-ga'),
-    'no-assign-module-variable': require('./rules/no-assign-module-variable'),
-    'no-async-client-component': require('./rules/no-async-client-component'),
-    'no-before-interactive-script-outside-document': require('./rules/no-before-interactive-script-outside-document'),
-    'no-css-tags': require('./rules/no-css-tags'),
-    'no-document-import-in-page': require('./rules/no-document-import-in-page'),
-    'no-duplicate-head': require('./rules/no-duplicate-head'),
-    'no-head-element': require('./rules/no-head-element'),
-    'no-head-import-in-document': require('./rules/no-head-import-in-document'),
-    'no-html-link-for-pages': require('./rules/no-html-link-for-pages'),
-    'no-img-element': require('./rules/no-img-element'),
-    'no-page-custom-font': require('./rules/no-page-custom-font'),
-    'no-script-component-in-head': require('./rules/no-script-component-in-head'),
-    'no-styled-jsx-in-document': require('./rules/no-styled-jsx-in-document'),
-    'no-sync-scripts': require('./rules/no-sync-scripts'),
-    'no-title-in-document-head': require('./rules/no-title-in-document-head'),
-    'no-typos': require('./rules/no-typos'),
-    'no-unwanted-polyfillio': require('./rules/no-unwanted-polyfillio'),
+    'google-font-display':
+      require('./rules/google-font-display') as typeof import('./rules/google-font-display'),
+    'google-font-preconnect':
+      require('./rules/google-font-preconnect') as typeof import('./rules/google-font-preconnect'),
+    'inline-script-id':
+      require('./rules/inline-script-id') as typeof import('./rules/inline-script-id'),
+    'next-script-for-ga':
+      require('./rules/next-script-for-ga') as typeof import('./rules/next-script-for-ga'),
+    'no-assign-module-variable':
+      require('./rules/no-assign-module-variable') as typeof import('./rules/no-assign-module-variable'),
+    'no-async-client-component':
+      require('./rules/no-async-client-component') as typeof import('./rules/no-async-client-component'),
+    'no-before-interactive-script-outside-document':
+      require('./rules/no-before-interactive-script-outside-document') as typeof import('./rules/no-before-interactive-script-outside-document'),
+    'no-css-tags':
+      require('./rules/no-css-tags') as typeof import('./rules/no-css-tags'),
+    'no-document-import-in-page':
+      require('./rules/no-document-import-in-page') as typeof import('./rules/no-document-import-in-page'),
+    'no-duplicate-head':
+      require('./rules/no-duplicate-head') as typeof import('./rules/no-duplicate-head'),
+    'no-head-element':
+      require('./rules/no-head-element') as typeof import('./rules/no-head-element'),
+    'no-head-import-in-document':
+      require('./rules/no-head-import-in-document') as typeof import('./rules/no-head-import-in-document'),
+    'no-html-link-for-pages':
+      require('./rules/no-html-link-for-pages') as typeof import('./rules/no-html-link-for-pages'),
+    'no-img-element':
+      require('./rules/no-img-element') as typeof import('./rules/no-img-element'),
+    'no-page-custom-font':
+      require('./rules/no-page-custom-font') as typeof import('./rules/no-page-custom-font'),
+    'no-script-component-in-head':
+      require('./rules/no-script-component-in-head') as typeof import('./rules/no-script-component-in-head'),
+    'no-styled-jsx-in-document':
+      require('./rules/no-styled-jsx-in-document') as typeof import('./rules/no-styled-jsx-in-document'),
+    'no-sync-scripts':
+      require('./rules/no-sync-scripts') as typeof import('./rules/no-sync-scripts'),
+    'no-title-in-document-head':
+      require('./rules/no-title-in-document-head') as typeof import('./rules/no-title-in-document-head'),
+    'no-typos':
+      require('./rules/no-typos') as typeof import('./rules/no-typos'),
+    'no-unwanted-polyfillio':
+      require('./rules/no-unwanted-polyfillio') as typeof import('./rules/no-unwanted-polyfillio'),
   },
   configs: {
     recommended: {

--- a/packages/font/src/local/loader.ts
+++ b/packages/font/src/local/loader.ts
@@ -2,6 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 let fontFromBuffer: any
 try {
+  // eslint-disable-next-line @next/internal/typechecked-require -- Module created during build.
   const mod = require('../fontkit').default
   fontFromBuffer = mod.default || mod
 } catch {}

--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -79,12 +79,15 @@ function getPlugins(
       : false
 
   const applyCommonJsItem = hasModuleExports
-    ? createConfigItem(require('../plugins/commonjs'), { type: 'plugin' })
+    ? createConfigItem(
+        require('../plugins/commonjs') as typeof import('../plugins/commonjs'),
+        { type: 'plugin' }
+      )
     : null
   const reactRefreshItem = hasReactRefresh
     ? createConfigItem(
         [
-          require('next/dist/compiled/react-refresh/babel'),
+          require('next/dist/compiled/react-refresh/babel') as typeof import('next/dist/compiled/react-refresh/babel'),
           { skipEnvCheck: true },
         ],
         { type: 'plugin' }
@@ -92,14 +95,21 @@ function getPlugins(
     : null
   const pageConfigItem =
     !isServer && isPageFile
-      ? createConfigItem([require('../plugins/next-page-config')], {
-          type: 'plugin',
-        })
+      ? createConfigItem(
+          [
+            require('../plugins/next-page-config') as typeof import('../plugins/next-page-config'),
+          ],
+          {
+            type: 'plugin',
+          }
+        )
       : null
   const disallowExportAllItem =
     !isServer && isPageFile
       ? createConfigItem(
-          [require('../plugins/next-page-disallow-re-export-all-exports')],
+          [
+            require('../plugins/next-page-disallow-re-export-all-exports') as typeof import('../plugins/next-page-disallow-re-export-all-exports'),
+          ],
           { type: 'plugin' }
         )
       : null
@@ -123,12 +133,14 @@ function getPlugins(
       : null
   const commonJsItem = isNextDist
     ? createConfigItem(
-        require('next/dist/compiled/babel/plugin-transform-modules-commonjs'),
+        require('next/dist/compiled/babel/plugin-transform-modules-commonjs') as typeof import('next/dist/compiled/babel/plugin-transform-modules-commonjs'),
         { type: 'plugin' }
       )
     : null
   const nextFontUnsupported = createConfigItem(
-    [require('../plugins/next-font-unsupported')],
+    [
+      require('../plugins/next-font-unsupported') as typeof import('../plugins/next-font-unsupported'),
+    ],
     { type: 'plugin' }
   )
 
@@ -341,7 +353,7 @@ async function getFreshConfig(
     options.plugins = [jsx, ...reactCompilerPluginsIfEnabled]
     options.presets = [
       [
-        require('next/dist/compiled/babel/preset-typescript'),
+        require('next/dist/compiled/babel/preset-typescript') as typeof import('next/dist/compiled/babel/preset-typescript'),
         { allowNamespaces: true },
       ],
     ]

--- a/packages/next/src/build/babel/preset.ts
+++ b/packages/next/src/build/babel/preset.ts
@@ -117,9 +117,12 @@ export default (
   return {
     sourceType: 'unambiguous',
     presets: [
-      [require('next/dist/compiled/babel/preset-env'), presetEnvConfig],
       [
-        require('next/dist/compiled/babel/preset-react'),
+        require('next/dist/compiled/babel/preset-env') as typeof import('next/dist/compiled/babel/preset-env'),
+        presetEnvConfig,
+      ],
+      [
+        require('next/dist/compiled/babel/preset-react') as typeof import('next/dist/compiled/babel/preset-react'),
         {
           // This adds @babel/plugin-transform-react-jsx-source and
           // @babel/plugin-transform-react-jsx-self automatically in development
@@ -129,13 +132,13 @@ export default (
         },
       ],
       [
-        require('next/dist/compiled/babel/preset-typescript'),
+        require('next/dist/compiled/babel/preset-typescript') as typeof import('next/dist/compiled/babel/preset-typescript'),
         { allowNamespaces: true, ...options['preset-typescript'] },
       ],
     ],
     plugins: [
       !useJsxRuntime && [
-        require('./plugins/jsx-pragma'),
+        require('./plugins/jsx-pragma') as typeof import('./plugins/jsx-pragma'),
         {
           // This produces the following injected import for modules containing JSX:
           //   import React from 'react';
@@ -147,35 +150,35 @@ export default (
         },
       ],
       [
-        require('./plugins/optimize-hook-destructuring'),
+        require('./plugins/optimize-hook-destructuring') as typeof import('./plugins/optimize-hook-destructuring'),
         {
           // only optimize hook functions imported from React/Preact
           lib: true,
         },
       ],
-      require('next/dist/compiled/babel/plugin-syntax-dynamic-import'),
+      require('next/dist/compiled/babel/plugin-syntax-dynamic-import') as typeof import('next/dist/compiled/babel/plugin-syntax-dynamic-import'),
       [
-        require('next/dist/compiled/babel/plugin-syntax-import-attributes'),
+        require('next/dist/compiled/babel/plugin-syntax-import-attributes') as typeof import('next/dist/compiled/babel/plugin-syntax-import-attributes'),
         {
           deprecatedAssertSyntax: true,
         },
       ],
-      require('./plugins/react-loadable-plugin'),
+      require('./plugins/react-loadable-plugin') as typeof import('./plugins/react-loadable-plugin'),
       // only enable this plugin if custom config for it was provided
       // otherwise we will only enable it if their browserslist triggers
       // preset-env to pull it in
       options['class-properties'] && [
-        require('next/dist/compiled/babel/plugin-proposal-class-properties'),
+        require('next/dist/compiled/babel/plugin-proposal-class-properties') as typeof import('next/dist/compiled/babel/plugin-proposal-class-properties'),
         options['class-properties'] || {},
       ],
       [
-        require('next/dist/compiled/babel/plugin-proposal-object-rest-spread'),
+        require('next/dist/compiled/babel/plugin-proposal-object-rest-spread') as typeof import('next/dist/compiled/babel/plugin-proposal-object-rest-spread'),
         {
           useBuiltIns: true,
         },
       ],
       !isServer && [
-        require('next/dist/compiled/babel/plugin-transform-runtime'),
+        require('next/dist/compiled/babel/plugin-transform-runtime') as typeof import('next/dist/compiled/babel/plugin-transform-runtime'),
         {
           corejs: false,
           helpers: true,
@@ -193,22 +196,23 @@ export default (
       ],
       [
         isTest && options['styled-jsx'] && options['styled-jsx']['babel-test']
-          ? require('styled-jsx/babel-test')
-          : require('styled-jsx/babel'),
+          ? (require('styled-jsx/babel-test') as typeof import('styled-jsx/babel-test'))
+          : (require('styled-jsx/babel') as typeof import('styled-jsx/babel')),
         styledJsxOptions(options['styled-jsx']),
       ],
-      require('./plugins/amp-attributes'),
+      require('./plugins/amp-attributes') as typeof import('./plugins/amp-attributes'),
       isProduction && [
-        require('next/dist/compiled/babel/plugin-transform-react-remove-prop-types'),
+        require('next/dist/compiled/babel/plugin-transform-react-remove-prop-types') as typeof import('next/dist/compiled/babel/plugin-transform-react-remove-prop-types'),
         {
           removeImport: true,
         },
       ],
-      isServer && require('next/dist/compiled/babel/plugin-syntax-bigint'),
+      isServer &&
+        (require('next/dist/compiled/babel/plugin-syntax-bigint') as typeof import('next/dist/compiled/babel/plugin-syntax-bigint')),
       // Always compile numeric separator because the resulting number is
       // smaller.
-      require('next/dist/compiled/babel/plugin-proposal-numeric-separator'),
-      require('next/dist/compiled/babel/plugin-proposal-export-namespace-from'),
+      require('next/dist/compiled/babel/plugin-proposal-numeric-separator') as typeof import('next/dist/compiled/babel/plugin-proposal-numeric-separator'),
+      require('next/dist/compiled/babel/plugin-proposal-export-namespace-from') as typeof import('next/dist/compiled/babel/plugin-proposal-export-namespace-from'),
     ].filter(Boolean),
   }
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -773,7 +773,7 @@ async function writeFullyStaticExport(
   configOutDir: string,
   nextBuildSpan: Span
 ): Promise<void> {
-  const exportApp = require('../export')
+  const exportApp = (require('../export') as typeof import('../export'))
     .default as typeof import('../export').default
 
   await exportApp(
@@ -2597,7 +2597,7 @@ export default async function build(
             )
           )
 
-          const exportApp = require('../export')
+          const exportApp = (require('../export') as typeof import('../export'))
             .default as typeof import('../export').default
 
           const exportConfig: NextConfigComplete = {

--- a/packages/next/src/build/load-jsconfig.ts
+++ b/packages/next/src/build/load-jsconfig.ts
@@ -10,7 +10,8 @@ import { hasNecessaryDependencies } from '../lib/has-necessary-dependencies'
 let TSCONFIG_WARNED = false
 
 export function parseJsonFile(filePath: string) {
-  const JSON5 = require('next/dist/compiled/json5')
+  const JSON5 =
+    require('next/dist/compiled/json5') as typeof import('next/dist/compiled/json5')
   const contents = readFileSync(filePath, 'utf8')
 
   // Special case an empty file
@@ -22,7 +23,8 @@ export function parseJsonFile(filePath: string) {
     return JSON5.parse(contents)
   } catch (err) {
     if (!isError(err)) throw err
-    const { codeFrameColumns } = require('next/dist/compiled/babel/code-frame')
+    const { codeFrameColumns } =
+      require('next/dist/compiled/babel/code-frame') as typeof import('next/dist/compiled/babel/code-frame')
     const codeFrame = codeFrameColumns(
       String(contents),
       {

--- a/packages/next/src/build/next-config-ts/require-hook.ts
+++ b/packages/next/src/build/next-config-ts/require-hook.ts
@@ -9,7 +9,7 @@ const extensions = ['.ts', '.cts', '.mts', '.cjs', '.mjs']
 export function registerHook(swcOptions: SWCOptions) {
   // lazy require swc since it loads React before even setting NODE_ENV
   // resulting loading Development React on Production
-  const { transformSync } = require('../swc')
+  const { transformSync } = require('../swc') as typeof import('../swc')
 
   require.extensions['.js'] = function (mod: any, oldFilename) {
     try {

--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -113,7 +113,7 @@ export async function transpileConfig({
     const nextConfigString = await readFile(nextConfigPath, 'utf8')
     // lazy require swc since it loads React before even setting NODE_ENV
     // resulting loading Development React on Production
-    const { transform } = require('../swc')
+    const { transform } = require('../swc') as typeof import('../swc')
     const { code } = await transform(nextConfigString, swcOptions)
 
     // register require hook only if require exists

--- a/packages/next/src/build/polyfills/process.ts
+++ b/packages/next/src/build/polyfills/process.ts
@@ -1,4 +1,4 @@
 module.exports =
   global.process?.env && typeof global.process?.env === 'object'
     ? global.process
-    : require('next/dist/compiled/process')
+    : (require('next/dist/compiled/process') as typeof import('next/dist/compiled/process'))

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1080,9 +1080,9 @@ export async function isPageStatic({
   const isPageStaticSpan = trace('is-page-static-utils', parentId)
   return isPageStaticSpan
     .traceAsyncFn(async (): Promise<PageIsStaticResult> => {
-      require('../shared/lib/runtime-config.external').setConfig(
-        runtimeEnvConfig
-      )
+      ;(
+        require('../shared/lib/runtime-config.external') as typeof import('../shared/lib/runtime-config.external')
+      ).setConfig(runtimeEnvConfig)
       setHttpClientAndAgentOptions({
         httpAgentOptions,
       })
@@ -1393,7 +1393,9 @@ export async function hasCustomGetInitialProps({
   checkingApp: boolean
   sriEnabled: boolean
 }): Promise<boolean> {
-  require('../shared/lib/runtime-config.external').setConfig(runtimeEnvConfig)
+  ;(
+    require('../shared/lib/runtime-config.external') as typeof import('../shared/lib/runtime-config.external')
+  ).setConfig(runtimeEnvConfig)
 
   const components = await loadComponents({
     distDir,
@@ -1424,7 +1426,9 @@ export async function getDefinedNamedExports({
   runtimeEnvConfig: any
   sriEnabled: boolean
 }): Promise<ReadonlyArray<string>> {
-  require('../shared/lib/runtime-config.external').setConfig(runtimeEnvConfig)
+  ;(
+    require('../shared/lib/runtime-config.external') as typeof import('../shared/lib/runtime-config.external')
+  ).setConfig(runtimeEnvConfig)
   const components = await loadComponents({
     distDir,
     page: page,

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -130,7 +130,8 @@ export async function webpackBuild(
     return await webpackBuildWithWorker(compilerNames)
   } else {
     debug('building all compilers in same process')
-    const webpackBuildImpl = require('./impl').webpackBuildImpl
+    const webpackBuildImpl = (require('./impl') as typeof import('./impl'))
+      .webpackBuildImpl
     const curResult = await webpackBuildImpl(null, null)
 
     // Mirror what happens in webpackBuildWithWorker

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -124,7 +124,10 @@ async function webpackBuildWithWorker(
 export async function webpackBuild(
   withWorker: boolean,
   compilerNames: typeof ORDERED_COMPILER_NAMES | null
-): ReturnType<typeof webpackBuildWithWorker> {
+): Promise<
+  | Awaited<ReturnType<typeof webpackBuildWithWorker>>
+  | Awaited<ReturnType<typeof import('./impl').webpackBuildImpl>>
+> {
   if (withWorker) {
     debug('using separate compiler workers')
     return await webpackBuildWithWorker(compilerNames)
@@ -132,7 +135,7 @@ export async function webpackBuild(
     debug('building all compilers in same process')
     const webpackBuildImpl = (require('./impl') as typeof import('./impl'))
       .webpackBuildImpl
-    const curResult = await webpackBuildImpl(null, null)
+    const curResult = await webpackBuildImpl(null)
 
     // Mirror what happens in webpackBuildWithWorker
     if (curResult.telemetryState) {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -280,7 +280,7 @@ export async function loadProjectInfo({
 
 export function hasExternalOtelApiPackage(): boolean {
   try {
-    require('@opentelemetry/api')
+    require('@opentelemetry/api') as typeof import('@opentelemetry/api')
     return true
   } catch {
     return false
@@ -388,8 +388,9 @@ export default async function getBaseWebpackConfig(
   let SWCBinaryTarget: [Feature, boolean] | undefined = undefined
   if (useSWCLoader) {
     // TODO: we do not collect wasm target yet
-    const binaryTarget = require('./swc')?.getBinaryMetadata?.()
-      ?.target as SWC_TARGET_TRIPLE
+    const binaryTarget = (
+      require('./swc') as typeof import('./swc')
+    )?.getBinaryMetadata?.()?.target as SWC_TARGET_TRIPLE
     SWCBinaryTarget = binaryTarget
       ? [`swc/target/${binaryTarget}` as const, true]
       : undefined
@@ -487,7 +488,9 @@ export default async function getBaseWebpackConfig(
       // Subscriber need to be initialized _before_ any actual swc's call (transform, etcs)
       // to collect correct trace spans when they are called.
       swcTraceProfilingInitialized = true
-      require('./swc')?.initCustomTraceSubscriber?.(
+      ;(
+        require('./swc') as typeof import('./swc')
+      )?.initCustomTraceSubscriber?.(
         path.join(distDir, `swc-trace-profile-${Date.now()}.json`)
       )
     }
@@ -888,7 +891,8 @@ export default async function getBaseWebpackConfig(
 
   const aliasCodeConditionTest = [codeCondition.test, pageExtensionsRegex]
 
-  const builtinModules = require('module').builtinModules
+  const builtinModules = (require('module') as typeof import('module'))
+    .builtinModules
 
   const shouldEnableSlowModuleDetection =
     !!config.experimental.slowModuleDetection && dev
@@ -1218,7 +1222,7 @@ export default async function getBaseWebpackConfig(
           : (compiler: webpack.Compiler) => {
               // @ts-ignore No typings yet
               const { MinifyPlugin } =
-                require('./webpack/plugins/minify-webpack-plugin/src/index.js') as typeof import('./webpack/plugins/minify-webpack-plugin/src')
+                require('./webpack/plugins/minify-webpack-plugin/src') as typeof import('./webpack/plugins/minify-webpack-plugin/src')
               new MinifyPlugin({
                 noMangling,
                 disableCharFreq: !isClient,
@@ -1239,9 +1243,8 @@ export default async function getBaseWebpackConfig(
               },
             })
           : (compiler: webpack.Compiler) => {
-              const {
-                CssMinimizerPlugin,
-              } = require('./webpack/plugins/css-minimizer-plugin')
+              const { CssMinimizerPlugin } =
+                require('./webpack/plugins/css-minimizer-plugin') as typeof import('./webpack/plugins/css-minimizer-plugin')
               new CssMinimizerPlugin({
                 postcssOptions: {
                   map: {
@@ -1979,7 +1982,9 @@ export default async function getBaseWebpackConfig(
       !isRspack && (isClient || isEdgeServer) && new DropClientPage(),
       isNodeServer &&
         !dev &&
-        new (require('./webpack/plugins/next-trace-entrypoints-plugin')
+        new ((
+          require('./webpack/plugins/next-trace-entrypoints-plugin') as typeof import('./webpack/plugins/next-trace-entrypoints-plugin')
+        )
           .TraceEntryPointsPlugin as typeof import('./webpack/plugins/next-trace-entrypoints-plugin').TraceEntryPointsPlugin)(
           {
             rootDir: dir,

--- a/packages/next/src/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/index.ts
@@ -63,7 +63,7 @@ export async function lazyPostCSS(
 ) {
   if (!postcssInstancePromise) {
     postcssInstancePromise = (async () => {
-      const postcss = require('postcss')
+      const postcss = require('postcss') as typeof import('postcss')
       // @ts-ignore backwards compat
       postcss.plugin = function postcssPlugin(name, initializer) {
         function creator(...args: any) {
@@ -596,7 +596,9 @@ export const css = curry(async function css(
     // Extract CSS as CSS file(s) in the client-side production bundle.
     const MiniCssExtractPlugin = isRspack
       ? getRspackCore().CssExtractRspackPlugin
-      : require('../../../plugins/mini-css-extract-plugin').default
+      : (
+          require('../../../plugins/mini-css-extract-plugin') as typeof import('../../../plugins/mini-css-extract-plugin')
+        ).default
 
     fns.push(
       plugin(

--- a/packages/next/src/build/webpack/config/blocks/css/loaders/client.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/loaders/client.ts
@@ -45,7 +45,9 @@ export function getClientStyleLoader({
 
   const MiniCssExtractPlugin = isRspack
     ? getRspackCore().rspack.CssExtractRspackPlugin
-    : require('../../../../plugins/mini-css-extract-plugin').default
+    : (
+        require('../../../../plugins/mini-css-extract-plugin') as typeof import('../../../../plugins/mini-css-extract-plugin')
+      ).default
 
   return {
     loader: MiniCssExtractPlugin.loader,

--- a/packages/next/src/build/webpack/loaders/css-loader/src/index.ts
+++ b/packages/next/src/build/webpack/loaders/css-loader/src/index.ts
@@ -169,9 +169,10 @@ export default async function loader(
         getModulesPlugins,
         normalizeSourceMap,
         sort,
-      } = require('./utils')
+      } = require('./utils') as typeof import('./utils')
 
-      const { icssParser, importParser, urlParser } = require('./plugins')
+      const { icssParser, importParser, urlParser } =
+        require('./plugins') as typeof import('./plugins')
 
       const replacements: any[] = []
       // if it's a font loader next-font-loader will have exports that should be exported as is

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-client-wrapper.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-client-wrapper.ts
@@ -13,7 +13,7 @@ export { findSourceMapURL } from 'next/dist/client/app-find-source-map-url'
 export const createServerReference = (
   (!!process.env.NEXT_RUNTIME
     ? // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client.edge')
+      (require('react-server-dom-webpack/client.edge') as typeof import('react-server-dom-webpack/client.edge'))
     : // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client')) as typeof import('react-server-dom-webpack/client')
+      (require('react-server-dom-webpack/client') as typeof import('react-server-dom-webpack/client'))) as typeof import('react-server-dom-webpack/client')
 ).createServerReference

--- a/packages/next/src/build/webpack/loaders/next-style-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-style-loader/index.ts
@@ -82,7 +82,7 @@ ${esModule ? 'export default {}' : ''}`
           ? `
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
-    var isEqualLocals = ${require('./runtime/isEqualLocals').toString()};
+    var isEqualLocals = ${(require('./runtime/isEqualLocals') as typeof import('./runtime/isEqualLocals')).toString()};
     console.log({isEqualLocals})
     var oldLocals = content.locals;
 
@@ -194,7 +194,7 @@ ${esModule ? 'export default' : 'module.exports ='} exported;`
           ? `
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
-    var isEqualLocals = ${require('./runtime/isEqualLocals').toString()};
+    var isEqualLocals = ${(require('./runtime/isEqualLocals') as typeof import('./runtime/isEqualLocals')).toString()};
     var oldLocals = content.locals;
 
     module.hot.accept(

--- a/packages/next/src/build/webpack/loaders/next-style-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-style-loader/index.ts
@@ -82,7 +82,11 @@ ${esModule ? 'export default {}' : ''}`
           ? `
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
-    var isEqualLocals = ${(require('./runtime/isEqualLocals') as typeof import('./runtime/isEqualLocals')).toString()};
+    
+    var isEqualLocals = ${
+      // eslint-disable-next-line @next/internal/typechecked-require -- Not a module.
+      require('./runtime/isEqualLocals').toString()
+    };
     console.log({isEqualLocals})
     var oldLocals = content.locals;
 
@@ -194,7 +198,10 @@ ${esModule ? 'export default' : 'module.exports ='} exported;`
           ? `
 if (module.hot) {
   if (!content.locals || module.hot.invalidate) {
-    var isEqualLocals = ${(require('./runtime/isEqualLocals') as typeof import('./runtime/isEqualLocals')).toString()};
+    var isEqualLocals = ${
+      // eslint-disable-next-line @next/internal/typechecked-require -- Not a module.
+      require('./runtime/isEqualLocals').toString()
+    };
     var oldLocals = content.locals;
 
     module.hot.accept(

--- a/packages/next/src/build/webpack/loaders/resolve-url-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/resolve-url-loader/index.ts
@@ -58,7 +58,7 @@ export default async function resolveUrlLoader(
   const callback = this.async()
   const { postcss } = options.postcss
     ? await options.postcss()
-    : { postcss: require('postcss') }
+    : { postcss: require('postcss') as typeof import('postcss') }
   process(postcss, this.resourcePath, content, {
     outputSourceMap: Boolean(options.sourceMap),
     transformDeclaration: valueProcessor(this.resourcePath, options),

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -283,7 +283,9 @@ function isInMiddlewareLayer(parser: webpack.javascript.JavascriptParser) {
 }
 
 function isNodeJsModule(moduleName: string) {
-  return require('module').builtinModules.includes(moduleName)
+  return (require('module') as typeof import('module')).builtinModules.includes(
+    moduleName
+  )
 }
 
 function isDynamicCodeEvaluationAllowed(

--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseScss.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseScss.ts
@@ -22,9 +22,8 @@ export function getScssError(
     let frame: string | undefined
     if (fileContent) {
       try {
-        const {
-          codeFrameColumns,
-        } = require('next/dist/compiled/babel/code-frame')
+        const { codeFrameColumns } =
+          require('next/dist/compiled/babel/code-frame') as typeof import('next/dist/compiled/babel/code-frame')
         frame = codeFrameColumns(
           fileContent,
           { start: { line: lineNumber, column } },

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -170,7 +170,7 @@ const nextDev = async (
 
   async function preflight(skipOnReboot: boolean) {
     const { getPackageVersion, getDependencies } = (await Promise.resolve(
-      require('../lib/get-package-version')
+      require('../lib/get-package-version') as typeof import('../lib/get-package-version')
     )) as typeof import('../lib/get-package-version')
 
     const [sassVersion, nodeSassVersion] = await Promise.all([

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -179,8 +179,10 @@ async function runSharedDependencyCheck(
   skipMessage: string
 ): Promise<TaskResult> {
   const currentPlatform = os.platform()
-  const spawn = require('next/dist/compiled/cross-spawn')
-  const { getSupportedArchTriples } = require('../build/swc')
+  const spawn =
+    require('next/dist/compiled/cross-spawn') as typeof import('next/dist/compiled/cross-spawn')
+  const { getSupportedArchTriples } =
+    require('../build/swc') as typeof import('../build/swc')
   const triples = getSupportedArchTriples()[currentPlatform]?.[os.arch()] ?? []
   // First, check if system have a tool installed. We can't install these by our own.
 
@@ -250,7 +252,7 @@ async function runSharedDependencyCheck(
  * Collect additional diagnostics information.
  */
 async function printVerboseInfo() {
-  const fs = require('fs')
+  const fs = require('fs') as typeof import('fs')
   const currentPlatform = os.platform()
 
   if (
@@ -277,9 +279,12 @@ async function printVerboseInfo() {
         default: async () => {
           // Node.js diagnostic report contains basic information, i.e OS version, CPU architecture, etc.
           // Only collect few addtional details here.
-          const isWsl = require('next/dist/compiled/is-wsl')
-          const ciInfo = require('next/dist/compiled/ci-info')
-          const isDocker = require('next/dist/compiled/is-docker')
+          const isWsl =
+            require('next/dist/compiled/is-wsl') as typeof import('next/dist/compiled/is-wsl')
+          const ciInfo =
+            require('next/dist/compiled/ci-info') as typeof import('next/dist/compiled/ci-info')
+          const isDocker =
+            require('next/dist/compiled/is-docker') as typeof import('next/dist/compiled/is-docker')
 
           const output = `
   WSL: ${isWsl}
@@ -367,7 +372,8 @@ async function printVerboseInfo() {
           // First, try to load next-swc via loadBindings.
           try {
             let nextConfig = await getNextConfig()
-            const { loadBindings } = require('../build/swc')
+            const { loadBindings } =
+              require('../build/swc') as typeof import('../build/swc')
             const bindings = await loadBindings(
               nextConfig.experimental?.useWasmBinary
             )
@@ -383,9 +389,8 @@ async function printVerboseInfo() {
             output.push(`loadBindings() failed: ${(e as Error).message}`)
           }
 
-          const {
-            platformArchTriples,
-          } = require('next/dist/compiled/@napi-rs/triples')
+          const { platformArchTriples } =
+            require('next/dist/compiled/@napi-rs/triples') as typeof import('next/dist/compiled/@napi-rs/triples')
           const triples = platformArchTriples[currentPlatform]?.[os.arch()]
 
           if (!triples || triples.length === 0) {
@@ -396,7 +401,7 @@ async function printVerboseInfo() {
           }
 
           // Trying to manually resolve corresponding target triples to see if bindings are physically located.
-          const path = require('path')
+          const path = require('path') as typeof import('path')
           let fallbackBindingsDirectory
           try {
             const nextPath = path.dirname(require.resolve('next/package.json'))

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -226,10 +226,10 @@ async function runSharedDependencyCheck(
       outputs.push(`Running ${tool.bin} ------------- `)
       // Captures output, doesn't matter if it fails or not since we'll forward both to output.
       const procPromise = new Promise((resolve) => {
-        proc.stdout.on('data', function (data: string) {
+        proc.stdout!.on('data', function (data: string) {
           outputs.push(data)
         })
-        proc.stderr.on('data', function (data: string) {
+        proc.stderr!.on('data', function (data: string) {
           outputs.push(data)
         })
         proc.on('close', (c: any) => resolve(c))

--- a/packages/next/src/client/add-locale.ts
+++ b/packages/next/src/client/add-locale.ts
@@ -4,7 +4,9 @@ import { normalizePathTrailingSlash } from './normalize-trailing-slash'
 export const addLocale: typeof Fn = (path, ...args) => {
   if (process.env.__NEXT_I18N_SUPPORT) {
     return normalizePathTrailingSlash(
-      require('../shared/lib/router/utils/add-locale').addLocale(path, ...args)
+      (
+        require('../shared/lib/router/utils/add-locale') as typeof import('../shared/lib/router/utils/add-locale')
+      ).addLocale(path, ...args)
     )
   }
   return path

--- a/packages/next/src/client/app-next-dev.ts
+++ b/packages/next/src/client/app-next-dev.ts
@@ -4,8 +4,8 @@ import './app-webpack'
 
 import { appBootstrap } from './app-bootstrap'
 
-const instrumentationHooks =
-  require('../lib/require-instrumentation-client') as typeof import('../lib/require-instrumentation-client')
+// eslint-disable-next-line @next/internal/typechecked-require
+const instrumentationHooks = require('../lib/require-instrumentation-client')
 
 appBootstrap(() => {
   const { hydrate } = require('./app-index') as typeof import('./app-index')

--- a/packages/next/src/client/app-next-dev.ts
+++ b/packages/next/src/client/app-next-dev.ts
@@ -4,9 +4,10 @@ import './app-webpack'
 
 import { appBootstrap } from './app-bootstrap'
 
-const instrumentationHooks = require('../lib/require-instrumentation-client')
+const instrumentationHooks =
+  require('../lib/require-instrumentation-client') as typeof import('../lib/require-instrumentation-client')
 
 appBootstrap(() => {
-  const { hydrate } = require('./app-index')
+  const { hydrate } = require('./app-index') as typeof import('./app-index')
   hydrate(instrumentationHooks)
 })

--- a/packages/next/src/client/app-next-turbopack.ts
+++ b/packages/next/src/client/app-next-turbopack.ts
@@ -5,8 +5,8 @@ import { appBootstrap } from './app-bootstrap'
 window.next.version += '-turbo'
 ;(self as any).__webpack_hash__ = ''
 
-const instrumentationHooks =
-  require('../lib/require-instrumentation-client') as typeof import('../lib/require-instrumentation-client')
+// eslint-disable-next-line @next/internal/typechecked-require
+const instrumentationHooks = require('../lib/require-instrumentation-client')
 
 appBootstrap(() => {
   const { hydrate } = require('./app-index') as typeof import('./app-index')

--- a/packages/next/src/client/app-next-turbopack.ts
+++ b/packages/next/src/client/app-next-turbopack.ts
@@ -5,9 +5,10 @@ import { appBootstrap } from './app-bootstrap'
 window.next.version += '-turbo'
 ;(self as any).__webpack_hash__ = ''
 
-const instrumentationHooks = require('../lib/require-instrumentation-client')
+const instrumentationHooks =
+  require('../lib/require-instrumentation-client') as typeof import('../lib/require-instrumentation-client')
 
 appBootstrap(() => {
-  const { hydrate } = require('./app-index')
+  const { hydrate } = require('./app-index') as typeof import('./app-index')
   hydrate(instrumentationHooks)
 })

--- a/packages/next/src/client/app-next.ts
+++ b/packages/next/src/client/app-next.ts
@@ -3,12 +3,15 @@
 import './app-webpack'
 import { appBootstrap } from './app-bootstrap'
 
-const instrumentationHooks = require('../lib/require-instrumentation-client')
+const instrumentationHooks =
+  // eslint-disable-next-line @next/internal/typechecked-require -- not a module
+  require('../lib/require-instrumentation-client')
 
 appBootstrap(() => {
-  const { hydrate } = require('./app-index')
+  const { hydrate } = require('./app-index') as typeof import('./app-index')
   // Include app-router and layout-router in the main chunk
-  require('next/dist/client/components/app-router')
-  require('next/dist/client/components/layout-router')
+  // TODO: Why not relative imports?
+  require('next/dist/client/components/app-router') as typeof import('next/dist/client/components/app-router')
+  require('next/dist/client/components/layout-router') as typeof import('next/dist/client/components/layout-router')
   hydrate(instrumentationHooks)
 })

--- a/packages/next/src/client/app-next.ts
+++ b/packages/next/src/client/app-next.ts
@@ -10,8 +10,9 @@ const instrumentationHooks =
 appBootstrap(() => {
   const { hydrate } = require('./app-index') as typeof import('./app-index')
   // Include app-router and layout-router in the main chunk
-  // TODO: Why not relative imports?
-  require('next/dist/client/components/app-router') as typeof import('next/dist/client/components/app-router')
-  require('next/dist/client/components/layout-router') as typeof import('next/dist/client/components/layout-router')
+  // eslint-disable-next-line @next/internal/typechecked-require -- Why not relative imports?
+  require('next/dist/client/components/app-router')
+  // eslint-disable-next-line @next/internal/typechecked-require -- Why not relative imports?
+  require('next/dist/client/components/layout-router')
   hydrate(instrumentationHooks)
 })

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -506,7 +506,9 @@ function Router({
       )
     }
     const HotReloader: typeof import('./react-dev-overlay/app/hot-reloader-client').default =
-      require('./react-dev-overlay/app/hot-reloader-client').default
+      (
+        require('./react-dev-overlay/app/hot-reloader-client') as typeof import('./react-dev-overlay/app/hot-reloader-client')
+      ).default
 
     content = (
       <HotReloader assetPrefix={assetPrefix} globalError={globalError}>

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -42,7 +42,7 @@ import { dispatchAppRouterAction } from './use-action-queue'
 import { useRouterBFCache, type RouterBFCacheEntry } from './bfcache'
 
 const Activity = process.env.__NEXT_ROUTER_BF_CACHE
-  ? require('react').unstable_Activity
+  ? (require('react') as typeof import('react')).unstable_Activity
   : null
 
 /**

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -43,7 +43,7 @@ import { useRouterBFCache, type RouterBFCacheEntry } from './bfcache'
 
 const Activity = process.env.__NEXT_ROUTER_BF_CACHE
   ? (require('react') as typeof import('react')).unstable_Activity
-  : null
+  : null!
 
 /**
  * Add refetch marker to router state at the point of the current layout segment.

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -6,9 +6,9 @@
 const { createFromReadableStream } = (
   !!process.env.NEXT_RUNTIME
     ? // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client.edge')
+      (require('react-server-dom-webpack/client.edge') as typeof import('react-server-dom-webpack/client.edge'))
     : // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client')
+      (require('react-server-dom-webpack/client') as typeof import('react-server-dom-webpack/client'))
 ) as typeof import('react-server-dom-webpack/client')
 
 import type {
@@ -220,7 +220,9 @@ export async function fetchServerResponse(
     // In dev, the Webpack runtime is minimal for each page.
     // We need to ensure the Webpack runtime is updated before executing client-side JS of the new page.
     if (process.env.NODE_ENV !== 'production' && !process.env.TURBOPACK) {
-      await require('../react-dev-overlay/app/hot-reloader-client').waitForWebpackRuntimeHotUpdate()
+      await (
+        require('../react-dev-overlay/app/hot-reloader-client') as typeof import('../react-dev-overlay/app/hot-reloader-client')
+      ).waitForWebpackRuntimeHotUpdate()
     }
 
     // Handle the `fetch` readable stream that can be unwrapped by `React.use`.

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -19,9 +19,9 @@ import {
 const { createFromFetch, createTemporaryReferenceSet, encodeReply } = (
   !!process.env.NEXT_RUNTIME
     ? // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client.edge')
+      (require('react-server-dom-webpack/client.edge') as typeof import('react-server-dom-webpack/client.edge'))
     : // eslint-disable-next-line import/no-extraneous-dependencies
-      require('react-server-dom-webpack/client')
+      (require('react-server-dom-webpack/client') as typeof import('react-server-dom-webpack/client'))
 ) as typeof import('react-server-dom-webpack/client')
 
 import {

--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -29,75 +29,81 @@ const notEnabled: any = () => {
 export const prefetch: typeof import('./segment-cache-impl/prefetch').prefetch =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/prefetch').prefetch(...args)
+        return (
+          require('./segment-cache-impl/prefetch') as typeof import('./segment-cache-impl/prefetch')
+        ).prefetch(...args)
       }
     : notEnabled
 
 export const navigate: typeof import('./segment-cache-impl/navigation').navigate =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/navigation').navigate(...args)
+        return (
+          require('./segment-cache-impl/navigation') as typeof import('./segment-cache-impl/navigation')
+        ).navigate(...args)
       }
     : notEnabled
 
 export const revalidateEntireCache: typeof import('./segment-cache-impl/cache').revalidateEntireCache =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/cache').revalidateEntireCache(
-          ...args
-        )
+        return (
+          require('./segment-cache-impl/cache') as typeof import('./segment-cache-impl/cache')
+        ).revalidateEntireCache(...args)
       }
     : notEnabled
 
 export const getCurrentCacheVersion: typeof import('./segment-cache-impl/cache').getCurrentCacheVersion =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/cache').getCurrentCacheVersion(
-          ...args
-        )
+        return (
+          require('./segment-cache-impl/cache') as typeof import('./segment-cache-impl/cache')
+        ).getCurrentCacheVersion(...args)
       }
     : notEnabled
 
 export const schedulePrefetchTask: typeof import('./segment-cache-impl/scheduler').schedulePrefetchTask =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/scheduler').schedulePrefetchTask(
-          ...args
-        )
+        return (
+          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+        ).schedulePrefetchTask(...args)
       }
     : notEnabled
 
 export const cancelPrefetchTask: typeof import('./segment-cache-impl/scheduler').cancelPrefetchTask =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/scheduler').cancelPrefetchTask(
-          ...args
-        )
+        return (
+          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+        ).cancelPrefetchTask(...args)
       }
     : notEnabled
 
 export const reschedulePrefetchTask: typeof import('./segment-cache-impl/scheduler').reschedulePrefetchTask =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/scheduler').reschedulePrefetchTask(
-          ...args
-        )
+        return (
+          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+        ).reschedulePrefetchTask(...args)
       }
     : notEnabled
 
 export const isPrefetchTaskDirty: typeof import('./segment-cache-impl/scheduler').isPrefetchTaskDirty =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/scheduler').isPrefetchTaskDirty(
-          ...args
-        )
+        return (
+          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+        ).isPrefetchTaskDirty(...args)
       }
     : notEnabled
 
 export const createCacheKey: typeof import('./segment-cache-impl/cache-key').createCacheKey =
   process.env.__NEXT_CLIENT_SEGMENT_CACHE
     ? function (...args) {
-        return require('./segment-cache-impl/cache-key').createCacheKey(...args)
+        return (
+          require('./segment-cache-impl/cache-key') as typeof import('./segment-cache-impl/cache-key')
+        ).createCacheKey(...args)
       }
     : notEnabled
 

--- a/packages/next/src/client/components/use-action-queue.ts
+++ b/packages/next/src/client/components/use-action-queue.ts
@@ -37,8 +37,7 @@ export function useActionQueue(
   if (process.env.NODE_ENV !== 'production') {
     const useSyncDevRenderIndicator = (
       require('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator') as typeof import('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator')
-    )
-      .useSyncDevRenderIndicator as typeof import('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator').useSyncDevRenderIndicator
+    ).useSyncDevRenderIndicator
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const syncDevRenderIndicator = useSyncDevRenderIndicator()
 

--- a/packages/next/src/client/components/use-action-queue.ts
+++ b/packages/next/src/client/components/use-action-queue.ts
@@ -35,9 +35,10 @@ export function useActionQueue(
   // this is conceptually how we're modeling the app router state, despite the
   // weird implementation details.
   if (process.env.NODE_ENV !== 'production') {
-    const useSyncDevRenderIndicator =
-      require('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator')
-        .useSyncDevRenderIndicator as typeof import('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator').useSyncDevRenderIndicator
+    const useSyncDevRenderIndicator = (
+      require('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator') as typeof import('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator')
+    )
+      .useSyncDevRenderIndicator as typeof import('./react-dev-overlay/utils/dev-indicator/use-sync-dev-render-indicator').useSyncDevRenderIndicator
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const syncDevRenderIndicator = useSyncDevRenderIndicator()
 

--- a/packages/next/src/client/detect-domain-locale.ts
+++ b/packages/next/src/client/detect-domain-locale.ts
@@ -2,8 +2,8 @@ import type { detectDomainLocale as Fn } from '../shared/lib/i18n/detect-domain-
 
 export const detectDomainLocale: typeof Fn = (...args) => {
   if (process.env.__NEXT_I18N_SUPPORT) {
-    return require('../shared/lib/i18n/detect-domain-locale').detectDomainLocale(
-      ...args
-    )
+    return (
+      require('../shared/lib/i18n/detect-domain-locale') as typeof import('../shared/lib/i18n/detect-domain-locale')
+    ).detectDomainLocale(...args)
   }
 }

--- a/packages/next/src/client/get-domain-locale.ts
+++ b/packages/next/src/client/get-domain-locale.ts
@@ -12,10 +12,12 @@ export function getDomainLocale(
   domainLocales?: readonly DomainLocale[]
 ) {
   if (process.env.__NEXT_I18N_SUPPORT) {
-    const normalizeLocalePath: typeof NormalizeFn =
-      require('./normalize-locale-path').normalizeLocalePath
-    const detectDomainLocale: typeof DetectFn =
-      require('./detect-domain-locale').detectDomainLocale
+    const normalizeLocalePath: typeof NormalizeFn = (
+      require('./normalize-locale-path') as typeof import('./normalize-locale-path')
+    ).normalizeLocalePath
+    const detectDomainLocale: typeof DetectFn = (
+      require('./detect-domain-locale') as typeof import('./detect-domain-locale')
+    ).detectDomainLocale
 
     const target = locale || normalizeLocalePath(path, locales).detectedLocale
     const domain = detectDomainLocale(domainLocales, undefined, target)

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -181,7 +181,8 @@ class Container extends React.Component<{
     } else {
       const {
         PagesDevOverlay,
-      }: typeof import('./components/react-dev-overlay/pages/pages-dev-overlay') = require('./components/react-dev-overlay/pages/pages-dev-overlay')
+      }: typeof import('./components/react-dev-overlay/pages/pages-dev-overlay') =
+        require('./components/react-dev-overlay/pages/pages-dev-overlay') as typeof import('./components/react-dev-overlay/pages/pages-dev-overlay')
       return <PagesDevOverlay>{this.props.children}</PagesDevOverlay>
     }
   }
@@ -269,7 +270,8 @@ export async function initialize(opts: { devClient?: any } = {}): Promise<{
   }
 
   if (initialData.scriptLoader) {
-    const { initScriptLoader } = require('./script')
+    const { initScriptLoader } =
+      require('./script') as typeof import('./script')
     initScriptLoader(initialData.scriptLoader)
   }
 
@@ -901,7 +903,8 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
     CachedComponent = pageEntrypoint.component
 
     if (process.env.NODE_ENV !== 'production') {
-      const { isValidElementType } = require('next/dist/compiled/react-is')
+      const { isValidElementType } =
+        require('next/dist/compiled/react-is') as typeof import('next/dist/compiled/react-is')
       if (!isValidElementType(CachedComponent)) {
         throw new Error(
           `The default export is not a React Component in page: "${initialData.page}"`
@@ -915,7 +918,9 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
 
   if (process.env.NODE_ENV === 'development') {
     const getServerError: typeof import('./components/react-dev-overlay/pages/client').getServerError =
-      require('./components/react-dev-overlay/pages/client').getServerError
+      (
+        require('./components/react-dev-overlay/pages/client') as typeof import('./components/react-dev-overlay/pages/client')
+      ).getServerError
     // Server-side runtime errors need to be re-thrown on the client-side so
     // that the overlay is rendered.
     if (initialErr) {

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -150,9 +150,8 @@ function defaultLoader({
         process.env.NEXT_RUNTIME !== 'edge'
       ) {
         // We use dynamic require because this should only error in development
-        const {
-          hasLocalMatch,
-        } = require('../../shared/lib/match-local-pattern')
+        const { hasLocalMatch } =
+          require('../../shared/lib/match-local-pattern') as typeof import('../../shared/lib/match-local-pattern')
         if (!hasLocalMatch(config.localPatterns, src)) {
           throw new Error(
             `Invalid src prop (${src}) on \`next/image\` does not match \`images.localPatterns\` configured in your \`next.config.js\`\n` +
@@ -179,9 +178,8 @@ function defaultLoader({
         process.env.NEXT_RUNTIME !== 'edge'
       ) {
         // We use dynamic require because this should only error in development
-        const {
-          hasRemoteMatch,
-        } = require('../../shared/lib/match-remote-pattern')
+        const { hasRemoteMatch } =
+          require('../../shared/lib/match-remote-pattern') as typeof import('../../shared/lib/match-remote-pattern')
         if (!hasRemoteMatch(config.domains, config.remotePatterns, parsedSrc)) {
           throw new Error(
             `Invalid src prop (${src}) on \`next/image\`, hostname "${parsedSrc.hostname}" is not configured under images in your \`next.config.js\`\n` +

--- a/packages/next/src/client/normalize-locale-path.ts
+++ b/packages/next/src/client/normalize-locale-path.ts
@@ -2,10 +2,9 @@ import type { normalizeLocalePath as Fn } from '../shared/lib/i18n/normalize-loc
 
 export const normalizeLocalePath: typeof Fn = (pathname, locales) => {
   if (process.env.__NEXT_I18N_SUPPORT) {
-    return require('../shared/lib/i18n/normalize-locale-path').normalizeLocalePath(
-      pathname,
-      locales
-    )
+    return (
+      require('../shared/lib/i18n/normalize-locale-path') as typeof import('../shared/lib/i18n/normalize-locale-path')
+    ).normalizeLocalePath(pathname, locales)
   }
   return { pathname, detectedLocale: undefined }
 }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -49,7 +49,8 @@ import type { PagesRenderContext, PagesSharedContext } from '../server/render'
 import type { AppSharedContext } from '../server/app-render/app-render'
 import { MultiFileWriter } from '../lib/multi-file-writer'
 
-const envConfig = require('../shared/lib/runtime-config.external')
+const envConfig =
+  require('../shared/lib/runtime-config.external') as typeof import('../shared/lib/runtime-config.external')
 
 ;(globalThis as any).__NEXT_DATA__ = {
   nextExport: true,

--- a/packages/next/src/lib/download-swc.ts
+++ b/packages/next/src/lib/download-swc.ts
@@ -2,9 +2,8 @@ import fs from 'fs'
 import path from 'path'
 import * as Log from '../build/output/log'
 import tar from 'next/dist/compiled/tar'
-const { WritableStream } = require('node:stream/web') as {
-  WritableStream: typeof global.WritableStream
-}
+const { WritableStream } =
+  require('node:stream/web') as typeof import('node:stream/web')
 import { getRegistry } from './helpers/get-registry'
 import { getCacheDirectory } from './helpers/get-cache-directory'
 

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -58,7 +58,9 @@ async function cliPrompt(cwd: string): Promise<{ config?: any }> {
 
   try {
     const cliSelect = (
-      await Promise.resolve(require('next/dist/compiled/cli-select'))
+      await Promise.resolve(
+        require('next/dist/compiled/cli-select') as typeof import('next/dist/compiled/cli-select')
+      )
     ).default
     const { value } = await cliSelect({
       values: await getESLintPromptValues(cwd),

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -905,8 +905,12 @@ function resolvePendingResult<
   // In dev we clone and freeze to prevent relying on mutating resolvedMetadata directly.
   // In prod we just pass resolvedMetadata through without any copying.
   if (process.env.NODE_ENV === 'development') {
-    parentResult = require('../../shared/lib/deep-freeze').deepFreeze(
-      require('./clone-metadata').cloneMetadata(parentResult)
+    parentResult = (
+      require('../../shared/lib/deep-freeze') as typeof import('../../shared/lib/deep-freeze')
+    ).deepFreeze(
+      (
+        require('./clone-metadata') as typeof import('./clone-metadata')
+      ).cloneMetadata(parentResult)
     )
   }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -905,6 +905,8 @@ function resolvePendingResult<
   // In dev we clone and freeze to prevent relying on mutating resolvedMetadata directly.
   // In prod we just pass resolvedMetadata through without any copying.
   if (process.env.NODE_ENV === 'development') {
+    // @ts-expect-error -- DeepReadonly<T> is by definition not assignable to T
+    // Instead, we should only accept DeepReadonly<ResolvedType>
     parentResult = (
       require('../../shared/lib/deep-freeze') as typeof import('../../shared/lib/deep-freeze')
     ).deepFreeze(

--- a/packages/next/src/lib/mkcert.ts
+++ b/packages/next/src/lib/mkcert.ts
@@ -4,9 +4,8 @@ import { X509Certificate, createPrivateKey } from 'node:crypto'
 import { getCacheDirectory } from './helpers/get-cache-directory'
 import * as Log from '../build/output/log'
 import { execSync } from 'node:child_process'
-const { WritableStream } = require('node:stream/web') as {
-  WritableStream: typeof global.WritableStream
-}
+const { WritableStream } =
+  require('node:stream/web') as typeof import('node:stream/web')
 
 const MKCERT_VERSION = 'v1.4.4'
 

--- a/packages/next/src/lib/require-instrumentation-client.ts
+++ b/packages/next/src/lib/require-instrumentation-client.ts
@@ -7,8 +7,8 @@
 if (process.env.NODE_ENV === 'development') {
   const measureName = 'Client Instrumentation Hook'
   const startTime = performance.now()
-  module.exports =
-    require('private-next-instrumentation-client') as typeof import('private-next-instrumentation-client')
+  // eslint-disable-next-line @next/internal/typechecked-require -- Not a module.
+  module.exports = require('private-next-instrumentation-client')
   const endTime = performance.now()
   const duration = endTime - startTime
 
@@ -22,6 +22,6 @@ if (process.env.NODE_ENV === 'development') {
     )
   }
 } else {
-  module.exports =
-    require('private-next-instrumentation-client') as typeof import('private-next-instrumentation-client')
+  // eslint-disable-next-line @next/internal/typechecked-require -- Not a module.
+  module.exports = require('private-next-instrumentation-client')
 }

--- a/packages/next/src/lib/require-instrumentation-client.ts
+++ b/packages/next/src/lib/require-instrumentation-client.ts
@@ -7,7 +7,8 @@
 if (process.env.NODE_ENV === 'development') {
   const measureName = 'Client Instrumentation Hook'
   const startTime = performance.now()
-  module.exports = require('private-next-instrumentation-client')
+  module.exports =
+    require('private-next-instrumentation-client') as typeof import('private-next-instrumentation-client')
   const endTime = performance.now()
   const duration = endTime - startTime
 
@@ -21,5 +22,6 @@ if (process.env.NODE_ENV === 'development') {
     )
   }
 } else {
-  module.exports = require('private-next-instrumentation-client')
+  module.exports =
+    require('private-next-instrumentation-client') as typeof import('private-next-instrumentation-client')
 }

--- a/packages/next/src/lib/resolve-from.ts
+++ b/packages/next/src/lib/resolve-from.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import isError from './is-error'
 import { realpathSync } from './realpath'
 
-const Module = require('module')
+const Module = require('module') as typeof import('module')
 
 export const resolveFrom = (
   fromDirectory: string,

--- a/packages/next/src/lib/resolve-from.ts
+++ b/packages/next/src/lib/resolve-from.ts
@@ -37,10 +37,13 @@ export const resolveFrom = (
   const fromFile = path.join(fromDirectory, 'noop.js')
 
   const resolveFileName = () =>
+    // @ts-expect-error
     Module._resolveFilename(moduleId, {
       id: fromFile,
       filename: fromFile,
-      paths: Module._nodeModulePaths(fromDirectory),
+      paths:
+        // @ts-expect-error
+        Module._nodeModulePaths(fromDirectory),
     })
 
   if (silent) {

--- a/packages/next/src/lib/typescript/diagnosticFormatter.ts
+++ b/packages/next/src/lib/typescript/diagnosticFormatter.ts
@@ -360,7 +360,8 @@ export function getFormattedDiagnostic(
   message += reason + '\n'
 
   if (!isLayoutOrPageError && diagnostic.file) {
-    const { codeFrameColumns } = require('next/dist/compiled/babel/code-frame')
+    const { codeFrameColumns } =
+      require('next/dist/compiled/babel/code-frame') as typeof import('next/dist/compiled/babel/code-frame')
     const pos = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!)
     const line = pos.line + 1
     const character = pos.character + 1

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -136,7 +136,8 @@ export async function verifyTypeScriptSetup({
 
     let result
     if (typeCheckPreflight) {
-      const { runTypeCheck } = require('./typescript/runTypeCheck')
+      const { runTypeCheck } =
+        require('./typescript/runTypeCheck') as typeof import('./typescript/runTypeCheck')
 
       // Verify the project passes type-checking before we go to webpack phase:
       result = await runTypeCheck(

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -834,7 +834,9 @@ export class Head extends React.Component<HeadProps> {
                 rel="canonical"
                 href={
                   canonicalBase +
-                  require('../server/utils').cleanAmpPath(dangerousAsPath)
+                  (
+                    require('../server/utils') as typeof import('../server/utils')
+                  ).cleanAmpPath(dangerousAsPath)
                 }
               />
             )}
@@ -1004,7 +1006,9 @@ export class NextScript extends React.Component<OriginProps> {
         process.env.NEXT_RUNTIME === 'edge'
           ? new TextEncoder().encode(data).buffer.byteLength
           : Buffer.from(data).byteLength
-      const prettyBytes = require('../lib/pretty-bytes').default
+      const prettyBytes = (
+        require('../lib/pretty-bytes') as typeof import('../lib/pretty-bytes')
+      ).default
 
       if (largePageDataBytes && bytes > largePageDataBytes) {
         if (process.env.NODE_ENV === 'production') {

--- a/packages/next/src/server/api-utils/get-cookie-parser.ts
+++ b/packages/next/src/server/api-utils/get-cookie-parser.ts
@@ -15,7 +15,8 @@ export function getCookieParser(headers: {
       return {}
     }
 
-    const { parse: parseCookieFn } = require('next/dist/compiled/cookie')
+    const { parse: parseCookieFn } =
+      require('next/dist/compiled/cookie') as typeof import('next/dist/compiled/cookie')
     return parseCookieFn(Array.isArray(cookie) ? cookie.join('; ') : cookie)
   }
 }

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -114,7 +114,7 @@ export function clearPreviewData<T>(
   }
 
   const { serialize } =
-    require('next/dist/compiled/cookie') as typeof import('cookie')
+    require('next/dist/compiled/cookie') as typeof import('next/dist/compiled/cookie')
   const previous = res.getHeader('Set-Cookie')
   res.setHeader(`Set-Cookie`, [
     ...(typeof previous === 'string'

--- a/packages/next/src/server/api-utils/node/api-resolver.ts
+++ b/packages/next/src/server/api-utils/node/api-resolver.ts
@@ -145,7 +145,7 @@ function setDraftMode<T>(
   // https://tools.ietf.org/html/rfc6265#section-4.1.1
   // `Max-Age: 0` is not valid, thus ignored, and the cookie is persisted.
   const { serialize } =
-    require('next/dist/compiled/cookie') as typeof import('cookie')
+    require('next/dist/compiled/cookie') as typeof import('next/dist/compiled/cookie')
   const previous = res.getHeader('Set-Cookie')
   res.setHeader(`Set-Cookie`, [
     ...(typeof previous === 'string'
@@ -211,7 +211,7 @@ function setPreviewData<T>(
   }
 
   const { serialize } =
-    require('next/dist/compiled/cookie') as typeof import('cookie')
+    require('next/dist/compiled/cookie') as typeof import('next/dist/compiled/cookie')
   const previous = res.getHeader('Set-Cookie')
   res.setHeader(`Set-Cookie`, [
     ...(typeof previous === 'string'

--- a/packages/next/src/server/api-utils/node/parse-body.ts
+++ b/packages/next/src/server/api-utils/node/parse-body.ts
@@ -58,7 +58,7 @@ export async function parseBody(
   if (type === 'application/json' || type === 'application/ld+json') {
     return parseJson(body)
   } else if (type === 'application/x-www-form-urlencoded') {
-    const qs = require('querystring')
+    const qs = require('querystring') as typeof import('querystring')
     return qs.decode(body)
   } else {
     return body

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -748,7 +748,7 @@ export async function handleAction({
         const bodySizeLimitBytes =
           bodySizeLimit !== defaultBodySizeLimit
             ? (
-                require('next/dist/compiled/bytes') as typeof import('bytes')
+                require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
               ).parse(bodySizeLimit)
             : 1024 * 1024 // 1 MB
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -757,7 +757,8 @@ export async function handleAction({
           transform(chunk, encoding, callback) {
             size += Buffer.byteLength(chunk, encoding)
             if (size > bodySizeLimitBytes) {
-              const { ApiError } = require('../api-utils')
+              const { ApiError } =
+                require('../api-utils') as typeof import('../api-utils')
 
               callback(
                 new ApiError(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1332,7 +1332,9 @@ async function renderToHTMLOrFlightImpl(
   } else if (process.env.NEXT_RUNTIME === 'edge') {
     requestId = crypto.randomUUID()
   } else {
-    requestId = require('next/dist/compiled/nanoid').nanoid()
+    requestId = (
+      require('next/dist/compiled/nanoid') as typeof import('next/dist/compiled/nanoid')
+    ).nanoid()
   }
 
   /**
@@ -1952,8 +1954,9 @@ async function renderToStream(
         // We assume we have dynamic HTML requiring a resume render to complete
         const postponed = getPostponedFromState(postponedState)
 
-        const resume = require('react-dom/server.edge')
-          .resume as (typeof import('react-dom/server.edge'))['resume']
+        const resume = (
+          require('react-dom/server.edge') as typeof import('react-dom/server.edge')
+        ).resume as (typeof import('react-dom/server.edge'))['resume']
 
         const htmlStream = await workUnitAsyncStorage.run(
           requestStore,
@@ -1990,7 +1993,9 @@ async function renderToStream(
     }
 
     // This is a regular dynamic render
-    const renderToReadableStream = require('react-dom/server.edge')
+    const renderToReadableStream = (
+      require('react-dom/server.edge') as typeof import('react-dom/server.edge')
+    )
       .renderToReadableStream as (typeof import('react-dom/server.edge'))['renderToReadableStream']
 
     const htmlStream = await workUnitAsyncStorage.run(
@@ -2149,7 +2154,8 @@ async function renderToStream(
         requestStore,
         renderToInitialFizzStream,
         {
-          ReactDOMServer: require('react-dom/server.edge'),
+          ReactDOMServer:
+            require('react-dom/server.edge') as typeof import('react-dom/server.edge'),
           element: (
             <ErrorApp
               reactServerStream={errorServerStream}
@@ -2413,8 +2419,9 @@ async function spawnDynamicValidationInDev(
       hmrRefreshHash: undefined,
     }
 
-    const prerender = require('react-dom/static.edge')
-      .prerender as (typeof import('react-dom/static.edge'))['prerender']
+    const prerender = (
+      require('react-dom/static.edge') as typeof import('react-dom/static.edge')
+    ).prerender as (typeof import('react-dom/static.edge'))['prerender']
     const pendingInitialClientResult = workUnitAsyncStorage.run(
       initialClientPrerenderStore,
       prerender,
@@ -2562,8 +2569,9 @@ async function spawnDynamicValidationInDev(
   let dynamicValidation = createDynamicValidationState()
 
   try {
-    const prerender = require('react-dom/static.edge')
-      .prerender as (typeof import('react-dom/static.edge'))['prerender']
+    const prerender = (
+      require('react-dom/static.edge') as typeof import('react-dom/static.edge')
+    ).prerender as (typeof import('react-dom/static.edge'))['prerender']
     let { prelude: unprocessedPrelude } =
       await prerenderAndAbortInSequentialTasks(
         () =>
@@ -3006,8 +3014,9 @@ async function prerenderToStream(
           hmrRefreshHash: undefined,
         }
 
-        const prerender = require('react-dom/static.edge')
-          .prerender as (typeof import('react-dom/static.edge'))['prerender']
+        const prerender = (
+          require('react-dom/static.edge') as typeof import('react-dom/static.edge')
+        ).prerender as (typeof import('react-dom/static.edge'))['prerender']
         const pendingInitialClientResult = workUnitAsyncStorage.run(
           initialClientPrerenderStore,
           prerender,
@@ -3163,8 +3172,9 @@ async function prerenderToStream(
       let clientIsDynamic = false
       let dynamicValidation = createDynamicValidationState()
 
-      const prerender = require('react-dom/static.edge')
-        .prerender as (typeof import('react-dom/static.edge'))['prerender']
+      const prerender = (
+        require('react-dom/static.edge') as typeof import('react-dom/static.edge')
+      ).prerender as (typeof import('react-dom/static.edge'))['prerender']
       let { prelude: unprocessedPrelude, postponed } =
         await prerenderAndAbortInSequentialTasks(
           () =>
@@ -3295,8 +3305,9 @@ async function prerenderToStream(
         if (postponed != null) {
           // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
           // so we can set all the postponed boundaries to client render mode before we store the HTML response
-          const resume = require('react-dom/server.edge')
-            .resume as (typeof import('react-dom/server.edge'))['resume']
+          const resume = (
+            require('react-dom/server.edge') as typeof import('react-dom/server.edge')
+          ).resume as (typeof import('react-dom/server.edge'))['resume']
 
           // We don't actually want to render anything so we just pass a stream
           // that never resolves. The resume call is going to abort immediately anyway
@@ -3396,8 +3407,9 @@ async function prerenderToStream(
         tags: [...implicitTags.tags],
         prerenderResumeDataCache,
       }
-      const prerender = require('react-dom/static.edge')
-        .prerender as (typeof import('react-dom/static.edge'))['prerender']
+      const prerender = (
+        require('react-dom/static.edge') as typeof import('react-dom/static.edge')
+      ).prerender as (typeof import('react-dom/static.edge'))['prerender']
       const { prelude, postponed } = await workUnitAsyncStorage.run(
         ssrPrerenderStore,
         prerender,
@@ -3525,8 +3537,9 @@ async function prerenderToStream(
         if (postponed != null) {
           // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
           // so we can set all the postponed boundaries to client render mode before we store the HTML response
-          const resume = require('react-dom/server.edge')
-            .resume as (typeof import('react-dom/server.edge'))['resume']
+          const resume = (
+            require('react-dom/server.edge') as typeof import('react-dom/server.edge')
+          ).resume as (typeof import('react-dom/server.edge'))['resume']
 
           // We don't actually want to render anything so we just pass a stream
           // that never resolves. The resume call is going to abort immediately anyway
@@ -3606,7 +3619,9 @@ async function prerenderToStream(
           )
         ))
 
-      const renderToReadableStream = require('react-dom/server.edge')
+      const renderToReadableStream = (
+        require('react-dom/server.edge') as typeof import('react-dom/server.edge')
+      )
         .renderToReadableStream as (typeof import('react-dom/server.edge'))['renderToReadableStream']
 
       const htmlStream = await workUnitAsyncStorage.run(
@@ -3780,7 +3795,8 @@ async function prerenderToStream(
         prerenderLegacyStore,
         renderToInitialFizzStream,
         {
-          ReactDOMServer: require('react-dom/server.edge'),
+          ReactDOMServer:
+            require('react-dom/server.edge') as typeof import('react-dom/server.edge'),
           element: (
             <ErrorApp
               reactServerStream={errorServerStream}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -342,7 +342,8 @@ async function createComponentTreeInternal({
   let MaybeComponent = LayoutOrPage
 
   if (process.env.NODE_ENV === 'development') {
-    const { isValidElementType } = require('next/dist/compiled/react-is')
+    const { isValidElementType } =
+      require('next/dist/compiled/react-is') as typeof import('next/dist/compiled/react-is')
     if (
       typeof MaybeComponent !== 'undefined' &&
       !isValidElementType(MaybeComponent)

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -48,7 +48,8 @@ export { collectSegmentData } from './collect-segment-data'
 let SegmentViewNode: typeof import('../../shared/lib/devtool/app-segment-tree').SegmentViewNode =
   () => null
 if (process.env.NODE_ENV === 'development') {
-  const appSegmentTree: typeof import('../../shared/lib/devtool/app-segment-tree') = require('../../shared/lib/devtool/app-segment-tree')
+  const appSegmentTree: typeof import('../../shared/lib/devtool/app-segment-tree') =
+    require('../../shared/lib/devtool/app-segment-tree') as typeof import('../../shared/lib/devtool/app-segment-tree')
   SegmentViewNode = appSegmentTree.SegmentViewNode
 }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -474,7 +474,9 @@ export default abstract class Server<
     this.serverOptions = options
 
     this.dir =
-      process.env.NEXT_RUNTIME === 'edge' ? dir : require('path').resolve(dir)
+      process.env.NEXT_RUNTIME === 'edge'
+        ? dir
+        : (require('path') as typeof import('path')).resolve(dir)
 
     this.quiet = quiet
     this.loadEnvConfig({ dev })
@@ -491,7 +493,10 @@ export default abstract class Server<
     this.distDir =
       process.env.NEXT_RUNTIME === 'edge'
         ? this.nextConfig.distDir
-        : require('path').join(this.dir, this.nextConfig.distDir)
+        : (require('path') as typeof import('path')).join(
+            this.dir,
+            this.nextConfig.distDir
+          )
     this.publicDir = this.getPublicDir()
     this.hasStaticDir = !minimalMode && this.getHasStaticDir()
 

--- a/packages/next/src/server/config-utils.ts
+++ b/packages/next/src/server/config-utils.ts
@@ -1,7 +1,8 @@
 let installed: boolean = false
 
 export function loadWebpackHook() {
-  const { init: initWebpack } = require('next/dist/compiled/webpack/webpack')
+  const { init: initWebpack } =
+    require('next/dist/compiled/webpack/webpack') as typeof import('next/dist/compiled/webpack/webpack')
   if (installed) {
     return
   }
@@ -10,7 +11,9 @@ export function loadWebpackHook() {
 
   // hook the Node.js require so that webpack requires are
   // routed to the bundled and now initialized webpack version
-  require('../server/require-hook').addHookAliases(
+  ;(
+    require('../server/require-hook') as typeof import('../server/require-hook')
+  ).addHookAliases(
     [
       ['webpack', 'next/dist/compiled/webpack/webpack-lib'],
       ['webpack/package', 'next/dist/compiled/webpack/package'],

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -172,10 +172,13 @@ export async function createHotReloaderTurbopack(
   // For the debugging purpose, check if createNext or equivalent next instance setup in test cases
   // works correctly. Normally `run-test` hides output so only will be visible when `--debug` flag is used.
   if (isTestMode) {
-    require('console').log('Creating turbopack project', {
-      dir: projectPath,
-      testMode: isTestMode,
-    })
+    ;(require('console') as typeof import('console')).log(
+      'Creating turbopack project',
+      {
+        dir: projectPath,
+        testMode: isTestMode,
+      }
+    )
   }
 
   const hasRewrites =

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1238,7 +1238,9 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                       // includes the source map in development which changes
                       // every time for both server and client so we calculate
                       // the hash without the source map for the page module
-                      const hash = require('crypto')
+                      const hash = (
+                        require('crypto') as typeof import('crypto')
+                      )
                         .createHash('sha1')
                         .update(mod.originalSource().buffer())
                         .digest()

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -77,9 +77,9 @@ import {
 let ReactDevOverlayImpl: PagesDevOverlayType
 const ReactDevOverlay: PagesDevOverlayType = (props) => {
   if (ReactDevOverlayImpl === undefined) {
-    ReactDevOverlayImpl =
-      require('../../client/components/react-dev-overlay/pages/pages-dev-overlay')
-        .PagesDevOverlay as PagesDevOverlayType
+    ReactDevOverlayImpl = (
+      require('../../client/components/react-dev-overlay/pages/pages-dev-overlay') as typeof import('../../client/components/react-dev-overlay/pages/pages-dev-overlay')
+    ).PagesDevOverlay as PagesDevOverlayType
   }
   return ReactDevOverlayImpl(props)
 }

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -90,7 +90,9 @@ export async function loadStaticPaths({
   })
 
   // update work memory runtime-config
-  require('../../shared/lib/runtime-config.external').setConfig(config)
+  ;(
+    require('../../shared/lib/runtime-config.external') as typeof import('../../shared/lib/runtime-config.external')
+  ).setConfig(config)
   setHttpClientAndAgentOptions({
     httpAgentOptions,
   })

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -55,7 +55,7 @@ export function getSharp(concurrency: number | null | undefined) {
     return _sharp
   }
   try {
-    _sharp = require('sharp')
+    _sharp = require('sharp') as typeof import('sharp')
     if (_sharp && _sharp.concurrency() > 1) {
       // Reducing concurrency should reduce the memory usage too.
       // We more aggressively reduce in dev but also reduce in prod.

--- a/packages/next/src/server/lib/cpu-profile.ts
+++ b/packages/next/src/server/lib/cpu-profile.ts
@@ -3,7 +3,7 @@ const isCpuProfileEnabled = process.env.NEXT_CPU_PROF || privateCpuProfileName
 
 if (isCpuProfileEnabled) {
   const { Session } = require('inspector') as typeof import('inspector')
-  const fs = require('fs')
+  const fs = require('fs') as typeof import('fs')
 
   const session = new Session()
   session.connect()

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -18,7 +18,8 @@ let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}
 let sandboxContext: undefined | typeof import('../web/sandbox/context')
 
 if (process.env.NODE_ENV !== 'production') {
-  sandboxContext = require('../web/sandbox/context')
+  sandboxContext =
+    require('../web/sandbox/context') as typeof import('../web/sandbox/context')
 }
 
 export function clearAllModuleContexts() {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -634,6 +634,7 @@ export async function initialize(opts: {
   if (config.experimental.testProxy) {
     // Intercept fetch and other testmode apis.
     const { wrapRequestHandlerWorker, interceptTestApis } =
+      // eslint-disable-next-line @next/internal/typechecked-require -- experimental/testmode is not built ins next/dist/esm
       require('next/dist/experimental/testmode/server') as typeof import('../../experimental/testmode/server')
     requestHandler = wrapRequestHandlerWorker(requestHandler)
     interceptTestApis()

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -326,11 +326,13 @@ export async function setupFsCheck(opts: {
       dynamicRoutes: {},
       notFoundRoutes: [],
       preview: {
-        previewModeId: require('crypto').randomBytes(16).toString('hex'),
-        previewModeSigningKey: require('crypto')
+        previewModeId: (require('crypto') as typeof import('crypto'))
+          .randomBytes(16)
+          .toString('hex'),
+        previewModeSigningKey: (require('crypto') as typeof import('crypto'))
           .randomBytes(32)
           .toString('hex'),
-        previewModeEncryptionKey: require('crypto')
+        previewModeEncryptionKey: (require('crypto') as typeof import('crypto'))
           .randomBytes(32)
           .toString('hex'),
       },

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -23,12 +23,13 @@ let api: typeof import('next/dist/compiled/@opentelemetry/api')
 // the version that is bundled with Next.js.
 // the API is ~stable, so this should be fine
 if (process.env.NEXT_RUNTIME === 'edge') {
-  api = require('@opentelemetry/api')
+  api = require('@opentelemetry/api') as typeof import('@opentelemetry/api')
 } else {
   try {
-    api = require('@opentelemetry/api')
+    api = require('@opentelemetry/api') as typeof import('@opentelemetry/api')
   } catch (err) {
-    api = require('next/dist/compiled/@opentelemetry/api')
+    api =
+      require('next/dist/compiled/@opentelemetry/api') as typeof import('next/dist/compiled/@opentelemetry/api')
   }
 }
 

--- a/packages/next/src/server/load-default-error-components.ts
+++ b/packages/next/src/server/load-default-error-components.ts
@@ -48,11 +48,10 @@ export type LoadComponentsReturnType = {
 async function loadDefaultErrorComponentsImpl(
   distDir: string
 ): Promise<LoadComponentsReturnType> {
-  const Document = interopDefault(
-    require('next/dist/pages/_document') as typeof import('next/dist/pages/_document')
-  )
-  const AppMod =
-    require('next/dist/pages/_app') as typeof import('next/dist/pages/_app')
+  // eslint-disable-next-line @next/internal/typechecked-require -- Why not relative imports?
+  const Document = interopDefault(require('next/dist/pages/_document'))
+  // eslint-disable-next-line @next/internal/typechecked-require -- Why not relative imports?
+  const AppMod = require('next/dist/pages/_app')
   const App = interopDefault(AppMod)
 
   // Load the compiled route module for this builtin error.

--- a/packages/next/src/server/load-default-error-components.ts
+++ b/packages/next/src/server/load-default-error-components.ts
@@ -48,8 +48,11 @@ export type LoadComponentsReturnType = {
 async function loadDefaultErrorComponentsImpl(
   distDir: string
 ): Promise<LoadComponentsReturnType> {
-  const Document = interopDefault(require('next/dist/pages/_document'))
-  const AppMod = require('next/dist/pages/_app')
+  const Document = interopDefault(
+    require('next/dist/pages/_document') as typeof import('next/dist/pages/_document')
+  )
+  const AppMod =
+    require('next/dist/pages/_app') as typeof import('next/dist/pages/_app')
   const App = interopDefault(AppMod)
 
   // Load the compiled route module for this builtin error.

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -346,6 +346,7 @@ export default class NextNodeServer extends BaseServer<
     if (this.serverOptions.experimentalTestProxy) {
       process.env.NEXT_PRIVATE_TEST_PROXY = 'true'
       const { interceptTestApis } =
+        // eslint-disable-next-line @next/internal/typechecked-require -- experimental/testmode is not built ins next/dist/esm
         require('next/dist/experimental/testmode/server') as typeof import('../experimental/testmode/server')
       interceptTestApis()
     }
@@ -1250,6 +1251,7 @@ export default class NextNodeServer extends BaseServer<
     const handler = this.makeRequestHandler()
     if (this.serverOptions.experimentalTestProxy) {
       const { wrapRequestHandlerNode } =
+        // eslint-disable-next-line @next/internal/typechecked-require -- experimental/testmode is not built ins next/dist/esm
         require('next/dist/experimental/testmode/server') as typeof import('../experimental/testmode/server')
       return wrapRequestHandlerNode(handler)
     }

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -36,7 +36,11 @@ let ServerImpl: typeof NextNodeServer
 
 const getServerImpl = async () => {
   if (ServerImpl === undefined) {
-    ServerImpl = (await Promise.resolve(require('./next-server'))).default
+    ServerImpl = (
+      await Promise.resolve(
+        require('./next-server') as typeof import('./next-server')
+      )
+    ).default
   }
   return ServerImpl
 }
@@ -231,8 +235,9 @@ export class NextServer implements NextWrapperServer {
   ): Promise<NextNodeServer> {
     let ServerImplementation: typeof NextNodeServer
     if (options.dev) {
-      ServerImplementation = require('./dev/next-dev-server')
-        .default as typeof import('./dev/next-dev-server').default
+      ServerImplementation = (
+        require('./dev/next-dev-server') as typeof import('./dev/next-dev-server')
+      ).default as typeof import('./dev/next-dev-server').default
     } else {
       ServerImplementation = await getServerImpl()
     }
@@ -515,7 +520,8 @@ function createServer(
     'typescript' in options &&
     'version' in (options as any).typescript
   ) {
-    const pluginMod: typeof import('./next-typescript') = require('./next-typescript')
+    const pluginMod: typeof import('./next-typescript') =
+      require('./next-typescript') as typeof import('./next-typescript')
     return pluginMod.createTSPlugin(
       options as any
     ) as unknown as NextWrapperServer

--- a/packages/next/src/server/node-environment-baseline.ts
+++ b/packages/next/src/server/node-environment-baseline.ts
@@ -3,7 +3,8 @@
 
 // expose AsyncLocalStorage on global for react usage if it isn't already provided by the environment
 if (typeof (globalThis as any).AsyncLocalStorage !== 'function') {
-  const { AsyncLocalStorage } = require('async_hooks')
+  const { AsyncLocalStorage } =
+    require('async_hooks') as typeof import('async_hooks')
   ;(globalThis as any).AsyncLocalStorage = AsyncLocalStorage
 }
 
@@ -11,7 +12,9 @@ if (typeof (globalThis as any).WebSocket !== 'function') {
   Object.defineProperty(globalThis, 'WebSocket', {
     configurable: true,
     get() {
-      return require('next/dist/compiled/ws').WebSocket
+      return (
+        require('next/dist/compiled/ws') as typeof import('next/dist/compiled/ws')
+      ).WebSocket
     },
     set(value) {
       Object.defineProperty(globalThis, 'WebSocket', {

--- a/packages/next/src/server/node-environment-extensions/node-crypto.tsx
+++ b/packages/next/src/server/node-environment-extensions/node-crypto.tsx
@@ -35,6 +35,7 @@ if (process.env.NEXT_RUNTIME === 'edge') {
   const randomBytesExpression = "`require('node:crypto').randomBytes(size)`"
   try {
     const _randomBytes = nodeCrypto.randomBytes
+    // @ts-expect-error -- TODO: tell TS the overloads are preserved
     nodeCrypto.randomBytes = function randomBytes() {
       if (typeof arguments[1] !== 'function') {
         // randomBytes is sync if the second arg is undefined
@@ -52,6 +53,7 @@ if (process.env.NEXT_RUNTIME === 'edge') {
     "`require('node:crypto').randomFillSync(...)`"
   try {
     const _randomFillSync = nodeCrypto.randomFillSync
+    // @ts-expect-error -- TODO: tell TS the overloads are preserved
     nodeCrypto.randomFillSync = function randomFillSync() {
       io(randomFillSyncExpression, 'random')
       return _randomFillSync.apply(this, arguments as any)
@@ -65,6 +67,7 @@ if (process.env.NEXT_RUNTIME === 'edge') {
   const randomIntExpression = "`require('node:crypto').randomInt(min, max)`"
   try {
     const _randomInt = nodeCrypto.randomInt
+    // @ts-expect-error -- TODO: tell TS the overloads are preserved
     nodeCrypto.randomInt = function randomInt() {
       if (typeof arguments[2] !== 'function') {
         // randomInt is sync if the third arg is undefined
@@ -82,6 +85,7 @@ if (process.env.NEXT_RUNTIME === 'edge') {
     "`require('node:crypto').generatePrimeSync(...)`"
   try {
     const _generatePrimeSync = nodeCrypto.generatePrimeSync
+    // @ts-expect-error -- TODO: tell TS the overloads are preserved
     nodeCrypto.generatePrimeSync = function generatePrimeSync() {
       io(generatePrimeSyncExpression, 'random')
       return _generatePrimeSync.apply(this, arguments as any)
@@ -96,6 +100,7 @@ if (process.env.NEXT_RUNTIME === 'edge') {
     "`require('node:crypto').generateKeyPairSync(...)`"
   try {
     const _generateKeyPairSync = nodeCrypto.generateKeyPairSync
+    // @ts-expect-error -- TODO: tell TS the overloads are preserved
     nodeCrypto.generateKeyPairSync = function generateKeyPairSync() {
       io(generateKeyPairSyncExpression, 'random')
       return _generateKeyPairSync.apply(this, arguments as any)

--- a/packages/next/src/server/node-environment-extensions/node-crypto.tsx
+++ b/packages/next/src/server/node-environment-extensions/node-crypto.tsx
@@ -12,7 +12,7 @@ import { io } from './utils'
 if (process.env.NEXT_RUNTIME === 'edge') {
   // nothing to patch
 } else {
-  const nodeCrypto = require('node:crypto')
+  const nodeCrypto = require('node:crypto') as typeof import('node:crypto')
 
   // require('node:crypto').getRandomValues is an alias for
   // crypto.getRandomValues which is extended in web-crypto.tsx

--- a/packages/next/src/server/node-environment-extensions/web-crypto.tsx
+++ b/packages/next/src/server/node-environment-extensions/web-crypto.tsx
@@ -14,6 +14,7 @@ if (process.env.NEXT_RUNTIME === 'edge') {
   webCrypto = crypto
 } else {
   if (typeof crypto === 'undefined') {
+    // @ts-expect-error -- TODO: Is this actually safe?
     webCrypto = (require('node:crypto') as typeof import('node:crypto'))
       .webcrypto
   } else {

--- a/packages/next/src/server/node-environment-extensions/web-crypto.tsx
+++ b/packages/next/src/server/node-environment-extensions/web-crypto.tsx
@@ -14,7 +14,8 @@ if (process.env.NEXT_RUNTIME === 'edge') {
   webCrypto = crypto
 } else {
   if (typeof crypto === 'undefined') {
-    webCrypto = require('node:crypto').webcrypto
+    webCrypto = (require('node:crypto') as typeof import('node:crypto'))
+      .webcrypto
   } else {
     webCrypto = crypto
   }

--- a/packages/next/src/server/node-polyfill-crypto.ts
+++ b/packages/next/src/server/node-polyfill-crypto.ts
@@ -8,6 +8,7 @@ if (!global.crypto) {
     configurable: true,
     get() {
       if (!webcrypto) {
+        // @ts-expect-error -- TODO: Is this actually safe?
         webcrypto = (require('node:crypto') as typeof import('node:crypto'))
           .webcrypto
       }

--- a/packages/next/src/server/node-polyfill-crypto.ts
+++ b/packages/next/src/server/node-polyfill-crypto.ts
@@ -8,7 +8,8 @@ if (!global.crypto) {
     configurable: true,
     get() {
       if (!webcrypto) {
-        webcrypto = require('node:crypto').webcrypto
+        webcrypto = (require('node:crypto') as typeof import('node:crypto'))
+          .webcrypto
       }
       return webcrypto
     },

--- a/packages/next/src/server/optimize-amp.ts
+++ b/packages/next/src/server/optimize-amp.ts
@@ -4,7 +4,8 @@ export default async function optimize(
 ): Promise<string> {
   let AmpOptimizer
   try {
-    AmpOptimizer = require('next/dist/compiled/@ampproject/toolbox-optimizer')
+    AmpOptimizer =
+      require('next/dist/compiled/@ampproject/toolbox-optimizer') as typeof import('next/dist/compiled/@ampproject/toolbox-optimizer')
   } catch (_) {
     return html
   }

--- a/packages/next/src/server/post-process.ts
+++ b/packages/next/src/server/post-process.ts
@@ -23,8 +23,9 @@ async function postProcessHTML(
   const postProcessors: Array<PostProcessorFunction> = [
     process.env.NEXT_RUNTIME !== 'edge' && inAmpMode && !process.env.TURBOPACK
       ? async (html: string) => {
-          const optimizeAmp = require('./optimize-amp')
-            .default as typeof import('./optimize-amp').default
+          const optimizeAmp = (
+            require('./optimize-amp') as typeof import('./optimize-amp')
+          ).default as typeof import('./optimize-amp').default
           html = await optimizeAmp!(html, renderOpts.ampOptimizerConfig)
           if (!renderOpts.ampSkipValidation && renderOpts.ampValidator) {
             await renderOpts.ampValidator(html, pathname)
@@ -35,7 +36,7 @@ async function postProcessHTML(
     process.env.NEXT_RUNTIME !== 'edge' && renderOpts.optimizeCss
       ? async (html: string) => {
           // eslint-disable-next-line import/no-extraneous-dependencies
-          const Critters = require('critters')
+          const Critters = require('critters') as typeof import('critters')
           const cssOptimizer = new Critters({
             ssrMode: true,
             reduceInlineStyles: false,

--- a/packages/next/src/server/post-process.ts
+++ b/packages/next/src/server/post-process.ts
@@ -37,6 +37,7 @@ async function postProcessHTML(
       ? async (html: string) => {
           // eslint-disable-next-line import/no-extraneous-dependencies
           const Critters = require('critters') as typeof import('critters')
+          // @ts-expect-error -- interopRequireDefault
           const cssOptimizer = new Critters({
             ssrMode: true,
             reduceInlineStyles: false,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -113,10 +113,15 @@ let postProcessHTML: typeof import('./post-process').postProcessHTML
 const DOCTYPE = '<!DOCTYPE html>'
 
 if (process.env.NEXT_RUNTIME !== 'edge') {
-  tryGetPreviewData =
-    require('./api-utils/node/try-get-preview-data').tryGetPreviewData
-  warn = require('../build/output/log').warn
-  postProcessHTML = require('./post-process').postProcessHTML
+  tryGetPreviewData = (
+    require('./api-utils/node/try-get-preview-data') as typeof import('./api-utils/node/try-get-preview-data')
+  ).tryGetPreviewData
+  warn = (
+    require('../build/output/log') as typeof import('../build/output/log')
+  ).warn
+  postProcessHTML = (
+    require('./post-process') as typeof import('./post-process')
+  ).postProcessHTML
 } else {
   warn = console.warn.bind(console)
   postProcessHTML = async (_pathname: string, html: string) => html
@@ -605,7 +610,8 @@ export async function renderToHTMLImpl(
   let asPath: string = renderOpts.resolvedAsPath || (req.url as string)
 
   if (dev) {
-    const { isValidElementType } = require('next/dist/compiled/react-is')
+    const { isValidElementType } =
+      require('next/dist/compiled/react-is') as typeof import('next/dist/compiled/react-is')
     if (!isValidElementType(Component)) {
       throw new Error(
         `The default export is not a React Component in page: "${pathname}"`

--- a/packages/next/src/server/require-hook.ts
+++ b/packages/next/src/server/require-hook.ts
@@ -6,7 +6,9 @@
 const path = require('path') as typeof import('path')
 const mod = require('module') as typeof import('module')
 const originalRequire = mod.prototype.require
-const resolveFilename = mod._resolveFilename
+const resolveFilename =
+  // @ts-expect-error
+  mod._resolveFilename
 
 let resolve: typeof require.resolve = process.env.NEXT_MINIMAL
   ? // @ts-ignore
@@ -32,6 +34,7 @@ export function addHookAliases(aliases: [string, string][] = []) {
 
 addHookAliases(toResolveMap(defaultOverrides))
 
+// @ts-expect-error
 mod._resolveFilename = function (
   originalResolveFilename: (
     request: string,
@@ -53,6 +56,7 @@ mod._resolveFilename = function (
   // We use `bind` here to avoid referencing outside variables to create potential memory leaks.
 }.bind(null, resolveFilename, hookPropertyMap)
 
+// @ts-expect-error
 // This is a hack to make sure that if a user requires a Next.js module that wasn't bundled
 // that needs to point to the rendering runtime version, it will point to the correct one.
 // This can happen on `pages` when a user requires a dependency that uses next/image for example.

--- a/packages/next/src/server/require-hook.ts
+++ b/packages/next/src/server/require-hook.ts
@@ -3,8 +3,8 @@
 // Individually compiled modules are as defined for the compilation in bundles/webpack/packages/*.
 
 // This module will only be loaded once per process.
-const path = require('path')
-const mod = require('module')
+const path = require('path') as typeof import('path')
+const mod = require('module') as typeof import('module')
 const originalRequire = mod.prototype.require
 const resolveFilename = mod._resolveFilename
 

--- a/packages/next/src/server/route-modules/app-page/module.render.ts
+++ b/packages/next/src/server/route-modules/app-page/module.render.ts
@@ -4,8 +4,9 @@ export const lazyRenderAppPage: AppPageRender = (...args) => {
   if (process.env.NEXT_MINIMAL) {
     throw new Error("Can't use lazyRenderAppPage in minimal mode")
   } else {
-    const render: AppPageRender =
-      require('./module.compiled').renderToHTMLOrFlight
+    const render: AppPageRender = (
+      require('./module.compiled') as typeof import('./module.compiled')
+    ).renderToHTMLOrFlight
 
     return render(...args)
   }

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -23,8 +23,10 @@ let vendoredReactSSR
 
 // the vendored Reacts are loaded from their original source in the edge runtime
 if (process.env.NEXT_RUNTIME !== 'edge') {
-  vendoredReactRSC = require('./vendored/rsc/entrypoints')
-  vendoredReactSSR = require('./vendored/ssr/entrypoints')
+  vendoredReactRSC =
+    require('./vendored/rsc/entrypoints') as typeof import('./vendored/rsc/entrypoints')
+  vendoredReactSSR =
+    require('./vendored/ssr/entrypoints') as typeof import('./vendored/ssr/entrypoints')
 }
 
 /**

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -19,7 +19,8 @@ import type { ServerComponentsHmrCache } from '../../response-cache'
 import type { FallbackRouteParams } from '../../request/fallback-params'
 
 let vendoredReactRSC
-let vendoredReactSSR
+// TODO: Ship react-dom/server.edge types
+let vendoredReactSSR: any
 
 // the vendored Reacts are loaded from their original source in the edge runtime
 if (process.env.NEXT_RUNTIME !== 'edge') {

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/amp-context.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/amp-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].AmpContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].AmpContext

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/app-router-context.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/app-router-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].AppRouterContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].AppRouterContext

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/head-manager-context.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/head-manager-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].HeadManagerContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].HeadManagerContext

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/hooks-client-context.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/hooks-client-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].HooksClientContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].HooksClientContext

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/image-config-context.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/image-config-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].ImageConfigContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].ImageConfigContext

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/router-context.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/router-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].RouterContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].RouterContext

--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/server-inserted-html.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/server-inserted-html.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].ServerInsertedHtml
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].ServerInsertedHtml

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
@@ -37,7 +37,8 @@ let ReactServerDOMTurbopackStaticEdge, ReactServerDOMWebpackStaticEdge
 
 if (process.env.TURBOPACK) {
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMTurbopackServerEdge = require('react-server-dom-turbopack/server.edge')
+  ReactServerDOMTurbopackServerEdge =
+    require('react-server-dom-turbopack/server.edge') as typeof import('react-server-dom-turbopack/server.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackServerEdge = getAltProxyForBindingsDEV(
       'Turbopack',
@@ -45,7 +46,8 @@ if (process.env.TURBOPACK) {
     )
   }
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMTurbopackServerNode = require('react-server-dom-turbopack/server.node')
+  ReactServerDOMTurbopackServerNode =
+    require('react-server-dom-turbopack/server.node') as typeof import('react-server-dom-turbopack/server.node')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackServerNode = getAltProxyForBindingsDEV(
       'Turbopack',
@@ -53,7 +55,8 @@ if (process.env.TURBOPACK) {
     )
   }
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMTurbopackStaticEdge = require('react-server-dom-turbopack/static.edge')
+  ReactServerDOMTurbopackStaticEdge =
+    require('react-server-dom-turbopack/static.edge') as typeof import('react-server-dom-turbopack/static.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackStaticEdge = getAltProxyForBindingsDEV(
       'Turbopack',
@@ -62,7 +65,8 @@ if (process.env.TURBOPACK) {
   }
 } else {
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMWebpackServerEdge = require('react-server-dom-webpack/server.edge')
+  ReactServerDOMWebpackServerEdge =
+    require('react-server-dom-webpack/server.edge') as typeof import('react-server-dom-webpack/server.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackServerEdge = getAltProxyForBindingsDEV(
       'Webpack',
@@ -70,7 +74,8 @@ if (process.env.TURBOPACK) {
     )
   }
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMWebpackServerNode = require('react-server-dom-webpack/server.node')
+  ReactServerDOMWebpackServerNode =
+    require('react-server-dom-webpack/server.node') as typeof import('react-server-dom-webpack/server.node')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackServerNode = getAltProxyForBindingsDEV(
       'Webpack',
@@ -78,7 +83,8 @@ if (process.env.TURBOPACK) {
     )
   }
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMWebpackStaticEdge = require('react-server-dom-webpack/static.edge')
+  ReactServerDOMWebpackStaticEdge =
+    require('react-server-dom-webpack/static.edge') as typeof import('react-server-dom-webpack/static.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackStaticEdge = getAltProxyForBindingsDEV(
       'Webpack',

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
@@ -36,8 +36,9 @@ let ReactServerDOMTurbopackServerNode, ReactServerDOMWebpackServerNode
 let ReactServerDOMTurbopackStaticEdge, ReactServerDOMWebpackStaticEdge
 
 if (process.env.TURBOPACK) {
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMTurbopackServerEdge =
+    // @ts-expect-error -- TODO: Add types
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-turbopack/server.edge') as typeof import('react-server-dom-turbopack/server.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackServerEdge = getAltProxyForBindingsDEV(
@@ -45,8 +46,9 @@ if (process.env.TURBOPACK) {
       'react-server-dom-turbopack/server.edge'
     )
   }
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMTurbopackServerNode =
+    // @ts-expect-error -- TODO: Add types
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-turbopack/server.node') as typeof import('react-server-dom-turbopack/server.node')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackServerNode = getAltProxyForBindingsDEV(
@@ -54,8 +56,9 @@ if (process.env.TURBOPACK) {
       'react-server-dom-turbopack/server.node'
     )
   }
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMTurbopackStaticEdge =
+    // @ts-expect-error -- TODO: Add types
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-turbopack/static.edge') as typeof import('react-server-dom-turbopack/static.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackStaticEdge = getAltProxyForBindingsDEV(
@@ -64,8 +67,8 @@ if (process.env.TURBOPACK) {
     )
   }
 } else {
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMWebpackServerEdge =
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-webpack/server.edge') as typeof import('react-server-dom-webpack/server.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackServerEdge = getAltProxyForBindingsDEV(
@@ -73,8 +76,8 @@ if (process.env.TURBOPACK) {
       'react-server-dom-webpack/server.edge'
     )
   }
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMWebpackServerNode =
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-webpack/server.node') as typeof import('react-server-dom-webpack/server.node')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackServerNode = getAltProxyForBindingsDEV(
@@ -82,8 +85,8 @@ if (process.env.TURBOPACK) {
       'react-server-dom-webpack/server.node'
     )
   }
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMWebpackStaticEdge =
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-webpack/static.edge') as typeof import('react-server-dom-webpack/static.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackStaticEdge = getAltProxyForBindingsDEV(

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-compiler-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-compiler-runtime.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactCompilerRuntime
+).vendored['react-rsc']!.ReactCompilerRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-compiler-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-compiler-runtime.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactCompilerRuntime
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactCompilerRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-dom.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-dom.ts
@@ -1,1 +1,3 @@
-module.exports = require('../../module.compiled').vendored['react-rsc'].ReactDOM
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactDOM

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-dom.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-dom.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactDOM
+).vendored['react-rsc']!.ReactDOM

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactJsxDevRuntime
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactJsxDevRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactJsxDevRuntime
+).vendored['react-rsc']!.ReactJsxDevRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-runtime.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactJsxRuntime
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactJsxRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-jsx-runtime.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactJsxRuntime
+).vendored['react-rsc']!.ReactJsxRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactServerDOMTurbopackServerEdge
+).vendored['react-rsc']!.ReactServerDOMTurbopackServerEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactServerDOMTurbopackServerEdge
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactServerDOMTurbopackServerEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactServerDOMTurbopackServerNode
+).vendored['react-rsc']!.ReactServerDOMTurbopackServerNode

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactServerDOMTurbopackServerNode
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactServerDOMTurbopackServerNode

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactServerDOMTurbopackStaticEdge
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactServerDOMTurbopackStaticEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactServerDOMTurbopackStaticEdge
+).vendored['react-rsc']!.ReactServerDOMTurbopackStaticEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactServerDOMWebpackServerEdge
+).vendored['react-rsc']!.ReactServerDOMWebpackServerEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactServerDOMWebpackServerEdge
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactServerDOMWebpackServerEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactServerDOMWebpackServerNode
+).vendored['react-rsc']!.ReactServerDOMWebpackServerNode

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactServerDOMWebpackServerNode
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactServerDOMWebpackServerNode

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].ReactServerDOMWebpackStaticEdge
+).vendored['react-rsc']!.ReactServerDOMWebpackStaticEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-rsc'
-].ReactServerDOMWebpackStaticEdge
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].ReactServerDOMWebpackStaticEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react.ts
@@ -1,1 +1,3 @@
-module.exports = require('../../module.compiled').vendored['react-rsc'].React
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-rsc'].React

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/react.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/react.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-rsc'].React
+).vendored['react-rsc']!.React

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/entrypoints.ts
@@ -32,8 +32,9 @@ function getAltProxyForBindingsDEV(
 
 let ReactServerDOMTurbopackClientEdge, ReactServerDOMWebpackClientEdge
 if (process.env.TURBOPACK) {
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMTurbopackClientEdge =
+    // @ts-expect-error -- TODO: Add types
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-turbopack/client.edge') as typeof import('react-server-dom-turbopack/client.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackClientEdge = getAltProxyForBindingsDEV(
@@ -42,8 +43,8 @@ if (process.env.TURBOPACK) {
     )
   }
 } else {
-  // eslint-disable-next-line import/no-extraneous-dependencies
   ReactServerDOMWebpackClientEdge =
+    // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-webpack/client.edge') as typeof import('react-server-dom-webpack/client.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackClientEdge = getAltProxyForBindingsDEV(

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/entrypoints.ts
@@ -33,7 +33,8 @@ function getAltProxyForBindingsDEV(
 let ReactServerDOMTurbopackClientEdge, ReactServerDOMWebpackClientEdge
 if (process.env.TURBOPACK) {
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMTurbopackClientEdge = require('react-server-dom-turbopack/client.edge')
+  ReactServerDOMTurbopackClientEdge =
+    require('react-server-dom-turbopack/client.edge') as typeof import('react-server-dom-turbopack/client.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMWebpackClientEdge = getAltProxyForBindingsDEV(
       'Turbopack',
@@ -42,7 +43,8 @@ if (process.env.TURBOPACK) {
   }
 } else {
   // eslint-disable-next-line import/no-extraneous-dependencies
-  ReactServerDOMWebpackClientEdge = require('react-server-dom-webpack/client.edge')
+  ReactServerDOMWebpackClientEdge =
+    require('react-server-dom-webpack/client.edge') as typeof import('react-server-dom-webpack/client.edge')
   if (process.env.NODE_ENV === 'development') {
     ReactServerDOMTurbopackClientEdge = getAltProxyForBindingsDEV(
       'Webpack',

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-compiler-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-compiler-runtime.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-ssr'
-].ReactCompilerRuntime
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].ReactCompilerRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-compiler-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-compiler-runtime.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].ReactCompilerRuntime
+).vendored['react-ssr']!.ReactCompilerRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom-server-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom-server-edge.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].ReactDOMServerEdge
+).vendored['react-ssr']!.ReactDOMServerEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom-server-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom-server-edge.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-ssr'
-].ReactDOMServerEdge
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].ReactDOMServerEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom.ts
@@ -1,1 +1,3 @@
-module.exports = require('../../module.compiled').vendored['react-ssr'].ReactDOM
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].ReactDOM

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-dom.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].ReactDOM
+).vendored['react-ssr']!.ReactDOM

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-ssr'
-].ReactJsxDevRuntime
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].ReactJsxDevRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].ReactJsxDevRuntime
+).vendored['react-ssr']!.ReactJsxDevRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-runtime.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-ssr'
-].ReactJsxRuntime
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].ReactJsxRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-runtime.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-jsx-runtime.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].ReactJsxRuntime
+).vendored['react-ssr']!.ReactJsxRuntime

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].ReactServerDOMTurbopackClientEdge
+).vendored['react-ssr']!.ReactServerDOMTurbopackClientEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-ssr'
-].ReactServerDOMTurbopackClientEdge
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].ReactServerDOMTurbopackClientEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'react-ssr'
-].ReactServerDOMWebpackClientEdge
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].ReactServerDOMWebpackClientEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].ReactServerDOMWebpackClientEdge
+).vendored['react-ssr']!.ReactServerDOMWebpackClientEdge

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react.ts
@@ -1,1 +1,3 @@
-module.exports = require('../../module.compiled').vendored['react-ssr'].React
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['react-ssr'].React

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/react.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/react.ts
@@ -1,3 +1,3 @@
 module.exports = (
   require('../../module.compiled') as typeof import('../../module.compiled')
-).vendored['react-ssr'].React
+).vendored['react-ssr']!.React

--- a/packages/next/src/server/route-modules/pages/module.render.ts
+++ b/packages/next/src/server/route-modules/pages/module.render.ts
@@ -4,7 +4,9 @@ export const lazyRenderPagesPage: PagesRender = (...args) => {
   if (process.env.NEXT_MINIMAL) {
     throw new Error("Can't use lazyRenderPagesPage in minimal mode")
   } else {
-    const render: PagesRender = require('./module.compiled').renderToHTML
+    const render: PagesRender = (
+      require('./module.compiled') as typeof import('./module.compiled')
+    ).renderToHTML
 
     return render(...args)
   }

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/amp-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/amp-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].AmpContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].AmpContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/app-router-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/app-router-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].AppRouterContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].AppRouterContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/head-manager-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/head-manager-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].HeadManagerContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].HeadManagerContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/hooks-client-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/hooks-client-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].HooksClientContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].HooksClientContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/html-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/html-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].HtmlContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].HtmlContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/image-config-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/image-config-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].ImageConfigContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].ImageConfigContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/loadable-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/loadable-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].LoadableContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].LoadableContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/loadable.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/loadable.ts
@@ -1,1 +1,3 @@
-module.exports = require('../../module.compiled').vendored['contexts'].Loadable
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].Loadable

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/router-context.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/router-context.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].RouterContext
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].RouterContext

--- a/packages/next/src/server/route-modules/pages/vendored/contexts/server-inserted-html.ts
+++ b/packages/next/src/server/route-modules/pages/vendored/contexts/server-inserted-html.ts
@@ -1,3 +1,3 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].ServerInsertedHtml
+module.exports = (
+  require('../../module.compiled') as typeof import('../../module.compiled')
+).vendored['contexts'].ServerInsertedHtml

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -119,7 +119,7 @@ export abstract class RouteModule<
     // this is only handled here for node, for edge it
     // is handled in the adapter/loader instead
     if (process.env.NEXT_RUNTIME !== 'edge') {
-      const { join } = require('node:path')
+      const { join } = require('node:path') as typeof import('node:path')
       const projectDir =
         getRequestMeta(req, 'projectDir') ||
         join(process.cwd(), this.projectDir)
@@ -284,7 +284,7 @@ export abstract class RouteModule<
     // if we want to share the normalizing logic here
     // we will need to allow passing in the i18n and similar info
     if (process.env.NEXT_RUNTIME !== 'edge') {
-      const { join } = require('node:path')
+      const { join } = require('node:path') as typeof import('node:path')
       const projectDir =
         getRequestMeta(req, 'projectDir') ||
         join(process.cwd(), this.projectDir)

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -88,6 +88,7 @@ function ensureTestApisIntercepted() {
     testApisIntercepted = true
     if (process.env.NEXT_PRIVATE_TEST_PROXY === 'true') {
       const { interceptTestApis, wrapRequestHandler } =
+        // eslint-disable-next-line @next/internal/typechecked-require -- experimental/testmode is not built ins next/dist/esm
         require('next/dist/experimental/testmode/server-edge') as typeof import('../../experimental/testmode/server-edge')
       interceptTestApis()
       propagator = wrapRequestHandler(propagator)

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -40,8 +40,9 @@ if (process.env.NODE_ENV === 'development') {
   const middleware =
     require('../../../client/components/react-dev-overlay/server/middleware-webpack') as typeof import('../../../client/components/react-dev-overlay/server/middleware-webpack')
   getServerError = middleware.getServerError
-  decorateServerError =
-    require('../../../shared/lib/error-source').decorateServerError
+  decorateServerError = (
+    require('../../../shared/lib/error-source') as typeof import('../../../shared/lib/error-source')
+  ).decorateServerError
 } else {
   getServerError = (error: Error, _: string) => error
   decorateServerError = (_: Error, __: string) => {}

--- a/packages/next/src/shared/lib/bloom-filter.ts
+++ b/packages/next/src/shared/lib/bloom-filter.ts
@@ -51,9 +51,9 @@ export class BloomFilter {
     if (process.env.NEXT_RUNTIME === 'nodejs') {
       if (this.errorRate < DEFAULT_ERROR_RATE) {
         const filterData = JSON.stringify(data)
-        const gzipSize = require('next/dist/compiled/gzip-size').sync(
-          filterData
-        )
+        const gzipSize = (
+          require('next/dist/compiled/gzip-size') as typeof import('next/dist/compiled/gzip-size')
+        ).sync(filterData)
 
         if (gzipSize > 1024) {
           console.warn(

--- a/packages/next/src/shared/lib/image-loader.ts
+++ b/packages/next/src/shared/lib/image-loader.ts
@@ -68,7 +68,9 @@ function defaultLoader({
         // We use dynamic require because this should only error in development
         const { hasRemoteMatch } =
           require('./match-remote-pattern') as typeof import('./match-remote-pattern')
-        if (!hasRemoteMatch(config.domains, config.remotePatterns, parsedSrc)) {
+        if (
+          !hasRemoteMatch(config.domains!, config.remotePatterns!, parsedSrc)
+        ) {
           throw new Error(
             `Invalid src prop (${src}) on \`next/image\`, hostname "${parsedSrc.hostname}" is not configured under images in your \`next.config.js\`\n` +
               `See more info: https://nextjs.org/docs/messages/next-image-unconfigured-host`

--- a/packages/next/src/shared/lib/image-loader.ts
+++ b/packages/next/src/shared/lib/image-loader.ts
@@ -38,7 +38,8 @@ function defaultLoader({
         process.env.NEXT_RUNTIME !== 'edge'
       ) {
         // We use dynamic require because this should only error in development
-        const { hasLocalMatch } = require('./match-local-pattern')
+        const { hasLocalMatch } =
+          require('./match-local-pattern') as typeof import('./match-local-pattern')
         if (!hasLocalMatch(config.localPatterns, src)) {
           throw new Error(
             `Invalid src prop (${src}) on \`next/image\` does not match \`images.localPatterns\` configured in your \`next.config.js\`\n` +
@@ -65,7 +66,8 @@ function defaultLoader({
         process.env.NEXT_RUNTIME !== 'edge'
       ) {
         // We use dynamic require because this should only error in development
-        const { hasRemoteMatch } = require('./match-remote-pattern')
+        const { hasRemoteMatch } =
+          require('./match-remote-pattern') as typeof import('./match-remote-pattern')
         if (!hasRemoteMatch(config.domains, config.remotePatterns, parsedSrc)) {
           throw new Error(
             `Invalid src prop (${src}) on \`next/image\`, hostname "${parsedSrc.hostname}" is not configured under images in your \`next.config.js\`\n` +

--- a/packages/next/src/shared/lib/page-path/normalize-page-path.ts
+++ b/packages/next/src/shared/lib/page-path/normalize-page-path.ts
@@ -20,7 +20,7 @@ export function normalizePagePath(page: string): string {
         : ensureLeadingSlash(page)
 
   if (process.env.NEXT_RUNTIME !== 'edge') {
-    const { posix } = require('path')
+    const { posix } = require('path') as typeof import('path')
     const resolvedPage = posix.normalize(normalized)
     if (resolvedPage !== normalized) {
       throw new NormalizeError(

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -2125,7 +2125,8 @@ export default class Router implements BaseRouter {
         ))
 
       if (process.env.NODE_ENV !== 'production') {
-        const { isValidElementType } = require('next/dist/compiled/react-is')
+        const { isValidElementType } =
+          require('next/dist/compiled/react-is') as typeof import('next/dist/compiled/react-is')
         if (!isValidElementType(routeInfo.Component)) {
           throw new Error(
             `The default export is not a React Component in page: "${pathname}"`

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -171,7 +171,8 @@ export function formatIssue(issue: Issue) {
     !isInternal(filePath)
   ) {
     const { start, end } = source.range
-    const { codeFrameColumns } = require('next/dist/compiled/babel/code-frame')
+    const { codeFrameColumns } =
+      require('next/dist/compiled/babel/code-frame') as typeof import('next/dist/compiled/babel/code-frame')
 
     message +=
       codeFrameColumns(

--- a/packages/next/src/telemetry/events/version.ts
+++ b/packages/next/src/telemetry/events/version.ts
@@ -46,7 +46,9 @@ type EventCliSessionStarted = {
 function hasBabelConfig(dir: string): boolean {
   try {
     const noopFile = path.join(dir, 'noop.js')
-    const res = require('next/dist/compiled/babel/core').loadPartialConfig({
+    const res = (
+      require('next/dist/compiled/babel/core') as typeof import('next/dist/compiled/babel/core')
+    ).loadPartialConfig({
       cwd: dir,
       filename: noopFile,
       sourceFileName: noopFile,

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -411,6 +411,7 @@ declare module 'next/dist/compiled/amphtml-validator' {
   import m from 'amphtml-validator'
   export = m
 }
+declare module 'next/dist/compiled/@ampproject/toolbox-optimizer'
 
 declare module 'next/dist/compiled/superstruct' {
   import * as m from 'superstruct'
@@ -553,6 +554,9 @@ declare module 'next/dist/compiled/jsonwebtoken' {
 declare module 'next/dist/compiled/lodash.curry' {
   import m from 'lodash.curry'
   export = m
+}
+declare module 'next/dist/compiled/nanoid' {
+  export * from 'nanoid'
 }
 declare module 'next/dist/compiled/picomatch' {
   import m from 'picomatch'

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -455,6 +455,20 @@ declare module 'next/dist/compiled/babel/core-lib-normalize-file'
 declare module 'next/dist/compiled/babel/core-lib-normalize-opts'
 declare module 'next/dist/compiled/babel/core-lib-block-hoist-plugin'
 declare module 'next/dist/compiled/babel/core-lib-plugin-pass'
+declare module 'next/dist/compiled/babel/plugin-syntax-dynamic-import'
+declare module 'next/dist/compiled/babel/plugin-syntax-import-attributes'
+declare module 'next/dist/compiled/babel/plugin-proposal-class-properties'
+declare module 'next/dist/compiled/babel/plugin-proposal-object-rest-spread'
+declare module 'next/dist/compiled/babel/plugin-transform-runtime'
+declare module 'styled-jsx/babel-test'
+declare module 'styled-jsx/babel'
+declare module 'next/dist/compiled/babel/plugin-transform-react-remove-prop-types'
+declare module 'next/dist/compiled/babel/plugin-syntax-bigint'
+declare module 'next/dist/compiled/babel/plugin-proposal-numeric-separator'
+declare module 'next/dist/compiled/babel/plugin-proposal-export-namespace-from'
+declare module 'next/dist/compiled/babel/preset-env'
+declare module 'next/dist/compiled/babel/preset-react'
+declare module 'next/dist/compiled/babel/preset-typescript'
 
 declare module 'next/dist/compiled/bytes' {
   import m from 'bytes'
@@ -556,6 +570,7 @@ declare module 'next/dist/compiled/path-to-regexp' {
   import m from 'path-to-regexp'
   export = m
 }
+declare module 'next/dist/compiled/react-refresh/babel'
 declare module 'next/dist/compiled/send' {
   import m from 'send'
   export = m

--- a/packages/react-refresh-utils/ReactRefreshWebpackPlugin.ts
+++ b/packages/react-refresh-utils/ReactRefreshWebpackPlugin.ts
@@ -154,7 +154,12 @@ class ReactFreshWebpackPlugin {
   RuntimeModule: typeof WebpackRuntimeModule
   Template: typeof WebpackTemplate
   constructor(
-    { version, RuntimeGlobals, RuntimeModule, Template } = require('webpack')
+    {
+      version,
+      RuntimeGlobals,
+      RuntimeModule,
+      Template,
+    } = require('webpack') as typeof import('webpack')
   ) {
     this.webpackMajorVersion = parseInt(version ?? '', 10)
     this.RuntimeGlobals = RuntimeGlobals

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,6 +869,12 @@ importers:
         specifier: '>=3.3.1'
         version: 5.6.3
 
+  packages/eslint-plugin-internal:
+    devDependencies:
+      eslint:
+        specifier: 9.12.0
+        version: 9.12.0
+
   packages/eslint-plugin-next:
     dependencies:
       fast-glob:
@@ -8802,10 +8808,6 @@ packages:
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@4.1.0:
-    resolution: {integrity: sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@4.2.0:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
@@ -18223,7 +18225,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.41.0':
     dependencies:
       comment-parser: 1.4.1
-      esquery: 1.5.0
+      esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.0.0
 
   '@esbuild/aix-ppc64@0.23.1':
@@ -18462,7 +18464,6 @@ snapshots:
     dependencies:
       eslint: 9.12.0
       eslint-visitor-keys: 3.4.3
-    optional: true
 
   '@eslint-community/regexpp@4.11.0': {}
 
@@ -21108,7 +21109,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/amphtml-validator@1.0.0':
     dependencies:
@@ -21234,23 +21235,22 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 7.28.0
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/eslint@7.28.0':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.0':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.6': {}
 
-  '@types/estree@1.0.7':
-    optional: true
+  '@types/estree@1.0.7': {}
 
   '@types/events@3.0.0': {}
 
@@ -21775,7 +21775,7 @@ snapshots:
 
   '@typescript-eslint/utils@5.62.0(eslint@9.12.0)(typescript@5.8.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.12.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.12.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 5.62.0
@@ -21801,7 +21801,7 @@ snapshots:
 
   '@typescript-eslint/utils@8.0.0(eslint@9.12.0)(typescript@5.8.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.12.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.12.0)
       '@typescript-eslint/scope-manager': 8.0.0
       '@typescript-eslint/types': 8.0.0
       '@typescript-eslint/typescript-estree': 8.0.0(typescript@5.8.2)
@@ -25402,10 +25402,7 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.1.0: {}
-
-  eslint-visitor-keys@4.2.0:
-    optional: true
+  eslint-visitor-keys@4.2.0: {}
 
   eslint@7.32.0:
     dependencies:
@@ -25540,7 +25537,7 @@ snapshots:
 
   eslint@9.12.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.12.0)
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.12.0)
       '@eslint-community/regexpp': 4.11.1
       '@eslint/config-array': 0.18.0
       '@eslint/core': 0.6.0
@@ -25550,7 +25547,7 @@ snapshots:
       '@humanfs/node': 0.16.5
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.3.1
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
@@ -25558,7 +25555,7 @@ snapshots:
       debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.1.0
-      eslint-visitor-keys: 4.1.0
+      eslint-visitor-keys: 4.2.0
       espree: 10.2.0
       esquery: 1.6.0
       esutils: 2.0.3
@@ -25582,7 +25579,7 @@ snapshots:
     dependencies:
       acorn: 8.14.0
       acorn-jsx: 5.3.2(acorn@8.14.0)
-      eslint-visitor-keys: 4.1.0
+      eslint-visitor-keys: 4.2.0
 
   espree@7.3.1:
     dependencies:
@@ -25616,7 +25613,7 @@ snapshots:
 
   estree-util-attach-comments@2.1.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   estree-util-build-jsx@2.2.2:
     dependencies:
@@ -25654,7 +25651,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   esutils@2.0.3: {}
 
@@ -26756,7 +26753,7 @@ snapshots:
 
   hast-util-to-estree@2.2.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.0
       '@types/hast': 2.3.1
       '@types/unist': 2.0.3
@@ -27503,11 +27500,11 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   is-reference@3.0.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   is-regex@1.1.4:
     dependencies:
@@ -29371,7 +29368,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.2
       micromark-factory-space: 2.0.1
@@ -29404,7 +29401,7 @@ snapshots:
   micromark-extension-mdx-jsx@3.0.1:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.2
@@ -29455,7 +29452,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
       micromark-util-character: 2.1.1
@@ -29538,7 +29535,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -29656,7 +29653,7 @@ snapshots:
   micromark-util-events-to-acorn@1.2.1:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-util-visit: 1.2.1
       micromark-util-types: 1.0.2
       uvu: 0.5.6
@@ -29666,7 +29663,7 @@ snapshots:
   micromark-util-events-to-acorn@2.0.2:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -30895,7 +30892,7 @@ snapshots:
 
   periscopic@3.1.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 3.0.3
       is-reference: 3.0.1
 


### PR DESCRIPTION
We now enforce via ESLint that `require()` calls in `packages/**/*.tsx?` expose the types of the underlying module via `require(source) as typeof import(source)`.

The rule has an autofixer so all you have to do is write `require(source)` and get completions for `require(source) as typeof import(source)`.

When moving files, TS would adjust the `import(source)` so when the lint rules finds mismatches like `require(requireSource) as typeof import(importSource)`, we'll favor `importSource` i.e. will autofix to `require(importSource) as typeof import(importSource)`.

I disabled the lint rule for the scenarios where I didn't feel comfortable moving to relative imports e.g. https://github.com/vercel/next.js/pull/80056/files#diff-21d0b6f147bdd2dba7964674d5b7a9e3f2b7e2c4d1e5e5423069d9ea2dfe1a6fR13-R15