### PR TITLE
fix React 18 test failures

### DIFF
--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -267,7 +267,7 @@ describe('ReactRefreshLogBox', () => {
       `export default function FunctionDefault() { throw new Error('no'); }`
     )
 
-    if (isReact18) {
+    if (isReact18 && isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        [
          {
@@ -280,8 +280,8 @@ describe('ReactRefreshLogBox', () => {
            "stack": [
              "FunctionDefault FunctionDefault.js (1:51)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
          {
@@ -294,8 +294,8 @@ describe('ReactRefreshLogBox', () => {
            "stack": [
              "FunctionDefault FunctionDefault.js (1:51)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
        ]
@@ -468,7 +468,7 @@ describe('ReactRefreshLogBox', () => {
 
     // TODO(veil): ignore-list Webpack runtime (https://linear.app/vercel/issue/NDX-945)
     // TODO(veil): Don't bail in Turbopack for sources outside of the project (https://linear.app/vercel/issue/NDX-944)
-    if (isReact18) {
+    if (isReact18 && isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        [
          {
@@ -481,8 +481,8 @@ describe('ReactRefreshLogBox', () => {
            "stack": [
              "ClickCount.render Child.js (4:11)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
          {
@@ -495,8 +495,8 @@ describe('ReactRefreshLogBox', () => {
            "stack": [
              "ClickCount.render Child.js (4:11)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
        ]

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -247,8 +247,8 @@ describe('pages/ error recovery', () => {
 
     // TODO(veil): ignore-list Webpack runtime (https://linear.app/vercel/issue/NDX-945)
     // TODO(veil): Don't bail in Turbopack for sources outside of the project (https://linear.app/vercel/issue/NDX-944)
-    // Somehow we end up with two in React 18 due to React's attempt to recover from this error.
-    if (isReact18) {
+    // Somehow we end up with two in React 18 + Turbopack due to React's attempt to recover from this error.
+    if (isReact18 && isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        [
          {
@@ -261,8 +261,8 @@ describe('pages/ error recovery', () => {
            "stack": [
              "Child child.js (3:9)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
          {
@@ -275,8 +275,8 @@ describe('pages/ error recovery', () => {
            "stack": [
              "Child child.js (3:9)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
        ]
@@ -536,7 +536,7 @@ describe('pages/ error recovery', () => {
     // TODO(veil): ignore-list Webpack runtime (https://linear.app/vercel/issue/NDX-945)
     // TODO(veil): Don't bail in Turbopack for sources outside of the project (https://linear.app/vercel/issue/NDX-944)
     // Somehow we end up with two in React 18 due to React's attempt to recover from this error.
-    if (isReact18) {
+    if (isReact18 && isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        [
          {
@@ -549,8 +549,8 @@ describe('pages/ error recovery', () => {
            "stack": [
              "ClassDefault.render index.js (5:11)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
          {
@@ -563,8 +563,8 @@ describe('pages/ error recovery', () => {
            "stack": [
              "ClassDefault.render index.js (5:11)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
        ]
@@ -652,7 +652,7 @@ describe('pages/ error recovery', () => {
     // TODO(veil): Don't bail in Turbopack for sources outside of the project (https://linear.app/vercel/issue/NDX-944)
     // We get an error because Foo didn't import React. Fair.
     // Somehow we end up with two in React 18 due to React's attempt to recover from this error.
-    if (isReact18) {
+    if (isReact18 && isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        [
          {
@@ -665,8 +665,8 @@ describe('pages/ error recovery', () => {
            "stack": [
              "Foo Foo.js (3:3)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
          {
@@ -679,8 +679,8 @@ describe('pages/ error recovery', () => {
            "stack": [
              "Foo Foo.js (3:3)",
              "Set.forEach <anonymous> (0:0)",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
-             "${isTurbopack ? '<FIXME-file-protocol>' : '<FIXME-next-dist-dir>'}",
+             "<FIXME-file-protocol>",
+             "<FIXME-file-protocol>",
            ],
          },
        ]


### PR DESCRIPTION
Fixes failing assertions related to the forked React 18 tests. It's unclear why this only requires forked handling in Turbopack + React 18, which we'll investigate separately.
[x-ref](https://github.com/vercel/next.js/actions/runs/15417191195/job/43385564776#step:34:533)