### PR TITLE
chore(turbopack): Update `rust-sourcemap` to `v9.2.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7171,8 +7171,9 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "9.2.1"
-source = "git+https://github.com/getsentry/rust-sourcemap?branch=master#24a07e376a634c7823ada1b55326454ba7fc921d"
+version = "9.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22afbcb92ce02d23815b9795523c005cb9d3c214f8b7a66318541c240ea7935"
 dependencies = [
  "base64-simd 0.8.0",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,7 +416,7 @@ smallvec = { version = "1.13.1", features = [
   "union",
   "const_new",
 ] }
-sourcemap = "9.2.1"
+sourcemap = "9.2.2"
 strsim = "0.11.1"
 shrink-to-fit = "0.2.10"
 swc-rustc-hash = { package = "rustc-hash", version = "1.1.0" } # used with swc
@@ -440,5 +440,3 @@ webbrowser = "0.8.7"
 
 [patch.crates-io]
 mdxjs = { git = "https://github.com/kdy1/mdxjs-rs", branch = "swc-core-26" }
-# Use unreleased version of sourcemap, in the name of performance
-sourcemap = { git = "https://github.com/getsentry/rust-sourcemap", branch = "master" }


### PR DESCRIPTION
### What?

Update the `sourcemap` crate to the latest

### Why?

A new version is released!

Closes PACK-4737