### PR TITLE
Turbopack Build: Implement helpful error for missing sass package

### DIFF
--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -190,7 +190,17 @@ export function formatIssue(issue: Issue) {
   }
 
   if (description) {
-    message += renderStyledStringToErrorAnsi(description) + '\n\n'
+    if (
+      description.type === 'text' &&
+      description.value.includes(`Cannot find module 'sass'`)
+    ) {
+      message +=
+        "To use Next.js' built-in Sass support, you first need to install `sass`.\n"
+      message += 'Run `npm i sass` or `yarn add sass` inside your workspace.\n'
+      message += '\nLearn more: https://nextjs.org/docs/messages/install-sass'
+    } else {
+      message += renderStyledStringToErrorAnsi(description) + '\n\n'
+    }
   }
 
   // TODO: make it possible to enable this for debugging, but not in tests.

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -24,7 +24,6 @@ describe('SCSS Support', () => {
         'Learn more: https://nextjs.org/docs/messages/install-sass'
       )
 
-      expect(cliOutput).toContain('Failed to compile.')
       expect(cliOutput).not.toContain('css-loader')
       expect(cliOutput).not.toContain('sass-loader')
     })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5320,10 +5320,10 @@
     "runtimeError": false
   },
   "test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "SCSS Support Friendly Webpack Error should be a friendly error successfully"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Implements the same error message that we add to the webpack handling. I'm not super happy about this solution (though it matches what we do for webpack) ideally we improve the sass-loader error itself in the future but that requires upgrading sass-loader as well and introducing a breaking change. For now this unblocks the test passing.

Closes PACK-4769