### PR TITLE
[devtool] display segment explorer as tree view

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
@@ -62,6 +62,7 @@ function PageSegmentTree({ tree }: { tree: Trie<SegmentNode> | undefined }) {
         tree={tree}
         node={tree.getRoot()}
         level={0}
+        segment=""
       />
     </div>
   )
@@ -69,10 +70,12 @@ function PageSegmentTree({ tree }: { tree: Trie<SegmentNode> | undefined }) {
 
 function PageSegmentTreeLayerPresentation({
   tree,
+  segment,
   node,
   level,
 }: {
   tree: Trie<SegmentNode>
+  segment: string
   node: TrieNode<SegmentNode>
   level: number
 }) {
@@ -81,11 +84,9 @@ function PageSegmentTreeLayerPresentation({
 
   const segments = pagePath.split('/') || []
   const fileName = segments.pop() || ''
-  const segmentPath = segments.join('/')
+  const childrenKeys = Object.keys(node.children)
 
-  let pagePathPrefix = segmentPath
-
-  const childrenKeys = Object.keys(node.children).sort((a, b) => {
+  const sortedChildrenKeys = childrenKeys.sort((a, b) => {
     // Prioritize if it's a file convention like layout or page,
     // then the rest parallel routes.
     const aHasExt = a.includes('.')
@@ -98,13 +99,11 @@ function PageSegmentTreeLayerPresentation({
 
   return (
     <div
-      className={cx(
-        'segment-explorer-item',
-        level > 1 && 'segment-explorer-item--nested'
-      )}
+      className="segment-explorer-item"
+      data-nextjs-devtool-segment-explorer-segment={segment}
     >
-      {!fileName || level === 0 ? null : (
-        <div className="segment-explorer-item-row">
+      {fileName ? (
+        <div className={cx('segment-explorer-item-row')}>
           <div className="segment-explorer-line">
             <div className={`segment-explorer-line-text-${nodeName}`}>
               <span
@@ -115,20 +114,36 @@ function PageSegmentTreeLayerPresentation({
               >
                 {nodeName === 'layout' ? ICONS.layout : ICONS.page}
               </span>
-              {pagePathPrefix === '' ? '' : `${pagePathPrefix}/`}
               <span className="segment-explorer-filename-path">{fileName}</span>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className={cx('segment-explorer-item-row')}>
+          <div className="segment-explorer-line">
+            <div className={`segment-explorer-line-text-${nodeName}`}>
+              <span
+                className={cx(
+                  'segment-explorer-line-icon',
+                  `segment-explorer-line-icon-${nodeName}`
+                )}
+              ></span>
+              <span className="segment-explorer-filename-path">
+                {`${segment}/`}
+              </span>
             </div>
           </div>
         </div>
       )}
 
-      <div className="tree-node-expanded-rendered-children">
-        {childrenKeys.map((segment) => {
-          const child = node.children[segment]
+      <div className="segment-explorer-segment-children">
+        {sortedChildrenKeys.map((childSegment) => {
+          const child = node.children[childSegment]
           return (
             child && (
               <PageSegmentTreeLayerPresentation
-                key={segment}
+                key={childSegment}
+                segment={childSegment}
                 tree={tree}
                 node={child}
                 level={level + 1}
@@ -163,15 +178,15 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     font-size: var(--size-14);
   }
 
-  .segment-explorer-item--nested {
-    padding-left: 20px;
-  }
-
   .segment-explorer-item-row {
     display: flex;
     align-items: center;
     gap: 8px;
     padding: 2px 0;
+  }
+
+  .segment-explorer-segment-children {
+    padding-left: 20px;
   }
 
   .segment-explorer-filename-path {

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/overview/segment-explorer.tsx
@@ -118,8 +118,8 @@ function PageSegmentTreeLayerPresentation({
             </div>
           </div>
         </div>
-      ) : (
-        <div className={cx('segment-explorer-item-row')}>
+      ) : segment ? (
+        <div className={'segment-explorer-item-row'}>
           <div className="segment-explorer-line">
             <div className={`segment-explorer-line-text-${nodeName}`}>
               <span
@@ -134,9 +134,12 @@ function PageSegmentTreeLayerPresentation({
             </div>
           </div>
         </div>
-      )}
+      ) : null}
 
-      <div className="segment-explorer-segment-children">
+      <div
+        className="segment-explorer-segment-children"
+        data-nextjs-devtool-segment-explorer-level={level}
+      >
         {sortedChildrenKeys.map((childSegment) => {
           const child = node.children[childSegment]
           return (
@@ -185,8 +188,11 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     padding: 2px 0;
   }
 
-  .segment-explorer-segment-children {
+  [data-nextjs-devtool-segment-explorer-level].segment-explorer-segment-children {
     padding-left: 20px;
+  }
+  [data-nextjs-devtool-segment-explorer-level='0'].segment-explorer-segment-children {
+    padding-left: 0px;
   }
 
   .segment-explorer-filename-path {

--- a/test/development/app-dir/segment-explorer/app/(v2)/blog/(team)/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/(v2)/blog/(team)/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h3>Nested Layout</h3>
+      <div className="nested-children">{children}</div>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/(v2)/blog/(team)/~/(overview)/grid/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/(v2)/blog/(team)/~/(overview)/grid/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      Page <br />
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/(v2)/blog/(team)/~/(overview)/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/(v2)/blog/(team)/~/(overview)/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h3>Nested Layout</h3>
+      <div className="nested-children">{children}</div>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/(v2)/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/(v2)/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h3>Nested Layout</h3>
+      <div className="nested-children">{children}</div>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -1,34 +1,62 @@
 import { nextTestSetup } from 'e2e-utils'
 import { openDevToolsIndicatorPopover } from 'next-test-utils'
+import { Playwright } from 'next-webdriver'
+
+async function getSegmentExplorerContent(browser: Playwright) {
+  // open the devtool button
+  await openDevToolsIndicatorPopover(browser)
+
+  // open the segment explorer
+  await browser.elementByCss('[data-segment-explorer]').click()
+
+  //  wait for the segment explorer to be visible
+  await browser.waitForElementByCss('[data-nextjs-devtool-segment-explorer]')
+
+  const content = await browser.elementByCss(
+    '[data-nextjs-devtool-segment-explorer]'
+  )
+  return content.text()
+}
 
 describe('segment-explorer', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should render the segment explorer', async () => {
+  it('should render the segment explorer for parallel routes', async () => {
     const browser = await next.browser('/parallel-routes')
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
+     "/
+     app/
+     layout.tsx
+     parallel-routes/
+     layout.tsx
+     page.tsx
+     @bar/
+     layout.tsx
+     page.tsx
+     @foo/
+     layout.tsx
+     page.tsx"
+    `)
+  })
 
-    // open the devtool button
-    await openDevToolsIndicatorPopover(browser)
-
-    // open the segment explorer
-    await browser.elementByCss('[data-segment-explorer]').click()
-
-    //  wait for the segment explorer to be visible
-    await browser.waitForElementByCss('[data-nextjs-devtool-segment-explorer]')
-
-    const content = await browser.elementByCss(
-      '[data-nextjs-devtool-segment-explorer]'
-    )
-    expect(await content.text()).toMatchInlineSnapshot(`
-     "app/layout.tsx
-     app/parallel-routes/layout.tsx
-     app/parallel-routes/page.tsx
-     app/parallel-routes/@bar/layout.tsx
-     app/parallel-routes/@bar/page.tsx
-     app/parallel-routes/@foo/layout.tsx
-     app/parallel-routes/@foo/page.tsx"
+  it('should render the segment explorer for nested routes', async () => {
+    const browser = await next.browser('/blog/~/grid')
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
+     "/
+     app/
+     layout.tsx
+     (v2)/
+     layout.tsx
+     blog/
+     (team)/
+     layout.tsx
+     ~/
+     (overview)/
+     layout.tsx
+     grid/
+     page.tsx"
     `)
   })
 })

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -26,8 +26,7 @@ describe('segment-explorer', () => {
   it('should render the segment explorer for parallel routes', async () => {
     const browser = await next.browser('/parallel-routes')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "/
-     app/
+     "app/
      layout.tsx
      parallel-routes/
      layout.tsx
@@ -44,8 +43,7 @@ describe('segment-explorer', () => {
   it('should render the segment explorer for nested routes', async () => {
     const browser = await next.browser('/blog/~/grid')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "/
-     app/
+     "app/
      layout.tsx
      (v2)/
      layout.tsx


### PR DESCRIPTION
### What

Show the segments as tree view for better visibility

<img width="200" alt="image" src="https://github.com/user-attachments/assets/20d5c57d-f6e3-4add-9b29-8372e1c4d3ea" /> <img height="220" alt="image" src="https://github.com/user-attachments/assets/7fc9cddb-7efb-4e82-9911-dcff133980e7" />

