### PR TITLE
[dev-overlay] Publish as production bundle

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -3136,8 +3136,7 @@ export async function next_bundle_devtools(task, opts) {
   await task.source('dist').webpack({
     watch: opts.dev,
     config: require('./next-devtools.webpack-config')({
-      // TODO: Use prod variant
-      dev: true,
+      dev: opts.dev,
     }),
     name: 'next-bundle-devtools-dev',
   })


### PR DESCRIPTION
`pnpm dev` will continue to serve a development bundle.
`pnpm build` will now produce a production bundle.
CI will therefore run tests with the production bundle.

Published Next DevTools bundle size is now 450kB (down from 1.1MB).