### PR TITLE
[dynamicIO] Fix false-positive dynamic viewport error

### DIFF
--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { assertNoErrorToast } from 'next-test-utils'
 
 import { createExpectError } from './utils'
 
@@ -18,11 +19,6 @@ function runTests(options: { withMinification: boolean }) {
         return
       }
 
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
       beforeEach(async () => {
         if (!withMinification) {
           await next.patchFile('next.config.js', (content) =>
@@ -34,14 +30,22 @@ function runTests(options: { withMinification: boolean }) {
         }
       })
 
-      it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
-        try {
+      if (isNextDev) {
+        it('does not show a validation error in the dev overlay', async () => {
           await next.start()
-        } catch {
-          throw new Error('expected build not to fail')
-        }
-        expect(next.cliOutput).toContain('◐ / ')
-      })
+          const browser = await next.browser('/')
+          await assertNoErrorToast(browser)
+        })
+      } else {
+        it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
+          try {
+            await next.start()
+          } catch {
+            throw new Error('expected build not to fail')
+          }
+          expect(next.cliOutput).toContain('◐ / ')
+        })
+      }
     })
     describe('Error Attribution with Sync IO - Guarded RSC with unguarded Client sync IO', () => {
       const { next, isNextDev, skipped } = nextTestSetup({

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/layout.tsx
@@ -1,8 +1,19 @@
+import { Suspense } from 'react'
+import { SyncIO } from './client'
+
 export default function Root({ children }: { children: React.ReactNode }) {
   return (
     <html>
       <body>
         <main>{children}</main>
+        <p>
+          In addition to `SyncIO` being rendered in the Page, we're also
+          rendering it in the Layout.
+        </p>
+        <p>The page should still prerender without errors.</p>
+        <Suspense fallback="">
+          <SyncIO />
+        </Suspense>
       </body>
     </html>
   )

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -851,8 +851,11 @@ export async function assertHasRedbox(browser: Playwright) {
   }
 }
 
-export async function assertNoRedbox(browser: Playwright) {
-  await waitFor(5000)
+export async function assertNoRedbox(
+  browser: Playwright,
+  { waitInMs = 5000 }: { waitInMs?: number } = {}
+) {
+  await waitFor(waitInMs)
   const redbox = browser.locateRedbox()
 
   if (await redbox.isVisible()) {
@@ -885,6 +888,26 @@ export async function hasErrorToast(browser: Playwright): Promise<boolean> {
       return !!node
     })
   )
+}
+
+export async function assertNoErrorToast(browser: Playwright): Promise<void> {
+  let didOpenRedbox = false
+
+  try {
+    await browser.waitForElementByCss('[data-issues]').click()
+    didOpenRedbox = true
+  } catch {
+    // We expect this to fail.
+  }
+
+  if (didOpenRedbox) {
+    // If a redbox was opened unexpectedly, we use the `assertNoRedbox` helper
+    // to print a useful error message containing the redbox contents.
+    await assertNoRedbox(browser, {
+      // We already know the redbox is open, so we can skip waiting for it.
+      waitInMs: 0,
+    })
+  }
 }
 
 export async function getToastErrorCount(browser: Playwright): Promise<number> {


### PR DESCRIPTION
When using sync IO like `new Date()` in a client component that has a parent Suspense boundary, we should not show a prerender validation error when `dynamicIO` is enabled.

Due to how we render the head node in parallel to the segment node, and because the `Viewport` component that's included in the head is an async component, we incorrectly showed the following validation error, because the prerender was aborted before the async (and cached) viewport element resolved.

> Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or uncached external data (`fetch(...)`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport

We can fix this by deferring the rendering of the segment node until the scheduled microtasks have been executed. This ensures that the viewport task is not pending when the abort occurs.