### PR TITLE
Use custom status code for RSC redirects

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -711,5 +711,6 @@
   "710": "Unable to remove an invalidated webpack cache. If this issue persists you can work around it by deleting %s",
   "711": "Can't resolve %s",
   "712": "`rspack.warnForEdgeRuntime` is not supported by the wasm bindings.",
-  "713": "Unexpected error during process lookup"
+  "713": "Unexpected error during process lookup",
+  "714": "Next.js RSC redirect protocol error: Missing Location header. This may indicate either a Next.js bug or that a third-party proxy is not correctly implementing the RSC redirect protocol."
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1396,7 +1396,9 @@ export const defaultConfig = {
     viewTransition: false,
     routerBFCache: false,
     removeUncaughtErrorAndRejectionListeners: false,
-    validateRSCRequestHeaders: false,
+    validateRSCRequestHeaders:
+      // TODO: remove once we've confirmed this mode is stable
+      !!process.env.__NEXT_TEST_MODE,
     staleTimes: {
       dynamic: 0,
       static: 300,

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -149,3 +149,32 @@ export const SYSTEM_ENTRYPOINTS = new Set<string>([
   CLIENT_STATIC_FILES_RUNTIME_AMP,
   CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
 ])
+
+/**
+ * Custom HTTP status code used to signal a redirect for React Server Component (RSC)
+ * requests that should be handled by the client-side RSC router, rather than
+ * being automatically followed by the browser like standard 307/308 redirects.
+ *
+ * Purpose:
+ * - To bypass the browser's default redirect behavior, which typically forwards
+ * original request headers and might not be ideal for RSC's stateful navigation.
+ * - To empower the client-side RSC router to intercept this signal and initiate
+ * a new, clean fetch or navigation to the target URL specified in the 'Location' header.
+ * This allows for better control over the request lifecycle for the redirected route.
+ *
+ * How it's used:
+ * - Server-side: When an RSC route intends to perform a redirect (originally as a
+ * 307 or 308), the status code is transformed into this custom value.
+ * The response must also include a 'Location' header with the redirect target URL.
+ * - Client-side: The RSC router is programmed to recognize this specific status code.
+ * Upon detection, it extracts the target URL from the 'Location' header and
+ * handles the navigation programmatically.
+ *
+ * Choice of Value (e.g., 278):
+ * - The specific value (like 278) is chosen from the 2xx range (indicating success)
+ * but is not a standard HTTP status code with predefined browser actions for redirection.
+ * This ensures browsers won't automatically follow it, while still signaling a
+ * successful server determination that requires client action. It should be an
+ * officially unassigned status code to minimize conflicts.
+ */
+export const RSC_REDIRECT_STATUS_CODE = 278

--- a/test/e2e/rsc-redirect/app/about/page.tsx
+++ b/test/e2e/rsc-redirect/app/about/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Page() {
+  return <div data-testid="about-page">About</div>
+}

--- a/test/e2e/rsc-redirect/app/layout.tsx
+++ b/test/e2e/rsc-redirect/app/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react'
+import React from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/rsc-redirect/app/next-config-redirect/page.tsx
+++ b/test/e2e/rsc-redirect/app/next-config-redirect/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      Next Config Redirect. This should redirect to /about by specifying a
+      redirect object in next.config.ts
+    </div>
+  )
+}

--- a/test/e2e/rsc-redirect/app/old-about/page.tsx
+++ b/test/e2e/rsc-redirect/app/old-about/page.tsx
@@ -1,0 +1,8 @@
+export default function OldAbout() {
+  return (
+    <div>
+      Old About - you should not see this page because middleware should
+      redirect you to /about
+    </div>
+  )
+}

--- a/test/e2e/rsc-redirect/app/page.tsx
+++ b/test/e2e/rsc-redirect/app/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import React from 'react'
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <Link href="/next-config-redirect" prefetch={false}>
+          Go to Next Config Redirect Page
+        </Link>
+      </div>
+      <div>
+        <Link href="/rsc-redirect" prefetch={false}>
+          Go to RSC redirect page
+        </Link>
+      </div>
+      <div>
+        <Link href="/about" prefetch={false}>
+          Go to About Page
+        </Link>
+      </div>
+      <div>
+        <Link href="/old-about" prefetch={false}>
+          Go to (Old) About Page
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/rsc-redirect/app/rsc-redirect/page.tsx
+++ b/test/e2e/rsc-redirect/app/rsc-redirect/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/about')
+}

--- a/test/e2e/rsc-redirect/index.test.ts
+++ b/test/e2e/rsc-redirect/index.test.ts
@@ -1,0 +1,54 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('RSC Redirect', () => {
+  const { next, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it.each([
+    {
+      path: '/next-config-redirect',
+      expectedStatus: 278,
+      skipNextDeploy: true,
+    },
+    { path: '/old-about', expectedStatus: 278 },
+    { path: '/rsc-redirect', expectedStatus: 200 },
+  ])(
+    'should handle $path redirect with correct status code',
+    async ({ path, expectedStatus, skipNextDeploy }) => {
+      if (skipNextDeploy && isNextDeploy) {
+        return
+      }
+      const statusCodes: number[] = []
+      const browser = await next.browser('/', {
+        beforePageLoad(page) {
+          page.on('response', (res) => {
+            statusCodes.push(res.status())
+          })
+        },
+      })
+
+      // Click the link
+      await browser.elementByCss(`a[href="${path}"]`).click()
+      await browser.waitForIdleNetwork()
+      // First check the URL to ensure we were redirected
+      await retry(async () => {
+        expect(await browser.url()).toBe(`${next.url}/about`)
+      })
+
+      // Then check the content to ensure the page loaded correctly
+      await browser.waitForElementByCss('[data-testid="about-page"]')
+      const content = await browser
+        .elementByCss('[data-testid="about-page"]')
+        .text()
+      expect(content).toBe('About')
+
+      // Finally check that the expected status code exists in the responses
+      expect(statusCodes).toContain(expectedStatus)
+      // Ensure we don't get standard HTTP redirect status codes
+      expect(statusCodes).not.toContain(307)
+      expect(statusCodes).not.toContain(308)
+    }
+  )
+})

--- a/test/e2e/rsc-redirect/middleware.ts
+++ b/test/e2e/rsc-redirect/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === '/old-about') {
+    const url = request.nextUrl.clone()
+    url.pathname = '/about'
+    return NextResponse.redirect(url)
+  }
+  return NextResponse.next()
+}

--- a/test/e2e/rsc-redirect/next.config.ts
+++ b/test/e2e/rsc-redirect/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from 'next'
+
+const config: NextConfig = {
+  async redirects() {
+    return [
+      {
+        source: '/next-config-redirect',
+        destination: '/about',
+        permanent: false,
+      },
+    ]
+  },
+}
+
+export default config


### PR DESCRIPTION
### Problem

The problem with 307/308 redirects in the context of RSC is that once the browser has to follow the redirect to know the detination. Ideally, we’d like to know the destination location without following the redirect so the client router can initiate a new RSC request to the redirected URL with correct `_rsc` parameter.

### Proposed Change

To address this, we modified Next.js to avoid sending a 307/308 status code during an RSC request. Instead, it now returns a custom 278 status, which serves as a redirect signal specifically for the client router. When the client detects this response, it computes a fresh hash and constructs the appropriate headers, then reissues the request to the location specified in the response header.

### Scope

Change Required:

- Middleware Redirect: including minimal mode
- Redirects in `next.config.ts`: excluding minimal mode, requiring follow-up


Change Not Required:

- Redirect from Static RSC: changed to 200 https://github.com/vercel/next.js/pull/80391
- Redirect from Dynamic RSC
- Redirect from Server Actions
- Redirects in Client Components