### PR TITLE
[devtool] fix explorer flag consuming and style

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -369,6 +369,8 @@ export async function handler(
           enableTainting: nextConfig.experimental.taint,
           // @ts-expect-error fix issue with readonly regex object type
           htmlLimitedBots: nextConfig.htmlLimitedBots,
+          devtoolSegmentExplorer:
+            nextConfig.experimental.devtoolSegmentExplorer,
           reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
 
           multiZoneDraftMode,

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -406,7 +406,7 @@ function DevToolsPopover({
               />
               {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER ? (
                 <MenuItem
-                  data-rendered-files
+                  data-segment-explorer
                   label="Segment Explorer"
                   value={<ChevronRight />}
                   onClick={() => setOpen(OVERLAYS.SegmentExplorer)}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
@@ -54,7 +54,10 @@ function PageSegmentTree({ tree }: { tree: Trie<SegmentNode> | undefined }) {
     return null
   }
   return (
-    <div className="segment-explorer-content">
+    <div
+      className="segment-explorer-content"
+      data-nextjs-devtool-segment-explorer
+    >
       <PageSegmentTreeLayerPresentation
         tree={tree}
         node={tree.getRoot()}
@@ -147,11 +150,6 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
 
   .segment-explorer-filename-path {
     display: inline-block;
-
-    &:hover {
-      color: var(--color-gray-1000);
-      text-decoration: none;
-    }
   }
 
   .segment-explorer-filename-path a {
@@ -161,6 +159,7 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
 
   .segment-explorer-line {
     white-space: pre;
+    cursor: default;
   }
 
   .segment-explorer-line-icon {

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1014,12 +1014,13 @@ function normalizePageOrLayoutFilePath(
   projectDir: string,
   layoutOrPagePath: string | undefined
 ) {
-  const dir = projectDir /*ctx.renderOpts.dir*/ || process.cwd()
   const relativePath = (layoutOrPagePath || '')
     // remove turbopack [project] prefix
     .replace(/^\[project\][\\/]/, '')
+    // remove the process.cwd() prefix
+    .replace(process.cwd() + '/', '')
     // remove the project root from the path
-    .replace(dir, '')
+    .replace(projectDir, '')
     // remove /(src/)?app/ dir prefix
     .replace(/^[\\/](src[\\/])?app[\\/]/, '')
 

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import { openDevToolsIndicatorPopover } from 'next-test-utils'
+
+describe('segment-explorer', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render the segment explorer', async () => {
+    const browser = await next.browser('/parallel-routes')
+
+    // open the devtool button
+    await openDevToolsIndicatorPopover(browser)
+
+    // open the segment explorer
+    await browser.elementByCss('[data-segment-explorer]').click()
+
+    //  wait for the segment explorer to be visible
+    await browser.waitForElementByCss('[data-nextjs-devtool-segment-explorer]')
+
+    const content = await browser.elementByCss(
+      '[data-nextjs-devtool-segment-explorer]'
+    )
+    expect(await content.text()).toMatchInlineSnapshot(`
+     "app/parallel-routes/page.tsx
+     app/parallel-routes/@foo/page.tsx
+     app/parallel-routes/@foo/layout.tsx
+     app/parallel-routes/@bar/page.tsx
+     app/parallel-routes/@bar/layout.tsx
+     app/parallel-routes/layout.tsx
+     app/layout.tsx"
+    `)
+  })
+})


### PR DESCRIPTION
### What

- The explorer flag consuming was broken while we doing the new interface refactoring. Fixed it in this PR.
- Removed the hover styling so it won't look like sth you can click now
- Add a simple test to avoid regression.