### PR TITLE
Refactor (App Router): Use direct dispatch for unhandled redirects

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -39,6 +39,7 @@ import { getSelectedParams } from './router-reducer/compute-changed-path'
 import type { FlightRouterState } from '../../server/app-render/types'
 import { useNavFailureHandler } from './nav-failure-handler'
 import {
+  dispatchNavigateAction,
   dispatchTraverseAction,
   publicAppRouterInstance,
   type AppRouterActionQueue,
@@ -285,12 +286,15 @@ function Router({
         event.preventDefault()
         const url = getURLFromRedirectError(error)
         const redirectType = getRedirectTypeFromError(error)
-        // TODO: This should access the router methods directly, rather than
-        // go through the public interface.
+
         if (redirectType === RedirectType.push) {
-          publicAppRouterInstance.push(url, {})
+          startTransition(() => {
+            dispatchNavigateAction(url, 'push', true, null)
+          })
         } else {
-          publicAppRouterInstance.replace(url, {})
+          startTransition(() => {
+            dispatchNavigateAction(url, 'replace', true, null)
+          })
         }
       }
     }


### PR DESCRIPTION
### Fixing a bug / Code Improvement

- Addresses an inline TODO comment in [packages/next/src/client/components/app-router.tsx#L288](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L288).

- **Tests added**: N/A; 
This change refactors an internal call pattern for an existing error handling mechanism. The core navigation logic dispatched by `dispatchNavigateAction` is already covered by existing tests for navigation and redirect handling. The functional behavior of `handleUnhandledRedirect` is intended to remain identical.

- **Errors**: N/A; 
This change does not introduce new user-facing errors.

---

### Description of Changes:

This PR refactors the `handleUnhandledRedirect` function within `packages/next/src/client/components/app-router.tsx`.

### What?
The handler previously used the public `publicAppRouterInstance.push/replace` methods to initiate navigation when an unhandled `RedirectError` is caught. This has been changed to directly call the lower-level internal function `dispatchNavigateAction`. The call to `dispatchNavigateAction` is wrapped in `startTransition` to maintain the existing non-blocking behavior.

**Before:**
```typescript
// TODO: This should access the router methods directly, rather than
// go through the public interface.
if (redirectType === RedirectType.push) {
  publicAppRouterInstance.push(url, {});
} else {
  publicAppRouterInstance.replace(url, {});
}
```
**After:**
```typescript
if (redirectType === RedirectType.push) {
  startTransition(() => {
    dispatchNavigateAction(url, 'push', true, null);
  });
} else {
  startTransition(() => {
    dispatchNavigateAction(url, 'replace', true, null);
  });
}
```

### Why?
This change aligns with the architectural direction for Next.js internals to utilize lower-level methods directly, rather than routing calls through the public API. This principle was articulated by @acdlite in PR #77426 (Lift public router instance to module level):

> "Right now, most internals go through the public interface, but going forward we should call the lower level methods directly."

This approach also mirrors the pattern established for the `<Link>` component's click handling, which was updated in PR #77300 (feat: useLinkStatus) to use dispatchNavigateAction directly.

By making this change, we improve internal consistency within the App Router and adhere more closely to the intended architectural layering. This is a step towards gradually decoupling the internal usage of `publicAppRouterInstance`, complementing other efforts such as the `TODO` noted for potentially removing `AppRouterContext` by forking the `useRouter` hook (see [packages/next/src/client/components/app-router.tsx#L543](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L543)).
### How?
The `publicAppRouterInstance.push/replace` calls were replaced with direct invocations of `dispatchNavigateAction`, passing the necessary parameters (`href, navigateType, shouldScroll: true, linkInstanceRef: null`) and wrapping the operation in `startTransition`.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
