### PR TITLE
[global-not-found] fix shared css imports not being picked

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -109,7 +109,7 @@ const pluginState = getProxiedPluginState({
 })
 
 const POSSIBLE_SHARED_CONVENTIONS = ['template', 'layout']
-const STANDALONE_BUNDLE_CONVENTIONS = new Set(['global-not-found'])
+const STANDALONE_BUNDLE_CONVENTION = 'global-not-found'
 
 function deduplicateCSSImportsForEntry(mergedCSSimports: CssImports) {
   // If multiple entry module connections are having the same CSS import,
@@ -160,9 +160,10 @@ function deduplicateCSSImportsForEntry(mergedCSSimports: CssImports) {
       // Or if it's any standalone entry such as `global-not-found`, it won't share any resources with other entry, skip it.
       if (
         trackedCSSImports.has(cssImport) &&
-        !STANDALONE_BUNDLE_CONVENTIONS.has(entryConventionName)
-      )
+        STANDALONE_BUNDLE_CONVENTION !== entryConventionName
+      ) {
         continue
+      }
 
       // Only track CSS imports that are in files that can inherit CSS.
       if (POSSIBLE_SHARED_CONVENTIONS.includes(entryConventionName)) {

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -151,7 +151,6 @@ function deduplicateCSSImportsForEntry(mergedCSSimports: CssImports) {
 
   const dedupedCSSImports: CssImports = {}
   const trackedCSSImports = new Set<string>()
-  const possibleSharedConventionSet = new Set(POSSIBLE_SHARED_CONVENTIONS)
 
   for (const [entryFilePath, cssImports] of sortedCSSImports) {
     const entryConventionName = path.parse(entryFilePath).name
@@ -166,7 +165,7 @@ function deduplicateCSSImportsForEntry(mergedCSSimports: CssImports) {
         continue
 
       // Only track CSS imports that are in files that can inherit CSS.
-      if (possibleSharedConventionSet.has(entryConventionName)) {
+      if (POSSIBLE_SHARED_CONVENTIONS.includes(entryConventionName)) {
         trackedCSSImports.add(cssImport)
       }
 

--- a/test/e2e/app-dir/global-not-found/css/app/call-not-found/page.tsx
+++ b/test/e2e/app-dir/global-not-found/css/app/call-not-found/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { notFound } from 'next/navigation'
+
+export default function Page() {
+  notFound()
+}

--- a/test/e2e/app-dir/global-not-found/css/app/client.tsx
+++ b/test/e2e/app-dir/global-not-found/css/app/client.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function Client() {
+  return <div id="client">client</div>
+}

--- a/test/e2e/app-dir/global-not-found/css/app/global-not-found.css
+++ b/test/e2e/app-dir/global-not-found/css/app/global-not-found.css
@@ -1,0 +1,3 @@
+.blue-text {
+  color: rgb(0, 0, 255);
+}

--- a/test/e2e/app-dir/global-not-found/css/app/global-not-found.tsx
+++ b/test/e2e/app-dir/global-not-found/css/app/global-not-found.tsx
@@ -1,0 +1,17 @@
+import { Client } from './client'
+import './global.css'
+import './global-not-found.css'
+
+export default function GlobalNotFound() {
+  return (
+    // html tag is different from actual page's layout
+    <html data-global-not-found="true">
+      <body>
+        <h1 id="global-error-title">global-not-found</h1>
+        <Client />
+        <p className="orange-text">orange text (from global.css)</p>
+        <p className="blue-text">blue text (from global-not-found.css)</p>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-not-found/css/app/global.css
+++ b/test/e2e/app-dir/global-not-found/css/app/global.css
@@ -1,0 +1,3 @@
+.orange-text {
+  color: rgb(255, 165, 0);
+}

--- a/test/e2e/app-dir/global-not-found/css/app/layout.tsx
+++ b/test/e2e/app-dir/global-not-found/css/app/layout.tsx
@@ -1,0 +1,16 @@
+import './global.css'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+      <footer>
+        <p className="orange-text">layout footer orange text</p>
+      </footer>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-not-found/css/app/page.tsx
+++ b/test/e2e/app-dir/global-not-found/css/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/global-not-found/css/global-not-found-css.test.ts
+++ b/test/e2e/app-dir/global-not-found/css/global-not-found-css.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('global-not-found - css', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should include css for global-not-found properly', async () => {
+    const browser = await next.browser('/does-not-exist')
+
+    // This css import is shared with `/` route's layout
+    const textColorOrange = await browser
+      .elementByCss('.orange-text')
+      .getComputedCss('color')
+    expect(textColorOrange).toBe('rgb(255, 165, 0)')
+
+    // This css import is only used in the global-not-found convention
+    const textColorRed = await browser
+      .elementByCss('.blue-text')
+      .getComputedCss('color')
+    expect(textColorRed).toBe('rgb(0, 0, 255)')
+  })
+})

--- a/test/e2e/app-dir/global-not-found/css/next.config.js
+++ b/test/e2e/app-dir/global-not-found/css/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    globalNotFound: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What

We noticed a weired behavior that in certain condition the CSS import is not being properly applied in the `global-not-found` page. Dig into the flight manifest and noticed that the CSS files are not properly collected for the `global-not-found` entry.

At the same time I also observed that:
- ✅ If there's a css file being used in a route's page.js and also in global-not-found.js, it will be applied properly.
- ❌ If there's a css file being used in a route's layout.js and also in global-not-found.js, it will not be applied;

Turns out it's because the CSS import was skipped in a certain condition, when the CSS import is used also used in `layout.js` of other routes. The skip happens in the CSS deduping algorithm that we introduced in #50406 to avoid CSS being bundled multiple times for every layer/entries.

`global-not-found` is a separate entry where the other parental conventions such as `layout.js` or `template.js` won't be shared in this entry, we'll just skip applying the CSS deduping algorithm for this special `global-not-found` entry.
 
 Closes NEXT-4480