### PR TITLE
[turbopack] Replace uses of `Value<Pattern>` with just `Pattern`


### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc,
+    Completion, FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
     fxindexmap, fxindexset, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{CustomProcessEnv, ProcessEnv};
@@ -823,9 +823,9 @@ impl AppProject {
                 client_module_context,
                 self.project().project_path().join(rcstr!("_")),
             )),
-            Request::parse(Value::new(Pattern::Constant(rcstr!(
+            Request::parse(Pattern::Constant(rcstr!(
                 "next/dist/client/app-next-turbopack.js"
-            )))),
+            ))),
             None,
             false,
         )

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -629,13 +629,12 @@ impl PagesProject {
                 client_module_context,
                 self.project().project_path().join(rcstr!("_")),
             )),
-            Request::parse(Value::new(Pattern::Constant(
+            Request::parse(Pattern::Constant(
                 match *self.project().next_mode().await? {
-                    NextMode::Development => "next/dist/client/next-dev-turbopack.js",
-                    NextMode::Build => "next/dist/client/next-turbopack.js",
-                }
-                .into(),
-            ))),
+                    NextMode::Development => rcstr!("next/dist/client/next-dev-turbopack.js"),
+                    NextMode::Build => rcstr!("next/dist/client/next-turbopack.js"),
+                },
+            )),
             Value::new(EcmaScriptModulesReferenceSubType::Undefined),
             false,
             None,

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -530,9 +530,9 @@ pub async fn get_client_runtime_entries(
     if matches!(ty, ClientContextType::App { .. },) {
         runtime_entries.push(
             RuntimeEntry::Request(
-                Request::parse(Value::new(Pattern::Constant(rcstr!(
+                Request::parse(Pattern::Constant(rcstr!(
                     "next/dist/client/app-next-turbopack.js"
-                ))))
+                )))
                 .to_resolved()
                 .await?,
                 project_root.join(rcstr!("_")).to_resolved().await?,

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context, Result};
 use rustc_hash::FxHashMap;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, Vc, fxindexmap};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::{
     reference_type::{CommonJsReferenceSubType, ReferenceType},
@@ -1009,7 +1009,7 @@ pub async fn get_next_package(context_directory: Vc<FileSystemPath>) -> Result<V
     let result = resolve(
         context_directory,
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
-        Request::parse(Value::new(Pattern::Constant(rcstr!("next/package.json")))),
+        Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
         node_cjs_resolve_options(context_directory.root()),
     );
     let source = result

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -36,13 +36,13 @@ pub async fn get_swc_ecma_transform_rule_impl(
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {
     use anyhow::bail;
-    use turbo_tasks::{TryFlatJoinIterExt, Value};
+    use turbo_tasks::TryFlatJoinIterExt;
     use turbo_tasks_fs::FileContent;
     use turbopack::{resolve_options, resolve_options_context::ResolveOptionsContext};
     use turbopack_core::{
         asset::Asset,
         reference_type::{CommonJsReferenceSubType, ReferenceType},
-        resolve::{handle_resolve_error, parse::Request, pattern::Pattern, resolve},
+        resolve::{handle_resolve_error, parse::Request, resolve},
     };
     use turbopack_ecmascript_plugins::transform::swc_ecma_transform_plugins::{
         SwcEcmaTransformPluginsTransformer, SwcPluginModule,
@@ -58,7 +58,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
             // one for implicit package name resolves to node_modules,
             // and one for explicit path to a .wasm binary.
             // Current resolve will fail with latter.
-            let request = Request::parse(Value::new(Pattern::Constant(name.as_str().into())));
+            let request = Request::parse_string(name.clone());
             let resolve_options = resolve_options(
                 *project_path,
                 ResolveOptionsContext {

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{self, FileSystemEntryType, FileSystemPath};
 use turbopack::module_options::{LoaderRuleItem, OptionWebpackRules, WebpackRules};
 use turbopack_core::{
@@ -115,9 +115,7 @@ pub async fn is_babel_loader_available(project_path: Vc<FileSystemPath>) -> Resu
     let result = resolve(
         project_path,
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
-        Request::parse(Value::new(Pattern::Constant(
-            "babel-loader/package.json".into(),
-        ))),
+        Request::parse(Pattern::Constant("babel-loader/package.json".into())),
         node_cjs_resolve_options(project_path),
     );
     let assets = result.primary_sources().await?;

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -259,14 +259,14 @@ async fn build_internal(
         .map(|r| async move {
             Ok(match r {
                 EntryRequest::Relative(p) => Request::relative(
-                    Value::new(p.clone().into()),
+                    p.clone().into(),
                     Default::default(),
                     Default::default(),
                     false,
                 ),
                 EntryRequest::Module(m, p) => Request::module(
                     m.clone(),
-                    Value::new(p.clone().into()),
+                    p.clone().into(),
                     Default::default(),
                     Default::default(),
                 ),

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -13,7 +13,7 @@ use owo_colors::OwoColorize;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    NonLocalValue, OperationVc, ResolvedVc, TransientInstance, TurboTasks, UpdateInfo, Value, Vc,
+    NonLocalValue, OperationVc, ResolvedVc, TransientInstance, TurboTasks, UpdateInfo, Vc,
     trace::TraceRawVcs,
     util::{FormatBytes, FormatDuration},
 };
@@ -310,14 +310,14 @@ async fn source(
         .iter()
         .map(|r| match r {
             EntryRequest::Relative(p) => Request::relative(
-                Value::new(p.clone().into()),
+                p.clone().into(),
                 Default::default(),
                 Default::default(),
                 false,
             ),
             EntryRequest::Module(m, p) => Request::module(
                 m.clone(),
-                Value::new(p.clone().into()),
+                p.clone().into(),
                 Default::default(),
                 Default::default(),
             ),

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
     debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
@@ -441,9 +441,7 @@ async fn import_mapping_to_result(
             ImportMapResult::Result(ResolveResult::primary(ResolveResultItem::Empty))
         }
         ReplacedImportMapping::PrimaryAlternative(name, context) => {
-            let request = Request::parse(Value::new(name.clone()))
-                .to_resolved()
-                .await?;
+            let request = Request::parse(name.clone()).to_resolved().await?;
             ImportMapResult::Alias(request, *context)
         }
         ReplacedImportMapping::Alternatives(list) => ImportMapResult::Alternatives(

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -276,7 +276,7 @@ impl AliasTemplate for Vc<ImportMapping> {
                         .await?,
                 ),
                 ImportMapping::Dynamic(replacement) => {
-                    (*replacement.replace(capture.clone().cell()).await?).clone()
+                    (*replacement.replace(Pattern::new(capture.clone())).await?).clone()
                 }
             }
             .resolved_cell())

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -674,7 +674,7 @@ impl Request {
     /// more complete.
     #[turbo_tasks::function]
     pub async fn request_pattern(self: Vc<Self>) -> Result<Vc<Pattern>> {
-        Ok(match &*self.await? {
+        Ok(Pattern::new(match &*self.await? {
             Request::Raw { path, .. } => path.clone(),
             Request::Relative { path, .. } => path.clone(),
             Request::Module { module, path, .. } => {
@@ -712,8 +712,7 @@ impl Request {
                     .try_join()
                     .await?,
             ),
-        }
-        .cell())
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -301,6 +301,10 @@ impl Request {
                 .await?,
         })
     }
+
+    pub fn parse_string(request: RcStr) -> Vc<Self> {
+        Self::parse(request.into())
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -308,11 +312,6 @@ impl Request {
     #[turbo_tasks::function]
     pub async fn parse(request: Pattern) -> Result<Vc<Self>> {
         Ok(Self::cell(Request::parse_ref(request).await?))
-    }
-
-    #[turbo_tasks::function]
-    pub async fn parse_string(request: RcStr) -> Result<Vc<Self>> {
-        Ok(Self::cell(Request::parse_ref(request.into()).await?))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -20,7 +20,7 @@ use turbo_tasks_fs::{
     util::normalize_path,
 };
 
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Hash, Clone, Debug, Default)]
 pub enum Pattern {
     Constant(RcStr),

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1180,8 +1180,9 @@ impl Pattern {
 }
 
 impl Pattern {
-    pub fn new(pattern: Pattern) -> Vc<Self> {
-        Pattern::new_internal(Value::new(pattern))
+    pub fn new(mut pattern: Pattern) -> Vc<Self> {
+        pattern.normalize();
+        Pattern::new_internal(pattern)
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -5,7 +5,7 @@ use indoc::formatdoc;
 use lightningcss::css_modules::CssModuleReference;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -195,9 +195,7 @@ impl ModuleCssAsset {
                                 original: name.to_string(),
                                 from: CssModuleComposeReference::new(
                                     Vc::upcast(self),
-                                    Request::parse(Value::new(
-                                        RcStr::from(specifier.clone()).into(),
-                                    )),
+                                    Request::parse(RcStr::from(specifier.clone()).into()),
                                 )
                                 .to_resolved()
                                 .await?,

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -102,7 +102,7 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
 
                 self.references.push(Vc::upcast(ImportAssetReference::new(
                     *self.origin,
-                    Request::parse(Value::new(RcStr::from(src).into())),
+                    Request::parse(RcStr::from(src).into()),
                     ImportAttributes::new_from_lightningcss(&i.clone().into_owned()).into(),
                     self.import_context.map(|ctx| *ctx),
                     IssueSource::from_line_col(
@@ -139,7 +139,7 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
 
             let vc = UrlAssetReference::new(
                 *self.origin,
-                Request::parse(Value::new(RcStr::from(src).into())),
+                Request::parse(RcStr::from(src).into()),
                 IssueSource::from_line_col(
                     ResolvedVc::upcast(self.source),
                     SourcePos {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -738,7 +738,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             let mut should_add_evaluation = false;
             let reference = EsmAssetReference::new(
                 origin,
-                Request::parse(Value::new(RcStr::from(&*r.module_path).into()))
+                Request::parse(RcStr::from(&*r.module_path).into())
                     .to_resolved()
                     .await?,
                 r.issue_source
@@ -915,9 +915,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     if let Some((request, webpack_runtime_span)) = webpack_runtime {
         let span = tracing::info_span!("webpack runtime reference");
         async {
-            let request = Request::parse(Value::new(request.into()))
-                .to_resolved()
-                .await?;
+            let request = Request::parse(request.into()).to_resolved().await?;
             let runtime = resolve_as_webpack_runtime(*origin, *request, *transforms)
                 .to_resolved()
                 .await?;
@@ -1625,7 +1623,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     analysis.add_reference_code_gen(
                         UrlAssetReference::new(
                             origin,
-                            Request::parse(Value::new(pat)).to_resolved().await?,
+                            Request::parse(pat).to_resolved().await?,
                             *compile_time_info.environment().rendering().await?,
                             issue_source(source, span),
                             in_try,
@@ -1658,7 +1656,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         analysis.add_reference_code_gen(
                             WorkerAssetReference::new(
                                 origin,
-                                Request::parse(Value::new(pat)).to_resolved().await?,
+                                Request::parse(pat).to_resolved().await?,
                                 issue_source(source, span),
                                 in_try,
                             ),
@@ -1747,7 +1745,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 analysis.add_reference_code_gen(
                     EsmAsyncAssetReference::new(
                         origin,
-                        Request::parse(Value::new(pat)).to_resolved().await?,
+                        Request::parse(pat).to_resolved().await?,
                         issue_source(source, span),
                         Value::new(import_annotations),
                         in_try,
@@ -1787,7 +1785,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 analysis.add_reference_code_gen(
                     CjsRequireAssetReference::new(
                         origin,
-                        Request::parse(Value::new(pat)).to_resolved().await?,
+                        Request::parse(pat).to_resolved().await?,
                         issue_source(source, span),
                         in_try,
                     ),
@@ -1839,7 +1837,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 analysis.add_reference_code_gen(
                     CjsRequireResolveAssetReference::new(
                         origin,
-                        Request::parse(Value::new(pat)).to_resolved().await?,
+                        Request::parse(pat).to_resolved().await?,
                         issue_source(source, span),
                         in_try,
                     ),
@@ -2027,7 +2025,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         analysis.add_reference(
                             CjsAssetReference::new(
                                 *origin,
-                                Request::parse(Value::new(pat)),
+                                Request::parse(pat),
                                 issue_source(source, span),
                                 in_try,
                             )
@@ -2089,7 +2087,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 analysis.add_reference(
                     CjsAssetReference::new(
                         *origin,
-                        Request::parse(Value::new(pat)),
+                        Request::parse(pat),
                         issue_source(source, span),
                         in_try,
                     )
@@ -2267,7 +2265,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                 analysis.add_reference(
                                     CjsAssetReference::new(
                                         *origin,
-                                        Request::parse(Value::new(pat)),
+                                        Request::parse(pat),
                                         issue_source(source, span),
                                         in_try,
                                     )
@@ -2338,7 +2336,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 analysis.add_reference(
                     CjsAssetReference::new(
                         *origin,
-                        Request::parse(Value::new(js_value_to_pattern(&args[1]))),
+                        Request::parse(js_value_to_pattern(&args[1])),
                         issue_source(source, span),
                         in_try,
                     )
@@ -2579,9 +2577,7 @@ async fn handle_free_var_reference(
                         } else {
                             state.origin
                         },
-                        Request::parse(Value::new(request.clone().into()))
-                            .to_resolved()
-                            .await?,
+                        Request::parse(request.clone().into()).to_resolved().await?,
                         IssueSource::from_swc_offsets(
                             state.source,
                             span.lo.to_u32(),
@@ -3008,7 +3004,7 @@ async fn require_resolve_visitor(
 ) -> Result<JsValue> {
     Ok(if args.len() == 1 {
         let pat = js_value_to_pattern(&args[0]);
-        let request = Request::parse(Value::new(pat.clone()));
+        let request = Request::parse(pat.clone());
         let resolved = cjs_resolve_source(origin, request, None, true)
             .resolve()
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -16,7 +16,7 @@ use swc_core::{
 use turbo_esregex::EsRegex;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ResolvedVc, Value, ValueToString, Vc, debug::ValueDebugFormat,
+    FxIndexMap, NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
@@ -188,7 +188,7 @@ impl RequireContextMap {
                 bail!("invariant error: this was already checked in `list_dir`");
             };
 
-            let request = Request::parse(Value::new(origin_relative.clone().into()))
+            let request = Request::parse(origin_relative.clone().into())
                 .to_resolved()
                 .await?;
             let result = cjs_resolve(origin, *request, issue_source.clone(), is_optional)

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     context::AssetContext,
@@ -129,7 +129,7 @@ impl ModuleReference for TsReferenceTypeAssetReference {
             *self.origin,
             Request::module(
                 self.module.clone(),
-                Value::new(RcStr::default().into()),
+                RcStr::default().into(),
                 RcStr::default(),
                 RcStr::default(),
             ),

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -11,7 +11,7 @@ use serde_with::serde_as;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, NonLocalValue, OperationValue, OperationVc, ResolvedVc, TaskInput, TryJoinIterExt,
-    Value, ValueToString, Vc, trace::TraceRawVcs,
+    ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::ProcessEnv;
@@ -569,7 +569,7 @@ impl EvaluateContext for WebpackLoaderContext {
                     bail!("Resolve options are not available in this context");
                 };
                 let lookup_path = self.cwd.join(lookup_path);
-                let request = Request::parse(Value::new(Pattern::Constant(request)));
+                let request = Request::parse(Pattern::Constant(request));
                 let options = resolve_options(lookup_path, *resolve_options_context);
 
                 let options = apply_webpack_resolve_options(options, webpack_options);

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Write, mem::take};
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, ValueDefault, Vc, fxindexset};
+use turbo_tasks::{ResolvedVc, ValueDefault, Vc, fxindexset};
 use turbo_tasks_fs::{FileContent, FileJsonContent, FileSystemPath};
 use turbopack_core::{
     asset::Asset,
@@ -401,7 +401,7 @@ pub async fn type_resolve(
         };
         Some(Request::module(
             format!("@types/{m}").into(),
-            Value::new(p.clone()),
+            p.clone(),
             RcStr::default(),
             RcStr::default(),
         ))


### PR DESCRIPTION
Replace uses of `Value<Pattern>` in the resolve crate with `Pattern`

This required a manual implementation of `TaskInput` which ended up being trivial since there are no captured `Vcs`. However, the `derive` macro failed because it is a recursive type.

### Why?
The Value<> type is confusing and error prone, lets destroy it!

As discussed over slack, turbo_tasks::Value type always implements is_resolved as true and is_transient as false which is incorrect and can enable smuggling transient vcs into turbo tasks.

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879


Closes PACK-4790