### PR TITLE
perf(turbopack/rcstr): Try incrementing the size to 16 bytes

### DIFF
--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT"
 
 [features]
+default = ["atom_size_128"]
 atom_size_64 = []
 atom_size_128 = []
 napi = ["dep:napi"]

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -75,7 +75,7 @@ impl TaggedValue {
     pub const fn new_tag(value: NonZeroU8) -> Self {
         let value = value.get() as RawTaggedValue;
         Self {
-            value: unsafe { std::mem::transmute(value) },
+            value: unsafe { RawTaggedNonZeroValue::new_unchecked(value) },
         }
     }
 


### PR DESCRIPTION
### What?

Try incrementing the size of `RcStr` to 16 bytes, to make more strings inlined.

### Why?

It might be faster

### How?

Closes PACK-4743