### PR TITLE
Remove unused vendored `server-inserted-metadata` module

### DIFF
--- a/packages/next/src/server/route-modules/app-page/vendored/contexts/server-inserted-metadata.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/contexts/server-inserted-metadata.ts
@@ -1,3 +1,0 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].ServerInsertedMetadata


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/78495

Found with the help of https://github.com/vercel/next.js/pull/80056: https://github.com/vercel/next.js/actions/runs/15436434717/job/43443835635?pr=80056#step:8:505