### PR TITLE
chore(ci): Disable flaky turbopack benchmarks

### DIFF
--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -45,7 +45,7 @@ jobs:
           tool: cargo-codspeed@2.10.1
 
       - name: Build the benchmark target(s)
-        run: cargo codspeed build -p turbo-rcstr -p turbopack-ecmascript
+        run: cargo codspeed build -p turbo-rcstr
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3


### PR DESCRIPTION
### What?

Disable flaky benchmarks for turbopack.

### Why?

Those benchmarks are very flaky even on local.

<img width="873" alt="image" src="https://github.com/user-attachments/assets/f3146200-7f48-4264-847f-7bd84db9a514" />


### How?



Closes PACK-4734