### PR TITLE
[turbopack] Remove uses of `Value<ReferenceType>` by making `ReferenceType` a TaskInput

### DIFF
--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -75,7 +75,7 @@ impl InstrumentationEndpoint {
             .asset_context
             .process(
                 *self.source,
-                Value::new(ReferenceType::Entry(EntryReferenceSubType::Instrumentation)),
+                ReferenceType::Entry(EntryReferenceSubType::Instrumentation),
             )
             .module()
             .to_resolved()

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -76,7 +76,7 @@ impl MiddlewareEndpoint {
             .asset_context
             .process(
                 *self.source,
-                Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
+                ReferenceType::Entry(EntryReferenceSubType::Middleware),
             )
             .module();
 
@@ -341,7 +341,7 @@ impl MiddlewareEndpoint {
         self.asset_context
             .process(
                 *self.source,
-                Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
+                ReferenceType::Entry(EntryReferenceSubType::Middleware),
             )
             .module()
     }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -876,19 +876,19 @@ impl PageEndpoint {
 
         let (reference_type, project_root, module_context, edge_module_context) = match this.ty {
             PageEndpointType::Html | PageEndpointType::SsrOnly => (
-                Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
+                ReferenceType::Entry(EntryReferenceSubType::Page),
                 this.pages_project.project().project_path(),
                 this.pages_project.ssr_module_context(),
                 this.pages_project.edge_ssr_module_context(),
             ),
             PageEndpointType::Data => (
-                Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
+                ReferenceType::Entry(EntryReferenceSubType::Page),
                 this.pages_project.project().project_path(),
                 this.pages_project.ssr_data_module_context(),
                 this.pages_project.edge_ssr_data_module_context(),
             ),
             PageEndpointType::Api => (
-                Value::new(ReferenceType::Entry(EntryReferenceSubType::PagesApi)),
+                ReferenceType::Entry(EntryReferenceSubType::PagesApi),
                 this.pages_project.project().project_path(),
                 this.pages_project.api_module_context(),
                 this.pages_project.edge_api_module_context(),

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1381,7 +1381,7 @@ impl Project {
         let module = edge_module_context
             .process(
                 source,
-                Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
+                ReferenceType::Entry(EntryReferenceSubType::Middleware),
             )
             .module();
 

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -19,7 +19,7 @@ use swc_core::{
     },
 };
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{self, File, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::AssetContent,
@@ -134,7 +134,7 @@ pub(crate) async fn build_server_actions_loader(
     let module = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(import_map))),
+            ReferenceType::Internal(ResolvedVc::cell(import_map)),
         )
         .module();
 
@@ -213,9 +213,7 @@ pub async fn to_rsc_context(
     let module = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::EcmaScriptModules(
-                EcmaScriptModulesReferenceSubType::Undefined,
-            )),
+            ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined),
         )
         .module()
         .to_resolved()

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::{
@@ -74,9 +74,8 @@ impl BaseLoaderTreeBuilder {
     }
 
     pub fn process_source(&self, source: Vc<Box<dyn Source>>) -> Vc<Box<dyn Module>> {
-        let reference_type = Value::new(ReferenceType::EcmaScriptModules(
-            EcmaScriptModulesReferenceSubType::Undefined,
-        ));
+        let reference_type =
+            ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined);
 
         self.server_component_transition
             .process(source, *self.module_asset_context, reference_type)

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, bail};
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -85,9 +85,7 @@ pub async fn bootstrap(
                     .into(),
                 ),
             )),
-            Value::new(ReferenceType::Internal(
-                InnerAssets::empty().to_resolved().await?,
-            )),
+            ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
         .module()
         .to_resolved()
@@ -100,7 +98,7 @@ pub async fn bootstrap(
     let asset = asset_context
         .process(
             bootstrap_asset,
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module()
         .to_resolved()

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, Vc, fxindexmap};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{context::AssetContext, module::Module, reference_type::ReferenceType};
 
@@ -49,7 +49,7 @@ pub async fn get_middleware_module(
     let module = asset_context
         .process(
             source,
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
 

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc, fxindexmap};
 use turbo_tasks_fs::{self, File, FileSystemPath, rope::RopeBuilder};
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -116,7 +116,7 @@ pub async fn get_app_page_entry(
     let mut rsc_entry = module_asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
 
@@ -196,7 +196,7 @@ async fn wrap_edge_page(
     let wrapped = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -93,7 +93,7 @@ pub async fn get_app_route_entry(
     let userland_module = module_asset_context
         .process(
             source,
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::AppRoute)),
+            ReferenceType::Entry(EntryReferenceSubType::AppRoute),
         )
         .module()
         .to_resolved()
@@ -106,7 +106,7 @@ pub async fn get_app_route_entry(
     let mut rsc_entry = module_asset_context
         .process(
             Vc::upcast(virtual_source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
 
@@ -162,7 +162,7 @@ async fn wrap_edge_route(
     let wrapped = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
 

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -75,9 +75,7 @@ pub async fn dynamic_image_metadata_source(
     let module = asset_context
         .process(
             source,
-            turbo_tasks::Value::new(ReferenceType::EcmaScriptModules(
-                EcmaScriptModulesReferenceSubType::Undefined,
-            )),
+            ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined),
         )
         .module();
     let exports = &*collect_direct_exports(module).await?;

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_transition.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::{ModuleAssetContext, css::chunk::CssChunkPlaceable, transition::Transition};
 use turbopack_core::{context::ProcessResult, reference_type::ReferenceType, source::Source};
 
@@ -25,7 +25,7 @@ impl Transition for NextCssClientReferenceTransition {
         self: Vc<Self>,
         source: Vc<Box<dyn Source>>,
         rsc_module_asset_context: Vc<ModuleAssetContext>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
         let module =
             self.await?

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -3,7 +3,7 @@ use std::{io::Write, iter::once};
 use anyhow::{Context, Result, bail};
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -160,10 +160,7 @@ impl EcmascriptClientReferenceModule {
 
         let proxy_module = self
             .server_asset_context
-            .process(
-                Vc::upcast(proxy_source),
-                Value::new(ReferenceType::Undefined),
-            )
+            .process(Vc::upcast(proxy_source), ReferenceType::Undefined)
             .module();
 
         let Some(proxy_module) =

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::{
     context::ProcessResult,
@@ -39,9 +39,9 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         self: Vc<Self>,
         source: Vc<Box<dyn Source>>,
         module_asset_context: Vc<ModuleAssetContext>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
-        let part = match &*reference_type {
+        let part = match reference_type {
             ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportPart(
                 part,
             )) => Some(part),
@@ -76,9 +76,7 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         let client_module = this.client_transition.process(
             client_source,
             module_asset_context,
-            Value::new(ReferenceType::Entry(
-                EntryReferenceSubType::AppClientComponent,
-            )),
+            ReferenceType::Entry(EntryReferenceSubType::AppClientComponent),
         );
         let ProcessResult::Module(client_module) = *client_module.await? else {
             return Ok(ProcessResult::Ignore.cell());
@@ -87,9 +85,7 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         let ssr_module = this.ssr_transition.process(
             source,
             module_asset_context,
-            Value::new(ReferenceType::Entry(
-                EntryReferenceSubType::AppClientComponent,
-            )),
+            ReferenceType::Entry(EntryReferenceSubType::AppClientComponent),
         );
 
         let ProcessResult::Module(ssr_module) = *ssr_module.await? else {

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::{
     context::{AssetContext, ProcessResult},
@@ -49,16 +49,14 @@ impl Transition for NextDynamicTransition {
         self: Vc<Self>,
         source: Vc<Box<dyn Source>>,
         module_asset_context: Vc<ModuleAssetContext>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
         let module_asset_context = self.process_context(module_asset_context);
         let module = match self.await?.client_transition {
-            Some(client_transition) => client_transition.process(
-                source,
-                module_asset_context,
-                Value::new(ReferenceType::Undefined),
-            ),
-            None => module_asset_context.process(source, Value::new(ReferenceType::Undefined)),
+            Some(client_transition) => {
+                client_transition.process(source, module_asset_context, ReferenceType::Undefined)
+            }
+            None => module_asset_context.process(source, ReferenceType::Undefined),
         };
 
         Ok(match &*module.try_into_module().await? {

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -1,6 +1,6 @@
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent, context::AssetContext, module::Module, reference_type::ReferenceType,
@@ -56,7 +56,7 @@ pub async fn wrap_edge_entry(
     asset_context
         .process(
             Vc::upcast(virtual_source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module()
 }

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -714,9 +714,7 @@ async fn get_mock_stylesheet(
                     .into(),
                 ),
             )),
-            Value::new(ReferenceType::Internal(
-                InnerAssets::empty().to_resolved().await?,
-            )),
+            ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
         .module();
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -77,7 +77,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     async fn before_resolve(
         self: Vc<Self>,
         lookup_path: Vc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
         request_vc: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let this = &*self.await?;

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -50,9 +50,9 @@ impl StructuredImageModuleType {
                     }
                     .cell(),
                 ),
-                Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap!(
+                ReferenceType::Internal(ResolvedVc::cell(fxindexmap!(
                     "IMAGE".into() => ResolvedVc::upcast(static_asset)
-                )))),
+                ))),
             )
             .module())
     }

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1011,7 +1011,7 @@ async fn insert_next_shared_aliases(
 pub async fn get_next_package(context_directory: Vc<FileSystemPath>) -> Result<Vc<FileSystemPath>> {
     let result = resolve(
         context_directory,
-        Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+        ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         Request::parse(Value::new(Pattern::Constant(rcstr!("next/package.json")))),
         node_cjs_resolve_options(context_directory.root()),
     );

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::{Result, bail};
 use serde::Serialize;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, Vc, fxindexmap};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -33,7 +33,7 @@ pub struct PageSsrEntryModule {
 #[turbo_tasks::function]
 pub async fn create_page_ssr_entry_module(
     pathname: RcStr,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     project_root: Vc<FileSystemPath>,
     ssr_module_context: Vc<Box<dyn AssetContext>>,
     source: Vc<Box<dyn Source>>,
@@ -50,8 +50,6 @@ pub async fn create_page_ssr_entry_module(
         .module()
         .to_resolved()
         .await?;
-
-    let reference_type = reference_type.into_value();
 
     let template_file = match (&reference_type, runtime) {
         (ReferenceType::Entry(EntryReferenceSubType::Page), _) => {
@@ -129,14 +127,14 @@ pub async fn create_page_ssr_entry_module(
         if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page) {
             let document_module = process_global_item(
                 *pages_structure_ref.document,
-                Value::new(reference_type.clone()),
+                reference_type.clone(),
                 ssr_module_context,
             )
             .to_resolved()
             .await?;
             let app_module = process_global_item(
                 *pages_structure_ref.app,
-                Value::new(reference_type.clone()),
+                reference_type.clone(),
                 ssr_module_context,
             )
             .to_resolved()
@@ -151,7 +149,7 @@ pub async fn create_page_ssr_entry_module(
     let mut ssr_module = ssr_module_context
         .process(
             source,
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
 
@@ -163,7 +161,7 @@ pub async fn create_page_ssr_entry_module(
                 ssr_module,
                 definition_page.clone(),
                 definition_pathname.clone(),
-                Value::new(reference_type),
+                reference_type,
                 pages_structure,
                 next_config,
             );
@@ -188,7 +186,7 @@ pub async fn create_page_ssr_entry_module(
 #[turbo_tasks::function]
 fn process_global_item(
     item: Vc<PagesStructureItem>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     module_context: Vc<Box<dyn AssetContext>>,
 ) -> Vc<Box<dyn Module>> {
     let source = Vc::upcast(FileSource::new(item.file_path()));
@@ -202,7 +200,7 @@ async fn wrap_edge_page(
     entry: ResolvedVc<Box<dyn Module>>,
     page: RcStr,
     pathname: RcStr,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     pages_structure: Vc<PagesStructure>,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn Module>>> {
@@ -288,7 +286,7 @@ async fn wrap_edge_page(
     let wrapped = asset_context
         .process(
             Vc::upcast(source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(inner_assets))),
+            ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
 

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{NonLocalValue, ResolvedVc, Value, Vc, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{self, FileJsonContent, FileSystemPath, glob::Glob};
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
@@ -79,7 +79,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         &self,
         fs_path: ResolvedVc<FileSystemPath>,
         lookup_path: ResolvedVc<FileSystemPath>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
         request: ResolvedVc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let request_value = &*request.await?;

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -132,7 +132,7 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
     fn before_resolve(
         &self,
         lookup_path: ResolvedVc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Vc<ResolveResultOption> {
         InvalidImportModuleIssue {
@@ -231,7 +231,7 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
         &self,
         fs_path: Vc<FileSystemPath>,
         _lookup_path: Vc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let path = fs_path.await?.path.to_string();
@@ -289,7 +289,7 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
         &self,
         fs_path: Vc<FileSystemPath>,
         _lookup_path: Vc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let stem = fs_path.file_stem().await?;
@@ -357,7 +357,7 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
     async fn before_resolve(
         &self,
         _lookup_path: Vc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
         request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         if let Request::Module {
@@ -413,7 +413,7 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
         &self,
         fs_path: Vc<FileSystemPath>,
         _lookup_path: Vc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let raw_fs_path = &*fs_path.await?;

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -72,12 +72,12 @@ pub async fn get_swc_ecma_transform_rule_impl(
             let plugin_wasm_module_resolve_result = handle_resolve_error(
                 resolve(
                     *project_path,
-                    Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                    ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
                     request,
                     resolve_options,
                 )
                 .as_raw_module_result(),
-                Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
                 // TODO proper error location
                 *project_path,
                 request,

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -114,7 +114,7 @@ pub async fn maybe_add_babel_loader(
 pub async fn is_babel_loader_available(project_path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
     let result = resolve(
         project_path,
-        Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+        ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         Request::parse(Value::new(Pattern::Constant(
             "babel-loader/package.json".into(),
         ))),

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, fxindexmap};
 use turbo_tasks_fs::{
     self, File, FileContent, FileSystemPath, FileSystemPathOption, rope::RopeBuilder,
 };
@@ -48,7 +48,7 @@ pub async fn create_page_loader_entry_module(
     let module = client_context
         .process(
             entry_asset,
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
+            ReferenceType::Entry(EntryReferenceSubType::Page),
         )
         .module()
         .to_resolved()
@@ -57,9 +57,9 @@ pub async fn create_page_loader_entry_module(
     let module = client_context
         .process(
             virtual_source,
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
+            ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
                 rcstr!("PAGE") => module,
-            }))),
+            })),
         )
         .module();
     Ok(module)

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
@@ -58,7 +58,7 @@ pub async fn assert_can_resolve_react_refresh(
     for request in [react_refresh_request_in_next(), react_refresh_request()] {
         let result = turbopack_core::resolve::resolve(
             *path,
-            Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+            ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
             request,
             resolve_options,
         )

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -282,7 +282,7 @@ async fn build_internal(
         entry_requests
             .into_iter()
             .map(|request_vc| async move {
-                let ty = Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined));
+                let ty = ReferenceType::Entry(EntryReferenceSubType::Undefined);
                 let request = request_vc.await?;
                 origin
                     .resolve_asset(request_vc, origin.resolve_options(ty.clone()), ty)

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_browser::{BrowserChunkingContext, react_refresh::assert_can_resolve_react_refresh};
@@ -131,7 +131,7 @@ pub async fn create_web_entry_source(
     let entries = entry_requests
         .into_iter()
         .map(|request| async move {
-            let ty = Value::new(ReferenceType::Entry(EntryReferenceSubType::Web));
+            let ty = ReferenceType::Entry(EntryReferenceSubType::Web);
             Ok(origin
                 .resolve_asset(request, origin.resolve_options(ty.clone()), ty)
                 .await?

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, Upcast, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Upcast, ValueToString, Vc};
 
 use super::ChunkableModule;
 use crate::{
@@ -42,10 +42,7 @@ async fn to_evaluatable(
     asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
     let module = asset_context
-        .process(
-            asset,
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::Runtime)),
-        )
+        .process(asset, ReferenceType::Entry(EntryReferenceSubType::Runtime))
         .module();
     let Some(entry) = Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module).await? else {
         bail!(

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
 use crate::{
@@ -69,7 +69,7 @@ pub trait AssetContext {
     fn resolve_options(
         self: Vc<Self>,
         origin_path: Vc<FileSystemPath>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Vc<ResolveOptions>;
 
     /// Resolves an request to an [ModuleResolveResult].
@@ -78,21 +78,21 @@ pub trait AssetContext {
         origin_path: Vc<FileSystemPath>,
         request: Vc<Request>,
         resolve_options: Vc<ResolveOptions>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Vc<ModuleResolveResult>;
 
     /// Process a source into a module.
     fn process(
         self: Vc<Self>,
         asset: Vc<Box<dyn Source>>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Vc<ProcessResult>;
 
     /// Process an [ResolveResult] into an [ModuleResolveResult].
     fn process_resolve_result(
         self: Vc<Self>,
         result: Vc<ResolveResult>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Vc<ModuleResolveResult>;
 
     /// Gets a new AssetContext with the transition applied.

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -27,7 +27,7 @@ impl InnerAssets {
 // TODO when plugins are supported, replace u8 with a trait that defines the
 // behavior.
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum CommonJsReferenceSubType {
     Custom(u8),
@@ -35,13 +35,13 @@ pub enum CommonJsReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub enum ImportWithType {
     Json,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum EcmaScriptModulesReferenceSubType {
     ImportPart(ModulePart),
@@ -170,7 +170,7 @@ impl ImportContext {
     }
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum CssReferenceSubType {
     AtImport(Option<ResolvedVc<ImportContext>>),
@@ -186,7 +186,7 @@ pub enum CssReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum UrlReferenceSubType {
     EcmaScriptNewUrl,
@@ -196,14 +196,14 @@ pub enum UrlReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub enum TypeScriptReferenceSubType {
     Custom(u8),
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub enum WorkerReferenceSubType {
     WebWorker,
@@ -215,7 +215,7 @@ pub enum WorkerReferenceSubType {
 
 // TODO(sokra) this was next.js specific values. We want to solve this in a
 // different way.
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub enum EntryReferenceSubType {
     Web,
@@ -231,7 +231,7 @@ pub enum EntryReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value()]
 #[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum ReferenceType {
     CommonJs(CommonJsReferenceSubType),

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -2,11 +2,11 @@ use std::fmt::Display;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, TaskInput, Vc};
+use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 
 use crate::{module::Module, resolve::ModulePart};
 
-/// Named references to inner assets. Modules can used them to allow to
+/// Named references to inner assets. Modules can use them to allow to
 /// per-module aliases of some requests to already created module assets.
 ///
 /// Name is usually in UPPER_CASE to make it clear that this is an inner asset.
@@ -27,22 +27,54 @@ impl InnerAssets {
 // TODO when plugins are supported, replace u8 with a trait that defines the
 // behavior.
 
-#[turbo_tasks::value()]
-#[derive(Debug, Default, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Default,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum CommonJsReferenceSubType {
     Custom(u8),
     #[default]
     Undefined,
 }
 
-#[turbo_tasks::value()]
-#[derive(Debug, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum ImportWithType {
     Json,
 }
 
-#[turbo_tasks::value()]
-#[derive(Debug, Default, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Default,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum EcmaScriptModulesReferenceSubType {
     ImportPart(ModulePart),
     Import,
@@ -170,8 +202,19 @@ impl ImportContext {
     }
 }
 
-#[turbo_tasks::value()]
-#[derive(Debug, Default, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Default,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum CssReferenceSubType {
     AtImport(Option<ResolvedVc<ImportContext>>),
     /// Reference from ModuleCssAsset to an imported ModuleCssAsset for retrieving the composed
@@ -186,8 +229,19 @@ pub enum CssReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value()]
-#[derive(Debug, Default, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Default,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum UrlReferenceSubType {
     EcmaScriptNewUrl,
     CssUrl,
@@ -196,15 +250,35 @@ pub enum UrlReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value()]
-#[derive(Debug, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum TypeScriptReferenceSubType {
     Custom(u8),
     Undefined,
 }
 
-#[turbo_tasks::value()]
-#[derive(Debug, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum WorkerReferenceSubType {
     WebWorker,
     SharedWorker,
@@ -215,8 +289,18 @@ pub enum WorkerReferenceSubType {
 
 // TODO(sokra) this was next.js specific values. We want to solve this in a
 // different way.
-#[turbo_tasks::value()]
-#[derive(Debug, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum EntryReferenceSubType {
     Web,
     Page,
@@ -231,8 +315,19 @@ pub enum EntryReferenceSubType {
     Undefined,
 }
 
-#[turbo_tasks::value()]
-#[derive(Debug, Default, Clone, Hash, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Default,
+    Clone,
+    Hash,
+    TaskInput,
+)]
 pub enum ReferenceType {
     CommonJs(CommonJsReferenceSubType),
     EcmaScriptModules(EcmaScriptModulesReferenceSubType),

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TaskInput, Vc};
 
 use crate::{module::Module, resolve::ModulePart};
 
@@ -28,7 +28,7 @@ impl InnerAssets {
 // behavior.
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum CommonJsReferenceSubType {
     Custom(u8),
     #[default]
@@ -36,13 +36,13 @@ pub enum CommonJsReferenceSubType {
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub enum ImportWithType {
     Json,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum EcmaScriptModulesReferenceSubType {
     ImportPart(ModulePart),
     Import,
@@ -171,7 +171,7 @@ impl ImportContext {
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum CssReferenceSubType {
     AtImport(Option<ResolvedVc<ImportContext>>),
     /// Reference from ModuleCssAsset to an imported ModuleCssAsset for retrieving the composed
@@ -187,7 +187,7 @@ pub enum CssReferenceSubType {
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum UrlReferenceSubType {
     EcmaScriptNewUrl,
     CssUrl,
@@ -197,14 +197,14 @@ pub enum UrlReferenceSubType {
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub enum TypeScriptReferenceSubType {
     Custom(u8),
     Undefined,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub enum WorkerReferenceSubType {
     WebWorker,
     SharedWorker,
@@ -216,7 +216,7 @@ pub enum WorkerReferenceSubType {
 // TODO(sokra) this was next.js specific values. We want to solve this in a
 // different way.
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub enum EntryReferenceSubType {
     Web,
     Page,
@@ -232,7 +232,7 @@ pub enum EntryReferenceSubType {
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Default, Clone, Hash, TaskInput)]
 pub enum ReferenceType {
     CommonJs(CommonJsReferenceSubType),
     EcmaScriptModules(EcmaScriptModulesReferenceSubType),

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1560,11 +1560,11 @@ pub async fn resolve_raw(
 #[turbo_tasks::function]
 pub async fn resolve(
     lookup_path: Vc<FileSystemPath>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    resolve_inline(lookup_path, reference_type.into_value(), request, options).await
+    resolve_inline(lookup_path, reference_type, request, options).await
 }
 
 pub async fn resolve_inline(
@@ -1584,7 +1584,6 @@ pub async fn resolve_inline(
         )
     };
     async {
-        let reference_type = Value::new(reference_type);
         let before_plugins_result =
             handle_before_resolve_plugins(lookup_path, reference_type.clone(), request, options)
                 .await?;
@@ -1611,7 +1610,7 @@ pub async fn resolve_inline(
 pub async fn url_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     issue_source: Option<IssueSource>,
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
@@ -1659,7 +1658,7 @@ pub async fn url_resolve(
 #[tracing::instrument(level = "trace", skip_all)]
 async fn handle_before_resolve_plugins(
     lookup_path: Vc<FileSystemPath>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Option<Vc<ResolveResult>>> {
@@ -1682,7 +1681,7 @@ async fn handle_before_resolve_plugins(
 #[tracing::instrument(level = "trace", skip_all)]
 async fn handle_after_resolve_plugins(
     lookup_path: Vc<FileSystemPath>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
     result: Vc<ResolveResult>,
@@ -1690,7 +1689,7 @@ async fn handle_after_resolve_plugins(
     async fn apply_plugins_to_path(
         path: Vc<FileSystemPath>,
         lookup_path: Vc<FileSystemPath>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
         request: Vc<Request>,
         options: Vc<ResolveOptions>,
     ) -> Result<Option<Vc<ResolveResult>>> {
@@ -2990,7 +2989,7 @@ async fn resolve_package_internal_with_imports_field(
 
 pub async fn handle_resolve_error(
     result: Vc<ModuleResolveResult>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     origin_path: Vc<FileSystemPath>,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
@@ -3034,7 +3033,7 @@ pub async fn handle_resolve_error(
 
 pub async fn handle_resolve_source_error(
     result: Vc<ResolveResult>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     origin_path: Vc<FileSystemPath>,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
@@ -3079,7 +3078,7 @@ pub async fn handle_resolve_source_error(
 async fn emit_resolve_error_issue(
     is_optional: bool,
     origin_path: Vc<FileSystemPath>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     err: anyhow::Error,
@@ -3093,7 +3092,7 @@ async fn emit_resolve_error_issue(
     ResolvingIssue {
         severity,
         file_path: origin_path.to_resolved().await?,
-        request_type: format!("{} request", reference_type.into_value()),
+        request_type: format!("{reference_type} request"),
         request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,
         error_message: Some(format!("{}", PrettyPrintError(&err))),
@@ -3107,7 +3106,7 @@ async fn emit_resolve_error_issue(
 async fn emit_unresolvable_issue(
     is_optional: bool,
     origin_path: Vc<FileSystemPath>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     source: Option<IssueSource>,
@@ -3120,7 +3119,7 @@ async fn emit_unresolvable_issue(
     ResolvingIssue {
         severity,
         file_path: origin_path.to_resolved().await?,
-        request_type: format!("{} request", reference_type.into_value()),
+        request_type: format!("{reference_type} request"),
         request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,
         error_message: None,

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Upcast, Value, Vc};
+use turbo_tasks::{ResolvedVc, Upcast, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{ModuleResolveResult, options::ResolveOptions, parse::Request};
@@ -40,11 +40,11 @@ pub trait ResolveOriginExt: Send {
         self: Vc<Self>,
         request: Vc<Request>,
         options: Vc<ResolveOptions>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send;
 
     /// Get the resolve options that apply for this origin.
-    fn resolve_options(self: Vc<Self>, reference_type: Value<ReferenceType>) -> Vc<ResolveOptions>;
+    fn resolve_options(self: Vc<Self>, reference_type: ReferenceType) -> Vc<ResolveOptions>;
 
     /// Adds a transition that is used for resolved assets.
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>>;
@@ -58,12 +58,12 @@ where
         self: Vc<Self>,
         request: Vc<Request>,
         options: Vc<ResolveOptions>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send {
         resolve_asset(Vc::upcast(self), request, options, reference_type)
     }
 
-    fn resolve_options(self: Vc<Self>, reference_type: Value<ReferenceType>) -> Vc<ResolveOptions> {
+    fn resolve_options(self: Vc<Self>, reference_type: ReferenceType) -> Vc<ResolveOptions> {
         self.asset_context()
             .resolve_options(self.origin_path(), reference_type)
     }
@@ -83,7 +83,7 @@ async fn resolve_asset(
     resolve_origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
 ) -> Result<Vc<ModuleResolveResult>> {
     if let Some(asset) = *resolve_origin.get_inner_asset(request).await? {
         return Ok(*ModuleResolveResult::module(asset));

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
 use crate::{
@@ -87,7 +87,7 @@ pub trait BeforeResolvePlugin {
     fn before_resolve(
         self: Vc<Self>,
         lookup_path: Vc<FileSystemPath>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
         request: Vc<Request>,
     ) -> Vc<ResolveResultOption>;
 }
@@ -104,7 +104,7 @@ pub trait AfterResolvePlugin {
         self: Vc<Self>,
         fs_path: Vc<FileSystemPath>,
         lookup_path: Vc<FileSystemPath>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
         request: Vc<Request>,
     ) -> Vc<ResolveResultOption>;
 }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -84,9 +84,7 @@ impl Module for ModuleCssAsset {
             .copied()
             .chain(
                 match *self
-                    .inner(Value::new(ReferenceType::Css(
-                        CssReferenceSubType::Internal,
-                    )))
+                    .inner(ReferenceType::Css(CssReferenceSubType::Internal))
                     .try_into_module()
                     .await?
                 {
@@ -160,15 +158,14 @@ struct ModuleCssClasses(FxIndexMap<String, Vec<ModuleCssClass>>);
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {
     #[turbo_tasks::function]
-    pub fn inner(&self, ty: Value<ReferenceType>) -> Vc<ProcessResult> {
-        self.asset_context
-            .process(*self.source, Value::new(ty.into_value()))
+    pub fn inner(&self, ty: ReferenceType) -> Vc<ProcessResult> {
+        self.asset_context.process(*self.source, ty)
     }
 
     #[turbo_tasks::function]
     async fn classes(self: Vc<Self>) -> Result<Vc<ModuleCssClasses>> {
         let inner = self
-            .inner(Value::new(ReferenceType::Css(CssReferenceSubType::Analyze)))
+            .inner(ReferenceType::Css(CssReferenceSubType::Analyze))
             .module();
 
         let inner = Vc::try_resolve_sidecast::<Box<dyn ProcessCss>>(inner)

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -183,7 +183,7 @@ pub fn css_resolve(
     url_resolve(
         origin,
         request,
-        Value::new(ReferenceType::Css(ty.into_value())),
+        ReferenceType::Css(ty.into_value()),
         issue_source,
         false,
     )

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -8,7 +8,7 @@ use lightningcss::{
 };
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
     issue::IssueSource,
@@ -77,7 +77,7 @@ impl ModuleReference for UrlAssetReference {
         url_resolve(
             *self.origin,
             *self.request,
-            Value::new(ReferenceType::Url(UrlReferenceSubType::CssUrl)),
+            ReferenceType::Url(UrlReferenceSubType::CssUrl),
             Some(self.issue_source.clone()),
             false,
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -6,7 +6,7 @@ use swc_core::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, TaskInput, Value, ValueToString, Vc, debug::ValueDebugFormat,
+    NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
 };
 use turbopack_core::{
@@ -106,7 +106,7 @@ impl ModuleReference for UrlAssetReference {
         url_resolve(
             *self.origin,
             *self.request,
-            Value::new(ReferenceType::Url(UrlReferenceSubType::EcmaScriptNewUrl)),
+            ReferenceType::Url(UrlReferenceSubType::EcmaScriptNewUrl),
             Some(self.issue_source.clone()),
             self.in_try,
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3507,14 +3507,14 @@ async fn resolve_as_webpack_runtime(
     request: Vc<Request>,
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<WebpackRuntime>> {
-    let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
+    let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
     let options = origin.resolve_options(ty.clone());
 
     let options = apply_cjs_specific_options(options);
 
     let resolved = resolve(
         origin.origin_path().parent().resolve().await?,
-        Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+        ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         request,
         options,
     );

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -85,9 +85,7 @@ impl ModuleReference for TsReferencePathAssetReference {
                     .asset_context()
                     .process(
                         Vc::upcast(FileSource::new(**path)),
-                        Value::new(ReferenceType::TypeScript(
-                            TypeScriptReferenceSubType::Undefined,
-                        )),
+                        ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
                     )
                     .module()
                     .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -7,8 +7,7 @@ use swc_core::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, Value, ValueToString, Vc, debug::ValueDebugFormat,
-    trace::TraceRawVcs,
+    NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
     chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext},
@@ -61,7 +60,7 @@ impl WorkerAssetReference {
             *self.origin,
             *self.request,
             // TODO support more worker types
-            Value::new(ReferenceType::Worker(WorkerReferenceSubType::WebWorker)),
+            ReferenceType::Worker(WorkerReferenceSubType::WebWorker),
             Some(self.issue_source.clone()),
             self.in_try,
         );

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     code_builder::{Code, CodeBuilder},
@@ -33,7 +33,7 @@ impl StaticEcmascriptCode {
         let module = asset_context
             .process(
                 Vc::upcast(FileSource::new(*asset_path)),
-                Value::new(ReferenceType::Runtime),
+                ReferenceType::Runtime,
             )
             .module()
             .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -54,9 +54,10 @@ impl Module for TsConfigModuleAsset {
         let configs = read_tsconfigs(
             self.source.content().file_content(),
             self.source,
-            apply_cjs_specific_options(self.origin.resolve_options(Value::new(
-                ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
-            ))),
+            apply_cjs_specific_options(
+                self.origin
+                    .resolve_options(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+            ),
         )
         .await?;
         references.extend(

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use swc_core::ecma::ast::Lit;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     file_source::FileSource,
@@ -159,14 +159,14 @@ pub struct WebpackRuntimeAssetReference {
 impl ModuleReference for WebpackRuntimeAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
+        let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
         let options = self.origin.resolve_options(ty.clone());
 
         let options = apply_cjs_specific_options(options);
 
         let resolved = resolve(
             self.origin.origin_path().parent().resolve().await?,
-            Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+            ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
             *self.request,
             options,
         );

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -15,7 +15,7 @@ use serde_json::Value as JsonValue;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{
     Completion, FxIndexMap, NonLocalValue, OperationVc, RawVc, ResolvedVc, TaskInput,
-    TryJoinIterExt, Value, Vc, apply_effects, duration_span, fxindexmap, mark_finished, prevent_gc,
+    TryJoinIterExt, Vc, apply_effects, duration_span, fxindexmap, mark_finished, prevent_gc,
     trace::TraceRawVcs, util::SharedError,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
@@ -98,9 +98,7 @@ async fn emit_evaluate_pool_assets_operation(
     let runtime_asset = asset_context
         .process(
             Vc::upcast(FileSource::new(embed_file_path(rcstr!("ipc/evaluate.ts")))),
-            Value::new(ReferenceType::Internal(
-                InnerAssets::empty().to_resolved().await?,
-            )),
+            ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
         .module()
         .to_resolved()
@@ -124,10 +122,10 @@ async fn emit_evaluate_pool_assets_operation(
                     File::from("import { run } from 'RUNTIME'; run(() => import('INNER'))").into(),
                 ),
             )),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
+            ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
                 rcstr!("INNER") => module_asset,
                 rcstr!("RUNTIME") => runtime_asset
-            }))),
+            })),
         )
         .module()
         .to_resolved()
@@ -137,9 +135,7 @@ async fn emit_evaluate_pool_assets_operation(
         let globals_module = asset_context
             .process(
                 Vc::upcast(FileSource::new(embed_file_path(rcstr!("globals.ts")))),
-                Value::new(ReferenceType::Internal(
-                    InnerAssets::empty().to_resolved().await?,
-                )),
+                ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
             )
             .module();
 

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -199,9 +199,7 @@ async fn config_changed(
     let config_asset = asset_context
         .process(
             Vc::upcast(FileSource::new(postcss_config_path)),
-            Value::new(ReferenceType::Internal(
-                InnerAssets::empty().to_resolved().await?,
-            )),
+            ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
         .module();
 
@@ -237,9 +235,7 @@ async fn extra_configs_changed(
                     match *asset_context
                         .process(
                             Vc::upcast(FileSource::new(path)),
-                            Value::new(ReferenceType::Internal(
-                                InnerAssets::empty().to_resolved().await?,
-                            )),
+                            ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
                         )
                         .try_into_module()
                         .await?
@@ -403,7 +399,7 @@ async fn postcss_executor(
     let config_asset = asset_context
         .process(
             config_loader_source(project_path, postcss_config_path),
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined)),
+            ReferenceType::Entry(EntryReferenceSubType::Undefined),
         )
         .module()
         .to_resolved()
@@ -413,9 +409,9 @@ async fn postcss_executor(
         Vc::upcast(FileSource::new(embed_file_path(rcstr!(
             "transforms/postcss.ts"
         )))),
-        Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
+        ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
             rcstr!("CONFIG") => config_asset
-        }))),
+        })),
     ))
 }
 

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -191,9 +191,7 @@ async fn webpack_loaders_executor(
         Vc::upcast(FileSource::new(embed_file_path(rcstr!(
             "transforms/webpack-loaders.ts"
         )))),
-        Value::new(ReferenceType::Internal(
-            InnerAssets::empty().to_resolved().await?,
-        )),
+        ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
     ))
 }
 
@@ -576,12 +574,7 @@ impl EvaluateContext for WebpackLoaderContext {
 
                 let options = apply_webpack_resolve_options(options, webpack_options);
 
-                let resolved = resolve(
-                    lookup_path,
-                    Value::new(ReferenceType::Undefined),
-                    request,
-                    options,
-                );
+                let resolved = resolve(lookup_path, ReferenceType::Undefined, request, options);
 
                 let request_str = request.to_string().await?;
                 let lookup_path_str = lookup_path.to_string().await?;

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -44,12 +44,12 @@ pub fn get_condition_maps(
 
 pub fn apply_esm_specific_options(
     options: Vc<ResolveOptions>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
 ) -> Vc<ResolveOptions> {
     apply_esm_specific_options_internal(
         options,
         matches!(
-            reference_type.into_value(),
+            reference_type,
             ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportWithType(_))
         ),
     )
@@ -94,7 +94,7 @@ pub async fn esm_resolve(
     is_optional: bool,
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
-    let ty = Value::new(ReferenceType::EcmaScriptModules(ty.into_value()));
+    let ty = ReferenceType::EcmaScriptModules(ty.into_value());
     let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), ty.clone())
         .resolve()
         .await?;
@@ -109,7 +109,7 @@ pub async fn cjs_resolve(
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO pass CommonJsReferenceSubType
-    let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
+    let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
     let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
         .resolve()
         .await?;
@@ -124,7 +124,7 @@ pub async fn cjs_resolve_source(
     is_optional: bool,
 ) -> Result<Vc<ResolveResult>> {
     // TODO pass CommonJsReferenceSubType
-    let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
+    let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
     let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
         .resolve()
         .await?;
@@ -151,7 +151,7 @@ async fn specific_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     is_optional: bool,
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -151,16 +151,16 @@ async fn resolve_extends(
         Request::Empty => {
             let request = Request::parse_string(rcstr!("./tsconfig"));
             Ok(resolve(parent_dir,
-                Value::new(ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)), request, resolve_options).first_source())
+                ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source())
         }
 
         // All other types are treated as module imports, and potentially joined with
         // "tsconfig.json". This includes "relative" imports like '.' and '..'.
         _ => {
-            let mut result = resolve(parent_dir, Value::new(ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)), request, resolve_options).first_source();
+            let mut result = resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
             if result.await?.is_none() {
                 let request = Request::parse_string(format!("{extends}/tsconfig").into());
-                result = resolve(parent_dir, Value::new(ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)), request, resolve_options).first_source();
+                result = resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
             }
             Ok(result)
         }
@@ -175,9 +175,7 @@ async fn resolve_extends_rooted_or_relative(
 ) -> Result<Vc<OptionSource>> {
     let mut result = resolve(
         lookup_path,
-        Value::new(ReferenceType::TypeScript(
-            TypeScriptReferenceSubType::Undefined,
-        )),
+        ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
         request,
         resolve_options,
     )
@@ -190,9 +188,7 @@ async fn resolve_extends_rooted_or_relative(
         let request = Request::parse_string(format!("{path}.json").into());
         result = resolve(
             lookup_path,
-            Value::new(ReferenceType::TypeScript(
-                TypeScriptReferenceSubType::Undefined,
-            )),
+            ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
             request,
             resolve_options,
         )
@@ -387,9 +383,7 @@ pub async fn type_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
 ) -> Result<Vc<ModuleResolveResult>> {
-    let ty = Value::new(ReferenceType::TypeScript(
-        TypeScriptReferenceSubType::Undefined,
-    ));
+    let ty = ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined);
     let context_path = origin.origin_path().parent();
     let options = origin.resolve_options(ty.clone());
     let options = apply_typescript_types_options(options);
@@ -418,9 +412,7 @@ pub async fn type_resolve(
     let result = if let Some(types_request) = types_request {
         let result1 = resolve(
             context_path,
-            Value::new(ReferenceType::TypeScript(
-                TypeScriptReferenceSubType::Undefined,
-            )),
+            ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
             request,
             options,
         );
@@ -429,9 +421,7 @@ pub async fn type_resolve(
         } else {
             resolve(
                 context_path,
-                Value::new(ReferenceType::TypeScript(
-                    TypeScriptReferenceSubType::Undefined,
-                )),
+                ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
                 types_request,
                 options,
             )
@@ -439,9 +429,7 @@ pub async fn type_resolve(
     } else {
         resolve(
             context_path,
-            Value::new(ReferenceType::TypeScript(
-                TypeScriptReferenceSubType::Undefined,
-            )),
+            ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
             request,
             options,
         )

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -439,9 +439,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     let test_asset = asset_context
         .process(
             Vc::upcast(test_source),
-            Value::new(ReferenceType::Internal(
-                InnerAssets::empty().to_resolved().await?,
-            )),
+            ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
         .module()
         .to_resolved()
@@ -450,9 +448,9 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     let jest_entry_asset = asset_context
         .process(
             Vc::upcast(jest_entry_source),
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
+            ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
                 rcstr!("TESTS") => test_asset,
-            }))),
+            })),
         )
         .module();
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -384,7 +384,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let entry_module = asset_context
         .process(
             Vc::upcast(FileSource::new(entry_asset)),
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined)),
+            ReferenceType::Entry(EntryReferenceSubType::Undefined),
         )
         .module();
 

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Value, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -73,9 +73,9 @@ impl WebAssemblyModuleAsset {
 
         let module = this.asset_context.process(
             loader_source,
-            Value::new(ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
+            ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
                 rcstr!("WASM_PATH") => ResolvedVc::upcast(RawWebAssemblyModuleAsset::new(*this.source, *this.asset_context).to_resolved().await?),
-            }))),
+            })),
         ).module();
 
         Ok(module)

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -116,7 +116,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                     rcstr!("node_file_trace"),
                 );
                 let module = module_asset_context
-                    .process(Vc::upcast(source), Value::new(ReferenceType::Undefined))
+                    .process(Vc::upcast(source), ReferenceType::Undefined)
                     .module();
                 let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, *output_dir)
                     .to_resolved()

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
             let module = module_asset_context
                 .process(
                     Vc::upcast(source),
-                    Value::new(turbopack_core::reference_type::ReferenceType::Undefined),
+                    turbopack_core::reference_type::ReferenceType::Undefined,
                 )
                 .module();
             let rebased = RebasedAsset::new(module, input, output);

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -420,7 +420,7 @@ impl ModuleAssetContext {
     async fn process_with_transition_rules(
         self: Vc<Self>,
         source: ResolvedVc<Box<dyn Source>>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
         let this = self.await?;
         Ok(
@@ -440,7 +440,7 @@ impl ModuleAssetContext {
     async fn process_default(
         self: Vc<Self>,
         source: ResolvedVc<Box<dyn Source>>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
         process_default(self, source, reference_type, Vec::new()).await
     }
@@ -449,14 +449,14 @@ impl ModuleAssetContext {
 async fn process_default(
     module_asset_context: Vc<ModuleAssetContext>,
     source: ResolvedVc<Box<dyn Source>>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     processed_rules: Vec<usize>,
 ) -> Result<Vc<ProcessResult>> {
     let span = tracing::info_span!(
         "process module",
         name = %source.ident().to_string().await?,
         layer = Empty,
-        reference_type = display(&*reference_type)
+        reference_type = display(&reference_type)
     );
     if !span.is_disabled() {
         // Need to use record, otherwise future is not Send for some reason.
@@ -476,7 +476,7 @@ async fn process_default(
 async fn process_default_internal(
     module_asset_context: Vc<ModuleAssetContext>,
     source: ResolvedVc<Box<dyn Source>>,
-    reference_type: Value<ReferenceType>,
+    reference_type: ReferenceType,
     processed_rules: Vec<usize>,
 ) -> Result<Vc<ProcessResult>> {
     let ident = source.ident().resolve().await?;
@@ -487,7 +487,6 @@ async fn process_default_internal(
         module_asset_context.resolve_options_context(),
     );
 
-    let reference_type = reference_type.into_value();
     let part: Option<ModulePart> = match &reference_type {
         ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportPart(part)) => {
             Some(part.clone())
@@ -541,7 +540,7 @@ async fn process_default_internal(
                                 return Ok(transition.process(
                                     *current_source,
                                     module_asset_context,
-                                    Value::new(reference_type),
+                                    reference_type,
                                 ));
                             } else {
                                 let mut processed_rules = processed_rules.clone();
@@ -549,7 +548,7 @@ async fn process_default_internal(
                                 return Box::pin(process_default(
                                     module_asset_context,
                                     current_source,
-                                    Value::new(reference_type),
+                                    reference_type,
                                     processed_rules,
                                 ))
                                 .await;
@@ -703,7 +702,7 @@ impl AssetContext for ModuleAssetContext {
     async fn resolve_options(
         self: Vc<Self>,
         origin_path: Vc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
     ) -> Result<Vc<ResolveOptions>> {
         let this = self.await?;
         let module_asset_context = if let Some(transition) = this.transition {
@@ -724,7 +723,7 @@ impl AssetContext for ModuleAssetContext {
         origin_path: Vc<FileSystemPath>,
         request: Vc<Request>,
         resolve_options: Vc<ResolveOptions>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ModuleResolveResult>> {
         let context_path = origin_path.parent().resolve().await?;
 
@@ -753,7 +752,7 @@ impl AssetContext for ModuleAssetContext {
     async fn process_resolve_result(
         self: Vc<Self>,
         result: Vc<ResolveResult>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ModuleResolveResult>> {
         let this = self.await?;
 
@@ -803,7 +802,7 @@ impl AssetContext for ModuleAssetContext {
                                     // for externals (and otherwise, this causes duplicate
                                     // CachedExternalModules for both `ImportPart(Evaluation)` and
                                     // `ImportPart(Export("CacheProvider"))`)
-                                    let reference_type = Value::new(match &*reference_type {
+                                    let reference_type = match reference_type {
                                         ReferenceType::EcmaScriptModules(_) => {
                                             ReferenceType::EcmaScriptModules(Default::default())
                                         }
@@ -817,7 +816,7 @@ impl AssetContext for ModuleAssetContext {
                                             ReferenceType::Url(Default::default())
                                         }
                                         _ => ReferenceType::Undefined,
-                                    });
+                                    };
 
                                     let external_result = externals_context
                                         .resolve_asset(
@@ -885,7 +884,7 @@ impl AssetContext for ModuleAssetContext {
     async fn process(
         self: Vc<Self>,
         asset: ResolvedVc<Box<dyn Source>>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
         let this = self.await?;
         if let Some(transition) = this.transition {

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 pub use full_context_transition::FullContextTransition;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, ValueDefault, Vc};
+use turbo_tasks::{ResolvedVc, ValueDefault, Vc};
 use turbopack_core::{
     compile_time_info::CompileTimeInfo, context::ProcessResult, module::Module,
     reference_type::ReferenceType, source::Source,
@@ -96,7 +96,7 @@ pub trait Transition {
         self: Vc<Self>,
         asset: Vc<Box<dyn Source>>,
         module_asset_context: Vc<ModuleAssetContext>,
-        reference_type: Value<ReferenceType>,
+        reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
         let asset = self.process_source(asset);
         let module_asset_context = self.process_context(module_asset_context);

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -1,7 +1,7 @@
 //! TODO(WEB-741) Remove this file once Sass is supported.
 
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
@@ -39,7 +39,7 @@ impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
         &self,
         fs_path: ResolvedVc<FileSystemPath>,
         lookup_path: ResolvedVc<FileSystemPath>,
-        _reference_type: Value<ReferenceType>,
+        _reference_type: ReferenceType,
         request: ResolvedVc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let extension = fs_path.extension().await?;

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -368,7 +368,7 @@ async fn node_file_trace_operation(
         rcstr!("test"),
     );
     let module = module_asset_context
-        .process(Vc::upcast(source), Value::new(ReferenceType::Undefined))
+        .process(Vc::upcast(source), ReferenceType::Undefined)
         .module();
 
     let rebased = RebasedAsset::new(Vc::upcast(module), *input_dir, *output_dir)

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -327,14 +327,14 @@ async fn node_file_trace_operation(
     directory: RcStr,
 ) -> Result<Vc<RebasedAsset>> {
     let workspace_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(DiskFileSystem::new(
-        "workspace".into(),
+        rcstr!("workspace"),
         package_root.clone(),
         vec![],
     ));
     let input_dir = workspace_fs.root().to_resolved().await?;
     let input = input_dir.join(format!("tests/{input}").into());
 
-    let output_fs = DiskFileSystem::new("output".into(), directory.clone(), vec![]);
+    let output_fs = DiskFileSystem::new(rcstr!("output"), directory.clone(), vec![]);
     let output_dir = output_fs.root().to_resolved().await?;
 
     let source = FileSource::new(input);
@@ -361,7 +361,7 @@ async fn node_file_trace_operation(
         ResolveOptionsContext {
             enable_node_native_modules: true,
             enable_node_modules: Some(input_dir),
-            custom_conditions: vec!["node".into()],
+            custom_conditions: vec![rcstr!("node")],
             ..Default::default()
         }
         .cell(),


### PR DESCRIPTION
Remove `Value::new` wrapper for `ReferenceType` parameters

### Why?

The `Value<>` type is confusing and error prone, lets destroy it!

As discussed over slack, `turbo_tasks::Value` type always implements `is_resolved` as `true` and `is_transient` as `false` which is incorrect and can enable smuggling transient vcs into turbo tasks. 

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879


Closes PACK-4776