### PR TITLE
Fix typo: 'has' → 'helps' in docs

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -47,7 +47,7 @@ Our documentation assumes some familiarity with web development. Before getting 
 - JavaScript
 - React
 
-If you're new to React or need a refresher, we recommend starting with our [React Foundations course](/learn/react-foundations), and the [Next.js Foundations course](/learn/dashboard-app) that has you building an application as you learn.
+If you're new to React or need a refresher, we recommend starting with our [React Foundations course](/learn/react-foundations), and the [Next.js Foundations course](/learn/dashboard-app) that helps you build an application as you learn.
 
 ## Accessibility
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated. -->
Fixes #80298
## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide: https://nextjs.org/docs/community/contribution-guide

### What?

Fixes a small typo in the `index.mdx` documentation file.

Original sentence:
> "that has you building an application as you learn."

Changed to:
> "that helps you build an application as you learn."

### Why?

The word "helps" fits better grammatically and improves the clarity of the sentence.

### How?

Made a single-word change (`has` → `helps`) in the `docs/index.mdx` file.

---

✅ No code logic was touched.  
✅ Only documentation was modified.

