### PR TITLE
[turbopack] Remove Value::new wrapper for Availabilityinfo parameters

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1256,7 +1256,7 @@ impl AppEndpoint {
             *client_references,
             *module_graphs.full,
             *client_chunking_context,
-            Value::new(client_shared_availability_info),
+            client_shared_availability_info,
             ssr_chunking_context.map(|ctx| *ctx),
         )
         .to_resolved()
@@ -1724,7 +1724,7 @@ impl AppEndpoint {
                                 .collect(),
                         ),
                         module_graph,
-                        Value::new(AvailabilityInfo::Root),
+                        AvailabilityInfo::Root,
                     )
                     .await?;
 
@@ -1740,7 +1740,7 @@ impl AppEndpoint {
                             app_entry.rsc_entry.ident(),
                             ChunkGroup::Entry(evaluatable_assets.collect()),
                             module_graph,
-                            Value::new(availability_info),
+                            availability_info,
                         )
                         .resolve()
                         .await?,
@@ -1776,7 +1776,7 @@ impl AppEndpoint {
                                 // TODO this should be ChunkGroup::Shared
                                 ChunkGroup::Entry(server_utils),
                                 module_graph,
-                                Value::new(current_availability_info),
+                                current_availability_info,
                             )
                             .await?;
 
@@ -1814,7 +1814,7 @@ impl AppEndpoint {
                                         server_component.await?.module,
                                     )]),
                                     module_graph,
-                                    Value::new(current_availability_info),
+                                    current_availability_info,
                                 )
                                 .await?;
 
@@ -1843,7 +1843,7 @@ impl AppEndpoint {
                                 Vc::cell(evaluatable_assets),
                                 module_graph,
                                 current_chunks,
-                                Value::new(current_availability_info),
+                                current_availability_info,
                             )
                             .to_resolved()
                             .await?,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -26,7 +26,7 @@ use next_core::{
 };
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, Vc,
+    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
     debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
@@ -75,11 +75,8 @@ pub(crate) async fn collect_next_dynamic_chunks(
                 }
             };
 
-            let async_loader = chunking_context.async_loader_chunk_item(
-                *module,
-                module_graph,
-                Value::new(availability_info),
-            );
+            let async_loader =
+                chunking_context.async_loader_chunk_item(*module, module_graph, availability_info);
             let async_chunk_group = async_loader.references().to_resolved().await?;
 
             let module_id = dynamic_entry

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -125,7 +125,7 @@ impl InstrumentationEndpoint {
             module.ident(),
             ChunkGroup::Entry(evaluatable_assets),
             module_graph,
-            Value::new(AvailabilityInfo::Root),
+            AvailabilityInfo::Root,
         );
 
         Ok(edge_files)
@@ -162,7 +162,7 @@ impl InstrumentationEndpoint {
                 .with_entry(*module),
                 module_graph,
                 OutputAssets::empty(),
-                Value::new(AvailabilityInfo::Root),
+                AvailabilityInfo::Root,
             )
             .await?;
         Ok(*chunk)

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -127,7 +127,7 @@ impl MiddlewareEndpoint {
             module.ident(),
             ChunkGroup::Entry(evaluatable_assets),
             module_graph,
-            Value::new(AvailabilityInfo::Root),
+            AvailabilityInfo::Root,
         );
         Ok(edge_files)
     }
@@ -163,7 +163,7 @@ impl MiddlewareEndpoint {
                 .with_entry(*module),
                 module_graph,
                 OutputAssets::empty(),
-                Value::new(AvailabilityInfo::Root),
+                AvailabilityInfo::Root,
             )
             .await?;
         Ok(*chunk)

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -842,7 +842,7 @@ impl PageEndpoint {
                 AssetIdent::from_path(*this.page.await?.base_path),
                 ChunkGroup::Entry(evaluatable_assets),
                 module_graph,
-                Value::new(AvailabilityInfo::Root),
+                AvailabilityInfo::Root,
             );
 
             Ok(client_chunk_group)
@@ -1038,7 +1038,7 @@ impl PageEndpoint {
                             layout.ident(),
                             ChunkGroup::Shared(layout),
                             ssr_module_graph,
-                            Value::new(current_availability_info),
+                            current_availability_info,
                         )
                         .await?;
 
@@ -1068,7 +1068,7 @@ impl PageEndpoint {
                     ssr_module.ident(),
                     ChunkGroup::Entry(evaluatable_assets.collect()),
                     ssr_module_graph,
-                    Value::new(current_availability_info),
+                    current_availability_info,
                 );
 
                 Ok(SsrChunk::Edge {
@@ -1090,7 +1090,7 @@ impl PageEndpoint {
                         runtime_entries.with_entry(*ssr_module_evaluatable),
                         ssr_module_graph,
                         current_chunks,
-                        Value::new(current_availability_info),
+                        current_availability_info,
                     )
                     .to_resolved()
                     .await?;

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -1,9 +1,7 @@
 use anyhow::Result;
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{
-    FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc,
-};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkingContext, availability_info::AvailabilityInfo},
     module::Module,
@@ -41,7 +39,7 @@ pub async fn get_app_client_references_chunks(
     app_client_references: Vc<ClientReferenceGraphResult>,
     module_graph: Vc<ModuleGraph>,
     client_chunking_context: Vc<Box<dyn ChunkingContext>>,
-    client_availability_info: Value<AvailabilityInfo>,
+    client_availability_info: AvailabilityInfo,
     ssr_chunking_context: Option<Vc<Box<dyn ChunkingContext>>>,
 ) -> Result<Vc<ClientReferencesChunks>> {
     async move {
@@ -161,7 +159,7 @@ pub async fn get_app_client_references_chunks(
 
             let chunk_group_info = module_graph.chunk_group_info();
 
-            let mut current_client_availability_info = client_availability_info.into_value();
+            let mut current_client_availability_info = client_availability_info;
             let mut current_client_chunks = OutputAssets::empty().to_resolved().await?;
             let mut current_ssr_availability_info = AvailabilityInfo::Root;
             let mut current_ssr_chunks = OutputAssets::empty().to_resolved().await?;
@@ -221,7 +219,7 @@ pub async fn get_app_client_references_chunks(
                                 entries: ssr_modules,
                             },
                             module_graph,
-                            Value::new(current_ssr_availability_info),
+                            current_ssr_availability_info,
                         )
                     })
                 } else {
@@ -259,7 +257,7 @@ pub async fn get_app_client_references_chunks(
                             entries: client_modules,
                         },
                         module_graph,
-                        Value::new(current_client_availability_info),
+                        current_client_availability_info,
                     ))
                 } else {
                     None

--- a/crates/next-core/src/next_app/app_client_shared_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_shared_chunks.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use tracing::Instrument;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     chunk::{
         ChunkGroupResult, ChunkingContext, EvaluatableAssets, availability_info::AvailabilityInfo,
@@ -38,7 +38,7 @@ pub async fn get_app_client_shared_chunk_group(
                         .collect(),
                 ),
                 module_graph,
-                Value::new(AvailabilityInfo::Root),
+                AvailabilityInfo::Root,
             )
             .resolve()
             .await

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -524,13 +524,13 @@ impl ChunkingContext for BrowserChunkingContext {
         ident: Vc<AssetIdent>,
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!("chunking", ident = ident.to_string().await?.to_string());
         async move {
             let this = self.await?;
             let modules = chunk_group.entries();
-            let input_availability_info = availability_info.into_value();
+            let input_availability_info = availability_info;
             let MakeChunkGroupResult {
                 chunks,
                 availability_info,
@@ -588,7 +588,7 @@ impl ChunkingContext for BrowserChunkingContext {
         ident: Vc<AssetIdent>,
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = {
             let ident = ident.to_string().await?.to_string();
@@ -596,7 +596,6 @@ impl ChunkingContext for BrowserChunkingContext {
         };
         async move {
             let this = self.await?;
-            let availability_info = availability_info.into_value();
 
             let entries = chunk_group.entries();
 
@@ -665,7 +664,7 @@ impl ChunkingContext for BrowserChunkingContext {
         _evaluatable_assets: Vc<EvaluatableAssets>,
         _module_graph: Vc<ModuleGraph>,
         _extra_chunks: Vc<OutputAssets>,
-        _availability_info: Value<AvailabilityInfo>,
+        _availability_info: AvailabilityInfo,
     ) -> Result<Vc<EntryChunkGroupResult>> {
         bail!("Browser chunking context does not support entry chunk groups")
     }
@@ -680,7 +679,7 @@ impl ChunkingContext for BrowserChunkingContext {
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
         module_graph: Vc<ModuleGraph>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
         Ok(if self.await?.manifest_chunks {
             let manifest_asset =

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -439,7 +439,7 @@ async fn build_internal(
                                         [ResolvedVc::upcast(ecmascript)].into_iter().collect(),
                                     ),
                                     module_graph,
-                                    Value::new(AvailabilityInfo::Root),
+                                    AvailabilityInfo::Root,
                                 )
                                 .await?
                                 .assets
@@ -462,7 +462,7 @@ async fn build_internal(
                                     EvaluatableAssets::one(*ResolvedVc::upcast(ecmascript)),
                                     module_graph,
                                     OutputAssets::empty(),
-                                    Value::new(AvailabilityInfo::Root),
+                                    AvailabilityInfo::Root,
                                 )
                                 .await?
                                 .asset,

--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ResolvedVc, TaskInput, Vc};
 
 use super::available_modules::{AvailableModules, AvailableModulesSet};
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Hash, Clone, Copy, Debug)]
+#[derive(Hash, Clone, Copy, Debug, TaskInput)]
 pub enum AvailabilityInfo {
     /// Availability of modules is not tracked
     Untracked,

--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -1,10 +1,22 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TaskInput, Vc};
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 
 use super::available_modules::{AvailableModules, AvailableModulesSet};
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Hash, Clone, Copy, Debug, TaskInput)]
+#[derive(
+    Eq,
+    PartialEq,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    TaskInput,
+    TraceRawVcs,
+    NonLocalValue,
+    Serialize,
+    Deserialize,
+)]
 pub enum AvailabilityInfo {
     /// Availability of modules is not tracked
     Untracked,

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result};
 use rustc_hash::FxHashMap;
-use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
 
 use super::{
     Chunk, ChunkGroupContent, ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkingContext,
@@ -105,7 +105,7 @@ pub async fn make_chunk_group(
         .into_iter()
         .map(async |module| {
             chunking_context
-                .async_loader_chunk_item(*module, module_graph, Value::new(availability_info))
+                .async_loader_chunk_item(*module, module_graph, availability_info)
                 .to_resolved()
                 .await
         })

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -3,7 +3,7 @@ use mime_guess::mime::TEXT_HTML_UTF_8;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Value, Vc, trace::TraceRawVcs,
+    NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbo_tasks_hash::{Xxh3Hash64Hasher, encode_hex};
@@ -159,7 +159,7 @@ impl DevHtmlAsset {
                                 .collect(),
                         ),
                         *module_graph,
-                        Value::new(AvailabilityInfo::Root),
+                        AvailabilityInfo::Root,
                     )
                 } else {
                     chunking_context.root_chunk_group_assets(

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{
         ChunkData, ChunkItem, ChunkType, ChunkingContext, ChunkingContextExt, ChunksData,
@@ -54,7 +54,7 @@ impl AsyncLoaderChunkItem {
             module.inner.ident(),
             ChunkGroup::Async(ResolvedVc::upcast(module.inner)),
             *self.module_graph,
-            Value::new(module.availability_info),
+            module.availability_info,
         ))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, availability_info::AvailabilityInfo},
@@ -27,12 +27,12 @@ impl AsyncLoaderModule {
     pub fn new(
         module: ResolvedVc<Box<dyn ChunkableModule>>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Vc<Self> {
         Self::cell(AsyncLoaderModule {
             inner: module,
             chunking_context,
-            availability_info: availability_info.into_value(),
+            availability_info,
         })
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -44,13 +44,13 @@ impl ManifestAsyncModule {
         module: ResolvedVc<Box<dyn ChunkableModule>>,
         module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Vc<Self> {
         Self::cell(ManifestAsyncModule {
             inner: module,
             module_graph,
             chunking_context,
-            availability_info: availability_info.into_value(),
+            availability_info,
         })
     }
 
@@ -60,7 +60,7 @@ impl ManifestAsyncModule {
             self.inner.ident(),
             ChunkGroup::Async(ResolvedVc::upcast(self.inner)),
             *self.module_graph,
-            Value::new(self.availability_info),
+            self.availability_info,
         )
     }
 
@@ -85,7 +85,7 @@ impl ManifestAsyncModule {
             self.ident(),
             ChunkGroup::Async(ResolvedVc::upcast(self)),
             *this.module_graph,
-            Value::new(this.availability_info),
+            this.availability_info,
         ))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{
         ChunkData, ChunkItem, ChunkType, ChunkingContext, ChunkingContextExt, ChunksData,
@@ -40,7 +40,7 @@ impl WorkerLoaderChunkItem {
             module.inner.ident().with_modifier(rcstr!("worker")),
             ChunkGroup::Isolated(ResolvedVc::upcast(module.inner)),
             *self.module_graph,
-            Value::new(AvailabilityInfo::Root),
+            AvailabilityInfo::Root,
         ))
     }
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -345,7 +345,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         ident: Vc<AssetIdent>,
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!("chunking", module = ident.to_string().await?.to_string());
         async move {
@@ -357,7 +357,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 modules,
                 module_graph,
                 ResolvedVc::upcast(self),
-                availability_info.into_value(),
+                availability_info,
             )
             .await?;
 
@@ -384,10 +384,8 @@ impl ChunkingContext for NodeJsChunkingContext {
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Result<Vc<EntryChunkGroupResult>> {
-        let availability_info = availability_info.into_value();
-
         let evaluatable_assets_ref = evaluatable_assets.await?;
         let entries = evaluatable_assets_ref
             .iter()
@@ -447,7 +445,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         _ident: Vc<AssetIdent>,
         _chunk_group: ChunkGroup,
         _module_graph: Vc<ModuleGraph>,
-        _availability_info: Value<AvailabilityInfo>,
+        _availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
         // TODO(alexkirsz) This method should be part of a separate trait that is
         // only implemented for client/edge runtimes.
@@ -464,7 +462,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
         module_graph: Vc<ModuleGraph>,
-        availability_info: Value<AvailabilityInfo>,
+        availability_info: AvailabilityInfo,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
         Ok(if self.await?.manifest_chunks {
             let manifest_asset =

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -410,7 +410,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 entry_module.ident(),
                 ChunkGroup::Entry(all_modules.into_iter().collect()),
                 module_graph,
-                Value::new(AvailabilityInfo::Root),
+                AvailabilityInfo::Root,
             ),
             Runtime::NodeJs => {
                 Vc::cell(vec![
@@ -434,7 +434,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                             evaluatable_assets,
                             module_graph,
                             OutputAssets::empty(),
-                            Value::new(AvailabilityInfo::Root),
+                            AvailabilityInfo::Root,
                         )
                         .await?
                         .asset,


### PR DESCRIPTION
Remove Value::new wrapper for Availabilityinfo parameters

### Why?
The Value<> type is confusing and error prone, lets destroy it!

As discussed over slack, turbo_tasks::Value type always implements is_resolved as true and is_transient as false which is incorrect and can enable smuggling transient vcs into turbo tasks.

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879

Closes PACK-4784