### PR TITLE
[test] More robust extraction off CSS sources in Flight chunks

### DIFF
--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -1,8 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
-const isPPREnabledByDefault = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-
 describe('app dir - css', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
@@ -490,47 +488,31 @@ describe('app dir - css', () => {
             // Even if it's deduped by Float, it should still only be included once in the payload.
 
             const matches = initialHtml
-              .match(/\/_next\/static\/css\/.+?\.css/g)
               // The same css chunk could be split into 2 RSC script
-              // normalize "/_next/static/css/app/\"])</script><script>self.__next_f.push([1,\"not-found.css"
+              // e.g.
+              // "/_next/static/css/app/"])</script><script>self.__next_f.push([1,"not-found.css"
+              // "/_next/stati"])</script><script>self.__next_f.push([1,"c/css/app/not-found.css?v=1749205445967"
               // to "/_next/static/css/app/not-found.css"
-              .map((href) =>
-                href.replace('"])</script><script>self.__next_f.push([1,"', '')
-              )
+              .replaceAll('"])</script><script>self.__next_f.push([1,"', '')
+              .match(/\/_next\/static\/css\/.+?\.css/g)
               .sort()
 
             // Heavy on testing React implementation details.
             // Assertions may change often but what needs to be checked on change is if styles are needlessly duplicated in Flight data
             // There are 3 matches, one for the rendered <link> (HTML), one for Float preload (Flight) and one for the <link> inside Flight payload.
             // And there is one match for the not found style
-            if (isPPREnabledByDefault) {
-              expect(matches).toEqual([
-                // may be split across chunks when we bump React
-                '/_next/static/css/app/css/css-duplicate-2/layout.css',
-                '/_next/static/css/app/css/css-duplicate-2/layout.css',
-                '/_next/static/css/app/css/css-duplicate-2/layout.css',
-                '/_next/static/css/app/css/layout.css',
-                '/_next/static/css/app/css/layout.css',
-                '/_next/static/css/app/css/layout.css',
-                '/_next/static/css/app/layout.css',
-                '/_next/static/css/app/layout.css',
-                '/_next/static/css/app/layout.css',
-                '/_next/static/css/app/not-found.css',
-              ])
-            } else {
-              expect(matches).toEqual([
-                '/_next/static/css/app/css/css-duplicate-2/layout.css',
-                '/_next/static/css/app/css/css-duplicate-2/layout.css',
-                '/_next/static/css/app/css/css-duplicate-2/layout.css',
-                '/_next/static/css/app/css/layout.css',
-                '/_next/static/css/app/css/layout.css',
-                '/_next/static/css/app/css/layout.css',
-                '/_next/static/css/app/layout.css',
-                '/_next/static/css/app/layout.css',
-                '/_next/static/css/app/layout.css',
-                '/_next/static/css/app/not-found.css',
-              ])
-            }
+            expect(matches).toEqual([
+              '/_next/static/css/app/css/css-duplicate-2/layout.css',
+              '/_next/static/css/app/css/css-duplicate-2/layout.css',
+              '/_next/static/css/app/css/css-duplicate-2/layout.css',
+              '/_next/static/css/app/css/layout.css',
+              '/_next/static/css/app/css/layout.css',
+              '/_next/static/css/app/css/layout.css',
+              '/_next/static/css/app/layout.css',
+              '/_next/static/css/app/layout.css',
+              '/_next/static/css/app/layout.css',
+              '/_next/static/css/app/not-found.css',
+            ])
           }
         })
 


### PR DESCRIPTION
We previously assumed that the CSS sources were exactly split around paths but that's not guaranteed. The split point can be arbitrary. 

This basically just flips the order of operations. Instead of matching and then normalizing, we normalize first and then match.

We start to hit the arbitrary cases in recent React syncs e.g. https://github.com/vercel/next.js/actions/runs/15472333068/job/43573301354?pr=80211#step:34:644