### PR TITLE
Turbopack Build: Implement locale:false middleware matcher

### DIFF
--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -385,6 +385,9 @@ async fn parse_route_matcher_from_js_value(
                                         matcher.original_source = value.into();
                                     }
                                 }
+                                Some("locale") => {
+                                    matcher.locale = value.as_bool().unwrap_or_default();
+                                }
                                 Some("missing") => {
                                     matcher.missing = Some(parse_matcher_kind_matcher(value))
                                 }

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -7141,12 +7141,11 @@
       "Middleware custom matchers i18n should not match /en/about",
       "Middleware custom matchers i18n should not match /hello/invalid",
       "Middleware custom matchers i18n should not match /invalid/hello",
-      "Middleware custom matchers with root should not match"
-    ],
-    "failed": [
+      "Middleware custom matchers with root should not match",
       "Middleware custom matchers i18n should match /nl-NL/about",
       "Middleware custom matchers i18n should match has query on client routing nl-NL_about"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Found `locale: false` matchers were 99% implemented but the value was not passed so it didn't work.

Closes PACK-4735