### PR TITLE
[test] add rspack flaky test to build manifest

### DIFF
--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -17765,8 +17765,6 @@
   },
   "test/integration/server-side-dev-errors/test/index.test.js": {
     "passed": [
-      "server-side dev errors should show server-side error for api route correctly",
-      "server-side dev errors should show server-side error for dynamic api route correctly",
       "server-side dev errors should show server-side error for dynamic gssp page correctly",
       "server-side dev errors should show server-side error for gsp page correctly",
       "server-side dev errors should show server-side error for gssp page correctly",
@@ -17775,7 +17773,10 @@
       "server-side dev errors should show server-side error for uncaught exception correctly",
       "server-side dev errors should show server-side error for uncaught rejection correctly"
     ],
-    "failed": [],
+    "failed": [
+      "server-side dev errors should show server-side error for api route correctly",
+      "server-side dev errors should show server-side error for dynamic api route correctly"
+    ],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
We already have these failing test cases tracked in rscpack dev manifest but missing in build manifest. When it's running with build manfiest it's still failing.

```
Run export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/rspack-build-tests-manifest.json"
Filtering tests using manifest: /root/actions-runner/_work/next.js/next.js/test/rspack-build-tests-manifest.json
```

x-ref: https://github.com/vercel/next.js/actions/runs/15557352135/job/43812766616?pr=80356