### PR TITLE
Turbopack: include obsolete entries in computation

### DIFF
--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
         {
             println!(
                 "  SST {sequence_number:08}.sst: {min_hash:016x} - {max_hash:016x} (p = 1/{})",
-                u64::MAX / (max_hash - min_hash)
+                u64::MAX / (max_hash - min_hash + 1)
             );
             println!("    AQMF {aqmf_entries} entries = {} KiB", aqmf_size / 1024);
             println!(

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -35,17 +35,18 @@ impl MetaFileBuilder {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    pub fn write(&self, db_path: &Path, seq: u32) -> Result<File> {
+    pub fn write(self, db_path: &Path, seq: u32) -> Result<File> {
         let file = db_path.join(format!("{seq:08}.meta"));
         self.write_internal(&file)
             .with_context(|| format!("Unable to write meta file {seq:08}.meta"))
     }
 
-    fn write_internal(&self, file: &Path) -> io::Result<File> {
+    fn write_internal(mut self, file: &Path) -> io::Result<File> {
         let mut file = BufWriter::new(File::create(file)?);
         file.write_u32::<BE>(0xFE4ADA4A)?; // Magic number
         file.write_u32::<BE>(self.family)?;
 
+        self.obsolete_sst_files.sort();
         file.write_u32::<BE>(self.obsolete_sst_files.len() as u32)?;
         for obsolete_sst in &self.obsolete_sst_files {
             file.write_u32::<BE>(*obsolete_sst)?;

--- a/turbopack/crates/turbo-persistence/src/sst_filter.rs
+++ b/turbopack/crates/turbo-persistence/src/sst_filter.rs
@@ -21,11 +21,11 @@ impl SstFilter {
     pub fn apply_filter(&mut self, meta: &mut MetaFile) {
         // Already obsolete entries need to be considered for usage computation
         for seq in meta.obsolete_entries() {
-            if let Some(state) = self.0.get_mut(seq) {
-                if matches!(state, SstState::UnusedObsolete) {
-                    // the obsolete state is used now
-                    *state = SstState::Obsolete;
-                }
+            if let Some(state) = self.0.get_mut(seq)
+                && matches!(state, SstState::UnusedObsolete)
+            {
+                // the obsolete state is used now
+                *state = SstState::Obsolete;
             }
         }
         meta.retain_entries(|seq| match self.0.entry(seq) {


### PR DESCRIPTION
### What?

We didn't include already removed entries in the usage computation. So a meta file was incorrectly marked as unused and was removed.

Closes PACK-4813