### PR TITLE
Add experimental flag for RSC request validation

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2084,6 +2084,8 @@ export default abstract class Server<
     // TODO: Consider not using custom request headers at all, and instead fully
     // encode everything into the search param.
     if (
+      !this.minimalMode &&
+      this.nextConfig.experimental.validateRSCRequestHeaders &&
       this.isAppSegmentPrefetchEnabled &&
       getRequestMeta(req, 'segmentPrefetchRSCRequest')
     ) {
@@ -3746,11 +3748,17 @@ export default abstract class Server<
     let page = pathname
     const bubbleNoFallback =
       getRequestMeta(ctx.req, 'bubbleNoFallback') ?? false
-    addRequestMeta(
-      ctx.req,
-      'cacheBustingSearchParam',
-      query[NEXT_RSC_UNION_QUERY]
-    )
+
+    if (
+      !this.minimalMode &&
+      this.nextConfig.experimental.validateRSCRequestHeaders
+    ) {
+      addRequestMeta(
+        ctx.req,
+        'cacheBustingSearchParam',
+        query[NEXT_RSC_UNION_QUERY]
+      )
+    }
     delete query[NEXT_RSC_UNION_QUERY]
 
     const options: MatchOptions = {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -406,6 +406,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         proxyTimeout: z.number().gte(0).optional(),
         routerBFCache: z.boolean().optional(),
         removeUncaughtErrorAndRejectionListeners: z.boolean().optional(),
+        validateRSCRequestHeaders: z.boolean().optional(),
         scrollRestoration: z.boolean().optional(),
         sri: z
           .object({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -539,6 +539,12 @@ export interface ExperimentalConfig {
    */
   removeUncaughtErrorAndRejectionListeners?: boolean
 
+  /**
+   * During an RSC request, validates that the request headers match the
+   * cache-busting search parameter sent by the client.
+   */
+  validateRSCRequestHeaders?: boolean
+
   serverActions?: {
     /**
      * Allows adjusting body parser size limit for server actions.
@@ -1368,6 +1374,7 @@ export const defaultConfig = {
     viewTransition: false,
     routerBFCache: false,
     removeUncaughtErrorAndRejectionListeners: false,
+    validateRSCRequestHeaders: false,
     staleTimes: {
       dynamic: 0,
       static: 300,

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/next.config.js
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/next.config.js
@@ -4,6 +4,7 @@
 const nextConfig = {
   experimental: {
     clientSegmentCache: true,
+    validateRSCRequestHeaders: true,
   },
 }
 


### PR DESCRIPTION
We're going to expand this to cover all RSC requests, not just segment prefetches. To decouple this from clientSegmentCache, I've added a new flag to control it. (Although for now, the behavior is still gated behind both flags, until we've made the check more robust.)