### PR TITLE
perf(turbopack): Optimize `Rope` correctly

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -550,6 +550,10 @@ impl InnerRope {
                     return data.into_iter().next().unwrap().into_bytes(len);
                 }
                 Err(data) => {
+                    // If we have a single element, we can return it directly.
+                    if let Local(bytes) = &data[0] {
+                        return bytes.clone();
+                    }
                     self.0 = data;
                 }
             }


### PR DESCRIPTION
### What?

Utilize _cheap clone_ of `bytes::Bytes`. I made an error in the previous pull request.

### Why?

 - In the name of the performance.
 - `bytes::Bytes` is cheap to clone.

Closes PACK-4806