### PR TITLE
[turbopack] Replace uses of `Value<ContentSourceData>` with just `ContentSourceData`

### DIFF
--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -1,4 +1,7 @@
-use std::{any::Any, fmt::Debug, future::Future, hash::Hash, sync::Arc, time::Duration};
+use std::{
+    any::Any, collections::BTreeMap, fmt::Debug, future::Future, hash::Hash, sync::Arc,
+    time::Duration,
+};
 
 use anyhow::Result;
 use either::Either;
@@ -281,6 +284,32 @@ where
     }
 }
 
+impl<K, V> TaskInput for BTreeMap<K, V>
+where
+    K: TaskInput + Ord,
+    V: TaskInput,
+{
+    async fn resolve_input(&self) -> Result<Self> {
+        let mut new_map = BTreeMap::new();
+        for (k, v) in self {
+            new_map.insert(
+                TaskInput::resolve_input(k).await?,
+                TaskInput::resolve_input(v).await?,
+            );
+        }
+        Ok(new_map)
+    }
+
+    fn is_resolved(&self) -> bool {
+        self.iter()
+            .all(|(k, v)| TaskInput::is_resolved(k) || TaskInput::is_resolved(v))
+    }
+
+    fn is_transient(&self) -> bool {
+        self.iter()
+            .any(|(k, v)| TaskInput::is_transient(k) || TaskInput::is_transient(v))
+    }
+}
 macro_rules! tuple_impls {
     ( $( $name:ident )+ ) => {
         impl<$($name: TaskInput),+> TaskInput for ($($name,)+)

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -46,7 +46,8 @@ impl_task_input! {
     RcStr,
     TaskId,
     ValueTypeId,
-    Duration
+    Duration,
+    String
 }
 
 impl<T> TaskInput for Vec<T>

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -104,7 +104,7 @@ impl GetContentSourceContent for IntrospectionSource {
     async fn get(
         self: ResolvedVc<Self>,
         path: RcStr,
-        _data: turbo_tasks::Value<ContentSourceData>,
+        _data: ContentSourceData,
     ) -> Result<Vc<ContentSourceContent>> {
         // get last segment
         let path = &path[path.rfind('/').unwrap_or(0) + 1..];

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexMap, FxIndexSet, ResolvedVc, State, TryJoinIterExt, Value, ValueToString,
-    Vc, fxindexset,
+    Completion, FxIndexMap, FxIndexSet, ResolvedVc, State, TryJoinIterExt, ValueToString, Vc,
+    fxindexset,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -270,7 +270,7 @@ impl GetContentSourceContent for AssetGraphGetContentSourceContent {
     async fn get(
         self: ResolvedVc<Self>,
         _path: RcStr,
-        _data: Value<ContentSourceData>,
+        _data: ContentSourceData,
     ) -> Result<Vc<ContentSourceContent>> {
         let this = self.await?;
         turbo_tasks::emit(ResolvedVc::upcast::<Box<dyn ContentSourceSideEffect>>(self));

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Completion, ResolvedVc, State, Value, Vc};
+use turbo_tasks::{Completion, ResolvedVc, State, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{
@@ -149,7 +149,7 @@ impl GetContentSourceContent for ActivateOnGetContentSource {
     async fn get(
         self: ResolvedVc<Self>,
         path: RcStr,
-        data: Value<ContentSourceData>,
+        data: ContentSourceData,
     ) -> Result<Vc<ContentSourceContent>> {
         turbo_tasks::emit(ResolvedVc::upcast::<Box<dyn ContentSourceSideEffect>>(self));
         Ok(self.await?.get_content.get(path, data))

--- a/turbopack/crates/turbopack-dev-server/src/source/headers.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/headers.rs
@@ -5,17 +5,21 @@ use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 
 /// A parsed query string from a http request
 #[derive(
-    Clone, Debug, PartialEq, Eq, Default, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Default,
+    Hash,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    TaskInput,
 )]
 #[serde(transparent)]
 pub struct Headers(BTreeMap<String, HeaderValue>);
 
-impl TaskInput for Headers {
-    fn is_transient(&self) -> bool {
-        // This is correct because Headers implements NonLocalValue
-        false
-    }
-}
 /// The value of an http header. HTTP headers might contain non-utf-8 bytes. An
 /// header might also occur multiple times.
 #[derive(

--- a/turbopack/crates/turbopack-dev-server/src/source/headers.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/headers.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, hash::Hash, mem::replace, ops::DerefMut};
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 
 /// A parsed query string from a http request
 #[derive(
@@ -10,9 +10,17 @@ use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
 #[serde(transparent)]
 pub struct Headers(BTreeMap<String, HeaderValue>);
 
+impl TaskInput for Headers {
+    fn is_transient(&self) -> bool {
+        // This is correct because Headers implements NonLocalValue
+        false
+    }
+}
 /// The value of an http header. HTTP headers might contain non-utf-8 bytes. An
 /// header might also occur multiple times.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue, TaskInput,
+)]
 #[serde(untagged)]
 pub enum HeaderValue {
     SingleString(String),

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     introspect::{Introspectable, IntrospectableChildren},
@@ -117,11 +117,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
     }
 
     #[turbo_tasks::function]
-    async fn get(
-        &self,
-        path: RcStr,
-        data: Value<ContentSourceData>,
-    ) -> Result<Vc<ContentSourceContent>> {
+    async fn get(&self, path: RcStr, data: ContentSourceData) -> Result<Vc<ContentSourceContent>> {
         let source = self.source.await?;
         Ok(
             get_content_source_get_operation(self.get_content, path, data)
@@ -143,7 +139,7 @@ fn get_content_source_vary_operation(
 fn get_content_source_get_operation(
     get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
     path: RcStr,
-    data: Value<ContentSourceData>,
+    data: ContentSourceData,
 ) -> Vc<ContentSourceContent> {
     get_content.get(path, data)
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -19,7 +19,7 @@ use futures::{TryStreamExt, stream::Stream as StreamTrait};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    Completion, NonLocalValue, OperationVc, ResolvedVc, Upcast, Value, ValueDefault, Vc,
+    Completion, NonLocalValue, OperationVc, ResolvedVc, TaskInput, Upcast, ValueDefault, Vc,
     trace::TraceRawVcs, util::SharedError,
 };
 use turbo_tasks_bytes::{Bytes, Stream, StreamRead};
@@ -72,8 +72,7 @@ pub trait GetContentSourceContent {
     }
 
     /// Get the content
-    fn get(self: Vc<Self>, path: RcStr, data: Value<ContentSourceData>)
-    -> Vc<ContentSourceContent>;
+    fn get(self: Vc<Self>, path: RcStr, data: ContentSourceData) -> Vc<ContentSourceContent>;
 }
 
 #[turbo_tasks::value(transparent)]
@@ -109,11 +108,7 @@ pub trait ContentSourceSideEffect {
 #[turbo_tasks::value_impl]
 impl GetContentSourceContent for ContentSourceContent {
     #[turbo_tasks::function]
-    fn get(
-        self: Vc<Self>,
-        _path: RcStr,
-        _data: Value<ContentSourceData>,
-    ) -> Vc<ContentSourceContent> {
+    fn get(self: Vc<Self>, _path: RcStr, _data: ContentSourceData) -> Vc<ContentSourceContent> {
         self
     }
 }
@@ -182,7 +177,7 @@ impl HeaderList {
 /// `ContentSource::vary()`. So make sure to request all information that's
 /// needed.
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]
-#[derive(Clone, Debug, Hash, Default)]
+#[derive(Clone, Debug, Hash, Default, TaskInput)]
 pub struct ContentSourceData {
     /// HTTP method, if requested.
     pub method: Option<RcStr>,

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -176,8 +176,19 @@ impl HeaderList {
 /// Note that you might not receive information that has not been requested via
 /// `ContentSource::vary()`. So make sure to request all information that's
 /// needed.
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
-#[derive(Clone, Debug, Hash, Default, TaskInput)]
+#[derive(
+    PartialEq,
+    Eq,
+    NonLocalValue,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    Hash,
+    Default,
+    TaskInput,
+)]
 pub struct ContentSourceData {
     /// HTTP method, if requested.
     pub method: Option<RcStr>,

--- a/turbopack/crates/turbopack-dev-server/src/source/query.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/query.rs
@@ -12,6 +12,8 @@ use super::ContentSourceDataFilter;
 #[serde(transparent)]
 pub struct Query(BTreeMap<String, QueryValue>);
 
+// This type contains no VCs so the default implementation works.
+// Query is also recursive through QueryValue so the derive macro doesnt work
 impl TaskInput for Query {
     fn is_transient(&self) -> bool {
         false

--- a/turbopack/crates/turbopack-dev-server/src/source/query.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/query.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, hash::Hash, ops::DerefMut};
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 
 use super::ContentSourceDataFilter;
 
@@ -11,6 +11,12 @@ use super::ContentSourceDataFilter;
 )]
 #[serde(transparent)]
 pub struct Query(BTreeMap<String, QueryValue>);
+
+impl TaskInput for Query {
+    fn is_transient(&self) -> bool {
+        false
+    }
+}
 
 impl Query {
     pub fn filter_with(&mut self, filter: &ContentSourceDataFilter) {

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -9,7 +9,7 @@ use hyper::{
     header::{HeaderName as HyperHeaderName, HeaderValue as HyperHeaderValue},
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{OperationVc, ResolvedVc, TransientInstance, Value, Vc};
+use turbo_tasks::{OperationVc, ResolvedVc, TransientInstance, Vc};
 
 use super::{
     ContentSource, ContentSourceContent, ContentSourceData, ContentSourceDataVary,
@@ -57,7 +57,7 @@ fn get_content_source_content_vary_operation(
 fn get_content_source_content_get_operation(
     get_content: ResolvedVc<Box<dyn GetContentSourceContent>>,
     path: RcStr,
-    data: Value<ContentSourceData>,
+    data: ContentSourceData,
 ) -> Vc<ContentSourceContent> {
     get_content.get(path, data)
 }
@@ -95,7 +95,7 @@ pub async fn resolve_source_request(
                 let content_op = get_content_source_content_get_operation(
                     get_content,
                     current_asset_path.clone(),
-                    Value::new(content_data),
+                    content_data,
                 );
                 match &*content_op.read_strongly_consistent().await? {
                     ContentSourceContent::Rewrite(rewrite) => {

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildren};
 
 use super::{
@@ -156,11 +156,7 @@ impl GetContentSourceContent for PrefixedRouterGetContentSourceContent {
     }
 
     #[turbo_tasks::function]
-    async fn get(
-        &self,
-        path: RcStr,
-        data: Value<ContentSourceData>,
-    ) -> Result<Vc<ContentSourceContent>> {
+    async fn get(&self, path: RcStr, data: ContentSourceData) -> Result<Vc<ContentSourceContent>> {
         let prefix = self.mapper.await?.prefix.await?;
         if let Some(path) = path.strip_prefix(&**prefix) {
             if path.is_empty() {

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     asset::Asset,
@@ -98,7 +98,7 @@ impl StaticAssetsContentSourceItem {
 #[turbo_tasks::value_impl]
 impl GetContentSourceContent for StaticAssetsContentSourceItem {
     #[turbo_tasks::function]
-    fn get(&self, _path: RcStr, _data: Value<ContentSourceData>) -> Vc<ContentSourceContent> {
+    fn get(&self, _path: RcStr, _data: ContentSourceData) -> Vc<ContentSourceContent> {
         let content = Vc::upcast::<Box<dyn Asset>>(FileSource::new(*self.path)).content();
         ContentSourceContent::static_content(content.versioned())
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{OperationVc, ResolvedVc, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{OperationVc, ResolvedVc, TryJoinIterExt, Vc};
 
 use super::{
     ContentSourceContent, ContentSourceData, ContentSourceDataVary, GetContentSourceContent,
@@ -69,11 +69,7 @@ impl GetContentSourceContent for WrappedGetContentSourceContent {
     }
 
     #[turbo_tasks::function]
-    async fn get(
-        &self,
-        path: RcStr,
-        data: Value<ContentSourceData>,
-    ) -> Result<Vc<ContentSourceContent>> {
+    async fn get(&self, path: RcStr, data: ContentSourceData) -> Result<Vc<ContentSourceContent>> {
         let res = self.inner.get(path, data);
         if let ContentSourceContent::Rewrite(rewrite) = &*res.await? {
             let rewrite = rewrite.await?;

--- a/turbopack/crates/turbopack-node/src/node_entry.rs
+++ b/turbopack/crates/turbopack-node/src/node_entry.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::chunk::{ChunkingContext, EvaluatableAsset, EvaluatableAssets};
 use turbopack_dev_server::source::ContentSourceData;
@@ -20,12 +20,10 @@ pub struct NodeRenderingEntries(Vec<ResolvedVc<NodeRenderingEntry>>);
 /// Trait that allows to get the entry module for rendering something in Node.js
 #[turbo_tasks::value_trait]
 pub trait NodeEntry {
-    fn entry(self: Vc<Self>, data: Value<ContentSourceData>) -> Vc<NodeRenderingEntry>;
+    fn entry(self: Vc<Self>, data: ContentSourceData) -> Vc<NodeRenderingEntry>;
     async fn entries(self: Vc<Self>) -> Result<Vc<NodeRenderingEntries>> {
         Ok(Vc::cell(vec![
-            self.entry(Value::new(Default::default()))
-                .to_resolved()
-                .await?,
+            self.entry(Default::default()).to_resolved().await?,
         ]))
     }
 }

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexSet, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::introspect::{
@@ -107,11 +107,7 @@ impl GetContentSourceContent for NodeApiContentSource {
     }
 
     #[turbo_tasks::function]
-    async fn get(
-        &self,
-        path: RcStr,
-        data: Value<ContentSourceData>,
-    ) -> Result<Vc<ContentSourceContent>> {
+    async fn get(&self, path: RcStr, data: ContentSourceData) -> Result<Vc<ContentSourceContent>> {
         let Some(params) = &*self.route_match.params(path.clone()).await? else {
             anyhow::bail!("Non matching path provided")
         };
@@ -123,7 +119,7 @@ impl GetContentSourceContent for NodeApiContentSource {
             raw_query: Some(raw_query),
             body: Some(body),
             ..
-        } = &*data
+        } = &data
         else {
             anyhow::bail!("Missing request data")
         };

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexSet, OperationVc, ResolvedVc, Value, Vc};
+use turbo_tasks::{FxIndexSet, OperationVc, ResolvedVc, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -165,11 +165,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
     }
 
     #[turbo_tasks::function]
-    async fn get(
-        &self,
-        path: RcStr,
-        data: Value<ContentSourceData>,
-    ) -> Result<Vc<ContentSourceContent>> {
+    async fn get(&self, path: RcStr, data: ContentSourceData) -> Result<Vc<ContentSourceContent>> {
         let pathname = self.pathname.await?;
         let Some(params) = &*self.route_match.params(path.clone()).await? else {
             anyhow::bail!("Non matching path ({}) provided for {}", path, pathname)
@@ -181,7 +177,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
             raw_headers: Some(raw_headers),
             raw_query: Some(raw_query),
             ..
-        } = &*data
+        } = &data
         else {
             anyhow::bail!("Missing request data")
         };


### PR DESCRIPTION
Remove Value<ContentSourceData> instead just use ContentSourceData

### Why?
The Value<> type is confusing and error prone, lets destroy it!

As discussed over slack, turbo_tasks::Value type always implements is_resolved as true and is_transient as false which is incorrect and can enable smuggling transient vcs into turbo tasks.

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879

Closes PACK-4793