### PR TITLE
[turbopack] optimize the TurboMalloc threadlocals

### DIFF
--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -34,6 +34,15 @@ pub struct AllocationCounters {
 }
 
 impl AllocationCounters {
+    const fn new() -> Self {
+        Self {
+            allocation_count: 0,
+            deallocation_count: 0,
+            allocations: 0,
+            deallocations: 0,
+            _not_send: PhantomData {},
+        }
+    }
     pub fn until_now(&self) -> AllocationInfo {
         let new = TurboMalloc::allocation_counters();
         AllocationInfo {
@@ -50,6 +59,7 @@ impl AllocationCounters {
 pub struct TurboMalloc;
 
 impl TurboMalloc {
+    // Returns the current amount of memory
     pub fn memory_usage() -> usize {
         get()
     }


### PR DESCRIPTION
Improve memory tracking in turbo-tasks-malloc

### What?

Made the thread_local initializer `const` compatible.  This skips per-thread lazy initialization of the threadlocal datastructure which allows us to skip a small amount of bootstrapping logic.

Additionally, this allows us to access the native llvm implementation of threadlocals which can improve performance.  See https://matklad.github.io/2020/10/03/fast-thread-locals-in-rust.html

### Performance

Confusingly, the benchmarks are not positive, but vercel-site appears to be.  Perhaps the 'small' benchmarks are just too small/

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/AwJ29EfoPcPdLSwCZxAz/51a29e9b-d653-4ba1-8e18-063b6a60c3a9.png)



Closes PACK-4803