### PR TITLE
Pass MouseEvent to onNavigate

### DIFF
--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -28,7 +28,7 @@ type OptionalKeys<T> = {
   [K in keyof T]-?: {} extends Pick<T, K> ? K : never
 }[keyof T]
 
-type OnNavigateEventHandler = (event: { preventDefault: () => void }) => void
+type OnNavigateEventHandler = (event: React.MouseEvent) => void
 
 type InternalLinkProps = {
   /**
@@ -235,39 +235,32 @@ function linkClicked(
     return
   }
 
-  e.preventDefault()
+  if (onNavigate) {
+    onNavigate(e)
 
-  const navigate = () => {
-    if (onNavigate) {
-      let isDefaultPrevented = false
-
-      onNavigate({
-        preventDefault: () => {
-          isDefaultPrevented = true
-        },
-      })
-
-      if (isDefaultPrevented) {
-        return
-      }
-    }
-
-    // If the router is an NextRouter instance it will have `beforePopState`
-    const routerScroll = scroll ?? true
-    if ('beforePopState' in router) {
-      router[replace ? 'replace' : 'push'](href, as, {
-        shallow,
-        locale,
-        scroll: routerScroll,
-      })
-    } else {
-      router[replace ? 'replace' : 'push'](as || href, {
-        scroll: routerScroll,
-      })
+    if (e.defaultPrevented) {
+      // cancel navigation entirely
+      return
     }
   }
 
-  navigate()
+  // prevent browser default behavior (hard navigation)
+  e.preventDefault()
+
+  // If the router is an NextRouter instance it will have `beforePopState`
+  const routerScroll = scroll ?? true
+  if ('beforePopState' in router) {
+    router[replace ? 'replace' : 'push'](href, as, {
+      shallow,
+      locale,
+      scroll: routerScroll,
+    })
+  } else {
+    router[replace ? 'replace' : 'push'](as || href, {
+      scroll: routerScroll,
+    })
+  }
+
 }
 
 type LinkPropsReal = React.PropsWithChildren<


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

Closes NEXT-
Fixes #

-->

### What?

Link's `onNavigate` callback will pass the mouse event object, instead of an object which only exposes the `preventDefault` attribute.

### Why?

In addition to cancelling navigation with `preventDefault()`, there are other use cases for `onNavigate`:
 * reading the `event.timeStamp` in order to measure navigation latency
 * reading `event.target.href` in order to determine if this should be a hard or soft navigation. For example, automatically detecting if the link points to a page served by a different root layout and forcing a hard navigation.
 * logging other event properties for debugging purposes

### How?

Instead of calling `onNavigate({ preventDefault: () => { ... } })` we call `onNavigate(e)`. Since the event has a `preventDefault` method, this change is backwards compatible.

### TODO
 - [ ] Update tests
 - [ ] Update documentation
 - [ ] Add to Changeset