### PR TITLE
[error-overlay] remove footer message

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-footer/error-overlay-footer.tsx
@@ -3,18 +3,11 @@ import { styles as feedbackStyles } from './error-feedback/error-feedback'
 
 export type ErrorOverlayFooterProps = {
   errorCode: string | undefined
-  footerMessage: string | undefined
 }
 
-export function ErrorOverlayFooter({
-  errorCode,
-  footerMessage,
-}: ErrorOverlayFooterProps) {
+export function ErrorOverlayFooter({ errorCode }: ErrorOverlayFooterProps) {
   return (
     <footer className="error-overlay-footer">
-      {footerMessage ? (
-        <p className="error-overlay-footer-message">{footerMessage}</p>
-      ) : null}
       {errorCode ? (
         <ErrorFeedback className="error-feedback" errorCode={errorCode} />
       ) : null}
@@ -42,14 +35,6 @@ export const styles = `
       font-weight: 500;
       margin: 0;
     }
-  }
-
-  .error-overlay-footer-message {
-    color: var(--color-gray-900);
-    margin: 0;
-    font-size: var(--size-14);
-    font-weight: 400;
-    line-height: var(--size-20);
   }
 
   ${feedbackStyles}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.stories.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.stories.tsx
@@ -43,18 +43,3 @@ export const NoErrorCode: Story = {
     errorCode: undefined,
   },
 }
-
-export const WithLongFooterMessage: Story = {
-  args: {
-    ...Default.args,
-    footerMessage:
-      'This is a very long footer message that demonstrates how the footer handles lengthy text. It could contain important information about the error or additional context for debugging.',
-  },
-}
-
-export const WithShortFooterMessage: Story = {
-  args: {
-    ...Default.args,
-    footerMessage: 'A brief error description.',
-  },
-}

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -51,7 +51,6 @@ export interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   runtimeErrors?: ReadyRuntimeError[]
   activeIdx?: number
   setActiveIndex?: (index: number) => void
-  footerMessage?: string
   dialogResizerRef?: React.RefObject<HTMLDivElement | null>
 }
 
@@ -69,7 +68,6 @@ export function ErrorOverlayLayout({
   runtimeErrors,
   activeIdx,
   setActiveIndex,
-  footerMessage,
   isTurbopack,
   dialogResizerRef,
   // This prop is used to animate the dialog, it comes from a parent component (<ErrorOverlay>)
@@ -90,7 +88,7 @@ export function ErrorOverlayLayout({
   )
 
   const faderRef = React.useRef<HTMLDivElement | null>(null)
-  const hasFooter = Boolean(footerMessage || errorCode)
+  const hasFooter = Boolean(errorCode)
   const dialogRef = React.useRef<HTMLDivElement | null>(null)
   useFocusTrap(dialogRef, null, rendered)
 
@@ -130,14 +128,7 @@ export function ErrorOverlayLayout({
           dialogResizerRef={dialogResizerRef}
           data-has-footer={hasFooter}
           onScroll={onScroll}
-          footer={
-            hasFooter && (
-              <ErrorOverlayFooter
-                footerMessage={footerMessage}
-                errorCode={errorCode}
-              />
-            )
-          }
+          footer={hasFooter && <ErrorOverlayFooter errorCode={errorCode} />}
         >
           <Resizer
             ref={dialogResizerRef}

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/build-error.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/build-error.tsx
@@ -43,7 +43,6 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
       errorMessage={formattedMessage}
       onClose={noop}
       error={error}
-      footerMessage="This error occurred during the build process and can only be dismissed by fixing the error."
       {...props}
     >
       <Terminal content={message} />

--- a/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/container/errors.tsx
@@ -157,10 +157,6 @@ export function Errors({
   const hydrationWarning = errorDetails.hydrationWarning
   const errorCode = extractNextErrorCode(error)
 
-  const footerMessage = isServerError
-    ? 'This error happened while generating the page. Any console logs will be displayed in the terminal window.'
-    : undefined
-
   return (
     <ErrorOverlayLayout
       errorCode={errorCode}
@@ -178,7 +174,6 @@ export function Errors({
       runtimeErrors={runtimeErrors}
       activeIdx={activeIdx}
       setActiveIndex={setActiveIndex}
-      footerMessage={footerMessage}
       dialogResizerRef={dialogResizerRef}
       {...props}
     >


### PR DESCRIPTION
### Why?

The footer message was preserved from the old overlay. We see it is not adding much value to the current error displayed, so removing it.

x-ref: [slack thread](https://vercel.slack.com/archives/C04A1276AGK/p1749031230329599)