### PR TITLE
feat: Add cache attributes to fetch spans

### DIFF
--- a/docs/01-app/02-guides/open-telemetry.mdx
+++ b/docs/01-app/02-guides/open-telemetry.mdx
@@ -275,6 +275,13 @@ Attributes:
   - `net.peer.port` (only if specified)
 - `next.span_name`
 - `next.span_type`
+- `next.cache.status` - The cache status of the fetch request:
+  - `hit` - The request was served from cache
+  - `miss` - The request was not found in cache and fetched from origin
+  - `skip` - Caching was disabled for this request
+  - `hmr` - The request was served from HMR (Hot Module Reload) cache during development
+- `next.cache.reason` - The reason for the caching behavior (e.g., `"fetchCache = force-cache"`, `"revalidate: 60"`, `"auto no cache"`)
+- `next.cache.revalidate` - The revalidate value used for this request (number of seconds, or `"undefined"` if not set)
 
 This span can be turned off by setting `NEXT_OTEL_FETCH_DISABLED=1` in your environment. This is useful when you want to use a custom fetch instrumentation library.
 

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -163,6 +163,9 @@ type NextAttributeNames =
   | 'next.span_name'
   | 'next.span_type'
   | 'next.clientComponentLoadCount'
+  | 'next.cache.status'
+  | 'next.cache.reason'
+  | 'next.cache.revalidate'
 type OTELAttributeNames = `http.${string}` | `net.${string}`
 type AttributeNames = NextAttributeNames | OTELAttributeNames
 

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/rsc-fetch-cached/page.tsx
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/rsc-fetch-cached/page.tsx
@@ -1,0 +1,19 @@
+// We want to trace this fetch in runtime with cache attributes
+export const dynamic = 'force-dynamic'
+
+export async function generateMetadata() {
+  return {}
+}
+
+export default async function Page() {
+  // This should generate cache attributes since we're using revalidate
+  const data = await fetch('https://example.vercel.sh', {
+    next: { revalidate: 60 },
+  })
+  return (
+    <>
+      <p>Cached Page</p>
+      <pre>{await data.text()}</pre>
+    </>
+  )
+}

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/rsc-fetch/edge/page.tsx
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/rsc-fetch/edge/page.tsx
@@ -9,5 +9,5 @@ export async function generateMetadata() {
 
 export default async function Page() {
   const data = await fetch('https://example.vercel.sh')
-  return <pre>RESONSE: {data.status}</pre>
+  return <pre>RESPONSE: {data.status}</pre>
 }

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -388,6 +388,33 @@ describe('opentelemetry', () => {
             ])
           })
 
+          it('should handle RSC with cached fetch and include cache attributes', async () => {
+            await next.fetch('/app/param/rsc-fetch-cached', env.fetchInit)
+
+            await expectTrace(getCollector(), [
+              {
+                name: 'GET /app/[param]/rsc-fetch-cached',
+                spans: [
+                  {
+                    name: 'fetch GET https://example.vercel.sh/',
+                    attributes: {
+                      'http.method': 'GET',
+                      'http.url': 'https://example.vercel.sh/',
+                      'net.peer.name': 'example.vercel.sh',
+                      'next.span_name': 'fetch GET https://example.vercel.sh/',
+                      'next.span_type': 'AppRender.fetch',
+                      'next.cache.status': expect.any(String),
+                      'next.cache.reason': expect.any(String),
+                      'next.cache.revalidate': 60,
+                    },
+                    kind: 2,
+                    status: { code: 0 },
+                  },
+                ],
+              },
+            ])
+          })
+
           it('should handle route handlers in app router', async () => {
             await next.fetch('/api/app/param/data', env.fetchInit)
 


### PR DESCRIPTION
  ### What?

  Adds OpenTelemetry cache attributes to fetch spans.

### Why?

  - Enhanced observability: Fetch spans now include cache behavior information (next.cache.status, next.cache.reason, next.cache.revalidate) to help developers understand caching patterns and performance
  - Better debugging: Cache attributes provide visibility into why fetches hit, miss, or skip the cache, making it easier to optimize application performance

### How?

  Added cache attribute setting to fetch spans in three key scenarios in `packages/next/src/server/lib/patch-fetch.ts`:

  1. Cache misses/skips (lines 625-631): When fetching fresh data
  2. Cache hits (lines 861-867): When serving from cache
  3. Foreground revalidates (lines 969-975): When revalidating stale entries

  Each span now includes:
  - `next.cache.status`: 'hit', 'miss', 'skip', or 'hmr'
  - `next.cache.reason`: Human-readable explanation (e.g., 'fetchCache = force-cache', 'revalidate: 60')
  - `next.cache.revalidate`: The revalidate value or 'undefined'

  Additional changes:
  - Added test coverage for cache attributes in fetch spans
  - Updated OpenTelemetry docs

---

Relevant discussion: https://github.com/vercel/next.js/discussions/80201