### PR TITLE
[turbopack] Remove the `_for_input` options from `turbo_tasks::value` and the `TypedForInput` trait.

### DIFF
--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TaskInput, Vc, fxindexmap};
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, fxindexmap, trace::TraceRawVcs};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
     context::AssetContext, module::Module, reference_type::ReferenceType, resolve::ModulePart,
@@ -9,8 +10,21 @@ use turbopack_static::ecma::StaticUrlJsModule;
 
 use super::source_asset::StructuredImageFileSource;
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, Hash, TaskInput)]
+#[derive(
+    Eq,
+    PartialEq,
+    Clone,
+    Copy,
+    Debug,
+    PartialOrd,
+    Ord,
+    Hash,
+    TaskInput,
+    TraceRawVcs,
+    NonLocalValue,
+    Serialize,
+    Deserialize,
+)]
 pub enum BlurPlaceholderMode {
     /// Do not generate a blur placeholder at all.
     None,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -127,9 +127,8 @@ pub use value::{TransientInstance, TransientValue};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
     Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,
-    TypedForInput, Upcast, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode,
-    VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
-    VcValueTypeCast,
+    Upcast, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead,
+    VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
 };
 
 pub type SliceMap<K, V> = Box<[(K, V)]>;
@@ -239,11 +238,8 @@ macro_rules! fxindexset {
 /// required for persistent caching of tasks to disk.
 ///
 /// - **`"auto"` *(default)*:** Derives the serialization traits and enables serialization.
-/// - **`"auto_for_input"`:** Same as `"auto"`, but also adds the marker trait [`TypedForInput`].
 /// - **`"custom"`:** Prevents deriving the serialization traits, but still enables serialization
 ///   (you must manually implement [`serde::Serialize`] and [`serde::Deserialize`]).
-/// - **`"custom_for_input"`:** Same as `"custom"`, but also adds the marker trait
-///   [`TypedForInput`].
 /// - **`"none"`:** Disables serialization and prevents deriving the traits.
 ///
 /// ## `shared`

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -116,23 +116,6 @@ impl ValueType {
     }
 
     /// This is internally used by `#[turbo_tasks::value]`
-    pub fn new_with_magic_serialization<
-        T: VcValueType + Debug + Eq + Hash + Serialize + for<'de> Deserialize<'de> + TraceRawVcs,
-    >() -> Self {
-        Self {
-            name: std::any::type_name::<T>().to_string(),
-            traits: AutoSet::new(),
-            trait_methods: AutoMap::new(),
-            magic_serialization: Some((
-                <dyn MagicAny>::as_serialize::<T>,
-                MagicAnyDeserializeSeed::new::<T>(),
-            )),
-            any_serialization: Some((any_as_serialize::<T>, AnyDeserializeSeed::new::<T>())),
-            raw_cell: <T::CellMode as VcCellMode<T>>::raw_cell,
-        }
-    }
-
-    /// This is internally used by `#[turbo_tasks::value]`
     pub fn new_with_any_serialization<
         T: VcValueType + Any + Serialize + for<'de> Deserialize<'de>,
     >() -> Self {

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     operation::{OperationValue, OperationVc},
     read::{ReadOwnedVcFuture, ReadVcFuture, VcDefaultRead, VcRead, VcTransparentRead},
     resolved::ResolvedVc,
-    traits::{Dynamic, TypedForInput, Upcast, VcValueTrait, VcValueType},
+    traits::{Dynamic, Upcast, VcValueTrait, VcValueType},
 };
 use crate::{
     CellId, RawVc, ResolveTypeError,

--- a/turbopack/crates/turbo-tasks/src/vc/traits.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/traits.rs
@@ -54,10 +54,3 @@ where
     T: VcValueTrait + ?Sized,
 {
 }
-
-/// Marker trait that a turbo_tasks::value is prepared for serialization as
-/// [`Value<...>`][crate::Value] input.
-///
-/// Either use [`#[turbo_tasks::value(serialization = "auto_for_input")]`][macro@crate::value] or
-/// avoid [`Value<...>`][crate::Value] in favor of a real [Vc][crate::Vc].
-pub trait TypedForInput: VcValueType {}

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -171,7 +171,7 @@ impl BrowserChunkingContextBuilder {
 /// It also uses a chunking heuristic that is incremental and cacheable.
 /// It splits "node_modules" separately as these are less likely to change
 /// during development
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub struct BrowserChunkingContext {
     name: Option<RcStr>,

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -139,7 +139,7 @@ impl From<serde_json::Value> for CompileTimeDefineValue {
     }
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Debug, Clone, Hash)]
 pub enum DefineableNameSegment {
     Name(RcStr),

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -51,7 +51,7 @@ impl Environment {
     }
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Debug, Hash, Clone, Copy, TaskInput)]
 pub enum ExecutionEnvironment {
     NodeJsBuildTime(ResolvedVc<NodeJsEnvironment>),

--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, Vc, trace::TraceRawVcs};
 
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
+#[turbo_tasks::value(shared)]
 #[derive(Hash, Debug, Copy, Clone)]
 pub struct CompileTarget {
     /// <https://nodejs.org/api/os.html#osarch>

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -322,7 +322,7 @@ impl ContentSourceDataFilter {
 /// Describes additional information that need to be sent to requests to
 /// ContentSource. By sending these information ContentSource responses are
 /// cached-keyed by them and they can access them.
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
+#[turbo_tasks::value(shared)]
 #[derive(Debug, Default, Clone, Hash)]
 pub struct ContentSourceDataVary {
     pub method: bool,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -23,7 +23,7 @@ use crate::{
     tree_shake::{PartId, find_turbopack_part_id_in_asserts},
 };
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Default, Debug, Clone, Hash)]
 pub struct ImportAnnotations {
     // TODO store this in more structured way

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -157,7 +157,7 @@ pub enum TreeShakingMode {
 #[turbo_tasks::value(transparent)]
 pub struct OptionTreeShaking(pub Option<TreeShakingMode>);
 
-#[turbo_tasks::value(shared, serialization = "auto_for_input")]
+#[turbo_tasks::value(shared)]
 #[derive(Hash, Debug, Default, Copy, Clone)]
 pub struct EcmascriptOptions {
     pub refresh: bool,
@@ -185,7 +185,7 @@ pub struct EcmascriptOptions {
     pub keep_last_successful_parse: bool,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Hash, Debug, Copy, Clone, TaskInput)]
 pub enum EcmascriptModuleAssetType {
     /// Module with EcmaScript code

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -26,7 +26,7 @@ use turbopack_core::{
     issue::{Issue, IssueSeverity, IssueStage, StyledString},
 };
 
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Debug, Clone, Hash)]
 pub enum EcmascriptInputTransform {
     Plugin(ResolvedVc<TransformPlugin>),
@@ -88,7 +88,7 @@ impl CustomTransformer for TransformPlugin {
     }
 }
 
-#[turbo_tasks::value(transparent, serialization = "auto_for_input")]
+#[turbo_tasks::value(transparent)]
 #[derive(Debug, Clone, Hash)]
 pub struct EcmascriptInputTransforms(Vec<EcmascriptInputTransform>);
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -96,7 +96,7 @@ impl NodeJsChunkingContextBuilder {
 }
 
 /// A chunking context for build mode.
-#[turbo_tasks::value(serialization = "auto_for_input")]
+#[turbo_tasks::value]
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub struct NodeJsChunkingContext {
     /// The root path of the project

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -76,7 +76,7 @@ pub enum ModuleRuleEffect {
     Ignore,
 }
 
-#[turbo_tasks::value(serialization = "auto_for_input", shared)]
+#[turbo_tasks::value(shared)]
 #[derive(Hash, Debug, Copy, Clone)]
 pub enum ModuleType {
     Ecmascript {


### PR DESCRIPTION
# Remove `auto_for_input` serialization mode from turbo-tasks

This PR removes the `auto_for_input` and `custom_for_input` serialization modes from turbo-tasks, along with the `TypedForInput` marker trait.

These were used for values passed via the `Value<>` type, but that is dead.


Closes PACK-4798