### PR TITLE
chore(next-swc-napi): Update tracing-chrome crate to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,12 +3706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "jsonc-parser"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9325,12 +9319,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-chrome"
-version = "0.5.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb13184244c7cd22758b79e7c993c515ad67a8e730edcb7e05fe7bcabb283c7"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
 dependencies = [
- "json",
- "tracing",
+ "serde_json",
+ "tracing-core",
  "tracing-subscriber",
 ]
 

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -69,7 +69,7 @@ supports-hyperlinks = "3.1.0"
 terminal_hyperlink = "0.1.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tracing-chrome = "0.5.0"
+tracing-chrome = "0.7.2"
 url = { workspace = true }
 urlencoding = { workspace = true }
 once_cell = { workspace = true }


### PR DESCRIPTION
I noticed that we were depending on the old unmaintained `json` crate (https://lib.rs/crates/json). Update `tracing-chrome` to a newer version (https://github.com/thoren-d/tracing-chrome/releases) that uses `serde_json` instead.

Closes PACK-4802