### PR TITLE
[turbopack] Replace uses of `Value<ExecutionEnvironment>` with just `ExecutionEnvironment`

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Value, Vc};
+use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
@@ -121,7 +121,7 @@ pub async fn get_client_compile_time_info(
     define_env: Vc<EnvMap>,
 ) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
-        Environment::new(Value::new(ExecutionEnvironment::Browser(
+        Environment::new(ExecutionEnvironment::Browser(
             BrowserEnvironment {
                 dom: true,
                 web_worker: false,
@@ -129,7 +129,7 @@ pub async fn get_client_compile_time_info(
                 browserslist_query: browserslist_query.to_owned(),
             }
             .resolved_cell(),
-        )))
+        ))
         .to_resolved()
         .await?,
     )

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{css::chunk::CssChunkType, resolve_options_context::ResolveOptionsContext};
@@ -85,9 +85,9 @@ pub async fn get_edge_compile_time_info(
     define_env: Vc<EnvMap>,
 ) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
-        Environment::new(Value::new(ExecutionEnvironment::EdgeWorker(
+        Environment::new(ExecutionEnvironment::EdgeWorker(
             EdgeWorkerEnvironment {}.resolved_cell(),
-        )))
+        ))
         .to_resolved()
         .await?,
     )

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -78,7 +78,7 @@ use crate::{
     },
 };
 
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
+#[turbo_tasks::value(shared)]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub enum ServerContextType {
     Pages {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Value, Vc};
+use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Vc};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
@@ -386,7 +386,7 @@ pub async fn get_server_compile_time_info(
     cwd: RcStr,
 ) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
-        Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+        Environment::new(ExecutionEnvironment::NodeJsLambda(
             NodeJsEnvironment {
                 compile_target: CompileTarget::current().to_resolved().await?,
                 node_version: NodeJsVersion::resolved_cell(NodeJsVersion::Current(
@@ -395,7 +395,7 @@ pub async fn get_server_compile_time_info(
                 cwd: ResolvedVc::cell(Some(cwd)),
             }
             .resolved_cell(),
-        )))
+        ))
         .to_resolved()
         .await?,
     )

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -10,8 +10,7 @@ use rustc_hash::FxHashSet;
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc,
-    apply_effects,
+    ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Vc, apply_effects,
 };
 use turbo_tasks_backend::{
     BackendOptions, NoopBackingStorage, TurboTasksBackend, noop_backing_storage,
@@ -234,9 +233,9 @@ async fn build_internal(
                 build_output_root,
                 build_output_root,
                 build_output_root,
-                Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+                Environment::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment::default().resolved_cell(),
-                )))
+                ))
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -322,7 +321,7 @@ async fn build_internal(
                 build_output_root,
                 build_output_root,
                 build_output_root,
-                Environment::new(Value::new(ExecutionEnvironment::Browser(
+                Environment::new(ExecutionEnvironment::Browser(
                     BrowserEnvironment {
                         dom: true,
                         web_worker: false,
@@ -330,7 +329,7 @@ async fn build_internal(
                         browserslist_query: browserslist_query.clone(),
                     }
                     .resolved_cell(),
-                )))
+                ))
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -373,9 +372,9 @@ async fn build_internal(
                 build_output_root,
                 build_output_root,
                 build_output_root,
-                Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+                Environment::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment::default().resolved_cell(),
-                )))
+                ))
                 .to_resolved()
                 .await?,
                 runtime_type,

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack::{
     ModuleAssetContext,
@@ -213,7 +213,7 @@ pub async fn get_client_compile_time_info(
 ) -> Result<Vc<CompileTimeInfo>> {
     let node_env = node_env.await?;
     CompileTimeInfo::builder(
-        Environment::new(Value::new(ExecutionEnvironment::Browser(
+        Environment::new(ExecutionEnvironment::Browser(
             BrowserEnvironment {
                 dom: true,
                 web_worker: false,
@@ -221,7 +221,7 @@ pub async fn get_client_compile_time_info(
                 browserslist_query,
             }
             .resolved_cell(),
-        )))
+        ))
         .to_resolved()
         .await?,
     )

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use swc_core::ecma::preset_env::{Version, Versions};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TaskInput, Value, Vc};
+use turbo_tasks::{ResolvedVc, TaskInput, Vc};
 use turbo_tasks_env::ProcessEnv;
 
 use crate::target::CompileTarget;
@@ -46,15 +46,13 @@ pub struct Environment {
 #[turbo_tasks::value_impl]
 impl Environment {
     #[turbo_tasks::function]
-    pub fn new(execution: Value<ExecutionEnvironment>) -> Vc<Self> {
-        Self::cell(Environment {
-            execution: execution.into_value(),
-        })
+    pub fn new(execution: ExecutionEnvironment) -> Vc<Self> {
+        Self::cell(Environment { execution })
     }
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Hash, Clone, Copy)]
+#[derive(Debug, Hash, Clone, Copy, TaskInput)]
 pub enum ExecutionEnvironment {
     NodeJsBuildTime(ResolvedVc<NodeJsEnvironment>),
     NodeJsLambda(ResolvedVc<NodeJsEnvironment>),

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -10,7 +10,7 @@ use swc_core::{
         visit::VisitMutWith,
     },
 };
-use turbo_tasks::{ResolvedVc, Value};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
@@ -103,14 +103,14 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
         for val in input.var_graph.values.values() {
             VcStorage::with(async {
                 let compile_time_info = CompileTimeInfo::builder(
-                    Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+                    Environment::new(ExecutionEnvironment::NodeJsLambda(
                         NodeJsEnvironment {
                             compile_target: CompileTarget::unknown().to_resolved().await?,
                             node_version: NodeJsVersion::default().resolved_cell(),
                             cwd: ResolvedVc::cell(None),
                         }
                         .resolved_cell(),
-                    )))
+                    ))
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -4015,7 +4015,7 @@ mod tests {
         },
         testing::{NormalizedOutput, fixture, run_test},
     };
-    use turbo_tasks::{ResolvedVc, Value, util::FormatDuration};
+    use turbo_tasks::{ResolvedVc, util::FormatDuration};
     use turbopack_core::{
         compile_time_info::CompileTimeInfo,
         environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
@@ -4416,7 +4416,7 @@ mod tests {
     ) -> (JsValue, u32) {
         turbo_tasks_testing::VcStorage::with(async {
             let compile_time_info = CompileTimeInfo::builder(
-                Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+                Environment::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment {
                         compile_target: CompileTarget {
                             arch: Arch::X64,
@@ -4429,7 +4429,7 @@ mod tests {
                         cwd: ResolvedVc::cell(None),
                     }
                     .resolved_cell(),
-                )))
+                ))
                 .to_resolved()
                 .await?,
             )

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -321,9 +321,9 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         .get_relative_path_to(&*project_root.await?)
         .context("Project path is in root path")?;
 
-    let env = Environment::new(Value::new(ExecutionEnvironment::NodeJsBuildTime(
+    let env = Environment::new(ExecutionEnvironment::NodeJsBuildTime(
         NodeJsEnvironment::default().resolved_cell(),
-    )))
+    ))
     .to_resolved()
     .await?;
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use serde_json::json;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    ReadConsistency, ReadRef, ResolvedVc, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc,
+    ReadConsistency, ReadRef, ResolvedVc, TryJoinIterExt, TurboTasks, ValueToString, Vc,
     apply_effects,
 };
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
@@ -227,7 +227,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
 
     let entry_asset = project_path.join(options.entry.into());
 
-    let env = Environment::new(Value::new(match options.environment {
+    let env = Environment::new(match options.environment {
         SnapshotEnvironment::Browser => {
             ExecutionEnvironment::Browser(
                 // TODO: load more from options.json
@@ -246,7 +246,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 NodeJsEnvironment::default().resolved_cell(),
             )
         }
-    }))
+    })
     .to_resolved()
     .await?;
 

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -3,7 +3,7 @@ use std::{fs, path::PathBuf};
 use criterion::{Bencher, BenchmarkId, Criterion};
 use regex::Regex;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ReadConsistency, ResolvedVc, TurboTasks, Value, Vc, apply_effects};
+use turbo_tasks::{ReadConsistency, ResolvedVc, TurboTasks, Vc, apply_effects};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, NullFileSystem};
 use turbopack::{
@@ -87,9 +87,9 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
 
                 let source = FileSource::new(input);
                 let compile_time_info = CompileTimeInfo::builder(
-                    Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+                    Environment::new(ExecutionEnvironment::NodeJsLambda(
                         NodeJsEnvironment::default().resolved_cell(),
-                    )))
+                    ))
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Result;
 use tokio::{spawn, time::sleep};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ReadConsistency, TurboTasks, UpdateInfo, Value, Vc, util::FormatDuration};
+use turbo_tasks::{ReadConsistency, TurboTasks, UpdateInfo, Vc, util::FormatDuration};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{emit_with_completion, register};
@@ -41,24 +41,22 @@ async fn main() -> Result<()> {
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);
-            let input = fs.root().join("demo".into());
-            let output = fs.root().join("out".into());
-            let entry = fs.root().join("demo/index.js".into());
+            let input = fs.root().join(rcstr!("demo"));
+            let output = fs.root().join(rcstr!("out"));
+            let entry = fs.root().join(rcstr!("demo/index.js"));
 
             let source = FileSource::new(entry);
             let module_asset_context = turbopack::ModuleAssetContext::new(
                 Default::default(),
-                CompileTimeInfo::new(Environment::new(Value::new(
-                    ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment::default().resolved_cell(),
-                    ),
+                CompileTimeInfo::new(Environment::new(ExecutionEnvironment::NodeJsLambda(
+                    NodeJsEnvironment::default().resolved_cell(),
                 ))),
                 Default::default(),
                 ResolveOptionsContext {
                     enable_typescript: true,
                     enable_react: true,
                     enable_node_modules: Some(fs.root().to_resolved().await?),
-                    custom_conditions: vec!["development".into()],
+                    custom_conditions: vec![rcstr!("development")],
                     ..Default::default()
                 }
                 .cell(),

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystem;
 use turbopack_core::{
@@ -23,9 +23,9 @@ use crate::{
 
 #[turbo_tasks::function]
 pub fn node_build_environment() -> Vc<Environment> {
-    Environment::new(Value::new(ExecutionEnvironment::NodeJsBuildTime(
+    Environment::new(ExecutionEnvironment::NodeJsBuildTime(
         NodeJsEnvironment::default().resolved_cell(),
-    )))
+    ))
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -26,7 +26,7 @@ use graph::{AggregatedGraph, AggregatedGraphNodeContent, aggregate};
 use module_options::{ModuleOptions, ModuleOptionsContext, ModuleRuleEffect, ModuleType};
 use tracing::{Instrument, field::Empty};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexSet, ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 pub use turbopack_core::condition;
 use turbopack_core::{
@@ -646,9 +646,9 @@ async fn process_default_internal(
 
 #[turbo_tasks::function]
 async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleAssetContext>> {
-    let env = Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+    let env = Environment::new(ExecutionEnvironment::NodeJsLambda(
         NodeJsEnvironment::default().resolved_cell(),
-    )))
+    ))
     .to_resolved()
     .await?;
 

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -29,8 +29,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{process::Command, time::timeout};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    ResolvedVc, TurboTasks, Value, ValueToString, Vc, apply_effects, backend::Backend,
-    trace::TraceRawVcs,
+    ResolvedVc, TurboTasks, ValueToString, Vc, apply_effects, backend::Backend, trace::TraceRawVcs,
 };
 use turbo_tasks_backend::TurboTasksBackend;
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
@@ -343,8 +342,8 @@ async fn node_file_trace_operation(
         // TODO It's easy to make a mistake here as this should match the config in the
         // binary. TODO These test cases should move into the
         // `node-file-trace` crate and use the same config.
-        CompileTimeInfo::new(Environment::new(Value::new(
-            ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
+        CompileTimeInfo::new(Environment::new(ExecutionEnvironment::NodeJsLambda(
+            NodeJsEnvironment::default().resolved_cell(),
         ))),
         ModuleOptionsContext {
             ecmascript: EcmascriptOptionsContext {


### PR DESCRIPTION
Remove Value<ExecutionEnvironment> instead just use ExecutionEnvironment

Why?
The Value<> type is confusing and error prone, lets destroy it!

As discussed over slack, turbo_tasks::Value type always implements is_resolved as true and is_transient as false which is incorrect and can enable smuggling transient vcs into turbo tasks.

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879

Closes PACK-4792