### PR TITLE
Webpack Build: Use name-contenthash instead of name-chunkhash for dynamic imports

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1281,7 +1281,7 @@ export default async function getBaseWebpackConfig(
           ? `[name].js`
           : `../[name].js`
         : `static/chunks/${isDevFallback ? 'fallback/' : ''}[name]${
-            dev ? '' : appDir ? '-[chunkhash]' : '-[contenthash]'
+            dev ? '' : '-[contenthash]'
           }.js`,
       library: isClient || isEdgeServer ? '_N_E' : undefined,
       libraryTarget: isClient || isEdgeServer ? 'assign' : 'commonjs2',

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -128,9 +128,6 @@ function getAppPathRequiredChunks(
     }
 
     // Get the actual chunk file names from the chunk file list.
-    // It's possible that the chunk is generated via `import()`, in
-    // that case the chunk file name will be '[name].[contenthash]'
-    // instead of '[name]-[chunkhash]'.
     if (chunk.id != null) {
       const chunkId = '' + chunk.id
       chunk.files.forEach((file) => {
@@ -229,7 +226,7 @@ export class ClientReferenceManifestPlugin {
           name: PLUGIN_NAME,
           // Have to be in the optimize stage to run after updating the CSS
           // asset hash via extract mini css plugin.
-          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
         },
         () => this.createAsset(compilation, compiler.context)
       )


### PR DESCRIPTION
Did a bit of digging into #78756. It seems we already read the file paths correctly, just needed to check it later in asset processing hook.

Closes PACK-4768