### PR TITLE
Update the warning text for when multiple lockfiles are found

### DIFF
--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -36,7 +36,7 @@ export function findRootDir(cwd: string) {
   // Only warn if not in a build worker to avoid duplicate warnings
   if (typeof process.send !== 'function' && lockFiles.length > 1) {
     Log.warnOnce(
-      `Warning: Found multiple lockfiles. Consider removing the lockfiles at ${lockFiles
+      `Warning: Found multiple lockfiles. Selecting ${lockFile}.\n   Consider removing the lockfiles at:${lockFiles
         .slice(0, lockFiles.length - 1)
         .map((str) => '\n   * ' + str)
         .join('')}\n`

--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -36,8 +36,8 @@ export function findRootDir(cwd: string) {
   // Only warn if not in a build worker to avoid duplicate warnings
   if (typeof process.send !== 'function' && lockFiles.length > 1) {
     Log.warnOnce(
-      `Warning: Found multiple lockfiles. Selecting ${lockFile}.\n   Consider removing the lockfiles at:${lockFiles
-        .slice(0, lockFiles.length - 1)
+      `Warning: Found multiple lockfiles. Selecting ${lockFiles[lockFiles.length - 1]}.\n   Consider removing the lockfiles at:${lockFiles
+        .slice(0, -1)
         .map((str) => '\n   * ' + str)
         .join('')}\n`
     )


### PR DESCRIPTION
## Improve multiple lockfiles warning message

### What?
Enhances the warning message when multiple lockfiles are detected to explicitly show which lockfile was ultimately selected. Based on feedback from @lukesandberg in a previous PR.

### Why?
The previous warning message only listed the lockfiles that should be removed but didn't indicate which one was actually being used. This improvement makes it clearer to users which lockfile Next.js is selecting when multiple are present.

### How?
Updated the warning message to include "Selecting [selected lockfile]" before suggesting which lockfiles to remove.

Closes PACK-4825