### PR TITLE
[devtools] Port cache invalidation logic from turbopack to webpack

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -707,5 +707,6 @@
   "706": "Invariant: static responses cannot be streamed %s",
   "707": "Invariant app-page handler received invalid cache entry %s",
   "708": "Failed to persist Chrome DevTools workspace UUID. The Chrome DevTools Workspace needs to be reconnected after the next page reload.",
-  "709": "`rspack.getModuleNamedExports` is not supported by the wasm bindings."
+  "709": "`rspack.getModuleNamedExports` is not supported by the wasm bindings.",
+  "710": "Unable to remove an invalidated webpack cache. If this issue persists you can work around it by deleting %s"
 }

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -289,8 +289,21 @@ export function getDefineEnv({
       : {}),
     'process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER':
       config.experimental.devtoolSegmentExplorer ?? false,
-    'process.env.__NEXT_TURBOPACK_PERSISTENT_CACHE':
-      config.experimental.turbopackPersistentCaching ?? false,
+
+    // The devtools need to know whether or not to show an option to clear the
+    // bundler cache. This option may be removed later once Turbopack's
+    // persistent cache feature is more stable.
+    //
+    // This environment value is currently best-effort:
+    // - It's possible to disable the webpack filesystem cache, but it's
+    //   unlikely for a user to do that.
+    // - Rspack's persistent cache is unstable and requires a different
+    //   configuration than webpack to enable (which we don't do).
+    //
+    // In the worst case we'll show an option to clear the cache, but it'll be a
+    // no-op that just restarts the development server.
+    'process.env.__NEXT_BUNDLER_HAS_PERSISTENT_CACHE':
+      !isTurbopack || (config.experimental.turbopackPersistentCaching ?? false),
   }
 
   const userDefines = config.compiler?.define ?? {}

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -289,6 +289,21 @@ export function hasExternalOtelApiPackage(): boolean {
 
 const UNSAFE_CACHE_REGEX = /[\\/]pages[\\/][^\\/]+(?:$|\?|#)/
 
+export function getCacheDirectories(
+  configs: webpack.Configuration[]
+): Set<string> {
+  return new Set(
+    configs
+      .map((cfg) => {
+        if (typeof cfg.cache === 'object' && cfg.cache.type === 'filesystem') {
+          return cfg.cache.cacheDirectory
+        }
+        return null
+      })
+      .filter((dir) => dir != null)
+  )
+}
+
 export default async function getBaseWebpackConfig(
   dir: string,
   {

--- a/packages/next/src/build/webpack/cache-invalidation.ts
+++ b/packages/next/src/build/webpack/cache-invalidation.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const INVALIDATION_MARKER = '__nextjs_invalidated_cache'
+
+/**
+ * Atomically write an invalidation marker.
+ *
+ * Because attempting to delete currently open cache files could cause issues,
+ * actual deletion of files is deferred until the next start-up (in
+ * `checkPersistentCacheInvalidationAndCleanup`).
+ *
+ * In the case that no database is currently open (e.g. via a separate CLI
+ * subcommand), you should call `cleanupPersistentCache` *after* this to eagerly
+ * remove the cache files.
+ */
+export async function invalidatePersistentCache(cacheDirectory: string) {
+  let file
+  try {
+    // We're just opening it so that `open()` creates the file.
+    file = await fs.open(path.join(cacheDirectory, INVALIDATION_MARKER), 'w')
+    // We don't currently write anything to the file, but we could choose to
+    // later, e.g. a reason for the invalidation.
+  } catch (err: any) {
+    // it's valid for the cache to not exist at all
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  } finally {
+    file?.close()
+  }
+}
+
+/**
+ * Called during startup. See if the cache is in a partially-completed
+ * invalidation state. Finds and delete any invalidated cache files.
+ */
+export async function checkPersistentCacheInvalidationAndCleanup(
+  cacheDirectory: string
+) {
+  const invalidated = await fs
+    .access(path.join(cacheDirectory, INVALIDATION_MARKER))
+    .then(
+      () => true,
+      () => false
+    )
+  if (invalidated) {
+    await cleanupPersistentCache(cacheDirectory)
+  }
+}
+
+/**
+ * Helper for `checkPersistentCacheInvalidationAndCleanup`. You can call this to
+ * explicitly clean up a database after running `invalidatePersistentCache` when
+ * webpack is not running.
+ *
+ * You should not run this if the cache has not yet been invalidated, as this
+ * operation is not atomic and could result in a partially-deleted and corrupted
+ * database.
+ */
+async function cleanupPersistentCache(cacheDirectory: string) {
+  try {
+    await cleanupPersistentCacheInner(cacheDirectory)
+  } catch (e) {
+    // generate a user-friendly error message
+    throw new Error(
+      `Unable to remove an invalidated webpack cache. If this issue persists ` +
+        `you can work around it by deleting ${cacheDirectory}`,
+      { cause: e }
+    )
+  }
+}
+
+async function cleanupPersistentCacheInner(cacheDirectory: string) {
+  const files = await fs.readdir(cacheDirectory)
+
+  // delete everything except the invalidation marker
+  await Promise.all(
+    files.map((name) =>
+      name !== INVALIDATION_MARKER
+        ? fs.rm(path.join(cacheDirectory, name), {
+            force: true, // ignore errors if path does not exist
+            recursive: true,
+            maxRetries: 2, // windows prevents deletion of open files
+          })
+        : null
+    )
+  )
+
+  // delete the invalidation marker last, once we're sure everything is cleaned
+  // up
+  await fs.rm(path.join(cacheDirectory, INVALIDATION_MARKER), {
+    force: true,
+    maxRetries: 2,
+  })
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -66,10 +66,10 @@ export function UserPreferences({
     setScale(value)
   }
 
-  function handleRestartDevServer() {
+  function handleRestartDevServer(invalidatePersistentCache: boolean) {
     let endpoint = '/__nextjs_restart_dev'
 
-    if (process.env.__NEXT_TURBOPACK_PERSISTENT_CACHE) {
+    if (invalidatePersistentCache) {
       endpoint = '/__nextjs_restart_dev?invalidatePersistentCache'
     }
 
@@ -198,14 +198,16 @@ export function UserPreferences({
               name="restart-dev-server"
               data-restart-dev-server
               className="action-button"
-              onClick={handleRestartDevServer}
+              onClick={() =>
+                handleRestartDevServer(/*invalidatePersistentCache*/ false)
+              }
             >
               <span>Restart</span>
             </button>
           </div>
         </div>
       </div>
-      {process.env.__NEXT_TURBOPACK_PERSISTENT_CACHE ? (
+      {process.env.__NEXT_BUNDLER_HAS_PERSISTENT_CACHE ? (
         <div className="preferences-container">
           <div className="preference-section">
             <div className="preference-header">
@@ -222,7 +224,9 @@ export function UserPreferences({
                 name="reset-bundler-cache"
                 data-reset-bundler-cache
                 className="action-button"
-                onClick={handleRestartDevServer}
+                onClick={() =>
+                  handleRestartDevServer(/*invalidatePersistentCache*/ true)
+                }
               >
                 <span>Reset Cache</span>
               </button>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -34,7 +34,7 @@ export function RestartServerButton({ error }: { error: Error }) {
   function handleClick() {
     let endpoint = '/__nextjs_restart_dev'
 
-    if (process.env.__NEXT_TURBOPACK_PERSISTENT_CACHE) {
+    if (process.env.__NEXT_BUNDLER_HAS_PERSISTENT_CACHE) {
       endpoint = '/__nextjs_restart_dev?invalidatePersistentCache'
     }
 
@@ -52,7 +52,7 @@ export function RestartServerButton({ error }: { error: Error }) {
       className="restart-dev-server-button"
       onClick={handleClick}
       title={
-        process.env.__NEXT_TURBOPACK_PERSISTENT_CACHE
+        process.env.__NEXT_BUNDLER_HAS_PERSISTENT_CACHE
           ? 'Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing.'
           : 'Restarts the development server without needing to leave the browser.'
       }


### PR DESCRIPTION
We want to support the "reset bundler cache" button in webpack/rspack. The webpack cache is a lot more stable, but it'd be good to have as a relative baseline once we have telemetry.

We don't use a persistent cache in rspack (it's an experimental feature). The reset button is incorrectly shown there, but I think that's fine for now. Clicking it just restarts the server.

## Testing

```
pnpm turbo build build-native
```

Webpack:

```
pnpm next dev examples/basic-css
```

Rspack:

```
pnpm next dev examples/with-rspack
```

Used the reset/restart buttons in the preferences UI:

<img src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/0a007d96-d3f0-4617-a8ea-d98bdaee60dd.png" width=500/>

Watched the contents of `.next/cache/webpack` to verify the reset of the cache.

Closes PACK-4842