### PR TITLE
build(turbopack): Update `swc_core` to `v26.4.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,7 +3033,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -7461,9 +7461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "11.0.2"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07eee3b76576a59386a0245cdf6ecc37b837da5d515c965f34362b338fa99141"
+checksum = "406a9d24fdd093e7d529233309f1b0514bb5ce4dff7a952ad6c3de04990647ff"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7554,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "26.3.3"
+version = "26.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31930a468e3178fe8ac7f47bd1fcccdd1d97d11abf6ffec7d7b8800196c36bf"
+checksum = "94ab2ee5cd6285e9a2ab41aa4e1ff58497ad9ac0054917a04b191d9af33f730d"
 dependencies = [
  "binding_macros",
  "par-core",
@@ -7995,9 +7995,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "14.0.3"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b232a4ba5106d7bfa4da9cb4a22c3f3fdac64d656cf45c60a349f8ded133462"
+checksum = "bb339d30ba6ee93da5d5638982faaa79586cd429fe331648abf42afa0eb0a7b5"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8063,9 +8063,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "20.0.3"
+version = "20.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c43654113e9a75edf05fbe2c66b5232e149f563c97bef58ff1a896daa288092"
+checksum = "9c38b93f633ff58a9607c0002da2f99c91b7c55a42ff6b6dd90806bb51ccd670"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8101,9 +8101,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "14.0.1"
+version = "14.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b59cd2d4c1989c38eae5cd5888f3a3120ecbe2e53b939e586d340b12de7c1e2"
+checksum = "60e07e6ecd47f748988902976d09c4022b1147772f88ad8a95852a20722ac7dc"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7461,9 +7461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "11.1.1"
+version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a7f469e8da44aa8b5f351b0f17171bde70730677d9090befb6f8d781f19a82"
+checksum = "d3155396ace6598e8a0fa08a02131ad65f8ec4494bf7f9481f66523348bb0114"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7554,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "26.4.2"
+version = "26.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3081532971b0e444602712e9209d3a3835b883b806fc99da6e8f524a5845055"
+checksum = "6b36f6c0fb2815a8a72a2db539804431284f6c35c21a140a226755c028ad1f52"
 dependencies = [
  "binding_macros",
  "par-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7554,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "26.4.0"
+version = "26.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab2ee5cd6285e9a2ab41aa4e1ff58497ad9ac0054917a04b191d9af33f730d"
+checksum = "cce442936df384bc50036eecfda8a9585e2c56bee366dd6ff1e4194ee75ef9ac"
 dependencies = [
  "binding_macros",
  "par-core",
@@ -8063,9 +8063,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "20.0.4"
+version = "20.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c38b93f633ff58a9607c0002da2f99c91b7c55a42ff6b6dd90806bb51ccd670"
+checksum = "cf26b860e6a0e23807c70b03175d0e09082cfe256130c4759fdf9372020d3a3f"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8457,9 +8457,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "15.0.1"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199e2f048c1998d550ebe5296e0876a3e5b2f963d75a925c2208466071edb9d8"
+checksum = "7d2c29dbfc54e02c14975aff9d2c75ae6fff0808d860d9971a493d37870e282f"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7461,9 +7461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "11.1.2"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3155396ace6598e8a0fa08a02131ad65f8ec4494bf7f9481f66523348bb0114"
+checksum = "44c332906667b0fa98622f19a19e43afa5aa63b652813f80645dd0f33eca1fbb"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7554,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "26.4.3"
+version = "26.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b36f6c0fb2815a8a72a2db539804431284f6c35c21a140a226755c028ad1f52"
+checksum = "d6d1783e7597476b56a78ecf32de11269455e0263b1f93729be2fdbd8eeb799a"
 dependencies = [
  "binding_macros",
  "par-core",
@@ -8204,9 +8204,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "15.1.0"
+version = "15.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb01eeec1de9e2cfd089e3afcf3db60df10c812f97a42d953d094eba32e9d26f"
+checksum = "49c0a76bff24b9fa13d5451e7a664d18158849c45434d863e0553e29fb31170b"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7461,9 +7461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406a9d24fdd093e7d529233309f1b0514bb5ce4dff7a952ad6c3de04990647ff"
+checksum = "75a7f469e8da44aa8b5f351b0f17171bde70730677d9090befb6f8d781f19a82"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7554,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "26.4.1"
+version = "26.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce442936df384bc50036eecfda8a9585e2c56bee366dd6ff1e4194ee75ef9ac"
+checksum = "a3081532971b0e444602712e9209d3a3835b883b806fc99da6e8f524a5845055"
 dependencies = [
  "binding_macros",
  "par-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "26.4.1", features = [
+swc_core = { version = "26.4.2", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "26.3.3", features = [
+swc_core = { version = "26.4.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "26.4.3", features = [
+swc_core = { version = "26.4.4", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "26.4.0", features = [
+swc_core = { version = "26.4.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "26.4.2", features = [
+swc_core = { version = "26.4.3", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",


### PR DESCRIPTION
### What?

ChangeLog: https://github.com/swc-project/swc/compare/swc_core%40v26.3.3...swc_core%40v26.4.4

### Why?

To allow using https://github.com/swc-project/swc/pull/10560



Closes PACK-4774