### PR TITLE
[test] solidate navigation test

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -908,7 +908,15 @@ describe('app-dir action handling', () => {
       await browser
         .elementByCss(`[href='/delayed-action/${runtime}/other']`)
         .click()
-        .waitForElementByCss('#other-page')
+
+      // wait for the url to change
+      await retry(async () => {
+        expect(await browser.url()).toBe(
+          `${next.url}/delayed-action/${runtime}/other`
+        )
+      })
+
+      await browser.waitForElementByCss('#other-page')
 
       await retry(async () => {
         expect(


### PR DESCRIPTION
### What

Unflaky test, ensure the url to change first then assert the element

```
pnpm test-dev-turbo test/e2e/app-dir/actions/app-action-node-middleware.test.ts (turbopack)

app-dir action handling > should forward action request to a worker that contains the action handler (edge)

page.waitForSelector: Timeout 10000ms exceeded.
Call log:
  - waiting for locator('#other-page')

  454 |   waitForElementByCss(selector: string, timeout = 10_000) {
  455 |     return this.startChain(async () => {
> 456 |       const el = await page.waitForSelector(selector, {
      |                             ^
  457 |         timeout,
  458 |         state: 'attached',
  459 |       })

  at waitForSelector (lib/browsers/playwright.ts:456:29)
  at e2e/app-dir/actions/app-action.test.ts:908:7
  at Proxy._chain (lib/browsers/playwright.ts:568:23)
  at Proxy._chain (lib/browsers/playwright.ts:549:17)
  at Proxy.startChain (lib/browsers/playwright.ts:455:17)
  at waitForElementByCss (e2e/app-dir/actions/app-action.test.ts:911:10)
```