### PR TITLE
Add response handling inside handlers

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -699,5 +699,12 @@
   "698": "Next DevTools: Can't dispatch %s in this environment. This is a bug in Next.js",
   "699": "Next DevTools: App Dev Overlay is already mounted. This is a bug in Next.js",
   "700": "Next DevTools: Pages Dev Overlay is already mounted. This is a bug in Next.js",
-  "701": "Failed to persist Chrome DevTools workspace UUID. The Chrome DevTools Workspace needs to be reconnected after the next page reload."
+  "701": "Invariant: app-route received invalid cache entry %s",
+  "702": "Invariant: unexpected APP_ROUTE cache data",
+  "703": "Route is configured with dynamic = error which cannot be statically generated.",
+  "704": "Route is configured with dynamic = error be statically generated.",
+  "705": "Route is configured with dynamic = error that cannot be statically generated.",
+  "706": "Invariant: static responses cannot be streamed %s",
+  "707": "Invariant app-page handler received invalid cache entry %s",
+  "708": "Failed to persist Chrome DevTools workspace UUID. The Chrome DevTools Workspace needs to be reconnected after the next page reload."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -693,10 +693,11 @@
   "692": "Expected clientReferenceManifest to be defined.",
   "693": "%s must not be used within a client component. Next.js should be preventing %s from being included in client components statically, but did not in this case.",
   "694": "createPrerenderPathname was called inside a client component scope.",
-  "695": "Expected workUnitAsyncStorage to have a store.",
-  "696": "Next DevTools: Can't dispatch %s in this environment. This is a bug in Next.js",
+  "695": "Invariant: received non-pages cache entry in pages handler",
+  "696": "Expected workUnitAsyncStorage to have a store.",
   "697": "Next DevTools: Can't render in this environment. This is a bug in Next.js",
-  "698": "Next DevTools: App Dev Overlay is already mounted. This is a bug in Next.js",
-  "699": "Next DevTools: Pages Dev Overlay is already mounted. This is a bug in Next.js",
-  "700": "Failed to persist Chrome DevTools workspace UUID. The Chrome DevTools Workspace needs to be reconnected after the next page reload."
+  "698": "Next DevTools: Can't dispatch %s in this environment. This is a bug in Next.js",
+  "699": "Next DevTools: App Dev Overlay is already mounted. This is a bug in Next.js",
+  "700": "Next DevTools: Pages Dev Overlay is already mounted. This is a bug in Next.js",
+  "701": "Failed to persist Chrome DevTools workspace UUID. The Chrome DevTools Workspace needs to be reconnected after the next page reload."
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -15,7 +15,10 @@ import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { interopDefault } from '../../server/app-render/interop-default'
 import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
 import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr'
-import { getFallbackRouteParams } from '../../server/request/fallback-params'
+import {
+  getFallbackRouteParams,
+  type FallbackRouteParams,
+} from '../../server/request/fallback-params'
 import { setReferenceManifestsSingleton } from '../../server/app-render/encryption-utils'
 import {
   isHtmlBotRequest,
@@ -27,7 +30,25 @@ import { getIsPossibleServerAction } from '../../server/lib/server-action-reques
 import {
   RSC_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_IS_PRERENDER_HEADER,
+  NEXT_DID_POSTPONE_HEADER,
 } from '../../client/components/app-router-headers'
+import { getBotType, isBot } from '../../shared/lib/router/utils/is-bot'
+import {
+  CachedRouteKind,
+  type CachedAppPageValue,
+  type CachedPageValue,
+  type ResponseCacheEntry,
+  type ResponseGenerator,
+} from '../../server/response-cache'
+import { decodePathParams } from '../../server/lib/router-utils/decode-path-params'
+import { FallbackMode, parseFallbackField } from '../../lib/fallback'
+import RenderResult from '../../server/render-result'
+import { CACHE_ONE_YEAR, NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
+import type { CacheControl } from '../../server/lib/cache-control'
+import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags'
+import { sendRenderResult } from '../../server/send-payload'
+import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 
 // These are injected by the loader afterwards.
 
@@ -62,7 +83,6 @@ export const __next_app__ = {
 }
 
 import * as entryBase from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
-import { getBotType } from '../../shared/lib/router/utils/is-bot'
 
 export * from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
 
@@ -105,7 +125,9 @@ export async function handler(
   const multiZoneDraftMode = process.env
     .__NEXT_MULTI_ZONE_DRAFT_MODE as any as boolean
 
-  const postponed = getRequestMeta(req, 'postponed')
+  const initialPostponed = getRequestMeta(req, 'postponed')
+  // TODO: replace with more specific flags
+  const minimalMode = getRequestMeta(req, 'minimalMode')
 
   const prepareResult = await routeModule.prepare(req, res, {
     srcPage,
@@ -133,19 +155,65 @@ export async function handler(
     subresourceIntegrityManifest,
     prerenderManifest,
     isDraftMode,
-    isOnDemandRevalidate,
+
+    revalidateOnlyGenerated,
     routerServerContext,
     nextConfig,
   } = prepareResult
 
   const pathname = parsedUrl.pathname || '/'
   const normalizedSrcPage = normalizeAppPath(srcPage)
-  let isIsr = Boolean(
-    prerenderManifest.dynamicRoutes[normalizedSrcPage] ||
-      prerenderManifest.routes[normalizedSrcPage] ||
-      prerenderManifest.routes[pathname]
+
+  let { isOnDemandRevalidate } = prepareResult
+
+  // TODO: rework this to not be necessary as a middleware
+  // rewrite should not need to pass this context like this
+  // maybe we rely on rewrite header instead
+  let resolvedPathname = getRequestMeta(req, 'rewroteURL') || pathname
+
+  if (resolvedPathname === '/index') {
+    resolvedPathname = '/'
+  }
+  resolvedPathname = decodePathParams(resolvedPathname)
+
+  const prerenderInfo = prerenderManifest.dynamicRoutes[normalizedSrcPage]
+  const isPrerendered = prerenderManifest.routes[resolvedPathname]
+
+  let isSSG = Boolean(
+    prerenderInfo ||
+      isPrerendered ||
+      prerenderManifest.routes[normalizedSrcPage]
   )
 
+  // if the page is dynamicParams: false and this pathname wasn't prerender
+  // trigger the no fallback handling
+  if (isSSG && prerenderInfo?.fallback === false && !isPrerendered) {
+    throw new NoFallbackError()
+  }
+
+  const userAgent = req.headers['user-agent'] || ''
+  const botType = getBotType(userAgent)
+  const isHtmlBot = isHtmlBotRequest(req)
+
+  /**
+   * If true, this indicates that the request being made is for an app
+   * prefetch request.
+   */
+  const isPrefetchRSCRequest =
+    getRequestMeta(req, 'isPrefetchRSCRequest') ??
+    Boolean(req.headers[NEXT_ROUTER_PREFETCH_HEADER])
+
+  // NOTE: Don't delete headers[RSC] yet, it still needs to be used in renderToHTML later
+
+  const isRSCRequest =
+    getRequestMeta(req, 'isRSCRequest') ?? Boolean(req.headers[RSC_HEADER])
+
+  const isPossibleServerAction = getIsPossibleServerAction(req)
+
+  /**
+   * If the route being rendered is an app page, and the ppr feature has been
+   * enabled, then the given route _could_ support PPR.
+   */
   const couldSupportPPR: boolean = checkIsAppPPREnabled(
     nextConfig.experimental.ppr
   )
@@ -164,22 +232,19 @@ export async function handler(
 
   // This page supports PPR if it is marked as being `PARTIALLY_STATIC` in the
   // prerender manifest and this is an app page.
-  const isRoutePPREnabled = Boolean(
+  const isRoutePPREnabled: boolean =
     couldSupportPPR &&
-      ((
-        prerenderManifest.routes[normalizedSrcPage] ??
-        prerenderManifest.routes[pathname] ??
-        prerenderManifest.dynamicRoutes[normalizedSrcPage]
-      )?.renderingMode === 'PARTIALLY_STATIC' ||
-        // Ideally we'd want to check the appConfig to see if this page has PPR
-        // enabled or not, but that would require plumbing the appConfig through
-        // to the server during development. We assume that the page supports it
-        // but only during development.
-        (hasDebugStaticShellQuery &&
-          (routeModule.isDev || routerServerContext?.experimentalTestProxy)))
-  )
-
-  const isDebugFallbackShell = hasDebugFallbackShellQuery && isRoutePPREnabled
+    ((
+      prerenderManifest.routes[normalizedSrcPage] ??
+      prerenderManifest.dynamicRoutes[normalizedSrcPage]
+    )?.renderingMode === 'PARTIALLY_STATIC' ||
+      // Ideally we'd want to check the appConfig to see if this page has PPR
+      // enabled or not, but that would require plumbing the appConfig through
+      // to the server during development. We assume that the page supports it
+      // but only during development.
+      (hasDebugStaticShellQuery &&
+        (routeModule.isDev === true ||
+          routerServerContext?.experimentalTestProxy === true)))
 
   const isDebugStaticShell: boolean =
     hasDebugStaticShellQuery && isRoutePPREnabled
@@ -189,23 +254,67 @@ export async function handler(
   const isDebugDynamicAccesses =
     isDebugStaticShell && routeModule.isDev === true
 
-  const isRSCRequest =
-    getRequestMeta(req, 'isRSCRequest') || Boolean(req.headers[RSC_HEADER])
+  const isDebugFallbackShell = hasDebugFallbackShellQuery && isRoutePPREnabled
 
-  const userAgent = req.headers['user-agent'] || ''
-  const botType = getBotType(userAgent)
-  const isHtmlBot = isHtmlBotRequest(req)
+  // If we're in minimal mode, then try to get the postponed information from
+  // the request metadata. If available, use it for resuming the postponed
+  // render.
+  const minimalPostponed = isRoutePPREnabled ? initialPostponed : undefined
+
+  // If PPR is enabled, and this is a RSC request (but not a prefetch), then
+  // we can use this fact to only generate the flight data for the request
+  // because we can't cache the HTML (as it's also dynamic).
+  const isDynamicRSCRequest =
+    isRoutePPREnabled && isRSCRequest && !isPrefetchRSCRequest
+
+  // Need to read this before it's stripped by stripFlightHeaders. We don't
+  // need to transfer it to the request meta because it's only read
+  // within this function; the static segment data should have already been
+  // generated, so we will always either return a static response or a 404.
+  const segmentPrefetchHeader = getRequestMeta(req, 'segmentPrefetchRSCRequest')
+
+  // TODO: investigate existing bug with shouldServeStreamingMetadata always
+  // being true for a revalidate due to modifying the base-server this.renderOpts
+  // when fixing this to correct logic it causes hydration issue since we set
+  // serveStreamingMetadata to true during export
+  let serveStreamingMetadata = !userAgent
+    ? true
+    : shouldServeStreamingMetadata(userAgent, nextConfig.htmlLimitedBots)
+
+  if (isHtmlBot && isRoutePPREnabled) {
+    isSSG = false
+    serveStreamingMetadata = false
+  }
+
+  // In development, we always want to generate dynamic HTML.
+  let supportsDynamicResponse: boolean =
+    // If we're in development, we always support dynamic HTML, unless it's
+    // a data request, in which case we only produce static HTML.
+    routeModule.isDev === true ||
+    // If this is not SSG or does not have static paths, then it supports
+    // dynamic HTML.
+    !isSSG ||
+    // If this request has provided postponed data, it supports dynamic
+    // HTML.
+    typeof initialPostponed === 'string' ||
+    // If this is a dynamic RSC request, then this render supports dynamic
+    // HTML (it's dynamic).
+    isDynamicRSCRequest
+
+  // When html bots request PPR page, perform the full dynamic rendering.
   const shouldWaitOnAllReady = isHtmlBot && isRoutePPREnabled
 
-  // If this is a dynamic route with PPR enabled and the default route
-  // matches were set, then we should pass the fallback route params to
-  // the renderer as this is a fallback revalidation request.
-  const fallbackRouteParams =
-    pageIsDynamic &&
-    isRoutePPREnabled &&
-    (getRequestMeta(req, 'renderFallbackShell') || isDebugFallbackShell)
-      ? getFallbackRouteParams(normalizedSrcPage)
-      : null
+  let ssgCacheKey: string | null = null
+  if (
+    !isDraftMode &&
+    isSSG &&
+    !supportsDynamicResponse &&
+    !isPossibleServerAction &&
+    !minimalPostponed &&
+    !isDynamicRSCRequest
+  ) {
+    ssgCacheKey = resolvedPathname
+  }
 
   const ComponentMod = {
     ...entryBase,
@@ -231,62 +340,97 @@ export async function handler(
     })
   }
 
-  const isPossibleServerAction = getIsPossibleServerAction(req)
-
-  /**
-   * If true, this indicates that the request being made is for an app
-   * prefetch request.
-   */
-  const isPrefetchRSCRequest =
-    getRequestMeta(req, 'isPrefetchRSCRequest') ??
-    Boolean(isRSCRequest && req.headers[NEXT_ROUTER_PREFETCH_HEADER])
-
-  // If PPR is enabled, and this is a RSC request (but not a prefetch), then
-  // we can use this fact to only generate the flight data for the request
-  // because we can't cache the HTML (as it's also dynamic).
-  const isDynamicRSCRequest =
-    isRoutePPREnabled && isRSCRequest && !isPrefetchRSCRequest
-
-  let supportsDynamicResponse: boolean =
-    // If we're in development, we always support dynamic HTML
-    routeModule.isDev === true ||
-    // If this is not SSG or does not have static paths, then it supports
-    // dynamic HTML.
-    !isIsr ||
-    // If this request has provided postponed data, it supports dynamic
-    // HTML.
-    typeof postponed === 'string' ||
-    // If this is a dynamic RSC request, then this render supports dynamic
-    // HTML (it's dynamic).
-    isDynamicRSCRequest
-
-  // This is a revalidation request if the request is for a static
-  // page and it is not being resumed from a postponed render and
-  // it is not a dynamic RSC request then it is a revalidation
-  // request.
-  const isRevalidate =
-    isIsr && !supportsDynamicResponse && !postponed && !isDynamicRSCRequest
-
-  let serveStreamingMetadata =
-    // During the export phase of `next build` we're hard-coding
-    // `serveStreamingMetadata` to `true`, so we need to do the same during
-    // revalidation.
-    isRevalidate ||
-    // Otherwise we're checking the user agent to decide if we should
-    // serve streaming metadata.
-    shouldServeStreamingMetadata(userAgent, nextConfig.htmlLimitedBots)
-
-  if (isHtmlBot && isRoutePPREnabled) {
-    isIsr = false
-    serveStreamingMetadata = false
-  }
-
   const method = req.method || 'GET'
   const tracer = getTracer()
   const activeSpan = tracer.getActiveScopeSpan()
 
   try {
-    const invokeRouteModule = async (span?: Span) => {
+    const invokeRouteModule = async (
+      span: Span | undefined,
+      context: AppPageRouteHandlerContext
+    ) => {
+      const nextReq = new NodeNextRequest(req)
+      const nextRes = new NodeNextResponse(res)
+
+      // TODO: adapt for putting the RDC inside the postponed data
+      // If we're in dev, and this isn't a prefetch or a server action,
+      // we should seed the resume data cache.
+      if (process.env.NODE_ENV === 'development') {
+        if (
+          nextConfig.experimental.dynamicIO &&
+          !isPrefetchRSCRequest &&
+          !context.renderOpts.isPossibleServerAction
+        ) {
+          const warmup = await routeModule.warmup(nextReq, nextRes, context)
+
+          // If the warmup is successful, we should use the resume data
+          // cache from the warmup.
+          if (warmup.metadata.devRenderResumeDataCache) {
+            context.renderOpts.devRenderResumeDataCache =
+              warmup.metadata.devRenderResumeDataCache
+          }
+        }
+      }
+
+      return routeModule.render(nextReq, nextRes, context).finally(() => {
+        if (!span) return
+
+        span.setAttributes({
+          'http.status_code': res.statusCode,
+          'next.rsc': false,
+        })
+
+        const rootSpanAttributes = tracer.getRootSpanAttributes()
+        // We were unable to get attributes, probably OTEL is not enabled
+        if (!rootSpanAttributes) {
+          return
+        }
+
+        if (
+          rootSpanAttributes.get('next.span_type') !==
+          BaseServerSpan.handleRequest
+        ) {
+          console.warn(
+            `Unexpected root span type '${rootSpanAttributes.get(
+              'next.span_type'
+            )}'. Please report this Next.js issue https://github.com/vercel/next.js`
+          )
+          return
+        }
+
+        const route = rootSpanAttributes.get('next.route')
+        if (route) {
+          const name = `${method} ${route}`
+
+          span.setAttributes({
+            'next.route': route,
+            'http.route': route,
+            'next.span_name': name,
+          })
+          span.updateName(name)
+        } else {
+          span.updateName(`${method} ${req.url}`)
+        }
+      })
+    }
+
+    const doRender = async ({
+      span,
+      postponed,
+      fallbackRouteParams,
+    }: {
+      span?: Span
+      /**
+       * The postponed data for this render. This is only provided when resuming
+       * a render that has been postponed.
+       */
+      postponed: string | undefined
+
+      /**
+       * The unknown route params for this render.
+       */
+      fallbackRouteParams: FallbackRouteParams | null
+    }): Promise<ResponseCacheEntry> => {
       const context: AppPageRouteHandlerContext = {
         query,
         params,
@@ -312,7 +456,8 @@ export async function handler(
           postponed,
           shouldWaitOnAllReady,
           serveStreamingMetadata,
-          supportsDynamicResponse,
+          supportsDynamicResponse:
+            typeof postponed === 'string' || supportsDynamicResponse,
           buildManifest,
           nextFontManifest,
           reactLoadableManifest,
@@ -323,7 +468,7 @@ export async function handler(
 
           dir: routeModule.projectDir,
           isDraftMode,
-          isRevalidate,
+          isRevalidate: isSSG && !postponed && !isDynamicRSCRequest,
           botType,
           isOnDemandRevalidate,
           isPossibleServerAction,
@@ -387,75 +532,621 @@ export async function handler(
           dev: routeModule.isDev,
         },
       }
-      const nextReq = new NodeNextRequest(req)
-      const nextRes = new NodeNextResponse(res)
 
-      // TODO: adapt for putting the RDC inside the postponed data
-      // If we're in dev, and this isn't a prefetch or a server action,
-      // we should seed the resume data cache.
-      if (process.env.NODE_ENV === 'development') {
-        if (
-          nextConfig.experimental.dynamicIO &&
-          !isPrefetchRSCRequest &&
-          !isPossibleServerAction
-        ) {
-          const warmup = await routeModule.warmup(nextReq, nextRes, context)
+      const result = await invokeRouteModule(span, context)
 
-          // If the warmup is successful, we should use the resume data
-          // cache from the warmup.
-          if (warmup.metadata.devRenderResumeDataCache) {
-            context.renderOpts.devRenderResumeDataCache =
-              warmup.metadata.devRenderResumeDataCache
+      const { metadata } = result
+
+      const {
+        cacheControl,
+        headers = {},
+        // Add any fetch tags that were on the page to the response headers.
+        fetchTags: cacheTags,
+      } = metadata
+
+      if (cacheTags) {
+        headers[NEXT_CACHE_TAGS_HEADER] = cacheTags
+      }
+
+      // Pull any fetch metrics from the render onto the request.
+      ;(req as any).fetchMetrics = metadata.fetchMetrics
+
+      // we don't throw static to dynamic errors in dev as isSSG
+      // is a best guess in dev since we don't have the prerender pass
+      // to know whether the path is actually static or not
+      if (
+        isSSG &&
+        cacheControl?.revalidate === 0 &&
+        !routeModule.isDev &&
+        !isRoutePPREnabled
+      ) {
+        const staticBailoutInfo = metadata.staticBailoutInfo
+
+        const err = new Error(
+          `Page changed from static to dynamic at runtime ${resolvedPathname}${
+            staticBailoutInfo?.description
+              ? `, reason: ${staticBailoutInfo.description}`
+              : ``
+          }` +
+            `\nsee more here https://nextjs.org/docs/messages/app-static-to-dynamic-error`
+        )
+
+        if (staticBailoutInfo?.stack) {
+          const stack = staticBailoutInfo.stack
+          err.stack = err.message + stack.substring(stack.indexOf('\n'))
+        }
+
+        throw err
+      }
+
+      return {
+        value: {
+          kind: CachedRouteKind.APP_PAGE,
+          html: result,
+          headers,
+          rscData: metadata.flightData,
+          postponed: metadata.postponed,
+          status: metadata.statusCode,
+          segmentData: metadata.segmentData,
+        } satisfies CachedAppPageValue,
+        cacheControl,
+      } satisfies ResponseCacheEntry
+    }
+
+    const responseGenerator: ResponseGenerator = async ({
+      hasResolved,
+      previousCacheEntry,
+      isRevalidating,
+      span,
+    }) => {
+      const isProduction = routeModule.isDev === false
+      const didRespond = hasResolved || res.writableEnded
+
+      // skip on-demand revalidate if cache is not present and
+      // revalidate-if-generated is set
+      if (
+        isOnDemandRevalidate &&
+        revalidateOnlyGenerated &&
+        !previousCacheEntry &&
+        !minimalMode
+      ) {
+        if (routerServerContext?.render404) {
+          await routerServerContext.render404(req, res)
+        } else {
+          res.statusCode = 404
+          res.end('This page could not be found')
+        }
+        return null
+      }
+
+      let fallbackMode: FallbackMode | undefined
+
+      if (prerenderInfo) {
+        fallbackMode = parseFallbackField(prerenderInfo.fallback)
+      }
+
+      // When serving a bot request, we want to serve a blocking render and not
+      // the prerendered page. This ensures that the correct content is served
+      // to the bot in the head.
+      if (fallbackMode === FallbackMode.PRERENDER && isBot(userAgent)) {
+        fallbackMode = FallbackMode.BLOCKING_STATIC_RENDER
+      }
+
+      if (previousCacheEntry?.isStale === -1) {
+        isOnDemandRevalidate = true
+      }
+
+      // TODO: adapt for PPR
+      // only allow on-demand revalidate for fallback: true/blocking
+      // or for prerendered fallback: false paths
+      if (
+        isOnDemandRevalidate &&
+        (fallbackMode !== FallbackMode.NOT_FOUND || previousCacheEntry)
+      ) {
+        fallbackMode = FallbackMode.BLOCKING_STATIC_RENDER
+      }
+
+      if (
+        !minimalMode &&
+        fallbackMode !== FallbackMode.BLOCKING_STATIC_RENDER &&
+        ssgCacheKey &&
+        !didRespond &&
+        !isDraftMode &&
+        pageIsDynamic &&
+        (isProduction || !isPrerendered)
+      ) {
+        let fallbackResponse: ResponseCacheEntry | null | undefined
+
+        if (isRoutePPREnabled && !isRSCRequest) {
+          // We use the response cache here to handle the revalidation and
+          // management of the fallback shell.
+          fallbackResponse = await routeModule.handleResponse({
+            cacheKey: isProduction ? normalizedSrcPage : null,
+            req,
+            nextConfig,
+            routeKind: RouteKind.APP_PAGE,
+            isFallback: true,
+            prerenderManifest,
+            isRoutePPREnabled,
+            responseGenerator: async () =>
+              doRender({
+                span,
+                // We pass `undefined` as rendering a fallback isn't resumed
+                // here.
+                postponed: undefined,
+                fallbackRouteParams:
+                  // If we're in production or we're debugging the fallback
+                  // shell then we should postpone when dynamic params are
+                  // accessed.
+                  isProduction || isDebugFallbackShell
+                    ? getFallbackRouteParams(normalizedSrcPage)
+                    : null,
+              }),
+            waitUntil: ctx.waitUntil,
+          })
+
+          // If the fallback response was set to null, then we should return null.
+          if (fallbackResponse === null) return null
+
+          // Otherwise, if we did get a fallback response, we should return it.
+          if (fallbackResponse) {
+            // Remove the cache control from the response to prevent it from being
+            // used in the surrounding cache.
+            delete fallbackResponse.cacheControl
+
+            return fallbackResponse
+          }
+        }
+      }
+      // Only requests that aren't revalidating can be resumed. If we have the
+      // minimal postponed data, then we should resume the render with it.
+      const postponed =
+        !isOnDemandRevalidate && !isRevalidating && minimalPostponed
+          ? minimalPostponed
+          : undefined
+
+      // When we're in minimal mode, if we're trying to debug the static shell,
+      // we should just return nothing instead of resuming the dynamic render.
+      if (
+        (isDebugStaticShell || isDebugDynamicAccesses) &&
+        typeof postponed !== 'undefined'
+      ) {
+        return {
+          cacheControl: { revalidate: 1, expire: undefined },
+          value: {
+            kind: CachedRouteKind.PAGES,
+            html: RenderResult.fromStatic(''),
+            pageData: {},
+            headers: undefined,
+            status: undefined,
+          } satisfies CachedPageValue,
+        }
+      }
+
+      // If this is a dynamic route with PPR enabled and the default route
+      // matches were set, then we should pass the fallback route params to
+      // the renderer as this is a fallback revalidation request.
+      const fallbackRouteParams =
+        pageIsDynamic &&
+        isRoutePPREnabled &&
+        (getRequestMeta(req, 'renderFallbackShell') || isDebugFallbackShell)
+          ? getFallbackRouteParams(pathname)
+          : null
+
+      // Perform the render.
+      return doRender({
+        span,
+        postponed,
+        fallbackRouteParams,
+      })
+    }
+
+    const handleResponse = async (span?: Span): Promise<null | void> => {
+      const cacheEntry = await routeModule.handleResponse({
+        cacheKey: ssgCacheKey,
+        responseGenerator: (c) =>
+          responseGenerator({
+            span,
+            ...c,
+          }),
+        routeKind: RouteKind.APP_PAGE,
+        isOnDemandRevalidate,
+        isRoutePPREnabled,
+        req,
+        nextConfig,
+        prerenderManifest,
+        waitUntil: ctx.waitUntil,
+      })
+
+      if (isDraftMode) {
+        res.setHeader(
+          'Cache-Control',
+          'private, no-cache, no-store, max-age=0, must-revalidate'
+        )
+      }
+
+      // In dev, we should not cache pages for any reason.
+      if (routeModule.isDev) {
+        res.setHeader('Cache-Control', 'no-store, must-revalidate')
+      }
+
+      if (!cacheEntry) {
+        if (ssgCacheKey) {
+          // A cache entry might not be generated if a response is written
+          // in `getInitialProps` or `getServerSideProps`, but those shouldn't
+          // have a cache key. If we do have a cache key but we don't end up
+          // with a cache entry, then either Next.js or the application has a
+          // bug that needs fixing.
+          throw new Error('invariant: cache entry required but not generated')
+        }
+        return null
+      }
+
+      if (cacheEntry.value?.kind !== CachedRouteKind.APP_PAGE) {
+        throw new Error(
+          `Invariant app-page handler received invalid cache entry ${cacheEntry.value?.kind}`
+        )
+      }
+
+      const didPostpone = typeof cacheEntry.value.postponed === 'string'
+
+      if (
+        isSSG &&
+        // We don't want to send a cache header for requests that contain dynamic
+        // data. If this is a Dynamic RSC request or wasn't a Prefetch RSC
+        // request, then we should set the cache header.
+        !isDynamicRSCRequest &&
+        (!didPostpone || isPrefetchRSCRequest)
+      ) {
+        if (!minimalMode) {
+          // set x-nextjs-cache header to match the header
+          // we set for the image-optimizer
+          res.setHeader(
+            'x-nextjs-cache',
+            isOnDemandRevalidate
+              ? 'REVALIDATED'
+              : cacheEntry.isMiss
+                ? 'MISS'
+                : cacheEntry.isStale
+                  ? 'STALE'
+                  : 'HIT'
+          )
+        }
+        // Set a header used by the client router to signal the response is static
+        // and should respect the `static` cache staleTime value.
+        res.setHeader(NEXT_IS_PRERENDER_HEADER, '1')
+      }
+      const { value: cachedData } = cacheEntry
+
+      // Coerce the cache control parameter from the render.
+      let cacheControl: CacheControl | undefined
+
+      // If this is a resume request in minimal mode it is streamed with dynamic
+      // content and should not be cached.
+      if (minimalPostponed) {
+        cacheControl = { revalidate: 0, expire: undefined }
+      }
+
+      // If this is in minimal mode and this is a flight request that isn't a
+      // prefetch request while PPR is enabled, it cannot be cached as it contains
+      // dynamic content.
+      else if (
+        minimalMode &&
+        isRSCRequest &&
+        !isPrefetchRSCRequest &&
+        isRoutePPREnabled
+      ) {
+        cacheControl = { revalidate: 0, expire: undefined }
+      } else if (!routeModule.isDev) {
+        // If this is a preview mode request, we shouldn't cache it
+        if (isDraftMode) {
+          cacheControl = { revalidate: 0, expire: undefined }
+        }
+
+        // If this isn't SSG, then we should set change the header only if it is
+        // not set already.
+        else if (!isSSG) {
+          if (!res.getHeader('Cache-Control')) {
+            cacheControl = { revalidate: 0, expire: undefined }
+          }
+        } else if (cacheEntry.cacheControl) {
+          // If the cache entry has a cache control with a revalidate value that's
+          // a number, use it.
+          if (typeof cacheEntry.cacheControl.revalidate === 'number') {
+            if (cacheEntry.cacheControl.revalidate < 1) {
+              throw new Error(
+                `Invalid revalidate configuration provided: ${cacheEntry.cacheControl.revalidate} < 1`
+              )
+            }
+
+            cacheControl = {
+              revalidate: cacheEntry.cacheControl.revalidate,
+              expire: cacheEntry.cacheControl?.expire ?? nextConfig.expireTime,
+            }
+          }
+          // Otherwise if the revalidate value is false, then we should use the
+          // cache time of one year.
+          else {
+            cacheControl = { revalidate: CACHE_ONE_YEAR, expire: undefined }
           }
         }
       }
 
-      return routeModule.render(nextReq, nextRes, context).finally(() => {
-        if (!span) return
+      cacheEntry.cacheControl = cacheControl
 
-        span.setAttributes({
-          'http.status_code': res.statusCode,
-          'next.rsc': false,
+      if (
+        typeof segmentPrefetchHeader === 'string' &&
+        cachedData?.kind === CachedRouteKind.APP_PAGE &&
+        cachedData.segmentData
+      ) {
+        // This is a prefetch request issued by the client Segment Cache. These
+        // should never reach the application layer (lambda). We should either
+        // respond from the cache (HIT) or respond with 204 No Content (MISS).
+
+        // Set a header to indicate that PPR is enabled for this route. This
+        // lets the client distinguish between a regular cache miss and a cache
+        // miss due to PPR being disabled. In other contexts this header is used
+        // to indicate that the response contains dynamic data, but here we're
+        // only using it to indicate that the feature is enabled — the segment
+        // response itself contains whether the data is dynamic.
+        res.setHeader(NEXT_DID_POSTPONE_HEADER, '2')
+
+        // Add the cache tags header to the response if it exists and we're in
+        // minimal mode while rendering a static page.
+        const tags = cachedData.headers?.[NEXT_CACHE_TAGS_HEADER]
+        if (minimalMode && isSSG && tags && typeof tags === 'string') {
+          res.setHeader(NEXT_CACHE_TAGS_HEADER, tags)
+        }
+
+        const matchedSegment = cachedData.segmentData.get(segmentPrefetchHeader)
+        if (matchedSegment !== undefined) {
+          // Cache hit
+          return sendRenderResult({
+            req,
+            res,
+            type: 'rsc',
+            generateEtags: nextConfig.generateEtags,
+            poweredByHeader: nextConfig.poweredByHeader,
+            result: RenderResult.fromStatic(matchedSegment),
+            cacheControl: cacheEntry.cacheControl,
+          })
+        }
+
+        // Cache miss. Either a cache entry for this route has not been generated
+        // (which technically should not be possible when PPR is enabled, because
+        // at a minimum there should always be a fallback entry) or there's no
+        // match for the requested segment. Respond with a 204 No Content. We
+        // don't bother to respond with 404, because these requests are only
+        // issued as part of a prefetch.
+        res.statusCode = 204
+        return sendRenderResult({
+          req,
+          res,
+          type: 'rsc',
+          generateEtags: nextConfig.generateEtags,
+          poweredByHeader: nextConfig.poweredByHeader,
+          result: RenderResult.fromStatic(''),
+          cacheControl: cacheEntry.cacheControl,
+        })
+      }
+
+      // If there's a callback for `onCacheEntry`, call it with the cache entry
+      // and the revalidate options.
+      const onCacheEntry = getRequestMeta(req, 'onCacheEntry')
+      if (onCacheEntry) {
+        const finished = await onCacheEntry(
+          {
+            ...cacheEntry,
+            // TODO: remove this when upstream doesn't
+            // always expect this value to be "PAGE"
+            value: {
+              ...cacheEntry.value,
+              kind: 'PAGE',
+            },
+          },
+          {
+            url: getRequestMeta(req, 'initURL'),
+          }
+        )
+        if (finished) {
+          // TODO: maybe we have to end the request?
+          return null
+        }
+      }
+
+      // If the request has a postponed state and it's a resume request we
+      // should error.
+      if (didPostpone && minimalPostponed) {
+        throw new Error(
+          'Invariant: postponed state should not be present on a resume request'
+        )
+      }
+
+      if (cachedData.headers) {
+        const headers = { ...cachedData.headers }
+
+        if (!minimalMode || !isSSG) {
+          delete headers[NEXT_CACHE_TAGS_HEADER]
+        }
+
+        for (let [key, value] of Object.entries(headers)) {
+          if (typeof value === 'undefined') continue
+
+          if (Array.isArray(value)) {
+            for (const v of value) {
+              res.appendHeader(key, v)
+            }
+          } else if (typeof value === 'number') {
+            value = value.toString()
+            res.appendHeader(key, value)
+          } else {
+            res.appendHeader(key, value)
+          }
+        }
+      }
+
+      // Add the cache tags header to the response if it exists and we're in
+      // minimal mode while rendering a static page.
+      const tags = cachedData.headers?.[NEXT_CACHE_TAGS_HEADER]
+      if (minimalMode && isSSG && tags && typeof tags === 'string') {
+        res.setHeader(NEXT_CACHE_TAGS_HEADER, tags)
+      }
+
+      // If the request is a data request, then we shouldn't set the status code
+      // from the response because it should always be 200. This should be gated
+      // behind the experimental PPR flag.
+      if (cachedData.status && (!isRSCRequest || !isRoutePPREnabled)) {
+        res.statusCode = cachedData.status
+      }
+
+      // Mark that the request did postpone.
+      if (didPostpone) {
+        res.setHeader(NEXT_DID_POSTPONE_HEADER, '1')
+      }
+
+      // we don't go through this block when preview mode is true
+      // as preview mode is a dynamic request (bypasses cache) and doesn't
+      // generate both HTML and payloads in the same request so continue to just
+      // return the generated payload
+      if (isRSCRequest && !isDraftMode) {
+        // If this is a dynamic RSC request, then stream the response.
+        if (typeof cachedData.rscData === 'undefined') {
+          if (cachedData.postponed) {
+            throw new Error('Invariant: Expected postponed to be undefined')
+          }
+
+          return sendRenderResult({
+            req,
+            res,
+            type: 'rsc',
+            generateEtags: nextConfig.generateEtags,
+            poweredByHeader: nextConfig.poweredByHeader,
+            result: cachedData.html,
+            // Dynamic RSC responses cannot be cached, even if they're
+            // configured with `force-static` because we have no way of
+            // distinguishing between `force-static` and pages that have no
+            // postponed state.
+            // TODO: distinguish `force-static` from pages with no postponed state (static)
+            cacheControl: isDynamicRSCRequest
+              ? { revalidate: 0, expire: undefined }
+              : cacheEntry.cacheControl,
+          })
+        }
+
+        // As this isn't a prefetch request, we should serve the static flight
+        // data.
+        return sendRenderResult({
+          req,
+          res,
+          type: 'rsc',
+          generateEtags: nextConfig.generateEtags,
+          poweredByHeader: nextConfig.poweredByHeader,
+          result: RenderResult.fromStatic(cachedData.rscData),
+          cacheControl: cacheEntry.cacheControl,
+        })
+      }
+
+      // This is a request for HTML data.
+      let body = cachedData.html
+
+      // If there's no postponed state, we should just serve the HTML. This
+      // should also be the case for a resume request because it's completed
+      // as a server render (rather than a static render).
+      if (!didPostpone || minimalMode) {
+        return sendRenderResult({
+          req,
+          res,
+          type: 'html',
+          generateEtags: nextConfig.generateEtags,
+          poweredByHeader: nextConfig.poweredByHeader,
+          result: body,
+          cacheControl: cacheEntry.cacheControl,
+        })
+      }
+
+      // If we're debugging the static shell or the dynamic API accesses, we
+      // should just serve the HTML without resuming the render. The returned
+      // HTML will be the static shell so all the Dynamic API's will be used
+      // during static generation.
+      if (isDebugStaticShell || isDebugDynamicAccesses) {
+        // Since we're not resuming the render, we need to at least add the
+        // closing body and html tags to create valid HTML.
+        body.chain(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(ENCODED_TAGS.CLOSED.BODY_AND_HTML)
+              controller.close()
+            },
+          })
+        )
+
+        return sendRenderResult({
+          req,
+          res,
+          type: 'html',
+          generateEtags: nextConfig.generateEtags,
+          poweredByHeader: nextConfig.poweredByHeader,
+          result: body,
+          cacheControl: { revalidate: 0, expire: undefined },
+        })
+      }
+
+      // This request has postponed, so let's create a new transformer that the
+      // dynamic data can pipe to that will attach the dynamic data to the end
+      // of the response.
+      const transformer = new TransformStream<Uint8Array, Uint8Array>()
+      body.chain(transformer.readable)
+
+      // Perform the render again, but this time, provide the postponed state.
+      // We don't await because we want the result to start streaming now, and
+      // we've already chained the transformer's readable to the render result.
+      doRender({
+        span,
+        postponed: cachedData.postponed,
+        // This is a resume render, not a fallback render, so we don't need to
+        // set this.
+        fallbackRouteParams: null,
+      })
+        .then(async (result) => {
+          if (!result) {
+            throw new Error('Invariant: expected a result to be returned')
+          }
+
+          if (result.value?.kind !== CachedRouteKind.APP_PAGE) {
+            throw new Error(
+              `Invariant: expected a page response, got ${result.value?.kind}`
+            )
+          }
+
+          // Pipe the resume result to the transformer.
+          await result.value.html.pipeTo(transformer.writable)
+        })
+        .catch((err) => {
+          // An error occurred during piping or preparing the render, abort
+          // the transformers writer so we can terminate the stream.
+          transformer.writable.abort(err).catch((e) => {
+            console.error("couldn't abort transformer", e)
+          })
         })
 
-        const rootSpanAttributes = tracer.getRootSpanAttributes()
-        // We were unable to get attributes, probably OTEL is not enabled
-        if (!rootSpanAttributes) {
-          return
-        }
-
-        if (
-          rootSpanAttributes.get('next.span_type') !==
-          BaseServerSpan.handleRequest
-        ) {
-          console.warn(
-            `Unexpected root span type '${rootSpanAttributes.get(
-              'next.span_type'
-            )}'. Please report this Next.js issue https://github.com/vercel/next.js`
-          )
-          return
-        }
-
-        const route = rootSpanAttributes.get('next.route')
-        if (route) {
-          const name = `${method} ${route}`
-
-          span.setAttributes({
-            'next.route': route,
-            'http.route': route,
-            'next.span_name': name,
-          })
-          span.updateName(name)
-        } else {
-          span.updateName(`${method} ${req.url}`)
-        }
+      return sendRenderResult({
+        req,
+        res,
+        type: 'html',
+        generateEtags: nextConfig.generateEtags,
+        poweredByHeader: nextConfig.poweredByHeader,
+        result: body,
+        // We don't want to cache the response if it has postponed data because
+        // the response being sent to the client it's dynamic parts are streamed
+        // to the client on the same request.
+        cacheControl: { revalidate: 0, expire: undefined },
       })
     }
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
     if (activeSpan) {
-      return await invokeRouteModule(activeSpan)
+      await handleResponse(activeSpan)
     } else {
       return await tracer.withPropagatedContext(req.headers, () =>
         tracer.trace(
@@ -468,7 +1159,7 @@ export async function handler(
               'http.target': req.url,
             },
           },
-          invokeRouteModule
+          handleResponse
         )
       )
     }
@@ -483,7 +1174,7 @@ export async function handler(
           routePath: srcPage,
           routeType: 'render',
           revalidateReason: getRevalidateReason({
-            isRevalidate,
+            isRevalidate: isSSG,
             isOnDemandRevalidate,
           }),
         },

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -5,12 +5,6 @@ import {
 } from '../../server/route-modules/app-route/module.compiled'
 import { RouteKind } from '../../server/route-kind'
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch'
-
-import * as userland from 'VAR_USERLAND'
-import {
-  RouterServerContextSymbol,
-  routerServerGlobal,
-} from '../../server/lib/router-utils/router-server-context'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { getRequestMeta } from '../../server/request-meta'
 import { getTracer, type Span, SpanKind } from '../../server/lib/trace/tracer'
@@ -30,6 +24,8 @@ import {
   CachedRouteKind,
   type ResponseCacheEntry,
 } from '../../server/response-cache'
+
+import * as userland from 'VAR_USERLAND'
 
 // These are injected by the loader afterwards. This is injected as a variable
 // instead of a replacement because this could also be `undefined` instead of
@@ -112,15 +108,11 @@ export async function handler(
     buildId,
     params,
     parsedUrl,
-    serverFilesManifest,
+    nextConfig,
     prerenderManifest,
+    routerServerContext,
     isOnDemandRevalidate,
   } = prepareResult
-
-  const routerServerContext =
-    routerServerGlobal[RouterServerContextSymbol]?.[
-      process.env.__NEXT_RELATIVE_PROJECT_DIR || ''
-    ]
 
   const onInstrumentationRequestError =
     routeModule.instrumentationOnRequestError.bind(routeModule)
@@ -146,9 +138,6 @@ export async function handler(
       errorContext
     )
   }
-
-  const nextConfig =
-    routerServerContext?.nextConfig || serverFilesManifest.config
 
   const pathname = parsedUrl.pathname || '/'
   const normalizedSrcPage = normalizeAppPath(srcPage)

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -8,7 +8,6 @@ import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { getRequestMeta } from '../../server/request-meta'
 import { getTracer, type Span, SpanKind } from '../../server/lib/trace/tracer'
-import type { ServerOnInstrumentationRequestError } from '../../server/app-render/types'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
 import {
@@ -18,11 +17,18 @@ import {
 import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { getRevalidateReason } from '../../server/instrumentation/utils'
 import { sendResponse } from '../../server/send-response'
-import { toNodeOutgoingHttpHeaders } from '../../server/web/utils'
+import {
+  fromNodeOutgoingHttpHeaders,
+  toNodeOutgoingHttpHeaders,
+} from '../../server/web/utils'
+import { decodePathParams } from '../../server/lib/router-utils/decode-path-params'
+import { getCacheControlHeader } from '../../server/lib/cache-control'
 import { INFINITE_CACHE, NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
+import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 import {
   CachedRouteKind,
   type ResponseCacheEntry,
+  type ResponseGenerator,
 } from '../../server/response-cache'
 
 import * as userland from 'VAR_USERLAND'
@@ -107,45 +113,54 @@ export async function handler(
   const {
     buildId,
     params,
-    parsedUrl,
     nextConfig,
+    parsedUrl,
+    isDraftMode,
     prerenderManifest,
     routerServerContext,
     isOnDemandRevalidate,
+    revalidateOnlyGenerated,
   } = prepareResult
 
-  const onInstrumentationRequestError =
-    routeModule.instrumentationOnRequestError.bind(routeModule)
+  const normalizedSrcPage = normalizeAppPath(srcPage)
 
-  const onError: ServerOnInstrumentationRequestError = (
-    err,
-    _,
-    errorContext
-  ) => {
-    if (routerServerContext?.logErrorWithOriginalStack) {
-      routerServerContext.logErrorWithOriginalStack(err, 'app-dir')
-    } else {
-      console.error(err)
-    }
-    return onInstrumentationRequestError(
-      req,
-      err,
-      {
-        path: req.url || '/',
-        headers: req.headers,
-        method: req.method || 'GET',
-      },
-      errorContext
-    )
+  // TODO: rework this to not be necessary as a middleware
+  // rewrite should not need to pass this context like this
+  // maybe we rely on rewrite header instead
+  let resolvedPathname = getRequestMeta(req, 'rewroteURL')
+
+  if (!resolvedPathname) {
+    resolvedPathname = parsedUrl.pathname || '/'
   }
 
-  const pathname = parsedUrl.pathname || '/'
-  const normalizedSrcPage = normalizeAppPath(srcPage)
+  if (resolvedPathname === '/index') {
+    resolvedPathname = '/'
+  }
+  resolvedPathname = decodePathParams(resolvedPathname)
+
   let isIsr = Boolean(
     prerenderManifest.dynamicRoutes[normalizedSrcPage] ||
-      prerenderManifest.routes[normalizedSrcPage] ||
-      prerenderManifest.routes[pathname]
+      prerenderManifest.routes[resolvedPathname]
   )
+
+  if (isIsr && !isDraftMode) {
+    const isPrerendered = Boolean(prerenderManifest.routes[resolvedPathname])
+    const prerenderInfo = prerenderManifest.dynamicRoutes[normalizedSrcPage]
+
+    if (prerenderInfo) {
+      if (prerenderInfo.fallback === false && !isPrerendered) {
+        throw new NoFallbackError()
+      }
+    }
+  }
+
+  let cacheKey: string | null = null
+
+  if (isIsr && !routeModule.isDev && !isDraftMode) {
+    cacheKey = resolvedPathname
+    // ensure /index and / is normalized to one key
+    cacheKey = cacheKey === '/index' ? '/' : cacheKey
+  }
 
   const supportsDynamicResponse: boolean =
     // If we're in development, we always support dynamic HTML
@@ -181,7 +196,13 @@ export async function handler(
         res.on('close', cb)
       },
       onAfterTaskError: undefined,
-      onInstrumentationRequestError: onError,
+      onInstrumentationRequestError: (error, _request, errorContext) =>
+        routeModule.onRequestError(
+          req,
+          error,
+          errorContext,
+          routerServerContext
+        ),
     },
     sharedContext: {
       buildId,
@@ -238,14 +259,194 @@ export async function handler(
       })
     }
 
-    let response: Response
+    const handleResponse = async (currentSpan?: Span) => {
+      const responseGenerator: ResponseGenerator = async ({
+        previousCacheEntry,
+      }) => {
+        try {
+          if (
+            !getRequestMeta(req, 'minimalMode') &&
+            isOnDemandRevalidate &&
+            revalidateOnlyGenerated &&
+            !previousCacheEntry
+          ) {
+            res.statusCode = 404
+            // on-demand revalidate always sets this header
+            res.setHeader('x-nextjs-cache', 'REVALIDATED')
+            res.end('This page could not be found')
+            return null
+          }
+
+          const response = await invokeRouteModule(currentSpan)
+
+          ;(req as any).fetchMetrics = (context.renderOpts as any).fetchMetrics
+          let pendingWaitUntil = context.renderOpts.pendingWaitUntil
+
+          // Attempt using provided waitUntil if available
+          // if it's not we fallback to sendResponse's handling
+          if (pendingWaitUntil) {
+            if (ctx.waitUntil) {
+              ctx.waitUntil(pendingWaitUntil)
+              pendingWaitUntil = undefined
+            }
+          }
+          const cacheTags = context.renderOpts.collectedTags
+
+          // If the request is for a static response, we can cache it so long
+          // as it's not edge.
+          if (isIsr) {
+            const blob = await response.blob()
+
+            // Copy the headers from the response.
+            const headers = toNodeOutgoingHttpHeaders(response.headers)
+
+            if (cacheTags) {
+              headers[NEXT_CACHE_TAGS_HEADER] = cacheTags
+            }
+
+            if (!headers['content-type'] && blob.type) {
+              headers['content-type'] = blob.type
+            }
+
+            const revalidate =
+              typeof context.renderOpts.collectedRevalidate === 'undefined' ||
+              context.renderOpts.collectedRevalidate >= INFINITE_CACHE
+                ? false
+                : context.renderOpts.collectedRevalidate
+
+            const expire =
+              typeof context.renderOpts.collectedExpire === 'undefined' ||
+              context.renderOpts.collectedExpire >= INFINITE_CACHE
+                ? undefined
+                : context.renderOpts.collectedExpire
+
+            // Create the cache entry for the response.
+            const cacheEntry: ResponseCacheEntry = {
+              value: {
+                kind: CachedRouteKind.APP_ROUTE,
+                status: response.status,
+                body: Buffer.from(await blob.arrayBuffer()),
+                headers,
+              },
+              cacheControl: { revalidate, expire },
+            }
+
+            return cacheEntry
+          } else {
+            // send response without caching if not ISR
+            await sendResponse(
+              nodeNextReq,
+              nodeNextRes,
+              response,
+              context.renderOpts.pendingWaitUntil
+            )
+            return null
+          }
+        } catch (err) {
+          // if this is a background revalidate we need to report
+          // the request error here as it won't be bubbled
+          if (previousCacheEntry?.isStale) {
+            await routeModule.onRequestError(
+              req,
+              err,
+              {
+                routerKind: 'App Router',
+                routePath: srcPage,
+                routeType: 'route',
+                revalidateReason: getRevalidateReason({
+                  isRevalidate,
+                  isOnDemandRevalidate,
+                }),
+              },
+              routerServerContext
+            )
+          }
+          throw err
+        }
+      }
+
+      const cacheEntry = await routeModule.handleResponse({
+        req,
+        nextConfig,
+        cacheKey,
+        routeKind: RouteKind.APP_ROUTE,
+        isFallback: false,
+        prerenderManifest,
+        isRoutePPREnabled: false,
+        isOnDemandRevalidate,
+        revalidateOnlyGenerated,
+        responseGenerator,
+        waitUntil: ctx.waitUntil,
+      })
+
+      // we don't create a cacheEntry for ISR
+      if (!isIsr) {
+        return null
+      }
+
+      if (cacheEntry?.value?.kind !== CachedRouteKind.APP_ROUTE) {
+        throw new Error(
+          `Invariant: app-route received invalid cache entry ${cacheEntry?.value?.kind}`
+        )
+      }
+
+      if (!getRequestMeta(req, 'minimalMode')) {
+        res.setHeader(
+          'x-nextjs-cache',
+          isOnDemandRevalidate
+            ? 'REVALIDATED'
+            : cacheEntry.isMiss
+              ? 'MISS'
+              : cacheEntry.isStale
+                ? 'STALE'
+                : 'HIT'
+        )
+      }
+
+      // Draft mode should never be cached
+      if (isDraftMode) {
+        res.setHeader(
+          'Cache-Control',
+          'private, no-cache, no-store, max-age=0, must-revalidate'
+        )
+      }
+
+      const headers = fromNodeOutgoingHttpHeaders(cacheEntry.value.headers)
+
+      if (!(getRequestMeta(req, 'minimalMode') && isIsr)) {
+        headers.delete(NEXT_CACHE_TAGS_HEADER)
+      }
+
+      // If cache control is already set on the response we don't
+      // override it to allow users to customize it via next.config
+      if (
+        cacheEntry.cacheControl &&
+        !res.getHeader('Cache-Control') &&
+        !headers.get('Cache-Control')
+      ) {
+        headers.set(
+          'Cache-Control',
+          getCacheControlHeader(cacheEntry.cacheControl)
+        )
+      }
+
+      await sendResponse(
+        nodeNextReq,
+        nodeNextRes,
+        new Response(cacheEntry.value.body, {
+          headers,
+          status: cacheEntry.value.status || 200,
+        })
+      )
+      return null
+    }
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
     if (activeSpan) {
-      response = await invokeRouteModule(activeSpan)
+      await handleResponse(activeSpan)
     } else {
-      response = await tracer.withPropagatedContext(req.headers, () =>
+      await tracer.withPropagatedContext(req.headers, () =>
         tracer.trace(
           BaseServerSpan.handleRequest,
           {
@@ -256,79 +457,14 @@ export async function handler(
               'http.target': req.url,
             },
           },
-          invokeRouteModule
+          handleResponse
         )
       )
     }
-
-    ;(req as any).fetchMetrics = (context.renderOpts as any).fetchMetrics
-
-    const cacheTags = context.renderOpts.collectedTags
-
-    // If the request is for a static response, we can cache it so long
-    // as it's not edge.
-    if (isIsr) {
-      const blob = await response.blob()
-
-      // Copy the headers from the response.
-      const headers = toNodeOutgoingHttpHeaders(response.headers)
-
-      if (cacheTags) {
-        headers[NEXT_CACHE_TAGS_HEADER] = cacheTags
-      }
-
-      if (!headers['content-type'] && blob.type) {
-        headers['content-type'] = blob.type
-      }
-
-      const revalidate =
-        typeof context.renderOpts.collectedRevalidate === 'undefined' ||
-        context.renderOpts.collectedRevalidate >= INFINITE_CACHE
-          ? false
-          : context.renderOpts.collectedRevalidate
-
-      const expire =
-        typeof context.renderOpts.collectedExpire === 'undefined' ||
-        context.renderOpts.collectedExpire >= INFINITE_CACHE
-          ? undefined
-          : context.renderOpts.collectedExpire
-
-      // Create the cache entry for the response.
-      const cacheEntry: ResponseCacheEntry = {
-        value: {
-          kind: CachedRouteKind.APP_ROUTE,
-          status: response.status,
-          body: Buffer.from(await blob.arrayBuffer()),
-          headers,
-        },
-        cacheControl: { revalidate, expire },
-      }
-
-      return cacheEntry
-    }
-    let pendingWaitUntil = context.renderOpts.pendingWaitUntil
-
-    // Attempt using provided waitUntil if available
-    // if it's not we fallback to sendResponse's handling
-    if (pendingWaitUntil) {
-      if (context.renderOpts.waitUntil) {
-        context.renderOpts.waitUntil(pendingWaitUntil)
-        pendingWaitUntil = undefined
-      }
-    }
-
-    // Send the response now that we have copied it into the cache.
-    await sendResponse(
-      nodeNextReq,
-      nodeNextRes,
-      response,
-      context.renderOpts.pendingWaitUntil
-    )
-    return null
   } catch (err) {
     // if we aren't wrapped by base-server handle here
     if (!activeSpan) {
-      await onError(err, req, {
+      await routeModule.onRequestError(req, err, {
         routerKind: 'App Router',
         routePath: normalizedSrcPage,
         routeType: 'route',

--- a/packages/next/src/build/templates/pages.ts
+++ b/packages/next/src/build/templates/pages.ts
@@ -1,19 +1,22 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import type RenderResult from '../../server/render-result'
 import type { ParsedUrlQuery } from 'node:querystring'
 import { PagesRouteModule } from '../../server/route-modules/pages/module.compiled'
 import { RouteKind } from '../../server/route-kind'
 import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { getTracer, SpanKind, type Span } from '../../server/lib/trace/tracer'
 import { formatUrl } from '../../shared/lib/router/utils/format-url'
-import {
-  RouterServerContextSymbol,
-  routerServerGlobal,
-} from '../../server/lib/router-utils/router-server-context'
-import { getRequestMeta } from '../../server/request-meta'
+import { addRequestMeta, getRequestMeta } from '../../server/request-meta'
 import { interopDefault } from '../../server/app-render/interop-default'
 import { getRevalidateReason } from '../../server/instrumentation/utils'
 import { normalizeDataPath } from '../../shared/lib/page-path/normalize-data-path'
+import {
+  CachedRouteKind,
+  type CachedPageValue,
+  type CachedRedirectValue,
+  type ResponseCacheEntry,
+  type ResponseGenerator,
+} from '../../server/response-cache'
+
 import { hoist } from './helpers'
 
 // Import the app and document modules.
@@ -22,6 +25,24 @@ import * as app from 'VAR_MODULE_APP'
 
 // Import the userland code.
 import * as userland from 'VAR_USERLAND'
+import {
+  getCacheControlHeader,
+  type CacheControl,
+} from '../../server/lib/cache-control'
+import { normalizeRepeatedSlashes } from '../../shared/lib/utils'
+import { getRedirectStatus } from '../../lib/redirect-status'
+import { CACHE_ONE_YEAR } from '../../lib/constants'
+import { sendRenderResult } from '../../server/send-payload'
+import RenderResult from '../../server/render-result'
+import { decodePathParams } from '../../server/lib/router-utils/decode-path-params'
+import { toResponseCacheEntry } from '../../server/response-cache/utils'
+import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
+import { RedirectStatusCode } from '../../client/components/redirect-status-code'
+import { isBot } from '../../shared/lib/router/utils/is-bot'
+import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
+import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-trailing-slash'
+import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
+import { normalizeLocalePath } from '../../shared/lib/i18n/normalize-locale-path'
 
 // Re-export the component (should be the default export).
 export default hoist(userland, 'default')
@@ -81,7 +102,7 @@ export async function handler(
   ctx: {
     waitUntil: (prom: Promise<void>) => void
   }
-): Promise<RenderResult | null> {
+): Promise<void> {
   let srcPage = 'VAR_DEFINITION_PAGE'
 
   // turbopack doesn't normalize `/index` in the page name
@@ -105,7 +126,7 @@ export async function handler(
     res.statusCode = 400
     res.end('Bad Request')
     ctx.waitUntil?.(Promise.resolve())
-    return null
+    return
   }
 
   const {
@@ -117,41 +138,123 @@ export async function handler(
     originalPathname,
     buildManifest,
     nextFontManifest,
-    isNextDataRequest,
     serverFilesManifest,
     reactLoadableManifest,
     prerenderManifest,
     isDraftMode,
     isOnDemandRevalidate,
+    revalidateOnlyGenerated,
     locale,
     locales,
     defaultLocale,
+    routerServerContext,
+    nextConfig,
   } = prepareResult
-
-  const routerServerContext =
-    routerServerGlobal[RouterServerContextSymbol]?.[
-      process.env.__NEXT_RELATIVE_PROJECT_DIR || ''
-    ]
-
-  const onError = routeModule.instrumentationOnRequestError.bind(routeModule)
-  const nextConfig =
-    routerServerContext?.nextConfig || serverFilesManifest.config
 
   const isExperimentalCompile =
     serverFilesManifest?.config?.experimental?.isExperimentalCompile
 
-  const isIsrFallback = Boolean(getRequestMeta(req, 'isIsrFallback'))
   const hasServerProps = Boolean(getServerSideProps)
   const hasStaticProps = Boolean(getStaticProps)
+  const hasStaticPaths = Boolean(getStaticPaths)
   const hasGetInitialProps = Boolean(
     (userland.default || userland).getInitialProps
   )
+  const isAmp = query.amp && config.amp
+  let cacheKey: null | string = null
+  let isIsrFallback = Boolean(getRequestMeta(req, 'isIsrFallback'))
+  let isNextDataRequest =
+    prepareResult.isNextDataRequest && (hasStaticProps || hasServerProps)
+
+  const is404Page = srcPage === '/404'
+  const is500Page = srcPage === '/500'
+  const isErrorPage = srcPage === '/_error'
+  const pathname = parsedUrl.pathname || '/'
+
+  // TODO: rework this to not be necessary as a middleware
+  // rewrite should not need to pass this context like this
+  // maybe we rely on rewrite header instead
+  let resolvedPathname = getRequestMeta(req, 'rewroteURL')
+
+  if (resolvedPathname) {
+    if (pathHasPrefix(resolvedPathname, '/_next/data/')) {
+      resolvedPathname = normalizeDataPath(resolvedPathname)
+    }
+
+    if (locale) {
+      resolvedPathname = normalizeLocalePath(
+        resolvedPathname,
+        nextConfig.i18n?.locales || []
+      ).pathname
+    }
+  } else {
+    resolvedPathname = pathname
+  }
+
+  if (resolvedPathname === '/index') {
+    resolvedPathname = '/'
+  }
+
+  if (!routeModule.isDev && !isDraftMode && hasStaticProps) {
+    cacheKey = `${locale ? `/${locale}` : ''}${
+      (srcPage === '/' || resolvedPathname === '/') && locale
+        ? ''
+        : resolvedPathname
+    }${isAmp ? '.amp' : ''}`
+
+    if (is404Page || is500Page || isErrorPage) {
+      cacheKey = `${locale ? `/${locale}` : ''}${srcPage}${isAmp ? '.amp' : ''}`
+    }
+
+    cacheKey = decodePathParams(cacheKey)
+
+    // ensure /index and / is normalized to one key
+    cacheKey = cacheKey === '/index' ? '/' : cacheKey
+  }
+
+  if (hasStaticPaths && !isDraftMode) {
+    const decodedPathname = removeTrailingSlash(
+      decodePathParams(
+        locale
+          ? addPathPrefix(resolvedPathname, `/${locale}`)
+          : resolvedPathname
+      )
+    )
+    const isPrerendered =
+      Boolean(prerenderManifest.routes[decodedPathname]) ||
+      prerenderManifest.notFoundRoutes.includes(decodedPathname)
+
+    const prerenderInfo = prerenderManifest.dynamicRoutes[srcPage]
+
+    if (prerenderInfo.fallback === false && !isPrerendered) {
+      throw new NoFallbackError()
+    }
+
+    if (
+      typeof prerenderInfo.fallback === 'string' &&
+      !isPrerendered &&
+      !isNextDataRequest
+    ) {
+      isIsrFallback = true
+    }
+  }
+
+  // When serving a bot request, we want to serve a blocking render and not
+  // the prerendered page. This ensures that the correct content is served
+  // to the bot in the head.
+  if (
+    (isIsrFallback && isBot(req.headers['user-agent'] || '')) ||
+    getRequestMeta(req, 'minimalMode')
+  ) {
+    isIsrFallback = false
+  }
+
+  const tracer = getTracer()
+  const activeSpan = tracer.getActiveScopeSpan()
 
   try {
     const method = req.method || 'GET'
-    const tracer = getTracer()
 
-    const activeSpan = tracer.getActiveScopeSpan()
     const resolvedUrl = formatUrl({
       pathname: parsedUrl.pathname,
       // make sure to only add query values from original URL
@@ -161,171 +264,515 @@ export async function handler(
     const publicRuntimeConfig: Record<string, string> =
       routerServerContext?.publicRuntimeConfig || nextConfig.publicRuntimeConfig
 
-    const invokeRouteModule = async (span?: Span) =>
-      routeModule
-        .render(req, res, {
-          query:
-            hasStaticProps && !isExperimentalCompile
-              ? ({
-                  ...params,
-                  ...(query.amp && config.amp
-                    ? {
-                        amp: query.amp as string,
-                      }
-                    : {}),
-                } as ParsedUrlQuery)
-              : {
-                  ...query,
-                  ...params,
+    const handleResponse = async (span?: Span) => {
+      const responseGenerator: ResponseGenerator = async ({
+        previousCacheEntry,
+      }) => {
+        const doRender = async () => {
+          try {
+            return await routeModule
+              .render(req, res, {
+                query:
+                  hasStaticProps && !isExperimentalCompile
+                    ? ({
+                        ...params,
+                        ...(isAmp
+                          ? {
+                              amp: query.amp,
+                            }
+                          : {}),
+                      } as ParsedUrlQuery)
+                    : {
+                        ...query,
+                        ...params,
+                      },
+                params,
+                page: srcPage,
+                renderContext: {
+                  isDraftMode,
+                  isFallback: isIsrFallback,
+                  developmentNotFoundSourcePage: getRequestMeta(
+                    req,
+                    'developmentNotFoundSourcePage'
+                  ),
                 },
-          params,
-          page: srcPage,
-          renderContext: {
-            isDraftMode,
-            isFallback: isIsrFallback,
-            developmentNotFoundSourcePage: getRequestMeta(
-              req,
-              'developmentNotFoundSourcePage'
-            ),
-          },
-          sharedContext: {
-            buildId,
-            customServer:
-              Boolean(routerServerContext?.isCustomServer) || undefined,
-            deploymentId: process.env.NEXT_DEPLOYMENT_ID,
-          },
-          renderOpts: {
-            params,
-            routeModule,
-            page: srcPage,
-            pageConfig: config || {},
-            Component: interopDefault(userland),
-            ComponentMod: userland,
-            getStaticProps,
-            getStaticPaths,
-            getServerSideProps,
-            supportsDynamicResponse: !hasStaticProps,
-            buildManifest,
-            nextFontManifest,
-            reactLoadableManifest,
+                sharedContext: {
+                  buildId,
+                  customServer:
+                    Boolean(routerServerContext?.isCustomServer) || undefined,
+                  deploymentId: process.env.NEXT_DEPLOYMENT_ID,
+                },
+                renderOpts: {
+                  params,
+                  routeModule,
+                  page: srcPage,
+                  pageConfig: config || {},
+                  Component: interopDefault(userland),
+                  ComponentMod: userland,
+                  getStaticProps,
+                  getStaticPaths,
+                  getServerSideProps,
+                  supportsDynamicResponse: !hasStaticProps,
+                  buildManifest,
+                  nextFontManifest,
+                  reactLoadableManifest,
 
-            assetPrefix: nextConfig.assetPrefix,
-            strictNextHead: Boolean(nextConfig.experimental.strictNextHead),
-            previewProps: prerenderManifest.preview,
-            images: nextConfig.images as any,
-            nextConfigOutput: nextConfig.output,
-            optimizeCss: Boolean(nextConfig.experimental.optimizeCss),
-            nextScriptWorkers: Boolean(
-              nextConfig.experimental.nextScriptWorkers
-            ),
-            domainLocales: nextConfig.i18n?.domains,
-            crossOrigin: nextConfig.crossOrigin,
+                  assetPrefix: nextConfig.assetPrefix,
+                  strictNextHead: Boolean(
+                    nextConfig.experimental.strictNextHead
+                  ),
+                  previewProps: prerenderManifest.preview,
+                  images: nextConfig.images as any,
+                  nextConfigOutput: nextConfig.output,
+                  optimizeCss: Boolean(nextConfig.experimental.optimizeCss),
+                  nextScriptWorkers: Boolean(
+                    nextConfig.experimental.nextScriptWorkers
+                  ),
+                  domainLocales: nextConfig.i18n?.domains,
+                  crossOrigin: nextConfig.crossOrigin,
 
-            multiZoneDraftMode,
-            basePath: nextConfig.basePath,
-            canonicalBase: nextConfig.amp.canonicalBase || '',
-            ampOptimizerConfig: nextConfig.experimental.amp?.optimizer,
-            disableOptimizedLoading:
-              nextConfig.experimental.disableOptimizedLoading,
-            largePageDataBytes: nextConfig.experimental.largePageDataBytes,
-            // Only the `publicRuntimeConfig` key is exposed to the client side
-            // It'll be rendered as part of __NEXT_DATA__ on the client side
-            runtimeConfig:
-              Object.keys(publicRuntimeConfig).length > 0
-                ? publicRuntimeConfig
-                : undefined,
+                  multiZoneDraftMode,
+                  basePath: nextConfig.basePath,
+                  canonicalBase: nextConfig.amp.canonicalBase || '',
+                  ampOptimizerConfig: nextConfig.experimental.amp?.optimizer,
+                  disableOptimizedLoading:
+                    nextConfig.experimental.disableOptimizedLoading,
+                  largePageDataBytes:
+                    nextConfig.experimental.largePageDataBytes,
+                  // Only the `publicRuntimeConfig` key is exposed to the client side
+                  // It'll be rendered as part of __NEXT_DATA__ on the client side
+                  runtimeConfig:
+                    Object.keys(publicRuntimeConfig).length > 0
+                      ? publicRuntimeConfig
+                      : undefined,
 
-            isExperimentalCompile,
+                  isExperimentalCompile,
 
-            experimental: {
-              clientTraceMetadata:
-                nextConfig.experimental.clientTraceMetadata || ([] as any),
-            },
+                  experimental: {
+                    clientTraceMetadata:
+                      nextConfig.experimental.clientTraceMetadata ||
+                      ([] as any),
+                  },
 
-            locale,
-            locales,
-            defaultLocale,
-            setIsrStatus: routerServerContext?.setIsrStatus,
+                  locale,
+                  locales,
+                  defaultLocale,
+                  setIsrStatus: routerServerContext?.setIsrStatus,
 
-            isNextDataRequest:
-              isNextDataRequest && (hasServerProps || hasStaticProps),
+                  isNextDataRequest:
+                    isNextDataRequest && (hasServerProps || hasStaticProps),
 
-            resolvedUrl,
-            // For getServerSideProps and getInitialProps we need to ensure we use the original URL
-            // and not the resolved URL to prevent a hydration mismatch on
-            // asPath
-            resolvedAsPath:
-              hasServerProps || hasGetInitialProps
-                ? formatUrl({
-                    // we use the original URL pathname less the _next/data prefix if
-                    // present
-                    pathname: isNextDataRequest
-                      ? normalizeDataPath(originalPathname)
-                      : originalPathname,
-                    query: originalQuery,
+                  resolvedUrl,
+                  // For getServerSideProps and getInitialProps we need to ensure we use the original URL
+                  // and not the resolved URL to prevent a hydration mismatch on
+                  // asPath
+                  resolvedAsPath:
+                    hasServerProps || hasGetInitialProps
+                      ? formatUrl({
+                          // we use the original URL pathname less the _next/data prefix if
+                          // present
+                          pathname: isNextDataRequest
+                            ? normalizeDataPath(originalPathname)
+                            : originalPathname,
+                          query: originalQuery,
+                        })
+                      : resolvedUrl,
+
+                  isOnDemandRevalidate,
+
+                  ErrorDebug: getRequestMeta(req, 'PagesErrorDebug'),
+                  err: getRequestMeta(req, 'invokeError'),
+                  dev: routeModule.isDev,
+
+                  // needed for experimental.optimizeCss feature
+                  distDir: `${routeModule.projectDir}/${routeModule.distDir}`,
+
+                  ampSkipValidation:
+                    nextConfig.experimental.amp?.skipValidation,
+                  ampValidator: getRequestMeta(req, 'ampValidator'),
+                },
+              })
+              .then((renderResult): ResponseCacheEntry => {
+                const { metadata } = renderResult
+
+                let cacheControl: CacheControl | undefined =
+                  metadata.cacheControl
+
+                if ('isNotFound' in metadata && metadata.isNotFound) {
+                  return {
+                    value: null,
+                    cacheControl,
+                  } satisfies ResponseCacheEntry
+                }
+
+                // Handle `isRedirect`.
+                if (metadata.isRedirect) {
+                  return {
+                    value: {
+                      kind: CachedRouteKind.REDIRECT,
+                      props: metadata.pageData ?? metadata.flightData,
+                    } satisfies CachedRedirectValue,
+                    cacheControl,
+                  } satisfies ResponseCacheEntry
+                }
+
+                return {
+                  value: {
+                    kind: CachedRouteKind.PAGES,
+                    html: renderResult,
+                    pageData: renderResult.metadata.pageData,
+                    headers: renderResult.metadata.headers,
+                    status: renderResult.metadata.statusCode,
+                  },
+                  cacheControl,
+                }
+              })
+              .finally(() => {
+                if (!span) return
+
+                span.setAttributes({
+                  'http.status_code': res.statusCode,
+                  'next.rsc': false,
+                })
+
+                const rootSpanAttributes = tracer.getRootSpanAttributes()
+                // We were unable to get attributes, probably OTEL is not enabled
+                if (!rootSpanAttributes) {
+                  return
+                }
+
+                if (
+                  rootSpanAttributes.get('next.span_type') !==
+                  BaseServerSpan.handleRequest
+                ) {
+                  console.warn(
+                    `Unexpected root span type '${rootSpanAttributes.get(
+                      'next.span_type'
+                    )}'. Please report this Next.js issue https://github.com/vercel/next.js`
+                  )
+                  return
+                }
+
+                const route = rootSpanAttributes.get('next.route')
+                if (route) {
+                  const name = `${method} ${route}`
+
+                  span.setAttributes({
+                    'next.route': route,
+                    'http.route': route,
+                    'next.span_name': name,
                   })
-                : resolvedUrl,
-
-            isOnDemandRevalidate,
-
-            ErrorDebug: getRequestMeta(req, 'PagesErrorDebug'),
-            err: getRequestMeta(req, 'invokeError'),
-            dev: routeModule.isDev,
-
-            // needed for experimental.optimizeCss feature
-            distDir: `${routeModule.projectDir}/${routeModule.distDir}`,
-
-            ampSkipValidation: nextConfig.experimental.amp?.skipValidation,
-            ampValidator: getRequestMeta(req, 'ampValidator'),
-          },
-        })
-        .finally(() => {
-          if (!span) return
-
-          span.setAttributes({
-            'http.status_code': res.statusCode,
-            'next.rsc': false,
-          })
-
-          const rootSpanAttributes = tracer.getRootSpanAttributes()
-          // We were unable to get attributes, probably OTEL is not enabled
-          if (!rootSpanAttributes) {
-            return
+                  span.updateName(name)
+                } else {
+                  span.updateName(`${method} ${req.url}`)
+                }
+              })
+          } catch (err: unknown) {
+            // if this is a background revalidate we need to report
+            // the request error here as it won't be bubbled
+            if (previousCacheEntry?.isStale) {
+              await routeModule.onRequestError(
+                req,
+                err,
+                {
+                  routerKind: 'Pages Router',
+                  routePath: srcPage,
+                  routeType: 'render',
+                  revalidateReason: getRevalidateReason({
+                    isRevalidate: hasStaticProps,
+                    isOnDemandRevalidate,
+                  }),
+                },
+                routerServerContext
+              )
+            }
+            throw err
           }
+        }
 
-          if (
-            rootSpanAttributes.get('next.span_type') !==
-            BaseServerSpan.handleRequest
-          ) {
-            console.warn(
-              `Unexpected root span type '${rootSpanAttributes.get(
-                'next.span_type'
-              )}'. Please report this Next.js issue https://github.com/vercel/next.js`
+        // if we've already generated this page we no longer
+        // serve the fallback
+        if (previousCacheEntry) {
+          isIsrFallback = false
+        }
+
+        if (isIsrFallback) {
+          const fallbackResponse = await routeModule.getResponseCache(req).get(
+            routeModule.isDev
+              ? null
+              : locale
+                ? `/${locale}${srcPage}`
+                : srcPage,
+            async ({
+              previousCacheEntry: previousFallbackCacheEntry = null,
+            }) => {
+              if (!routeModule.isDev) {
+                return toResponseCacheEntry(previousFallbackCacheEntry)
+              }
+              return doRender()
+            },
+            {
+              routeKind: RouteKind.PAGES,
+              isFallback: true,
+              isRoutePPREnabled: false,
+              isOnDemandRevalidate: false,
+              incrementalCache: await routeModule.getIncrementalCache(
+                req,
+                nextConfig,
+                prerenderManifest
+              ),
+              waitUntil: ctx.waitUntil,
+            }
+          )
+          if (fallbackResponse) {
+            // Remove the cache control from the response to prevent it from being
+            // used in the surrounding cache.
+            delete fallbackResponse.cacheControl
+            return fallbackResponse
+          }
+        }
+
+        if (
+          !getRequestMeta(req, 'minimalMode') &&
+          isOnDemandRevalidate &&
+          revalidateOnlyGenerated &&
+          !previousCacheEntry
+        ) {
+          res.statusCode = 404
+          // on-demand revalidate always sets this header
+          res.setHeader('x-nextjs-cache', 'REVALIDATED')
+          res.end('This page could not be found')
+          return null
+        }
+
+        if (
+          isIsrFallback &&
+          previousCacheEntry?.value?.kind === CachedRouteKind.PAGES
+        ) {
+          return {
+            value: {
+              kind: CachedRouteKind.PAGES,
+              html: new RenderResult(
+                Buffer.from(previousCacheEntry.value.html),
+                {
+                  contentType: 'text/html;utf-8',
+                  metadata: {
+                    statusCode: previousCacheEntry.value.status,
+                    headers: previousCacheEntry.value.headers,
+                  },
+                }
+              ),
+              pageData: {},
+              status: previousCacheEntry.value.status,
+              headers: previousCacheEntry.value.headers,
+            } satisfies CachedPageValue,
+            cacheControl: { revalidate: 0, expire: undefined },
+          } satisfies ResponseCacheEntry
+        }
+        return doRender()
+      }
+
+      const result = await routeModule.handleResponse({
+        cacheKey,
+        req,
+        nextConfig,
+        routeKind: RouteKind.PAGES,
+        isOnDemandRevalidate,
+        revalidateOnlyGenerated,
+        waitUntil: ctx.waitUntil,
+        responseGenerator: responseGenerator,
+        prerenderManifest,
+      })
+
+      // response is finished is no cache entry
+      if (!result) {
+        return
+      }
+
+      if (!getRequestMeta(req, 'minimalMode')) {
+        res.setHeader(
+          'x-nextjs-cache',
+          isOnDemandRevalidate
+            ? 'REVALIDATED'
+            : result.isMiss
+              ? 'MISS'
+              : result.isStale
+                ? 'STALE'
+                : 'HIT'
+        )
+      }
+
+      let cacheControl: CacheControl | undefined
+
+      if (!hasStaticProps || isIsrFallback) {
+        if (!res.getHeader('Cache-Control')) {
+          cacheControl = { revalidate: 0, expire: undefined }
+        }
+      } else if (is404Page) {
+        const notFoundRevalidate = getRequestMeta(req, 'notFoundRevalidate')
+
+        cacheControl = {
+          revalidate:
+            typeof notFoundRevalidate === 'undefined' ? 0 : notFoundRevalidate,
+          expire: undefined,
+        }
+      } else if (is500Page) {
+        cacheControl = { revalidate: 0, expire: undefined }
+      } else if (result.cacheControl) {
+        // If the cache entry has a cache control with a revalidate value that's
+        // a number, use it.
+        if (typeof result.cacheControl.revalidate === 'number') {
+          if (result.cacheControl.revalidate < 1) {
+            throw new Error(
+              `Invalid revalidate configuration provided: ${result.cacheControl.revalidate} < 1`
             )
-            return
           }
 
-          const route = rootSpanAttributes.get('next.route')
-          if (route) {
-            const name = `${method} ${route}`
-
-            span.setAttributes({
-              'next.route': route,
-              'http.route': route,
-              'next.span_name': name,
-            })
-            span.updateName(name)
-          } else {
-            span.updateName(`${method} ${req.url}`)
+          cacheControl = {
+            revalidate: result.cacheControl.revalidate,
+            expire: result.cacheControl?.expire ?? nextConfig.expireTime,
           }
-        })
+        } else {
+          // revalidate: false
+          cacheControl = {
+            revalidate: CACHE_ONE_YEAR,
+            expire: undefined,
+          }
+        }
+      }
+
+      // If cache control is already set on the response we don't
+      // override it to allow users to customize it via next.config
+      if (cacheControl && !res.getHeader('Cache-Control')) {
+        res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
+      }
+
+      // notFound: true case
+      if (!result.value) {
+        // add revalidate metadata before rendering 404 page
+        // so that we can use this as source of truth for the
+        // cache-control header instead of what the 404 page returns
+        // for the revalidate value
+        addRequestMeta(
+          req,
+          'notFoundRevalidate',
+          result.cacheControl?.revalidate
+        )
+
+        res.statusCode = 404
+
+        if (isNextDataRequest) {
+          res.end('{"notFound":true}')
+          return
+        }
+        // TODO: should route-module itself handle rendering the 404
+        if (routerServerContext?.render404) {
+          await routerServerContext.render404(req, res, parsedUrl, false)
+        } else {
+          res.end('This page could not be found')
+        }
+        return
+      }
+
+      if (result.value.kind === CachedRouteKind.REDIRECT) {
+        if (isNextDataRequest) {
+          res.setHeader('content-type', 'application/json')
+          res.end(JSON.stringify(result.value.props))
+          return
+        } else {
+          const handleRedirect = (pageData: any) => {
+            const redirect = {
+              destination: pageData.pageProps.__N_REDIRECT,
+              statusCode: pageData.pageProps.__N_REDIRECT_STATUS,
+              basePath: pageData.pageProps.__N_REDIRECT_BASE_PATH,
+            }
+            const statusCode = getRedirectStatus(redirect)
+            const { basePath } = nextConfig
+
+            if (
+              basePath &&
+              redirect.basePath !== false &&
+              redirect.destination.startsWith('/')
+            ) {
+              redirect.destination = `${basePath}${redirect.destination}`
+            }
+
+            if (redirect.destination.startsWith('/')) {
+              redirect.destination = normalizeRepeatedSlashes(
+                redirect.destination
+              )
+            }
+
+            res.statusCode = statusCode
+            res.setHeader('Location', redirect.destination)
+            if (statusCode === RedirectStatusCode.PermanentRedirect) {
+              res.setHeader('Refresh', `0;url=${redirect.destination}`)
+            }
+            res.end(redirect.destination)
+          }
+          await handleRedirect(result.value.props)
+          return null
+        }
+      }
+
+      if (result.value.kind !== CachedRouteKind.PAGES) {
+        throw new Error(
+          `Invariant: received non-pages cache entry in pages handler`
+        )
+      }
+
+      // In dev, we should not cache pages for any reason.
+      if (routeModule.isDev) {
+        res.setHeader('Cache-Control', 'no-store, must-revalidate')
+      }
+
+      // Draft mode should never be cached
+      if (isDraftMode) {
+        res.setHeader(
+          'Cache-Control',
+          'private, no-cache, no-store, max-age=0, must-revalidate'
+        )
+      }
+
+      // when invoking _error before pages/500 we don't actually
+      // send the _error response
+      if (
+        getRequestMeta(req, 'customErrorRender') ||
+        (isErrorPage &&
+          getRequestMeta(req, 'minimalMode') &&
+          res.statusCode === 500)
+      ) {
+        return null
+      }
+
+      await sendRenderResult({
+        req,
+        res,
+        // If we are rendering the error page it's not a data request
+        // anymore
+        result:
+          isNextDataRequest && !isErrorPage && !is500Page
+            ? new RenderResult(
+                Buffer.from(JSON.stringify(result.value.pageData)),
+                {
+                  contentType: 'application/json',
+                  metadata: result.value.html.metadata,
+                }
+              )
+            : result.value.html,
+        generateEtags: nextConfig.generateEtags,
+        poweredByHeader: nextConfig.poweredByHeader,
+        cacheControl: routeModule.isDev ? undefined : cacheControl,
+        type: isNextDataRequest ? 'json' : 'html',
+      })
+    }
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
     if (activeSpan) {
-      return await invokeRouteModule(activeSpan)
+      await handleResponse()
     } else {
-      return await tracer.withPropagatedContext(req.headers, () =>
+      await tracer.withPropagatedContext(req.headers, () =>
         tracer.trace(
           BaseServerSpan.handleRequest,
           {
@@ -336,19 +783,14 @@ export async function handler(
               'http.target': req.url,
             },
           },
-          invokeRouteModule
+          handleResponse
         )
       )
     }
   } catch (err) {
-    await onError(
+    await routeModule.onRequestError(
       req,
       err,
-      {
-        path: req.url || '/',
-        headers: req.headers,
-        method: req.method || 'GET',
-      },
       {
         routerKind: 'Pages Router',
         routePath: srcPage,
@@ -357,15 +799,11 @@ export async function handler(
           isRevalidate: hasStaticProps,
           isOnDemandRevalidate,
         }),
-      }
+      },
+      routerServerContext
     )
 
     // rethrow so that we can handle serving error page
     throw err
-  } finally {
-    // We don't allow any waitUntil work in pages API routes currently
-    // so if callback is present return with resolved promise since no
-    // pending work
-    ctx.waitUntil?.(Promise.resolve())
   }
 }

--- a/packages/next/src/build/templates/pages.ts
+++ b/packages/next/src/build/templates/pages.ts
@@ -226,16 +226,18 @@ export async function handler(
 
     const prerenderInfo = prerenderManifest.dynamicRoutes[srcPage]
 
-    if (prerenderInfo.fallback === false && !isPrerendered) {
-      throw new NoFallbackError()
-    }
+    if (prerenderInfo) {
+      if (prerenderInfo.fallback === false && !isPrerendered) {
+        throw new NoFallbackError()
+      }
 
-    if (
-      typeof prerenderInfo.fallback === 'string' &&
-      !isPrerendered &&
-      !isNextDataRequest
-    ) {
-      isIsrFallback = true
+      if (
+        typeof prerenderInfo.fallback === 'string' &&
+        !isPrerendered &&
+        !isNextDataRequest
+      ) {
+        isIsrFallback = true
+      }
     }
   }
 
@@ -589,7 +591,7 @@ export async function handler(
         return
       }
 
-      if (!getRequestMeta(req, 'minimalMode')) {
+      if (hasStaticProps && !getRequestMeta(req, 'minimalMode')) {
         res.setHeader(
           'x-nextjs-cache',
           isOnDemandRevalidate

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -202,6 +202,8 @@ export interface RenderOptsPartial {
   cacheLifeProfiles?: {
     [profile: string]: import('../use-cache/cache-life').CacheLife
   }
+  isOnDemandRevalidate?: boolean
+  isPossibleServerAction?: boolean
   setIsrStatus?: (key: string, value: boolean | null) => void
   isRevalidate?: boolean
   nextExport?: boolean

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -85,7 +85,6 @@ export class IncrementalCache implements IncrementalCacheType {
   readonly hasCustomCacheHandler: boolean
   readonly prerenderManifest: DeepReadonly<PrerenderManifest>
   readonly requestHeaders: Record<string, undefined | string | string[]>
-  readonly requestProtocol?: 'http' | 'https'
   readonly allowedRevalidateHeaderKeys?: string[]
   readonly minimalMode?: boolean
   readonly fetchCacheKeyPrefix?: string
@@ -107,7 +106,6 @@ export class IncrementalCache implements IncrementalCacheType {
     minimalMode,
     serverDistDir,
     requestHeaders,
-    requestProtocol,
     maxMemoryCacheSize,
     getPrerenderManifest,
     fetchCacheKeyPrefix,
@@ -119,7 +117,6 @@ export class IncrementalCache implements IncrementalCacheType {
     minimalMode?: boolean
     serverDistDir?: string
     flushToDisk?: boolean
-    requestProtocol?: 'http' | 'https'
     allowedRevalidateHeaderKeys?: string[]
     requestHeaders: IncrementalCache['requestHeaders']
     maxMemoryCacheSize?: number
@@ -166,7 +163,6 @@ export class IncrementalCache implements IncrementalCacheType {
     const minimalModeKey = 'minimalMode'
     this[minimalModeKey] = minimalMode
     this.requestHeaders = requestHeaders
-    this.requestProtocol = requestProtocol
     this.allowedRevalidateHeaderKeys = allowedRevalidateHeaderKeys
     this.prerenderManifest = getPrerenderManifest()
     this.cacheControls = new SharedCacheControls(this.prerenderManifest)

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -23,7 +23,6 @@ import { addRequestMeta, getRequestMeta } from '../request-meta'
 import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
 import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
 import setupCompression from 'next/dist/compiled/compression'
-import { NoFallbackError } from '../base-server'
 import { signalFromNodeResponse } from '../web/spec-extension/adapters/next-request'
 import { isPostpone } from './router-utils/is-postpone'
 import { parseUrl as parseUrlUtil } from '../../shared/lib/router/utils/parse-url'
@@ -51,6 +50,7 @@ import type { ServerInitResult } from './render-server'
 import { filterInternalHeaders } from './server-ipc/utils'
 import { blockCrossSite } from './router-utils/block-cross-site'
 import { traceGlobals } from '../../trace/shared'
+import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 import {
   RouterServerContextSymbol,
   routerServerGlobal,
@@ -686,10 +686,11 @@ export async function initialize(opts: {
     nextConfig: config,
     hostname: handlers.server.hostname,
     revalidate: handlers.server.revalidate.bind(handlers.server),
+    render404: handlers.server.render404.bind(handlers.server),
     experimentalTestProxy: renderServerOpts.experimentalTestProxy,
     logErrorWithOriginalStack: opts.dev
       ? handlers.server.logErrorWithOriginalStack.bind(handlers.server)
-      : (err: unknown) => Log.error(err),
+      : (err: unknown) => !opts.quiet && Log.error(err),
     setIsrStatus: devBundlerService?.setIsrStatus.bind(devBundlerService),
   }
 

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -251,7 +251,7 @@ export function getResolveRoutes(
     }
 
     async function checkTrue() {
-      const pathname = parsedUrl.pathname || ''
+      const pathname = parsedUrl.pathname || '/'
 
       if (checkLocaleApi(pathname)) {
         return
@@ -435,7 +435,7 @@ export function getResolveRoutes(
         }
 
         if (route.name === 'check_fs') {
-          const pathname = parsedUrl.pathname || ''
+          const pathname = parsedUrl.pathname || '/'
 
           if (invokedOutputs?.has(pathname) || checkLocaleApi(pathname)) {
             return

--- a/packages/next/src/server/lib/router-utils/router-server-context.ts
+++ b/packages/next/src/server/lib/router-utils/router-server-context.ts
@@ -1,4 +1,6 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { NextConfigComplete } from '../../config-shared'
+import type { UrlWithParsedQuery } from 'node:url'
 
 export type RevalidateFn = (config: {
   urlPath: string
@@ -19,6 +21,13 @@ export type RouterServerContext = Record<
     // revalidate function to bypass going through network
     // to invoke revalidate request (uses mocked req/res)
     revalidate?: RevalidateFn
+    // function to render the 404 page
+    render404?: (
+      req: IncomingMessage,
+      res: ServerResponse,
+      parsedUrl?: UrlWithParsedQuery,
+      setHeaders?: boolean
+    ) => Promise<void>
     // current loaded public runtime config
     publicRuntimeConfig?: NextConfigComplete['publicRuntimeConfig']
     // exposing nextConfig for dev mode specifically

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -225,6 +225,12 @@ export interface RequestMeta {
    * ErrorOverlay component to use in development for pages router
    */
   PagesErrorDebug?: PagesDevOverlayBridgeType
+
+  /**
+   * Whether server is in minimal mode (this will be replaced with more
+   * specific flags in future)
+   */
+  minimalMode?: boolean
 }
 
 /**

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -39,13 +39,13 @@ export default class ResponseCache implements ResponseCacheBase {
     expiresAt: number
   }
 
-  private minimalMode?: boolean
+  // we don't use minimal_mode name here as this.minimal_mode is
+  // statically replace for server runtimes but we need it to
+  // be dynamic here
+  private minimal_mode?: boolean
 
-  constructor(minimalMode: boolean) {
-    // this is a hack to avoid Webpack knowing this is equal to this.minimalMode
-    // because we replace this.minimalMode to true in production bundles.
-    const minimalModeKey = 'minimalMode'
-    this[minimalModeKey] = minimalMode
+  constructor(minimal_mode: boolean) {
+    this.minimal_mode = minimal_mode
   }
 
   public async get(
@@ -58,6 +58,7 @@ export default class ResponseCache implements ResponseCacheBase {
       incrementalCache: IncrementalResponseCache
       isRoutePPREnabled?: boolean
       isFallback?: boolean
+      waitUntil?: (prom: Promise<any>) => void
     }
   ): Promise<ResponseCacheEntry | null> {
     // If there is no key for the cache, we can't possibly look this up in the
@@ -71,130 +72,140 @@ export default class ResponseCache implements ResponseCacheBase {
       isOnDemandRevalidate = false,
       isFallback = false,
       isRoutePPREnabled = false,
+      waitUntil,
     } = context
 
     const response = await this.batcher.batch(
       { key, isOnDemandRevalidate },
-      async (cacheKey, resolve) => {
-        // We keep the previous cache entry around to leverage when the
-        // incremental cache is disabled in minimal mode.
-        if (
-          this.minimalMode &&
-          this.previousCacheItem?.key === cacheKey &&
-          this.previousCacheItem.expiresAt > Date.now()
-        ) {
-          return this.previousCacheItem.entry
-        }
+      (cacheKey, resolve) => {
+        const prom = (async () => {
+          // We keep the previous cache entry around to leverage when the
+          // incremental cache is disabled in minimal mode.
+          if (
+            this.minimal_mode &&
+            this.previousCacheItem?.key === cacheKey &&
+            this.previousCacheItem.expiresAt > Date.now()
+          ) {
+            return this.previousCacheItem.entry
+          }
 
-        // Coerce the kindHint into a given kind for the incremental cache.
-        const kind = routeKindToIncrementalCacheKind(context.routeKind)
+          // Coerce the kindHint into a given kind for the incremental cache.
+          const kind = routeKindToIncrementalCacheKind(context.routeKind)
 
-        let resolved = false
-        let cachedResponse: IncrementalResponseCacheEntry | null = null
-        try {
-          cachedResponse = !this.minimalMode
-            ? await incrementalCache.get(key, {
-                kind,
-                isRoutePPREnabled: context.isRoutePPREnabled,
-                isFallback,
-              })
-            : null
+          let resolved = false
+          let cachedResponse: IncrementalResponseCacheEntry | null = null
+          try {
+            cachedResponse = !this.minimal_mode
+              ? await incrementalCache.get(key, {
+                  kind,
+                  isRoutePPREnabled: context.isRoutePPREnabled,
+                  isFallback,
+                })
+              : null
 
-          if (cachedResponse && !isOnDemandRevalidate) {
-            resolve(cachedResponse)
-            resolved = true
+            if (cachedResponse && !isOnDemandRevalidate) {
+              resolve(cachedResponse)
+              resolved = true
 
-            if (!cachedResponse.isStale || context.isPrefetch) {
-              // The cached value is still valid, so we don't need
-              // to update it yet.
+              if (!cachedResponse.isStale || context.isPrefetch) {
+                // The cached value is still valid, so we don't need
+                // to update it yet.
+                return null
+              }
+            }
+
+            const cacheEntry = await responseGenerator({
+              hasResolved: resolved,
+              previousCacheEntry: cachedResponse,
+              isRevalidating: true,
+            })
+
+            // If the cache entry couldn't be generated, we don't want to cache
+            // the result.
+            if (!cacheEntry) {
+              // Unset the previous cache item if it was set.
+              if (this.minimal_mode) this.previousCacheItem = undefined
               return null
             }
-          }
 
-          const cacheEntry = await responseGenerator({
-            hasResolved: resolved,
-            previousCacheEntry: cachedResponse,
-            isRevalidating: true,
-          })
+            const resolveValue = await fromResponseCacheEntry({
+              ...cacheEntry,
+              isMiss: !cachedResponse,
+            })
+            if (!resolveValue) {
+              // Unset the previous cache item if it was set.
+              if (this.minimal_mode) this.previousCacheItem = undefined
+              return null
+            }
 
-          // If the cache entry couldn't be generated, we don't want to cache
-          // the result.
-          if (!cacheEntry) {
-            // Unset the previous cache item if it was set.
-            if (this.minimalMode) this.previousCacheItem = undefined
-            return null
-          }
+            // For on-demand revalidate wait to resolve until cache is set.
+            // Otherwise resolve now.
+            if (!isOnDemandRevalidate && !resolved) {
+              resolve(resolveValue)
+              resolved = true
+            }
 
-          const resolveValue = await fromResponseCacheEntry({
-            ...cacheEntry,
-            isMiss: !cachedResponse,
-          })
-          if (!resolveValue) {
-            // Unset the previous cache item if it was set.
-            if (this.minimalMode) this.previousCacheItem = undefined
-            return null
-          }
-
-          // For on-demand revalidate wait to resolve until cache is set.
-          // Otherwise resolve now.
-          if (!isOnDemandRevalidate && !resolved) {
-            resolve(resolveValue)
-            resolved = true
-          }
-
-          // We want to persist the result only if it has a cache control value
-          // defined.
-          if (resolveValue.cacheControl) {
-            if (this.minimalMode) {
-              this.previousCacheItem = {
-                key: cacheKey,
-                entry: resolveValue,
-                expiresAt: Date.now() + 1000,
+            // We want to persist the result only if it has a cache control value
+            // defined.
+            if (resolveValue.cacheControl) {
+              if (this.minimal_mode) {
+                this.previousCacheItem = {
+                  key: cacheKey,
+                  entry: resolveValue,
+                  expiresAt: Date.now() + 1000,
+                }
+              } else {
+                await incrementalCache.set(key, resolveValue.value, {
+                  cacheControl: resolveValue.cacheControl,
+                  isRoutePPREnabled,
+                  isFallback,
+                })
               }
-            } else {
-              await incrementalCache.set(key, resolveValue.value, {
-                cacheControl: resolveValue.cacheControl,
+            }
+
+            return resolveValue
+          } catch (err) {
+            // When a path is erroring we automatically re-set the existing cache
+            // with new revalidate and expire times to prevent non-stop retrying.
+            if (cachedResponse?.cacheControl) {
+              const newRevalidate = Math.min(
+                Math.max(cachedResponse.cacheControl.revalidate || 3, 3),
+                30
+              )
+
+              const newExpire =
+                cachedResponse.cacheControl.expire === undefined
+                  ? undefined
+                  : Math.max(
+                      newRevalidate + 3,
+                      cachedResponse.cacheControl.expire
+                    )
+
+              await incrementalCache.set(key, cachedResponse.value, {
+                cacheControl: { revalidate: newRevalidate, expire: newExpire },
                 isRoutePPREnabled,
                 isFallback,
               })
             }
+
+            // While revalidating in the background we can't reject as we already
+            // resolved the cache entry so log the error here.
+            if (resolved) {
+              console.error(err)
+              return null
+            }
+
+            // We haven't resolved yet, so let's throw to indicate an error.
+            throw err
           }
+        })()
 
-          return resolveValue
-        } catch (err) {
-          // When a path is erroring we automatically re-set the existing cache
-          // with new revalidate and expire times to prevent non-stop retrying.
-          if (cachedResponse?.cacheControl) {
-            const newRevalidate = Math.min(
-              Math.max(cachedResponse.cacheControl.revalidate || 3, 3),
-              30
-            )
-
-            const newExpire =
-              cachedResponse.cacheControl.expire === undefined
-                ? undefined
-                : Math.max(
-                    newRevalidate + 3,
-                    cachedResponse.cacheControl.expire
-                  )
-
-            await incrementalCache.set(key, cachedResponse.value, {
-              cacheControl: { revalidate: newRevalidate, expire: newExpire },
-              isRoutePPREnabled,
-              isFallback,
-            })
-          }
-
-          // While revalidating in the background we can't reject as we already
-          // resolved the cache entry so log the error here.
-          if (resolved) {
-            console.error(err)
-            return null
-          }
-
-          // We haven't resolved yet, so let's throw to indicate an error.
-          throw err
+        // we need to ensure background revalidates are
+        // passed to waitUntil
+        if (waitUntil) {
+          waitUntil(prom)
         }
+        return prom
       }
     )
 

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -187,6 +187,7 @@ export type ResponseGenerator = (state: {
   hasResolved: boolean
   previousCacheEntry?: IncrementalResponseCacheEntry | null
   isRevalidating?: boolean
+  span?: any
 }) => Promise<ResponseCacheEntry | null>
 
 export const enum IncrementalCacheKind {

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -724,6 +724,14 @@ export class AppRouteRouteModule extends RouteModule<
               case 'force-dynamic': {
                 // Routes of generated paths should be dynamic
                 workStore.forceDynamic = true
+                if (workStore.isStaticGeneration) {
+                  const err = new DynamicServerError(
+                    'Route is configured with dynamic = error which cannot be statically generated.'
+                  )
+                  workStore.dynamicUsageDescription = err.message
+                  workStore.dynamicUsageStack = err.stack
+                  throw err
+                }
                 break
               }
               case 'force-static':

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -13,7 +13,7 @@ import type {
 import type { CacheControl } from './lib/cache-control'
 
 import { byteLength } from './api-utils/web'
-import BaseServer, { NoFallbackError } from './base-server'
+import BaseServer from './base-server'
 import { generateETag } from './lib/etag'
 import { addRequestMeta, getRequestMeta } from './request-meta'
 import WebResponseCache from './response-cache/web'
@@ -34,6 +34,7 @@ import { UNDERSCORE_NOT_FOUND_ROUTE } from '../api/constants'
 import { getEdgeInstrumentationModule } from './web/globals'
 import type { ServerOnInstrumentationRequestError } from './app-render/types'
 import { getEdgePreviewProps } from './web/get-edge-preview-props'
+import { NoFallbackError } from '../shared/lib/no-fallback-error.external'
 
 interface WebServerOptions extends Options {
   buildId: string
@@ -79,7 +80,6 @@ export default class NextWebServer extends BaseServer<
     return new IncrementalCache({
       dev,
       requestHeaders,
-      requestProtocol: 'https',
       allowedRevalidateHeaderKeys:
         this.nextConfig.experimental.allowedRevalidateHeaderKeys,
       minimalMode: this.minimalMode,

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -200,7 +200,6 @@ export async function adapter(
       fetchCacheKeyPrefix: process.env.__NEXT_FETCH_CACHE_KEY_PREFIX,
       dev: process.env.NODE_ENV === 'development',
       requestHeaders: params.request.headers as any,
-      requestProtocol: 'https',
       getPrerenderManifest: () => {
         return {
           version: -1 as any, // letting us know this doesn't conform to spec

--- a/packages/next/src/shared/lib/no-fallback-error.external.ts
+++ b/packages/next/src/shared/lib/no-fallback-error.external.ts
@@ -1,0 +1,6 @@
+export class NoFallbackError extends Error {
+  constructor() {
+    super()
+    this.message = 'Internal: NoFallbackError'
+  }
+}

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -49,6 +49,8 @@ describe('server-side dev errors', () => {
   function stripInternalHandler(output) {
     return output
       .replace(/.*at async handler .*next-route-loader.*/, '')
+      .replace(/.*at async handleResponse.*/, '')
+      .replace(/.*at async doRender \(.*/, '')
       .split(/\n/)
       .filter((item) => !!item.trim())
       .join('\n')


### PR DESCRIPTION
This continues the `handler` signature work from https://github.com/vercel/next.js/pull/78166 and moves the cache/response handling work inside of the pages handler which allows it to be fully invoked independent of `next-server`/`router-server`.

Validated against our deploy tests https://github.com/vercel/vercel/actions/runs/15583209888/job/43883202911?pr=13433 and https://github.com/vercel/next.js/actions/runs/15583265934/job/43883389321