### PR TITLE
[devtool] style the segment explorer as nested view

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
@@ -194,12 +194,9 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
   .segment-explorer-line-icon-page {
     color: inherit;
   }
-  .segment-explorer-line-icon-layout {
-    color: var(--color-gray-1-00);
-  }
 
   .segment-explorer-line-text-page {
-    color: var(--color-blue-900);
+    color: var(--color-gray-1000);
     font-weight: 500;
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
@@ -76,13 +76,33 @@ function PageSegmentTreeLayerPresentation({
   node: TrieNode<SegmentNode>
   level: number
 }) {
-  const segments = node.value?.pagePath?.split('/') || []
-  const fileName = segments[segments.length - 1] || ''
+  const pagePath = node.value?.pagePath || ''
   const nodeName = node.value?.type
-  const pagePathPrefix = segments.slice(0, -1).join('/')
+
+  const segments = pagePath.split('/') || []
+  const fileName = segments.pop() || ''
+  const segmentPath = segments.join('/')
+
+  let pagePathPrefix = segmentPath
+
+  const childrenKeys = Object.keys(node.children).sort((a, b) => {
+    // Prioritize if it's a file convention like layout or page,
+    // then the rest parallel routes.
+    const aHasExt = a.includes('.')
+    const bHasExt = b.includes('.')
+    if (aHasExt && !bHasExt) return -1
+    if (!aHasExt && bHasExt) return 1
+    // Otherwise sort alphabetically
+    return a.localeCompare(b)
+  })
 
   return (
-    <div className="segment-explorer-item">
+    <div
+      className={cx(
+        'segment-explorer-item',
+        level > 1 && 'segment-explorer-item--nested'
+      )}
+    >
       {!fileName || level === 0 ? null : (
         <div className="segment-explorer-item-row">
           <div className="segment-explorer-line">
@@ -103,17 +123,19 @@ function PageSegmentTreeLayerPresentation({
       )}
 
       <div className="tree-node-expanded-rendered-children">
-        {Object.entries(node.children).map(
-          ([key, child]) =>
+        {childrenKeys.map((segment) => {
+          const child = node.children[segment]
+          return (
             child && (
               <PageSegmentTreeLayerPresentation
-                key={key}
+                key={segment}
                 tree={tree}
                 node={child}
                 level={level + 1}
               />
             )
-        )}
+          )
+        })}
       </div>
     </div>
   )
@@ -139,6 +161,10 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     overflow-y: auto;
     padding: 0 12px;
     font-size: var(--size-14);
+  }
+
+  .segment-explorer-item--nested {
+    padding-left: 20px;
   }
 
   .segment-explorer-item-row {

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -22,13 +22,13 @@ describe('segment-explorer', () => {
       '[data-nextjs-devtool-segment-explorer]'
     )
     expect(await content.text()).toMatchInlineSnapshot(`
-     "app/parallel-routes/page.tsx
-     app/parallel-routes/@foo/page.tsx
-     app/parallel-routes/@foo/layout.tsx
-     app/parallel-routes/@bar/page.tsx
-     app/parallel-routes/@bar/layout.tsx
+     "app/layout.tsx
      app/parallel-routes/layout.tsx
-     app/layout.tsx"
+     app/parallel-routes/page.tsx
+     app/parallel-routes/@bar/layout.tsx
+     app/parallel-routes/@bar/page.tsx
+     app/parallel-routes/@foo/layout.tsx
+     app/parallel-routes/@foo/page.tsx"
     `)
   })
 })


### PR DESCRIPTION
### What

Move the segment explorer display towards nested view, get it closer to the nested tree structure look

<img width="391" alt="image" src="https://github.com/user-attachments/assets/d1d8be8a-c89b-4631-bbdf-e3d53733b5b4" />

