### PR TITLE
[test] add custom timeout for start server

### DIFF
--- a/test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts
+++ b/test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts
@@ -4,6 +4,9 @@ describe('clientTraceMetadata', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     dependencies: require('./package.json').dependencies,
+    // This test sometimes takes longer than the default timeout, extending it bit longer
+    // to avoid flakiness.
+    startServerTimeout: 15_000,
   })
 
   describe('app router', () => {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -44,6 +44,7 @@ export interface NextInstanceOpts {
   forcedPort?: string
   serverReadyPattern?: RegExp
   patchFileDelay?: number
+  startServerTimeout?: number
 }
 
 /**
@@ -84,6 +85,7 @@ export class NextInstance {
   public env: Record<string, string>
   public forcedPort?: string
   public dirSuffix: string = ''
+  public startServerTimeout: number = 10_000 // 10 seconds
   public serverReadyPattern: RegExp = / ✓ Ready in /
   patchFileDelay: number = 0
 
@@ -386,7 +388,7 @@ export class NextInstance {
 
   protected setServerReadyTimeout(
     reject: (reason?: unknown) => void,
-    ms = 10_000
+    ms: number
   ): NodeJS.Timeout {
     return setTimeout(() => {
       reject(

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -93,7 +93,10 @@ export class NextDevInstance extends NextInstance {
           }
         })
 
-        const serverReadyTimeoutId = this.setServerReadyTimeout(reject)
+        const serverReadyTimeoutId = this.setServerReadyTimeout(
+          reject,
+          this.startServerTimeout
+        )
 
         const readyCb = (msg) => {
           const resolveServer = () => {

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -149,7 +149,10 @@ export class NextStartInstance extends NextInstance {
           }
         })
 
-        const serverReadyTimeoutId = this.setServerReadyTimeout(reject)
+        const serverReadyTimeoutId = this.setServerReadyTimeout(
+          reject,
+          this.startServerTimeout
+        )
 
         const readyCb = (msg) => {
           const colorStrippedMsg = stripAnsi(msg)


### PR DESCRIPTION
### What

`test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts` test sometimes timeout due to the slow startup, pretty flaky.

```
 ✓ Starting...
     Loading config from /tmp/next-install-e9f56a0641ac83c050954cb684516d799b7cc95ce010d329c42113c3147636e9/next.config.js
  
     We detected TypeScript in your project and created a tsconfig.json file for you.
     Loading config from /tmp/next-install-e9f56a0641ac83c050954cb684516d799b7cc95ce010d329c42113c3147636e9/next.config.js
   ○ Compiling /instrumentation ...
  Failed to create next instance Error: Failed to start server after 10000ms, waiting for this log pattern: / ✓ Ready in /
      at Timeout._onTimeout (/root/actions-runner/_work/next.js/next.js/test/lib/next-modes/base.ts:393:9)
      at listOnTimeout (node:internal/timers:573:17)
      at processTimers (node:internal/timers:514:7)
  Stopped next server
  destroyed next instance: 586.074ms
  FAIL default test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts (17.369 s)
```

This PR adds a custom timeout option that can help us custom the waiting time for starting server, so for this case we can wait bit longer, rather than directly increasing the timeout of start server for all tests

### Testing Util Changes

Adding a new option `startServerTimeout` to `nextTestSetup` that you can wait slightly longer for the server startup 

```diff
const { next } = nextTestSetup({
    files: __dirname,
+    startServerTimeout: 15_000,
  })
```