### PR TITLE
Prerender with streaming metadata during revalidation

### DIFF
--- a/test/e2e/app-dir/ppr-metadata-streaming/app/partially-static/page.tsx
+++ b/test/e2e/app-dir/ppr-metadata-streaming/app/partially-static/page.tsx
@@ -1,0 +1,28 @@
+import { unstable_cacheLife as cacheLife } from 'next/cache'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}
+
+async function getCachedDate() {
+  'use cache'
+
+  cacheLife({ revalidate: 1, expire: 5 * 60 })
+
+  return new Date().toISOString()
+}
+
+export default async function Page() {
+  return (
+    <div>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Dynamic />
+      </Suspense>
+      <p id="date">{await getCachedDate()}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
+++ b/test/e2e/app-dir/ppr-metadata-streaming/next.config.js
@@ -4,6 +4,7 @@
 const nextConfig = {
   experimental: {
     ppr: true,
+    useCache: true,
   },
 }
 


### PR DESCRIPTION
During the export phase of `next build` we're hard-coding `serveStreamingMetadata` to `true`, so we need to do the same during revalidation.

Otherwise we're checking the user agent to decide if we should serve streaming metadata.

This fixes a hydration error that occurred when hydrating the resumed PPR shell. The error was not present for the initial resume of the prerendered shell, and only after the shell was revalidated once.