### PR TITLE
[test] Stop opening browser by default in local Dev Overlay Storybook

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -87,7 +87,7 @@
     "types": "tsc --project tsconfig.build.json --declaration --emitDeclarationOnly --stripInternal --declarationDir dist",
     "typescript": "tsec --noEmit",
     "ncc-compiled": "taskr ncc",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "BROWSER=none storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook"
   },


### PR DESCRIPTION
This doesn't properly work with if a different Chrome release channel is used. It opens Chrome stable even if I have Beta as my default.
It's also annoying if you restart it and have a tab already open in you non-default browser.
We don't open a browser in Next.js for those same reasons.

Storybook will display a URL to click in the terminal so all this adds is one click if you start it for the first time.