### PR TITLE
chore(turbopack): Remove unused dependencies reported by cargo-shear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4552,12 +4552,10 @@ name = "next-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "auto-hash-map",
  "either",
  "futures",
  "indexmap 2.7.1",
  "next-core",
- "petgraph 0.6.3",
  "regex",
  "rustc-hash 2.1.1",
  "serde",
@@ -4569,13 +4567,10 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-env",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
  "turbopack",
  "turbopack-browser",
- "turbopack-cli-utils",
  "turbopack-core",
  "turbopack-ecmascript",
- "turbopack-env",
  "turbopack-node",
  "turbopack-nodejs",
  "turbopack-wasm",
@@ -4611,18 +4606,7 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-backend",
  "turbo-tasks-build",
- "turbo-tasks-env",
- "turbo-tasks-fs",
  "turbo-tasks-malloc",
- "turbopack",
- "turbopack-browser",
- "turbopack-cli-utils",
- "turbopack-core",
- "turbopack-ecmascript",
- "turbopack-ecmascript-runtime",
- "turbopack-env",
- "turbopack-node",
- "turbopack-nodejs",
  "turbopack-trace-utils",
 ]
 
@@ -4633,7 +4617,6 @@ dependencies = [
  "allsorts",
  "anyhow",
  "async-trait",
- "auto-hash-map",
  "base64 0.21.4",
  "either",
  "futures",
@@ -4656,7 +4639,6 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "swc_core",
- "swc_relay",
  "thiserror 1.0.69",
  "tracing",
  "turbo-esregex",
@@ -4674,12 +4656,10 @@ dependencies = [
  "turbopack-ecmascript",
  "turbopack-ecmascript-plugins",
  "turbopack-ecmascript-runtime",
- "turbopack-env",
  "turbopack-image",
  "turbopack-node",
  "turbopack-nodejs",
  "turbopack-static",
- "turbopack-trace-server",
  "turbopack-trace-utils",
 ]
 
@@ -4690,7 +4670,6 @@ dependencies = [
  "anyhow",
  "base64 0.21.4",
  "chrono",
- "dashmap 6.1.0",
  "easy-error",
  "either",
  "hex",
@@ -4704,7 +4683,6 @@ dependencies = [
  "react_remove_properties",
  "regex",
  "remove_console",
- "rustc-hash 1.1.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -4719,7 +4697,6 @@ dependencies = [
  "turbo-rcstr",
  "turbopack-ecmascript-plugins",
  "urlencoding",
- "walkdir",
 ]
 
 [[package]]
@@ -4727,13 +4704,10 @@ name = "next-swc-napi"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "backtrace",
  "console-subscriber",
- "dashmap 6.1.0",
  "dhat",
  "getrandom 0.2.15",
  "iana-time-zone",
- "indexmap 2.7.1",
  "lightningcss-napi",
  "mdxjs",
  "napi",
@@ -4745,7 +4719,6 @@ dependencies = [
  "next-custom-transforms",
  "once_cell",
  "owo-colors 3.5.0",
- "par-core",
  "rand 0.9.0",
  "rustc-hash 2.1.1",
  "serde",
@@ -4763,7 +4736,6 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-fs",
  "turbo-tasks-malloc",
- "turbopack",
  "turbopack-core",
  "turbopack-ecmascript-hmr-protocol",
  "turbopack-ecmascript-plugins",
@@ -7568,6 +7540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31930a468e3178fe8ac7f47bd1fcccdd1d97d11abf6ffec7d7b8800196c36bf"
 dependencies = [
  "binding_macros",
+ "par-core",
  "swc",
  "swc_allocator",
  "swc_atoms",
@@ -9127,16 +9100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-scoped"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4beb8ba13bc53ac53ce1d52b42f02e5d8060f0f42138862869beb769722b256"
-dependencies = [
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "tokio-socks"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9531,7 +9494,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "either",
  "jiff",
  "lzzzz",
  "memmap2 0.9.5",
@@ -9542,7 +9504,6 @@ dependencies = [
  "rand 0.9.0",
  "rayon",
  "rustc-hash 2.1.1",
- "serde",
  "smallvec",
  "tempfile",
  "thread_local",
@@ -9588,7 +9549,6 @@ dependencies = [
  "syn 2.0.100",
  "tracing",
  "tracing-subscriber",
- "walkdir",
 ]
 
 [[package]]
@@ -9636,7 +9596,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "async-trait",
  "auto-hash-map",
  "bitfield",
  "byteorder",
@@ -9659,15 +9618,11 @@ dependencies = [
  "smallvec",
  "thread_local",
  "tokio",
- "tokio-scoped",
  "tracing",
  "turbo-persistence",
- "turbo-prehash",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
- "turbo-tasks-hash",
- "turbo-tasks-malloc",
  "turbo-tasks-testing",
 ]
 
@@ -9704,8 +9659,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenvs",
- "indexmap 2.7.1",
- "serde",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -9719,7 +9672,6 @@ dependencies = [
  "anyhow",
  "httpmock",
  "reqwest 0.11.17",
- "serde",
  "tokio",
  "turbo-rcstr",
  "turbo-tasks",
@@ -9769,8 +9721,6 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-hash",
  "turbo-tasks-testing",
- "unicode-segmentation",
- "unsize",
  "urlencoding",
 ]
 
@@ -9847,11 +9797,9 @@ name = "turbo-tasks-testing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "auto-hash-map",
  "futures",
  "rustc-hash 2.1.1",
  "tokio",
- "turbo-rcstr",
  "turbo-tasks",
 ]
 
@@ -9862,8 +9810,6 @@ dependencies = [
  "anyhow",
  "codspeed-criterion-compat",
  "difference",
- "futures",
- "indexmap 2.7.1",
  "lazy_static",
  "regex",
  "rstest",
@@ -9927,9 +9873,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "either",
- "indexmap 2.7.1",
  "indoc",
- "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "serde_qs",
@@ -9956,7 +9900,6 @@ dependencies = [
  "console-subscriber",
  "dunce",
  "futures",
- "mime",
  "owo-colors 3.5.0",
  "regex",
  "rustc-hash 2.1.1",
@@ -9969,7 +9912,6 @@ dependencies = [
  "turbo-tasks-backend",
  "turbo-tasks-build",
  "turbo-tasks-env",
- "turbo-tasks-fetch",
  "turbo-tasks-fs",
  "turbo-tasks-malloc",
  "turbopack",
@@ -10062,13 +10004,10 @@ name = "turbopack-css"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
  "indoc",
  "lightningcss",
- "once_cell",
  "parcel_selectors",
  "parcel_sourcemap",
- "regex",
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
@@ -10079,10 +10018,8 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
  "turbopack-core",
  "turbopack-ecmascript",
- "turbopack-swc-utils",
  "urlencoding",
 ]
 
@@ -10096,7 +10033,6 @@ dependencies = [
  "futures",
  "hyper 0.14.28",
  "hyper-tungstenite",
- "indexmap 2.7.1",
  "mime",
  "mime_guess",
  "parking_lot",
@@ -10139,7 +10075,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "once_cell",
- "par-core",
  "parking_lot",
  "petgraph 0.6.3",
  "regex",
@@ -10155,7 +10090,6 @@ dependencies = [
  "turbo-esregex",
  "turbo-rcstr",
  "turbo-tasks",
- "turbo-tasks-backend",
  "turbo-tasks-build",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
@@ -10165,7 +10099,6 @@ dependencies = [
  "turbopack-resolve",
  "turbopack-swc-utils",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -10186,7 +10119,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "indexmap 2.7.1",
- "lightningcss",
  "modularize_imports",
  "rustc-hash 2.1.1",
  "serde",
@@ -10226,8 +10158,6 @@ name = "turbopack-env"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
- "serde",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -10261,7 +10191,6 @@ name = "turbopack-json"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "serde",
  "serde_json",
  "turbo-rcstr",
  "turbo-tasks",
@@ -10278,7 +10207,6 @@ dependencies = [
  "anyhow",
  "markdown",
  "mdxjs",
- "serde",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -10299,9 +10227,7 @@ dependencies = [
  "either",
  "futures",
  "futures-retry",
- "indexmap 2.7.1",
  "indoc",
- "mime",
  "once_cell",
  "owo-colors 3.5.0",
  "parking_lot",
@@ -10330,12 +10256,7 @@ name = "turbopack-nodejs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "either",
- "indexmap 2.7.1",
  "indoc",
- "rustc-hash 2.1.1",
- "serde",
- "smallvec",
  "tracing",
  "turbo-rcstr",
  "turbo-tasks",
@@ -10353,7 +10274,6 @@ name = "turbopack-resolve"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
  "lazy_static",
  "regex",
  "serde",
@@ -10371,7 +10291,6 @@ name = "turbopack-static"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "serde",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -10420,15 +10339,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dunce",
- "futures",
- "indexmap 2.7.1",
  "once_cell",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "testing",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "turbo-rcstr",
  "turbo-tasks",
@@ -10439,7 +10355,6 @@ dependencies = [
  "turbo-tasks-fs",
  "turbopack",
  "turbopack-browser",
- "turbopack-cli-utils",
  "turbopack-core",
  "turbopack-ecmascript-plugins",
  "turbopack-ecmascript-runtime",
@@ -10496,7 +10411,6 @@ name = "turbopack-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
  "indoc",
  "serde",
  "turbo-rcstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,7 +249,6 @@ next-custom-transforms = { path = "crates/next-custom-transforms" }
 
 # Turbopack
 auto-hash-map = { path = "turbopack/crates/turbo-tasks-auto-hash-map" }
-swc-ast-explorer = { path = "turbopack/crates/turbopack-swc-ast-explorer" }
 turbo-prehash = { path = "turbopack/crates/turbo-prehash" }
 turbo-rcstr = { path = "turbopack/crates/turbo-rcstr", features = ["napi"] }
 turbo-esregex = { path = "turbopack/crates/turbo-esregex" }
@@ -265,12 +264,10 @@ turbo-tasks-fs = { path = "turbopack/crates/turbo-tasks-fs" }
 turbo-tasks-hash = { path = "turbopack/crates/turbo-tasks-hash" }
 turbo-tasks-macros = { path = "turbopack/crates/turbo-tasks-macros" }
 turbo-tasks-macros-shared = { path = "turbopack/crates/turbo-tasks-macros-shared" }
-turbo-tasks-macros-tests = { path = "turbopack/crates/turbo-tasks-macros-tests" }
 turbo-tasks-testing = { path = "turbopack/crates/turbo-tasks-testing" }
 turbopack = { path = "turbopack/crates/turbopack" }
 turbopack-bench = { path = "turbopack/crates/turbopack-bench" }
 turbopack-nodejs = { path = "turbopack/crates/turbopack-nodejs" }
-turbopack-cli = { path = "turbopack/crates/turbopack-cli" }
 turbopack-cli-utils = { path = "turbopack/crates/turbopack-cli-utils" }
 turbopack-core = { path = "turbopack/crates/turbopack-core" }
 turbopack-create-test-app = { path = "turbopack/crates/turbopack-create-test-app" }
@@ -290,7 +287,6 @@ turbopack-resolve = { path = "turbopack/crates/turbopack-resolve" }
 turbopack-static = { path = "turbopack/crates/turbopack-static" }
 turbopack-swc-utils = { path = "turbopack/crates/turbopack-swc-utils" }
 turbopack-test-utils = { path = "turbopack/crates/turbopack-test-utils" }
-turbopack-tests = { path = "turbopack/crates/turbopack-tests" }
 turbopack-trace-server = { path = "turbopack/crates/turbopack-trace-server" }
 turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
@@ -299,12 +295,12 @@ turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 swc_core = { version = "26.3.3", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
+  "parallel_rayon",
 ] }
 testing = { version = "12.0.0" }
 
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.18.0" }
-miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "1.0.1"
 modularize_imports = { version = "0.86.0" }
 styled_components = { version = "0.114.0" }
@@ -325,19 +321,16 @@ allsorts = { version = "0.14.0", default-features = false, features = [
   "flate2_rust",
 ] }
 anyhow = "1.0.98"
-assert_cmd = "2.0.8"
 async-compression = { version = "0.3.13", default-features = false, features = [
   "gzip",
   "tokio",
 ] }
 async-trait = "0.1.64"
-atty = "0.2.14"
 bitfield = "0.18.0"
 bytes = "1.1.0"
 chrono = "0.4.23"
 clap = { version = "4.5.2", features = ["derive"] }
 concurrent-queue = "2.5.0"
-console = "0.15.5"
 console-subscriber = "0.4.1"
 const_format = "0.2.30"
 criterion = { package = "codspeed-criterion-compat", version = "2.10.1" }
@@ -345,7 +338,6 @@ crossbeam-channel = "0.5.8"
 dashmap = "6.1.0"
 data-encoding = "2.3.3"
 dhat = { version = "0.3.2" }
-dialoguer = "0.10.3"
 dunce = "1.0.3"
 either = "1.9.0"
 erased-serde = "0.4.5"
@@ -355,11 +347,9 @@ hashbrown = "0.14.5"
 httpmock = { version = "0.6.8", default-features = false }
 image = { version = "0.25.0", default-features = false }
 indexmap = "2.7.1"
-indicatif = "0.17.3"
 indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-log = "0.4.17"
 lightningcss = { version = "1.0.0-alpha.66", features = [
   "serde",
   "visitor",
@@ -380,19 +370,15 @@ napi = { version = "2", default-features = false, features = [
     "napi5",
     "compat-mode"
 ] }
-nohash-hasher = "0.2.0"
 notify = "8.0.0"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
-par-core = { version = "1.0.3", features = ["rayon"] }
 parcel_selectors = "0.28.1"
 parking_lot = "0.12.1"
 pathdiff = "0.2.1"
 petgraph = "0.6.3"
 pin-project-lite = "0.2.9"
 postcard = "1.0.4"
-predicates = "2.1.5"
-pretty_assertions = "1.3.0"
 proc-macro2 = "1.0.79"
 qstring = "0.7.2"
 quote = "1.0.23"
@@ -419,18 +405,15 @@ smallvec = { version = "1.13.1", features = [
 sourcemap = "9.2.2"
 strsim = "0.11.1"
 shrink-to-fit = "0.2.10"
-swc-rustc-hash = { package = "rustc-hash", version = "1.1.0" } # used with swc
 syn = "2.0.100"
 tempfile = "3.3.0"
 thread_local = "1.1.8"
 thiserror = "1.0.48"
-tiny-gradient = "0.1.0"
 tokio = "1.43.0"
 tokio-util = { version = "0.7.13", features = ["io", "rt"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 triomphe = { git = "https://github.com/sokra/triomphe", branch = "sokra/unstable" }
-unicode-segmentation = "1.10.1"
 unsize = "1.1.0"
 url = "2.2.2"
 urlencoding = "2.1.2"

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -43,12 +43,20 @@ tokio-console = ["dep:console-subscriber"]
 [lints]
 workspace = true
 
+[package.metadata.cargo-shear]
+ignored = [
+  # we need to set features on these packages when building for WASM, but we don't directly use them
+  "getrandom",
+  "iana-time-zone",
+  # the plugins feature needs to set a feature on this transitively depended-on package, we never
+  # directly import it
+  "turbopack-ecmascript-plugins",
+]
+
 [dependencies]
 anyhow = "1.0.66"
-backtrace = "0.3"
 console-subscriber = { workspace = true, optional = true }
 dhat = { workspace = true, optional = true }
-indexmap = { workspace = true }
 owo-colors = { workspace = true }
 napi = { workspace = true }
 napi-derive = "2"
@@ -65,7 +73,6 @@ tracing-chrome = "0.5.0"
 url = { workspace = true }
 urlencoding = { workspace = true }
 once_cell = { workspace = true }
-dashmap = { workspace = true }
 
 swc_core = { workspace = true, features = [
     "base_concurrent",
@@ -86,7 +93,6 @@ swc_core = { workspace = true, features = [
     "ecma_utils",
     "ecma_visit",
 ] }
-par-core = { workspace = true, features = ["rayon"] }
 
 # Dependencies for the native, non-wasm32 build.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -106,7 +112,6 @@ turbo-tasks-malloc = { workspace = true, default-features = false, features = [
     "custom_allocator"
 ] }
 
-turbopack = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-ecmascript-hmr-protocol = { workspace = true }
 turbopack-trace-utils = { workspace = true }

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -14,12 +14,10 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
-auto-hash-map = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 next-core = { workspace = true }
-petgraph = { workspace = true, features = ["serde-1"]}
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
@@ -30,13 +28,10 @@ turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
-turbo-tasks-hash = { workspace = true }
 turbopack = { workspace = true }
 turbopack-browser = { workspace = true }
-turbopack-cli-utils = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-ecmascript = { workspace = true }
-turbopack-env = { workspace = true }
 turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
 turbopack-wasm = { workspace = true }

--- a/crates/next-build-test/Cargo.toml
+++ b/crates/next-build-test/Cargo.toml
@@ -24,18 +24,7 @@ tracing-subscriber = "0.3"
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-backend = { workspace = true }
-turbo-tasks-env = { workspace = true }
-turbo-tasks-fs = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
-turbopack = { workspace = true }
-turbopack-browser = { workspace = true }
-turbopack-cli-utils = { workspace = true }
-turbopack-core = { workspace = true }
-turbopack-ecmascript = { workspace = true }
-turbopack-ecmascript-runtime = { workspace = true }
-turbopack-env = { workspace = true }
-turbopack-node = { workspace = true }
-turbopack-nodejs = { workspace = true }
 turbopack-trace-utils = { workspace = true }
 
 [build-dependencies]

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -35,7 +35,6 @@ rustc-hash = { workspace = true }
 react_remove_properties = "0.40.0"
 remove_console = "0.41.0"
 itertools = { workspace = true }
-auto-hash-map = { workspace = true }
 percent-encoding = "2.3.1"
 serde_path_to_error = { workspace = true }
 
@@ -57,7 +56,6 @@ swc_core = { workspace = true, features = [
   "ecma_visit",
 ] }
 modularize_imports = { workspace = true }
-swc_relay = { workspace = true }
 
 turbo-rcstr = { workspace = true }
 turbo-esregex = { workspace = true }
@@ -73,12 +71,10 @@ turbopack-core = { workspace = true }
 turbopack-ecmascript = { workspace = true }
 turbopack-ecmascript-plugins = { workspace = true, features = ["transform_emotion"] }
 turbopack-ecmascript-runtime = { workspace = true }
-turbopack-env = { workspace = true }
 turbopack-image = { workspace = true }
 turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
 turbopack-static = { workspace = true }
-turbopack-trace-server = { workspace = true }
 turbopack-trace-utils = { workspace = true }
 
 [build-dependencies]

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -10,6 +10,13 @@ plugin = [
   "turbopack-ecmascript-plugins/swc_ecma_transform_plugin",
 ]
 
+[package.metadata.cargo-shear]
+ignored = [
+  # when using the `plugin` feature, we need to set a feature flag on `turbopack-ecmascript-plugins`
+  # so we must list it as a dependency even though we don't directly use it
+  "turbopack-ecmascript-plugins",
+]
+
 [lints]
 workspace = true
 
@@ -25,14 +32,12 @@ once_cell = { workspace = true }
 pathdiff = { workspace = true }
 regex = "1.5"
 rustc-hash = { workspace = true }
-swc-rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 sha1 = "0.10.1"
 tracing = { version = "0.1.37" }
 anyhow = { workspace = true }
 lazy_static = { workspace = true }
-dashmap = "6.1.0"
 
 swc_core = { workspace = true, features = [
   "base",
@@ -69,4 +74,3 @@ preset_env_base = "3.0.1"
 [dev-dependencies]
 swc_core = { workspace = true, features = ["testing_transform"]}
 testing = { workspace = true }
-walkdir = "2.3.2"

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -13,7 +13,6 @@ print_stats = ["stats"]
 
 [dependencies]
 anyhow = { workspace = true }
-either = { workspace = true }
 pot = "3.0.0"
 byteorder = "1.5.0"
 jiff = "0.2.10"
@@ -24,7 +23,6 @@ qfilter = { version = "0.2.4", features = ["serde"] }
 quick_cache = { version = "0.6.9" }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
-serde = { workspace = true }
 smallvec = { workspace = true}
 thread_local = { workspace = true }
 tracing = { workspace = true }

--- a/turbopack/crates/turbo-static/Cargo.toml
+++ b/turbopack/crates/turbo-static/Cargo.toml
@@ -20,7 +20,6 @@ serde_path_to_error = "0.1.16"
 syn = { version = "2", features = ["parsing", "full", "visit", "extra-traits"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing.workspace = true
-walkdir = "2.5.0"
 
 [lints]
 workspace = true

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -26,7 +26,6 @@ lmdb = ["dep:lmdb-rkv"]
 [dependencies]
 anyhow = { workspace = true }
 arc-swap = { version = "1.7.1" }
-async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 bitfield = { workspace = true }
 byteorder = "1.5.0"
@@ -45,15 +44,11 @@ serde = { workspace = true }
 serde_path_to_error = { workspace = true }
 smallvec = { workspace = true }
 tokio = { workspace = true }
-tokio-scoped = "0.2.0"
 tracing = { workspace = true }
 thread_local = { workspace = true }
 turbo-persistence = { workspace = true }
-turbo-prehash = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
-turbo-tasks-hash = { workspace = true }
-turbo-tasks-malloc = { workspace = true, default-features = false }
 turbo-tasks-testing = { workspace = true }
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-tasks-env/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-env/Cargo.toml
@@ -14,8 +14,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 dotenvs = "0.1.0"
-indexmap = { workspace = true, features = ["serde"] }
-serde = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fetch/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fetch/Cargo.toml
@@ -26,7 +26,6 @@ reqwest = { workspace = true, features = ["rustls-tls"] }
 [dependencies]
 anyhow = { workspace = true }
 reqwest = { workspace = true }
-serde = { workspace = true }
 tokio = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -49,12 +49,10 @@ serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-unsize = "1.1.0"
-triomphe = { workspace = true, features = ["unsize"] }
+triomphe = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }
-unicode-segmentation = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-tasks-testing/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-testing/Cargo.toml
@@ -15,9 +15,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-auto-hash-map = { workspace = true }
 futures = { workspace = true }
 rustc-hash = { workspace = true }
 tokio = { workspace = true }
-turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true, features = ["non_operation_vc_strongly_consistent"] }

--- a/turbopack/crates/turbopack-browser/Cargo.toml
+++ b/turbopack/crates/turbopack-browser/Cargo.toml
@@ -21,9 +21,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 either = { workspace = true }
-indexmap = { workspace = true }
 indoc = { workspace = true }
-rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_qs = { workspace = true }

--- a/turbopack/crates/turbopack-cli/Cargo.toml
+++ b/turbopack/crates/turbopack-cli/Cargo.toml
@@ -42,7 +42,6 @@ clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 dunce = { workspace = true }
 futures = { workspace = true }
-mime = { workspace = true }
 owo-colors = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
@@ -53,7 +52,6 @@ turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 turbo-tasks-env = { workspace = true }
-turbo-tasks-fetch = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-malloc = { workspace = true, default-features = false }
 turbopack = { workspace = true }

--- a/turbopack/crates/turbopack-css/Cargo.toml
+++ b/turbopack/crates/turbopack-css/Cargo.toml
@@ -14,13 +14,10 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-indexmap = { workspace = true }
 indoc = { workspace = true }
 lightningcss = { workspace = true }
-once_cell = { workspace = true }
 parcel_selectors = { workspace = true }
 parcel_sourcemap = "2.1.1"
-regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
@@ -34,10 +31,8 @@ tracing = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
-turbo-tasks-hash = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-ecmascript = { workspace = true }
-turbopack-swc-utils = { workspace = true }
 urlencoding = { workspace = true }
 
 [build-dependencies]

--- a/turbopack/crates/turbopack-dev-server/Cargo.toml
+++ b/turbopack/crates/turbopack-dev-server/Cargo.toml
@@ -22,7 +22,6 @@ auto-hash-map = { workspace = true }
 futures = { workspace = true }
 hyper = { version = "0.14", features = ["full"] }
 hyper-tungstenite = "0.9.0"
-indexmap = { workspace = true, features = ["serde"] }
 mime = { workspace = true }
 mime_guess = "2.0.4"
 parking_lot = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -25,7 +25,6 @@ workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 indexmap = { workspace = true }
-lightningcss = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -43,7 +43,6 @@ turbopack-core = { workspace = true }
 turbopack-resolve = { workspace = true }
 turbopack-swc-utils = { workspace = true }
 url = { workspace = true }
-urlencoding = { workspace = true }
 
 swc_core = { workspace = true, features = [
   "ecma_ast",
@@ -72,11 +71,9 @@ swc_core = { workspace = true, features = [
   "testing",
   "base",
 ] }
-par-core = { workspace = true, features = ["rayon"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
-turbo-tasks-backend = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 

--- a/turbopack/crates/turbopack-env/Cargo.toml
+++ b/turbopack/crates/turbopack-env/Cargo.toml
@@ -14,8 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-indexmap = { workspace = true }
-serde = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }

--- a/turbopack/crates/turbopack-json/Cargo.toml
+++ b/turbopack/crates/turbopack-json/Cargo.toml
@@ -21,7 +21,6 @@ turbo-tasks-fs = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-ecmascript = { workspace = true }
 
-serde = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/turbopack/crates/turbopack-mdx/Cargo.toml
+++ b/turbopack/crates/turbopack-mdx/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-serde = { workspace = true }
 
 markdown = { workspace = true }
 mdxjs = { workspace = true }

--- a/turbopack/crates/turbopack-node/Cargo.toml
+++ b/turbopack/crates/turbopack-node/Cargo.toml
@@ -25,9 +25,7 @@ const_format = { workspace = true }
 either = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 futures-retry = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
 indoc = { workspace = true }
-mime = { workspace = true }
 once_cell = { workspace = true }
 owo-colors = { workspace = true }
 parking_lot = { workspace = true }

--- a/turbopack/crates/turbopack-nodejs/Cargo.toml
+++ b/turbopack/crates/turbopack-nodejs/Cargo.toml
@@ -20,12 +20,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-either = { workspace = true }
-indexmap = { workspace = true }
 indoc = { workspace = true }
-rustc-hash = { workspace = true }
-serde = { workspace = true }
-smallvec = { workspace = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 

--- a/turbopack/crates/turbopack-resolve/Cargo.toml
+++ b/turbopack/crates/turbopack-resolve/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbopack-static/Cargo.toml
+++ b/turbopack/crates/turbopack-static/Cargo.toml
@@ -23,7 +23,5 @@ turbopack-core = { workspace = true }
 turbopack-css = { workspace = true }
 turbopack-ecmascript = { workspace = true }
 
-serde = { workspace = true }
-
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbopack-tests/Cargo.toml
+++ b/turbopack/crates/turbopack-tests/Cargo.toml
@@ -18,15 +18,12 @@ turbopack = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 dunce = { workspace = true }
-futures = { workspace = true }
-indexmap = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 testing = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
@@ -35,7 +32,6 @@ turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 turbopack-browser = { workspace = true, features = ["test"] }
-turbopack-cli-utils = { workspace = true }
 turbopack-core = { workspace = true, features = ["issue_path"] }
 turbopack-ecmascript-plugins = { workspace = true, features = [
   "transform_emotion",

--- a/turbopack/crates/turbopack-wasm/Cargo.toml
+++ b/turbopack/crates/turbopack-wasm/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-indexmap = { workspace = true }
 indoc = { workspace = true }
 serde = { workspace = true }
 turbo-rcstr = { workspace = true }

--- a/turbopack/crates/turbopack/Cargo.toml
+++ b/turbopack/crates/turbopack/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
@@ -48,7 +47,6 @@ turbopack-wasm = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 difference = "2.0"
-futures = { workspace = true }
 rstest = { workspace = true }
 rstest_reuse = "0.5.0"
 tokio = { workspace = true }


### PR DESCRIPTION
Remove unused dependencies to (hopefully) speed up the build.

https://github.com/boshen/cargo-shear

```
$ cargo shear --expand --exclude=wasm
Analyzing /home/bgw.linux/next.js

No unused dependencies!
```

Closes PACK-4763