### PR TITLE
docs: fix grammar in Code of Conduct section ('them' → 'it') 

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -31,7 +31,7 @@ The Next.js community can be found on [GitHub Discussions](https://github.com/ve
 
 To chat with other community members you can join the Next.js [Discord](https://nextjs.org/discord) server.
 
-Do note that our [Code of Conduct](https://github.com/vercel/next.js/blob/canary/CODE_OF_CONDUCT.md) applies to all Next.js community channels. Users are **highly encouraged** to read and adhere to them to avoid repercussions.
+Do note that our [Code of Conduct](https://github.com/vercel/next.js/blob/canary/CODE_OF_CONDUCT.md) applies to all Next.js community channels. Users are **highly encouraged** to read and adhere to it to avoid repercussions.
 
 ## Contributing
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## What?

Fixed a grammatical issue in the Code of Conduct section of `packages/next/README.md`.  
Changed “adhere to them” to “adhere to it”.

## Why?

"Code of Conduct" is a singular noun, so using "them" is grammatically incorrect. The correct pronoun is "it".

## How?

Edited the relevant sentence in `packages/next/README.md`.

<!--
Closes NEXT-
Fixes #
-->
