### PR TITLE
[dynamicIO] prioritize preprocessing RSC rows when prerendering

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -692,5 +692,6 @@
   "691": "Accessed fallback \\`params\\` during prerendering.",
   "692": "Expected clientReferenceManifest to be defined.",
   "693": "%s must not be used within a client component. Next.js should be preventing %s from being included in client components statically, but did not in this case.",
-  "694": "createPrerenderPathname was called inside a client component scope."
+  "694": "createPrerenderPathname was called inside a client component scope.",
+  "695": "Expected workUnitAsyncStorage to have a store."
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3780,25 +3780,32 @@ async function prerenderToStream(
     )
 
     try {
-      const fizzStream = await renderToInitialFizzStream({
-        ReactDOMServer: require('react-dom/server.edge'),
-        element: (
-          <ErrorApp
-            reactServerStream={errorServerStream}
-            ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
-            preinitScripts={errorPreinitScripts}
-            clientReferenceManifest={clientReferenceManifest}
-            gracefullyDegrade={!!botType}
-            nonce={nonce}
-          />
-        ),
-        streamOptions: {
-          nonce,
-          // Include hydration scripts in the HTML
-          bootstrapScripts: [errorBootstrapScript],
-          formState,
-        },
-      })
+      // TODO we should use the same prerender semantics that we initially rendered
+      // with in this case too. The only reason why this is ok atm is because it's essentially
+      // an empty page and no user code runs.
+      const fizzStream = await workUnitAsyncStorage.run(
+        prerenderLegacyStore,
+        renderToInitialFizzStream,
+        {
+          ReactDOMServer: require('react-dom/server.edge'),
+          element: (
+            <ErrorApp
+              reactServerStream={errorServerStream}
+              ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+              preinitScripts={errorPreinitScripts}
+              clientReferenceManifest={clientReferenceManifest}
+              gracefullyDegrade={!!botType}
+              nonce={nonce}
+            />
+          ),
+          streamOptions: {
+            nonce,
+            // Include hydration scripts in the HTML
+            bootstrapScripts: [errorBootstrapScript],
+            formState,
+          },
+        }
+      )
 
       if (shouldGenerateStaticFlightData(workStore)) {
         const flightData = await streamToBuffer(

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { assertNoErrorToast } from 'next-test-utils'
 
 import { createExpectError } from './utils'
 
@@ -18,11 +19,6 @@ function runTests(options: { withMinification: boolean }) {
         return
       }
 
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
       beforeEach(async () => {
         if (!withMinification) {
           await next.patchFile('next.config.js', (content) =>
@@ -34,14 +30,22 @@ function runTests(options: { withMinification: boolean }) {
         }
       })
 
-      it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
-        try {
+      if (isNextDev) {
+        it('does not show a validation error in the dev overlay', async () => {
           await next.start()
-        } catch {
-          throw new Error('expected build not to fail')
-        }
-        expect(next.cliOutput).toContain('◐ / ')
-      })
+          const browser = await next.browser('/')
+          await assertNoErrorToast(browser)
+        })
+      } else {
+        it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
+          try {
+            await next.start()
+          } catch {
+            throw new Error('expected build not to fail')
+          }
+          expect(next.cliOutput).toContain('◐ / ')
+        })
+      }
     })
     describe('Error Attribution with Sync IO - Guarded RSC with unguarded Client sync IO', () => {
       const { next, isNextDev, skipped } = nextTestSetup({

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/app/layout.tsx
@@ -3,6 +3,12 @@ export default function Root({ children }: { children: React.ReactNode }) {
     <html>
       <body>
         <main>{children}</main>
+        <div>
+          We add extra content here because it increases the size of the dev RSC
+          payload which exercises the preloading of the RSC chunks more. We want
+          a greater page weight than this simple test would otherwise have
+          produced.
+        </div>
       </body>
     </html>
   )

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -851,8 +851,11 @@ export async function assertHasRedbox(browser: Playwright) {
   }
 }
 
-export async function assertNoRedbox(browser: Playwright) {
-  await waitFor(5000)
+export async function assertNoRedbox(
+  browser: Playwright,
+  { waitInMs = 5000 }: { waitInMs?: number } = {}
+) {
+  await waitFor(waitInMs)
   const redbox = browser.locateRedbox()
 
   if (await redbox.isVisible()) {
@@ -870,6 +873,26 @@ export async function assertNoRedbox(browser: Playwright) {
     )
     Error.captureStackTrace(error, assertNoRedbox)
     throw error
+  }
+}
+
+export async function assertNoErrorToast(browser: Playwright): Promise<void> {
+  let didOpenRedbox = false
+
+  try {
+    await browser.waitForElementByCss('[data-issues]').click()
+    didOpenRedbox = true
+  } catch {
+    // We expect this to fail.
+  }
+
+  if (didOpenRedbox) {
+    // If a redbox was opened unexpectedly, we use the `assertNoRedbox` helper
+    // to print a useful error message containing the redbox contents.
+    await assertNoRedbox(browser, {
+      // We already know the redbox is open, so we can skip waiting for it.
+      waitInMs: 0,
+    })
   }
 }
 


### PR DESCRIPTION
When prerendering with dynamicIO we take advantage of a few things about microtask behavior to ensure that anything prerenderable in RSC is included in the HTML prerender. We found however that with large enough RSC payloads certain things that should have been prerenderable could be incorrectly excluded when paired with sync IO in the client because this causes the prerender to abort earlier than one task. To prevent this we allow the RSC response to pre-process entirely before continuing with the prerender. This is possible as long as the RSC prerender is fully complete before the HTML prerender begins.

We only do this when dynamicIO is enabled and only during prerender. By construction this means that this also never happens in edge runtime.