### PR TITLE
guarantee cache busting param correctness

### DIFF
--- a/packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts
+++ b/packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts
@@ -57,7 +57,13 @@ export const setCacheBustingSearchParam = (
   const rawQuery = existingSearch.startsWith('?')
     ? existingSearch.slice(1)
     : existingSearch
-  const pairs = rawQuery.split('&').filter(Boolean)
-  pairs.push(`${NEXT_RSC_UNION_QUERY}=${uniqueCacheKey}`)
+
+  // Always remove any existing cache busting param and add a fresh one to ensure
+  // we have the correct value based on current request headers
+  const pairs = rawQuery
+    .split('&')
+    .filter((pair) => !pair.startsWith(`${NEXT_RSC_UNION_QUERY}=`))
+    .filter(Boolean)
+
   url.search = pairs.length ? `?${pairs.join('&')}` : ''
 }

--- a/packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts
+++ b/packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts
@@ -62,8 +62,8 @@ export const setCacheBustingSearchParam = (
   // we have the correct value based on current request headers
   const pairs = rawQuery
     .split('&')
-    .filter((pair) => !pair.startsWith(`${NEXT_RSC_UNION_QUERY}=`))
-    .filter(Boolean)
+    .filter((pair) => pair && !pair.startsWith(`${NEXT_RSC_UNION_QUERY}=`))
 
+  pairs.push(`${NEXT_RSC_UNION_QUERY}=${uniqueCacheKey}`)
   url.search = pairs.length ? `?${pairs.join('&')}` : ''
 }


### PR DESCRIPTION
[RSC validation](https://github.com/vercel/next.js/pull/80157) requires `_rsc` search param to match the RSC [hash](https://github.com/vercel/next.js/blob/06-10-remove_existing_cache_busting_param_and_add_fresh_one/packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts#L3) of request headers.


To guarantee any request initiated from Next.js meets the criteria, we are going to remove existing cache busting param and add fresh one **just in case the pre-existing param does not match the hash**.

Existing E2E tests should cover this change.