### PR TITLE
Revert "[test] fix flaky test of basepath navigation"

### DIFF
--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -12,12 +12,7 @@ describe('app dir - basepath', () => {
 
   it('should successfully hard navigate from pages -> app', async () => {
     const browser = await next.browser('/base/pages-path')
-    await browser.waitForElementByCss('#to-another').click()
-    // Wait for url to change, ensure the navigation is finished,
-    // then we can assert if the element is present.
-    await retry(async () => {
-      expect(await browser.url()).toBe(`${next.url}/base/another`)
-    }, 5_000)
+    await browser.elementByCss('#to-another').click()
     await browser.waitForElementByCss('#page-2')
   })
 


### PR DESCRIPTION
Reverts vercel/next.js#80213
x-ref: https://github.com/vercel/next.js/actions/runs/15497907587/job/43641053388
The test was not properly fixed, still observing the navigation failing in CI, need further investigation