### PR TITLE
Turbopack: Fix sst filter handling and order for meta files

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -333,7 +333,7 @@ impl TurboPersistence {
             .collect::<Result<Vec<MetaFile>>>()?;
 
         let mut sst_filter = SstFilter::new();
-        for meta_file in meta_files.iter_mut() {
+        for meta_file in meta_files.iter_mut().rev() {
             sst_filter.apply_filter(meta_file);
         }
 
@@ -468,7 +468,7 @@ impl TurboPersistence {
             .collect::<Result<Vec<_>>>()?;
 
         let mut sst_filter = SstFilter::new();
-        for meta_file in new_meta_files.iter_mut() {
+        for meta_file in new_meta_files.iter_mut().rev() {
             sst_filter.apply_filter(meta_file);
         }
 
@@ -501,7 +501,7 @@ impl TurboPersistence {
 
         {
             let mut inner = self.inner.write();
-            for meta_file in inner.meta_files.iter_mut() {
+            for meta_file in inner.meta_files.iter_mut().rev() {
                 sst_filter.apply_filter(meta_file);
             }
             inner.meta_files.append(&mut new_meta_files);

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -505,6 +505,8 @@ impl TurboPersistence {
                 sst_filter.apply_filter(meta_file);
             }
             inner.meta_files.append(&mut new_meta_files);
+            // apply_and_get_remove need to run in reverse order
+            inner.meta_files.reverse();
             inner.meta_files.retain(|meta| {
                 if sst_filter.apply_and_get_remove(meta) {
                     meta_seq_numbers_to_delete.push(meta.sequence_number());
@@ -513,6 +515,7 @@ impl TurboPersistence {
                     true
                 }
             });
+            inner.meta_files.reverse();
             has_delete_file = !sst_seq_numbers_to_delete.is_empty()
                 || !blob_seq_numbers_to_delete.is_empty()
                 || !meta_seq_numbers_to_delete.is_empty();

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -258,7 +258,7 @@ impl MetaFile {
             return Ok(MetaLookupResult::FamilyMiss);
         }
         let mut miss_result = MetaLookupResult::RangeMiss;
-        for entry in self.entries.iter() {
+        for entry in self.entries.iter().rev() {
             if key_hash < entry.min_hash || key_hash > entry.max_hash {
                 continue;
             }


### PR DESCRIPTION
### What?

* fixes a bug where it crashes with `Unable to open static sorted file 00000286.sst` after a compaction which leaves a partial meta file.
  meta files need to be handled in reverse order as higher sequence numbers override lower ones
* fixes another bug where SST files in meta files were processed in incorrect order
  This could cause reading outdated values, maybe causing the incorrect graph problem or stale tasks/errors

Closes PACK-4770