### PR TITLE
[turbopack] Remove Value::new wrapper for ServerContextType parameters

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -237,7 +237,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.rsc_ty().owned().await?),
+            self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -250,7 +250,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.rsc_ty().owned().await?),
+            self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -263,7 +263,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.route_ty().owned().await?),
+            self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -276,7 +276,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.route_ty().owned().await?),
+            self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -288,7 +288,7 @@ impl AppProject {
     async fn rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.rsc_ty().owned().await?),
+            self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -299,7 +299,7 @@ impl AppProject {
     async fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.rsc_ty().owned().await?),
+            self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -310,7 +310,7 @@ impl AppProject {
     async fn route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.route_ty().owned().await?),
+            self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -323,7 +323,7 @@ impl AppProject {
     ) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.route_ty().owned().await?),
+            self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -587,7 +587,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.ssr_ty().owned().await?),
+            self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -600,7 +600,7 @@ impl AppProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(self.ssr_ty().owned().await?),
+            self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -612,7 +612,7 @@ impl AppProject {
     async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.ssr_ty().owned().await?),
+            self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -623,7 +623,7 @@ impl AppProject {
     async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
-            Value::new(self.ssr_ty().owned().await?),
+            self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -755,7 +755,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
-            Value::new(self.rsc_ty().owned().await?),
+            self.rsc_ty().owned().await?,
             self.project().next_mode(),
         ))
     }

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -7,7 +7,7 @@ use next_core::{
 };
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Completion, ResolvedVc, Value, Vc};
+use turbo_tasks::{Completion, ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -105,12 +105,12 @@ impl InstrumentationEndpoint {
         let module_graph = this.project.module_graph(*module);
 
         let evaluatable_assets = get_server_runtime_entries(
-            Value::new(ServerContextType::Instrumentation {
+            ServerContextType::Instrumentation {
                 app_dir: this.app_dir,
                 ecmascript_client_reference_transition_name: this
                     .ecmascript_client_reference_transition_name
                     .clone(),
-            }),
+            },
             this.project.next_mode(),
         )
         .resolve_entries(*this.asset_context)
@@ -150,12 +150,12 @@ impl InstrumentationEndpoint {
                     .node_root()
                     .join(rcstr!("server/instrumentation.js")),
                 get_server_runtime_entries(
-                    Value::new(ServerContextType::Instrumentation {
+                    ServerContextType::Instrumentation {
                         app_dir: this.app_dir,
                         ecmascript_client_reference_transition_name: this
                             .ecmascript_client_reference_transition_name
                             .clone(),
-                    }),
+                    },
                     this.project.next_mode(),
                 )
                 .resolve_entries(*this.asset_context)

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -11,7 +11,7 @@ use next_core::{
 };
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Completion, ResolvedVc, Value, Vc};
+use turbo_tasks::{Completion, ResolvedVc, Vc};
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -107,12 +107,12 @@ impl MiddlewareEndpoint {
         let module_graph = this.project.module_graph(*module);
 
         let evaluatable_assets = get_server_runtime_entries(
-            Value::new(ServerContextType::Middleware {
+            ServerContextType::Middleware {
                 app_dir: this.app_dir,
                 ecmascript_client_reference_transition_name: this
                     .ecmascript_client_reference_transition_name
                     .clone(),
-            }),
+            },
             this.project.next_mode(),
         )
         .resolve_entries(*this.asset_context)
@@ -151,12 +151,12 @@ impl MiddlewareEndpoint {
                     .node_root()
                     .join(rcstr!("server/middleware.js")),
                 get_server_runtime_entries(
-                    Value::new(ServerContextType::Middleware {
+                    ServerContextType::Middleware {
                         app_dir: this.app_dir,
                         ecmascript_client_reference_transition_name: this
                             .ecmascript_client_reference_transition_name
                             .clone(),
-                    }),
+                    },
                     this.project.next_mode(),
                 )
                 .resolve_entries(*this.asset_context)

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -443,9 +443,9 @@ impl PagesProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(ServerContextType::Pages {
+            ServerContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -458,9 +458,9 @@ impl PagesProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(ServerContextType::Pages {
+            ServerContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -473,9 +473,9 @@ impl PagesProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(ServerContextType::PagesApi {
+            ServerContextType::PagesApi {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -488,9 +488,9 @@ impl PagesProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(ServerContextType::PagesApi {
+            ServerContextType::PagesApi {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -503,9 +503,9 @@ impl PagesProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(ServerContextType::PagesData {
+            ServerContextType::PagesData {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
@@ -520,9 +520,9 @@ impl PagesProject {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
-            Value::new(ServerContextType::PagesData {
+            ServerContextType::PagesData {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
@@ -537,9 +537,9 @@ impl PagesProject {
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
-            Value::new(ServerContextType::Pages {
+            ServerContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -553,9 +553,9 @@ impl PagesProject {
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
-            Value::new(ServerContextType::Pages {
+            ServerContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
@@ -579,9 +579,9 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
-            Value::new(ServerContextType::Pages {
+            ServerContextType::Pages {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
         ))
     }
@@ -589,9 +589,9 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
-            Value::new(ServerContextType::PagesData {
+            ServerContextType::PagesData {
                 pages_dir: self.pages_dir().to_resolved().await?,
-            }),
+            },
             self.project().next_mode(),
         ))
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -25,7 +25,7 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Completions, FxIndexMap, IntoTraitRef, NonLocalValue, OperationValue, OperationVc,
-    ReadRef, ResolvedVc, State, TaskInput, TransientInstance, TryFlatJoinIterExt, Value, Vc,
+    ReadRef, ResolvedVc, State, TaskInput, TransientInstance, TryFlatJoinIterExt, Vc,
     debug::ValueDebugFormat,
     fxindexmap,
     graph::{AdjacencyMap, GraphTraversal},
@@ -1289,11 +1289,11 @@ impl Project {
             get_server_module_options_context(
                 self.project_path(),
                 self.execution_context(),
-                Value::new(ServerContextType::Middleware {
+                ServerContextType::Middleware {
                     app_dir,
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 NextRuntime::Edge,
@@ -1301,11 +1301,11 @@ impl Project {
             ),
             get_edge_resolve_options_context(
                 self.project_path(),
-                Value::new(ServerContextType::Middleware {
+                ServerContextType::Middleware {
                     app_dir,
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 self.execution_context(),
@@ -1344,11 +1344,11 @@ impl Project {
             get_server_module_options_context(
                 self.project_path(),
                 self.execution_context(),
-                Value::new(ServerContextType::Middleware {
+                ServerContextType::Middleware {
                     app_dir,
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 NextRuntime::NodeJs,
@@ -1356,10 +1356,10 @@ impl Project {
             ),
             get_server_resolve_options_context(
                 self.project_path(),
-                Value::new(ServerContextType::Middleware {
+                ServerContextType::Middleware {
                     app_dir,
                     ecmascript_client_reference_transition_name,
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 self.execution_context(),
@@ -1456,11 +1456,11 @@ impl Project {
             get_server_module_options_context(
                 self.project_path(),
                 self.execution_context(),
-                Value::new(ServerContextType::Instrumentation {
+                ServerContextType::Instrumentation {
                     app_dir,
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 NextRuntime::NodeJs,
@@ -1468,10 +1468,10 @@ impl Project {
             ),
             get_server_resolve_options_context(
                 self.project_path(),
-                Value::new(ServerContextType::Instrumentation {
+                ServerContextType::Instrumentation {
                     app_dir,
                     ecmascript_client_reference_transition_name,
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 self.execution_context(),
@@ -1511,11 +1511,11 @@ impl Project {
             get_server_module_options_context(
                 self.project_path(),
                 self.execution_context(),
-                Value::new(ServerContextType::Instrumentation {
+                ServerContextType::Instrumentation {
                     app_dir,
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 NextRuntime::Edge,
@@ -1523,10 +1523,10 @@ impl Project {
             ),
             get_edge_resolve_options_context(
                 self.project_path(),
-                Value::new(ServerContextType::Instrumentation {
+                ServerContextType::Instrumentation {
                     app_dir,
                     ecmascript_client_reference_transition_name,
-                }),
+                },
                 self.next_mode(),
                 self.next_config(),
                 self.execution_context(),

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -104,7 +104,7 @@ pub async fn get_edge_compile_time_info(
 #[turbo_tasks::function]
 pub async fn get_edge_resolve_options_context(
     project_path: ResolvedVc<FileSystemPath>,
-    ty: Value<ServerContextType>,
+    ty: ServerContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -118,8 +118,6 @@ pub async fn get_edge_resolve_options_context(
     )
     .to_resolved()
     .await?;
-
-    let ty: ServerContextType = ty.into_value();
 
     let mut before_resolve_plugins = vec![ResolvedVc::upcast(
         ModuleFeatureReportResolvePlugin::new(*project_path)

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -287,7 +287,7 @@ pub async fn get_next_client_fallback_import_map(ty: ClientContextType) -> Resul
 #[turbo_tasks::function]
 pub async fn get_next_server_import_map(
     project_path: ResolvedVc<FileSystemPath>,
-    ty: Value<ServerContextType>,
+    ty: ServerContextType,
     next_config: Vc<NextConfig>,
     next_mode: Vc<NextMode>,
     execution_context: Vc<ExecutionContext>,
@@ -311,8 +311,6 @@ pub async fn get_next_server_import_map(
         [],
     )
     .await?;
-
-    let ty = ty.into_value();
 
     let external = ImportMapping::External(None, ExternalType::CommonJs, ExternalTraced::Traced)
         .resolved_cell();
@@ -384,7 +382,7 @@ pub async fn get_next_server_import_map(
 #[turbo_tasks::function]
 pub async fn get_next_edge_import_map(
     project_path: ResolvedVc<FileSystemPath>,
-    ty: Value<ServerContextType>,
+    ty: ServerContextType,
     next_config: Vc<NextConfig>,
     next_mode: Vc<NextMode>,
     execution_context: Vc<ExecutionContext>,
@@ -453,7 +451,6 @@ pub async fn get_next_edge_import_map(
     )
     .await?;
 
-    let ty = ty.into_value();
     match &ty {
         ServerContextType::Pages { .. }
         | ServerContextType::PagesData { .. }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Value, Vc};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
@@ -79,7 +79,7 @@ use crate::{
 };
 
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub enum ServerContextType {
     Pages {
         pages_dir: ResolvedVc<FileSystemPath>,
@@ -128,7 +128,7 @@ impl ServerContextType {
 #[turbo_tasks::function]
 pub async fn get_server_resolve_options_context(
     project_path: ResolvedVc<FileSystemPath>,
-    ty: Value<ServerContextType>,
+    ty: ServerContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
@@ -193,8 +193,6 @@ pub async fn get_server_resolve_options_context(
 
     external_packages.retain(|item| !transpiled_packages.contains(item));
 
-    let ty = ty.into_value();
-
     let server_external_packages_plugin = ExternalCjsModulesResolvePlugin::new(
         *project_path,
         project_path.root(),
@@ -234,7 +232,7 @@ pub async fn get_server_resolve_options_context(
         .to_resolved()
         .await?;
     let next_node_shared_runtime_plugin =
-        NextNodeSharedRuntimeResolvePlugin::new(*project_path, Value::new(ty.clone()))
+        NextNodeSharedRuntimeResolvePlugin::new(*project_path, ty.clone())
             .to_resolved()
             .await?;
 
@@ -411,7 +409,7 @@ pub async fn get_server_compile_time_info(
 pub async fn get_server_module_options_context(
     project_path: ResolvedVc<FileSystemPath>,
     execution_context: ResolvedVc<ExecutionContext>,
-    ty: Value<ServerContextType>,
+    ty: ServerContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
     next_runtime: NextRuntime,
@@ -420,7 +418,7 @@ pub async fn get_server_module_options_context(
     let next_mode = mode.await?;
     let mut next_server_rules = get_next_server_transforms_rules(
         next_config,
-        ty.clone().into_value(),
+        ty.clone(),
         mode,
         false,
         next_runtime,
@@ -429,7 +427,7 @@ pub async fn get_server_module_options_context(
     .await?;
     let mut foreign_next_server_rules = get_next_server_transforms_rules(
         next_config,
-        ty.clone().into_value(),
+        ty.clone(),
         mode,
         true,
         next_runtime,
@@ -437,7 +435,7 @@ pub async fn get_server_module_options_context(
     )
     .await?;
     let mut internal_custom_rules = get_next_server_internal_transforms_rules(
-        ty.clone().into_value(),
+        ty.clone(),
         next_config.mdx_rs().await?.is_some(),
     )
     .await?;
@@ -570,7 +568,6 @@ pub async fn get_server_module_options_context(
         ..Default::default()
     };
 
-    let ty = ty.into_value();
     let module_options_context = match ty {
         ServerContextType::Pages { .. }
         | ServerContextType::PagesData { .. }
@@ -976,7 +973,7 @@ pub async fn get_server_module_options_context(
 
 #[turbo_tasks::function]
 pub fn get_server_runtime_entries(
-    _ty: Value<ServerContextType>,
+    _ty: ServerContextType,
     _mode: Vc<NextMode>,
 ) -> Vc<RuntimeEntries> {
     let runtime_entries = vec![];

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use lazy_static::lazy_static;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 use turbopack_core::{
     diagnostics::DiagnosticExt,
@@ -263,9 +263,8 @@ impl NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     pub fn new(
         root: ResolvedVc<FileSystemPath>,
-        server_context_type: Value<ServerContextType>,
+        server_context_type: ServerContextType,
     ) -> Vc<Self> {
-        let server_context_type = server_context_type.into_value();
         NextNodeSharedRuntimeResolvePlugin {
             root,
             server_context_type,


### PR DESCRIPTION
Remove Value::new wrapper for ServerContextType parameters

### Why?
The Value<> type is confusing and error prone, lets destroy it!

As discussed over slack, turbo_tasks::Value type always implements is_resolved as true and is_transient as false which is incorrect and can enable smuggling transient vcs into turbo tasks.

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879

Closes PACK-4785