### PR TITLE
[metadata] only serve block streaming metadata for html bots

### DIFF
--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -12,10 +12,11 @@ export function shouldServeStreamingMetadata(
     htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING,
     'i'
   )
-  return (
-    // When it's static generation, userAgents are not available - do not serve streaming metadata
-    !!userAgent && !blockingMetadataUARegex.test(userAgent)
-  )
+  // Only block metadata for HTML-limited bots
+  if (userAgent && blockingMetadataUARegex.test(userAgent)) {
+    return false
+  }
+  return true
 }
 
 // When the request UA is a html-limited bot, we should do a dynamic render.

--- a/test/integration/next-image-new/app-dir/app/valid-html-w3c/page.js
+++ b/test/integration/next-image-new/app-dir/app/valid-html-w3c/page.js
@@ -1,15 +1,8 @@
-import Head from 'next/head'
 import Image from 'next/image'
 
 const Page = () => {
   return (
     <div>
-      <Head>
-        <title>Title</title>
-        <meta name="description" content="Description..." />
-        <link rel="icon" type="image/jpeg" href="/test.jpg" />
-      </Head>
-
       <main>
         <Image src="/test.jpg" width="400" height="400" alt="basic image" />
       </main>
@@ -18,3 +11,11 @@ const Page = () => {
 }
 
 export default Page
+
+export const metadata = {
+  title: 'Title',
+  description: 'Description...',
+  icons: {
+    icon: '/test.jpg',
+  },
+}


### PR DESCRIPTION
### What

We should only do blocking metadata if we explicitly match a configured bot. Streaming metadata should be the default. This change is especially for cases like prerender or revalidation, where it's happened on background in Node.js process without user agent in request. So when normal users visit the streaming metadata option is aligned on both cases.

Closes NEXT-4491