### PR TITLE
Discard `Infinity` expiration for implicit tags

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -867,10 +867,12 @@ export function cache(
               workUnitStore.implicitTags.expirationsByCacheKind.get(kind)
 
             if (lazyExpiration) {
-              if (isResolvedLazyResult(lazyExpiration)) {
-                implicitTagsExpiration = lazyExpiration.value
-              } else {
-                implicitTagsExpiration = await lazyExpiration
+              const expiration = isResolvedLazyResult(lazyExpiration)
+                ? lazyExpiration.value
+                : await lazyExpiration
+
+              if (expiration < Infinity) {
+                implicitTagsExpiration = expiration
               }
             }
           }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -871,6 +871,11 @@ export function cache(
                 ? lazyExpiration.value
                 : await lazyExpiration
 
+              // If a cache handler returns an expiration time of Infinity, it
+              // signals to Next.js that it handles checking cache entries for
+              // staleness based on the expiration of the implicit tags passed
+              // into the `get` method. In this case, we keep the default of 0,
+              // which means that the implicit tags are not considered expired.
               if (expiration < Infinity) {
                 implicitTagsExpiration = expiration
               }

--- a/test/e2e/app-dir/use-cache-custom-handler/handler.js
+++ b/test/e2e/app-dir/use-cache-custom-handler/handler.js
@@ -24,7 +24,9 @@ const cacheHandler = {
 
   async getExpiration(...tags) {
     console.log('ModernCustomCacheHandler::getExpiration', JSON.stringify(tags))
-    return defaultCacheHandler.getExpiration(...tags)
+    // Expecting soft tags in `get` to be used by the cache handler for checking
+    // the expiration of a cache entry, instead of letting Next.js handle it.
+    return Infinity
   },
 
   async expireTags(...tags) {


### PR DESCRIPTION
When a cache handler returns `Infinity` from its `getExpiration` method, it signals to Next.js that soft/implicit tags are supposed to be passed into the `get` method instead to be checked for expiration. Documenting this in the `CacheHandlerV2` interface, and always passing in the soft tags was implemented in #79213. However, we missed handling the infinite expiration value, which led to regarding all cache entries returned from those cache handlers as stale.

The first commit provokes the error, the second commit fixes it.

We'll also soon (re-)add proper deploy tests that will verify scenarios like this one end-to-end when deployed to Vercel.

/cc @laugharn 