### PR TITLE
[dev-overlay] Remove positive tab-index

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/hydration-diff/diff-view.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/hydration-diff/diff-view.tsx
@@ -120,7 +120,6 @@ export function PseudoHtmlDiff({
       data-nextjs-container-errors-pseudo-html-collapse={isDiffCollapsed}
     >
       <button
-        tabIndex={10} // match CallStackFrame
         data-nextjs-container-errors-pseudo-html-collapse-button
         onClick={() => toggleCollapseHtml(!isDiffCollapsed)}
       >

--- a/packages/next/src/client/components/react-dev-overlay/ui/components/terminal/editor-link.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/terminal/editor-link.tsx
@@ -19,7 +19,6 @@ export function EditorLink({ file, location }: EditorLinkProps) {
     <div
       data-with-open-in-editor-link
       data-with-open-in-editor-link-import-trace
-      tabIndex={10}
       role={'link'}
       onClick={open}
       title={'Click to open in your editor'}


### PR DESCRIPTION
Can be disorienting if more focusable content is added. See https://dequeuniversity.com/tips/tabindex-positive-numbers