### PR TITLE
[dev-tools] style: preferences section title

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -157,6 +157,15 @@ export const DEV_TOOLS_INFO_STYLES = `
     margin: 0;
   }
 
+  .dev-tools-info-section-title {
+    padding: 8px 0px;
+    color: var(--color-gray-1000);
+    font-size: var(--size-16);
+    font-weight: 600;
+    line-height: var(--size-20);
+    margin: 0;
+  }
+
   .dev-tools-info-article {
     padding: 8px 6px;
     color: var(--color-gray-1000);

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -83,6 +83,7 @@ export function UserPreferences({
 
   return (
     <DevToolsInfo title="Preferences" {...props}>
+      <h2 className="dev-tools-info-section-title">General</h2>
       <div className="preferences-container">
         <div className="preference-section">
           <div className="preference-header">
@@ -180,7 +181,7 @@ export function UserPreferences({
           </div>
         </div>
       </div>
-      <h1 className="dev-tools-info-title">Development Server</h1>
+      <h2 className="dev-tools-info-section-title">Development Server</h2>
       <div className="preferences-container">
         <div className="preference-section">
           <div className="preference-header">


### PR DESCRIPTION
Style change in https://github.com/vercel/next.js/pull/80097 affected style when adding the "Development Section" at https://github.com/vercel/next.js/pull/80072. Therefore add the style back to the section titles, and use "General" for the existing preferernces.

| Before | After |
|--------|--------|
| ![CleanShot 2025-06-03 at 21 39 30@2x](https://github.com/user-attachments/assets/130825a9-6540-4c4b-ba1b-4c830e04382a) | ![CleanShot 2025-06-03 at 21 39 17@2x](https://github.com/user-attachments/assets/3dc1444d-1588-4e4c-973a-ace88d501c95) | 
