### PR TITLE
[turbopack] Eliminate many calls to `into` and from and cell involving RcStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10180,6 +10180,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_with",
+ "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, time::Instant};
 use tracing::Instrument;
 use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Effects, FxIndexSet, NonLocalValue, OperationValue, OperationVc, ReadRef,
     ResolvedVc, TaskInput, TransientInstance, TryJoinIterExt, UpdateInfo, Vc, get_effects,
@@ -426,7 +426,7 @@ pub async fn project_new(
     let options: ProjectOptions = options.into();
     let container = turbo_tasks
         .run_once(async move {
-            let project = ProjectContainer::new("next.js".into(), options.dev);
+            let project = ProjectContainer::new(rcstr!("next.js"), options.dev);
             let project = project.to_resolved().await?;
             project.initialize(options).await?;
             Ok(project)

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -821,7 +821,7 @@ impl AppProject {
         let client_main_module = cjs_resolve(
             Vc::upcast(PlainResolveOrigin::new(
                 client_module_context,
-                self.project().project_path().join("_".into()),
+                self.project().project_path().join(rcstr!("_")),
             )),
             Request::parse(Value::new(Pattern::Constant(rcstr!(
                 "next/dist/client/app-next-turbopack.js"
@@ -1177,7 +1177,7 @@ impl AppEndpoint {
 
         let node_root = project.node_root().to_resolved().await?;
         let client_relative_path = project.client_relative_path().to_resolved().await?;
-        let server_path = node_root.join("server".into());
+        let server_path = node_root.join(rcstr!("server"));
 
         let mut server_assets = fxindexset![];
         let mut client_assets = fxindexset![];
@@ -1318,11 +1318,11 @@ impl AppEndpoint {
         // load it as a RawModule.
         let next_package = get_next_package(project.project_path());
         let polyfill_source =
-            FileSource::new(next_package.join("dist/build/polyfills/polyfill-nomodule.js".into()));
+            FileSource::new(next_package.join(rcstr!("dist/build/polyfills/polyfill-nomodule.js")));
         let polyfill_output_path = client_chunking_context.chunk_path(
             Some(Vc::upcast(polyfill_source)),
             polyfill_source.ident(),
-            ".js".into(),
+            rcstr!(".js"),
         );
         let polyfill_output_asset = ResolvedVc::upcast(
             RawOutput::new(polyfill_output_path, Vc::upcast(polyfill_source))
@@ -1482,10 +1482,10 @@ impl AppEndpoint {
                 //
                 // they are created in `setup-dev-bundler.ts`
                 let mut file_paths_from_root = fxindexset![
-                    "server/server-reference-manifest.js".into(),
-                    "server/middleware-build-manifest.js".into(),
-                    "server/next-font-manifest.js".into(),
-                    "server/interception-route-rewrite-manifest.js".into(),
+                    rcstr!("server/server-reference-manifest.js"),
+                    rcstr!("server/middleware-build-manifest.js"),
+                    rcstr!("server/next-font-manifest.js"),
+                    rcstr!("server/interception-route-rewrite-manifest.js"),
                 ];
                 let mut wasm_paths_from_root = fxindexset![];
 
@@ -1506,7 +1506,7 @@ impl AppEndpoint {
                 let all_assets =
                     get_asset_paths_from_root(&node_root_value, &all_output_assets).await?;
 
-                let entry_file = "app-edge-has-no-entrypoint".into();
+                let entry_file = rcstr!("app-edge-has-no-entrypoint");
 
                 if emit_manifests == EmitManifests::Full {
                     let dynamic_import_entries = collect_next_dynamic_chunks(

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -6,7 +6,7 @@ use next_core::{
     next_server::{ServerContextType, get_server_runtime_entries},
 };
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -85,7 +85,7 @@ impl InstrumentationEndpoint {
             *self.asset_context,
             self.project.project_path(),
             *userland_module,
-            "instrumentation".into(),
+            rcstr!("instrumentation"),
         )
         .to_resolved()
         .await?;
@@ -148,7 +148,7 @@ impl InstrumentationEndpoint {
             .entry_chunk_group(
                 this.project
                     .node_root()
-                    .join("server/instrumentation.js".into()),
+                    .join(rcstr!("server/instrumentation.js")),
                 get_server_runtime_entries(
                     Value::new(ServerContextType::Instrumentation {
                         app_dir: this.app_dir,
@@ -190,7 +190,7 @@ impl InstrumentationEndpoint {
             let instrumentation_definition = InstrumentationDefinition {
                 files: file_paths_from_root,
                 wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
-                name: "instrumentation".into(),
+                name: rcstr!("instrumentation"),
                 ..Default::default()
             };
             let middleware_manifest_v2 = MiddlewaresManifestV2 {
@@ -198,7 +198,7 @@ impl InstrumentationEndpoint {
                 ..Default::default()
             };
             let middleware_manifest_v2 = VirtualOutputAsset::new(
-                node_root.join("server/instrumentation/middleware-manifest.json".into()),
+                node_root.join(rcstr!("server/instrumentation/middleware-manifest.json")),
                 AssetContent::file(
                     FileContent::Content(File::from(serde_json::to_string_pretty(
                         &middleware_manifest_v2,

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -44,7 +44,7 @@ pub struct InstrumentationEndpoint {
     is_edge: bool,
 
     app_dir: Option<ResolvedVc<FileSystemPath>>,
-    ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+    ecmascript_client_reference_transition_name: Option<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
@@ -56,7 +56,7 @@ impl InstrumentationEndpoint {
         source: ResolvedVc<Box<dyn Source>>,
         is_edge: bool,
         app_dir: Option<ResolvedVc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<RcStr>,
     ) -> Vc<Self> {
         Self {
             project,
@@ -108,7 +108,8 @@ impl InstrumentationEndpoint {
             Value::new(ServerContextType::Instrumentation {
                 app_dir: this.app_dir,
                 ecmascript_client_reference_transition_name: this
-                    .ecmascript_client_reference_transition_name,
+                    .ecmascript_client_reference_transition_name
+                    .clone(),
             }),
             this.project.next_mode(),
         )
@@ -152,7 +153,8 @@ impl InstrumentationEndpoint {
                     Value::new(ServerContextType::Instrumentation {
                         app_dir: this.app_dir,
                         ecmascript_client_reference_transition_name: this
-                            .ecmascript_client_reference_transition_name,
+                            .ecmascript_client_reference_transition_name
+                            .clone(),
                     }),
                     this.project.next_mode(),
                 )

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -47,7 +47,7 @@ pub struct MiddlewareEndpoint {
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
     source: ResolvedVc<Box<dyn Source>>,
     app_dir: Option<ResolvedVc<FileSystemPath>>,
-    ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+    ecmascript_client_reference_transition_name: Option<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
@@ -58,7 +58,7 @@ impl MiddlewareEndpoint {
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
         source: ResolvedVc<Box<dyn Source>>,
         app_dir: Option<ResolvedVc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<RcStr>,
     ) -> Vc<Self> {
         Self {
             project,
@@ -110,7 +110,8 @@ impl MiddlewareEndpoint {
             Value::new(ServerContextType::Middleware {
                 app_dir: this.app_dir,
                 ecmascript_client_reference_transition_name: this
-                    .ecmascript_client_reference_transition_name,
+                    .ecmascript_client_reference_transition_name
+                    .clone(),
             }),
             this.project.next_mode(),
         )
@@ -151,7 +152,8 @@ impl MiddlewareEndpoint {
                     Value::new(ServerContextType::Middleware {
                         app_dir: this.app_dir,
                         ecmascript_client_reference_transition_name: this
-                            .ecmascript_client_reference_transition_name,
+                            .ecmascript_client_reference_transition_name
+                            .clone(),
                     }),
                     this.project.next_mode(),
                 )

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -10,7 +10,7 @@ use next_core::{
     util::{MiddlewareMatcherKind, NextRuntime, parse_config_from_source},
 };
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -95,7 +95,7 @@ impl MiddlewareEndpoint {
             *self.asset_context,
             self.project.project_path(),
             module,
-            "middleware".into(),
+            rcstr!("middleware"),
         ))
     }
 
@@ -147,7 +147,9 @@ impl MiddlewareEndpoint {
 
         let EntryChunkGroupResult { asset: chunk, .. } = *chunking_context
             .entry_chunk_group(
-                this.project.node_root().join("server/middleware.js".into()),
+                this.project
+                    .node_root()
+                    .join(rcstr!("server/middleware.js")),
                 get_server_runtime_entries(
                     Value::new(ServerContextType::Middleware {
                         app_dir: this.app_dir,
@@ -235,8 +237,8 @@ impl MiddlewareEndpoint {
                 .collect()
         } else {
             vec![MiddlewareMatcher {
-                regexp: Some("^/.*$".into()),
-                original_source: "/:path*".into(),
+                regexp: Some(rcstr!("^/.*$")),
+                original_source: rcstr!("/:path*"),
                 ..Default::default()
             }]
         };
@@ -258,7 +260,7 @@ impl MiddlewareEndpoint {
             let middleware_manifest_v2 = VirtualOutputAsset::new(
                 this.project
                     .node_root()
-                    .join("server/middleware/middleware-manifest.json".into()),
+                    .join(rcstr!("server/middleware/middleware-manifest.json")),
                 AssetContent::file(
                     FileContent::Content(File::from(serde_json::to_string_pretty(
                         &middleware_manifest_v2,
@@ -305,20 +307,20 @@ impl MiddlewareEndpoint {
                 files: file_paths_from_root,
                 wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                 assets: paths_to_bindings(all_assets),
-                name: "middleware".into(),
-                page: "/".into(),
+                name: rcstr!("middleware"),
+                page: rcstr!("/"),
                 regions,
                 matchers: matchers.clone(),
                 env: this.project.edge_env().owned().await?,
             };
             let middleware_manifest_v2 = MiddlewaresManifestV2 {
-                middleware: [("/".into(), edge_function_definition)]
+                middleware: [(rcstr!("/"), edge_function_definition)]
                     .into_iter()
                     .collect(),
                 ..Default::default()
             };
             let middleware_manifest_v2 = VirtualOutputAsset::new(
-                node_root.join("server/middleware/middleware-manifest.json".into()),
+                node_root.join(rcstr!("server/middleware/middleware-manifest.json")),
                 AssetContent::file(
                     FileContent::Content(File::from(serde_json::to_string_pretty(
                         &middleware_manifest_v2,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -277,7 +277,7 @@ impl PagesProject {
         Ok(if let Some(pages) = self.pages_structure().await?.pages {
             pages.project_path()
         } else {
-            self.project().project_path().join("pages".into())
+            self.project().project_path().join(rcstr!("pages"))
         })
     }
 
@@ -286,11 +286,11 @@ impl PagesProject {
         Ok(TransitionOptions {
             named_transitions: [
                 (
-                    "next-dynamic".into(),
+                    rcstr!("next-dynamic"),
                     ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
                 ),
                 (
-                    "next-dynamic-client".into(),
+                    rcstr!("next-dynamic-client"),
                     ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
                 ),
             ]
@@ -306,11 +306,11 @@ impl PagesProject {
         Ok(TransitionOptions {
             named_transitions: [
                 (
-                    "next-dynamic".into(),
+                    rcstr!("next-dynamic"),
                     ResolvedVc::upcast(NextDynamicTransition::new_marker().to_resolved().await?),
                 ),
                 (
-                    "next-dynamic-client".into(),
+                    rcstr!("next-dynamic-client"),
                     ResolvedVc::upcast(
                         NextDynamicTransition::new_client(Vc::upcast(self.client_transition()))
                             .to_resolved()
@@ -627,7 +627,7 @@ impl PagesProject {
         let client_main_module = esm_resolve(
             Vc::upcast(PlainResolveOrigin::new(
                 client_module_context,
-                self.project().project_path().join("_".into()),
+                self.project().project_path().join(rcstr!("_")),
             )),
             Request::parse(Value::new(Pattern::Constant(
                 match *self.project().next_mode().await? {
@@ -1148,7 +1148,7 @@ impl PageEndpoint {
             this.pages_project
                 .project()
                 .node_root()
-                .join("server".into()),
+                .join(rcstr!("server")),
             project.server_chunking_context(true),
             project.edge_chunking_context(true),
             this.pages_project.ssr_runtime_entries(),
@@ -1164,7 +1164,7 @@ impl PageEndpoint {
             this.pages_project
                 .project()
                 .node_root()
-                .join("server/data".into()),
+                .join(rcstr!("server/data")),
             this.pages_project.project().server_chunking_context(true),
             this.pages_project.project().edge_chunking_context(true),
             this.pages_project.ssr_data_runtime_entries(),
@@ -1371,9 +1371,9 @@ impl PageEndpoint {
                     //
                     // they are created in `setup-dev-bundler.ts`
                     let mut file_paths_from_root = vec![
-                        "server/server-reference-manifest.js".into(),
-                        "server/middleware-build-manifest.js".into(),
-                        "server/next-font-manifest.js".into(),
+                        rcstr!("server/server-reference-manifest.js"),
+                        rcstr!("server/middleware-build-manifest.js"),
+                        rcstr!("server/next-font-manifest.js"),
                     ];
                     let mut wasm_paths_from_root = fxindexset![];
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -110,8 +110,8 @@ impl PagesProject {
             routes: &mut FxIndexMap<RcStr, Route>,
             page: Vc<PagesStructureItem>,
             make_route: impl Fn(
-                Vc<RcStr>,
-                Vc<RcStr>,
+                RcStr,
+                RcStr,
                 Vc<PagesStructureItem>,
             ) -> BoxFuture<'static, Result<Route>>,
         ) -> Result<()> {
@@ -121,9 +121,8 @@ impl PagesProject {
                 ..
             } = *page.await?;
             let pathname: RcStr = format!("/{}", next_router_path.await?.path).into();
-            let pathname_vc = Vc::cell(pathname.clone());
-            let original_name = Vc::cell(format!("/{}", original_path.await?.path).into());
-            let route = make_route(pathname_vc, original_name, page).await?;
+            let original_name = format!("/{}", original_path.await?.path).into();
+            let route = make_route(pathname.clone(), original_name, page).await?;
             routes.insert(pathname, route);
             Ok(())
         }
@@ -132,8 +131,8 @@ impl PagesProject {
             routes: &mut FxIndexMap<RcStr, Route>,
             dir: Vc<PagesDirectoryStructure>,
             make_route: impl Fn(
-                Vc<RcStr>,
-                Vc<RcStr>,
+                RcStr,
+                RcStr,
                 Vc<PagesStructureItem>,
             ) -> BoxFuture<'static, Result<Route>>,
         ) -> Result<()> {
@@ -177,15 +176,15 @@ impl PagesProject {
             .await?;
         }
 
-        let make_page_route = |pathname, original_name, page| -> BoxFuture<_> {
+        let make_page_route = |pathname: RcStr, original_name: RcStr, page| -> BoxFuture<_> {
             Box::pin(async move {
                 Ok(Route::Page {
                     html_endpoint: ResolvedVc::upcast(
                         PageEndpoint::new(
                             PageEndpointType::Html,
                             self,
-                            pathname,
-                            original_name,
+                            pathname.clone(),
+                            original_name.clone(),
                             page,
                             pages_structure,
                         )
@@ -227,12 +226,11 @@ impl PagesProject {
             ..
         } = *item.await?;
         let pathname: RcStr = format!("/{}", next_router_path.await?.path).into();
-        let pathname_vc = Vc::cell(pathname.clone());
-        let original_name = Vc::cell(format!("/{}", original_path.await?.path).into());
+        let original_name = format!("/{}", original_path.await?.path).into();
         let endpoint = Vc::upcast(PageEndpoint::new(
             ty,
             self,
-            pathname_vc,
+            pathname,
             original_name,
             item,
             self.pages_structure(),
@@ -655,8 +653,8 @@ impl PagesProject {
 struct PageEndpoint {
     ty: PageEndpointType,
     pages_project: ResolvedVc<PagesProject>,
-    pathname: ResolvedVc<RcStr>,
-    original_name: ResolvedVc<RcStr>,
+    pathname: RcStr,
+    original_name: RcStr,
     page: ResolvedVc<PagesStructureItem>,
     pages_structure: ResolvedVc<PagesStructure>,
 }
@@ -706,8 +704,8 @@ impl PageEndpoint {
     fn new(
         ty: PageEndpointType,
         pages_project: ResolvedVc<PagesProject>,
-        pathname: ResolvedVc<RcStr>,
-        original_name: ResolvedVc<RcStr>,
+        pathname: RcStr,
+        original_name: RcStr,
         page: ResolvedVc<PagesStructureItem>,
         pages_structure: ResolvedVc<PagesStructure>,
     ) -> Vc<Self> {
@@ -733,7 +731,7 @@ impl PageEndpoint {
         let page_loader = create_page_loader_entry_module(
             Vc::upcast(this.pages_project.client_module_context()),
             self.source(),
-            *this.pathname,
+            this.pathname.clone(),
         );
         if matches!(
             *this.pages_project.project().next_mode().await?,
@@ -865,7 +863,7 @@ impl PageEndpoint {
         let client_relative_path = self.client_relative_path();
         let page_loader = PageLoaderAsset::new(
             node_root,
-            *this.pathname,
+            this.pathname.clone(),
             client_relative_path,
             client_chunks,
         );
@@ -902,13 +900,12 @@ impl PageEndpoint {
             .module();
 
         let config = parse_config_from_source(ssr_module, NextRuntime::default()).await?;
-        let pathname = &**this.pathname.await?;
 
         Ok(
             // `/_app` and `/_document` never get rendered directly so they don't need to be
             // wrapped in the route module, and don't need to be handled as edge runtime as the
             // rendering for edge is part of the page bundle.
-            if pathname == "/_app" || pathname == "/_document" {
+            if this.pathname == "/_app" || this.pathname == "/_document" {
                 InternalSsrChunkModule {
                     ssr_module: ssr_module.to_resolved().await?,
                     app_module: None,
@@ -920,12 +917,12 @@ impl PageEndpoint {
                 }
             } else if config.runtime == NextRuntime::Edge {
                 let modules = create_page_ssr_entry_module(
-                    *this.pathname,
+                    this.pathname.clone(),
                     reference_type,
                     project_root,
                     Vc::upcast(edge_module_context),
                     self.source(),
-                    *this.original_name,
+                    this.original_name.clone(),
                     *this.pages_structure,
                     config.runtime,
                     this.pages_project.project().next_config(),
@@ -941,12 +938,12 @@ impl PageEndpoint {
                 }
             } else {
                 let modules = create_page_ssr_entry_module(
-                    *this.pathname,
+                    this.pathname.clone(),
                     reference_type,
                     project_root,
                     Vc::upcast(module_context),
                     self.source(),
-                    *this.original_name,
+                    this.original_name.clone(),
                     *this.pages_structure,
                     config.runtime,
                     this.pages_project.project().next_config(),
@@ -1082,7 +1079,7 @@ impl PageEndpoint {
                 }
                 .cell())
             } else {
-                let pathname = &**this.pathname.await?;
+                let pathname = &this.pathname;
 
                 let asset_path = get_asset_path_from_pathname(pathname, ".js");
 
@@ -1183,7 +1180,7 @@ impl PageEndpoint {
             this.pages_project
                 .project()
                 .node_root()
-                .join("server".into()),
+                .join(rcstr!("server")),
             this.pages_project.project().server_chunking_context(false),
             this.pages_project.project().edge_chunking_context(false),
             this.pages_project.ssr_runtime_entries(),
@@ -1200,17 +1197,17 @@ impl PageEndpoint {
         let chunk_path = entry_chunk.path().await?;
 
         let asset_path = node_root
-            .join("server".into())
+            .join(rcstr!("server"))
             .await?
             .get_path_to(&chunk_path)
             .context("ssr chunk entry path must be inside the node root")?;
 
         let pages_manifest = PagesManifest {
-            pages: [(self.pathname.owned().await?, asset_path.into())]
+            pages: [(self.pathname.clone(), asset_path.into())]
                 .into_iter()
                 .collect(),
         };
-        let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname.await?);
+        let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
         let asset = Vc::upcast(VirtualOutputAsset::new(
             node_root
                 .join(format!("server/pages{manifest_path_prefix}/pages-manifest.json",).into()),
@@ -1227,7 +1224,7 @@ impl PageEndpoint {
     ) -> Result<Vc<OutputAssets>> {
         let node_root = self.pages_project.project().node_root();
         let client_relative_path = self.pages_project.project().client_relative_path();
-        let loadable_path_prefix = get_asset_prefix_from_pathname(&self.pathname.await?);
+        let loadable_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
         Ok(create_react_loadable_manifest(
             dynamic_import_entries,
             client_relative_path,
@@ -1245,10 +1242,10 @@ impl PageEndpoint {
         let node_root = self.pages_project.project().node_root();
         let client_relative_path = self.pages_project.project().client_relative_path();
         let build_manifest = BuildManifest {
-            pages: fxindexmap!(self.pathname.owned().await? => client_chunks),
+            pages: fxindexmap!(self.pathname.clone() => client_chunks),
             ..Default::default()
         };
-        let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname.await?);
+        let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
         Ok(Vc::upcast(
             build_manifest
                 .build_output(
@@ -1284,12 +1281,12 @@ impl PageEndpoint {
         };
         let emit_manifests = !matches!(this.ty, PageEndpointType::Data);
 
-        let pathname = this.pathname.owned().await?;
-        let original_name = &*this.original_name.await?;
+        let pathname = &this.pathname;
+        let original_name = &this.original_name;
 
         let client_assets = OutputAssets::new(client_assets).to_resolved().await?;
 
-        let manifest_path_prefix = get_asset_prefix_from_pathname(&pathname);
+        let manifest_path_prefix = get_asset_prefix_from_pathname(pathname);
         let node_root = this.pages_project.project().node_root();
         let next_font_manifest_output = create_font_manifest(
             this.pages_project.project().client_root(),
@@ -1297,7 +1294,7 @@ impl PageEndpoint {
             this.pages_project.pages_dir(),
             original_name,
             &manifest_path_prefix,
-            &pathname,
+            pathname,
             *client_assets,
             false,
         )
@@ -1398,7 +1395,7 @@ impl PageEndpoint {
                     let all_assets =
                         get_asset_paths_from_root(&node_root_value, &all_output_assets).await?;
 
-                    let named_regex = get_named_middleware_regex(&pathname).into();
+                    let named_regex = get_named_middleware_regex(pathname).into();
                     let matchers = MiddlewareMatcher {
                         regexp: Some(named_regex),
                         original_source: pathname.clone(),
@@ -1416,13 +1413,12 @@ impl PageEndpoint {
                         None
                     };
 
-                    let original_name = this.original_name.owned().await?;
                     let edge_function_definition = EdgeFunctionDefinition {
                         files: file_paths_from_root,
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                         assets: paths_to_bindings(all_assets),
                         name: pathname.clone(),
-                        page: original_name.clone(),
+                        page: this.original_name.clone(),
                         regions,
                         matchers: vec![matchers],
                         env: this.pages_project.project().edge_env().owned().await?,
@@ -1434,8 +1430,7 @@ impl PageEndpoint {
                             .collect(),
                         ..Default::default()
                     };
-                    let manifest_path_prefix =
-                        get_asset_prefix_from_pathname(&this.pathname.await?);
+                    let manifest_path_prefix = get_asset_prefix_from_pathname(&this.pathname);
                     let middleware_manifest_v2 = VirtualOutputAsset::new(
                         node_root.join(
                             format!("server/pages{manifest_path_prefix}/middleware-manifest.json")
@@ -1489,10 +1484,10 @@ pub struct InternalSsrChunkModule {
 impl Endpoint for PageEndpoint {
     #[turbo_tasks::function]
     async fn output(self: ResolvedVc<Self>) -> Result<Vc<EndpointOutput>> {
-        let this = self.await?;
-        let original_name = this.original_name.await?;
+        let this = &*self.await?;
+        let original_name = &this.original_name;
         let span = {
-            match this.ty {
+            match &this.ty {
                 PageEndpointType::Html => {
                     tracing::info_span!("page endpoint HTML", name = original_name.to_string())
                 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -70,7 +70,7 @@ use turbopack_node::execution_context::ExecutionContext;
 use turbopack_nodejs::NodeJsChunkingContext;
 
 use crate::{
-    app::{AppProject, ECMASCRIPT_CLIENT_TRANSITION_NAME, OptionAppProject},
+    app::{AppProject, OptionAppProject},
     empty::EmptyEndpoint,
     entrypoints::Entrypoints,
     instrumentation::InstrumentationEndpoint,
@@ -779,10 +779,10 @@ impl Project {
             NodeJsChunkingContext::builder(
                 self.project_root_path().to_resolved().await?,
                 node_root,
-                self.node_root_to_root_path().to_resolved().await?,
+                self.node_root_to_root_path().owned().await?,
                 node_root,
-                node_root.join("build/chunks".into()).to_resolved().await?,
-                node_root.join("build/assets".into()).to_resolved().await?,
+                node_root.join(rcstr!("build/chunks")).to_resolved().await?,
+                node_root.join(rcstr!("build/assets")).to_resolved().await?,
                 node_build_environment().to_resolved().await?,
                 next_mode.runtime_type(),
             )
@@ -984,45 +984,47 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) fn edge_env(&self) -> Vc<EnvMap> {
         let edge_env = fxindexmap! {
-            "__NEXT_BUILD_ID".into() => self.build_id.clone(),
-            "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY".into() => self.encryption_key.clone(),
-            "__NEXT_PREVIEW_MODE_ID".into() => self.preview_props.preview_mode_id.clone(),
-            "__NEXT_PREVIEW_MODE_ENCRYPTION_KEY".into() => self.preview_props.preview_mode_encryption_key.clone(),
-            "__NEXT_PREVIEW_MODE_SIGNING_KEY".into() => self.preview_props.preview_mode_signing_key.clone(),
+            rcstr!("__NEXT_BUILD_ID") => self.build_id.clone(),
+            rcstr!("NEXT_SERVER_ACTIONS_ENCRYPTION_KEY") => self.encryption_key.clone(),
+            rcstr!("__NEXT_PREVIEW_MODE_ID") => self.preview_props.preview_mode_id.clone(),
+            rcstr!("__NEXT_PREVIEW_MODE_ENCRYPTION_KEY") => self.preview_props.preview_mode_encryption_key.clone(),
+            rcstr!("__NEXT_PREVIEW_MODE_SIGNING_KEY") => self.preview_props.preview_mode_signing_key.clone(),
         };
         Vc::cell(edge_env)
     }
 
     #[turbo_tasks::function]
-    pub(super) fn client_chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>> {
-        get_client_chunking_context(
+    pub(super) async fn client_chunking_context(
+        self: Vc<Self>,
+    ) -> Result<Vc<Box<dyn ChunkingContext>>> {
+        Ok(get_client_chunking_context(
             self.project_root_path(),
             self.client_relative_path(),
-            Vc::cell("/ROOT".into()),
-            self.next_config().computed_asset_prefix(),
-            self.next_config().chunk_suffix_path(),
+            rcstr!("/ROOT"),
+            self.next_config().computed_asset_prefix().owned().await?,
+            self.next_config().chunk_suffix_path().owned().await?,
             self.client_compile_time_info().environment(),
             self.next_mode(),
             self.module_ids(),
             self.next_config().turbo_minify(self.next_mode()),
             self.next_config().client_source_maps(self.next_mode()),
             self.no_mangling(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
-    pub(super) fn server_chunking_context(
+    pub(super) async fn server_chunking_context(
         self: Vc<Self>,
         client_assets: bool,
-    ) -> Vc<NodeJsChunkingContext> {
-        if client_assets {
+    ) -> Result<Vc<NodeJsChunkingContext>> {
+        Ok(if client_assets {
             get_server_chunking_context_with_client_assets(
                 self.next_mode(),
                 self.project_root_path(),
                 self.node_root(),
-                self.node_root_to_root_path(),
+                self.node_root_to_root_path().owned().await?,
                 self.client_relative_path(),
-                self.next_config().computed_asset_prefix(),
+                self.next_config().computed_asset_prefix().owned().await?,
                 self.server_compile_time_info().environment(),
                 self.module_ids(),
                 self.next_config().turbo_minify(self.next_mode()),
@@ -1034,29 +1036,29 @@ impl Project {
                 self.next_mode(),
                 self.project_root_path(),
                 self.node_root(),
-                self.node_root_to_root_path(),
+                self.node_root_to_root_path().owned().await?,
                 self.server_compile_time_info().environment(),
                 self.module_ids(),
                 self.next_config().turbo_minify(self.next_mode()),
                 self.next_config().server_source_maps(),
                 self.no_mangling(),
             )
-        }
+        })
     }
 
     #[turbo_tasks::function]
-    pub(super) fn edge_chunking_context(
+    pub(super) async fn edge_chunking_context(
         self: Vc<Self>,
         client_assets: bool,
-    ) -> Vc<Box<dyn ChunkingContext>> {
-        if client_assets {
+    ) -> Result<Vc<Box<dyn ChunkingContext>>> {
+        Ok(if client_assets {
             get_edge_chunking_context_with_client_assets(
                 self.next_mode(),
                 self.project_root_path(),
                 self.node_root(),
-                self.node_root_to_root_path(),
+                self.node_root_to_root_path().owned().await?,
                 self.client_relative_path(),
-                self.next_config().computed_asset_prefix(),
+                self.next_config().computed_asset_prefix().owned().await?,
                 self.edge_compile_time_info().environment(),
                 self.module_ids(),
                 self.next_config().turbo_minify(self.next_mode()),
@@ -1068,14 +1070,14 @@ impl Project {
                 self.next_mode(),
                 self.project_root_path(),
                 self.node_root(),
-                self.node_root_to_root_path(),
+                self.node_root_to_root_path().owned().await?,
                 self.edge_compile_time_info().environment(),
                 self.module_ids(),
                 self.next_config().turbo_minify(self.next_mode()),
                 self.next_config().server_source_maps(),
                 self.no_mangling(),
             )
-        }
+        })
     }
 
     #[turbo_tasks::function]
@@ -1264,14 +1266,12 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let app_project = *self.app_project().await?;
 
-        let ecmascript_client_reference_transition_name = match app_project {
-            Some(app_project) => Some(app_project.client_transition_name().to_resolved().await?),
-            None => None,
-        };
+        let ecmascript_client_reference_transition_name =
+            app_project.map(|_| AppProject::client_transition_name());
 
         if let Some(app_project) = app_project {
             transitions.push((
-                ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
+                AppProject::client_transition_name(),
                 app_project
                     .edge_ecmascript_client_reference_transition()
                     .to_resolved()
@@ -1291,7 +1291,8 @@ impl Project {
                 self.execution_context(),
                 Value::new(ServerContextType::Middleware {
                     app_dir,
-                    ecmascript_client_reference_transition_name,
+                    ecmascript_client_reference_transition_name:
+                        ecmascript_client_reference_transition_name.clone(),
                 }),
                 self.next_mode(),
                 self.next_config(),
@@ -1302,7 +1303,8 @@ impl Project {
                 self.project_path(),
                 Value::new(ServerContextType::Middleware {
                     app_dir,
-                    ecmascript_client_reference_transition_name,
+                    ecmascript_client_reference_transition_name:
+                        ecmascript_client_reference_transition_name.clone(),
                 }),
                 self.next_mode(),
                 self.next_config(),
@@ -1319,14 +1321,12 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let app_project = *self.app_project().await?;
 
-        let ecmascript_client_reference_transition_name = match app_project {
-            Some(app_project) => Some(app_project.client_transition_name().to_resolved().await?),
-            None => None,
-        };
+        let ecmascript_client_reference_transition_name =
+            app_project.map(|_| AppProject::client_transition_name());
 
         if let Some(app_project) = app_project {
             transitions.push((
-                ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
+                AppProject::client_transition_name(),
                 app_project
                     .edge_ecmascript_client_reference_transition()
                     .to_resolved()
@@ -1346,7 +1346,8 @@ impl Project {
                 self.execution_context(),
                 Value::new(ServerContextType::Middleware {
                     app_dir,
-                    ecmascript_client_reference_transition_name,
+                    ecmascript_client_reference_transition_name:
+                        ecmascript_client_reference_transition_name.clone(),
                 }),
                 self.next_mode(),
                 self.next_config(),
@@ -1411,7 +1412,7 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let ecmascript_client_reference_transition_name = (*self.app_project().await?)
             .as_ref()
-            .map(|app_project| app_project.client_transition_name());
+            .map(|_| AppProject::client_transition_name());
 
         let middleware_asset_context = self.middleware_context();
 
@@ -1431,14 +1432,13 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let app_project = &*self.app_project().await?;
 
-        let ecmascript_client_reference_transition_name = match app_project {
-            Some(app_project) => Some(app_project.client_transition_name().to_resolved().await?),
-            None => None,
-        };
+        let ecmascript_client_reference_transition_name = app_project
+            .as_ref()
+            .map(|_| AppProject::client_transition_name());
 
         if let Some(app_project) = app_project {
             transitions.push((
-                ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
+                AppProject::client_transition_name(),
                 app_project
                     .ecmascript_client_reference_transition()
                     .to_resolved()
@@ -1458,7 +1458,8 @@ impl Project {
                 self.execution_context(),
                 Value::new(ServerContextType::Instrumentation {
                     app_dir,
-                    ecmascript_client_reference_transition_name,
+                    ecmascript_client_reference_transition_name:
+                        ecmascript_client_reference_transition_name.clone(),
                 }),
                 self.next_mode(),
                 self.next_config(),
@@ -1486,14 +1487,13 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let app_project = &*self.app_project().await?;
 
-        let ecmascript_client_reference_transition_name = match app_project {
-            Some(app_project) => Some(app_project.client_transition_name().to_resolved().await?),
-            None => None,
-        };
+        let ecmascript_client_reference_transition_name = app_project
+            .as_ref()
+            .map(|_| AppProject::client_transition_name());
 
         if let Some(app_project) = app_project {
             transitions.push((
-                ECMASCRIPT_CLIENT_TRANSITION_NAME.into(),
+                AppProject::client_transition_name(),
                 app_project
                     .edge_ecmascript_client_reference_transition()
                     .to_resolved()
@@ -1513,7 +1513,8 @@ impl Project {
                 self.execution_context(),
                 Value::new(ServerContextType::Instrumentation {
                     app_dir,
-                    ecmascript_client_reference_transition_name,
+                    ecmascript_client_reference_transition_name:
+                        ecmascript_client_reference_transition_name.clone(),
                 }),
                 self.next_mode(),
                 self.next_config(),
@@ -1555,7 +1556,7 @@ impl Project {
         let app_dir = *find_app_dir(self.project_path()).await?;
         let ecmascript_client_reference_transition_name = (*self.app_project().await?)
             .as_ref()
-            .map(|app_project| app_project.client_transition_name());
+            .map(|_| AppProject::client_transition_name());
 
         let instrumentation_asset_context = if is_edge {
             self.edge_instrumentation_context()

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -693,7 +693,7 @@ impl Project {
         Ok(self.client_root().join(
             format!(
                 "{}/_next",
-                next_config.base_path.clone().unwrap_or_else(|| rcstr!("")),
+                next_config.base_path.clone().unwrap_or_default(),
             )
             .into(),
         ))

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -467,7 +467,7 @@ impl ProjectContainer {
             .await?
             .dist_dir
             .as_ref()
-            .map_or_else(|| ".next".into(), |d| d.clone());
+            .map_or_else(|| rcstr!(".next"), |d| d.clone());
 
         Ok(Project {
             root_path,
@@ -657,13 +657,13 @@ impl Project {
 
     #[turbo_tasks::function]
     pub fn client_fs(self: Vc<Self>) -> Vc<Box<dyn FileSystem>> {
-        let virtual_fs = VirtualFileSystem::new_with_name("client-fs".into());
+        let virtual_fs = VirtualFileSystem::new_with_name(rcstr!("client-fs"));
         Vc::upcast(virtual_fs)
     }
 
     #[turbo_tasks::function]
     pub fn output_fs(&self) -> Vc<DiskFileSystem> {
-        DiskFileSystem::new("output".into(), self.project_path.clone(), vec![])
+        DiskFileSystem::new(rcstr!("output"), self.project_path.clone(), vec![])
     }
 
     #[turbo_tasks::function]
@@ -693,7 +693,7 @@ impl Project {
         Ok(self.client_root().join(
             format!(
                 "{}/_next",
-                next_config.base_path.clone().unwrap_or_else(|| "".into()),
+                next_config.base_path.clone().unwrap_or_else(|| rcstr!("")),
             )
             .into(),
         ))
@@ -766,7 +766,7 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) async fn should_create_webpack_stats(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(
-            self.env.read("TURBOPACK_STATS".into()).await?.is_some(),
+            self.env.read(rcstr!("TURBOPACK_STATS")).await?.is_some(),
         ))
     }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -5,7 +5,7 @@ use indexmap::map::{Entry, OccupiedEntry};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueDefault, ValueToString,
     Vc, debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
@@ -131,7 +131,7 @@ pub async fn get_metadata_route_name(meta: MetadataItem) -> Result<Vc<RcStr>> {
             };
 
             match stem.as_str() {
-                "manifest" => Vc::cell("manifest.webmanifest".into()),
+                "manifest" => Vc::cell(rcstr!("manifest.webmanifest")),
                 _ => Vc::cell(stem.clone()),
             }
         }

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -263,8 +263,8 @@ pub struct OptionAppDir(Option<ResolvedVc<FileSystemPath>>);
 /// Finds and returns the [DirectoryTree] of the app directory if existing.
 #[turbo_tasks::function]
 pub async fn find_app_dir(project_path: Vc<FileSystemPath>) -> Result<Vc<OptionAppDir>> {
-    let app = project_path.join("app".into());
-    let src_app = project_path.join("src/app".into());
+    let app = project_path.join(rcstr!("app"));
+    let src_app = project_path.join(rcstr!("src/app"));
     let app_dir = if *app.get_type().await? == FileSystemEntryType::Directory {
         app
     } else if *src_app.get_type().await? == FileSystemEntryType::Directory {
@@ -763,7 +763,7 @@ fn directory_tree_to_entrypoints(
         app_dir,
         global_metadata,
         is_global_not_found_enabled,
-        "".into(),
+        rcstr!(""),
         directory_tree,
         AppPage::new(),
         root_layouts,
@@ -911,7 +911,7 @@ async fn directory_tree_to_loader_tree_internal(
         if modules.not_found.is_none() {
             modules.not_found = Some(
                 get_next_package(app_dir)
-                    .join("dist/client/components/not-found-error.js".into())
+                    .join(rcstr!("dist/client/components/not-found-error.js"))
                     .to_resolved()
                     .await?,
             );
@@ -919,7 +919,7 @@ async fn directory_tree_to_loader_tree_internal(
         if modules.forbidden.is_none() {
             modules.forbidden = Some(
                 get_next_package(app_dir)
-                    .join("dist/client/components/forbidden-error.js".into())
+                    .join(rcstr!("dist/client/components/forbidden-error.js"))
                     .to_resolved()
                     .await?,
             );
@@ -927,7 +927,7 @@ async fn directory_tree_to_loader_tree_internal(
         if modules.unauthorized.is_none() {
             modules.unauthorized = Some(
                 get_next_package(app_dir)
-                    .join("dist/client/components/unauthorized-error.js".into())
+                    .join(rcstr!("dist/client/components/unauthorized-error.js"))
                     .to_resolved()
                     .await?,
             );
@@ -945,7 +945,7 @@ async fn directory_tree_to_loader_tree_internal(
     let current_level_is_parallel_route = is_parallel_route(&directory_name);
 
     if current_level_is_parallel_route {
-        tree.segment = "children".into();
+        tree.segment = rcstr!("children");
     }
 
     if let Some(page) = (app_path == for_app_path || app_path.is_catchall())
@@ -953,10 +953,10 @@ async fn directory_tree_to_loader_tree_internal(
         .flatten()
     {
         tree.parallel_routes.insert(
-            "children".into(),
+            rcstr!("children"),
             AppPageLoaderTree {
                 page: app_page.clone(),
-                segment: "__PAGE__".into(),
+                segment: rcstr!("__PAGE__"),
                 parallel_routes: FxIndexMap::default(),
                 modules: AppDirModules {
                     page: Some(page),
@@ -968,7 +968,7 @@ async fn directory_tree_to_loader_tree_internal(
         );
 
         if current_level_is_parallel_route {
-            tree.segment = "page$".into();
+            tree.segment = rcstr!("page$");
         }
     }
 
@@ -1022,10 +1022,10 @@ async fn directory_tree_to_loader_tree_internal(
                         || current_tree.get_specificity() < subtree.get_specificity())
                 {
                     tree.parallel_routes
-                        .insert("children".into(), subtree.clone());
+                        .insert(rcstr!("children"), subtree.clone());
                 }
             } else {
-                tree.parallel_routes.insert("children".into(), subtree);
+                tree.parallel_routes.insert(rcstr!("children"), subtree);
             }
         } else if let Some(key) = parallel_route_key {
             bail!(
@@ -1089,7 +1089,7 @@ async fn directory_tree_to_loader_tree_internal(
         }
     } else if tree.parallel_routes.get("children").is_none() {
         tree.parallel_routes.insert(
-            "children".into(),
+            rcstr!("children"),
             default_route_tree(
                 app_dir,
                 global_metadata,
@@ -1119,7 +1119,7 @@ async fn default_route_tree(
 ) -> Result<AppPageLoaderTree> {
     Ok(AppPageLoaderTree {
         page: app_page.clone(),
-        segment: "__DEFAULT__".into(),
+        segment: rcstr!("__DEFAULT__"),
         parallel_routes: FxIndexMap::default(),
         modules: if let Some(default) = default_component {
             AppDirModules {
@@ -1131,7 +1131,7 @@ async fn default_route_tree(
             AppDirModules {
                 default: Some(
                     get_next_package(app_dir)
-                        .join("dist/client/components/parallel-route-default.js".into())
+                        .join(rcstr!("dist/client/components/parallel-route-default.js"))
                         .to_resolved()
                         .await?,
                 ),
@@ -1276,7 +1276,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         if modules.layout.is_none() {
             modules.layout = Some(
                 get_next_package(*app_dir)
-                    .join("dist/client/components/default-layout.js".into())
+                    .join(rcstr!("dist/client/components/default-layout.js"))
                     .to_resolved()
                     .await?,
             );
@@ -1285,7 +1285,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         if modules.not_found.is_none() {
             modules.not_found = Some(
                 get_next_package(*app_dir)
-                    .join("dist/client/components/not-found-error.js".into())
+                    .join(rcstr!("dist/client/components/not-found-error.js"))
                     .to_resolved()
                     .await?,
             );
@@ -1293,7 +1293,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         if modules.forbidden.is_none() {
             modules.forbidden = Some(
                 get_next_package(*app_dir)
-                    .join("dist/client/components/forbidden-error.js".into())
+                    .join(rcstr!("dist/client/components/forbidden-error.js"))
                     .to_resolved()
                     .await?,
             );
@@ -1301,7 +1301,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         if modules.unauthorized.is_none() {
             modules.unauthorized = Some(
                 get_next_package(*app_dir)
-                    .join("dist/client/components/unauthorized-error.js".into())
+                    .join(rcstr!("dist/client/components/unauthorized-error.js"))
                     .to_resolved()
                     .await?,
             );
@@ -1320,13 +1320,13 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             page: app_page.clone(),
             segment: directory_name.clone(),
             parallel_routes: fxindexmap! {
-                "children".into() => AppPageLoaderTree {
+                rcstr!("children") => AppPageLoaderTree {
                     page: app_page.clone(),
-                    segment: "/_not-found".into(),
+                    segment: rcstr!("/_not-found"),
                     parallel_routes: fxindexmap! {
-                        "children".into() => AppPageLoaderTree {
+                        rcstr!("children") => AppPageLoaderTree {
                             page: app_page.clone(),
-                            segment: "__PAGE__".into(),
+                            segment: rcstr!("__PAGE__"),
                             parallel_routes: FxIndexMap::default(),
                             modules: if use_global_not_found {
                                 // if global-not-found.js is present:
@@ -1336,7 +1336,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                                     page: match modules.global_not_found {
                                         Some(v) => Some(v),
                                         None => Some(get_next_package(*app_dir)
-                                            .join("dist/client/components/global-not-found.js".into())
+                                            .join(rcstr!("dist/client/components/global-not-found.js"))
                                             .to_resolved()
                                             .await?),
                                     },
@@ -1349,7 +1349,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                                     page: match modules.not_found {
                                         Some(v) => Some(v),
                                         None => Some(get_next_package(*app_dir)
-                                            .join("dist/client/components/not-found-error.js".into())
+                                            .join(rcstr!("dist/client/components/not-found-error.js"))
                                             .to_resolved()
                                             .await?),
                                     },
@@ -1544,7 +1544,7 @@ impl Issue for DirectoryTreeIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("An issue occurred while preparing your Next.js app".into()).cell()
+        StyledString::Text(rcstr!("An issue occurred while preparing your Next.js app")).cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -119,7 +119,7 @@ impl HmrEntryModuleReference {
 impl ValueToString for HmrEntryModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("entry".into())
+        Vc::cell(rcstr!("entry"))
     }
 }
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -102,14 +102,14 @@ async fn next_client_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarRefer
     Ok(free_var_references!(
         ..defines(&*define_env.await?).into_iter(),
         Buffer = FreeVarReference::EcmaScriptModule {
-            request: "node:buffer".into(),
+            request: rcstr!("node:buffer"),
             lookup_path: None,
-            export: Some("Buffer".into()),
+            export: Some(rcstr!("Buffer")),
         },
         process = FreeVarReference::EcmaScriptModule {
-            request: "node:process".into(),
+            request: rcstr!("node:process"),
             lookup_path: None,
-            export: Some("default".into()),
+            export: Some(rcstr!("default")),
         }
     )
     .cell())
@@ -265,7 +265,7 @@ pub async fn get_client_module_options_context(
     // foreign_code_context_condition. This allows to import codes from
     // node_modules that requires webpack loaders, which next-dev implicitly
     // does by default.
-    let conditions = vec!["browser".into(), mode.await?.condition().into()];
+    let conditions = vec![rcstr!("browser"), mode.await?.condition().into()];
     let foreign_enable_webpack_loaders = webpack_loader_options(
         project_path,
         next_config,
@@ -273,7 +273,7 @@ pub async fn get_client_module_options_context(
         conditions
             .iter()
             .cloned()
-            .chain(once("foreign".into()))
+            .chain(once(rcstr!("foreign")))
             .collect(),
     )
     .await?;
@@ -522,7 +522,7 @@ pub async fn get_client_runtime_entries(
             runtime_entries.push(
                 RuntimeEntry::Request(
                     request.to_resolved().await?,
-                    project_root.join("_".into()).to_resolved().await?,
+                    project_root.join(rcstr!("_")).to_resolved().await?,
                 )
                 .resolved_cell(),
             )

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
@@ -425,9 +425,9 @@ pub async fn get_client_module_options_context(
 pub async fn get_client_chunking_context(
     root_path: ResolvedVc<FileSystemPath>,
     client_root: ResolvedVc<FileSystemPath>,
-    client_root_to_root_path: ResolvedVc<RcStr>,
-    asset_prefix: ResolvedVc<Option<RcStr>>,
-    chunk_suffix_path: ResolvedVc<Option<RcStr>>,
+    client_root_to_root_path: RcStr,
+    asset_prefix: Option<RcStr>,
+    chunk_suffix_path: Option<RcStr>,
     environment: ResolvedVc<Environment>,
     mode: Vc<NextMode>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
@@ -442,14 +442,14 @@ pub async fn get_client_chunking_context(
         client_root_to_root_path,
         client_root,
         client_root
-            .join("static/chunks".into())
+            .join(rcstr!("static/chunks"))
             .to_resolved()
             .await?,
         get_client_assets_path(*client_root).to_resolved().await?,
         environment,
         next_mode.runtime_type(),
     )
-    .chunk_base_path(asset_prefix)
+    .chunk_base_path(asset_prefix.clone())
     .chunk_suffix_path(chunk_suffix_path)
     .minify_type(if *minify.await? {
         MinifyType::Minify {
@@ -494,7 +494,7 @@ pub async fn get_client_chunking_context(
 
 #[turbo_tasks::function]
 pub fn get_client_assets_path(client_root: Vc<FileSystemPath>) -> Vc<FileSystemPath> {
-    client_root.join("static/media".into())
+    client_root.join(rcstr!("static/media"))
 }
 
 #[turbo_tasks::function]
@@ -532,12 +532,12 @@ pub async fn get_client_runtime_entries(
     if matches!(*ty, ClientContextType::App { .. },) {
         runtime_entries.push(
             RuntimeEntry::Request(
-                Request::parse(Value::new(Pattern::Constant(
-                    "next/dist/client/app-next-turbopack.js".into(),
-                )))
+                Request::parse(Value::new(Pattern::Constant(rcstr!(
+                    "next/dist/client/app-next-turbopack.js"
+                ))))
                 .to_resolved()
                 .await?,
-                project_root.join("_".into()).to_resolved().await?,
+                project_root.join(rcstr!("_")).to_resolved().await?,
             )
             .resolved_cell(),
         );

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -80,7 +80,7 @@ impl ChunkableModuleReference for CssClientReference {
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Isolated {
             _ty: ChunkGroupType::Evaluated,
-            merge_tag: Some("client".into()),
+            merge_tag: Some(rcstr!("client")),
         }))
     }
 }
@@ -97,6 +97,6 @@ impl ModuleReference for CssClientReference {
 impl ValueToString for CssClientReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("css client reference to client".into())
+        Vc::cell(rcstr!("css client reference to client"))
     }
 }

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -176,16 +176,6 @@ impl EcmascriptClientReferenceModule {
     }
 }
 
-#[turbo_tasks::function]
-fn ecmascript_client_reference_client_ref_modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript client reference to client".into())
-}
-
-#[turbo_tasks::function]
-fn ecmascript_client_reference_ssr_ref_modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript client reference to ssr".into())
-}
-
 pub fn ecmascript_client_reference_merge_tag() -> RcStr {
     rcstr!("client")
 }
@@ -222,7 +212,7 @@ impl Module for EcmascriptClientReferenceModule {
                     *ResolvedVc::upcast(*client_module),
                     ChunkGroupType::Evaluated,
                     Some(ecmascript_client_reference_merge_tag()),
-                    ecmascript_client_reference_client_ref_modifier(),
+                    rcstr!("ecmascript client reference to client"),
                 )
                 .to_resolved()
                 .await?,
@@ -232,7 +222,7 @@ impl Module for EcmascriptClientReferenceModule {
                     *ResolvedVc::upcast(*ssr_module),
                     ChunkGroupType::Entry,
                     Some(ecmascript_client_reference_merge_tag_ssr()),
-                    ecmascript_client_reference_ssr_ref_modifier(),
+                    rcstr!("ecmascript client reference to ssr"),
                 )
                 .to_resolved()
                 .await?,
@@ -298,11 +288,6 @@ struct EcmascriptClientReferenceProxyChunkItem {
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
-#[turbo_tasks::function]
-fn client_reference_description() -> Vc<RcStr> {
-    Vc::cell("client references".into())
-}
-
 #[turbo_tasks::value_impl]
 impl ChunkItem for EcmascriptClientReferenceProxyChunkItem {
     #[turbo_tasks::function]
@@ -348,7 +333,7 @@ pub(crate) struct EcmascriptClientReference {
     module: ResolvedVc<Box<dyn Module>>,
     ty: ChunkGroupType,
     merge_tag: Option<RcStr>,
-    description: ResolvedVc<RcStr>,
+    description: RcStr,
 }
 
 #[turbo_tasks::value_impl]
@@ -358,7 +343,7 @@ impl EcmascriptClientReference {
         module: ResolvedVc<Box<dyn Module>>,
         ty: ChunkGroupType,
         merge_tag: Option<RcStr>,
-        description: ResolvedVc<RcStr>,
+        description: RcStr,
     ) -> Vc<Self> {
         Self::cell(EcmascriptClientReference {
             module,
@@ -392,6 +377,6 @@ impl ModuleReference for EcmascriptClientReference {
 impl ValueToString for EcmascriptClientReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        *self.description
+        Vc::cell(self.description.clone())
     }
 }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_esregex::EsRegex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, OperationValue, ResolvedVc, TaskInput, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -1655,7 +1655,7 @@ impl Issue for OutdatedConfigIssue {
     fn title(&self) -> Vc<StyledString> {
         StyledString::Line(vec![
             StyledString::Code(self.old_name.clone()),
-            StyledString::Text(" has been replaced by ".into()),
+            StyledString::Text(rcstr!(" has been replaced by ")),
             StyledString::Code(self.new_name.clone()),
         ])
         .cell()

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -37,9 +37,8 @@ impl NextDynamicEntryModule {
     }
 }
 
-#[turbo_tasks::function]
-fn dynamic_ref_description() -> Vc<RcStr> {
-    Vc::cell("next/dynamic reference".into())
+fn dynamic_ref_description() -> RcStr {
+    rcstr!("next/dynamic reference")
 }
 
 #[turbo_tasks::value_impl]
@@ -105,9 +104,10 @@ impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
         );
 
         let mut exports = BTreeMap::new();
+        let default = rcstr!("default");
         exports.insert(
-            "default".into(),
-            EsmExport::ImportedBinding(module_reference, "default".into(), false),
+            default.clone(),
+            EsmExport::ImportedBinding(module_reference, default, false),
         );
 
         Ok(EcmascriptExports::EsmExports(

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -71,9 +71,9 @@ async fn next_edge_free_vars(
     Ok(free_var_references!(
         ..defines(&*define_env.await?).into_iter(),
         Buffer = FreeVarReference::EcmaScriptModule {
-            request: "buffer".into(),
+            request: rcstr!("buffer"),
             lookup_path: Some(project_path),
-            export: Some("Buffer".into()),
+            export: Some(rcstr!("Buffer")),
         },
     )
     .cell())
@@ -176,7 +176,7 @@ pub async fn get_edge_resolve_options_context(
     );
 
     if ty.supports_react_server() {
-        custom_conditions.push("react-server".into());
+        custom_conditions.push(rcstr!("react-server"));
     };
 
     let resolve_options_context = ResolveOptionsContext {
@@ -228,16 +228,16 @@ pub async fn get_edge_chunking_context_with_client_assets(
     turbo_source_maps: Vc<bool>,
     no_mangling: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
-    let output_root = node_root.join("server/edge".into()).to_resolved().await?;
+    let output_root = node_root.join(rcstr!("server/edge")).to_resolved().await?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
         root_path,
         output_root,
         output_root_to_root_path,
         client_root,
-        output_root.join("chunks/ssr".into()).to_resolved().await?,
+        output_root.join(rcstr!("chunks/ssr")).to_resolved().await?,
         client_root
-            .join("static/media".into())
+            .join(rcstr!("static/media"))
             .to_resolved()
             .await?,
         environment,

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
@@ -109,10 +109,15 @@ pub async fn get_edge_resolve_options_context(
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
-    let next_edge_import_map =
-        get_next_edge_import_map(*project_path, ty, next_config, mode, execution_context)
-            .to_resolved()
-            .await?;
+    let next_edge_import_map = get_next_edge_import_map(
+        *project_path,
+        ty.clone(),
+        next_config,
+        mode,
+        execution_context,
+    )
+    .to_resolved()
+    .await?;
 
     let ty: ServerContextType = ty.into_value();
 
@@ -214,9 +219,9 @@ pub async fn get_edge_chunking_context_with_client_assets(
     mode: Vc<NextMode>,
     root_path: ResolvedVc<FileSystemPath>,
     node_root: ResolvedVc<FileSystemPath>,
-    output_root_to_root_path: ResolvedVc<RcStr>,
+    output_root_to_root_path: RcStr,
     client_root: ResolvedVc<FileSystemPath>,
-    asset_prefix: ResolvedVc<Option<RcStr>>,
+    asset_prefix: Option<RcStr>,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
@@ -279,22 +284,22 @@ pub async fn get_edge_chunking_context(
     mode: Vc<NextMode>,
     root_path: ResolvedVc<FileSystemPath>,
     node_root: ResolvedVc<FileSystemPath>,
-    node_root_to_root_path: ResolvedVc<RcStr>,
+    node_root_to_root_path: RcStr,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
     turbo_source_maps: Vc<bool>,
     no_mangling: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
-    let output_root = node_root.join("server/edge".into()).to_resolved().await?;
+    let output_root = node_root.join(rcstr!("server/edge")).to_resolved().await?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
         root_path,
         output_root,
         node_root_to_root_path,
         output_root,
-        output_root.join("chunks".into()).to_resolved().await?,
-        output_root.join("assets".into()).to_resolved().await?,
+        output_root.join(rcstr!("chunks")).to_resolved().await?,
+        output_root.join(rcstr!("assets")).to_resolved().await?,
         environment,
         next_mode.runtime_type(),
     )
@@ -302,7 +307,7 @@ pub async fn get_edge_chunking_context(
     // instead. This special blob url is handled by the custom fetch
     // implementation in the edge sandbox. It will respond with the
     // asset from the output directory.
-    .asset_base_path(ResolvedVc::cell(Some("blob:server/edge/".into())))
+    .asset_base_path(Some(rcstr!("blob:server/edge/")))
     .minify_type(if *turbo_minify.await? {
         MinifyType::Minify {
             mangle: (!*no_mangling.await?).then_some(MangleType::OptimalSize),

--- a/crates/next-core/src/next_font/font_fallback.rs
+++ b/crates/next-core/src/next_font/font_fallback.rs
@@ -32,9 +32,9 @@ pub(crate) static DEFAULT_SERIF_FONT: Lazy<DefaultFallbackFont> =
 #[turbo_tasks::value(shared)]
 pub(crate) struct AutomaticFontFallback {
     /// e.g. `__Roboto_Fallback_c123b8`
-    pub scoped_font_family: ResolvedVc<RcStr>,
+    pub scoped_font_family: RcStr,
     /// The name of font locally, used in `src: local("{}")`
-    pub local_font_family: ResolvedVc<RcStr>,
+    pub local_font_family: RcStr,
     pub adjustment: Option<FontAdjustment>,
 }
 

--- a/crates/next-core/src/next_font/font_fallback.rs
+++ b/crates/next-core/src/next_font/font_fallback.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 
 pub(crate) struct DefaultFallbackFont {
@@ -14,16 +14,16 @@ pub(crate) struct DefaultFallbackFont {
 // From https://github.com/vercel/next.js/blob/a3893bf69c83fb08e88c87bf8a21d987a0448c8e/packages/font/src/utils.ts#L4
 pub(crate) static DEFAULT_SANS_SERIF_FONT: Lazy<DefaultFallbackFont> =
     Lazy::new(|| DefaultFallbackFont {
-        name: "Arial".into(),
-        capsize_key: "arial".into(),
+        name: rcstr!("Arial"),
+        capsize_key: rcstr!("arial"),
         az_avg_width: 934.5116279069767,
         units_per_em: 2048,
     });
 
 pub(crate) static DEFAULT_SERIF_FONT: Lazy<DefaultFallbackFont> =
     Lazy::new(|| DefaultFallbackFont {
-        name: "Times New Roman".into(),
-        capsize_key: "timesNewRoman".into(),
+        name: rcstr!("Times New Roman"),
+        capsize_key: rcstr!("timesNewRoman"),
         az_avg_width: 854.3953488372093,
         units_per_em: 2048,
     });

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -65,12 +65,10 @@ pub(super) async fn get_font_fallback(
             match fallback {
                 Ok(fallback) => FontFallback::Automatic(AutomaticFontFallback {
                     scoped_font_family: get_scoped_font_family(
-                        FontFamilyType::Fallback.cell(),
-                        options_vc.font_family(),
-                    )
-                    .to_resolved()
-                    .await?,
-                    local_font_family: ResolvedVc::cell(fallback.font_family),
+                        FontFamilyType::Fallback,
+                        options_vc.font_family().await?,
+                    ),
+                    local_font_family: fallback.font_family,
                     adjustment: fallback.adjustment,
                 })
                 .cell(),

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{IssueExt, IssueSeverity, StyledString};
@@ -53,7 +53,7 @@ pub(super) async fn get_font_fallback(
         None => {
             let metrics_json = load_next_js_templateon(
                 lookup_path,
-                "dist/server/capsize-font-metrics.json".into(),
+                rcstr!("dist/server/capsize-font-metrics.json"),
             )
             .await?;
             let fallback = lookup_fallback(
@@ -83,9 +83,9 @@ pub(super) async fn get_font_fallback(
                             .into(),
                         )
                         .resolved_cell(),
-                        description: StyledString::Text(
-                            "Skipping generating a fallback font.".into(),
-                        )
+                        description: StyledString::Text(rcstr!(
+                            "Skipping generating a fallback font."
+                        ))
                         .resolved_cell(),
                         severity: IssueSeverity::Warning.resolved_cell(),
                     }
@@ -170,6 +170,7 @@ fn lookup_fallback(
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+    use turbo_rcstr::rcstr;
     use turbo_tasks_fs::json::parse_json_with_source_context;
 
     use super::{FontAdjustment, FontMetricsMap};
@@ -209,7 +210,7 @@ mod tests {
         assert_eq!(
             lookup_fallback("Inter", font_metrics, true)?,
             Fallback {
-                font_family: "Arial".into(),
+                font_family: rcstr!("Arial"),
                 adjustment: Some(FontAdjustment {
                     ascent: 0.901_989_700_374_532,
                     descent: -0.224_836_142_322_097_4,
@@ -255,7 +256,7 @@ mod tests {
         assert_eq!(
             lookup_fallback("Roboto Slab", font_metrics, true)?,
             Fallback {
-                font_family: "Times New Roman".into(),
+                font_family: rcstr!("Times New Roman"),
                 adjustment: Some(FontAdjustment {
                     ascent: 0.885_645_438_273_993_8,
                     descent: -0.229_046_234_036_377_7,

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -29,16 +29,17 @@ pub(super) struct NextFontGoogleOptions {
     pub subsets: Option<Vec<RcStr>>,
 }
 
+impl NextFontGoogleOptions {
+    pub async fn font_family(self: Vc<Self>) -> Result<RcStr> {
+        Ok(self.await?.font_family.clone())
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl NextFontGoogleOptions {
     #[turbo_tasks::function]
     pub fn new(options: Value<NextFontGoogleOptions>) -> Vc<NextFontGoogleOptions> {
         Self::cell(options.into_value())
-    }
-
-    #[turbo_tasks::function]
-    pub fn font_family(&self) -> Vc<RcStr> {
-        Vc::cell((*self.font_family).into())
     }
 }
 

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -437,7 +437,7 @@ mod tests {
         )?;
 
         let options = options_from_request(&request, &data)?;
-        assert_eq!(options.styles, vec![RcStr::from("italic")]);
+        assert_eq!(options.styles, vec![rcstr!("italic")]);
 
         Ok(())
     }
@@ -469,7 +469,7 @@ mod tests {
         )?;
 
         let options = options_from_request(&request, &data)?;
-        assert_eq!(options.styles, vec![RcStr::from("normal")]);
+        assert_eq!(options.styles, vec![rcstr!("normal")]);
 
         Ok(())
     }

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, Value, Vc, fxindexset, trace::TraceRawVcs,
 };
@@ -156,7 +156,7 @@ pub(super) fn options_from_request(
         if font_data.styles.len() == 1 {
             styles.push(font_data.styles[0].clone());
         } else {
-            styles.push("normal".into());
+            styles.push(rcstr!("normal"));
         }
     }
 
@@ -171,7 +171,7 @@ pub(super) fn options_from_request(
         }
     }
 
-    let display = argument.display.unwrap_or_else(|| "swap".into());
+    let display = argument.display.unwrap_or_else(|| rcstr!("swap"));
 
     if !ALLOWED_DISPLAY_VALUES.contains(&display.as_str()) {
         anyhow::bail!(
@@ -214,7 +214,7 @@ pub(super) fn options_from_request(
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use turbo_rcstr::RcStr;
+    use turbo_rcstr::{RcStr, rcstr};
     use turbo_tasks::FxIndexMap;
     use turbo_tasks_fs::json::parse_json_with_source_context;
 
@@ -281,10 +281,10 @@ mod tests {
         assert_eq!(
             options_from_request(&request, &data)?,
             NextFontGoogleOptions {
-                font_family: "ABeeZee".into(),
+                font_family: rcstr!("ABeeZee"),
                 weights: FontWeights::Variable,
-                styles: vec!["normal".into()],
-                display: "swap".into(),
+                styles: vec![rcstr!("normal")],
+                display: rcstr!("swap"),
                 preload: true,
                 selected_variable_axes: None,
                 fallback: None,

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -194,7 +194,7 @@ fn pick_font_for_fallback_generation(
 
                 // Prefer normal style if they have the same weight
                 if used_font_distance == current_font_distance
-                    && current_descriptor.style != Some("italic".into())
+                    && current_descriptor.style != Some(rcstr!("italic"))
                 {
                     used_descriptor = current_descriptor;
                     continue;
@@ -281,18 +281,18 @@ fn parse_weight_string(weight_str: &str) -> Result<f64> {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use turbo_rcstr::RcStr;
+    use turbo_rcstr::{RcStr, rcstr};
 
     use crate::next_font::local::{
         font_fallback::pick_font_for_fallback_generation,
         options::{FontDescriptor, FontDescriptors, FontWeight},
     };
 
-    fn generate_font_descriptor(weight: &FontWeight, style: &Option<String>) -> FontDescriptor {
+    fn generate_font_descriptor(weight: &FontWeight, style: Option<RcStr>) -> FontDescriptor {
         FontDescriptor {
-            ext: "ttf".into(),
-            path: "foo.ttf".into(),
-            style: style.clone().map(RcStr::from),
+            ext: rcstr!("ttf"),
+            path: rcstr!("foo.ttf"),
+            style,
             weight: Some(weight.clone()),
         }
     }
@@ -301,34 +301,34 @@ mod tests {
     fn test_picks_weight_closest_to_400() -> Result<()> {
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Fixed("300".into()), &None),
-                generate_font_descriptor(&FontWeight::Fixed("600".into()), &None)
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("300")), None),
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("600")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Fixed("300".into()), &None)
+            &generate_font_descriptor(&FontWeight::Fixed(rcstr!("300")), None)
         );
 
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Fixed("200".into()), &None),
-                generate_font_descriptor(&FontWeight::Fixed("500".into()), &None)
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("200")), None),
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("500")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Fixed("500".into()), &None)
+            &generate_font_descriptor(&FontWeight::Fixed(rcstr!("500")), None)
         );
 
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Fixed("normal".into()), &None),
-                generate_font_descriptor(&FontWeight::Fixed("700".into()), &None)
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("normal")), None),
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("700")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Fixed("normal".into()), &None)
+            &generate_font_descriptor(&FontWeight::Fixed(rcstr!("normal")), None)
         );
 
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Fixed("bold".into()), &None),
-                generate_font_descriptor(&FontWeight::Fixed("900".into()), &None)
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("bold")), None),
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("900")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Fixed("bold".into()), &None)
+            &generate_font_descriptor(&FontWeight::Fixed(rcstr!("bold")), None)
         );
 
         Ok(())
@@ -338,10 +338,10 @@ mod tests {
     fn test_picks_thinner_weight_if_same_distance_to_400() -> Result<()> {
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Fixed("300".into()), &None),
-                generate_font_descriptor(&FontWeight::Fixed("500".into()), &None)
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("300")), None),
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("500")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Fixed("300".into()), &None)
+            &generate_font_descriptor(&FontWeight::Fixed(rcstr!("300")), None)
         );
 
         Ok(())
@@ -351,26 +351,26 @@ mod tests {
     fn test_picks_variable_closest_to_400() -> Result<()> {
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Variable("100".into(), "300".into()), &None),
-                generate_font_descriptor(&FontWeight::Variable("600".into(), "900".into()), &None)
+                generate_font_descriptor(&FontWeight::Variable(rcstr!("100"), rcstr!("300")), None),
+                generate_font_descriptor(&FontWeight::Variable(rcstr!("600"), rcstr!("900")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Variable("100".into(), "300".into()), &None)
+            &generate_font_descriptor(&FontWeight::Variable(rcstr!("100"), rcstr!("300")), None)
         );
 
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Variable("100".into(), "200".into()), &None),
-                generate_font_descriptor(&FontWeight::Variable("500".into(), "800".into()), &None)
+                generate_font_descriptor(&FontWeight::Variable(rcstr!("100"), rcstr!("200")), None),
+                generate_font_descriptor(&FontWeight::Variable(rcstr!("500"), rcstr!("800")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Variable("500".into(), "800".into()), &None)
+            &generate_font_descriptor(&FontWeight::Variable(rcstr!("500"), rcstr!("800")), None)
         );
 
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Variable("100".into(), "900".into()), &None),
-                generate_font_descriptor(&FontWeight::Variable("300".into(), "399".into()), &None)
+                generate_font_descriptor(&FontWeight::Variable(rcstr!("100"), rcstr!("900")), None),
+                generate_font_descriptor(&FontWeight::Variable(rcstr!("300"), rcstr!("399")), None)
             ]))?,
-            &generate_font_descriptor(&FontWeight::Variable("100".into(), "900".into()), &None)
+            &generate_font_descriptor(&FontWeight::Variable(rcstr!("100"), rcstr!("900")), None)
         );
 
         Ok(())
@@ -380,10 +380,10 @@ mod tests {
     fn test_prefer_normal_over_italic() -> Result<()> {
         assert_eq!(
             pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-                generate_font_descriptor(&FontWeight::Fixed("400".into()), &Some("normal".into())),
-                generate_font_descriptor(&FontWeight::Fixed("400".into()), &Some("italic".into()))
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("400")), Some(rcstr!("normal"))),
+                generate_font_descriptor(&FontWeight::Fixed(rcstr!("400")), Some(rcstr!("italic")))
             ]))?,
-            &generate_font_descriptor(&FontWeight::Fixed("400".into()), &Some("normal".into()))
+            &generate_font_descriptor(&FontWeight::Fixed(rcstr!("400")), Some(rcstr!("normal")))
         );
 
         Ok(())
@@ -392,10 +392,13 @@ mod tests {
     #[test]
     fn test_errors_on_invalid_weight() -> Result<()> {
         match pick_font_for_fallback_generation(&FontDescriptors::Many(vec![
-            generate_font_descriptor(&FontWeight::Variable("normal".into(), "bold".into()), &None),
-            generate_font_descriptor(&FontWeight::Variable("400".into(), "bold".into()), &None),
-            generate_font_descriptor(&FontWeight::Variable("normal".into(), "700".into()), &None),
-            generate_font_descriptor(&FontWeight::Variable("100".into(), "abc".into()), &None),
+            generate_font_descriptor(
+                &FontWeight::Variable(rcstr!("normal"), rcstr!("bold")),
+                None,
+            ),
+            generate_font_descriptor(&FontWeight::Variable(rcstr!("400"), rcstr!("bold")), None),
+            generate_font_descriptor(&FontWeight::Variable(rcstr!("normal"), rcstr!("700")), None),
+            generate_font_descriptor(&FontWeight::Variable(rcstr!("100"), rcstr!("abc")), None),
         ])) {
             Ok(_) => panic!(),
             Err(err) => {

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -3,6 +3,7 @@ use allsorts::{
     font_data::{DynamicFontTableProvider, FontData},
 };
 use anyhow::{Context, Result, bail};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
@@ -38,7 +39,7 @@ pub(super) async fn get_font_fallbacks(
 ) -> Result<Vc<FontFallbackResult>> {
     let options = &*options_vc.await?;
     let scoped_font_family =
-        get_scoped_font_family(FontFamilyType::Fallback.cell(), options_vc.font_family());
+        get_scoped_font_family(FontFamilyType::Fallback, options_vc.font_family().await?);
 
     let mut font_fallbacks = vec![];
     match options.adjust_font_fallback {
@@ -49,8 +50,8 @@ pub(super) async fn get_font_fallbacks(
             match adjustment {
                 FontResult::Ok(adjustment) => font_fallbacks.push(
                     FontFallback::Automatic(AutomaticFontFallback {
-                        scoped_font_family: scoped_font_family.to_resolved().await?,
-                        local_font_family: ResolvedVc::cell("Arial".into()),
+                        scoped_font_family,
+                        local_font_family: rcstr!("Arial"),
                         adjustment: Some(adjustment),
                     })
                     .resolved_cell(),
@@ -67,8 +68,8 @@ pub(super) async fn get_font_fallbacks(
             match adjustment {
                 FontResult::Ok(adjustment) => font_fallbacks.push(
                     FontFallback::Automatic(AutomaticFontFallback {
-                        scoped_font_family: scoped_font_family.to_resolved().await?,
-                        local_font_family: ResolvedVc::cell("Times New Roman".into()),
+                        scoped_font_family,
+                        local_font_family: rcstr!("Times New Roman"),
                         adjustment: Some(adjustment),
                     })
                     .resolved_cell(),

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -163,7 +163,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                     lookup_path.join(
                         format!(
                             "{}.js",
-                            get_request_id(options_vc.font_family(), request_hash).await?
+                            get_request_id(options_vc.font_family().await?, request_hash)
                         )
                         .into(),
                     ),
@@ -182,7 +182,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let css_virtual_path = lookup_path.join(
                     format!(
                         "/{}.module.css",
-                        get_request_id(options.font_family(), request_hash).await?
+                        get_request_id(options.font_family().await?, request_hash)
                     )
                     .into(),
                 );

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use font_fallback::FontFallbackResult;
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{
     FileContent, FileSystemPath, glob::Glob, json::parse_json_with_source_context,
@@ -68,9 +68,9 @@ impl NextFontLocalResolvePlugin {
 impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
     fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_request_glob(Glob::new(
-            "{next,@vercel/turbopack-next/internal}/font/local/*".into(),
-        ))
+        BeforeResolvePluginCondition::from_request_glob(Glob::new(rcstr!(
+            "{next,@vercel/turbopack-next/internal}/font/local/*"
+        )))
     }
 
     #[turbo_tasks::function]
@@ -348,9 +348,9 @@ impl Issue for FontResolvingIssue {
     async fn title(self: Vc<Self>) -> Result<Vc<StyledString>> {
         let this = self.await?;
         Ok(StyledString::Line(vec![
-            StyledString::Text("Font file not found: Can't resolve '".into()),
+            StyledString::Text(rcstr!("Font file not found: Can't resolve '")),
             StyledString::Code(this.font_path.owned().await?),
-            StyledString::Text("'".into()),
+            StyledString::Text(rcstr!("'")),
         ])
         .cell())
     }

--- a/crates/next-core/src/next_font/local/options.rs
+++ b/crates/next-core/src/next_font/local/options.rs
@@ -34,16 +34,17 @@ pub(super) struct NextFontLocalOptions {
     pub variable_name: RcStr,
 }
 
+impl NextFontLocalOptions {
+    pub async fn font_family(self: Vc<Self>) -> Result<RcStr> {
+        Ok(self.await?.variable_name.clone())
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl NextFontLocalOptions {
     #[turbo_tasks::function]
     pub fn new(options: Value<NextFontLocalOptions>) -> Vc<NextFontLocalOptions> {
         Self::cell(options.into_value())
-    }
-
-    #[turbo_tasks::function]
-    pub fn font_family(&self) -> Vc<RcStr> {
-        Vc::cell(self.variable_name.clone())
     }
 }
 

--- a/crates/next-core/src/next_font/local/options.rs
+++ b/crates/next-core/src/next_font/local/options.rs
@@ -205,6 +205,7 @@ pub(super) fn options_from_request(request: &NextFontLocalRequest) -> Result<Nex
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+    use turbo_rcstr::rcstr;
     use turbo_tasks_fs::json::parse_json_with_source_context;
 
     use super::{NextFontLocalOptions, options_from_request};
@@ -232,19 +233,19 @@ mod tests {
             options_from_request(&request)?,
             NextFontLocalOptions {
                 fonts: FontDescriptors::One(FontDescriptor {
-                    path: "./Roboto-Regular.ttf".into(),
+                    path: rcstr!("./Roboto-Regular.ttf"),
                     weight: None,
                     style: None,
-                    ext: "ttf".into(),
+                    ext: rcstr!("ttf"),
                 }),
                 default_style: None,
                 default_weight: None,
-                display: "swap".into(),
+                display: rcstr!("swap"),
                 preload: true,
                 fallback: None,
                 adjust_font_fallback: AdjustFontFallback::Arial,
                 variable: None,
-                variable_name: "myFont".into()
+                variable_name: rcstr!("myFont")
             },
         );
 
@@ -280,26 +281,26 @@ mod tests {
             NextFontLocalOptions {
                 fonts: FontDescriptors::Many(vec![
                     FontDescriptor {
-                        path: "./Roboto-Regular.ttf".into(),
-                        weight: Some(FontWeight::Fixed("400".into())),
-                        style: Some("normal".into()),
-                        ext: "ttf".into(),
+                        path: rcstr!("./Roboto-Regular.ttf"),
+                        weight: Some(FontWeight::Fixed(rcstr!("400"))),
+                        style: Some(rcstr!("normal")),
+                        ext: rcstr!("ttf"),
                     },
                     FontDescriptor {
-                        path: "./Roboto-Italic.ttf".into(),
-                        weight: Some(FontWeight::Fixed("400".into())),
+                        path: rcstr!("./Roboto-Italic.ttf"),
+                        weight: Some(FontWeight::Fixed(rcstr!("400"))),
                         style: None,
-                        ext: "ttf".into(),
+                        ext: rcstr!("ttf"),
                     }
                 ]),
-                default_weight: Some(FontWeight::Fixed("300".into())),
-                default_style: Some("italic".into()),
-                display: "swap".into(),
+                default_weight: Some(FontWeight::Fixed(rcstr!("300"))),
+                default_style: Some(rcstr!("italic")),
+                display: rcstr!("swap"),
                 preload: true,
                 fallback: None,
                 adjust_font_fallback: AdjustFontFallback::Arial,
                 variable: None,
-                variable_name: "myFont".into()
+                variable_name: rcstr!("myFont")
             },
         );
 
@@ -361,19 +362,19 @@ mod tests {
             options_from_request(&request)?,
             NextFontLocalOptions {
                 fonts: FontDescriptors::One(FontDescriptor {
-                    path: "./Roboto-Regular.woff".into(),
-                    weight: Some(FontWeight::Fixed("500".into())),
-                    style: Some("italic".into()),
-                    ext: "woff".into(),
+                    path: rcstr!("./Roboto-Regular.woff"),
+                    weight: Some(FontWeight::Fixed(rcstr!("500"))),
+                    style: Some(rcstr!("italic")),
+                    ext: rcstr!("woff"),
                 }),
-                default_style: Some("italic".into()),
-                default_weight: Some(FontWeight::Fixed("500".into())),
-                display: "optional".into(),
+                default_style: Some(rcstr!("italic")),
+                default_weight: Some(FontWeight::Fixed(rcstr!("500"))),
+                display: rcstr!("optional"),
                 preload: false,
-                fallback: Some(vec!["Fallback".into()]),
+                fallback: Some(vec![rcstr!("Fallback")]),
                 adjust_font_fallback: AdjustFontFallback::TimesNewRoman,
-                variable: Some("myvar".into()),
-                variable_name: "myFont".into()
+                variable: Some(rcstr!("myvar")),
+                variable_name: rcstr!("myFont")
             },
         );
 

--- a/crates/next-core/src/next_font/local/stylesheet.rs
+++ b/crates/next-core/src/next_font/local/stylesheet.rs
@@ -18,7 +18,7 @@ pub(super) async fn build_stylesheet(
     css_properties: Vc<FontCssProperties>,
 ) -> Result<Vc<RcStr>> {
     let scoped_font_family =
-        get_scoped_font_family(FontFamilyType::WebFont.cell(), options.font_family());
+        get_scoped_font_family(FontFamilyType::WebFont, options.font_family().await?);
 
     Ok(Vc::cell(
         formatdoc!(
@@ -39,7 +39,7 @@ pub(super) async fn build_stylesheet(
 /// Builds a string of `@font-face` definitions for each local font file
 #[turbo_tasks::function]
 pub(super) async fn build_font_face_definitions(
-    scoped_font_family: Vc<RcStr>,
+    scoped_font_family: RcStr,
     options: Vc<NextFontLocalOptions>,
     has_size_adjust: Vc<bool>,
 ) -> Result<Vc<RcStr>> {
@@ -70,7 +70,7 @@ pub(super) async fn build_font_face_definitions(
                     {}{}
                 }}
             "#,
-            *scoped_font_family.await?,
+            scoped_font_family,
             query_str,
             ext_to_format(&font.ext)?,
             options.display,

--- a/crates/next-core/src/next_font/local/util.rs
+++ b/crates/next-core/src/next_font/local/util.rs
@@ -17,7 +17,7 @@ pub(super) async fn build_font_family_string(
     let mut font_families = vec![
         format!(
             "'{}'",
-            *get_scoped_font_family(FontFamilyType::WebFont.cell(), options.font_family(),).await?
+            get_scoped_font_family(FontFamilyType::WebFont, options.font_family().await?)
         )
         .into(),
     ];
@@ -25,7 +25,7 @@ pub(super) async fn build_font_family_string(
     for font_fallback in &*font_fallbacks.await? {
         match &*font_fallback.await? {
             FontFallback::Automatic(fallback) => {
-                font_families.push(format!("'{}'", *fallback.scoped_font_family.await?).into());
+                font_families.push(format!("'{}'", fallback.scoped_font_family).into());
             }
             FontFallback::Manual(fallbacks) => {
                 font_families.extend_from_slice(fallbacks);

--- a/crates/next-core/src/next_font/stylesheet.rs
+++ b/crates/next-core/src/next_font/stylesheet.rs
@@ -38,8 +38,8 @@ pub(crate) async fn build_fallback_definition(fallbacks: Vc<FontFallbacks>) -> R
                     {}
                 }}
             "#,
-                fallback.scoped_font_family.await?,
-                fallback.local_font_family.await?,
+                fallback.scoped_font_family,
+                fallback.local_font_family,
                 override_properties
             ));
         }

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, json::parse_json_with_source_context};
 use turbo_tasks_hash::hash_xxh3_hash64;
@@ -88,12 +88,12 @@ pub(crate) async fn can_use_next_font(
         NextFontIssue {
             path: path.to_resolved().await?,
             title: StyledString::Line(vec![
-                StyledString::Code("next/font:".into()),
-                StyledString::Text(" error:".into()),
+                StyledString::Code(rcstr!("next/font:")),
+                StyledString::Text(rcstr!(" error:")),
             ])
             .resolved_cell(),
             description: StyledString::Line(vec![
-                StyledString::Text("Cannot be used within ".into()),
+                StyledString::Text(rcstr!("Cannot be used within ")),
                 StyledString::Code(request.path),
             ])
             .resolved_cell(),

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -46,31 +46,21 @@ pub(crate) enum FontFamilyType {
 ///   e.g. `__Roboto_Fallback_c123b8`
 /// * `font_family_name` - The font name to scope, e.g. `Roboto`
 /// * `request_hash` - The hash value of the font request
-#[turbo_tasks::function]
-pub(crate) async fn get_scoped_font_family(
-    ty: Vc<FontFamilyType>,
-    font_family_name: Vc<RcStr>,
-) -> Result<Vc<RcStr>> {
-    let font_family_base = font_family_name.await?.to_string();
-    let font_family_name = match &*ty.await? {
-        FontFamilyType::WebFont => font_family_base,
-        FontFamilyType::Fallback => format!("{font_family_base} Fallback"),
-    };
-
-    Ok(Vc::cell(font_family_name.into()))
+pub(crate) fn get_scoped_font_family(ty: FontFamilyType, font_family_name: RcStr) -> RcStr {
+    match ty {
+        FontFamilyType::WebFont => font_family_name,
+        FontFamilyType::Fallback => format!("{font_family_name} Fallback").into(),
+    }
 }
 
-/// Returns a [Vc] for [String] uniquely identifying the request for the font.
-#[turbo_tasks::function]
-pub async fn get_request_id(font_family: Vc<RcStr>, request_hash: u32) -> Result<Vc<RcStr>> {
-    Ok(Vc::cell(
-        format!(
-            "{}_{:x?}",
-            font_family.await?.to_lowercase().replace(' ', "_"),
-            request_hash
-        )
-        .into(),
-    ))
+/// Returns a [RcStr] for [String] uniquely identifying the request for the font.
+pub fn get_request_id(font_family: RcStr, request_hash: u32) -> RcStr {
+    format!(
+        "{}_{:x?}",
+        font_family.to_lowercase().replace(' ', "_"),
+        request_hash
+    )
+    .into()
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -456,7 +456,7 @@ pub async fn get_next_edge_import_map(
     .await?;
 
     let ty = ty.into_value();
-    match ty {
+    match &ty {
         ServerContextType::Pages { .. }
         | ServerContextType::PagesData { .. }
         | ServerContextType::PagesApi { .. }
@@ -486,7 +486,7 @@ pub async fn get_next_edge_import_map(
     insert_next_server_special_aliases(
         &mut import_map,
         project_path,
-        ty,
+        ty.clone(),
         NextRuntime::Edge,
         next_config,
     )
@@ -607,14 +607,14 @@ async fn insert_next_server_special_aliases(
         .resolved_cell(),
     );
 
-    match ty {
+    match &ty {
         ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {}
         ServerContextType::PagesData { .. } => {}
         // the logic closely follows the one in createRSCAliases in webpack-config.ts
         ServerContextType::AppSSR { app_dir }
         | ServerContextType::AppRSC { app_dir, .. }
         | ServerContextType::AppRoute { app_dir, .. } => {
-            let next_package = get_next_package(*app_dir).to_resolved().await?;
+            let next_package = get_next_package(**app_dir).to_resolved().await?;
             import_map.insert_exact_alias(
                 "styled-jsx",
                 request_to_import_mapping(next_package, "styled-jsx"),
@@ -624,10 +624,10 @@ async fn insert_next_server_special_aliases(
                 request_to_import_mapping(next_package, "styled-jsx/*"),
             );
 
-            rsc_aliases(import_map, project_path, ty, runtime, next_config).await?;
+            rsc_aliases(import_map, project_path, ty.clone(), runtime, next_config).await?;
         }
         ServerContextType::Middleware { .. } | ServerContextType::Instrumentation { .. } => {
-            rsc_aliases(import_map, project_path, ty, runtime, next_config).await?;
+            rsc_aliases(import_map, project_path, ty.clone(), runtime, next_config).await?;
         }
     }
 
@@ -636,7 +636,7 @@ async fn insert_next_server_special_aliases(
     // context, it'll resolve to the noop where it's allowed, or aliased into
     // the error which throws a runtime error. This works with in combination of
     // build-time error as well, refer https://github.com/vercel/next.js/blob/0060de1c4905593ea875fa7250d4b5d5ce10897d/packages/next-swc/crates/next-core/src/next_server/context.rs#L103
-    match ty {
+    match &ty {
         ServerContextType::Pages { .. } => {
             insert_exact_alias_map(
                 import_map,

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 use rustc_hash::FxHashMap;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, Value, Vc, fxindexmap};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::{
@@ -333,7 +333,7 @@ pub async fn get_next_server_import_map(
             import_map.insert_exact_alias(
                 "styled-jsx/style",
                 ImportMapping::External(
-                    Some("styled-jsx/style.js".into()),
+                    Some(rcstr!("styled-jsx/style.js")),
                     ExternalType::CommonJs,
                     ExternalTraced::Traced,
                 )
@@ -1014,7 +1014,7 @@ pub async fn get_next_package(context_directory: Vc<FileSystemPath>) -> Result<V
     let result = resolve(
         context_directory,
         Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-        Request::parse(Value::new(Pattern::Constant("next/package.json".into()))),
+        Request::parse(Value::new(Pattern::Constant(rcstr!("next/package.json")))),
         node_cjs_resolve_options(context_directory.root()),
     );
     let source = result
@@ -1113,7 +1113,7 @@ fn insert_package_alias(
 ) {
     import_map.insert_wildcard_alias(
         prefix,
-        ImportMapping::PrimaryAlternative("./*".into(), Some(package_root)).resolved_cell(),
+        ImportMapping::PrimaryAlternative(rcstr!("./*"), Some(package_root)).resolved_cell(),
     );
 }
 

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -244,8 +244,8 @@ async fn wrap_edge_page(
             "nextConfig" => serde_json::to_string(next_config_val)?.into(),
             "dev" => serde_json::Value::Bool(dev).to_string().into(),
             "pageRouteModuleOptions" => serde_json::to_string(&get_route_module_options(page.clone(), pathname.clone()))?.into(),
-            "errorRouteModuleOptions" => serde_json::to_string(&get_route_module_options("/_error".into(), "/_error".into()))?.into(),
-            "user500RouteModuleOptions" => serde_json::to_string(&get_route_module_options("/500".into(), "/500".into()))?.into(),
+            "errorRouteModuleOptions" => serde_json::to_string(&get_route_module_options(rcstr!("/_error"), rcstr!("/_error")))?.into(),
+            "user500RouteModuleOptions" => serde_json::to_string(&get_route_module_options(rcstr!("/500"), rcstr!("/500")))?.into(),
         },
         fxindexmap! {
             // TODO
@@ -322,12 +322,12 @@ struct RouteDefinition {
 fn get_route_module_options(page: RcStr, pathname: RcStr) -> PartialRouteModuleOptions {
     PartialRouteModuleOptions {
         definition: RouteDefinition {
-            kind: "PAGES".into(),
+            kind: rcstr!("PAGES"),
             page,
             pathname,
             // The following aren't used in production.
-            bundle_path: "".into(),
-            filename: "".into(),
+            bundle_path: rcstr!(""),
+            filename: rcstr!(""),
         },
     }
 }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -159,7 +159,7 @@ pub async fn get_server_resolve_options_context(
     // Always load these predefined packages as external.
     let mut external_packages: Vec<RcStr> = load_next_js_templateon(
         project_path,
-        "dist/lib/server-external-packages.json".into(),
+        rcstr!("dist/lib/server-external-packages.json"),
     )
     .await?;
 
@@ -214,7 +214,7 @@ pub async fn get_server_resolve_options_context(
     );
 
     if ty.supports_react_server() {
-        custom_conditions.push("react-server".into());
+        custom_conditions.push(rcstr!("react-server"));
     };
 
     let external_cjs_modules_plugin = if *next_config.bundle_pages_router_dependencies().await? {
@@ -483,7 +483,7 @@ pub async fn get_server_module_options_context(
         conditions
             .iter()
             .cloned()
-            .chain(once("foreign".into()))
+            .chain(once(rcstr!("foreign")))
             .collect(),
     )
     .await?;
@@ -1007,11 +1007,11 @@ pub async fn get_server_chunking_context_with_client_assets(
         node_root_to_root_path,
         client_root,
         node_root
-            .join("server/chunks/ssr".into())
+            .join(rcstr!("server/chunks/ssr"))
             .to_resolved()
             .await?,
         client_root
-            .join("static/media".into())
+            .join(rcstr!("static/media"))
             .to_resolved()
             .await?,
         environment,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::FileSystemPath;
@@ -79,7 +79,7 @@ use crate::{
 };
 
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]
-#[derive(Debug, Copy, Clone, Hash)]
+#[derive(Debug, Clone, Hash)]
 pub enum ServerContextType {
     Pages {
         pages_dir: ResolvedVc<FileSystemPath>,
@@ -95,20 +95,20 @@ pub enum ServerContextType {
     },
     AppRSC {
         app_dir: ResolvedVc<FileSystemPath>,
-        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<RcStr>,
         client_transition: Option<ResolvedVc<Box<dyn Transition>>>,
     },
     AppRoute {
         app_dir: ResolvedVc<FileSystemPath>,
-        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<RcStr>,
     },
     Middleware {
         app_dir: Option<ResolvedVc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<RcStr>,
     },
     Instrumentation {
         app_dir: Option<ResolvedVc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
+        ecmascript_client_reference_transition_name: Option<RcStr>,
     },
 }
 
@@ -133,10 +133,15 @@ pub async fn get_server_resolve_options_context(
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
-    let next_server_import_map =
-        get_next_server_import_map(*project_path, ty, next_config, mode, execution_context)
-            .to_resolved()
-            .await?;
+    let next_server_import_map = get_next_server_import_map(
+        *project_path,
+        ty.clone(),
+        next_config,
+        mode,
+        execution_context,
+    )
+    .to_resolved()
+    .await?;
     let foreign_code_context_condition =
         foreign_code_context_condition(next_config, project_path).await?;
     let root_dir = project_path.root().to_resolved().await?;
@@ -229,11 +234,11 @@ pub async fn get_server_resolve_options_context(
         .to_resolved()
         .await?;
     let next_node_shared_runtime_plugin =
-        NextNodeSharedRuntimeResolvePlugin::new(*project_path, Value::new(ty))
+        NextNodeSharedRuntimeResolvePlugin::new(*project_path, Value::new(ty.clone()))
             .to_resolved()
             .await?;
 
-    let mut before_resolve_plugins = match ty {
+    let mut before_resolve_plugins = match &ty {
         ServerContextType::Pages { .. }
         | ServerContextType::AppSSR { .. }
         | ServerContextType::AppRSC { .. } => {
@@ -415,7 +420,7 @@ pub async fn get_server_module_options_context(
     let next_mode = mode.await?;
     let mut next_server_rules = get_next_server_transforms_rules(
         next_config,
-        ty.into_value(),
+        ty.clone().into_value(),
         mode,
         false,
         next_runtime,
@@ -424,7 +429,7 @@ pub async fn get_server_module_options_context(
     .await?;
     let mut foreign_next_server_rules = get_next_server_transforms_rules(
         next_config,
-        ty.into_value(),
+        ty.clone().into_value(),
         mode,
         true,
         next_runtime,
@@ -432,7 +437,7 @@ pub async fn get_server_module_options_context(
     )
     .await?;
     let mut internal_custom_rules = get_next_server_internal_transforms_rules(
-        ty.into_value(),
+        ty.clone().into_value(),
         next_config.mdx_rs().await?.is_some(),
     )
     .await?;
@@ -983,9 +988,9 @@ pub async fn get_server_chunking_context_with_client_assets(
     mode: Vc<NextMode>,
     root_path: ResolvedVc<FileSystemPath>,
     node_root: ResolvedVc<FileSystemPath>,
-    node_root_to_root_path: ResolvedVc<RcStr>,
+    node_root_to_root_path: RcStr,
     client_root: ResolvedVc<FileSystemPath>,
-    asset_prefix: ResolvedVc<Option<RcStr>>,
+    asset_prefix: Option<RcStr>,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
@@ -1058,7 +1063,7 @@ pub async fn get_server_chunking_context(
     mode: Vc<NextMode>,
     root_path: ResolvedVc<FileSystemPath>,
     node_root: ResolvedVc<FileSystemPath>,
-    node_root_to_root_path: ResolvedVc<RcStr>,
+    node_root_to_root_path: RcStr,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
     turbo_minify: Vc<bool>,
@@ -1074,8 +1079,14 @@ pub async fn get_server_chunking_context(
         node_root,
         node_root_to_root_path,
         node_root,
-        node_root.join("server/chunks".into()).to_resolved().await?,
-        node_root.join("server/assets".into()).to_resolved().await?,
+        node_root
+            .join(rcstr!("server/chunks"))
+            .to_resolved()
+            .await?,
+        node_root
+            .join(rcstr!("server/assets"))
+            .to_resolved()
+            .await?,
         environment,
         next_mode.runtime_type(),
     )

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use next_custom_transforms::transforms::strip_page_exports::ExportFilter;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
 use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -86,7 +86,7 @@ pub async fn get_next_server_transforms_rules(
     if !foreign_code {
         rules.push(get_next_page_static_info_assert_rule(
             mdx_rs,
-            Some(context_ty),
+            Some(context_ty.clone()),
             None,
         ));
     }
@@ -95,7 +95,7 @@ pub async fn get_next_server_transforms_rules(
     let cache_kinds = next_config.cache_kinds().to_resolved().await?;
     let mut is_app_dir = false;
 
-    let is_server_components = match context_ty {
+    let is_server_components = match &context_ty {
         ServerContextType::Pages { pages_dir } | ServerContextType::PagesApi { pages_dir } => {
             if !foreign_code {
                 rules.push(get_next_disallow_export_all_in_page_rule(
@@ -109,7 +109,7 @@ pub async fn get_next_server_transforms_rules(
             if !foreign_code {
                 rules.push(
                     get_next_pages_transforms_rule(
-                        *pages_dir,
+                        **pages_dir,
                         ExportFilter::StripDefaultExport,
                         mdx_rs,
                     )

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use next_custom_transforms::transforms::strip_page_exports::ExportFilter;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
 use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};

--- a/crates/next-core/src/next_telemetry.rs
+++ b/crates/next-core/src/next_telemetry.rs
@@ -1,4 +1,4 @@
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Vc, fxindexmap};
 use turbopack_core::diagnostics::{Diagnostic, DiagnosticPayload};
 
@@ -17,7 +17,7 @@ pub struct NextFeatureTelemetry {
 impl NextFeatureTelemetry {
     pub fn new(feature_name: RcStr, enabled: bool) -> Self {
         NextFeatureTelemetry {
-            event_name: "EVENT_BUILD_FEATURE_USAGE".into(),
+            event_name: rcstr!("EVENT_BUILD_FEATURE_USAGE"),
             feature_name,
             enabled,
         }
@@ -28,7 +28,7 @@ impl NextFeatureTelemetry {
 impl Diagnostic for NextFeatureTelemetry {
     #[turbo_tasks::function]
     fn category(&self) -> Vc<RcStr> {
-        Vc::cell("NextFeatureTelemetry_category_tbd".into())
+        Vc::cell(rcstr!("NextFeatureTelemetry_category_tbd"))
     }
 
     #[turbo_tasks::function]
@@ -57,7 +57,7 @@ pub struct ModuleFeatureTelemetry {
 impl ModuleFeatureTelemetry {
     pub fn new(feature_name: RcStr, invocation_count: usize) -> Self {
         ModuleFeatureTelemetry {
-            event_name: "EVENT_BUILD_FEATURE_USAGE".into(),
+            event_name: rcstr!("EVENT_BUILD_FEATURE_USAGE"),
             feature_name,
             invocation_count,
         }
@@ -68,7 +68,7 @@ impl ModuleFeatureTelemetry {
 impl Diagnostic for ModuleFeatureTelemetry {
     #[turbo_tasks::function]
     fn category(&self) -> Vc<RcStr> {
-        Vc::cell("ModuleFeatureTelemetry_category_tbd".into())
+        Vc::cell(rcstr!("ModuleFeatureTelemetry_category_tbd"))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -25,14 +25,10 @@ use crate::{embed_js::next_js_file_path, util::get_asset_path_from_pathname};
 pub async fn create_page_loader_entry_module(
     client_context: Vc<Box<dyn AssetContext>>,
     entry_asset: Vc<Box<dyn Source>>,
-    pathname: Vc<RcStr>,
+    pathname: RcStr,
 ) -> Result<Vc<Box<dyn Module>>> {
     let mut result = RopeBuilder::default();
-    writeln!(
-        result,
-        "const PAGE_PATH = {};\n",
-        StringifyJs(&*pathname.await?)
-    )?;
+    writeln!(result, "const PAGE_PATH = {};\n", StringifyJs(&pathname))?;
 
     let page_loader_path = next_js_file_path("entry/page-loader.ts".into());
     let base_code = page_loader_path.read();
@@ -72,7 +68,7 @@ pub async fn create_page_loader_entry_module(
 #[turbo_tasks::value(shared)]
 pub struct PageLoaderAsset {
     pub server_root: ResolvedVc<FileSystemPath>,
-    pub pathname: ResolvedVc<RcStr>,
+    pub pathname: RcStr,
     pub rebase_prefix_path: ResolvedVc<FileSystemPathOption>,
     pub page_chunks: ResolvedVc<OutputAssets>,
 }
@@ -82,7 +78,7 @@ impl PageLoaderAsset {
     #[turbo_tasks::function]
     pub fn new(
         server_root: ResolvedVc<FileSystemPath>,
-        pathname: ResolvedVc<RcStr>,
+        pathname: RcStr,
         rebase_prefix_path: ResolvedVc<FileSystemPathOption>,
         page_chunks: ResolvedVc<OutputAssets>,
     ) -> Vc<Self> {
@@ -141,7 +137,7 @@ impl OutputAsset for PageLoaderAsset {
         Ok(root.join(
             format!(
                 "static/chunks/pages{}",
-                get_asset_path_from_pathname(&self.pathname.await?, ".js")
+                get_asset_path_from_pathname(&self.pathname, ".js")
             )
             .into(),
         ))
@@ -181,7 +177,7 @@ impl Asset for PageLoaderAsset {
 
         let content = format!(
             "__turbopack_load_page_chunks__({}, {:#})\n",
-            StringifyJs(&this.pathname.await?),
+            StringifyJs(&this.pathname),
             StringifyJs(&chunks_data)
         );
 

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc, fxindexmap};
 use turbo_tasks_fs::{
     self, File, FileContent, FileSystemPath, FileSystemPathOption, rope::RopeBuilder,
@@ -30,7 +30,7 @@ pub async fn create_page_loader_entry_module(
     let mut result = RopeBuilder::default();
     writeln!(result, "const PAGE_PATH = {};\n", StringifyJs(&pathname))?;
 
-    let page_loader_path = next_js_file_path("entry/page-loader.ts".into());
+    let page_loader_path = next_js_file_path(rcstr!("entry/page-loader.ts"));
     let base_code = page_loader_path.read();
     if let FileContent::Content(base_file) = &*base_code.await? {
         result += base_file.content()
@@ -58,7 +58,7 @@ pub async fn create_page_loader_entry_module(
         .process(
             virtual_source,
             Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
-                "PAGE".into() => module,
+                rcstr!("PAGE") => module,
             }))),
         )
         .module();

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -121,11 +121,6 @@ impl PageLoaderAsset {
     }
 }
 
-#[turbo_tasks::function]
-fn page_loader_chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("page loader chunk".into())
-}
-
 #[turbo_tasks::value_impl]
 impl OutputAsset for PageLoaderAsset {
     #[turbo_tasks::function]

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -32,7 +32,7 @@ use swc_core::{
     },
     quote,
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 
 use crate::FxIndexMap;
 
@@ -2778,7 +2778,7 @@ impl DirectiveVisitor<'_> {
 
                         if value == "use cache" {
                             self.directive = Some(Directive::UseCache {
-                                cache_kind: "default".into(),
+                                cache_kind: rcstr!("default"),
                             });
                             self.increment_cache_usage_counter("default");
                         } else {

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, hash_map},
+    collections::{hash_map, BTreeMap},
     convert::{TryFrom, TryInto},
     mem::{replace, take},
     path::{Path, PathBuf},
@@ -16,23 +16,23 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
 use swc_core::{
-    atoms::{Atom, atom},
+    atoms::{atom, Atom},
     common::{
-        BytePos, DUMMY_SP, FileName, Mark, SourceMap, Span, SyntaxContext,
         comments::{Comment, CommentKind, Comments, SingleThreadedComments},
         errors::HANDLER,
-        source_map::{PURE_SP, SourceMapGenConfig},
+        source_map::{SourceMapGenConfig, PURE_SP},
         util::take::Take,
+        BytePos, FileName, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        codegen::{self, Emitter, text_writer::JsWriter},
-        utils::{ExprFactory, private_ident, quote_ident},
-        visit::{VisitMut, VisitMutWith, noop_visit_mut_type, visit_mut_pass},
+        codegen::{self, text_writer::JsWriter, Emitter},
+        utils::{private_ident, quote_ident, ExprFactory},
+        visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
     },
     quote,
 };
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::{rcstr, RcStr};
 
 use crate::FxIndexMap;
 

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -32,7 +32,7 @@ use swc_core::{
     },
     quote,
 };
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 
 use crate::FxIndexMap;
 
@@ -2778,7 +2778,7 @@ impl DirectiveVisitor<'_> {
 
                         if value == "use cache" {
                             self.directive = Some(Directive::UseCache {
-                                cache_kind: rcstr!("default"),
+                                cache_kind: "default".into(),
                             });
                             self.increment_cache_usage_counter("default");
                         } else {

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{hash_map, BTreeMap},
+    collections::{BTreeMap, hash_map},
     convert::{TryFrom, TryInto},
     mem::{replace, take},
     path::{Path, PathBuf},
@@ -16,23 +16,23 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
 use swc_core::{
-    atoms::{atom, Atom},
+    atoms::{Atom, atom},
     common::{
+        BytePos, DUMMY_SP, FileName, Mark, SourceMap, Span, SyntaxContext,
         comments::{Comment, CommentKind, Comments, SingleThreadedComments},
         errors::HANDLER,
-        source_map::{SourceMapGenConfig, PURE_SP},
+        source_map::{PURE_SP, SourceMapGenConfig},
         util::take::Take,
-        BytePos, FileName, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        codegen::{self, text_writer::JsWriter, Emitter},
-        utils::{private_ident, quote_ident, ExprFactory},
-        visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
+        codegen::{self, Emitter, text_writer::JsWriter},
+        utils::{ExprFactory, private_ident, quote_ident},
+        visit::{VisitMut, VisitMutWith, noop_visit_mut_type, visit_mut_pass},
     },
     quote,
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 
 use crate::FxIndexMap;
 
@@ -2778,7 +2778,7 @@ impl DirectiveVisitor<'_> {
 
                         if value == "use cache" {
                             self.directive = Some(Directive::UseCache {
-                                cache_kind: RcStr::from("default"),
+                                cache_kind: rcstr!("default"),
                             });
                             self.increment_cache_usage_counter("default");
                         } else {

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -37,8 +37,8 @@ mod tagged_value;
 ///
 /// ## Conversion
 ///
-/// Converting a `String` or `&str` to an `RcStr` can be perfomed using `.into()` or
-/// `RcStr::from(...)`:
+/// Converting a `String` or `&str` to an `RcStr` can be perfomed using `.into()`,
+/// `RcStr::from(...)`, or the `rcstr!` macro.
 ///
 /// ```
 /// # use turbo_rcstr::RcStr;
@@ -46,6 +46,7 @@ mod tagged_value;
 /// let s = "foo";
 /// let rc_s1: RcStr = s.into();
 /// let rc_s2 = RcStr::from(s);
+/// let rc_s3 = rcstr!("foo");
 /// assert_eq!(rc_s1, rc_s2);
 /// ```
 ///

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -50,6 +50,11 @@ mod tagged_value;
 /// assert_eq!(rc_s1, rc_s2);
 /// ```
 ///
+/// Generally speaking you should
+///  * use `rcstr!` when converting a `const`-compatible `str`
+///  * use `RcStr::from` for readability
+///  * use `.into()` when context makes it clear.
+///
 /// Converting from an [`RcStr`] to a `&str` should be done with [`RcStr::as_str`]. Converting to a
 /// `String` should be done with [`RcStr::into_owned`].
 ///

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1285,7 +1285,7 @@ impl FileSystemPath {
 
     #[turbo_tasks::function]
     pub fn extension(&self) -> Vc<RcStr> {
-        Vc::cell(self.extension_ref().unwrap_or("").into())
+        Vc::cell(self.extension_ref().map(RcStr::from).unwrap_or_default())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2431,6 +2431,8 @@ pub fn register() {
 
 #[cfg(test)]
 mod tests {
+    use turbo_rcstr::rcstr;
+
     use super::*;
 
     #[test]
@@ -2456,26 +2458,26 @@ mod tests {
         turbo_tasks_testing::VcStorage::with(async {
             let fs = Vc::upcast(VirtualFileSystem::new());
 
-            let path_txt = FileSystemPath::new_normalized(fs, "foo/bar.txt".into());
+            let path_txt = FileSystemPath::new_normalized(fs, rcstr!("foo/bar.txt"));
 
-            let path_json = path_txt.with_extension("json".into());
+            let path_json = path_txt.with_extension(rcstr!("json"));
             assert_eq!(&*path_json.await.unwrap().path, "foo/bar.json");
 
-            let path_no_ext = path_txt.with_extension("".into());
+            let path_no_ext = path_txt.with_extension(rcstr!(""));
             assert_eq!(&*path_no_ext.await.unwrap().path, "foo/bar");
 
-            let path_new_ext = path_no_ext.with_extension("json".into());
+            let path_new_ext = path_no_ext.with_extension(rcstr!("json"));
             assert_eq!(&*path_new_ext.await.unwrap().path, "foo/bar.json");
 
-            let path_no_slash_txt = FileSystemPath::new_normalized(fs, "bar.txt".into());
+            let path_no_slash_txt = FileSystemPath::new_normalized(fs, rcstr!("bar.txt"));
 
-            let path_no_slash_json = path_no_slash_txt.with_extension("json".into());
+            let path_no_slash_json = path_no_slash_txt.with_extension(rcstr!("json"));
             assert_eq!(path_no_slash_json.await.unwrap().path.as_str(), "bar.json");
 
-            let path_no_slash_no_ext = path_no_slash_txt.with_extension("".into());
+            let path_no_slash_no_ext = path_no_slash_txt.with_extension(rcstr!(""));
             assert_eq!(path_no_slash_no_ext.await.unwrap().path.as_str(), "bar");
 
-            let path_no_slash_new_ext = path_no_slash_no_ext.with_extension("json".into());
+            let path_no_slash_new_ext = path_no_slash_no_ext.with_extension(rcstr!("json"));
             assert_eq!(
                 path_no_slash_new_ext.await.unwrap().path.as_str(),
                 "bar.json"
@@ -2494,19 +2496,19 @@ mod tests {
         turbo_tasks_testing::VcStorage::with(async {
             let fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new());
 
-            let path = FileSystemPath::new_normalized(fs, "".into());
+            let path = FileSystemPath::new_normalized(fs, rcstr!(""));
             assert_eq!(path.file_stem().await.unwrap().as_deref(), None);
 
-            let path = FileSystemPath::new_normalized(fs, "foo/bar.txt".into());
+            let path = FileSystemPath::new_normalized(fs, rcstr!("foo/bar.txt"));
             assert_eq!(path.file_stem().await.unwrap().as_deref(), Some("bar"));
 
-            let path = FileSystemPath::new_normalized(fs, "bar.txt".into());
+            let path = FileSystemPath::new_normalized(fs, rcstr!("bar.txt"));
             assert_eq!(path.file_stem().await.unwrap().as_deref(), Some("bar"));
 
-            let path = FileSystemPath::new_normalized(fs, "foo/bar".into());
+            let path = FileSystemPath::new_normalized(fs, rcstr!("foo/bar"));
             assert_eq!(path.file_stem().await.unwrap().as_deref(), Some("bar"));
 
-            let path = FileSystemPath::new_normalized(fs, "foo/.bar".into());
+            let path = FileSystemPath::new_normalized(fs, rcstr!("foo/.bar"));
             assert_eq!(path.file_stem().await.unwrap().as_deref(), Some(".bar"));
 
             anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -23,7 +23,6 @@ pub mod source_context;
 pub mod util;
 pub(crate) mod virtual_fs;
 mod watcher;
-
 use std::{
     borrow::Cow,
     cmp::{Ordering, min},
@@ -57,7 +56,7 @@ use tokio::{
     sync::{RwLock, RwLockReadGuard},
 };
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     ApplyEffectsContext, Completion, InvalidationReason, Invalidator, NonLocalValue, ReadRef,
     ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, effect, mark_session_dependent,
@@ -2404,7 +2403,7 @@ impl FileSystem for NullFileSystem {
 impl ValueToString for NullFileSystem {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(RcStr::from("null"))
+        Vc::cell(rcstr!("null"))
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -11,7 +11,7 @@ use clap::{Args, Parser, Subcommand};
 use rand::{Rng, RngCore, SeedableRng};
 use rustc_hash::FxHashSet;
 use tokio::time::sleep;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TransientInstance, Vc, trace::TraceRawVcs};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
@@ -142,7 +142,7 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
 
 #[turbo_tasks::function(operation)]
 fn disk_file_system_operation(fs_root: RcStr) -> Vc<DiskFileSystem> {
-    DiskFileSystem::new("project".into(), fs_root, Vec::new())
+    DiskFileSystem::new(rcstr!("project"), fs_root, Vec::new())
 }
 
 #[turbo_tasks::function(operation)]

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -3,7 +3,7 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_testing::{Registration, register, run};
 
@@ -93,7 +93,7 @@ impl ValueToString for MyEnumValue {
     fn to_string(&self) -> Vc<RcStr> {
         match self {
             MyEnumValue::Yeah(value) => Vc::cell(value.to_string().into()),
-            MyEnumValue::Nah => Vc::cell("nah".into()),
+            MyEnumValue::Nah => Vc::cell(rcstr!("nah")),
             MyEnumValue::More(more) => more.to_string(),
         }
     }

--- a/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/collectibles.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use auto_hash_map::AutoSet;
 use rustc_hash::FxHashSet;
 use tokio::time::sleep;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{CollectiblesSource, ResolvedVc, ValueToString, Vc, emit};
 use turbo_tasks_testing::{Registration, register, run};
 
@@ -17,7 +17,7 @@ static REGISTRATION: Registration = register!();
 #[tokio::test]
 async fn transitive_emitting() {
     run(&REGISTRATION, || async {
-        let result_op = my_transitive_emitting_function("".into(), "".into());
+        let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
@@ -35,8 +35,8 @@ async fn transitive_emitting() {
 #[tokio::test]
 async fn transitive_emitting_indirect() {
     run(&REGISTRATION, || async {
-        let result_op = my_transitive_emitting_function("".into(), "".into());
-        let collectibles_op = my_transitive_emitting_function_collectibles("".into(), "".into());
+        let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
+        let collectibles_op = my_transitive_emitting_function_collectibles(rcstr!(""), rcstr!(""));
         let list = collectibles_op.connect().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
         let mut expected = ["123", "42"].into_iter().collect::<FxHashSet<_>>();
@@ -103,34 +103,34 @@ async fn taking_collectibles_extra_layer() {
 #[tokio::test]
 async fn taking_collectibles_parallel() {
     run(&REGISTRATION, || async {
-        let result_op = my_transitive_emitting_function("".into(), "a".into());
+        let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!("a"));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
         assert_eq!(result_val.0, 0);
 
-        let result_op = my_transitive_emitting_function("".into(), "b".into());
-        let result_val = result_op.connect().strongly_consistent().await?;
-        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
-        assert_eq!(list.len(), 2);
-        assert_eq!(result_val.0, 0);
-
-        let result_op =
-            my_transitive_emitting_function_with_child_scope("".into(), "b".into(), "1".into());
+        let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!("b"));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
         assert_eq!(result_val.0, 0);
 
         let result_op =
-            my_transitive_emitting_function_with_child_scope("".into(), "b".into(), "2".into());
+            my_transitive_emitting_function_with_child_scope(rcstr!(""), rcstr!("b"), rcstr!("1"));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
         assert_eq!(result_val.0, 0);
 
         let result_op =
-            my_transitive_emitting_function_with_child_scope("".into(), "c".into(), "3".into());
+            my_transitive_emitting_function_with_child_scope(rcstr!(""), rcstr!("b"), rcstr!("2"));
+        let result_val = result_op.connect().strongly_consistent().await?;
+        let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
+        assert_eq!(list.len(), 2);
+        assert_eq!(result_val.0, 0);
+
+        let result_op =
+            my_transitive_emitting_function_with_child_scope(rcstr!(""), rcstr!("c"), rcstr!("3"));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
@@ -145,7 +145,7 @@ async fn taking_collectibles_parallel() {
 #[tokio::test]
 async fn taking_collectibles_with_resolve() {
     run(&REGISTRATION, || async {
-        let result_op = my_transitive_emitting_function_with_resolve("resolve".into());
+        let result_op = my_transitive_emitting_function_with_resolve(rcstr!("resolve"));
         result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
         assert_eq!(list.len(), 2);
@@ -161,7 +161,7 @@ struct Collectibles(AutoSet<ResolvedVc<Box<dyn ValueToString>>>);
 
 #[turbo_tasks::function(operation)]
 async fn my_collecting_function() -> Result<Vc<Thing>> {
-    let result_op = my_transitive_emitting_function("".into(), "".into());
+    let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
     let result_vc = result_op.connect();
     result_vc.await?;
     result_op.take_collectibles::<Box<dyn ValueToString>>();
@@ -182,13 +182,13 @@ async fn my_collecting_function_indirect() -> Result<Vc<Thing>> {
 
 #[turbo_tasks::function(operation)]
 async fn my_multi_emitting_function() -> Result<Vc<Thing>> {
-    my_transitive_emitting_function("".into(), "a".into())
+    my_transitive_emitting_function(rcstr!(""), rcstr!("a"))
         .connect()
         .await?;
-    my_transitive_emitting_function("".into(), "b".into())
+    my_transitive_emitting_function(rcstr!(""), rcstr!("b"))
         .connect()
         .await?;
-    my_emitting_function("".into()).await?;
+    my_emitting_function(rcstr!("")).await?;
     Ok(Thing::cell(Thing(0)))
 }
 

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -3,7 +3,7 @@ use std::{any::Any, fmt::Debug, future::Future, hash::Hash, sync::Arc, time::Dur
 use anyhow::Result;
 use either::Either;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 
 use crate::{
     MagicAny, ResolvedVc, TaskId, TransientInstance, TransientValue, Value, ValueTypeId, Vc,
@@ -364,7 +364,7 @@ mod tests {
         )]
         struct MultipleUnnamedFields(u32, RcStr);
 
-        assert_task_input(MultipleUnnamedFields(42, "42".into()));
+        assert_task_input(MultipleUnnamedFields(42, rcstr!("42")));
         Ok(())
     }
 
@@ -393,7 +393,7 @@ mod tests {
 
         assert_task_input(MultipleNamedFields {
             named: 42,
-            other: "42".into(),
+            other: rcstr!("42"),
         });
         Ok(())
     }
@@ -448,7 +448,7 @@ mod tests {
     fn test_multiple_variants_and_heterogeneous_fields() -> Result<()> {
         assert_task_input(MultipleVariantsAndHeterogeneousFields::Variant5 {
             named: 42,
-            other: "42".into(),
+            other: rcstr!("42"),
         });
         Ok(())
     }
@@ -468,12 +468,12 @@ mod tests {
 
         assert_task_input(NestedVariants::Variant5 {
             named: OneVariant::Variant,
-            other: "42".into(),
+            other: rcstr!("42"),
         });
         assert_task_input(NestedVariants::Variant2(
             MultipleVariantsAndHeterogeneousFields::Variant5 {
                 named: 42,
-                other: "42".into(),
+                other: rcstr!("42"),
             },
         ));
         Ok(())

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -3,7 +3,7 @@ use std::{any::Any, fmt::Debug, future::Future, hash::Hash, sync::Arc, time::Dur
 use anyhow::Result;
 use either::Either;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 
 use crate::{
     MagicAny, ResolvedVc, TaskId, TransientInstance, TransientValue, Value, ValueTypeId, Vc,
@@ -322,6 +322,7 @@ tuple_impls! { A B C D E F G H I J K L }
 
 #[cfg(test)]
 mod tests {
+    use turbo_rcstr::rcstr;
     use turbo_tasks_macros::TaskInput;
 
     use super::*;
@@ -406,7 +407,7 @@ mod tests {
         struct GenericField<T>(T);
 
         assert_task_input(GenericField(42));
-        assert_task_input(GenericField(RcStr::from("42")));
+        assert_task_input(GenericField(rcstr!("42")));
         Ok(())
     }
 

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -367,7 +367,7 @@ impl ChunkingContext for BrowserChunkingContext {
         if let Some(name) = &self.name {
             Vc::cell(name.clone())
         } else {
-            Vc::cell("unknown".into())
+            Vc::cell(rcstr!("unknown"))
         }
     }
 

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -97,17 +97,17 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn asset_base_path(mut self, asset_base_path: ResolvedVc<Option<RcStr>>) -> Self {
+    pub fn asset_base_path(mut self, asset_base_path: Option<RcStr>) -> Self {
         self.chunking_context.asset_base_path = asset_base_path;
         self
     }
 
-    pub fn chunk_base_path(mut self, chunk_base_path: ResolvedVc<Option<RcStr>>) -> Self {
+    pub fn chunk_base_path(mut self, chunk_base_path: Option<RcStr>) -> Self {
         self.chunking_context.chunk_base_path = chunk_base_path;
         self
     }
 
-    pub fn chunk_suffix_path(mut self, chunk_suffix_path: ResolvedVc<Option<RcStr>>) -> Self {
+    pub fn chunk_suffix_path(mut self, chunk_suffix_path: Option<RcStr>) -> Self {
         self.chunking_context.chunk_suffix_path = chunk_suffix_path;
         self
     }
@@ -182,7 +182,7 @@ pub struct BrowserChunkingContext {
     /// This path is used to compute the url to request chunks from
     output_root: ResolvedVc<FileSystemPath>,
     /// The relative path from the output_root to the root_path.
-    output_root_to_root_path: ResolvedVc<RcStr>,
+    output_root_to_root_path: RcStr,
     /// This path is used to compute the url to request assets from
     client_root: ResolvedVc<FileSystemPath>,
     /// Chunks are placed at this path
@@ -191,13 +191,13 @@ pub struct BrowserChunkingContext {
     asset_root_path: ResolvedVc<FileSystemPath>,
     /// Base path that will be prepended to all chunk URLs when loading them.
     /// This path will not appear in chunk paths or chunk data.
-    chunk_base_path: ResolvedVc<Option<RcStr>>,
+    chunk_base_path: Option<RcStr>,
     /// Suffix path that will be appended to all chunk URLs when loading them.
     /// This path will not appear in chunk paths or chunk data.
-    chunk_suffix_path: ResolvedVc<Option<RcStr>>,
+    chunk_suffix_path: Option<RcStr>,
     /// URL prefix that will be prepended to all static asset URLs when loading
     /// them.
-    asset_base_path: ResolvedVc<Option<RcStr>>,
+    asset_base_path: Option<RcStr>,
     /// Enable HMR for this chunking
     enable_hot_module_replacement: bool,
     /// Enable tracing for this chunking
@@ -226,7 +226,7 @@ impl BrowserChunkingContext {
     pub fn builder(
         root_path: ResolvedVc<FileSystemPath>,
         output_root: ResolvedVc<FileSystemPath>,
-        output_root_to_root_path: ResolvedVc<RcStr>,
+        output_root_to_root_path: RcStr,
         client_root: ResolvedVc<FileSystemPath>,
         chunk_root_path: ResolvedVc<FileSystemPath>,
         asset_root_path: ResolvedVc<FileSystemPath>,
@@ -243,9 +243,9 @@ impl BrowserChunkingContext {
                 chunk_root_path,
                 should_use_file_source_map_uris: false,
                 asset_root_path,
-                chunk_base_path: ResolvedVc::cell(None),
-                chunk_suffix_path: ResolvedVc::cell(None),
-                asset_base_path: ResolvedVc::cell(None),
+                chunk_base_path: None,
+                chunk_suffix_path: None,
+                asset_base_path: None,
                 enable_hot_module_replacement: false,
                 enable_tracing: false,
                 environment,
@@ -272,13 +272,13 @@ impl BrowserChunkingContext {
     }
 
     /// Returns the asset base path.
-    pub fn chunk_base_path(&self) -> Vc<Option<RcStr>> {
-        *self.chunk_base_path
+    pub fn chunk_base_path(&self) -> Option<RcStr> {
+        self.chunk_base_path.clone()
     }
 
     /// Returns the asset suffix path.
-    pub fn chunk_suffix_path(&self) -> Vc<Option<RcStr>> {
-        *self.chunk_suffix_path
+    pub fn chunk_suffix_path(&self) -> Option<RcStr> {
+        self.chunk_suffix_path.clone()
     }
 
     /// Returns the source map type.
@@ -383,7 +383,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     fn output_root_to_root_path(&self) -> Vc<RcStr> {
-        *self.output_root_to_root_path
+        Vc::cell(self.output_root_to_root_path.clone())
     }
 
     #[turbo_tasks::function]
@@ -446,7 +446,6 @@ impl ChunkingContext for BrowserChunkingContext {
             format!(
                 "{}{}",
                 self.asset_base_path
-                    .await?
                     .as_ref()
                     .map(|s| s.as_str())
                     .unwrap_or("/"),

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -60,7 +60,7 @@ impl EcmascriptBrowserChunk {
 impl ValueToString for EcmascriptBrowserChunk {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("Ecmascript Dev Chunk".into())
+        Vc::cell(rcstr!("Ecmascript Dev Chunk"))
     }
 }
 
@@ -103,7 +103,7 @@ impl OutputAsset for EcmascriptBrowserChunk {
         let ident = this.ident_for_path();
         Ok(this
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, rcstr!(".js")))
     }
 
     #[turbo_tasks::function]
@@ -158,21 +158,11 @@ impl GenerateSourceMap for EcmascriptBrowserChunk {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("dev ecmascript chunk".into())
-}
-
-#[turbo_tasks::function]
-fn introspectable_details() -> Vc<RcStr> {
-    Vc::cell("generates a development ecmascript chunk".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for EcmascriptBrowserChunk {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("dev ecmascript chunk"))
     }
 
     #[turbo_tasks::function]
@@ -182,14 +172,14 @@ impl Introspectable for EcmascriptBrowserChunk {
 
     #[turbo_tasks::function]
     fn details(&self) -> Vc<RcStr> {
-        introspectable_details()
+        Vc::cell(rcstr!("generates a development ecmascript chunk"))
     }
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
         let chunk = ResolvedVc::upcast::<Box<dyn Introspectable>>(self.chunk);
-        children.insert((ResolvedVc::cell("chunk".into()), chunk));
+        children.insert((rcstr!("chunk"), chunk));
         Ok(Vc::cell(children))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -246,7 +246,7 @@ impl EcmascriptBrowserEvaluateChunk {
 impl ValueToString for EcmascriptBrowserEvaluateChunk {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("Ecmascript Browser Evaluate Chunk".into())
+        Vc::cell(rcstr!("Ecmascript Browser Evaluate Chunk"))
     }
 }
 
@@ -258,7 +258,7 @@ impl OutputAsset for EcmascriptBrowserEvaluateChunk {
         let ident = self.ident_for_path();
         Ok(this
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, rcstr!(".js")))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -78,7 +78,11 @@ impl EcmascriptBrowserEvaluateChunk {
         let chunking_context = this.chunking_context.await?;
         let environment = this.chunking_context.environment();
 
-        let output_root_to_root_path = this.chunking_context.output_root_to_root_path();
+        let output_root_to_root_path = this
+            .chunking_context
+            .output_root_to_root_path()
+            .owned()
+            .await?;
         let source_maps = *this
             .chunking_context
             .reference_chunk_source_maps(Vc::upcast(self))

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -64,7 +64,7 @@ impl EcmascriptDevChunkList {
 impl ValueToString for EcmascriptDevChunkList {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("Ecmascript Dev Chunk List".into())
+        Vc::cell(rcstr!("Ecmascript Dev Chunk List"))
     }
 }
 
@@ -90,7 +90,7 @@ impl OutputAsset for EcmascriptDevChunkList {
         let ident = AssetIdent::new(Value::new(ident));
         Ok(this
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, rcstr!(".js")))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -12,12 +13,14 @@ use turbopack_resolve::{
 
 #[turbo_tasks::function]
 fn react_refresh_request() -> Vc<Request> {
-    Request::parse_string("@next/react-refresh-utils/dist/runtime".into())
+    Request::parse_string(rcstr!("@next/react-refresh-utils/dist/runtime"))
 }
 
 #[turbo_tasks::function]
 fn react_refresh_request_in_next() -> Vc<Request> {
-    Request::parse_string("next/dist/compiled/@next/react-refresh-utils/dist/runtime".into())
+    Request::parse_string(rcstr!(
+        "next/dist/compiled/@next/react-refresh-utils/dist/runtime"
+    ))
 }
 
 #[turbo_tasks::value]
@@ -84,7 +87,7 @@ impl Issue for ReactRefreshResolvingIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Could not resolve React Refresh runtime".into()).cell()
+        StyledString::Text(rcstr!("Could not resolve React Refresh runtime")).cell()
     }
 
     #[turbo_tasks::function]
@@ -101,13 +104,13 @@ impl Issue for ReactRefreshResolvingIssue {
     fn description(&self) -> Vc<OptionStyledString> {
         Vc::cell(Some(
             StyledString::Line(vec![
-                StyledString::Text(
-                    "React Refresh will be disabled.\nTo enable React Refresh, install the ".into(),
-                ),
-                StyledString::Code("react-refresh".into()),
-                StyledString::Text(" and ".into()),
-                StyledString::Code("@next/react-refresh-utils".into()),
-                StyledString::Text(" modules.".into()),
+                StyledString::Text(rcstr!(
+                    "React Refresh will be disabled.\nTo enable React Refresh, install the "
+                )),
+                StyledString::Code(rcstr!("react-refresh")),
+                StyledString::Text(rcstr!(" and ")),
+                StyledString::Code(rcstr!("@next/react-refresh-utils")),
+                StyledString::Text(rcstr!(" modules.")),
             ])
             .resolved_cell(),
         ))

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -230,7 +230,7 @@ async fn build_internal(
             NodeJsChunkingContext::builder(
                 project_path,
                 build_output_root,
-                ResolvedVc::cell(build_output_root_to_root_path.clone()),
+                build_output_root_to_root_path.clone(),
                 build_output_root,
                 build_output_root,
                 build_output_root,
@@ -318,7 +318,7 @@ async fn build_internal(
             let mut builder = BrowserChunkingContext::builder(
                 project_path,
                 build_output_root,
-                ResolvedVc::cell(build_output_root_to_root_path),
+                build_output_root_to_root_path,
                 build_output_root,
                 build_output_root,
                 build_output_root,
@@ -369,7 +369,7 @@ async fn build_internal(
             let mut builder = NodeJsChunkingContext::builder(
                 project_path,
                 build_output_root,
-                ResolvedVc::cell(build_output_root_to_root_path),
+                build_output_root_to_root_path,
                 build_output_root,
                 build_output_root,
                 build_output_root,

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use rustc_hash::FxHashSet;
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc,
     apply_effects,
@@ -208,12 +208,12 @@ async fn build_internal(
         .into();
     let root_path = project_fs.root().to_resolved().await?;
     let project_path = root_path.join(project_relative).to_resolved().await?;
-    let build_output_root = output_fs.root().join("dist".into()).to_resolved().await?;
+    let build_output_root = output_fs.root().join(rcstr!("dist")).to_resolved().await?;
 
     let node_env = NodeEnv::Production.cell();
 
     let build_output_root_to_root_path = project_path
-        .join("dist".into())
+        .join(rcstr!("dist"))
         .await?
         .get_relative_path_to(&*root_path.await?)
         .context("Project path is in root path")?;
@@ -276,7 +276,7 @@ async fn build_internal(
         .await?)
         .to_vec();
 
-    let origin = PlainResolveOrigin::new(asset_context, project_fs.root().join("_".into()));
+    let origin = PlainResolveOrigin::new(asset_context, project_fs.root().join(rcstr!("_")));
     let project_dir = &project_dir;
     let entries = async move {
         entry_requests
@@ -433,7 +433,7 @@ async fn build_internal(
                                                     .unwrap()
                                                     .into(),
                                             )
-                                            .with_extension("entry.js".into()),
+                                            .with_extension(rcstr!("entry.js")),
                                     ),
                                     ChunkGroup::Entry(
                                         [ResolvedVc::upcast(ecmascript)].into_iter().collect(),
@@ -458,7 +458,7 @@ async fn build_internal(
                                                 .unwrap()
                                                 .into(),
                                         )
-                                        .with_extension("entry.js".into()),
+                                        .with_extension(rcstr!("entry.js")),
                                     EvaluatableAssets::one(*ResolvedVc::upcast(ecmascript)),
                                     module_graph,
                                     OutputAssets::empty(),

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -11,7 +11,7 @@ use std::{
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashSet;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, OperationVc, ResolvedVc, TransientInstance, TurboTasks, UpdateInfo, Value, Vc,
     trace::TraceRawVcs,
@@ -271,16 +271,16 @@ async fn source(
     let env = load_env(*root_path);
     let build_output_root = output_fs
         .root()
-        .join(".turbopack/build".into())
+        .join(rcstr!(".turbopack/build"))
         .to_resolved()
         .await?;
 
     let build_output_root_to_root_path = project_path
-        .join(".turbopack/build".into())
+        .join(rcstr!(".turbopack/build"))
         .await?
         .get_relative_path_to(&*root_path.await?)
         .context("Project path is in root path")?;
-    let build_output_root_to_root_path = ResolvedVc::cell(build_output_root_to_root_path);
+    let build_output_root_to_root_path = build_output_root_to_root_path;
 
     let build_chunking_context = NodeJsChunkingContext::builder(
         root_path,
@@ -288,11 +288,11 @@ async fn source(
         build_output_root_to_root_path,
         build_output_root,
         build_output_root
-            .join("chunks".into())
+            .join(rcstr!("chunks"))
             .to_resolved()
             .await?,
         build_output_root
-            .join("assets".into())
+            .join(rcstr!("assets"))
             .to_resolved()
             .await?,
         node_build_environment().to_resolved().await?,
@@ -328,7 +328,7 @@ async fn source(
         execution_context,
         entry_requests,
         server_root,
-        Vc::cell("/ROOT".into()),
+        rcstr!("/ROOT"),
         env,
         eager_compile,
         NodeEnv::Development.cell(),

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -338,7 +338,7 @@ async fn source(
     .to_resolved()
     .await?;
     let static_source = ResolvedVc::upcast(
-        StaticAssetsContentSource::new(Default::default(), project_path.join("public".into()))
+        StaticAssetsContentSource::new(Default::default(), project_path.join(rcstr!("public")))
             .to_resolved()
             .await?,
     );
@@ -354,7 +354,7 @@ async fn source(
     let main_source = ResolvedVc::upcast(main_source);
     Ok(Vc::upcast(PrefixedRouterContentSource::new(
         Default::default(),
-        vec![("__turbopack__".into(), introspect)],
+        vec![(rcstr!("__turbopack__"), introspect)],
         *main_source,
     )))
 }

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
@@ -36,7 +36,7 @@ use crate::{
 pub async fn get_client_chunking_context(
     root_path: ResolvedVc<FileSystemPath>,
     server_root: ResolvedVc<FileSystemPath>,
-    server_root_to_root_path: ResolvedVc<RcStr>,
+    server_root_to_root_path: RcStr,
     environment: ResolvedVc<Environment>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     Ok(Vc::upcast(
@@ -45,8 +45,8 @@ pub async fn get_client_chunking_context(
             server_root,
             server_root_to_root_path,
             server_root,
-            server_root.join("/_chunks".into()).to_resolved().await?,
-            server_root.join("/_assets".into()).to_resolved().await?,
+            server_root.join(rcstr!("/_chunks")).to_resolved().await?,
+            server_root.join(rcstr!("/_assets")).to_resolved().await?,
             environment,
             RuntimeType::Development,
         )
@@ -100,7 +100,7 @@ pub async fn create_web_entry_source(
     execution_context: Vc<ExecutionContext>,
     entry_requests: Vec<Vc<Request>>,
     server_root: Vc<FileSystemPath>,
-    server_root_to_root_path: ResolvedVc<RcStr>,
+    server_root_to_root_path: RcStr,
     _env: Vc<Box<dyn ProcessEnv>>,
     eager_compile: bool,
     node_env: Vc<NodeEnv>,
@@ -118,7 +118,7 @@ pub async fn create_web_entry_source(
     let chunking_context = get_client_chunking_context(
         root_path,
         server_root,
-        *server_root_to_root_path,
+        server_root_to_root_path,
         compile_time_info.environment(),
     )
     .to_resolved()

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -76,7 +76,7 @@ pub async fn get_client_runtime_entries(
         runtime_entries.push(
             RuntimeEntry::Request(
                 request.to_resolved().await?,
-                project_path.join("_".into()).to_resolved().await?,
+                project_path.join(rcstr!("_")).to_resolved().await?,
             )
             .resolved_cell(),
         )
@@ -84,7 +84,7 @@ pub async fn get_client_runtime_entries(
 
     runtime_entries.push(
         RuntimeEntry::Source(ResolvedVc::upcast(
-            FileSource::new(embed_file_path("entry/bootstrap.ts".into()))
+            FileSource::new(embed_file_path(rcstr!("entry/bootstrap.ts")))
                 .to_resolved()
                 .await?,
         ))
@@ -127,7 +127,7 @@ pub async fn create_web_entry_source(
 
     let runtime_entries = entries.resolve_entries(asset_context);
 
-    let origin = PlainResolveOrigin::new(asset_context, root_path.join("_".into()));
+    let origin = PlainResolveOrigin::new(asset_context, root_path.join(rcstr!("_")));
     let entries = entry_requests
         .into_iter()
         .map(|request| async move {
@@ -196,7 +196,7 @@ pub async fn create_web_entry_source(
         .await?;
 
     let entry_asset = Vc::upcast(DevHtmlAsset::new(
-        server_root.join("index.html".into()).to_resolved().await?,
+        server_root.join(rcstr!("index.html")).to_resolved().await?,
         entries,
     ));
 

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::Xxh3Hash64Hasher;
@@ -38,11 +37,6 @@ impl ChunksData {
         }
         Ok(Vc::cell(hasher.finish()))
     }
-}
-
-#[turbo_tasks::function]
-fn module_chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("module chunk".into())
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::{Context, Result, anyhow};
 use swc_core::ecma::preset_env::{Version, Versions};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TaskInput, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 
@@ -146,7 +146,7 @@ impl Environment {
         let env = self;
         match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
-                Vc::cell(vec![".js".into(), ".node".into(), ".json".into()])
+                Vc::cell(vec![rcstr!(".js"), rcstr!(".node"), rcstr!(".json")])
             }
             ExecutionEnvironment::EdgeWorker(_) | ExecutionEnvironment::Browser(_) => {
                 Vc::<Vec<RcStr>>::default()
@@ -174,11 +174,11 @@ impl Environment {
         let env = self;
         match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
-                Vc::cell(vec!["node".into()])
+                Vc::cell(vec![rcstr!("node")])
             }
             ExecutionEnvironment::Browser(_) => Vc::<Vec<RcStr>>::default(),
             ExecutionEnvironment::EdgeWorker(_) => {
-                Vc::cell(vec!["edge-light".into(), "worker".into()])
+                Vc::cell(vec![rcstr!("edge-light"), rcstr!("worker")])
             }
             ExecutionEnvironment::Custom(_) => todo!(),
         }
@@ -302,7 +302,7 @@ pub struct RuntimeVersions(#[turbo_tasks(trace_ignore)] pub Versions);
 
 #[turbo_tasks::function]
 pub async fn get_current_nodejs_version(env: Vc<Box<dyn ProcessEnv>>) -> Result<Vc<RcStr>> {
-    let path_read = env.read("PATH".into()).await?;
+    let path_read = env.read(rcstr!("PATH")).await?;
     let path = path_read.as_ref().context("env must have PATH")?;
     let mut cmd = Command::new("node");
     cmd.arg("--version");

--- a/turbopack/crates/turbopack-core/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/mod.rs
@@ -9,7 +9,7 @@ use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 type VcDynIntrospectable = ResolvedVc<Box<dyn Introspectable>>;
 
 #[turbo_tasks::value(transparent)]
-pub struct IntrospectableChildren(FxIndexSet<(ResolvedVc<RcStr>, VcDynIntrospectable)>);
+pub struct IntrospectableChildren(FxIndexSet<(RcStr, VcDynIntrospectable)>);
 
 #[turbo_tasks::value_trait]
 pub trait Introspectable {

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 
 use super::{
@@ -20,16 +20,11 @@ impl IntrospectableModule {
     }
 }
 
-#[turbo_tasks::function]
-fn ty() -> Vc<RcStr> {
-    Vc::cell("asset".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for IntrospectableModule {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        ty()
+        Vc::cell(rcstr!("asset"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 
 use super::{
@@ -25,16 +25,11 @@ impl IntrospectableOutputAsset {
     }
 }
 
-#[turbo_tasks::function]
-fn ty() -> Vc<RcStr> {
-    Vc::cell("output asset".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for IntrospectableOutputAsset {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        ty()
+        Vc::cell(rcstr!("output asset"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/introspect/source.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/source.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 
 use super::{Introspectable, utils::content_to_details};
@@ -17,16 +17,11 @@ impl IntrospectableSource {
     }
 }
 
-#[turbo_tasks::function]
-fn ty() -> Vc<RcStr> {
-    Vc::cell("source".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for IntrospectableSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        ty()
+        Vc::cell(rcstr!("source"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 use turbo_tasks_fs::FileContent;
 
@@ -13,39 +13,32 @@ use crate::{
     reference::{ModuleReference, ModuleReferences},
 };
 
-#[turbo_tasks::function]
-fn reference_ty() -> Vc<RcStr> {
-    Vc::cell("reference".into())
+fn reference_ty() -> RcStr {
+    rcstr!("reference")
 }
 
-#[turbo_tasks::function]
-fn parallel_reference_ty() -> Vc<RcStr> {
-    Vc::cell("parallel reference".into())
+fn parallel_reference_ty() -> RcStr {
+    rcstr!("parallel reference")
 }
 
-#[turbo_tasks::function]
-fn parallel_inherit_async_reference_ty() -> Vc<RcStr> {
-    Vc::cell("parallel reference (inherit async module)".into())
+fn parallel_inherit_async_reference_ty() -> RcStr {
+    rcstr!("parallel reference (inherit async module)")
 }
 
-#[turbo_tasks::function]
-fn async_reference_ty() -> Vc<RcStr> {
-    Vc::cell("async reference".into())
+fn async_reference_ty() -> RcStr {
+    rcstr!("async reference")
 }
 
-#[turbo_tasks::function]
-fn isolated_reference_ty() -> Vc<RcStr> {
-    Vc::cell("isolated reference".into())
+fn isolated_reference_ty() -> RcStr {
+    rcstr!("isolated reference")
 }
 
-#[turbo_tasks::function]
-fn shared_reference_ty() -> Vc<RcStr> {
-    Vc::cell("shared reference".into())
+fn shared_reference_ty() -> RcStr {
+    rcstr!("shared reference")
 }
 
-#[turbo_tasks::function]
-fn traced_reference_ty() -> Vc<RcStr> {
-    Vc::cell("traced reference".into())
+fn traced_reference_ty() -> RcStr {
+    rcstr!("traced reference")
 }
 
 #[turbo_tasks::function]
@@ -59,7 +52,7 @@ pub async fn content_to_details(content: Vc<AssetContent>) -> Result<Vc<RcStr>> 
                     Err(_) => Vc::cell(format!("{} binary bytes", content.len()).into()),
                 }
             }
-            FileContent::NotFound => Vc::cell("not found".into()),
+            FileContent::NotFound => Vc::cell(rcstr!("not found")),
         },
         AssetContent::Redirect { target, link_type } => {
             Vc::cell(format!("redirect to {target} with type {link_type:?}").into())
@@ -75,21 +68,27 @@ pub async fn children_from_module_references(
     let mut children = FxIndexSet::default();
     let references = references.await?;
     for &reference in &*references {
-        let mut key = key;
-        if let Some(chunkable) =
+        let key = if let Some(chunkable) =
             ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference)
         {
             match &*chunkable.chunking_type().await? {
-                None => {}
-                Some(ChunkingType::Parallel { .. }) => key = parallel_reference_ty(),
-                Some(ChunkingType::Async) => key = async_reference_ty(),
-                Some(ChunkingType::Isolated { .. }) => key = isolated_reference_ty(),
-                Some(ChunkingType::Shared { .. }) => key = shared_reference_ty(),
-                Some(ChunkingType::Traced) => key = traced_reference_ty(),
+                None => key.clone(),
+                Some(ChunkingType::Parallel { inherit_async, .. }) => {
+                    if *inherit_async {
+                        parallel_inherit_async_reference_ty()
+                    } else {
+                        parallel_reference_ty()
+                    }
+                }
+                Some(ChunkingType::Async) => async_reference_ty(),
+                Some(ChunkingType::Isolated { .. }) => isolated_reference_ty(),
+                Some(ChunkingType::Shared { .. }) => shared_reference_ty(),
+                Some(ChunkingType::Traced) => traced_reference_ty(),
             }
-        }
+        } else {
+            key.clone()
+        };
 
-        let key = key.to_resolved().await?;
         for &module in reference
             .resolve_reference()
             .resolve()
@@ -98,7 +97,10 @@ pub async fn children_from_module_references(
             .await?
             .iter()
         {
-            children.insert((key, IntrospectableModule::new(*module).to_resolved().await?));
+            children.insert((
+                key.clone(),
+                IntrospectableModule::new(*module).to_resolved().await?,
+            ));
         }
         for &output_asset in reference
             .resolve_reference()
@@ -107,7 +109,7 @@ pub async fn children_from_module_references(
             .iter()
         {
             children.insert((
-                key,
+                key.clone(),
                 IntrospectableOutputAsset::new(*output_asset)
                     .to_resolved()
                     .await?,
@@ -121,12 +123,12 @@ pub async fn children_from_module_references(
 pub async fn children_from_output_assets(
     references: Vc<OutputAssets>,
 ) -> Result<Vc<IntrospectableChildren>> {
-    let key = reference_ty().to_resolved().await?;
+    let key = reference_ty();
     let mut children = FxIndexSet::default();
     let references = references.await?;
     for &reference in &*references {
         children.insert((
-            key,
+            key.clone(),
             IntrospectableOutputAsset::new(*ResolvedVc::upcast(reference))
                 .to_resolved()
                 .await?,

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -49,7 +49,7 @@ impl ModuleReferences {
 #[turbo_tasks::value]
 pub struct SingleModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
-    description: ResolvedVc<RcStr>,
+    description: RcStr,
 }
 
 #[turbo_tasks::value_impl]
@@ -64,7 +64,7 @@ impl ModuleReference for SingleModuleReference {
 impl ValueToString for SingleModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        *self.description
+        Vc::cell(self.description.clone())
     }
 }
 
@@ -73,7 +73,7 @@ impl SingleModuleReference {
     /// Create a new [Vc<SingleModuleReference>] that resolves to the given
     /// asset.
     #[turbo_tasks::function]
-    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: ResolvedVc<RcStr>) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: RcStr) -> Vc<Self> {
         Self::cell(SingleModuleReference { asset, description })
     }
 
@@ -129,7 +129,7 @@ impl ValueToString for SingleChunkableModuleReference {
 #[turbo_tasks::value]
 pub struct SingleOutputAssetReference {
     asset: ResolvedVc<Box<dyn OutputAsset>>,
-    description: ResolvedVc<RcStr>,
+    description: RcStr,
 }
 
 #[turbo_tasks::value_impl]
@@ -144,7 +144,7 @@ impl ModuleReference for SingleOutputAssetReference {
 impl ValueToString for SingleOutputAssetReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        *self.description
+        Vc::cell(self.description.clone())
     }
 }
 
@@ -153,10 +153,7 @@ impl SingleOutputAssetReference {
     /// Create a new [Vc<SingleOutputAssetReference>] that resolves to the given
     /// asset.
     #[turbo_tasks::function]
-    pub fn new(
-        asset: ResolvedVc<Box<dyn OutputAsset>>,
-        description: ResolvedVc<RcStr>,
-    ) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn OutputAsset>>, description: RcStr) -> Vc<Self> {
         Self::cell(SingleOutputAssetReference { asset, description })
     }
 

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -87,13 +87,13 @@ impl SingleModuleReference {
 #[turbo_tasks::value]
 pub struct SingleChunkableModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
-    description: ResolvedVc<RcStr>,
+    description: RcStr,
 }
 
 #[turbo_tasks::value_impl]
 impl SingleChunkableModuleReference {
     #[turbo_tasks::function]
-    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: ResolvedVc<RcStr>) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn Module>>, description: RcStr) -> Vc<Self> {
         Self::cell(SingleChunkableModuleReference { asset, description })
     }
 }
@@ -121,7 +121,7 @@ impl ModuleReference for SingleChunkableModuleReference {
 impl ValueToString for SingleChunkableModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        *self.description
+        Vc::cell(self.description.clone())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1270,7 +1270,7 @@ async fn imports_field(lookup_path: Vc<FileSystemPath>) -> Result<Vc<ImportsFiel
 
 #[turbo_tasks::function]
 pub fn package_json() -> Vc<Vec<RcStr>> {
-    Vc::cell(vec!["package.json".into()])
+    Vc::cell(vec![rcstr!("package.json")])
 }
 
 #[turbo_tasks::value(shared)]
@@ -1326,7 +1326,7 @@ pub async fn find_context_file_or_package_key(
     package_key: Value<RcStr>,
 ) -> Result<Vc<FindContextFileResult>> {
     let mut refs = Vec::new();
-    let package_json_path = lookup_path.join("package.json".into());
+    let package_json_path = lookup_path.join(rcstr!("package.json"));
     if let Some(package_json_path) = exists(package_json_path, &mut refs).await? {
         if let Some(json) = &*read_package_json(*package_json_path).await? {
             if json.get(&**package_key).is_some() {
@@ -1519,7 +1519,7 @@ pub async fn resolve_raw(
         .and_then(|pat| pat.filter_could_not_match("/ROOT/fsd8nz8og54z"))
     {
         let path = Pattern::new(pat);
-        let matches = read_matches(lookup_dir.root(), "/ROOT/".into(), true, path).await?;
+        let matches = read_matches(lookup_dir.root(), rcstr!("/ROOT/"), true, path).await?;
         if matches.len() > 10000 {
             let path_str = path.to_string().await?;
             println!(
@@ -1538,7 +1538,7 @@ pub async fn resolve_raw(
     }
 
     {
-        let matches = read_matches(lookup_dir, "".into(), force_in_lookup_dir, path).await?;
+        let matches = read_matches(lookup_dir, rcstr!(""), force_in_lookup_dir, path).await?;
         if matches.len() > 10000 {
             println!(
                 "WARN: resolving pattern {} in {} leads to {} results",
@@ -1834,7 +1834,7 @@ async fn resolve_internal_inline(
                 let mut results = Vec::new();
                 let matches = read_matches(
                     lookup_path,
-                    "".into(),
+                    rcstr!(""),
                     *force_in_lookup_dir,
                     Pattern::new(path.clone()).resolve().await?,
                 )
@@ -2101,7 +2101,7 @@ async fn resolve_into_folder(
     package_path: ResolvedVc<FileSystemPath>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    let package_json_path = package_path.join("package.json".into());
+    let package_json_path = package_path.join(rcstr!("package.json"));
     let options_value = options.await?;
 
     for resolve_into_package in options_value.into_package.iter() {
@@ -2133,7 +2133,7 @@ async fn resolve_into_folder(
                         // we continue to try other alternatives
                         if !result.is_unresolvable_ref() {
                             let mut result: ResolveResultBuilder =
-                                result.with_request_ref(".".into()).into();
+                                result.with_request_ref(rcstr!(".")).into();
                             result.affecting_sources.push(ResolvedVc::upcast(
                                 FileSource::new(package_json_path).to_resolved().await?,
                             ));
@@ -2166,7 +2166,7 @@ async fn resolve_into_folder(
 
     Ok(resolve_internal_inline(*package_path, request, options)
         .await?
-        .with_request(".".into()))
+        .with_request(rcstr!(".")))
 }
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
@@ -2231,23 +2231,23 @@ async fn resolve_relative_request(
                 Some((base, "js")) => (
                     base,
                     vec![
-                        Pattern::Constant(".ts".into()),
-                        Pattern::Constant(".tsx".into()),
-                        Pattern::Constant(".js".into()),
+                        Pattern::Constant(rcstr!(".ts")),
+                        Pattern::Constant(rcstr!(".tsx")),
+                        Pattern::Constant(rcstr!(".js")),
                     ],
                 ),
                 Some((base, "mjs")) => (
                     base,
                     vec![
-                        Pattern::Constant(".mts".into()),
-                        Pattern::Constant(".mjs".into()),
+                        Pattern::Constant(rcstr!(".mts")),
+                        Pattern::Constant(rcstr!(".mjs")),
                     ],
                 ),
                 Some((base, "cjs")) => (
                     base,
                     vec![
-                        Pattern::Constant(".cts".into()),
-                        Pattern::Constant(".cjs".into()),
+                        Pattern::Constant(rcstr!(".cts")),
+                        Pattern::Constant(rcstr!(".cjs")),
                     ],
                 ),
                 _ => {
@@ -2269,7 +2269,7 @@ async fn resolve_relative_request(
     let mut results = Vec::new();
     let matches = read_matches(
         lookup_path,
-        "".into(),
+        rcstr!(""),
         force_in_lookup_dir,
         Pattern::new(new_path).resolve().await?,
     )
@@ -2588,7 +2588,7 @@ async fn resolve_module_request(
             FindPackageItem::PackageFile(package_path) => {
                 if path.is_match("") {
                     let resolved = resolved(
-                        RequestKey::new(".".into()),
+                        RequestKey::new(rcstr!(".")),
                         *package_path,
                         lookup_path,
                         request,
@@ -2652,7 +2652,7 @@ async fn resolve_into_package(
                 conditions,
                 unspecified_conditions,
             } => {
-                let package_json_path = package_path.join("package.json".into());
+                let package_json_path = package_path.join(rcstr!("package.json"));
                 let ExportsFieldResult::Some(exports_field) =
                     &*exports_field(package_json_path).await?
                 else {
@@ -2911,7 +2911,7 @@ async fn handle_exports_imports_field(
     for (result_path, conditions) in results {
         if let Some(result_path) = result_path.with_normalized_path() {
             let request = Request::parse(Value::new(Pattern::Concatenation(vec![
-                Pattern::Constant("./".into()),
+                Pattern::Constant(rcstr!("./")),
                 result_path,
             ])))
             .to_resolved()

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1927,7 +1927,7 @@ async fn resolve_internal_inline(
                 fragment,
             } => {
                 let mut new_pat = path.clone();
-                new_pat.push_front(RcStr::from(".").into());
+                new_pat.push_front(rcstr!(".").into());
                 let relative =
                     Request::relative(Value::new(new_pat), query.clone(), fragment.clone(), true);
 
@@ -2700,7 +2700,7 @@ async fn resolve_into_package(
 
     if could_match_others {
         let mut new_pat = path.clone();
-        new_pat.push_front(RcStr::from(".").into());
+        new_pat.push_front(rcstr!(".").into());
 
         let relative = Request::relative(Value::new(new_pat), query, fragment, true)
             .to_resolved()

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -10,7 +10,7 @@ use anyhow::{Result, bail};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, SliceMap, TaskInput,
     TryJoinIterExt, Value, ValueToString, Vc, trace::TraceRawVcs,
@@ -2606,13 +2606,13 @@ async fn resolve_module_request(
 
     let module_result =
         merge_results_with_affecting_sources(results, result.affecting_sources.clone())
-            .with_replaced_request_key(".".into(), Value::new(RequestKey::new(module.into())));
+            .with_replaced_request_key(rcstr!("."), Value::new(RequestKey::new(module.into())));
 
     if options_value.prefer_relative {
         let module_prefix: RcStr = format!("./{module}").into();
         let pattern = Pattern::concat([
             module_prefix.clone().into(),
-            RcStr::from("/").into(),
+            rcstr!("/").into(),
             path.clone(),
         ]);
         let relative = Request::relative(Value::new(pattern), query, fragment, true)

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, future::Future, pin::Pin};
 
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc,
     debug::ValueDebugFormat, trace::TraceRawVcs,
@@ -463,9 +463,9 @@ impl ValueToString for ImportMapResult {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         match self {
-            ImportMapResult::Result(_) => Ok(Vc::cell("Resolved by import map".into())),
-            ImportMapResult::External(_, _, _) => Ok(Vc::cell("TODO external".into())),
-            ImportMapResult::AliasExternal { .. } => Ok(Vc::cell("TODO external".into())),
+            ImportMapResult::Result(_) => Ok(Vc::cell(rcstr!("Resolved by import map"))),
+            ImportMapResult::External(_, _, _) => Ok(Vc::cell(rcstr!("TODO external"))),
+            ImportMapResult::AliasExternal { .. } => Ok(Vc::cell(rcstr!("TODO external"))),
             ImportMapResult::Alias(request, context) => {
                 let s = if let Some(path) = context {
                     let path = path.to_string().await?;
@@ -491,7 +491,7 @@ impl ValueToString for ImportMapResult {
                     .collect::<Vec<_>>();
                 Ok(Vc::cell(strings.join(" | ").into()))
             }
-            ImportMapResult::NoEntry => Ok(Vc::cell("No import map entry".into())),
+            ImportMapResult::NoEntry => Ok(Vc::cell(rcstr!("No import map entry"))),
         }
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -846,7 +846,7 @@ mod tests {
         assert_eq!(
             (
                 Pattern::Constant(rcstr!("foo")),
-                RcStr::from("?"),
+                rcstr!("?"),
                 RcStr::default()
             ),
             split_off_query_fragment("foo?")
@@ -855,14 +855,14 @@ mod tests {
             (
                 Pattern::Constant(rcstr!("foo")),
                 RcStr::default(),
-                RcStr::from("#")
+                rcstr!("#")
             ),
             split_off_query_fragment("foo#")
         );
         assert_eq!(
             (
                 Pattern::Constant(rcstr!("foo")),
-                RcStr::from("?bar=baz"),
+                rcstr!("?bar=baz"),
                 RcStr::default()
             ),
             split_off_query_fragment("foo?bar=baz")
@@ -871,7 +871,7 @@ mod tests {
             (
                 Pattern::Constant(rcstr!("foo")),
                 RcStr::default(),
-                RcStr::from("#stuff?bar=baz")
+                rcstr!("#stuff?bar=baz")
             ),
             split_off_query_fragment("foo#stuff?bar=baz")
         );
@@ -879,8 +879,8 @@ mod tests {
         assert_eq!(
             (
                 Pattern::Constant(rcstr!("foo")),
-                RcStr::from("?bar=baz"),
-                RcStr::from("#stuff")
+                rcstr!("?bar=baz"),
+                rcstr!("#stuff")
             ),
             split_off_query_fragment("foo?bar=baz#stuff")
         );

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -1,7 +1,7 @@
 use anyhow::{Ok, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 
 use super::pattern::Pattern;
@@ -124,7 +124,7 @@ impl Request {
                 path: Pattern::Constant(path),
                 ..
             } => path.clone(),
-            Request::Empty => "".into(),
+            Request::Empty => rcstr!(""),
             Request::PackageInternal {
                 path: Pattern::Constant(path),
                 ..
@@ -158,7 +158,7 @@ impl Request {
 
         if let Some(remainder) = r.strip_prefix("//") {
             return Ok(Request::Uri {
-                protocol: "//".into(),
+                protocol: rcstr!("//"),
                 remainder: remainder.into(),
                 query: RcStr::default(),
                 fragment: RcStr::default(),
@@ -380,12 +380,12 @@ impl Request {
                 Self::parse(Value::new(pat))
             }
             Request::PackageInternal { path } => {
-                let mut pat = Pattern::Constant("./".into());
+                let mut pat = Pattern::Constant(rcstr!("./"));
                 pat.push(path.clone());
                 Self::parse(Value::new(pat))
             }
             Request::Unknown { path } => {
-                let mut pat = Pattern::Constant("./".into());
+                let mut pat = Pattern::Constant(rcstr!("./"));
                 pat.push(path.clone());
                 Self::parse(Value::new(pat))
             }
@@ -717,7 +717,7 @@ impl Request {
             }
             Request::ServerRelative { path, .. } => path.clone(),
             Request::Windows { path, .. } => path.clone(),
-            Request::Empty => Pattern::Constant("".into()),
+            Request::Empty => Pattern::Constant(rcstr!("")),
             Request::PackageInternal { path } => path.clone(),
             Request::DataUri {
                 media_type,
@@ -785,7 +785,7 @@ impl ValueToString for Request {
             }
             Request::ServerRelative { path, .. } => format!("server relative {path}").into(),
             Request::Windows { path, .. } => format!("windows {path}").into(),
-            Request::Empty => "empty".into(),
+            Request::Empty => rcstr!("empty"),
             Request::PackageInternal { path } => format!("package internal {path}").into(),
             Request::DataUri {
                 media_type,
@@ -802,7 +802,7 @@ impl ValueToString for Request {
                 ..
             } => format!("uri \"{protocol}\" \"{remainder}\"").into(),
             Request::Unknown { path } => format!("unknown {path}").into(),
-            Request::Dynamic => "dynamic".into(),
+            Request::Dynamic => rcstr!("dynamic"),
             Request::Alternatives { requests } => {
                 let vec = requests.iter().map(|i| i.to_string()).try_join().await?;
                 vec.iter()
@@ -835,7 +835,7 @@ mod tests {
     fn test_split_query_fragment() {
         assert_eq!(
             (
-                Pattern::Constant("foo".into()),
+                Pattern::Constant(rcstr!("foo")),
                 RcStr::default(),
                 RcStr::default()
             ),
@@ -845,7 +845,7 @@ mod tests {
         // from `import './foo'`, ditto for fragments.
         assert_eq!(
             (
-                Pattern::Constant("foo".into()),
+                Pattern::Constant(rcstr!("foo")),
                 RcStr::from("?"),
                 RcStr::default()
             ),
@@ -853,7 +853,7 @@ mod tests {
         );
         assert_eq!(
             (
-                Pattern::Constant("foo".into()),
+                Pattern::Constant(rcstr!("foo")),
                 RcStr::default(),
                 RcStr::from("#")
             ),
@@ -861,7 +861,7 @@ mod tests {
         );
         assert_eq!(
             (
-                Pattern::Constant("foo".into()),
+                Pattern::Constant(rcstr!("foo")),
                 RcStr::from("?bar=baz"),
                 RcStr::default()
             ),
@@ -869,7 +869,7 @@ mod tests {
         );
         assert_eq!(
             (
-                Pattern::Constant("foo".into()),
+                Pattern::Constant(rcstr!("foo")),
                 RcStr::default(),
                 RcStr::from("#stuff?bar=baz")
             ),
@@ -878,7 +878,7 @@ mod tests {
 
         assert_eq!(
             (
-                Pattern::Constant("foo".into()),
+                Pattern::Constant(rcstr!("foo")),
                 RcStr::from("?bar=baz"),
                 RcStr::from("#stuff")
             ),

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{
     FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
@@ -53,6 +53,6 @@ impl FileSystem for ServerFileSystem {
 impl ValueToString for ServerFileSystem {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("root-of-the-server".into())
+        Vc::cell(rcstr!("root-of-the-server"))
     }
 }

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -77,9 +77,9 @@ impl OutputAsset for SourceMapAsset {
                 chunking_context,
                 ident_for_path,
             } => chunking_context
-                .chunk_path(Some(Vc::upcast(self)), *ident_for_path, ".js".into())
-                .append(".map".into()),
-            PathType::Fixed { path } => path.append(".map".into()),
+                .chunk_path(Some(Vc::upcast(self)), *ident_for_path, rcstr!(".js"))
+                .append(rcstr!(".map")),
+            PathType::Fixed { path } => path.append(rcstr!(".map")),
         })
     }
 }
@@ -98,21 +98,11 @@ impl Asset for SourceMapAsset {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("source map".into())
-}
-
-#[turbo_tasks::function]
-fn introspectable_details() -> Vc<RcStr> {
-    Vc::cell("source map of an asset".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for SourceMapAsset {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("source map"))
     }
 
     #[turbo_tasks::function]
@@ -122,7 +112,7 @@ impl Introspectable for SourceMapAsset {
 
     #[turbo_tasks::function]
     fn details(&self) -> Vc<RcStr> {
-        introspectable_details()
+        Vc::cell(rcstr!("source map of an asset"))
     }
 
     #[turbo_tasks::function]
@@ -131,7 +121,7 @@ impl Introspectable for SourceMapAsset {
         if let Some(asset) =
             ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.generate_source_map)
         {
-            children.insert((ResolvedVc::cell("asset".into()), asset));
+            children.insert((rcstr!("asset"), asset));
         }
         Ok(Vc::cell(children))
     }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -412,11 +412,6 @@ pub trait CssChunkItem: ChunkItem {
 }
 
 #[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("css chunk".into())
-}
-
-#[turbo_tasks::function]
 fn entry_module_key() -> Vc<RcStr> {
     Vc::cell("entry module".into())
 }
@@ -425,7 +420,7 @@ fn entry_module_key() -> Vc<RcStr> {
 impl Introspectable for CssChunk {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell("css chunk".into())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -411,16 +411,11 @@ pub trait CssChunkItem: ChunkItem {
     fn content(self: Vc<Self>) -> Vc<CssChunkItemContent>;
 }
 
-#[turbo_tasks::function]
-fn entry_module_key() -> Vc<RcStr> {
-    Vc::cell("entry module".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for CssChunk {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        Vc::cell("css chunk".into())
+        Vc::cell(rcstr!("css chunk"))
     }
 
     #[turbo_tasks::function]
@@ -456,7 +451,7 @@ impl Introspectable for CssChunk {
                 .iter()
                 .map(|chunk_item| async move {
                     Ok((
-                        entry_module_key().to_resolved().await?,
+                        rcstr!("entry module"),
                         IntrospectableModule::new(chunk_item.module())
                             .to_resolved()
                             .await?,
@@ -477,7 +472,7 @@ pub struct CssChunkType {}
 impl ValueToString for CssChunkType {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("css".into())
+        Vc::cell(rcstr!("css"))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -100,7 +100,7 @@ impl OutputAsset for SingleItemCssChunk {
         Ok(self.await?.chunking_context.chunk_path(
             Some(Vc::upcast(self)),
             self.ident_for_path(),
-            ".single.css".into(),
+            rcstr!(".single.css"),
         ))
     }
 
@@ -156,21 +156,11 @@ impl GenerateSourceMap for SingleItemCssChunk {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("single asset css chunk".into())
-}
-
-#[turbo_tasks::function]
-fn entry_module_key() -> Vc<RcStr> {
-    Vc::cell("entry module".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for SingleItemCssChunk {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("single asset css chunk"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashMap;
 use smallvec::smallvec;
 use swc_core::base::sourcemap::SourceMapBuilder;
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath, rope::Rope};
 use turbopack_core::{
@@ -635,7 +635,7 @@ impl Issue for ParsingIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Parsing css source code failed".into()).cell()
+        StyledString::Text(rcstr!("Parsing css source code failed")).cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -434,7 +434,7 @@ async fn process_content(
 
                             ParsingIssue {
                                 file: fs_path_vc,
-                                msg: ResolvedVc::cell(err.to_string().into()),
+                                msg: err.to_string().into(),
                                 source,
                             }
                             .resolved_cell()
@@ -471,7 +471,7 @@ async fn process_content(
                 };
                 ParsingIssue {
                     file: fs_path_vc,
-                    msg: ResolvedVc::cell(e.to_string().into()),
+                    msg: e.to_string().into(),
                     source,
                 }
                 .resolved_cell()
@@ -520,9 +520,8 @@ impl CssError {
             CssError::CssSelectorInModuleNotPure { selector } => {
                 ParsingIssue {
                     file,
-                    msg: ResolvedVc::cell(
-                        format!("{CSS_MODULE_ERROR}, (lightningcss, {selector})").into(),
-                    ),
+                    msg: format!("{CSS_MODULE_ERROR}, (lightningcss, {selector})").into(),
+
                     source: None,
                 }
                 .resolved_cell()
@@ -617,7 +616,7 @@ fn generate_css_source_map(source_map: &parcel_sourcemap::SourceMap) -> Result<R
 
 #[turbo_tasks::value]
 struct ParsingIssue {
-    msg: ResolvedVc<RcStr>,
+    msg: RcStr,
     file: ResolvedVc<FileSystemPath>,
     source: Option<IssueSource>,
 }
@@ -650,7 +649,7 @@ impl Issue for ParsingIssue {
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
         Ok(Vc::cell(Some(
-            StyledString::Text(self.msg.await?.as_str().into()).resolved_cell(),
+            StyledString::Text(self.msg.clone()).resolved_cell(),
         )))
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -40,11 +40,6 @@ pub struct DevHtmlAsset {
     body: Option<RcStr>,
 }
 
-#[turbo_tasks::function]
-fn dev_html_chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("dev html chunk".into())
-}
-
 #[turbo_tasks::value_impl]
 impl OutputAsset for DevHtmlAsset {
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Display};
 
 use anyhow::Result;
 use rustc_hash::FxHashSet;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{File, json::parse_json_with_source_context};
 use turbopack_core::{
@@ -22,22 +22,30 @@ pub struct IntrospectionSource {
     pub roots: FxHashSet<ResolvedVc<Box<dyn Introspectable>>>,
 }
 
+fn introspection_source() -> RcStr {
+    rcstr!("introspection-source")
+}
+
 #[turbo_tasks::value_impl]
 impl Introspectable for IntrospectionSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        Vc::cell("introspection-source".into())
+        Vc::cell(introspection_source())
     }
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<RcStr> {
-        Vc::cell("introspection-source".into())
+        Vc::cell(introspection_source())
     }
 
     #[turbo_tasks::function]
     fn children(&self) -> Vc<IntrospectableChildren> {
-        let name = ResolvedVc::cell("root".into());
-        Vc::cell(self.roots.iter().map(|root| (name, *root)).collect())
+        Vc::cell(
+            self.roots
+                .iter()
+                .map(|root| (rcstr!("root"), *root))
+                .collect(),
+        )
     }
 }
 
@@ -127,9 +135,7 @@ impl GetContentSourceContent for IntrospectionSource {
         let has_children = !children.is_empty();
         let children = children
             .iter()
-            .map(|&(name, child)| async move {
-                let name = name.await;
-                let name = str_or_err(&name);
+            .map(|(name, child)| async move {
                 let ty = child.ty().await;
                 let ty = str_or_err(&ty);
                 let title = child.title().await;

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -177,7 +177,7 @@ async fn expand(
     }
     for (sub_path, asset) in assets {
         if &*sub_path == "index.html" {
-            map.insert("".into(), asset);
+            map.insert(rcstr!(""), asset);
         } else if let Some(p) = sub_path.strip_suffix("/index.html") {
             map.insert(p.into(), asset);
             map.insert(format!("{p}/").into(), asset);
@@ -192,7 +192,7 @@ async fn expand(
 fn get_sub_paths(sub_path: &str) -> ([RcStr; 3], usize) {
     let sub_paths_buffer: [RcStr; 3];
     let n = if sub_path == "index.html" {
-        sub_paths_buffer = ["".into(), sub_path.into(), Default::default()];
+        sub_paths_buffer = [rcstr!(""), sub_path.into(), Default::default()];
         2
     } else if let Some(p) = sub_path.strip_suffix("/index.html") {
         sub_paths_buffer = [p.into(), format!("{p}/").into(), sub_path.into()];

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, iter::once};
 
 use anyhow::Result;
 use rustc_hash::FxHashSet;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, FxIndexMap, FxIndexSet, ResolvedVc, State, TryJoinIterExt, Value, ValueToString,
     Vc, fxindexset,
@@ -293,16 +293,11 @@ impl ContentSourceSideEffect for AssetGraphGetContentSourceContent {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("asset graph content source".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for AssetGraphContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("asset graph content source"))
     }
 
     #[turbo_tasks::function]
@@ -315,23 +310,20 @@ impl Introspectable for AssetGraphContentSource {
         Vc::cell(if let Some(expanded) = &self.expanded {
             format!("{} assets expanded", expanded.get().len()).into()
         } else {
-            "eager".into()
+            rcstr!("eager")
         })
     }
 
     #[turbo_tasks::function]
     async fn children(self: Vc<Self>) -> Result<Vc<IntrospectableChildren>> {
         let this = self.await?;
-        let key = ResolvedVc::cell("root".into());
-        let inner_key = ResolvedVc::cell("inner".into());
-        let expanded_key = ResolvedVc::cell("expanded".into());
 
         let root_assets = this.root_assets.await?;
         let root_asset_children = root_assets
             .iter()
             .map(|&asset| async move {
                 Ok((
-                    key,
+                    rcstr!("root"),
                     IntrospectableOutputAsset::new(*ResolvedVc::upcast(asset))
                         .to_resolved()
                         .await?,
@@ -346,7 +338,7 @@ impl Introspectable for AssetGraphContentSource {
             .filter(|&a| !root_assets.contains(a))
             .map(|&asset| async move {
                 Ok((
-                    inner_key,
+                    rcstr!("inner"),
                     IntrospectableOutputAsset::new(*ResolvedVc::upcast(asset))
                         .to_resolved()
                         .await?,
@@ -360,17 +352,12 @@ impl Introspectable for AssetGraphContentSource {
                 .into_iter()
                 .chain(expanded_asset_children)
                 .chain(once((
-                    expanded_key,
+                    rcstr!("expanded"),
                     ResolvedVc::upcast(FullyExpanded(self.to_resolved().await?).resolved_cell()),
                 )))
                 .collect(),
         ))
     }
-}
-
-#[turbo_tasks::function]
-fn fully_expanded_introspectable_type() -> Vc<RcStr> {
-    Vc::cell("fully expanded asset graph content source".into())
 }
 
 #[turbo_tasks::value]
@@ -380,7 +367,7 @@ struct FullyExpanded(ResolvedVc<AssetGraphContentSource>);
 impl Introspectable for FullyExpanded {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        fully_expanded_introspectable_type()
+        Vc::cell(rcstr!("fully expanded asset graph content source"))
     }
 
     #[turbo_tasks::function]
@@ -391,14 +378,16 @@ impl Introspectable for FullyExpanded {
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let source = self.0.await?;
-        let key = ResolvedVc::cell("asset".into());
 
         let expanded_assets =
             expand(&*source.root_assets.await?, &*source.root_path.await?, None).await?;
         let children = expanded_assets
             .iter()
             .map(|(_k, &v)| async move {
-                Ok((key, IntrospectableOutputAsset::new(*v).to_resolved().await?))
+                Ok((
+                    rcstr!("asset"),
+                    IntrospectableOutputAsset::new(*v).to_resolved().await?,
+                ))
             })
             .try_join()
             .await?

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
@@ -47,7 +47,7 @@ impl ContentSource for CombinedContentSource {
 impl Introspectable for CombinedContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        Vc::cell("combined content source".into())
+        Vc::cell(rcstr!("combined content source"))
     }
 
     #[turbo_tasks::function]
@@ -85,7 +85,6 @@ impl Introspectable for CombinedContentSource {
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
-        let source = ResolvedVc::cell("source".into());
         Ok(Vc::cell(
             self.sources
                 .iter()
@@ -95,7 +94,7 @@ impl Introspectable for CombinedContentSource {
                 .await?
                 .into_iter()
                 .flatten()
-                .map(|i| (source, i))
+                .map(|i| (rcstr!("source"), i))
                 .collect(),
         ))
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ResolvedVc, State, TryJoinIterExt, Value, Vc};
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{Completion, ResolvedVc, State, Value, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{
@@ -90,38 +90,20 @@ impl MapGetContentSourceContent for ConditionalContentSourceMapper {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("conditional content source".into())
-}
-
-#[turbo_tasks::function]
-fn activator_key() -> Vc<RcStr> {
-    Vc::cell("activator".into())
-}
-
-#[turbo_tasks::function]
-fn action_key() -> Vc<RcStr> {
-    Vc::cell("action".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for ConditionalContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("conditional content source"))
     }
 
     #[turbo_tasks::function]
     fn details(&self) -> Vc<RcStr> {
-        Vc::cell(
-            if *self.activated.get() {
-                "activated"
-            } else {
-                "not activated"
-            }
-            .into(),
-        )
+        Vc::cell(if *self.activated.get() {
+            rcstr!("activated")
+        } else {
+            rcstr!("not activated")
+        })
     }
 
     #[turbo_tasks::function]
@@ -139,16 +121,12 @@ impl Introspectable for ConditionalContentSource {
         Ok(Vc::cell(
             [
                 ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.activator)
-                    .map(|i| (activator_key(), i)),
+                    .map(|i| (rcstr!("activator"), i)),
                 ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.action)
-                    .map(|i| (action_key(), i)),
+                    .map(|i| (rcstr!("action"), i)),
             ]
             .into_iter()
             .flatten()
-            .map(|(k, v)| async move { Ok((k.to_resolved().await?, v)) })
-            .try_join()
-            .await?
-            .into_iter()
             .collect(),
         ))
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -156,7 +156,7 @@ impl Introspectable for IssueFilePathContentSource {
             if let Some(source) = ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(self.source) {
                 source.ty()
             } else {
-                Vc::cell("IssueContextContentSource".into())
+                Vc::cell(rcstr!("IssueContextContentSource"))
             },
         )
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/lazy_instantiated.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{ContentSource, route_tree::RouteTree};
@@ -28,21 +28,11 @@ impl ContentSource for LazyInstantiatedContentSource {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("lazy instantiated content source".into())
-}
-
-#[turbo_tasks::function]
-fn source_key() -> Vc<RcStr> {
-    Vc::cell("source".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for LazyInstantiatedContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("lazy instantiated content source"))
     }
 
     #[turbo_tasks::function]
@@ -51,13 +41,9 @@ impl Introspectable for LazyInstantiatedContentSource {
             [ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(
                 self.get_source.content_source().to_resolved().await?,
             )
-            .map(|i| (source_key(), i))]
+            .map(|i| (rcstr!("source"), i))]
             .into_iter()
             .flatten()
-            .map(|(k, v)| async move { Ok((k.to_resolved().await?, v)) })
-            .try_join()
-            .await?
-            .into_iter()
             .collect(),
         ))
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
@@ -63,14 +63,9 @@ async fn get_introspection_children(
             .iter()
             .cloned()
             .chain(std::iter::once((RcStr::default(), *fallback)))
-            .map(|(path, source)| async move {
-                Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source)
-                    .map(|i| (ResolvedVc::cell(path), i)))
+            .filter_map(|(path, source)| {
+                ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source).map(|i| (path, i))
             })
-            .try_join()
-            .await?
-            .into_iter()
-            .flatten()
             .collect(),
     ))
 }
@@ -169,7 +164,7 @@ impl GetContentSourceContent for PrefixedRouterGetContentSourceContent {
         let prefix = self.mapper.await?.prefix.await?;
         if let Some(path) = path.strip_prefix(&**prefix) {
             if path.is_empty() {
-                return Ok(self.get_content.get("".into(), data));
+                return Ok(self.get_content.get(RcStr::default(), data));
             } else if prefix.is_empty() {
                 return Ok(self.get_content.get(path.into(), data));
             } else if let Some(path) = path.strip_prefix('/') {
@@ -184,7 +179,7 @@ impl GetContentSourceContent for PrefixedRouterGetContentSourceContent {
 impl Introspectable for PrefixedRouterContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        Vc::cell("prefixed router content source".into())
+        Vc::cell(rcstr!("prefixed router content source"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
@@ -108,7 +108,7 @@ impl GetContentSourceContent for StaticAssetsContentSourceItem {
 impl Introspectable for StaticAssetsContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        Vc::cell("static assets directory content source".into())
+        Vc::cell(rcstr!("static assets directory content source"))
     }
 
     #[turbo_tasks::function]
@@ -144,7 +144,7 @@ impl Introspectable for StaticAssetsContentSource {
                             todo!("unsupported DirectoryContent variant: {entry:?}")
                         }
                     };
-                    Ok((ResolvedVc::cell(name.clone()), child))
+                    Ok((name.clone(), child))
                 }
             })
             .try_join()

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
@@ -2,18 +2,17 @@ use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::ecma::{ast::Program, transforms::base::resolver, visit::VisitMutWith};
 use turbo_rcstr::RcStr;
-use turbo_tasks::ResolvedVc;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 use super::{is_client_module, server_to_client_proxy::create_proxy_module};
 
 #[derive(Debug)]
 pub struct ClientDirectiveTransformer {
-    transition_name: ResolvedVc<RcStr>,
+    transition_name: RcStr,
 }
 
 impl ClientDirectiveTransformer {
-    pub fn new(transition_name: ResolvedVc<RcStr>) -> Self {
+    pub fn new(transition_name: RcStr) -> Self {
         Self { transition_name }
     }
 }
@@ -23,8 +22,10 @@ impl CustomTransformer for ClientDirectiveTransformer {
     #[tracing::instrument(level = tracing::Level::TRACE, name = "client_directive", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         if is_client_module(program) {
-            let transition_name = &*self.transition_name.await?;
-            *program = create_proxy_module(transition_name, &format!("./{}", ctx.file_name_str));
+            *program = create_proxy_module(
+                self.transition_name.as_str(),
+                &format!("./{}", ctx.file_name_str),
+            );
             program.visit_mut_with(&mut resolver(
                 ctx.unresolved_mark,
                 ctx.top_level_mark,

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::ecma::ast::Program;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
@@ -66,8 +67,10 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Unsupported SWC EcmaScript transform plugins on this platform.".into())
-            .cell()
+        StyledString::Text(rcstr!(
+            "Unsupported SWC EcmaScript transform plugins on this platform."
+        ))
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -114,7 +114,7 @@ pub async fn get_browser_runtime_code(
         code.push_code(
             &*embed_static_code(
                 asset_context,
-                "shared-node/base-externals-utils.ts".into(),
+                rcstr!("shared-node/base-externals-utils.ts"),
                 generate_source_map,
             )
             .await?,
@@ -124,7 +124,7 @@ pub async fn get_browser_runtime_code(
         code.push_code(
             &*embed_static_code(
                 asset_context,
-                "shared-node/node-externals-utils.ts".into(),
+                rcstr!("shared-node/node-externals-utils.ts"),
                 generate_source_map,
             )
             .await?,
@@ -134,7 +134,7 @@ pub async fn get_browser_runtime_code(
         code.push_code(
             &*embed_static_code(
                 asset_context,
-                "shared-node/node-wasm-utils.ts".into(),
+                rcstr!("shared-node/node-wasm-utils.ts"),
                 generate_source_map,
             )
             .await?,

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use indoc::writedoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Value, Vc};
 use turbopack_core::{
     code_builder::{Code, CodeBuilder},
@@ -17,17 +17,17 @@ use crate::{RuntimeType, asset_context::get_runtime_asset_context, embed_js::emb
 #[turbo_tasks::function]
 pub async fn get_browser_runtime_code(
     environment: Vc<Environment>,
-    chunk_base_path: Vc<Option<RcStr>>,
-    chunk_suffix_path: Vc<Option<RcStr>>,
+    chunk_base_path: Option<RcStr>,
+    chunk_suffix_path: Option<RcStr>,
     runtime_type: Value<RuntimeType>,
-    output_root_to_root_path: Vc<RcStr>,
+    output_root_to_root_path: RcStr,
     generate_source_map: bool,
 ) -> Result<Vc<Code>> {
     let asset_context = get_runtime_asset_context(environment).await?;
 
     let shared_runtime_utils_code = embed_static_code(
         asset_context,
-        "shared/runtime-utils.ts".into(),
+        rcstr!("shared/runtime-utils.ts"),
         generate_source_map,
     );
 
@@ -78,10 +78,8 @@ pub async fn get_browser_runtime_code(
     };
 
     let mut code: CodeBuilder = CodeBuilder::default();
-    let relative_root_path = output_root_to_root_path.await?;
-    let chunk_base_path = &*chunk_base_path.await?;
+    let relative_root_path = output_root_to_root_path;
     let chunk_base_path = chunk_base_path.as_ref().map_or_else(|| "", |f| f.as_str());
-    let chunk_suffix_path = &*chunk_suffix_path.await?;
     let chunk_suffix_path = chunk_suffix_path
         .as_ref()
         .map_or_else(|| "", |f| f.as_str());

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -11,7 +11,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc};
 use turbopack_core::{issue::IssueSource, source::Source};
 
@@ -658,7 +658,7 @@ impl Visit for Analyzer<'_> {
     fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier) {
         self.data
             .exports
-            .insert("default".into(), n.exported.to_id());
+            .insert(rcstr!("default"), n.exported.to_id());
     }
 
     fn visit_export_namespace_specifier(&mut self, n: &ExportNamespaceSpecifier) {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -25,7 +25,7 @@ use swc_core::{
     },
 };
 use turbo_esregex::EsRegex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
 use turbopack_core::compile_time_info::{
     CompileTimeDefineValue, DefineableNameSegment, FreeVarReference,
@@ -3847,6 +3847,7 @@ fn is_unresolved_id(i: &Id, unresolved_mark: Mark) -> bool {
 #[doc(hidden)]
 pub mod test_utils {
     use anyhow::Result;
+    use turbo_rcstr::rcstr;
     use turbo_tasks::{FxIndexMap, Vc};
     use turbopack_core::{compile_time_info::CompileTimeInfo, error::PrettyPrintError};
 
@@ -3907,9 +3908,18 @@ pub mod test_utils {
                 Ok(options) => {
                     let mut map = FxIndexMap::default();
 
-                    map.insert("./a".into(), format!("[context: {}]/a", options.dir).into());
-                    map.insert("./b".into(), format!("[context: {}]/b", options.dir).into());
-                    map.insert("./c".into(), format!("[context: {}]/c", options.dir).into());
+                    map.insert(
+                        rcstr!("./a"),
+                        format!("[context: {}]/a", options.dir).into(),
+                    );
+                    map.insert(
+                        rcstr!("./b"),
+                        format!("[context: {}]/b", options.dir).into(),
+                    );
+                    map.insert(
+                        rcstr!("./c"),
+                        format!("[context: {}]/c", options.dir).into(),
+                    );
 
                     JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(
                         RequireContextValue(map),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -25,7 +25,7 @@ use swc_core::{
     },
 };
 use turbo_esregex::EsRegex;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
 use turbopack_core::compile_time_info::{
     CompileTimeDefineValue, DefineableNameSegment, FreeVarReference,

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbopack_core::{
     chunk::{

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -152,11 +152,6 @@ impl EcmascriptChunkItem for AsyncLoaderChunkItem {
     }
 }
 
-#[turbo_tasks::function]
-fn chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("chunk".into())
-}
-
 #[turbo_tasks::value_impl]
 impl ChunkItem for AsyncLoaderChunkItem {
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -12,11 +12,6 @@ use turbopack_core::{
 
 use crate::async_chunk::chunk_item::AsyncLoaderChunkItem;
 
-#[turbo_tasks::function]
-fn async_loader_modifier() -> Vc<RcStr> {
-    Vc::cell("async loader".into())
-}
-
 /// The AsyncLoaderModule is a module that loads another module async, by
 /// putting it into a separate chunk group.
 #[turbo_tasks::value]
@@ -47,11 +42,6 @@ impl AsyncLoaderModule {
     }
 }
 
-#[turbo_tasks::function]
-fn inner_module_reference_description() -> Vc<RcStr> {
-    Vc::cell("async module".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Module for AsyncLoaderModule {
     #[turbo_tasks::function]
@@ -64,7 +54,7 @@ impl Module for AsyncLoaderModule {
         Ok(Vc::cell(vec![ResolvedVc::upcast(
             SingleModuleReference::new(
                 *ResolvedVc::upcast(self.await?.inner),
-                inner_module_reference_description(),
+                rcstr!("async module"),
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
@@ -20,7 +20,7 @@ pub struct EcmascriptChunkType {}
 impl ValueToString for EcmascriptChunkType {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("ecmascript".into())
+        Vc::cell(rcstr!("ecmascript"))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, TaskInput, Upcast, ValueToString, Vc, trace::TraceRawVcs,
 };
@@ -271,7 +272,7 @@ async fn module_factory_with_code_generation_issue(
                 CodeGenerationIssue {
                     severity: IssueSeverity::Error.resolved_cell(),
                     path: chunk_item.asset_ident().path().to_resolved().await?,
-                    title: StyledString::Text("Code generation for chunk item errored".into())
+                    title: StyledString::Text(rcstr!("Code generation for chunk item errored"))
                         .resolved_cell(),
                     message: StyledString::Text(error_message).resolved_cell(),
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -165,21 +165,11 @@ impl EcmascriptChunk {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("ecmascript chunk".into())
-}
-
-#[turbo_tasks::function]
-fn chunk_item_module_key() -> Vc<RcStr> {
-    Vc::cell("module".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for EcmascriptChunk {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("ecmascript chunk"))
     }
 
     #[turbo_tasks::function]
@@ -203,10 +193,9 @@ impl Introspectable for EcmascriptChunk {
         let mut children = children_from_output_assets(self.references())
             .owned()
             .await?;
-        let chunk_item_module_key = chunk_item_module_key().to_resolved().await?;
         for chunk_item in self.await?.content.included_chunk_items().await? {
             children.insert((
-                chunk_item_module_key,
+                rcstr!("module"),
                 IntrospectableModule::new(chunk_item.module())
                     .to_resolved()
                     .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob};
 use turbopack_core::{
@@ -150,7 +151,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Invalid value for sideEffects in package.json".into()).cell()
+        StyledString::Text(rcstr!("Invalid value for sideEffects in package.json")).cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -105,16 +105,17 @@ impl ManifestAsyncModule {
     }
 }
 
-#[turbo_tasks::function]
-fn manifest_chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("manifest chunk".into())
+fn manifest_chunk_reference_description() -> RcStr {
+    rcstr!("manifest chunk")
 }
 
 #[turbo_tasks::value_impl]
 impl Module for ManifestAsyncModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.inner.ident().with_modifier(rcstr!("manifest chunk"))
+        self.inner
+            .ident()
+            .with_modifier(manifest_chunk_reference_description())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -77,16 +77,6 @@ impl ManifestLoaderChunkItem {
     }
 }
 
-#[turbo_tasks::function]
-fn manifest_loader_chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("manifest loader chunk".into())
-}
-
-#[turbo_tasks::function]
-fn chunk_data_reference_description() -> Vc<RcStr> {
-    Vc::cell("chunk data reference".into())
-}
-
 #[turbo_tasks::value_impl]
 impl ChunkItem for ManifestLoaderChunkItem {
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -5,6 +5,7 @@ use swc_core::{
     ecma::ast::{ArrayLit, ArrayPat, Expr, Ident},
     quote,
 };
+use turbo_rcstr::rcstr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
     trace::TraceRawVcs,
@@ -213,7 +214,7 @@ impl AsyncModule {
                     .collect::<Vec<_>>();
 
                 return Ok(CodeGeneration::hoisted_stmts([
-                    CodeGenerationHoistedStmt::new("__turbopack_async_dependencies__".into(),
+                    CodeGenerationHoistedStmt::new(rcstr!("__turbopack_async_dependencies__"),
                         quote!(
                             "var __turbopack_async_dependencies__ = __turbopack_handle_async_dependencies__($deps);"
                                 as Stmt,
@@ -226,7 +227,7 @@ impl AsyncModule {
                             })
                         )
                     ),
-                    CodeGenerationHoistedStmt::new("__turbopack_async_dependencies__ await".into(),
+                    CodeGenerationHoistedStmt::new(rcstr!("__turbopack_async_dependencies__ await"),
                         quote!(
                             "($deps = __turbopack_async_dependencies__.then ? (await \
                             __turbopack_async_dependencies__)() : __turbopack_async_dependencies__);" as Stmt,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -5,7 +5,7 @@ use swc_core::{
     ecma::ast::{Decl, Expr, ExprStmt, Ident, Stmt},
     quote,
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -453,9 +453,9 @@ impl Issue for InvalidExport {
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<StyledString>> {
         Ok(StyledString::Line(vec![
-            StyledString::Text("Export ".into()),
+            StyledString::Text(rcstr!("Export ")),
             StyledString::Code(self.export.clone()),
-            StyledString::Text(" doesn't exist in target module".into()),
+            StyledString::Text(rcstr!(" doesn't exist in target module")),
         ])
         .cell())
     }
@@ -481,20 +481,20 @@ impl Issue for InvalidExport {
         Ok(Vc::cell(Some(
             StyledString::Stack(vec![
                 StyledString::Line(vec![
-                    StyledString::Text("The export ".into()),
+                    StyledString::Text(rcstr!("The export ")),
                     StyledString::Code(self.export.clone()),
-                    StyledString::Text(" was not found in module ".into()),
+                    StyledString::Text(rcstr!(" was not found in module ")),
                     StyledString::Strong(self.module.ident().to_string().owned().await?),
-                    StyledString::Text(".".into()),
+                    StyledString::Text(rcstr!(".")),
                 ]),
                 if let Some(did_you_mean) = did_you_mean {
                     StyledString::Line(vec![
-                        StyledString::Text("Did you mean to import ".into()),
+                        StyledString::Text(rcstr!("Did you mean to import ")),
                         StyledString::Code(did_you_mean.clone()),
-                        StyledString::Text("?".into()),
+                        StyledString::Text(rcstr!("?")),
                     ])
                 } else {
-                    StyledString::Strong("The module has no exports at all.".into())
+                    StyledString::Strong(rcstr!("The module has no exports at all."))
                 },
                 StyledString::Text(
                     "All exports of the module are statically known (It doesn't have dynamic \
@@ -511,7 +511,7 @@ impl Issue for InvalidExport {
         let export_names = all_known_export_names(*self.module).await?;
         Ok(Vc::cell(Some(
             StyledString::Line(vec![
-                StyledString::Text("These are the exports of the module:\n".into()),
+                StyledString::Text(rcstr!("These are the exports of the module:\n")),
                 StyledString::Code(
                     export_names
                         .iter()

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -11,7 +11,7 @@ use swc_core::{
     },
     quote, quote_expr,
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
     trace::TraceRawVcs,
@@ -461,7 +461,7 @@ async fn emit_star_exports_issue(source_ident: Vc<AssetIdent>, message: RcStr) -
     AnalyzeIssue::new(
         IssueSeverity::Warning,
         source_ident,
-        Vc::cell("unexpected export *".into()),
+        Vc::cell(rcstr!("unexpected export *")),
         StyledString::Text(message).cell(),
         None,
         None,
@@ -680,12 +680,12 @@ impl EsmExports {
         Ok(CodeGeneration::new(
             vec![],
             [dynamic_stmt
-                .map(|stmt| CodeGenerationHoistedStmt::new("__turbopack_dynamic__".into(), stmt))]
+                .map(|stmt| CodeGenerationHoistedStmt::new(rcstr!("__turbopack_dynamic__"), stmt))]
             .into_iter()
             .flatten()
             .collect(),
             vec![CodeGenerationHoistedStmt::new(
-                "__turbopack_esm__".into(),
+                rcstr!("__turbopack_esm__"),
                 quote!("$turbopack_esm($getters);" as Stmt,
                     turbopack_esm: Expr = TURBOPACK_ESM.into(),
                     getters: Expr = getters

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -7,6 +7,7 @@ use swc_core::{
     ecma::ast::{Expr, Ident},
     quote,
 };
+use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
@@ -62,7 +63,7 @@ impl ImportMetaBinding {
         );
 
         Ok(CodeGeneration::hoisted_stmt(
-            "import.meta".into(),
+            rcstr!("import.meta"),
             // [NOTE] url property is lazy-evaluated, as it should be computed once
             // turbopack_runtime injects a function to calculate an absolute path.
             quote!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -118,7 +118,7 @@ impl CachedExternalModule {
 impl Module for CachedExternalModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        let fs = VirtualFileSystem::new_with_name("externals".into());
+        let fs = VirtualFileSystem::new_with_name(rcstr!("externals"));
 
         AssetIdent::from_path(fs.root().join(self.request.clone()))
             .with_layer(rcstr!("external"))
@@ -212,7 +212,7 @@ pub struct CachedExternalModuleChunkItem {
 // Without this wrapper, VirtualFileSystem::new_with_name always returns a new filesystem
 #[turbo_tasks::function]
 fn external_fs() -> Vc<VirtualFileSystem> {
-    VirtualFileSystem::new_with_name("externals".into())
+    VirtualFileSystem::new_with_name(rcstr!("externals"))
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1468,34 +1468,34 @@ async fn compile_time_info_for_module_type(
     };
     free_var_references
         .entry(vec![
-            DefineableNameSegment::Name("import".into()),
-            DefineableNameSegment::Name("meta".into()),
+            DefineableNameSegment::Name(rcstr!("import")),
+            DefineableNameSegment::Name(rcstr!("meta")),
             DefineableNameSegment::TypeOf,
         ])
         .or_insert("object".into());
     free_var_references
         .entry(vec![
-            DefineableNameSegment::Name("exports".into()),
+            DefineableNameSegment::Name(rcstr!("exports")),
             DefineableNameSegment::TypeOf,
         ])
         .or_insert(typeof_exports.into());
     free_var_references
         .entry(vec![
-            DefineableNameSegment::Name("module".into()),
+            DefineableNameSegment::Name(rcstr!("module")),
             DefineableNameSegment::TypeOf,
         ])
         .or_insert(typeof_module.into());
     free_var_references
         .entry(vec![
-            DefineableNameSegment::Name("require".into()),
+            DefineableNameSegment::Name(rcstr!("require")),
             DefineableNameSegment::TypeOf,
         ])
         .or_insert("function".into());
     free_var_references
-        .entry(vec![DefineableNameSegment::Name("require".into())])
+        .entry(vec![DefineableNameSegment::Name(rcstr!("require"))])
         .or_insert(require.into());
 
-    let dir_name: RcStr = "__dirname".into();
+    let dir_name: RcStr = rcstr!("__dirname");
     free_var_references
         .entry(vec![
             DefineableNameSegment::Name(dir_name.clone()),
@@ -1507,7 +1507,7 @@ async fn compile_time_info_for_module_type(
         .or_insert(FreeVarReference::InputRelative(
             InputRelativeConstant::DirName,
         ));
-    let file_name: RcStr = "__filename".into();
+    let file_name: RcStr = rcstr!("__filename");
 
     free_var_references
         .entry(vec![
@@ -1522,7 +1522,7 @@ async fn compile_time_info_for_module_type(
         ));
 
     // Compiletime rewrite the nodejs `global` to `globalThis`
-    let global: RcStr = "global".into();
+    let global: RcStr = rcstr!("global");
     free_var_references
         .entry(vec![
             DefineableNameSegment::Name(global.clone()),
@@ -3349,7 +3349,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
         self.esm_exports.insert(
-            "default".into(),
+            rcstr!("default"),
             EsmExport::LocalBinding(magic_identifier::mangle("default export").into(), false),
         );
         self.analysis
@@ -3365,7 +3365,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         match &export.decl {
             DefaultDecl::Class(ClassExpr { ident, .. }) | DefaultDecl::Fn(FnExpr { ident, .. }) => {
                 self.esm_exports.insert(
-                    "default".into(),
+                    rcstr!("default"),
                     EsmExport::LocalBinding(
                         ident
                             .as_ref()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -51,7 +51,7 @@ use swc_core::{
     },
 };
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
     Value, ValueToString, Vc, trace::TraceRawVcs,
@@ -979,8 +979,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             AnalyzeIssue::new(
                 IssueSeverity::Error,
                 source.ident(),
-                Vc::cell("unexpected top level await".into()),
-                StyledString::Text("top level await is only supported in ESM modules.".into())
+                Vc::cell(rcstr!("unexpected top level await")),
+                StyledString::Text(rcstr!("top level await is only supported in ESM modules."))
                     .cell(),
                 None,
                 Some(issue_source(source, span)),

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use either::Either;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -77,7 +77,7 @@ async fn resolve_reference_from_dir(
         (Some(abs_path), Some(rel_path)) => Either::Right(
             read_matches(
                 parent_path.root().resolve().await?,
-                "/ROOT/".into(),
+                rcstr!("/ROOT/"),
                 true,
                 Pattern::new(abs_path.or_any_nested_file()),
             )
@@ -86,7 +86,7 @@ async fn resolve_reference_from_dir(
             .chain(
                 read_matches(
                     parent_path,
-                    "".into(),
+                    rcstr!(""),
                     true,
                     Pattern::new(rel_path.or_any_nested_file()),
                 )
@@ -98,7 +98,7 @@ async fn resolve_reference_from_dir(
             // absolute path only
             read_matches(
                 parent_path.root().resolve().await?,
-                "/ROOT/".into(),
+                rcstr!("/ROOT/"),
                 true,
                 Pattern::new(abs_path.or_any_nested_file()),
             )
@@ -109,7 +109,7 @@ async fn resolve_reference_from_dir(
             // relative path only
             read_matches(
                 parent_path,
-                "".into(),
+                rcstr!(""),
                 true,
                 Pattern::new(rel_path.or_any_nested_file()),
             )

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -14,7 +14,7 @@ use swc_core::{
     quote, quote_expr,
 };
 use turbo_esregex::EsRegex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ResolvedVc, Value, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -355,7 +355,7 @@ impl ModuleReference for ResolvedModuleReference {
 impl ValueToString for ResolvedModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("resolved reference".into())
+        Vc::cell(rcstr!("resolved reference"))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use swc_core::{ecma::ast::Expr, quote};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
@@ -39,7 +39,7 @@ pub async fn request_to_string(request: Vc<Request>) -> Result<Vc<RcStr>> {
             .await?
             .request()
             // TODO: Handle Request::Dynamic, Request::Alternatives
-            .unwrap_or_else(|| "unknown".into()),
+            .unwrap_or(rcstr!("unknown")),
     ))
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -5,7 +5,7 @@ use swc_core::{
     ecma::ast::{Expr, ExprOrSpread, Lit, NewExpr},
     quote_expr,
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, Value, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -72,8 +72,8 @@ impl WorkerAssetReference {
         let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module) else {
             CodeGenerationIssue {
                 severity: IssueSeverity::Bug.resolved_cell(),
-                title: StyledString::Text("non-ecmascript placeable asset".into()).resolved_cell(),
-                message: StyledString::Text("asset is not placeable in ESM chunks".into())
+                title: StyledString::Text(rcstr!("non-ecmascript placeable asset")).resolved_cell(),
+                message: StyledString::Text(rcstr!("asset is not placeable in ESM chunks"))
                     .resolved_cell(),
                 path: self.origin.origin_path().to_resolved().await?,
             }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, glob::Glob};
 use turbopack_core::{
@@ -299,7 +300,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                 let esm_exports = esm_exports.await?;
                 if esm_exports.exports.keys().any(|name| name == "default") {
                     exports.insert(
-                        "default".into(),
+                        rcstr!("default"),
                         EsmExport::ImportedBinding(
                             ResolvedVc::upcast(
                                 EcmascriptModulePartReference::new_part(
@@ -309,7 +310,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                                 .to_resolved()
                                 .await?,
                             ),
-                            "default".into(),
+                            rcstr!("default"),
                             false,
                         ),
                     );

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use swc_core::{common::DUMMY_SP, ecma::ast::Ident, quote};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
@@ -55,7 +55,7 @@ impl ValueToString for EcmascriptModulePartReference {
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(match &self.part {
             Some(part) => Vc::cell(part.to_string().into()),
-            None => Vc::cell("module".into()),
+            None => Vc::cell(rcstr!("module")),
         })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -18,7 +18,7 @@ use swc_core::{
     },
     quote,
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -305,9 +305,9 @@ impl Issue for UnsupportedServerActionIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(
-            "Server actions (\"use server\") are not yet supported in Turbopack".into(),
-        )
+        StyledString::Text(rcstr!(
+            "Server actions (\"use server\") are not yet supported in Turbopack"
+        ))
         .cell()
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
@@ -327,7 +327,7 @@ impl Module for EcmascriptModulePartAsset {
                     *self.full_module,
                     part,
                 )),
-                Vc::cell("part reference".into()),
+                rcstr!("part reference"),
             ))
         };
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -23,7 +23,7 @@ use swc_core::{
         utils::{ExprCtx, ExprExt, find_pat_ids, private_ident, quote_ident},
     },
 };
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::FxIndexSet;
 
 use super::{

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -23,7 +23,7 @@ use swc_core::{
         utils::{ExprCtx, ExprExt, find_pat_ids, private_ident, quote_ident},
     },
 };
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::FxIndexSet;
 
 use super::{

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -84,7 +84,7 @@ impl Module for SideEffectsModule {
                     Ok(ResolvedVc::upcast(
                         SingleChunkableModuleReference::new(
                             *ResolvedVc::upcast(*side_effect),
-                            Vc::cell(rcstr!("side effect")),
+                            rcstr!("side effect"),
                         )
                         .to_resolved()
                         .await?,
@@ -97,7 +97,7 @@ impl Module for SideEffectsModule {
         references.push(ResolvedVc::upcast(
             SingleChunkableModuleReference::new(
                 *ResolvedVc::upcast(self.resolved_as),
-                Vc::cell(rcstr!("resolved as")),
+                rcstr!("resolved as"),
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde_json::Value as JsonValue;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::DirectoryContent;
 use turbopack_core::{
@@ -138,7 +138,7 @@ impl Module for TsConfigModuleAsset {
                 let mut current = self.source.ident().path().parent().resolve().await?;
                 loop {
                     if let DirectoryContent::Entries(entries) = &*current
-                        .join("node_modules/@types".into())
+                        .join(rcstr!("node_modules/@types"))
                         .read_dir()
                         .await?
                     {

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -143,7 +143,7 @@ impl ModuleReference for WebpackEntryAssetReference {
 impl ValueToString for WebpackEntryAssetReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("webpack entry".into())
+        Vc::cell(rcstr!("webpack entry"))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -6,6 +6,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     reference::{ModuleReference, ModuleReferences},
@@ -46,7 +47,7 @@ pub async fn module_references(
             let (emitter, collector) = IssueEmitter::new(
                 source,
                 source_map.clone(),
-                Some("Parsing webpack bundle failed".into()),
+                Some(rcstr!("Parsing webpack bundle failed")),
             );
             let handler = Handler::with_emitter(true, false, Box::new(emitter));
             HANDLER.set(&handler, || {

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbopack_core::{
     chunk::{
@@ -78,11 +78,6 @@ impl EcmascriptChunkItem for WorkerLoaderChunkItem {
         }
         .into())
     }
-}
-
-#[turbo_tasks::function]
-fn chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("worker chunk".into())
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -116,6 +116,6 @@ impl ModuleReference for WorkerModuleReference {
 impl ValueToString for WorkerModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("worker module".into())
+        Vc::cell(rcstr!("worker module"))
     }
 }

--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 use anyhow::Result;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
@@ -37,7 +38,7 @@ impl ProcessEnvAsset {
 impl Source for ProcessEnvAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.root.join(".env.js".into()))
+        AssetIdent::from_path(self.root.join(rcstr!(".env.js")))
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/dotenv.rs
+++ b/turbopack/crates/turbopack-env/src/dotenv.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{Vc, fxindexmap};
 use turbo_tasks_env::{CommandLineProcessEnv, CustomProcessEnv, ProcessEnv};
 use turbo_tasks_fs::FileSystemPath;
@@ -11,13 +12,13 @@ use crate::TryDotenvProcessEnv;
 pub async fn load_env(project_path: Vc<FileSystemPath>) -> Result<Vc<Box<dyn ProcessEnv>>> {
     let env: Vc<Box<dyn ProcessEnv>> = Vc::upcast(CommandLineProcessEnv::new());
 
-    let node_env = env.read("NODE_ENV".into()).await?;
+    let node_env = env.read(rcstr!("NODE_ENV")).await?;
     let node_env = node_env.as_deref().unwrap_or("development");
 
     let env = Vc::upcast(CustomProcessEnv::new(
         env,
         Vc::cell(fxindexmap! {
-            "NODE_ENV".into() => node_env.into(),
+            rcstr!("NODE_ENV") => node_env.into(),
         }),
     ));
 

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -1,3 +1,4 @@
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString};
@@ -13,7 +14,7 @@ pub struct ProcessEnvIssue {
 impl Issue for ProcessEnvIssue {
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Error loading dotenv file".into()).cell()
+        StyledString::Text(rcstr!("Error loading dotenv file")).cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-image/Cargo.toml
+++ b/turbopack/crates/turbopack-image/Cargo.toml
@@ -35,6 +35,7 @@ regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
+turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbopack-core = { workspace = true }

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -17,6 +17,7 @@ use image::{
 use mime::Mime;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -171,7 +172,7 @@ fn load_image_internal(
                     .into(),
             )
             .resolved_cell(),
-            title: Some(StyledString::Text("AVIF image not supported".into()).resolved_cell()),
+            title: Some(StyledString::Text(rcstr!("AVIF image not supported")).resolved_cell()),
             issue_severity: Some(IssueSeverity::Warning.resolved_cell()),
         }
         .resolved_cell()
@@ -189,7 +190,7 @@ fn load_image_internal(
                     .into(),
             )
             .resolved_cell(),
-            title: Some(StyledString::Text("WEBP image not supported".into()).resolved_cell()),
+            title: Some(StyledString::Text(rcstr!("WEBP image not supported")).resolved_cell()),
             issue_severity: Some(IssueSeverity::Warning.resolved_cell()),
         }
         .resolved_cell()
@@ -515,7 +516,7 @@ impl Issue for ImageProcessingIssue {
     fn title(&self) -> Vc<StyledString> {
         *self
             .title
-            .unwrap_or(StyledString::Text("Processing image failed".into()).resolved_cell())
+            .unwrap_or(StyledString::Text(rcstr!("Processing image failed")).resolved_cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -19,11 +19,6 @@ use turbopack_core::{
     source_transform::SourceTransform,
 };
 
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("mdx".into())
-}
-
 #[turbo_tasks::value(shared, operation)]
 #[derive(Hash, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use mdxjs::{MdxParseOptions, Options, compile};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueDefault, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
 use turbopack_core::{
@@ -110,7 +110,7 @@ struct MdxTransformedAsset {
 impl Source for MdxTransformedAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().rename_as("*.tsx".into())
+        self.source.ident().rename_as(rcstr!("*.tsx"))
     }
 }
 
@@ -279,7 +279,7 @@ impl Issue for MdxIssue {
 
     #[turbo_tasks::function]
     fn title(self: Vc<Self>) -> Vc<StyledString> {
-        StyledString::Text("MDX Parse Error".into()).cell()
+        StyledString::Text(rcstr!("MDX Parse Error")).cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -12,6 +12,7 @@ use futures_retry::{FutureRetry, RetryPolicy};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value as JsonValue;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{
     Completion, FxIndexMap, NonLocalValue, OperationVc, RawVc, ResolvedVc, TaskInput,
     TryJoinIterExt, Value, Vc, apply_effects, duration_span, fxindexmap, mark_finished, prevent_gc,
@@ -96,7 +97,7 @@ async fn emit_evaluate_pool_assets_operation(
 ) -> Result<Vc<EmittedEvaluatePoolAssets>> {
     let runtime_asset = asset_context
         .process(
-            Vc::upcast(FileSource::new(embed_file_path("ipc/evaluate.ts".into()))),
+            Vc::upcast(FileSource::new(embed_file_path(rcstr!("ipc/evaluate.ts")))),
             Value::new(ReferenceType::Internal(
                 InnerAssets::empty().to_resolved().await?,
             )),
@@ -118,14 +119,14 @@ async fn emit_evaluate_pool_assets_operation(
     let entry_module = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                runtime_asset.ident().path().join("evaluate.js".into()),
+                runtime_asset.ident().path().join(rcstr!("evaluate.js")),
                 AssetContent::file(
                     File::from("import { run } from 'RUNTIME'; run(() => import('INNER'))").into(),
                 ),
             )),
             Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
-                "INNER".into() => module_asset,
-                "RUNTIME".into() => runtime_asset
+                rcstr!("INNER") => module_asset,
+                rcstr!("RUNTIME") => runtime_asset
             }))),
         )
         .module()
@@ -135,7 +136,7 @@ async fn emit_evaluate_pool_assets_operation(
     let runtime_entries = {
         let globals_module = asset_context
             .process(
-                Vc::upcast(FileSource::new(embed_file_path("globals.ts".into()))),
+                Vc::upcast(FileSource::new(embed_file_path(rcstr!("globals.ts")))),
                 Value::new(ReferenceType::Internal(
                     InnerAssets::empty().to_resolved().await?,
                 )),
@@ -704,7 +705,7 @@ pub struct EvaluationIssue {
 impl Issue for EvaluationIssue {
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Error evaluating Node.js code".into()).cell()
+        StyledString::Text(rcstr!("Error evaluating Node.js code")).cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -7,7 +7,7 @@ use std::{iter::once, thread::available_parallelism};
 use anyhow::{Result, bail};
 pub use node_entry::{NodeEntry, NodeRenderingEntries, NodeRenderingEntry};
 use rustc_hash::FxHashMap;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal},
@@ -189,7 +189,7 @@ async fn separate_assets_operation(
 fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<()> {
     emit(
         Vc::upcast(VirtualOutputAsset::new(
-            dir.join("package.json".into()),
+            dir.join(rcstr!("package.json")),
             AssetContent::file(File::from("{\"type\": \"commonjs\"}").into()),
         )),
         dir,
@@ -255,7 +255,7 @@ pub async fn get_intermediate_asset(
     other_entries: Vc<EvaluatableAssets>,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
     Ok(Vc::upcast(chunking_context.root_entry_chunk_group_asset(
-        chunking_context.chunk_path(None, main_entry.ident(), ".js".into()),
+        chunking_context.chunk_path(None, main_entry.ident(), rcstr!(".js")),
         other_entries.with_entry(*main_entry),
         ModuleGraph::from_modules(
             Vc::cell(vec![ChunkGroupEntry::Entry(

--- a/turbopack/crates/turbopack-node/src/render/issue.rs
+++ b/turbopack/crates/turbopack-node/src/render/issue.rs
@@ -1,7 +1,7 @@
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString};
-
 #[turbo_tasks::value(shared)]
 #[derive(Copy, Clone)]
 pub struct RenderingIssue {
@@ -14,7 +14,7 @@ pub struct RenderingIssue {
 impl Issue for RenderingIssue {
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Error during SSR Rendering".into()).cell()
+        StyledString::Text(rcstr!("Error during SSR Rendering")).cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde_json::Value as JsonValue;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexSet, ResolvedVc, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
@@ -156,16 +156,11 @@ impl GetContentSourceContent for NodeApiContentSource {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("node api content source".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for NodeApiContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("node api content source"))
     }
 
     #[turbo_tasks::function]
@@ -190,13 +185,13 @@ impl Introspectable for NodeApiContentSource {
         for &entry in self.entry.entries().await?.iter() {
             let entry = entry.await?;
             set.insert((
-                ResolvedVc::cell("module".into()),
+                rcstr!("module"),
                 IntrospectableModule::new(Vc::upcast(*entry.module))
                     .to_resolved()
                     .await?,
             ));
             set.insert((
-                ResolvedVc::cell("intermediate asset".into()),
+                rcstr!("intermediate asset"),
                 IntrospectableOutputAsset::new(get_intermediate_asset(
                     *entry.chunking_context,
                     Vc::upcast(*entry.module),

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -7,7 +7,7 @@ use futures::{
 };
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     RawVc, ResolvedVc, TaskInput, ValueToString, Vc, duration_span, mark_finished, prevent_gc,
     trace::TraceRawVcs, util::SharedError,
@@ -115,7 +115,7 @@ async fn proxy_error(
     let status_code = 500;
     let body = error_html(
         status_code,
-        "An error occurred while proxying the request to Node.js".into(),
+        rcstr!("An error occurred while proxying the request to Node.js"),
         format!("{message}\n\n{}", details.join("\n")).into(),
     )
     .owned()
@@ -289,8 +289,8 @@ async fn render_stream_internal(
                 yield RenderItem::Headers(ResponseHeaders {
                     status,
                     headers: vec![(
-                        "content-type".into(),
-                        "text/html; charset=utf-8".into(),
+                        rcstr!("content-type"),
+                        rcstr!("text/html; charset=utf-8"),
                     )],
                 });
                 yield RenderItem::BodyChunk(body.into_owned().into_bytes().into());

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -7,6 +7,7 @@ use futures::{
 };
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{
     RawVc, ResolvedVc, TaskInput, ValueToString, Vc, duration_span, mark_finished, prevent_gc,
     trace::TraceRawVcs, util::SharedError,
@@ -163,7 +164,7 @@ async fn static_error(
         .to_string();
 
     body.push_str(
-        error_html_body(500, "Error rendering page".into(), message.into())
+        error_html_body(500, rcstr!("Error rendering page"), message.into())
             .await?
             .as_str(),
     );

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde_json::Value as JsonValue;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexSet, OperationVc, ResolvedVc, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
@@ -258,16 +258,11 @@ async fn static_streamed_content_to_proxy_result_operation(
     Ok(*proxy_result)
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("node render content source".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for NodeRenderContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("node render content source"))
     }
 
     #[turbo_tasks::function]
@@ -292,13 +287,13 @@ impl Introspectable for NodeRenderContentSource {
         for &entry in self.entry.entries().await?.iter() {
             let entry = entry.await?;
             set.insert((
-                ResolvedVc::cell("module".into()),
+                rcstr!("module"),
                 IntrospectableModule::new(Vc::upcast(*entry.module))
                     .to_resolved()
                     .await?,
             ));
             set.insert((
-                ResolvedVc::cell("intermediate asset".into()),
+                rcstr!("intermediate asset"),
                 IntrospectableOutputAsset::new(get_intermediate_asset(
                     *entry.chunking_context,
                     *entry.module,

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -8,7 +8,7 @@ use futures::try_join;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use serde_with::serde_as;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, NonLocalValue, OperationValue, OperationVc, ResolvedVc, TaskInput, TryJoinIterExt,
     Value, ValueToString, Vc, trace::TraceRawVcs,
@@ -188,9 +188,9 @@ async fn webpack_loaders_executor(
     evaluate_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<ProcessResult>> {
     Ok(evaluate_context.process(
-        Vc::upcast(FileSource::new(embed_file_path(
-            "transforms/webpack-loaders.ts".into(),
-        ))),
+        Vc::upcast(FileSource::new(embed_file_path(rcstr!(
+            "transforms/webpack-loaders.ts"
+        )))),
         Value::new(ReferenceType::Internal(
             InnerAssets::empty().to_resolved().await?,
         )),
@@ -742,7 +742,7 @@ impl Issue for BuildDependencyIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Build dependencies are not yet supported".into()).cell()
+        StyledString::Text(rcstr!("Build dependencies are not yet supported")).cell()
     }
 
     #[turbo_tasks::function]
@@ -759,7 +759,7 @@ impl Issue for BuildDependencyIssue {
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
         Ok(Vc::cell(Some(
             StyledString::Line(vec![
-                StyledString::Text("The file at ".into()),
+                StyledString::Text(rcstr!("The file at ")),
                 StyledString::Code(self.path.await?.to_string().into()),
                 StyledString::Text(
                     " is a build dependency, which is not yet implemented.
@@ -802,7 +802,7 @@ impl Issue for EvaluateEmittedErrorIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Issue while running loader".into()).cell()
+        StyledString::Text(rcstr!("Issue while running loader")).cell()
     }
 
     #[turbo_tasks::function]
@@ -854,7 +854,7 @@ impl Issue for EvaluateErrorLoggingIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Error logging while running loader".into()).cell()
+        StyledString::Text(rcstr!("Error logging while running loader")).cell()
     }
 
     #[turbo_tasks::function]
@@ -886,7 +886,7 @@ impl Issue for EvaluateErrorLoggingIssue {
                 LogType::Warn => StyledString::Text(fmt_args("<w> ".to_string(), &log.args).into()),
                 LogType::Info => StyledString::Text(fmt_args("<i> ".to_string(), &log.args).into()),
                 LogType::Log => StyledString::Text(fmt_args("<l> ".to_string(), &log.args).into()),
-                LogType::Clear => StyledString::Strong("---".into()),
+                LogType::Clear => StyledString::Strong(rcstr!("---")),
                 _ => {
                     unimplemented!("{:?} is not implemented", log.log_type)
                 }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Upcast, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -36,7 +36,7 @@ pub struct NodeJsChunkingContextBuilder {
 }
 
 impl NodeJsChunkingContextBuilder {
-    pub fn asset_prefix(mut self, asset_prefix: ResolvedVc<Option<RcStr>>) -> Self {
+    pub fn asset_prefix(mut self, asset_prefix: Option<RcStr>) -> Self {
         self.chunking_context.asset_prefix = asset_prefix;
         self
     }
@@ -104,7 +104,7 @@ pub struct NodeJsChunkingContext {
     /// This path is used to compute the url to request chunks or assets from
     output_root: ResolvedVc<FileSystemPath>,
     /// The relative path from the output_root to the root_path.
-    output_root_to_root_path: ResolvedVc<RcStr>,
+    output_root_to_root_path: RcStr,
     /// This path is used to compute the url to request chunks or assets from
     client_root: ResolvedVc<FileSystemPath>,
     /// Chunks are placed at this path
@@ -112,7 +112,7 @@ pub struct NodeJsChunkingContext {
     /// Static assets are placed at this path
     asset_root_path: ResolvedVc<FileSystemPath>,
     /// Static assets requested from this url base
-    asset_prefix: ResolvedVc<Option<RcStr>>,
+    asset_prefix: Option<RcStr>,
     /// The environment chunks will be evaluated in.
     environment: ResolvedVc<Environment>,
     /// The kind of runtime to include in the output.
@@ -138,7 +138,7 @@ impl NodeJsChunkingContext {
     pub fn builder(
         root_path: ResolvedVc<FileSystemPath>,
         output_root: ResolvedVc<FileSystemPath>,
-        output_root_to_root_path: ResolvedVc<RcStr>,
+        output_root_to_root_path: RcStr,
         client_root: ResolvedVc<FileSystemPath>,
         chunk_root_path: ResolvedVc<FileSystemPath>,
         asset_root_path: ResolvedVc<FileSystemPath>,
@@ -153,7 +153,7 @@ impl NodeJsChunkingContext {
                 client_root,
                 chunk_root_path,
                 asset_root_path,
-                asset_prefix: ResolvedVc::cell(None),
+                asset_prefix: None,
                 enable_file_tracing: false,
                 environment,
                 runtime_type,
@@ -183,16 +183,17 @@ impl NodeJsChunkingContext {
     }
 }
 
+impl NodeJsChunkingContext {
+    pub async fn asset_prefix(self: Vc<Self>) -> Result<Option<RcStr>> {
+        Ok(self.await?.asset_prefix.clone())
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl NodeJsChunkingContext {
     #[turbo_tasks::function]
     fn new(this: Value<NodeJsChunkingContext>) -> Vc<Self> {
         this.into_value().cell()
-    }
-
-    #[turbo_tasks::function]
-    pub fn asset_prefix(&self) -> Vc<Option<RcStr>> {
-        *self.asset_prefix
     }
 
     #[turbo_tasks::function]
@@ -235,7 +236,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     fn output_root_to_root_path(&self) -> Vc<RcStr> {
-        *self.output_root_to_root_path
+        Vc::cell(self.output_root_to_root_path.clone())
     }
 
     #[turbo_tasks::function]
@@ -263,11 +264,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         Ok(Vc::cell(
             format!(
                 "{}{}",
-                self.asset_prefix
-                    .await?
-                    .as_ref()
-                    .map(|s| s.clone())
-                    .unwrap_or_else(|| "/".into()),
+                self.asset_prefix.clone().unwrap_or(rcstr!("/")),
                 asset_path
             )
             .into(),

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -221,7 +221,7 @@ impl NodeJsChunkingContext {
 impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     fn name(&self) -> Vc<RcStr> {
-        Vc::cell("unknown".into())
+        Vc::cell(rcstr!("unknown"))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -52,7 +52,7 @@ impl EcmascriptBuildNodeChunk {
 impl ValueToString for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("Ecmascript Build Node Chunk".into())
+        Vc::cell(rcstr!("Ecmascript Build Node Chunk"))
     }
 }
 
@@ -82,7 +82,7 @@ impl OutputAsset for EcmascriptBuildNodeChunk {
         let ident = this.chunk.ident().with_modifier(modifier());
         Ok(this
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, rcstr!(".js")))
     }
 
     #[turbo_tasks::function]
@@ -129,21 +129,11 @@ impl GenerateSourceMap for EcmascriptBuildNodeChunk {
     }
 }
 
-#[turbo_tasks::function]
-fn introspectable_type() -> Vc<RcStr> {
-    Vc::cell("ecmascript build node chunk".into())
-}
-
-#[turbo_tasks::function]
-fn introspectable_details() -> Vc<RcStr> {
-    Vc::cell("generates a production EcmaScript chunk targeting Node.js".into())
-}
-
 #[turbo_tasks::value_impl]
 impl Introspectable for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
     fn ty(&self) -> Vc<RcStr> {
-        introspectable_type()
+        Vc::cell(rcstr!("ecmascript build node chunk"))
     }
 
     #[turbo_tasks::function]
@@ -153,14 +143,16 @@ impl Introspectable for EcmascriptBuildNodeChunk {
 
     #[turbo_tasks::function]
     fn details(&self) -> Vc<RcStr> {
-        introspectable_details()
+        Vc::cell(rcstr!(
+            "generates a production EcmaScript chunk targeting Node.js"
+        ))
     }
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = FxIndexSet::default();
         let introspectable_chunk = ResolvedVc::upcast::<Box<dyn Introspectable>>(self.chunk);
-        children.insert((ResolvedVc::cell("chunk".into()), introspectable_chunk));
+        children.insert((rcstr!("chunk"), introspectable_chunk));
         Ok(Vc::cell(children))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{Result, bail};
 use indoc::writedoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
@@ -160,18 +160,8 @@ impl EcmascriptBuildNodeEntryChunk {
 impl ValueToString for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("Ecmascript Build Node Evaluate Chunk".into())
+        Vc::cell(rcstr!("Ecmascript Build Node Evaluate Chunk"))
     }
-}
-
-#[turbo_tasks::function]
-fn modifier() -> Vc<RcStr> {
-    Vc::cell("ecmascript build node evaluate chunk".into())
-}
-
-#[turbo_tasks::function]
-fn chunk_reference_description() -> Vc<RcStr> {
-    Vc::cell("chunk".into())
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{Result, bail};
 use indoc::writedoc;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystem, FileSystemPath};
 use turbopack_core::{
@@ -99,7 +99,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
         AssetIdent::from_path(
             turbopack_ecmascript_runtime::embed_fs()
                 .root()
-                .join("runtime.js".into()),
+                .join(rcstr!("runtime.js")),
         )
     }
 
@@ -118,7 +118,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
 impl ValueToString for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell("Ecmascript Build Node Runtime Chunk".into())
+        Vc::cell(rcstr!("Ecmascript Build Node Runtime Chunk"))
     }
 }
 
@@ -131,7 +131,7 @@ impl OutputAsset for EcmascriptBuildNodeRuntimeChunk {
 
         Ok(this
             .chunking_context
-            .chunk_path(Some(Vc::upcast(self)), ident, ".js".into()))
+            .chunk_path(Some(Vc::upcast(self)), ident, rcstr!(".js")))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     issue::IssueSource,
@@ -63,8 +64,8 @@ async fn apply_esm_specific_options_internal(
     // TODO set fully_specified when in strict ESM mode
     // options.fully_specified = true;
     for conditions in get_condition_maps(&mut options) {
-        conditions.insert("import".into(), ConditionValue::Set);
-        conditions.insert("require".into(), ConditionValue::Unset);
+        conditions.insert(rcstr!("import"), ConditionValue::Set);
+        conditions.insert(rcstr!("require"), ConditionValue::Unset);
     }
 
     if clear_extensions {
@@ -80,8 +81,8 @@ async fn apply_esm_specific_options_internal(
 pub async fn apply_cjs_specific_options(options: Vc<ResolveOptions>) -> Result<Vc<ResolveOptions>> {
     let mut options: ResolveOptions = options.owned().await?;
     for conditions in get_condition_maps(&mut options) {
-        conditions.insert("import".into(), ConditionValue::Unset);
-        conditions.insert("require".into(), ConditionValue::Set);
+        conditions.insert(rcstr!("import"), ConditionValue::Unset);
+        conditions.insert(rcstr!("require"), ConditionValue::Set);
     }
     Ok(options.into())
 }

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use turbo_rcstr::rcstr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::resolve::{
@@ -143,16 +144,16 @@ async fn base_resolve_options(
 
     let conditions = {
         let mut conditions: ResolutionConditions = [
-            ("import".into(), ConditionValue::Unknown),
-            ("require".into(), ConditionValue::Unknown),
+            (rcstr!("import"), ConditionValue::Unknown),
+            (rcstr!("require"), ConditionValue::Unknown),
         ]
         .into_iter()
         .collect();
         if opt.browser {
-            conditions.insert("browser".into(), ConditionValue::Set);
+            conditions.insert(rcstr!("browser"), ConditionValue::Set);
         }
         if opt.module {
-            conditions.insert("module".into(), ConditionValue::Set);
+            conditions.insert(rcstr!("module"), ConditionValue::Set);
         }
         if let Some(environment) = emulating {
             for condition in environment.resolve_conditions().await?.iter() {
@@ -167,7 +168,7 @@ async fn base_resolve_options(
         let prod = conditions.get("production").cloned();
         if prod.is_none() {
             conditions.insert(
-                "production".into(),
+                rcstr!("production"),
                 if matches!(dev, Some(ConditionValue::Set)) {
                     ConditionValue::Unset
                 } else {
@@ -177,7 +178,7 @@ async fn base_resolve_options(
         }
         if dev.is_none() {
             conditions.insert(
-                "development".into(),
+                rcstr!("development"),
                 if matches!(prod, Some(ConditionValue::Set)) {
                     ConditionValue::Unset
                 } else {
@@ -195,22 +196,22 @@ async fn base_resolve_options(
     } else {
         let mut ext = Vec::new();
         if opt.enable_typescript && opt.enable_react {
-            ext.push(".tsx".into());
+            ext.push(rcstr!(".tsx"));
         }
         if opt.enable_typescript {
-            ext.push(".ts".into());
+            ext.push(rcstr!(".ts"));
         }
         if opt.enable_react {
-            ext.push(".jsx".into());
+            ext.push(rcstr!(".jsx"));
         }
-        ext.push(".js".into());
+        ext.push(rcstr!(".js"));
         if opt.enable_mjs_extension {
-            ext.push(".mjs".into());
+            ext.push(rcstr!(".mjs"));
         }
         if opt.enable_node_native_modules {
-            ext.push(".node".into());
+            ext.push(rcstr!(".node"));
         }
-        ext.push(".json".into());
+        ext.push(rcstr!(".json"));
         ext
     };
     Ok(ResolveOptions {
@@ -219,7 +220,7 @@ async fn base_resolve_options(
             if *environment.resolve_node_modules().await? {
                 vec![ResolveModules::Nested(
                     root.to_resolved().await?,
-                    vec!["node_modules".into()],
+                    vec![rcstr!("node_modules")],
                 )]
             } else {
                 Vec::new()
@@ -227,7 +228,7 @@ async fn base_resolve_options(
         } else {
             let mut mods = Vec::new();
             if let Some(dir) = opt.enable_node_modules {
-                mods.push(ResolveModules::Nested(dir, vec!["node_modules".into()]));
+                mods.push(ResolveModules::Nested(dir, vec![rcstr!("node_modules")]));
             }
             mods
         },
@@ -238,16 +239,16 @@ async fn base_resolve_options(
             }];
             if opt.browser {
                 resolve_into.push(ResolveIntoPackage::MainField {
-                    field: "browser".into(),
+                    field: rcstr!("browser"),
                 });
             }
             if opt.module {
                 resolve_into.push(ResolveIntoPackage::MainField {
-                    field: "module".into(),
+                    field: rcstr!("module"),
                 });
             }
             resolve_into.push(ResolveIntoPackage::MainField {
-                field: "main".into(),
+                field: rcstr!("main"),
             });
             resolve_into
         },
@@ -257,11 +258,11 @@ async fn base_resolve_options(
                 unspecified_conditions: ConditionValue::Unset,
             }];
             if opt.browser {
-                resolve_in.push(ResolveInPackage::AliasField("browser".into()));
+                resolve_in.push(ResolveInPackage::AliasField(rcstr!("browser")));
             }
             resolve_in
         },
-        default_files: vec!["index".into()],
+        default_files: vec![rcstr!("index")],
         import_map: Some(import_map),
         resolved_map: opt.resolved_map,
         after_resolve_plugins: opt.after_resolve_plugins.clone(),

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -263,8 +263,8 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
         resource_path.to_str().unwrap()
     );
 
-    let root_fs = DiskFileSystem::new("workspace".into(), REPO_ROOT.clone(), vec![]);
-    let project_fs = DiskFileSystem::new("project".into(), REPO_ROOT.clone(), vec![]);
+    let root_fs = DiskFileSystem::new(rcstr!("workspace"), REPO_ROOT.clone(), vec![]);
+    let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone(), vec![]);
     let project_root = project_fs.root().to_resolved().await?;
 
     let relative_path = resource_path.strip_prefix(&*REPO_ROOT).context(format!(
@@ -277,9 +277,9 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
     let project_path = project_root.join(relative_path.clone());
     let tests_path = project_fs
         .root()
-        .join("turbopack/crates/turbopack-tests".into());
+        .join(rcstr!("turbopack/crates/turbopack-tests"));
 
-    let options_file = path.join("options.json".into());
+    let options_file = path.join(rcstr!("options.json"));
 
     let mut options = TestOptions::default();
     if matches!(*options_file.get_type().await?, FileSystemEntryType::File) {
@@ -309,14 +309,14 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         ref options,
     } = *prepared_test.await?;
 
-    let jest_entry_path = tests_path.join("js/jest-entry.ts".into());
-    let test_path = project_path.join("input/index.js".into());
+    let jest_entry_path = tests_path.join(rcstr!("js/jest-entry.ts"));
+    let test_path = project_path.join(rcstr!("input/index.js"));
 
-    let chunk_root_path = path.join("output".into()).to_resolved().await?;
-    let static_root_path = path.join("static".into()).to_resolved().await?;
+    let chunk_root_path = path.join(rcstr!("output")).to_resolved().await?;
+    let static_root_path = path.join(rcstr!("static")).to_resolved().await?;
 
     let chunk_root_path_in_root_path_offset = project_path
-        .join("output".into())
+        .join(rcstr!("output"))
         .await?
         .get_relative_path_to(&*project_root.await?)
         .context("Project path is in root path")?;
@@ -343,7 +343,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     import_map.insert_wildcard_alias(
         "esm-external/",
         ImportMapping::External(
-            Some("*".into()),
+            Some(rcstr!("*")),
             ExternalType::EcmaScriptModule,
             ExternalTraced::Untraced,
         )
@@ -387,12 +387,12 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         ResolveOptionsContext {
             enable_typescript: true,
             enable_node_modules: Some(project_root),
-            custom_conditions: vec!["development".into()],
+            custom_conditions: vec![rcstr!("development")],
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),
                 ResolveOptionsContext {
                     enable_node_modules: Some(project_root),
-                    custom_conditions: vec!["development".into()],
+                    custom_conditions: vec![rcstr!("development")],
                     browser: true,
                     ..Default::default()
                 }
@@ -451,7 +451,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         .process(
             Vc::upcast(jest_entry_source),
             Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
-                "TESTS".into() => test_asset,
+                rcstr!("TESTS") => test_asset,
             }))),
         )
         .module();
@@ -515,7 +515,7 @@ async fn snapshot_issues(
 
     turbopack_test_utils::snapshot::snapshot_issues(
         plain_issues,
-        path.join("issues".into()),
+        path.join(rcstr!("issues")),
         &REPO_ROOT,
     )
     .await

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -410,7 +410,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     let chunking_context = NodeJsChunkingContext::builder(
         project_root,
         chunk_root_path,
-        ResolvedVc::cell(chunk_root_path_in_root_path_offset),
+        chunk_root_path_in_root_path_offset,
         static_root_path,
         chunk_root_path,
         static_root_path,

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -342,15 +342,15 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .await?
         .map(|asset| EvaluatableAssets::one(asset.to_evaluatable(asset_context)));
 
-    let chunk_root_path = project_path.join("output".into()).to_resolved().await?;
-    let static_root_path = project_path.join("static".into()).to_resolved().await?;
+    let chunk_root_path = project_path.join(rcstr!("output")).to_resolved().await?;
+    let static_root_path = project_path.join(rcstr!("static")).to_resolved().await?;
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match options.runtime {
         Runtime::Browser => Vc::upcast(
             BrowserChunkingContext::builder(
                 project_root,
                 project_path,
-                ResolvedVc::cell(project_path_to_project_root),
+                project_path_to_project_root,
                 project_path,
                 chunk_root_path,
                 static_root_path,
@@ -363,7 +363,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             NodeJsChunkingContext::builder(
                 project_root,
                 project_path,
-                ResolvedVc::cell(project_path_to_project_root),
+                project_path_to_project_root,
                 project_path,
                 chunk_root_path,
                 static_root_path,

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -188,7 +188,7 @@ async fn run_inner_operation(resource: RcStr) -> Result<()> {
         .try_join()
         .await?;
 
-    snapshot_issues(plain_issues, out_vc.join("issues".into()), &REPO_ROOT)
+    snapshot_issues(plain_issues, out_vc.join(rcstr!("issues")), &REPO_ROOT)
         .await
         .context("Unable to handle issues")?;
 
@@ -210,7 +210,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Err(_) => SnapshotOptions::default(),
         Ok(options_str) => parse_json_with_source_context(&options_str).unwrap(),
     };
-    let project_fs = DiskFileSystem::new("project".into(), REPO_ROOT.clone(), vec![]);
+    let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone(), vec![]);
     let project_root = project_fs.root().to_resolved().await?;
 
     let relative_path = test_path.strip_prefix(&*REPO_ROOT)?;
@@ -430,7 +430,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                                         .unwrap()
                                         .into(),
                                 )
-                                .with_extension("entry.js".into()),
+                                .with_extension(rcstr!("entry.js")),
                             evaluatable_assets,
                             module_graph,
                             OutputAssets::empty(),
@@ -503,7 +503,7 @@ async fn maybe_load_env(
     _context: Vc<Box<dyn AssetContext>>,
     path: Vc<FileSystemPath>,
 ) -> Result<Option<Vc<Box<dyn Source>>>> {
-    let dotenv_path = path.join("input/.env".into());
+    let dotenv_path = path.join(rcstr!("input/.env"));
 
     if !dotenv_path.read().await?.is_content() {
         return Ok(None);

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use anyhow::Result;
 use indoc::{formatdoc, writedoc};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::Vc;
 use turbo_tasks_fs::File;
 use turbopack_core::{asset::AssetContent, source::Source, virtual_source::VirtualSource};
@@ -56,7 +56,7 @@ pub(crate) async fn instantiating_loader_source(
     let code: RcStr = code.into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().append("_.loader.mjs".into()),
+        source.ident().path().append(rcstr!("_.loader.mjs")),
         AssetContent::file(File::from(code).into()),
     )))
 }
@@ -80,7 +80,7 @@ pub(crate) async fn compiling_loader_source(
     .into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().append("_.loader.mjs".into()),
+        source.ident().path().append(rcstr!("_.loader.mjs")),
         AssetContent::file(File::from(code).into()),
     )))
 }

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -74,7 +74,7 @@ impl WebAssemblyModuleAsset {
         let module = this.asset_context.process(
             loader_source,
             Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
-                "WASM_PATH".into() => ResolvedVc::upcast(RawWebAssemblyModuleAsset::new(*this.source, *this.asset_context).to_resolved().await?),
+                rcstr!("WASM_PATH") => ResolvedVc::upcast(RawWebAssemblyModuleAsset::new(*this.source, *this.asset_context).to_resolved().await?),
             }))),
         ).module();
 

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -108,12 +108,9 @@ impl WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
         Ok(Vc::cell(vec![ResolvedVc::upcast(
-            SingleChunkableModuleReference::new(
-                Vc::upcast(self.loader()),
-                Vc::cell("wasm loader".into()),
-            )
-            .to_resolved()
-            .await?,
+            SingleChunkableModuleReference::new(Vc::upcast(self.loader()), rcstr!("wasm loader"))
+                .to_resolved()
+                .await?,
         )]))
     }
 }

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -223,6 +223,7 @@ impl RuleCondition {
 
 #[cfg(test)]
 pub mod tests {
+    use turbo_rcstr::rcstr;
     use turbo_tasks::Vc;
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
     use turbo_tasks_fs::{FileContent, FileSystem, VirtualFileSystem};
@@ -245,7 +246,7 @@ pub mod tests {
     #[turbo_tasks::function]
     pub async fn run_leaves_test() -> Result<()> {
         let fs = VirtualFileSystem::new();
-        let virtual_path = fs.root().join("foo.js".into());
+        let virtual_path = fs.root().join(rcstr!("foo.js"));
         let virtual_source = Vc::upcast::<Box<dyn Source>>(VirtualSource::new(
             virtual_path,
             AssetContent::File(FileContent::NotFound.cell().to_resolved().await?).cell(),
@@ -253,7 +254,7 @@ pub mod tests {
         .to_resolved()
         .await?;
 
-        let non_virtual_path = fs.root().join("bar.js".into());
+        let non_virtual_path = fs.root().join(rcstr!("bar.js"));
         let non_virtual_source = Vc::upcast::<Box<dyn Source>>(FileSource::new(non_virtual_path))
             .to_resolved()
             .await?;
@@ -336,7 +337,7 @@ pub mod tests {
                 condition
                     .matches(
                         virtual_source,
-                        &*fs.root().join("foo".into()).await?,
+                        &*fs.root().join(rcstr!("foo")).await?,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -394,7 +395,7 @@ pub mod tests {
     #[turbo_tasks::function]
     pub async fn run_rule_condition_tree_test() -> Result<()> {
         let fs = VirtualFileSystem::new();
-        let virtual_path = fs.root().join("foo.js".into());
+        let virtual_path = fs.root().join(rcstr!("foo.js"));
         let virtual_source = Vc::upcast::<Box<dyn Source>>(VirtualSource::new(
             virtual_path,
             AssetContent::File(FileContent::NotFound.cell().to_resolved().await?).cell(),
@@ -402,7 +403,7 @@ pub mod tests {
         .to_resolved()
         .await?;
 
-        let non_virtual_path = fs.root().join("bar.js".into());
+        let non_virtual_path = fs.root().join(rcstr!("bar.js"));
         let non_virtual_source = Vc::upcast::<Box<dyn Source>>(FileSource::new(non_virtual_path))
             .to_resolved()
             .await?;


### PR DESCRIPTION
Adopt the `rcstr!` macro in turbopack

Instead of `"foo".into()` call `rcstr!("foo")` while being slightly more annoying to type the macro approach is more readabie and faster as it can leverage constant folding for small strings and amortize construction of larger strings.  In general these performance improvement are very small but consistent.

At the same time, eliminate uses of turbo-tasks where they were amortizing construction of RcStr instances since the `rcstr!` macro can do the same thing.  Generally speaking we should prefer `RcStr` over `ResolvedVc<RcStr>` as a task input since it has much more reasonable equality semantics and observationally many of these values were constructed via `Vc::cell("foo".into())`.

## Why?

Generally this should be a small consistent memory and performance improvement.  My understanding is that many uses of `ResolvedVc<RcStr>` actually predate `RcStr` when we were using `String` directly.  In that world, turbotasks are fulfilling a vital function, but now that we can rely on RcStr this is much less needed.

## How?

Mostly this was a bunch of regex replacements and manual fixups.  An AstGrep rule would have been ideal but beyond matching `RcStr::from("...")` this doesn't work since it was mostly calls to `into()` which rely on type inference.  Still by seeding the codebase with the pattern we can probably prevent regressions.

## Performance

From measuring vercel-site this is a latency progression of a few percent.  codspeed agrees!

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/AwJ29EfoPcPdLSwCZxAz/c08ffcaa-2856-4742-a049-1306491d69ba.png)



Closes PACK-4764