### PR TITLE
[dev-overlay] Move hot reloader client code out of react-dev-overlay

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -505,9 +505,9 @@ function Router({
         </DevRootHTTPAccessFallbackBoundary>
       )
     }
-    const HotReloader: typeof import('./react-dev-overlay/app/hot-reloader-client').default =
+    const HotReloader: typeof import('../dev/hot-reloader/app/hot-reloader-app').default =
       (
-        require('./react-dev-overlay/app/hot-reloader-client') as typeof import('./react-dev-overlay/app/hot-reloader-client')
+        require('../dev/hot-reloader/app/hot-reloader-app') as typeof import('../dev/hot-reloader/app/hot-reloader-app')
       ).default
 
     content = (

--- a/packages/next/src/client/components/react-dev-overlay/app/client-entry.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/client-entry.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { getSocketUrl } from '../utils/get-socket-url'
+import { getSocketUrl } from '../../../dev/hot-reloader/get-socket-url'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../../../server/dev/hot-reloader-types'
 import GlobalError from '../../global-error'
 import { AppDevOverlayErrorBoundary } from './app-dev-overlay-error-boundary'

--- a/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hooks.ts
@@ -19,7 +19,7 @@ export const usePagesDevOverlayBridge = () => {
 
   React.useEffect(() => {
     const { handleStaticIndicator } =
-      require('./hot-reloader-client') as typeof import('./hot-reloader-client')
+      require('../../../dev/hot-reloader/pages/hot-reloader-pages') as typeof import('../../../dev/hot-reloader/pages/hot-reloader-pages')
 
     Router.events.on('routeChangeComplete', handleStaticIndicator)
 

--- a/packages/next/src/client/components/react-dev-overlay/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/shared.ts
@@ -5,7 +5,6 @@ import type { SupportedErrorEvent } from './ui/container/runtime-error/render-er
 import { parseComponentStack } from './utils/parse-component-stack'
 import type { DebugInfo } from './types'
 import type { DevIndicatorServerState } from '../../../server/dev/dev-indicator-server-state'
-import type { HMR_ACTION_TYPES } from '../../../server/dev/hot-reloader-types'
 import { parseStack } from './utils/parse-stack'
 import { isConsoleError } from '../errors/console-error'
 
@@ -344,27 +343,4 @@ export function useErrorOverlayReducer(
       }
     }
   }, getInitialState(routerType))
-}
-
-export const REACT_REFRESH_FULL_RELOAD =
-  '[Fast Refresh] performing full reload\n\n' +
-  "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React rendering tree.\n" +
-  'You might have a file which exports a React component but also exports a value that is imported by a non-React component file.\n' +
-  'Consider migrating the non-React component export to a separate file and importing it into both files.\n\n' +
-  'It is also possible the parent component of the component you edited is a class component, which disables Fast Refresh.\n' +
-  'Fast Refresh requires at least one parent function component in your React tree.'
-
-export const REACT_REFRESH_FULL_RELOAD_FROM_ERROR =
-  '[Fast Refresh] performing full reload because your application had an unrecoverable error'
-
-export function reportInvalidHmrMessage(
-  message: HMR_ACTION_TYPES | MessageEvent<unknown>,
-  err: unknown
-) {
-  console.warn(
-    '[HMR] Invalid message: ' +
-      JSON.stringify(message) +
-      '\n' +
-      ((err instanceof Error && err?.stack) || '')
-  )
 }

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -221,7 +221,7 @@ export async function fetchServerResponse(
     // We need to ensure the Webpack runtime is updated before executing client-side JS of the new page.
     if (process.env.NODE_ENV !== 'production' && !process.env.TURBOPACK) {
       await (
-        require('../react-dev-overlay/app/hot-reloader-client') as typeof import('../react-dev-overlay/app/hot-reloader-client')
+        require('../../dev/hot-reloader/app/hot-reloader-app') as typeof import('../../dev/hot-reloader/app/hot-reloader-app')
       ).waitForWebpackRuntimeHotUpdate()
     }
 

--- a/packages/next/src/client/dev/amp-dev.ts
+++ b/packages/next/src/client/dev/amp-dev.ts
@@ -1,12 +1,9 @@
 /* globals __webpack_hash__ */
 import { displayContent } from './fouc'
 import initOnDemandEntries from './on-demand-entries-client'
-import {
-  addMessageListener,
-  connectHMR,
-} from '../components/react-dev-overlay/pages/websocket'
+import { addMessageListener, connectHMR } from './hot-reloader/pages/websocket'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../server/dev/hot-reloader-types'
-import { reportInvalidHmrMessage } from '../components/react-dev-overlay/shared'
+import { reportInvalidHmrMessage } from './hot-reloader/shared'
 
 /// <reference types="webpack/module.d.ts" />
 

--- a/packages/next/src/client/dev/error-overlay/websocket.ts
+++ b/packages/next/src/client/dev/error-overlay/websocket.ts
@@ -1,4 +1,4 @@
 // next-contentlayer is relying on this internal path
 // https://github.com/contentlayerdev/contentlayer/blob/2f491c540e1d3667577f57fa368b150bff427aaf/packages/next-contentlayer/src/hooks/useLiveReload.ts#L1
 // Drop this file if https://github.com/contentlayerdev/contentlayer/pull/649 is merged/released
-export { addMessageListener } from '../../components/react-dev-overlay/pages/websocket'
+export { addMessageListener } from '../hot-reloader/pages/websocket'

--- a/packages/next/src/client/dev/hot-middleware-client.ts
+++ b/packages/next/src/client/dev/hot-middleware-client.ts
@@ -2,8 +2,8 @@ import type {
   NextRouter,
   PrivateRouteInfo,
 } from '../../shared/lib/router/router'
-import connect from '../components/react-dev-overlay/pages/hot-reloader-client'
-import { sendMessage } from '../components/react-dev-overlay/pages/websocket'
+import connect from './hot-reloader/pages/hot-reloader-pages'
+import { sendMessage } from './hot-reloader/pages/websocket'
 
 // Define a local type for the window.next object
 interface NextWindow {

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -3,31 +3,32 @@
 import type { ReactNode } from 'react'
 import { useEffect, startTransition, useRef } from 'react'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
-import formatWebpackMessages from '../utils/format-webpack-messages'
-import { useRouter } from '../../navigation'
-import { REACT_REFRESH_FULL_RELOAD, reportInvalidHmrMessage } from '../shared'
+import formatWebpackMessages from '../../../components/react-dev-overlay/utils/format-webpack-messages'
+import { useRouter } from '../../../components/navigation'
+import { REACT_REFRESH_FULL_RELOAD } from '../shared'
+import { reportInvalidHmrMessage } from '../shared'
 import { dispatcher } from 'next/dist/compiled/next-devtools'
-import { ReplaySsrOnlyErrors } from './replay-ssr-only-errors'
-import { AppDevOverlayErrorBoundary } from './app-dev-overlay-error-boundary'
-import { useErrorHandler } from '../../errors/use-error-handler'
-import { RuntimeErrorHandler } from '../../errors/runtime-error-handler'
+import { ReplaySsrOnlyErrors } from '../../../components/react-dev-overlay/app/replay-ssr-only-errors'
+import { AppDevOverlayErrorBoundary } from '../../../components/react-dev-overlay/app/app-dev-overlay-error-boundary'
+import { useErrorHandler } from '../../../components/errors/use-error-handler'
+import { RuntimeErrorHandler } from '../../../components/errors/runtime-error-handler'
 import {
   useSendMessage,
   useTurbopack,
   useWebsocket,
   useWebsocketPing,
-} from '../utils/use-websocket'
+} from './use-websocket'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../../../server/dev/hot-reloader-types'
 import type {
   HMR_ACTION_TYPES,
   TurbopackMsgToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import { REACT_REFRESH_FULL_RELOAD_FROM_ERROR } from '../shared'
-import { useUntrackedPathname } from '../../navigation-untracked'
-import type { GlobalErrorComponent } from '../../global-error'
-import reportHmrLatency from '../utils/report-hmr-latency'
-import { TurbopackHmr } from '../utils/turbopack-hot-reloader-common'
-import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../app-router-headers'
+import { useUntrackedPathname } from '../../../components/navigation-untracked'
+import type { GlobalErrorComponent } from '../../../components/global-error'
+import reportHmrLatency from '../../../components/react-dev-overlay/utils/report-hmr-latency'
+import { TurbopackHmr } from '../../../components/react-dev-overlay/utils/turbopack-hot-reloader-common'
+import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../../components/app-router-headers'
 
 let mostRecentCompilationHash: any = null
 let __nextDevClientId = Math.round(Math.random() * 100 + Date.now())

--- a/packages/next/src/client/dev/hot-reloader/app/use-websocket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/use-websocket.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useRef } from 'react'
 import { GlobalLayoutRouterContext } from '../../../../shared/lib/app-router-context.shared-runtime'
-import { getSocketUrl } from './get-socket-url'
+import { getSocketUrl } from '../get-socket-url'
 import type { TurbopackMsgToBrowser } from '../../../../server/dev/hot-reloader-types'
 
 export function useWebsocket(assetPrefix: string) {

--- a/packages/next/src/client/dev/hot-reloader/get-socket-url.ts
+++ b/packages/next/src/client/dev/hot-reloader/get-socket-url.ts
@@ -1,4 +1,4 @@
-import { normalizedAssetPrefix } from '../../../../shared/lib/normalized-asset-prefix'
+import { normalizedAssetPrefix } from '../../../shared/lib/normalized-asset-prefix'
 
 function getSocketProtocol(assetPrefix: string): string {
   let protocol = window.location.protocol

--- a/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
@@ -43,23 +43,21 @@ import {
   onDevIndicator,
   buildingIndicatorHide,
   buildingIndicatorShow,
-} from './client'
+} from '../../../components/react-dev-overlay/pages/client'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { addMessageListener, sendMessage } from './websocket'
-import formatWebpackMessages from '../utils/format-webpack-messages'
+import formatWebpackMessages from '../../../components/react-dev-overlay/utils/format-webpack-messages'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../../../server/dev/hot-reloader-types'
 import type {
   HMR_ACTION_TYPES,
   TurbopackMsgToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
-import {
-  REACT_REFRESH_FULL_RELOAD,
-  REACT_REFRESH_FULL_RELOAD_FROM_ERROR,
-  reportInvalidHmrMessage,
-} from '../shared'
-import { RuntimeErrorHandler } from '../../errors/runtime-error-handler'
-import reportHmrLatency from '../utils/report-hmr-latency'
-import { TurbopackHmr } from '../utils/turbopack-hot-reloader-common'
+import { REACT_REFRESH_FULL_RELOAD } from '../shared'
+import { REACT_REFRESH_FULL_RELOAD_FROM_ERROR } from '../shared'
+import { reportInvalidHmrMessage } from '../shared'
+import { RuntimeErrorHandler } from '../../../components/errors/runtime-error-handler'
+import reportHmrLatency from '../../../components/react-dev-overlay/utils/report-hmr-latency'
+import { TurbopackHmr } from '../../../components/react-dev-overlay/utils/turbopack-hot-reloader-common'
 
 // This alternative WebpackDevServer combines the functionality of:
 // https://github.com/webpack/webpack-dev-server/blob/webpack-1/client/index.js

--- a/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
@@ -2,7 +2,7 @@ import {
   HMR_ACTIONS_SENT_TO_BROWSER,
   type HMR_ACTION_TYPES,
 } from '../../../../server/dev/hot-reloader-types'
-import { getSocketUrl } from '../utils/get-socket-url'
+import { getSocketUrl } from '../get-socket-url'
 
 let source: WebSocket
 

--- a/packages/next/src/client/dev/hot-reloader/shared.ts
+++ b/packages/next/src/client/dev/hot-reloader/shared.ts
@@ -1,0 +1,24 @@
+import type { HMR_ACTION_TYPES } from '../../../server/dev/hot-reloader-types'
+
+export const REACT_REFRESH_FULL_RELOAD =
+  '[Fast Refresh] performing full reload\n\n' +
+  "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React rendering tree.\n" +
+  'You might have a file which exports a React component but also exports a value that is imported by a non-React component file.\n' +
+  'Consider migrating the non-React component export to a separate file and importing it into both files.\n\n' +
+  'It is also possible the parent component of the component you edited is a class component, which disables Fast Refresh.\n' +
+  'Fast Refresh requires at least one parent function component in your React tree.'
+
+export const REACT_REFRESH_FULL_RELOAD_FROM_ERROR =
+  '[Fast Refresh] performing full reload because your application had an unrecoverable error'
+
+export function reportInvalidHmrMessage(
+  message: HMR_ACTION_TYPES | MessageEvent<unknown>,
+  err: unknown
+) {
+  console.warn(
+    '[HMR] Invalid message: ' +
+      JSON.stringify(message) +
+      '\n' +
+      ((err instanceof Error && err?.stack) || '')
+  )
+}

--- a/packages/next/src/client/dev/on-demand-entries-client.ts
+++ b/packages/next/src/client/dev/on-demand-entries-client.ts
@@ -1,5 +1,5 @@
 import Router from '../router'
-import { sendMessage } from '../components/react-dev-overlay/pages/websocket'
+import { sendMessage } from './hot-reloader/pages/websocket'
 
 export default async (page?: string) => {
   // Never send pings when using Turbopack as it's not used.

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -5,15 +5,15 @@ import { displayContent } from './dev/fouc'
 import {
   connectHMR,
   addMessageListener,
-} from './components/react-dev-overlay/pages/websocket'
+} from './dev/hot-reloader/pages/websocket'
 import {
   assign,
   urlQueryToSearchParams,
 } from '../shared/lib/router/utils/querystring'
 import { HMR_ACTIONS_SENT_TO_BROWSER } from '../server/dev/hot-reloader-types'
 import { RuntimeErrorHandler } from './components/errors/runtime-error-handler'
-import { REACT_REFRESH_FULL_RELOAD_FROM_ERROR } from './components/react-dev-overlay/shared'
-import { performFullReload } from './components/react-dev-overlay/pages/hot-reloader-client'
+import { REACT_REFRESH_FULL_RELOAD_FROM_ERROR } from './dev/hot-reloader/shared'
+import { performFullReload } from './dev/hot-reloader/pages/hot-reloader-pages'
 import {
   buildingIndicatorHide,
   buildingIndicatorShow,

--- a/packages/next/src/client/tracing/report-to-socket.ts
+++ b/packages/next/src/client/tracing/report-to-socket.ts
@@ -1,4 +1,4 @@
-import { sendMessage } from '../components/react-dev-overlay/pages/websocket'
+import { sendMessage } from '../dev/hot-reloader/pages/websocket'
 import type { Span } from './tracer'
 
 export default function reportToSocket(span: Span) {


### PR DESCRIPTION
The hot-reloader logic will remain outside of the upcoming `next-devtools` folder. We're shipping the org chart.