### PR TITLE
Turbopack Build: Fix /index/index handling

### DIFF
--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -65,6 +65,10 @@ pub async fn create_page_loader_entry_module(
     Ok(module)
 }
 
+// This is only used in development mode. A special chunk is emitted for each page that contains the
+// page's chunks. This chunk is used to load the page's chunks in the browser on navigation.
+// In production, the page's chunks are loaded by the page loader using the build manifest.
+// The reason we need this in development is that the chunks are not known ahead of time.
 #[turbo_tasks::value(shared)]
 pub struct PageLoaderAsset {
     pub server_root: ResolvedVc<FileSystemPath>,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -222,7 +222,6 @@ export async function turbopackBuild(): Promise<{
     await manifestLoader.writeManifests({
       devRewrites: undefined,
       productionRewrites: rewrites,
-      entrypoints: currentEntrypoints,
     })
 
     const shutdownPromise = project.shutdown()

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -691,7 +691,6 @@ function doRender(input: RenderRouteInfo): Promise<any> {
       if (!currentHrefs.has(href)) {
         const styleTag = document.createElement('style')
         styleTag.setAttribute('data-n-href', href)
-        styleTag.setAttribute('media', 'x')
 
         if (nonce) {
           styleTag.setAttribute('nonce', nonce)

--- a/packages/next/src/client/next-dev-turbopack.ts
+++ b/packages/next/src/client/next-dev-turbopack.ts
@@ -26,7 +26,10 @@ initialize({
   devClient,
 })
   .then(({ assetPrefix }) => {
-    // for the page loader
+    // This is only used in development mode. A special chunk is emitted for each page that contains the page's chunks.
+    // This chunk is used to load the page's chunks in the browser on navigation.
+    // In production, the page's chunks are loaded by the page loader using the build manifest.
+    // The reason we need this in development is that the chunks are not known ahead of time.
     ;(self as any).__turbopack_load_page_chunks__ = (
       page: string,
       chunksData: any

--- a/packages/next/src/client/next-turbopack.ts
+++ b/packages/next/src/client/next-turbopack.ts
@@ -24,18 +24,6 @@ declare let __turbopack_load__: any
 
 initialize({})
   .then(() => {
-    // for the page loader
-    ;(self as any).__turbopack_load_page_chunks__ = (
-      page: string,
-      chunksData: any
-    ) => {
-      const chunkPromises = chunksData.map(__turbopack_load__)
-
-      Promise.all(chunkPromises).catch((err) =>
-        console.error('failed to load chunks for page ' + page, err)
-      )
-    }
-
     return hydrate({ beforeRender: displayContent })
   })
   .catch((err) => {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1124,7 +1124,6 @@ export async function createHotReloaderTurbopack(
   await manifestLoader.writeManifests({
     devRewrites: opts.fsChecker.rewrites,
     productionRewrites: undefined,
-    entrypoints: currentEntrypoints,
   })
 
   async function handleProjectUpdates() {

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -243,7 +243,6 @@ export async function handleRouteType({
         await manifestLoader.writeManifests({
           devRewrites,
           productionRewrites,
-          entrypoints,
         })
 
         processIssues(
@@ -334,7 +333,6 @@ export async function handleRouteType({
       await manifestLoader.writeManifests({
         devRewrites,
         productionRewrites,
-        entrypoints,
       })
 
       processIssues(currentEntryIssues, key, writtenEndpoint, true, logErrors)
@@ -397,7 +395,6 @@ export async function handleRouteType({
       await manifestLoader.writeManifests({
         devRewrites,
         productionRewrites,
-        entrypoints,
       })
 
       processIssues(currentEntryIssues, key, writtenEndpoint, dev, logErrors)
@@ -423,7 +420,6 @@ export async function handleRouteType({
       await manifestLoader.writeManifests({
         devRewrites,
         productionRewrites,
-        entrypoints,
       })
       processIssues(currentEntryIssues, key, writtenEndpoint, true, logErrors)
 
@@ -688,7 +684,6 @@ export async function handleEntrypoints({
     await manifestLoader.writeManifests({
       devRewrites,
       productionRewrites: undefined,
-      entrypoints: currentEntrypoints,
     })
 
     dev.serverFields.actualInstrumentationHookFile = '/instrumentation'
@@ -756,7 +751,6 @@ export async function handleEntrypoints({
           await manifestLoader.writeManifests({
             devRewrites,
             productionRewrites: undefined,
-            entrypoints: currentEntrypoints,
           })
 
           finishBuilding?.()
@@ -947,7 +941,6 @@ export async function handlePagesErrorRoute({
   await manifestLoader.writeManifests({
     devRewrites,
     productionRewrites,
-    entrypoints,
   })
 }
 

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -467,11 +467,20 @@ export class TurbopackManifestLoader {
       )};`
     )
 
+    const pagesEntries: Record<string, readonly string[]> = {}
+
+    for (const key in buildManifest.pages) {
+      // Filter out anything that doesn't end in `.js`.
+      pagesEntries[key] = buildManifest.pages[key].filter((item) =>
+        item.endsWith('.js')
+      )
+    }
+
     const pagesKeys = Object.keys(buildManifest.pages)
     const sortedPageKeys = getSortedRoutes(pagesKeys)
     const clientBuildManifest: ClientBuildManifest = {
       __rewrites: normalizeRewritesForBuildManifest(rewrites) as any,
-      ...(buildManifest.pages as any),
+      ...pagesEntries,
       sortedPages: sortedPageKeys,
     }
     const clientBuildManifestJs = `self.__BUILD_MANIFEST = ${JSON.stringify(

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -467,20 +467,11 @@ export class TurbopackManifestLoader {
       )};`
     )
 
-    const pagesEntries: Record<string, readonly string[]> = {}
-
-    for (const key in buildManifest.pages) {
-      // Filter out anything that doesn't end in `.js`.
-      pagesEntries[key] = buildManifest.pages[key].filter((item) =>
-        item.endsWith('.js')
-      )
-    }
-
     const pagesKeys = Object.keys(buildManifest.pages)
     const sortedPageKeys = getSortedRoutes(pagesKeys)
     const clientBuildManifest: ClientBuildManifest = {
       __rewrites: normalizeRewritesForBuildManifest(rewrites) as any,
-      ...pagesEntries,
+      ...(buildManifest.pages as any),
       sortedPages: sortedPageKeys,
     }
     const clientBuildManifestJs = `self.__BUILD_MANIFEST = ${JSON.stringify(

--- a/test/integration/client-404/test/index.test.js
+++ b/test/integration/client-404/test/index.test.js
@@ -9,6 +9,7 @@ import {
   nextBuild,
   nextStart,
   retry,
+  getPageFilesFromBuildManifest,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { check } from 'next-test-utils'
@@ -45,11 +46,14 @@ const clientNavigation = (context, isProd = false) => {
 
     if (isProd) {
       it('should hard navigate to URL on failing to load missing bundle', async () => {
+        const files = getPageFilesFromBuildManifest(appDir, '/missing')
         const browser = await webdriver(context.appPort, '/to-missing-link', {
           beforePageLoad(page) {
-            page.route('**/pages/missing**', (route) => {
-              route.abort('internetdisconnected')
-            })
+            for (const file of files) {
+              page.route(`**/_next/${file}`, (route) => {
+                route.abort('internetdisconnected')
+              })
+            }
           },
         })
         await browser.eval(() => (window.beforeNav = 'hi'))

--- a/test/integration/error-load-fail/test/index.test.js
+++ b/test/integration/error-load-fail/test/index.test.js
@@ -2,7 +2,14 @@
 
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { nextBuild, nextStart, findPort, killApp, check } from 'next-test-utils'
+import {
+  nextBuild,
+  nextStart,
+  findPort,
+  killApp,
+  check,
+  getPageFilesFromBuildManifest,
+} from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
 let app
@@ -18,12 +25,15 @@ describe('Failing to load _error', () => {
         const appPort = await findPort()
         app = await nextStart(appDir, appPort)
 
+        const files = getPageFilesFromBuildManifest(appDir, '/_error')
         const browser = await webdriver(appPort, '/', {
           beforePageLoad(page) {
             // Make _error route fail to load
-            page.route('**/_error*.js', (route) => {
-              route.abort('blockedbyclient')
-            })
+            for (const file of files) {
+              page.route(`**/_next/${file}`, (route) => {
+                route.abort('internetdisconnected')
+              })
+            }
           },
         })
 

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15207,11 +15207,10 @@
       "nested index.js production mode should ssr page /index",
       "nested index.js production mode should ssr page /index/index",
       "nested index.js production mode should ssr page /index/project",
-      "nested index.js production mode should ssr page /index/user"
-    ],
-    "failed": [
+      "nested index.js production mode should ssr page /index/user",
       "nested index.js production mode should follow link to /index/index"
     ],
+    "failed": [],
     "pending": [
       "nested index.js development mode should 404 on /index/index/index",
       "nested index.js development mode should client render page /",
@@ -16868,11 +16867,10 @@
   },
   "test/integration/prerender-export/test/index.test.js": {
     "passed": [
-      "SSG Prerender export production mode export mode should copy prerender files and honor exportTrailingSlash"
-    ],
-    "failed": [
+      "SSG Prerender export production mode export mode should copy prerender files and honor exportTrailingSlash",
       "SSG Prerender export production mode export mode should navigate between pages successfully"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Fixes `/index/index` navigation handling. The `_buildManifest.js` was implemented without leveraging the info coming from Turbopack, that works in development because there is no content hashing, for builds we want to include the actual files. This PR handles that. 

As a follow-up we'll want to skip generating the intermediate asset that is not used in production.

Closes PACK-4820