### PR TITLE
Fix race condition in `types-and-precompiled`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint-eslint": "cross-env ESLINT_USE_FLAT_CONFIG=false eslint . --ext js,jsx,mjs,ts,tsx,mts,mdx --config .eslintrc.json --no-eslintrc",
     "lint-ast-grep": "ast-grep scan",
     "lint-no-typescript": "run-p prettier-check lint-eslint lint-language",
-    "types-and-precompiled": "run-p lint-typescript check-precompiled check-compiler-fixtures types:test-lib",
+    "types-and-precompiled": "run-p lint-typescript check-compiler-fixtures types:test-lib && pnpm check-precompiled",
     "check-compiler-fixtures": "find crates/next-custom-transforms/tests/fixture -type f -name 'tsconfig.json' -print0 | xargs --null -n1 -I'{}' pnpm tsc --noEmit --project '{}'",
     "validate-externals-doc": "node ./scripts/validate-externals-doc.js",
     "lint": "run-p test-types lint-typescript prettier-check lint-eslint lint-ast-grep lint-language",


### PR DESCRIPTION
`ncc` will vendor packages into `src/compiled` which is also read during type-checking. We now run `ncc` after type-checking is completed to avoid this. type-checking is more important. That's why it comes first so that `ncc` doesn't shadow type issues. 

Ideally we run both and the use both exit codes but more complex to implement.

Fixes
```
error TS6053: File '/root/actions-runner/_work/next.js/next.js/packages/next/src/compiled/@edge-runtime/cookies/index.d.ts' not found.
...
```
-- https://github.com/vercel/next.js/actions/runs/15445231129/job/43472984624?pr=80111