### PR TITLE
Turbopack Build: docs for unsupported composes handling

### DIFF
--- a/docs/01-app/05-api-reference/08-turbopack.mdx
+++ b/docs/01-app/05-api-reference/08-turbopack.mdx
@@ -99,6 +99,8 @@ Some features are not yet implemented or not planned:
   - Standalone `:local` and `:global` pseudo-classes (only the function variant `:global(...)` is supported).
   - The `@value` rule (superseded by CSS variables).
   - `:import` and `:export` ICSS rules.
+  - `composes` in `.module.css` composing a `.css` file. In webpack this would treat the `.css` file as a CSS Module, with Turbopack the `.css` file will always be global. This means that if you want to use `composes` in a CSS Module, you need to change the `.css` file to a `.module.css` file.
+  - `@import` in CSS Modules importing `.css` as a CSS Module. In webpack this would treat the `.css` file as a CSS Module, with Turbopack the `.css` file will always be global. This means that if you want to use `@import` in a CSS Module, you need to change the `.css` file to a `.module.css` file.
 - **`webpack()` configuration** in `next.config.js`
   Turbopack replaces webpack, so `webpack()` configs are not recognized. Use the [`turbopack` config](/docs/app/api-reference/config/next-config-js/turbopack) instead.
 - **AMP**

--- a/test/integration/css-features/test/css-modules.test.js
+++ b/test/integration/css-features/test/css-modules.test.js
@@ -120,29 +120,33 @@ describe('CSS Modules: Import Global CSS', () => {
     }
   )
 })
+// Disabled with Turbopack because importing `.css` files in `.module.css` is handled as `.css` file not `.module.css` file
+;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
+  'CSS Modules: Importing Invalid Global CSS',
+  () => {
+    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+      'production mode',
+      () => {
+        const appDir = join(fixturesDir, 'module-import-global-invalid')
 
-describe('CSS Modules: Importing Invalid Global CSS', () => {
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-    'production mode',
-    () => {
-      const appDir = join(fixturesDir, 'module-import-global-invalid')
-
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
-
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
+        beforeAll(async () => {
+          await remove(join(appDir, '.next'))
         })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('pages/styles.css')
-        expect(stderr).toContain('Selector "a" is not pure')
-      })
-    }
-  )
-})
+
+        // eslint-disable-next-line jest/no-identical-title
+        it('should fail to build', async () => {
+          const { code, stderr } = await nextBuild(appDir, [], {
+            stderr: true,
+          })
+          expect(code).not.toBe(0)
+          expect(stderr).toContain('Failed to compile')
+          expect(stderr).toContain('pages/styles.css')
+          expect(stderr).toContain('Selector "a" is not pure')
+        })
+      }
+    )
+  }
+)
 
 // Turbopack uses LightningCSS which doesn't support `@value`.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -10304,13 +10304,12 @@
       "Valid CSS Module Usage from within node_modules production mode should've prerendered with relevant data",
       "cssmodules-pure-no-check usage should apply styles correctly",
       "cssmodules-pure-no-check usage should have compiled successfully",
-      "cssmodules-pure-no-check usage should've emitted a CSS file"
-    ],
-    "failed": [
+      "cssmodules-pure-no-check usage should've emitted a CSS file",
       "CSS Module Composes Usage (External) production mode should've emitted a single CSS file",
       "Valid Nested CSS Module Usage from within node_modules production mode should've emitted a single CSS file",
       "Valid Nested CSS Module Usage from within node_modules production mode should've prerendered with relevant data"
     ],
+    "failed": [],
     "pending": [
       "Invalid CSS Module Usage in node_modules production mode should fail to build",
       "Invalid Global CSS Module Usage in node_modules production mode should fail to build"


### PR DESCRIPTION
## What?

Adds additional documentation about `.css` (not `.module.css`) files being imported from a `.module.css` (CSS Module) using `composes` or `@import` and updates the tests to reflect the specific case not being supported.

Closes PACK-4787