### PR TITLE
provide declarations for server-only/client-only

### DIFF
--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -43,6 +43,30 @@ declare module '*.module.scss' {
   export default classes
 }
 
+// We implement the behavior of `import 'server-only'` and `import 'client-only'` on the compiler level
+// and thus don't require having them installed as dependencies.
+// By default it works fine with typescript, because (surprisingly) TSC *doesn't check side-effecting imports*.
+// But this behavior can be overridden with `noUncheckedSideEffectImports`
+// (https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports)
+// which'd cause `import 'server-only'` to start erroring.
+// To prevent that, we add declarations for them here.
+
+declare module 'server-only' {
+  /**
+   * `import 'server-only'` marks your module as only usable on the server
+   * and prevents it from being used on the client.
+   * Read more: https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning
+   */
+}
+
+declare module 'client-only' {
+  /**
+   * `import 'client-only'` marks your module as only usable on the client
+   * and prevents it from being used on the server.
+   * Read more: https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning
+   */
+}
+
 interface Window {
   MSInputMethodContext?: unknown
   /** @internal */

--- a/test/production/typescript-checked-side-effect-imports/.gitignore
+++ b/test/production/typescript-checked-side-effect-imports/.gitignore
@@ -1,0 +1,2 @@
+# tsconfig.json in tests is excluded by default, but we customize it for this test, so it needs to be included
+!tsconfig.json

--- a/test/production/typescript-checked-side-effect-imports/app/client/page.tsx
+++ b/test/production/typescript-checked-side-effect-imports/app/client/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+import 'client-only'
+
+export default function Page() {
+  return <>Hello</>
+}

--- a/test/production/typescript-checked-side-effect-imports/app/layout.tsx
+++ b/test/production/typescript-checked-side-effect-imports/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/typescript-checked-side-effect-imports/app/server/page.tsx
+++ b/test/production/typescript-checked-side-effect-imports/app/server/page.tsx
@@ -1,0 +1,5 @@
+import 'server-only'
+
+export default function Page() {
+  return <>Hello</>
+}

--- a/test/production/typescript-checked-side-effect-imports/index.test.ts
+++ b/test/production/typescript-checked-side-effect-imports/index.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('Imports of server/client-only with noUncheckedSideEffectImports', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true, // No need to run this in deployment mode.
+    skipStart: true,
+  })
+  if (skipped) return
+
+  let buildResult: Awaited<ReturnType<(typeof next)['build']>>
+  beforeAll(async () => {
+    buildResult = await next.build()
+  })
+
+  it('Should build without typescript errors', async () => {
+    // If something's wrong with our declarations of these modules, TSC will error with:
+    //   `Type error: Cannot find module 'server-only' or its corresponding type declarations.`
+    expect(buildResult.cliOutput).not.toContain('server-only')
+    expect(buildResult.cliOutput).not.toContain('client-only')
+    expect(buildResult.exitCode).toBe(0)
+  })
+})

--- a/test/production/typescript-checked-side-effect-imports/next.config.ts
+++ b/test/production/typescript-checked-side-effect-imports/next.config.ts
@@ -1,0 +1,3 @@
+import type { NextConfig } from 'next'
+const nextConfig: NextConfig = {}
+export default nextConfig

--- a/test/production/typescript-checked-side-effect-imports/tsconfig.json
+++ b/test/production/typescript-checked-side-effect-imports/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    // the only change from the default tsconfig.
+    // this forces `import 'server-only'` and `import 'client-only'` to be checked.
+    "noUncheckedSideEffectImports": true,
+
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
We implement the behavior of `import 'server-only'` and `import 'client-only'` on the compiler level and thus don't require having them installed as dependencies. By default it works fine with typescript, because (surprisingly) TSC *doesn't check side-effecting imports*.
But this behavior can be overridden with [`noUncheckedSideEffectImports`](https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports) which'd cause `import 'server-only'` to start erroring. To prevent that, we add declarations for them in next's global type declarations.