### PR TITLE
[metadata] fix nonce prop for hoist script

### DIFF
--- a/packages/next/src/server/app-render/metadata-insertion/create-server-inserted-metadata.tsx
+++ b/packages/next/src/server/app-render/metadata-insertion/create-server-inserted-metadata.tsx
@@ -15,6 +15,6 @@ export function createServerInsertedMetadata(nonce: string | undefined) {
     }
 
     inserted = true
-    return `<script nonce="${nonce}">${REINSERT_ICON_SCRIPT}</script>`
+    return `<script ${nonce ? `nonce="${nonce}"` : ''}>${REINSERT_ICON_SCRIPT}</script>`
   }
 }


### PR DESCRIPTION
### What

Only render `nonce` prop on icon hoist script when it's presented