### PR TITLE
chore(turbopack): Fix building local crates with `--all-features`

### DIFF
--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -344,7 +344,7 @@ impl StaticSortedFile {
             bail!(
                 "Corrupted file seq:{} block:{} > number of blocks {} (block_offsets: {:x}, \
                  blocks: {:x})",
-                self.sequence_number,
+                self.meta.sequence_number,
                 block_index,
                 self.meta.block_count,
                 self.meta.block_offsets_start(),
@@ -357,7 +357,7 @@ impl StaticSortedFile {
             bail!(
                 "Corrupted file seq:{} block:{} block offset locations {} + 4 bytes > file end {} \
                  (block_offsets: {:x}, blocks: {:x})",
-                self.sequence_number,
+                self.meta.sequence_number,
                 block_index,
                 offset,
                 self.mmap.len(),
@@ -377,7 +377,7 @@ impl StaticSortedFile {
             bail!(
                 "Corrupted file seq:{} block:{} block {} - {} > file end {} (block_offsets: {:x}, \
                  blocks: {:x})",
-                self.sequence_number,
+                self.meta.sequence_number,
                 block_index,
                 block_start,
                 block_end,

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -787,13 +787,13 @@ impl FileSystem for DiskFileSystem {
                         f.flush()?;
                         #[cfg(feature = "write_version")]
                         {
-                            let mut full_path = full_path.into_owned();
+                            let mut full_path = full_path.to_owned();
                             let hash = hash_xxh3_hash64(file);
                             let ext = full_path.extension();
                             let ext = if let Some(ext) = ext {
                                 format!("{:016x}.{}", hash, ext.to_string_lossy())
                             } else {
-                                format!("{:016x}", hash)
+                                format!("{hash:016x}")
                             };
                             full_path.set_extension(ext);
                             let mut f = std::fs::File::create(&full_path)?;

--- a/turbopack/crates/turbo-tasks-macros-shared/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros-shared/Cargo.toml
@@ -14,4 +14,4 @@ workspace = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["full", "extra-traits"] }
+syn = { workspace = true, features = ["full", "extra-traits", "visit"] }


### PR DESCRIPTION
This is a prerequisite for using https://github.com/boshen/cargo-shear, which uses `--all-features`. This also avoids some noise in Rust Analyzer, which also uses `--all-features`.

Closes PACK-4761