### PR TITLE
[turbopack] Remove the final uses of `Value<..>` and delete the type

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -29,8 +29,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Value, ValueToString, Vc,
-    fxindexmap, fxindexset, trace::TraceRawVcs,
+    Completion, FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, fxindexmap,
+    fxindexset, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
     self, File, FileContent, FileSystem, FileSystemPath, FileSystemPathOption, VirtualFileSystem,
@@ -635,7 +635,7 @@ impl PagesProject {
                     NextMode::Build => rcstr!("next/dist/client/next-turbopack.js"),
                 },
             )),
-            Value::new(EcmaScriptModulesReferenceSubType::Undefined),
+            EcmaScriptModulesReferenceSubType::Undefined,
             false,
             None,
         )

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -272,7 +272,7 @@ pub async fn parse_segment_config_from_source(
 
     let result = &*parse(
         *source,
-        turbo_tasks::Value::new(if path.path.ends_with(".ts") {
+        if path.path.ends_with(".ts") {
             EcmascriptModuleAssetType::Typescript {
                 tsx: false,
                 analyze_types: false,
@@ -284,7 +284,7 @@ pub async fn parse_segment_config_from_source(
             }
         } else {
             EcmascriptModuleAssetType::Ecmascript
-        }),
+        },
         EcmascriptInputTransforms::empty(),
     )
     .await?;

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -63,11 +63,11 @@ async fn all_in_one() {
     .unwrap()
 }
 
-#[turbo_tasks::value(transparent, serialization = "auto_for_input")]
+#[turbo_tasks::value(transparent)]
 #[derive(Debug, Clone, Hash)]
 struct MyTransparentValue(u32);
 
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
+#[turbo_tasks::value(shared)]
 #[derive(Debug, Clone, Hash, TaskInput)]
 enum MyEnumValue {
     Yeah(u32),

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
@@ -27,7 +27,7 @@ async fn all_in_one() {
         }
         .into();
 
-        let result = my_function(a, b.get_last(), c, Value::new(MyEnumValue::Yeah(42)));
+        let result = my_function(a, b.get_last(), c, MyEnumValue::Yeah(42));
         assert_eq!(*result.my_trait_function().await?, "42");
         assert_eq!(*result.my_trait_function2().await?, "42");
         assert_eq!(*result.my_trait_function3().await?, "4242");
@@ -68,7 +68,7 @@ async fn all_in_one() {
 struct MyTransparentValue(u32);
 
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 enum MyEnumValue {
     Yeah(u32),
     Nah,
@@ -159,12 +159,12 @@ async fn my_function(
     a: Vc<MyTransparentValue>,
     b: Vc<MyEnumValue>,
     c: Vc<MyStructValue>,
-    d: Value<MyEnumValue>,
+    d: MyEnumValue,
 ) -> Result<Vc<MyStructValue>> {
     assert_eq!(*a.await?, 4242);
     assert_eq!(*b.await?, MyEnumValue::Yeah(42));
     assert_eq!(c.await?.value, 42);
-    assert_eq!(d.into_value(), MyEnumValue::Yeah(42));
+    assert_eq!(d, MyEnumValue::Yeah(42));
     Ok(c)
 }
 

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -123,7 +123,7 @@ pub use state::{State, TransientState};
 pub use task::{SharedReference, TypedSharedReference, task_input::TaskInput};
 pub use trait_ref::{IntoTraitRef, TraitRef};
 pub use turbo_tasks_macros::{TaskInput, function, value_impl};
-pub use value::{TransientInstance, TransientValue, Value};
+pub use value::{TransientInstance, TransientValue};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
     Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -78,7 +78,6 @@ macro_rules! impl_auto_marker_trait {
         {}
         unsafe impl<T: $trait> $trait for $crate::State<T> {}
         unsafe impl<T: $trait> $trait for $crate::TransientState<T> {}
-        unsafe impl<T: $trait> $trait for $crate::Value<T> {}
         unsafe impl<T: $trait> $trait for $crate::TransientValue<T> {}
         unsafe impl<T: $trait> $trait for $crate::TransientInstance<T> {}
 

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -1,6 +1,5 @@
 use std::{
-    any::Any, collections::BTreeMap, fmt::Debug, future::Future, hash::Hash, sync::Arc,
-    time::Duration,
+    collections::BTreeMap, fmt::Debug, future::Future, hash::Hash, sync::Arc, time::Duration,
 };
 
 use anyhow::Result;
@@ -9,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 
 use crate::{
-    MagicAny, ResolvedVc, TaskId, TransientInstance, TransientValue, Value, ValueTypeId, Vc,
+    MagicAny, ResolvedVc, TaskId, TransientInstance, TransientValue, ValueTypeId, Vc,
     trace::TraceRawVcs,
 };
 
@@ -167,29 +166,6 @@ where
 
     async fn resolve_input(&self) -> Result<Self> {
         Ok(*self)
-    }
-}
-
-impl<T> TaskInput for Value<T>
-where
-    T: Any
-        + std::fmt::Debug
-        + Clone
-        + std::hash::Hash
-        + Eq
-        + Send
-        + Sync
-        + Serialize
-        + for<'de> Deserialize<'de>
-        + TraceRawVcs
-        + 'static,
-{
-    fn is_resolved(&self) -> bool {
-        true
-    }
-
-    fn is_transient(&self) -> bool {
-        false
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/value.rs
+++ b/turbopack/crates/turbo-tasks/src/value.rs
@@ -1,67 +1,11 @@
 use std::{fmt::Debug, marker::PhantomData, ops::Deref};
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
 
 use crate::{
-    ReadRef, SharedReference,
-    debug::{ValueDebugFormat, ValueDebugString},
+    SharedReference,
     trace::{TraceRawVcs, TraceRawVcsContext},
 };
-
-/// Pass a value by value (`Value<Xxx>`) instead of by reference (`Vc<Xxx>`).
-///
-/// Persistent, requires serialization.
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
-pub struct Value<T> {
-    inner: T,
-}
-
-impl<T> Value<T> {
-    pub fn new(value: T) -> Self {
-        Self { inner: value }
-    }
-
-    pub fn into_value(self) -> T {
-        self.inner
-    }
-}
-
-impl<T> Deref for Value<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<T: Copy> Copy for Value<T> {}
-
-impl<T: Default> Default for Value<T> {
-    fn default() -> Self {
-        Value::new(Default::default())
-    }
-}
-
-impl<T: ValueDebugFormat> Value<T> {
-    pub async fn dbg(&self) -> Result<ReadRef<ValueDebugString>> {
-        self.dbg_depth(usize::MAX).await
-    }
-
-    pub async fn dbg_depth(&self, depth: usize) -> Result<ReadRef<ValueDebugString>> {
-        self.inner
-            .value_debug_format(depth)
-            .try_to_value_debug_string()
-            .await?
-            .await
-    }
-}
-
-impl<T: TraceRawVcs> TraceRawVcs for Value<T> {
-    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
-        self.inner.trace_raw_vcs(trace_context)
-    }
-}
 
 /// Pass a value by value (`Value<Xxx>`) instead of by reference (`Vc<Xxx>`).
 ///

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Upcast, Value, ValueToString, Vc,
+    NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Upcast, ValueToString, Vc,
     trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
@@ -38,7 +38,7 @@ use crate::ecmascript::{
 };
 
 #[turbo_tasks::value]
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, TaskInput)]
 pub enum CurrentChunkMethod {
     StringLiteral,
     DocumentCurrentScript,
@@ -161,7 +161,7 @@ impl BrowserChunkingContextBuilder {
     }
 
     pub fn build(self) -> Vc<BrowserChunkingContext> {
-        BrowserChunkingContext::new(Value::new(self.chunking_context))
+        BrowserChunkingContext::new(self.chunking_context)
     }
 }
 
@@ -172,7 +172,7 @@ impl BrowserChunkingContextBuilder {
 /// It splits "node_modules" separately as these are less likely to change
 /// during development
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub struct BrowserChunkingContext {
     name: Option<RcStr>,
     /// The root path of the project
@@ -295,8 +295,8 @@ impl BrowserChunkingContext {
 #[turbo_tasks::value_impl]
 impl BrowserChunkingContext {
     #[turbo_tasks::function]
-    fn new(this: Value<BrowserChunkingContext>) -> Vc<Self> {
-        this.into_value().cell()
+    fn new(this: BrowserChunkingContext) -> Vc<Self> {
+        this.cell()
     }
 
     #[turbo_tasks::function]
@@ -323,7 +323,7 @@ impl BrowserChunkingContext {
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         other_chunks: Vc<OutputAssets>,
-        source: Value<EcmascriptDevChunkListSource>,
+        source: EcmascriptDevChunkListSource,
     ) -> Vc<Box<dyn OutputAsset>> {
         Vc::upcast(EcmascriptDevChunkList::new(
             self,
@@ -565,7 +565,7 @@ impl ChunkingContext for BrowserChunkingContext {
                         ident,
                         EvaluatableAssets::empty(),
                         Vc::cell(assets.clone()),
-                        Value::new(EcmascriptDevChunkListSource::Dynamic),
+                        EcmascriptDevChunkListSource::Dynamic,
                     )
                     .to_resolved()
                     .await?,
@@ -634,7 +634,7 @@ impl ChunkingContext for BrowserChunkingContext {
                         ident,
                         entries,
                         other_assets,
-                        Value::new(EcmascriptDevChunkListSource::Entry),
+                        EcmascriptDevChunkListSource::Entry,
                     )
                     .to_resolved()
                     .await?,

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -5,7 +5,7 @@ use either::Either;
 use indoc::writedoc;
 use serde::Serialize;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -171,7 +171,7 @@ impl EcmascriptBrowserEvaluateChunk {
                     environment,
                     chunking_context.chunk_base_path(),
                     chunking_context.chunk_suffix_path(),
-                    Value::new(chunking_context.runtime_type()),
+                    chunking_context.runtime_type(),
                     output_root_to_root_path,
                     source_maps,
                 );
@@ -182,7 +182,7 @@ impl EcmascriptBrowserEvaluateChunk {
                     environment,
                     chunking_context.chunk_base_path(),
                     chunking_context.chunk_suffix_path(),
-                    Value::new(chunking_context.runtime_type()),
+                    chunking_context.runtime_type(),
                     output_root_to_root_path,
                     source_maps,
                 );

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -42,14 +42,14 @@ impl EcmascriptDevChunkList {
         ident: ResolvedVc<AssetIdent>,
         evaluatable_assets: ResolvedVc<EvaluatableAssets>,
         chunks: ResolvedVc<OutputAssets>,
-        source: Value<EcmascriptDevChunkListSource>,
+        source: EcmascriptDevChunkListSource,
     ) -> Vc<Self> {
         EcmascriptDevChunkList {
             chunking_context,
             ident,
             evaluatable_assets,
             chunks,
-            source: source.into_value(),
+            source,
         }
         .cell()
     }
@@ -112,7 +112,7 @@ impl Asset for EcmascriptDevChunkList {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, TaskInput)]
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[serde(rename_all = "camelCase")]
 pub enum EcmascriptDevChunkListSource {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
+use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -112,8 +113,19 @@ impl Asset for EcmascriptDevChunkList {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, TaskInput)]
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[derive(
+    Eq,
+    PartialEq,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    TaskInput,
+    NonLocalValue,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub enum EcmascriptDevChunkListSource {
     /// The chunk list is from a runtime entry.

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -101,7 +101,7 @@ macro_rules! free_var_references {
 
 // TODO: replace with just a `serde_json::Value`
 // https://linear.app/vercel/issue/WEB-1641/compiletimedefinevalue-should-just-use-serde-jsonvalue
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub enum CompileTimeDefineValue {
     Bool(bool),

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
+use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::environment::Environment;
@@ -102,7 +102,7 @@ macro_rules! free_var_references {
 // TODO: replace with just a `serde_json::Value`
 // https://linear.app/vercel/issue/WEB-1641/compiletimedefinevalue-should-just-use-serde-jsonvalue
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub enum CompileTimeDefineValue {
     Bool(bool),
     String(RcStr),

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::Result;
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::Vc;
 use turbopack_core::{
     code_builder::{Code, CodeBuilder},
     context::AssetContext,
@@ -19,7 +19,7 @@ pub async fn get_browser_runtime_code(
     environment: Vc<Environment>,
     chunk_base_path: Option<RcStr>,
     chunk_suffix_path: Option<RcStr>,
-    runtime_type: Value<RuntimeType>,
+    runtime_type: RuntimeType,
     output_root_to_root_path: RcStr,
     generate_source_map: bool,
 ) -> Result<Vc<Code>> {
@@ -32,7 +32,7 @@ pub async fn get_browser_runtime_code(
     );
 
     let mut runtime_base_code = vec!["browser/runtime/base/runtime-base.ts"];
-    match *runtime_type {
+    match runtime_type {
         RuntimeType::Production => runtime_base_code.push("browser/runtime/base/build-base.ts"),
         RuntimeType::Development => {
             runtime_base_code.push("browser/runtime/base/dev-base.ts");
@@ -50,7 +50,7 @@ pub async fn get_browser_runtime_code(
         .await?;
 
     let mut runtime_backend_code = vec![];
-    match (chunk_loading, *runtime_type) {
+    match (chunk_loading, runtime_type) {
         (ChunkLoading::Edge, RuntimeType::Development) => {
             runtime_backend_code.push("browser/runtime/edge/runtime-backend-edge.ts");
             runtime_backend_code.push("browser/runtime/edge/dev-backend-edge.ts");
@@ -157,7 +157,7 @@ pub async fn get_browser_runtime_code(
             chunksToRegister.forEach(registerChunk);
         "#
     )?;
-    if matches!(*runtime_type, RuntimeType::Development) {
+    if matches!(runtime_type, RuntimeType::Development) {
         writedoc!(
             code,
             r#"

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -110,8 +110,20 @@ use crate::{
     transform::remove_shebang,
 };
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Hash, Debug, Clone, Copy, Default, TaskInput)]
+#[derive(
+    Eq,
+    PartialEq,
+    Hash,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    TaskInput,
+    TraceRawVcs,
+    NonLocalValue,
+    Serialize,
+    Deserialize,
+)]
 pub enum SpecifiedModuleType {
     #[default]
     Automatic,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -70,8 +70,8 @@ pub use transform::{
 };
 use turbo_rcstr::rcstr;
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Value,
-    ValueToString, Vc, trace::TraceRawVcs,
+    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
@@ -174,7 +174,7 @@ pub struct EcmascriptOptions {
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Hash, Debug, Copy, Clone)]
+#[derive(Hash, Debug, Copy, Clone, TaskInput)]
 pub enum EcmascriptModuleAssetType {
     /// Module with EcmaScript code
     Ecmascript,
@@ -235,7 +235,7 @@ impl EcmascriptModuleAssetBuilder {
             EcmascriptModuleAsset::new_with_inner_assets(
                 *self.source,
                 *self.asset_context,
-                Value::new(self.ty),
+                self.ty,
                 *self.transforms,
                 *self.options,
                 *self.compile_time_info,
@@ -245,7 +245,7 @@ impl EcmascriptModuleAssetBuilder {
             EcmascriptModuleAsset::new(
                 *self.source,
                 *self.asset_context,
-                Value::new(self.ty),
+                self.ty,
                 *self.transforms,
                 *self.options,
                 *self.compile_time_info,
@@ -501,8 +501,7 @@ impl EcmascriptModuleAsset {
     pub fn new(
         source: ResolvedVc<Box<dyn Source>>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
-
-        ty: Value<EcmascriptModuleAssetType>,
+        ty: EcmascriptModuleAssetType,
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
@@ -510,7 +509,7 @@ impl EcmascriptModuleAsset {
         Self::cell(EcmascriptModuleAsset {
             source,
             asset_context,
-            ty: ty.into_value(),
+            ty,
             transforms,
             options,
 
@@ -524,7 +523,7 @@ impl EcmascriptModuleAsset {
     pub async fn new_with_inner_assets(
         source: ResolvedVc<Box<dyn Source>>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
-        ty: Value<EcmascriptModuleAssetType>,
+        ty: EcmascriptModuleAssetType,
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
@@ -543,7 +542,7 @@ impl EcmascriptModuleAsset {
             Ok(Self::cell(EcmascriptModuleAsset {
                 source,
                 asset_context,
-                ty: ty.into_value(),
+                ty,
                 transforms,
                 options,
                 compile_time_info,
@@ -570,7 +569,7 @@ impl EcmascriptModuleAsset {
 
     #[turbo_tasks::function]
     pub fn parse(&self) -> Vc<ParseResult> {
-        parse(*self.source, Value::new(self.ty), *self.transforms)
+        parse(*self.source, self.ty, *self.transforms)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -24,7 +24,7 @@ use swc_core::{
 };
 use tracing::{Instrument, Level, instrument};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc, util::WrapFuture};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, util::WrapFuture};
 use turbo_tasks_fs::{FileContent, FileSystemPath, rope::Rope};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
@@ -176,11 +176,11 @@ impl SourceMapGenConfig for InlineSourcesContentConfig {
 #[turbo_tasks::function]
 pub async fn parse(
     source: ResolvedVc<Box<dyn Source>>,
-    ty: Value<EcmascriptModuleAssetType>,
+    ty: EcmascriptModuleAssetType,
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
     let name = source.ident().to_string().await?.to_string();
-    let span = tracing::info_span!("parse ecmascript", name = name, ty = display(&*ty));
+    let span = tracing::info_span!("parse ecmascript", name = name, ty = display(&ty));
 
     match parse_internal(source, ty, transforms)
         .instrument(span)
@@ -196,7 +196,7 @@ pub async fn parse(
 
 async fn parse_internal(
     source: ResolvedVc<Box<dyn Source>>,
-    ty: Value<EcmascriptModuleAssetType>,
+    ty: EcmascriptModuleAssetType,
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
     let content = source.content();
@@ -204,7 +204,6 @@ async fn parse_internal(
     let fs_path = &*fs_path_vc.await?;
     let ident = &*source.ident().to_string().await?;
     let file_path_hash = hash_xxh3_hash64(&*source.ident().to_string().await?) as u128;
-    let ty = ty.into_value();
     let content = match content.await {
         Ok(content) => content,
         Err(error) => {

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
-use turbo_tasks::{NonLocalValue, Value, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, TaskInput, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbopack_core::{
     chunk::ChunkingContext, compile_time_info::CompileTimeDefineValue, module_graph::ModuleGraph,
 };
@@ -12,18 +12,27 @@ use crate::{
     create_visitor,
 };
 
-#[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    TaskInput,
+)]
 pub struct ConstantValueCodeGen {
     value: CompileTimeDefineValue,
     path: AstPath,
 }
 
 impl ConstantValueCodeGen {
-    pub fn new(value: Value<CompileTimeDefineValue>, path: AstPath) -> Self {
-        ConstantValueCodeGen {
-            value: value.into_value(),
-            path,
-        }
+    pub fn new(value: CompileTimeDefineValue, path: AstPath) -> Self {
+        ConstantValueCodeGen { value, path }
     }
     pub async fn code_generation(
         &self,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -6,7 +6,7 @@ use swc_core::{
     quote,
 };
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{
@@ -143,7 +143,7 @@ impl EsmAssetReference {
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
         issue_source: IssueSource,
-        annotations: Value<ImportAnnotations>,
+        annotations: ImportAnnotations,
         export_name: Option<ModulePart>,
         import_externals: bool,
     ) -> Self {
@@ -151,7 +151,7 @@ impl EsmAssetReference {
             origin,
             request,
             issue_source,
-            annotations: annotations.into_value(),
+            annotations,
             export_name,
             import_externals,
         }
@@ -225,7 +225,7 @@ impl ModuleReference for EsmAssetReference {
         let result = esm_resolve(
             self.get_origin().resolve().await?,
             *self.request,
-            Value::new(ty),
+            ty,
             false,
             Some(self.issue_source.clone()),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -7,8 +7,7 @@ use swc_core::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, Value, ValueToString, Vc, debug::ValueDebugFormat,
-    trace::TraceRawVcs,
+    NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption},
@@ -59,7 +58,7 @@ impl EsmAsyncAssetReference {
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
         issue_source: IssueSource,
-        annotations: Value<ImportAnnotations>,
+        annotations: ImportAnnotations,
         in_try: bool,
         import_externals: bool,
     ) -> Self {
@@ -67,7 +66,7 @@ impl EsmAsyncAssetReference {
             origin,
             request,
             issue_source,
-            annotations: annotations.into_value(),
+            annotations,
             in_try,
             import_externals,
         }
@@ -81,7 +80,7 @@ impl ModuleReference for EsmAsyncAssetReference {
         esm_resolve(
             self.get_origin().resolve().await?,
             *self.request,
-            Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
+            EcmaScriptModulesReferenceSubType::DynamicImport,
             self.in_try,
             Some(self.issue_source.clone()),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -54,7 +54,7 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
-    Value, ValueToString, Vc, trace::TraceRawVcs,
+    ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -511,7 +511,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let raw_module = module.await?;
 
     let source = raw_module.source;
-    let ty = Value::new(raw_module.ty);
+    let ty = raw_module.ty;
     let transforms = raw_module.transforms;
     let options = raw_module.options;
     let options = options.await?;
@@ -523,7 +523,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let path = origin.origin_path();
 
     // Is this a typescript file that requires analzying type references?
-    let analyze_types = match &*ty {
+    let analyze_types = match &ty {
         EcmascriptModuleAssetType::Typescript { analyze_types, .. } => *analyze_types,
         EcmascriptModuleAssetType::TypescriptDeclaration => true,
         EcmascriptModuleAssetType::Ecmascript => false,
@@ -744,7 +744,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 r.issue_source
                     .clone()
                     .unwrap_or_else(|| IssueSource::from_source_only(source)),
-                Value::new(r.annotations.clone()),
+                r.annotations.clone(),
                 match options.tree_shaking_mode {
                     Some(TreeShakingMode::ModuleFragments) => match &r.imported_symbol {
                         ImportedSymbol::ModuleEvaluation => {
@@ -1381,7 +1381,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                                             r_ref.origin,
                                             r_ref.request,
                                             r_ref.issue_source.clone(),
-                                            Value::new(r_ref.annotations.clone()),
+                                            r_ref.annotations.clone(),
                                             Some(ModulePart::export(export.clone())),
                                             r_ref.import_externals,
                                         )
@@ -1747,7 +1747,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         origin,
                         Request::parse(pat).to_resolved().await?,
                         issue_source(source, span),
-                        Value::new(import_annotations),
+                        import_annotations,
                         in_try,
                         state.import_externals,
                     ),
@@ -2540,7 +2540,7 @@ async fn handle_free_var_reference(
         ),
         FreeVarReference::Value(value) => {
             analysis.add_code_gen(ConstantValueCodeGen::new(
-                Value::new(value.clone()),
+                value.clone(),
                 ast_path.to_vec().into(),
             ));
         }
@@ -2610,7 +2610,7 @@ async fn handle_free_var_reference(
                 InputRelativeConstant::FileName => source_path,
             };
             analysis.add_code_gen(ConstantValueCodeGen::new(
-                Value::new(as_abs_path(source_path).await?.into()),
+                as_abs_path(source_path).await?.into(),
                 ast_path.to_vec().into(),
             ));
         }

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -12,7 +12,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::source::Source;
 
@@ -190,12 +190,7 @@ pub async fn webpack_runtime(
     source: Vc<Box<dyn Source>>,
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<WebpackRuntime>> {
-    let parsed = parse(
-        source,
-        Value::new(EcmascriptModuleAssetType::Ecmascript),
-        transforms,
-    )
-    .await?;
+    let parsed = parse(source, EcmascriptModuleAssetType::Ecmascript, transforms).await?;
     match &*parsed {
         ParseResult::Ok {
             program,

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -7,7 +7,7 @@ use swc_core::{
     },
 };
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     reference::{ModuleReference, ModuleReferences},
     source::Source,
@@ -26,12 +26,7 @@ pub async fn module_references(
     runtime: ResolvedVc<WebpackRuntime>,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ModuleReferences>> {
-    let parsed = parse(
-        *source,
-        Value::new(EcmascriptModuleAssetType::Ecmascript),
-        *transforms,
-    )
-    .await?;
+    let parsed = parse(*source, EcmascriptModuleAssetType::Ecmascript, *transforms).await?;
     match &*parsed {
         ParseResult::Ok {
             program,

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Value, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
     issue::IssueSource,
     reference_type::{CommonJsReferenceSubType, EcmaScriptModulesReferenceSubType, ReferenceType},
@@ -90,11 +90,11 @@ pub async fn apply_cjs_specific_options(options: Vc<ResolveOptions>) -> Result<V
 pub async fn esm_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
-    ty: Value<EcmaScriptModulesReferenceSubType>,
+    ty: EcmaScriptModulesReferenceSubType,
     is_optional: bool,
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
-    let ty = ReferenceType::EcmaScriptModules(ty.into_value());
+    let ty = ReferenceType::EcmaScriptModules(ty);
     let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), ty.clone())
         .resolve()
         .await?;


### PR DESCRIPTION
Remove the final uses of `Value<..>` and destroy it.

### Why?
The `Value<>` type is confusing and error prone, lets destroy it!

As discussed over slack, turbo_tasks::Value type always implements is_resolved as true and is_transient as false which is incorrect and can enable smuggling transient vcs into turbo tasks.

• https://vercel.slack.com/archives/C03EWR7LGEN/p1743456121241529
• https://vercel.slack.com/archives/C04NGV98TPS/p1743455453764879

Closes PACK-4797