### PR TITLE
Turbopack: really fix export collection

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -20,7 +20,7 @@ use swc_core::{
             PropName, PropOrSpread, Stmt, Str, VarDecl, VarDeclKind, VarDeclarator, op,
         },
         atoms::Atom,
-        utils::{ExprCtx, ExprExt, find_pat_ids, private_ident, quote_ident},
+        utils::{ExprCtx, ExprExt, find_pat_ids, quote_ident},
     },
 };
 use turbo_rcstr::RcStr;
@@ -1007,8 +1007,14 @@ impl DepGraph {
                             DefaultDecl::TsInterfaceDecl(_) => unreachable!(),
                         };
 
+                        // Mirror what `EsmModuleItem::code_generation` does, these are live
+                        // bindings if the class/function has an identifier.
                         let default_var = id.unwrap_or_else(|| {
-                            private_ident!(magic_identifier::mangle("default export"))
+                            Ident::new(
+                                magic_identifier::mangle("default export").into(),
+                                DUMMY_SP,
+                                Default::default(),
+                            )
                         });
 
                         {
@@ -1073,8 +1079,13 @@ impl DepGraph {
                         exports.push((default_var.to_id(), "default".into()));
                     }
                     ModuleDecl::ExportDefaultExpr(export) => {
-                        let default_var =
-                            private_ident!(magic_identifier::mangle("default export"));
+                        // Mirror what `EsmModuleItem::code_generation` does, these are live
+                        // bindings if the class/function has an identifier.
+                        let default_var = Ident::new(
+                            magic_identifier::mangle("default export").into(),
+                            DUMMY_SP,
+                            Default::default(),
+                        );
 
                         {
                             // For

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
@@ -277,7 +277,7 @@ graph TD
     N7["Items: [ItemId(1, ImportBinding(2))]"];
     N8["Items: [ItemId(1, ImportBinding(3))]"];
     N9["Items: [ItemId(1, ImportBinding(4))]"];
-    N10["Items: [ItemId(2, Normal), ItemId(3, Normal), ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #5), &quot;default&quot;))]"];
+    N10["Items: [ItemId(2, Normal), ItemId(3, Normal), ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #0), &quot;default&quot;))]"];
     N4 --> N0;
     N9 --> N4;
     N1 --> N0;

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
@@ -917,7 +917,7 @@ graph TD
     N26["Items: [ItemId(20, VarDeclarator(0))]"];
     N27["Items: [ItemId(21, VarDeclarator(0))]"];
     N28["Items: [ItemId(22, VarDeclarator(0)), ItemId(Export((&quot;gridArea&quot;, #2), &quot;gridArea&quot;))]"];
-    N29["Items: [ItemId(23, VarDeclarator(0)), ItemId(24, Normal), ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #12), &quot;default&quot;))]"];
+    N29["Items: [ItemId(23, VarDeclarator(0)), ItemId(24, Normal), ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #0), &quot;default&quot;))]"];
     N30["Items: [ItemId(Export((&quot;gridAutoColumns&quot;, #2), &quot;gridAutoColumns&quot;))]"];
     N31["Items: [ItemId(Export((&quot;gridAutoFlow&quot;, #2), &quot;gridAutoFlow&quot;))]"];
     N32["Items: [ItemId(Export((&quot;gridAutoRows&quot;, #2), &quot;gridAutoRows&quot;))]"];

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
@@ -121,7 +121,7 @@ graph TD
 graph TD
     N0["Items: [ItemId(0, ImportOfModule)]"];
     N1["Items: [ItemId(0, ImportBinding(0))]"];
-    N2["Items: [ItemId(1, VarDeclarator(0)), ItemId(2, Normal), ItemId(3, Normal), ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #4), &quot;default&quot;))]"];
+    N2["Items: [ItemId(1, VarDeclarator(0)), ItemId(2, Normal), ItemId(3, Normal), ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #0), &quot;default&quot;))]"];
     N1 --> N0;
 ```
 # Entrypoints

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -687,7 +687,7 @@ graph TD
     N21["Items: [ItemId(15, VarDeclarator(0))]"];
     N22["Items: [ItemId(16, VarDeclarator(0))]"];
     N23["Items: [ItemId(17, VarDeclarator(0)), ItemId(Export((&quot;routeModule&quot;, #2), &quot;routeModule&quot;))]"];
-    N24["Items: [ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #3), &quot;default&quot;))]"];
+    N24["Items: [ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #0), &quot;default&quot;))]"];
     N25["Items: [ItemId(Export((&quot;config&quot;, #2), &quot;config&quot;))]"];
     N26["Items: [ItemId(Export((&quot;getServerSideProps&quot;, #2), &quot;getServerSideProps&quot;))]"];
     N27["Items: [ItemId(Export((&quot;getStaticPaths&quot;, #2), &quot;getStaticPaths&quot;))]"];


### PR DESCRIPTION
- For `export default class Foo`, we don't insert a `var __TURBOPACK__default__export__ = Foo` variable because it should be a live binding. So put the correct name/syntax context into `ImportMap.exports`
- The `__TURBOPACK__default__export__` generated by module fragment tree shaking should use the same syntax context as the one generated by `module_item.rs` (which is `SyntaxContext(0)`).

Closes PACK-4794