### PR TITLE
[turbopack] Track allocation statistics more accurately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9452,7 +9452,9 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "mimalloc",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9452,7 +9452,6 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "mimalloc",
  "rustc-hash 2.1.1",
 ]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -84,9 +84,6 @@ fn init() {
 
     let rt = Builder::new_multi_thread()
         .enable_all()
-        .on_thread_stop(|| {
-            TurboMalloc::thread_stop();
-        })
         .disable_lifo_slot()
         .build()
         .unwrap();

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -74,7 +74,6 @@ fn init() {
 
     use tokio::runtime::Builder;
     use turbo_tasks::panic_hooks::handle_panic;
-    use turbo_tasks_malloc::TurboMalloc;
 
     let prev_hook = take_hook();
     set_hook(Box::new(move |info| {

--- a/crates/next-api/benches/hmr.rs
+++ b/crates/next-api/benches/hmr.rs
@@ -156,9 +156,6 @@ fn load_next_config() -> RcStr {
 fn runtime() -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .on_thread_stop(|| {
-            turbo_tasks_malloc::TurboMalloc::thread_stop();
-        })
         .build()
         .context("Failed to build tokio runtime")
         .unwrap()

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -73,7 +73,6 @@ fn main() {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .on_thread_stop(|| {
-                    TurboMalloc::thread_stop();
                     tracing::debug!("threads stopped");
                 })
                 .build()

--- a/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
@@ -3,7 +3,6 @@ use arbitrary::Arbitrary;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{self, NonLocalValue, TurboTasks, Vc, trace::TraceRawVcs};
-use turbo_tasks_malloc::TurboMalloc;
 
 #[derive(
     Arbitrary, Clone, Debug, PartialEq, Eq, NonLocalValue, Serialize, Deserialize, TraceRawVcs,
@@ -26,9 +25,6 @@ pub struct TaskSpec {
 static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .on_thread_stop(|| {
-            TurboMalloc::thread_stop();
-        })
         .build()
         .unwrap()
 });

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -20,3 +20,7 @@ mimalloc = { version = "0.1.42", features = [
 [features]
 custom_allocator = ["dep:mimalloc"]
 default = ["custom_allocator"]
+
+[dependencies]
+lazy_static = {workspace = true}
+rustc-hash = {workspace = true}

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -22,5 +22,4 @@ custom_allocator = ["dep:mimalloc"]
 default = ["custom_allocator"]
 
 [dependencies]
-lazy_static = {workspace = true}
 rustc-hash = {workspace = true}

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -25,7 +25,7 @@ impl AllocationInfo {
     }
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, Eq, PartialEq)]
 pub struct AllocationCounters {
     pub allocations: usize,
     pub deallocations: usize,

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     marker::PhantomData,
 };
 
-use self::counter::{add, flush, global_counters, remove, update};
+use self::counter::{add, global_counters, remove, update};
 
 #[derive(Default, Clone, Debug)]
 pub struct AllocationInfo {
@@ -129,10 +129,6 @@ impl TurboMalloc {
     // Returns statistics for all allocations in the application that are tracked by TurboMalloc.
     pub fn global_allocation_counters() -> AllocationCounters {
         global_counters()
-    }
-
-    pub fn thread_stop() {
-        flush();
     }
 
     pub fn allocation_counters() -> AllocationCounters {

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -58,9 +58,7 @@ fn bench_small_apps(c: &mut Criterion) {
 
                 b.iter(move || {
                     let mut rt = tokio::runtime::Builder::new_multi_thread();
-                    rt.enable_all().on_thread_stop(|| {
-                        TurboMalloc::thread_stop();
-                    });
+                    rt.enable_all();
                     let rt = rt.build().unwrap();
 
                     let apps_dir = apps_dir.clone();

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -14,8 +14,7 @@ use rustc_hash::FxHashSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, OperationVc, ResolvedVc, TransientInstance, TurboTasks, UpdateInfo, Vc,
-    trace::TraceRawVcs,
-    util::{FormatBytes, FormatDuration},
+    trace::TraceRawVcs, util::FormatDuration,
 };
 use turbo_tasks_backend::{
     BackendOptions, NoopBackingStorage, TurboTasksBackend, noop_backing_storage,
@@ -428,7 +427,7 @@ pub async fn start_server(args: &DevArguments) -> Result<()> {
                 "{event_type} - initial compilation {start} ({memory})",
                 event_type = "event".purple(),
                 start = FormatDuration(start.elapsed()),
-                memory = FormatBytes(TurboMalloc::memory_usage())
+                memory = TurboMalloc::global_allocation_counters()
             );
         }
 
@@ -454,7 +453,7 @@ pub async fn start_server(args: &DevArguments) -> Result<()> {
                             event_type = "event".purple(),
                             duration = FormatDuration(duration),
                             tasks = tasks,
-                            memory = FormatBytes(TurboMalloc::memory_usage())
+                            memory = TurboMalloc::global_allocation_counters()
                         );
                     }
                     (true, false) => {
@@ -464,7 +463,7 @@ pub async fn start_server(args: &DevArguments) -> Result<()> {
                             event_type = "event".purple(),
                             duration = FormatDuration(duration),
                             tasks = tasks,
-                            memory = FormatBytes(TurboMalloc::memory_usage())
+                            memory = TurboMalloc::global_allocation_counters()
                         );
                     }
                     (false, true) => {
@@ -490,7 +489,7 @@ pub async fn start_server(args: &DevArguments) -> Result<()> {
                     print!(
                         "\x1b[2K{event_type} - updating for {progress_counter}s... ({memory})\r",
                         event_type = "event".purple(),
-                        memory = FormatBytes(TurboMalloc::memory_usage())
+                        memory = TurboMalloc::global_allocation_counters()
                     );
                 } else {
                     print!(

--- a/turbopack/crates/turbopack-cli/src/main.rs
+++ b/turbopack/crates/turbopack-cli/src/main.rs
@@ -25,9 +25,7 @@ fn main() {
     let args = Arguments::parse();
 
     let mut rt = tokio::runtime::Builder::new_multi_thread();
-    rt.enable_all().on_thread_stop(|| {
-        TurboMalloc::thread_stop();
-    });
+    rt.enable_all();
 
     #[cfg(not(codspeed))]
     rt.disable_lifo_slot();


### PR DESCRIPTION
## What?

Publish every per-thread set of counters to a global `HashSet` and then aggregate on demand to compute accurate statistics.  The previous approach meant that we would over count per thread allocations by 100K and only reconcile when `TurboMalloc::unload` was called which was only ever done for `tokio` threads.

Use this to replace the current `memory_usage` statistics and also implement a new feature to compute and dump statistics when the `TURBO_MALLOC_SHOW_STATS=1` variable is set.

```
TurboMalloc:
peak-allocated: xxx bytes
allocations: <number>
deallocations: <number>
```

We can then track these on some of our larger benchmarks.

## Why?

I think this will create a complementary set of memory metrics as compared to MaxRss.  MaxRss is useful but in many ways, overcounts.  This on the other hand will undercount since it only tracks the memory directly allocated through malloc.  Still this accounts for the vast majority of memory and is the thing we have the most control over.
