### PR TITLE
[turbopack] Remove uses of `Value<ClientContextType>` by making `ClientContextType` a TaskInput

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -207,7 +207,7 @@ impl AppProject {
             self.project().project_path(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
-            Value::new(self.client_ty().owned().await?),
+            self.client_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().encryption_key(),
@@ -219,7 +219,7 @@ impl AppProject {
     async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.client_ty().owned().await?),
+            self.client_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -784,7 +784,7 @@ impl AppProject {
     async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         Ok(get_client_runtime_entries(
             self.project().project_path(),
-            Value::new(self.client_ty().owned().await?),
+            self.client_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -336,9 +336,9 @@ impl PagesProject {
             self.project().project_path(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
-            Value::new(ClientContextType::Pages {
+            ClientContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             self.project().encryption_key(),
@@ -350,9 +350,9 @@ impl PagesProject {
     async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
             self.project().project_path(),
-            Value::new(ClientContextType::Pages {
+            ClientContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -566,9 +566,9 @@ impl PagesProject {
     async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         let client_runtime_entries = get_client_runtime_entries(
             self.project().project_path(),
-            Value::new(ClientContextType::Pages {
+            ClientContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -139,7 +139,7 @@ pub async fn get_client_compile_time_info(
     .await
 }
 
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
+#[turbo_tasks::value(shared)]
 #[derive(Debug, Copy, Clone, Hash, TaskInput)]
 pub enum ClientContextType {
     Pages {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -91,7 +91,7 @@ const EDGE_UNSUPPORTED_NODE_INTERNALS: [&str; 44] = [
 #[turbo_tasks::function]
 pub async fn get_next_client_import_map(
     project_path: ResolvedVc<FileSystemPath>,
-    ty: Value<ClientContextType>,
+    ty: ClientContextType,
     next_config: Vc<NextConfig>,
     next_mode: Vc<NextMode>,
     execution_context: Vc<ExecutionContext>,
@@ -118,7 +118,7 @@ pub async fn get_next_client_import_map(
     )
     .await?;
 
-    match ty.into_value() {
+    match ty {
         ClientContextType::Pages { .. } => {}
         ClientContextType::App { app_dir } => {
             let react_flavor = if *next_config.enable_ppr().await?
@@ -236,7 +236,7 @@ pub async fn get_next_client_import_map(
         },
     );
 
-    match ty.into_value() {
+    match ty {
         ClientContextType::Pages { .. }
         | ClientContextType::App { .. }
         | ClientContextType::Fallback => {
@@ -259,12 +259,10 @@ pub async fn get_next_client_import_map(
 /// Computes the Next-specific client fallback import map, which provides
 /// polyfills to Node.js externals.
 #[turbo_tasks::function]
-pub async fn get_next_client_fallback_import_map(
-    ty: Value<ClientContextType>,
-) -> Result<Vc<ImportMap>> {
+pub async fn get_next_client_fallback_import_map(ty: ClientContextType) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
-    match ty.into_value() {
+    match ty {
         ClientContextType::Pages {
             pages_dir: context_dir,
         }


### PR DESCRIPTION
Refactor ClientContextType to use TaskInput instead of Value wrapper

### Why?
The `Value<>` type is confusing and error prone, lets destroy it!

As discussed over slack, `turbo_tasks::Value` type always implements `is_resolved` as `true` and `is_transient` as `false` which is incorrect and can enable smuggling transient vcs into turbo tasks. 

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879


Closes PACK-4775