### PR TITLE
[dev-overlay] Expand clickable area for Select component in user preferences

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/ui/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -1,4 +1,4 @@
-import { useState, type HTMLProps } from 'react'
+import React, { useState, type HTMLProps } from 'react'
 import { css } from '../../../../../utils/css'
 import EyeIcon from '../../../../icons/eye-icon'
 import { STORAGE_KEY_POSITION, STORAGE_KEY_THEME } from '../../../../../shared'
@@ -237,14 +237,40 @@ export function UserPreferences({
 function Select({
   children,
   prefix,
+  value,
   ...props
 }: {
   prefix?: React.ReactNode
-} & Omit<React.HTMLProps<HTMLSelectElement>, 'prefix'>) {
+  value?: string | number
+} & Omit<React.HTMLProps<HTMLSelectElement>, 'prefix' | 'value'>) {
+  let displayValue = ''
+  let longestText = ''
+
+  React.Children.forEach(children, (child) => {
+    if (
+      React.isValidElement<React.OptionHTMLAttributes<HTMLOptionElement>>(child)
+    ) {
+      const childText = child.props.children as string
+      if (childText.length > longestText.length) {
+        longestText = childText
+      }
+      if (child.props.value === value) {
+        displayValue = childText
+      }
+    }
+  })
+
   return (
     <div className="select-button">
       {prefix}
-      <select {...props}>{children}</select>
+      <div className="select-value-wrapper">
+        <span>{longestText}</span>
+        <span>{displayValue}</span>
+      </div>
+
+      <select value={value} {...props}>
+        {children}
+      </select>
       <ChevronDownIcon />
     </div>
   )
@@ -328,18 +354,34 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
   }
 
   .select-button {
+    position: relative;
     &:focus-within {
       outline: var(--focus-ring);
     }
 
     select {
       all: unset;
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
     }
 
     option {
       color: var(--color-gray-1000);
       background: var(--color-background-100);
     }
+  }
+
+  .select-value-wrapper {
+    display: grid;
+  }
+
+  .select-value-wrapper > span {
+    grid-area: 1 / 1;
+  }
+  .select-value-wrapper > span:first-child {
+    visibility: hidden;
   }
 
   :global(.icon) {


### PR DESCRIPTION
The `Select` component in the User Preferences panel had a clickable area limited to the text of the selected option, not the entire visible button area. This made the component feel unresponsive.

We fixed it with some spans and css stuff. Also, the dropdown options are now full-width, which I feel like is an upgrade, due to improved visual consistency. See [material design](https://m3.material.io/components/menus/overview) as an example of the full-width selection options:
![image](https://github.com/user-attachments/assets/be9f2254-caa2-47cc-8278-dc1d09c06dfd)


fixes #80299

What we did to make it clickable:

1. Made select cover the space of its parent container with `position: absolute; inset: 0;`, then `opacity: 0;` so there's no duplicate select text, and `cursor: pointer;` so that the cursor changes to reflect the element's clickability. 
2. Added custom spans to display the text, since we made select invisible.
3. Added a second `span` acting as a strut to have a max width (otherwise the button sizing becomes dynamic), putting them in a div wrapper with `display: grid;`, then targeting the spans themselves with `grid-area: 1 / 1;` so they overlap, then setting the span:first-child (longest element) with `visibility: hidden;` so we don't get duplicated text.


## After:

![fixed click](https://github.com/user-attachments/assets/d64c1a2e-7e42-46d1-a146-c330a1ce313a)

## Before:

![before fixed click](https://github.com/user-attachments/assets/2ac41d84-d492-4047-b82e-da8a9d20f2cc)


### Why we decided against `align-items: center; justify-content: flex-start;` and just went with the programmatic spans:
We'd have to hardcode a bunch of separate padding.
![image](https://github.com/user-attachments/assets/8a4bf67c-0a55-46ff-bebe-4ba79c0028b4)

### Why we need the `span`s and not just the `select`:
Only adjusting the positions on `select` takes it out of the document's layout flow. The parent div (`.select-button`) would then calculate its width based on its remaining in-flow children (the icon and the chevron), causing it to shrink and ignore the space needed for the text.
![image](https://github.com/user-attachments/assets/32a87228-0c75-4e21-ba7e-a4f072d7fa93)


This is a partial continuation of #80025 (dark mode for options), but this change felt separate and extensive enough to warrant its own PR.