### PR TITLE
[test] fix flaky test of basepath navigation

### DIFF
--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -17,7 +17,7 @@ describe('app dir - basepath', () => {
     // then we can assert if the element is present.
     await retry(async () => {
       expect(await browser.url()).toBe(`${next.url}/base/another`)
-    })
+    }, 5_000)
     await browser.waitForElementByCss('#page-2')
   })
 

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -12,7 +12,7 @@ describe('app dir - basepath', () => {
 
   it('should successfully hard navigate from pages -> app', async () => {
     const browser = await next.browser('/base/pages-path')
-    await browser.elementByCss('#to-another').click()
+    await browser.waitForElementByCss('#to-another').click()
     // Wait for url to change, ensure the navigation is finished,
     // then we can assert if the element is present.
     await retry(async () => {

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -13,6 +13,11 @@ describe('app dir - basepath', () => {
   it('should successfully hard navigate from pages -> app', async () => {
     const browser = await next.browser('/base/pages-path')
     await browser.elementByCss('#to-another').click()
+    // Wait for url to change, ensure the navigation is finished,
+    // then we can assert if the element is present.
+    await retry(async () => {
+      expect(await browser.url()).toBe(`${next.url}/base/another`)
+    })
     await browser.waitForElementByCss('#page-2')
   })
 


### PR DESCRIPTION
### What

The navigation test case in basepath is flaky. When the navigation happened, we need to wait for the url change otherwise the element assertion is easy to fail on CI.

x-ref: https://github.com/vercel/next.js/actions/runs/15473866317/job/43564737619?pr=80212

```
● app dir - basepath › should successfully hard navigate from pages -> app

    page.waitForSelector: Timeout 10000ms exceeded.
    Call log:
      - waiting for locator('#page-2')

      454 |   waitForElementByCss(selector: string, timeout = 10_000) {
      455 |     return this.startChain(async () => {
    > 456 |       const el = await page.waitForSelector(selector, {
          |                             ^
      457 |         timeout,
      458 |         state: 'attached',
      459 |       })
```