### PR TITLE
[build-sourcemaps] Only compute codeframe once

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -275,12 +275,6 @@ function getSourcemappedFrameIfPossible(
     }
   }
 
-  const sourceContent: string | null =
-    sourceMapConsumer.sourceContentFor(
-      sourcePosition.source,
-      /* returnNullOnMissing */ true
-    ) ?? null
-
   const applicableSourceMap = findApplicableSourceMapPayload(
     frame,
     sourceMapPayload
@@ -321,16 +315,27 @@ function getSourcemappedFrameIfPossible(
     ignored,
   }
 
-  const codeFrame = getOriginalCodeFrame(
-    originalFrame,
-    sourceContent,
-    inspectOptions.colors
+  return Object.defineProperty(
+    {
+      stack: originalFrame,
+      code: null,
+    },
+    'code',
+    {
+      get: () => {
+        const sourceContent: string | null =
+          sourceMapConsumer.sourceContentFor(
+            sourcePosition.source,
+            /* returnNullOnMissing */ true
+          ) ?? null
+        return getOriginalCodeFrame(
+          originalFrame,
+          sourceContent,
+          inspectOptions.colors
+        )
+      },
+    }
   )
-
-  return {
-    stack: originalFrame,
-    code: codeFrame,
-  }
 }
 
 function parseAndSourceMap(
@@ -372,10 +377,10 @@ function parseAndSourceMap(
       )
 
       if (
-        sourcemappedFrame.code !== null &&
         sourceFrame === null &&
         // TODO: Is this the right choice?
-        !sourcemappedFrame.stack.ignored
+        !sourcemappedFrame.stack.ignored &&
+        sourcemappedFrame.code !== null
       ) {
         sourceFrame = sourcemappedFrame.code
       }

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -315,6 +315,9 @@ function getSourcemappedFrameIfPossible(
     ignored,
   }
 
+  /** undefined = not yet computed*/
+  let codeFrame: string | null | undefined
+
   return Object.defineProperty(
     {
       stack: originalFrame,
@@ -323,16 +326,19 @@ function getSourcemappedFrameIfPossible(
     'code',
     {
       get: () => {
-        const sourceContent: string | null =
-          sourceMapConsumer.sourceContentFor(
-            sourcePosition.source,
-            /* returnNullOnMissing */ true
-          ) ?? null
-        return getOriginalCodeFrame(
-          originalFrame,
-          sourceContent,
-          inspectOptions.colors
-        )
+        if (codeFrame === undefined) {
+          const sourceContent: string | null =
+            sourceMapConsumer.sourceContentFor(
+              sourcePosition.source,
+              /* returnNullOnMissing */ true
+            ) ?? null
+          codeFrame = getOriginalCodeFrame(
+            originalFrame,
+            sourceContent,
+            inspectOptions.colors
+          )
+        }
+        return codeFrame
       },
     }
   )


### PR DESCRIPTION
We used to eagerly compute the codeframe but then only use it for a single frame.
Now we move computation to a getter i.e. we only compute a codeframe when we actually use it.
