### PR TITLE
[test] Only run build_and_deploy once for PRs from upstream

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -28,6 +28,15 @@ env:
 jobs:
   deploy-target:
     runs-on: ubuntu-latest
+    # TL;DR: Only trigger for push events or pull_request events from forks.
+    #
+    # PRs from forks will only trigger a pull_request event where sha and workflow_sha are different.
+    # PRs from vercel/next.js will trigger push and pull_request event. Both events
+    # events from vercel/next.js, will have the sha and workflow_sha.
+    # We only need one run so skip the pull_request event.
+    # The pull_request event would not give us a sha that we can use to query this
+    # workflow which is required for vercel-packages to work.
+    if: ${{ github.event_name != 'pull_request' || github.sha != github.workflow_sha }}
     outputs:
       value: ${{ steps.deploy-target.outputs.value }}
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -696,17 +696,10 @@ jobs:
 
   buildPassed:
     needs: ['deploy-target', 'build', 'build-wasm', 'build-native']
-    if: always()
+    if: ${{ always() && needs.deploy-target.outputs.value != '' }}
     name: thank you, build
     runs-on: ubuntu-latest
     steps:
-      - name: Waiting for passing build_and_deploy from push event
-        # If we bailed out early, don't mark this as passed i.e. deploy-target must
-        # have passed. Everything else can be skipped.
-        # We assume that a workflow from a different event is still running
-        # and eventually produces a passed job.
-        if: ${{ needs.deploy-target.outputs.value == '' }}
-        run: exit 1
       - run: exit 1
         if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -36,10 +36,13 @@ jobs:
     # We only need one run so skip the pull_request event.
     # The pull_request event would not give us a sha that we can use to query this
     # workflow which is required for vercel-packages to work.
-    if: ${{ github.event_name != 'pull_request' || github.sha != github.workflow_sha }}
     outputs:
       value: ${{ steps.deploy-target.outputs.value }}
     steps:
+      - run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "sha=${{ github.sha }}"
+          echo "workflow_sha=${{ github.workflow_sha }}"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -702,7 +702,9 @@ jobs:
 
   buildPassed:
     needs: ['deploy-target', 'build', 'build-wasm', 'build-native']
-    if: always()
+    # If we bailed out early, don't mark this as passed i.e. deploy-target must
+    # have passed. Everything else can be skipped.
+    if: always() && ${{ needs.deploy-target.outputs.value != '' }}
     name: thank you, build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -696,12 +696,17 @@ jobs:
 
   buildPassed:
     needs: ['deploy-target', 'build', 'build-wasm', 'build-native']
-    # If we bailed out early, don't mark this as passed i.e. deploy-target must
-    # have passed. Everything else can be skipped.
-    if: always() && ${{ needs.deploy-target.outputs.value != '' }}
+    if: always()
     name: thank you, build
     runs-on: ubuntu-latest
     steps:
+      - name: Waiting for passing build_and_deploy from push event
+        # If we bailed out early, don't mark this as passed i.e. deploy-target must
+        # have passed. Everything else can be skipped.
+        # We assume that a workflow from a different event is still running
+        # and eventually produces a passed job.
+        if: ${{ needs.deploy-target.outputs.value == '' }}
+        run: exit 1
       - run: exit 1
         if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -28,21 +28,12 @@ env:
 jobs:
   deploy-target:
     runs-on: ubuntu-latest
-    # TL;DR: Only trigger for push events or pull_request events from forks.
-    #
-    # PRs from forks will only trigger a pull_request event where sha and workflow_sha are different.
-    # PRs from vercel/next.js will trigger push and pull_request event. Both events
-    # events from vercel/next.js, will have the sha and workflow_sha.
-    # We only need one run so skip the pull_request event.
-    # The pull_request event would not give us a sha that we can use to query this
-    # workflow which is required for vercel-packages to work.
+    # Don't trigger this job on `pull_request` events from upstream branches.
+    # Those would already run this job on the `push` event
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork }}
     outputs:
       value: ${{ steps.deploy-target.outputs.value }}
     steps:
-      - run: |
-          echo "event_name=${{ github.event_name }}"
-          echo "sha=${{ github.sha }}"
-          echo "workflow_sha=${{ github.workflow_sha }}"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1


### PR DESCRIPTION
PRs from upstream (i.e. not from forks) will always trigger a push and pull_request event. We only want one (the push). The pull_request event is not usable by vercel-packages since the commit will not have workflows associated with it. This also matches the behavior from before we started [running build_and_deploy on PRs from forks](https://github.com/vercel/next.js/issues/78737).

Keep in mind that `build-and-deploy` will now temporarily be marked as complete thus passing the GitHub required check. This is only a problem if `build-and-test` finished before the actual `build-and-deploy` from the `push` event. I tried it failing the `buildPassed` from the PR event but that marks the whole PR as failed in GH. Not a pleasent UX.

## Test plan

- [x] build_and_deploy runs only once for this PR (PR from upstream): https://github.com/vercel/next.js/actions/workflows/build_and_deploy.yml?query=branch%3Asebbie%2Fpr-from-upstream
- [x] build_and_deploy runs on [PR from fork](https://github.com/vercel/next.js/pull/80327): https://github.com/vercel/next.js/actions/runs/15542806123/job/43757359615?pr=80327