### PR TITLE
docs: Middleware fetching is not cached

### DIFF
--- a/docs/01-app/03-building-your-application/01-routing/14-middleware.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/14-middleware.mdx
@@ -20,6 +20,8 @@ Middleware is _not_ a good fit for:
 - Slow data fetching
 - Session management
 
+These fetch options, `options.cache`, `options.next.revalidate`, or `options.next.tags`, have no effect when used on Middleware.
+
 ## Convention
 
 Use the file `middleware.ts` (or `.js`) in the root of your project to define Middleware. For example, at the same level as `pages` or `app`, or inside `src` if applicable.

--- a/docs/01-app/03-building-your-application/01-routing/14-middleware.mdx
+++ b/docs/01-app/03-building-your-application/01-routing/14-middleware.mdx
@@ -20,7 +20,7 @@ Middleware is _not_ a good fit for:
 - Slow data fetching
 - Session management
 
-These fetch options, `options.cache`, `options.next.revalidate`, or `options.next.tags`, have no effect when used on Middleware.
+Using fetch with `options.cache`, `options.next.revalidate`, or `options.next.tags`, has no effect in Middleware.
 
 ## Convention
 

--- a/docs/01-app/04-deep-dive/caching.mdx
+++ b/docs/01-app/04-deep-dive/caching.mdx
@@ -31,6 +31,8 @@ By default, Next.js will cache as much as possible to improve performance and re
 
 Caching behavior changes depending on whether the route is statically or dynamically rendered, data is cached or uncached, and whether a request is part of an initial visit or a subsequent navigation. Depending on your use case, you can configure the caching behavior for individual routes and data requests.
 
+Fetch caching is **not** supported in `middleware`. Any fetches done inside of your `middleware` will be uncached.
+
 ## Request Memoization
 
 Next.js extends the [`fetch` API](#fetch) to automatically **memoize** requests that have the same URL and options. This means you can call a fetch function for the same data in multiple places in a React component tree while only executing it once.


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4751/docs-missing-middleware-caching-information-also-ts-types-issue
Fixes: https://github.com/vercel/next.js/issues/77900

Note that the TypeScript (should the TS plugin detect fetch `options.next` used in middleware and error out?)  issue is still pending. It will be eventually handled.