### PR TITLE
fix(next-swc-wasm): Only enable turbo-rcstr's napi feature when building the next-swc-napi crate/package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,7 @@ next-custom-transforms = { path = "crates/next-custom-transforms" }
 # Turbopack
 auto-hash-map = { path = "turbopack/crates/turbo-tasks-auto-hash-map" }
 turbo-prehash = { path = "turbopack/crates/turbo-prehash" }
-turbo-rcstr = { path = "turbopack/crates/turbo-rcstr", features = ["napi"] }
+turbo-rcstr = { path = "turbopack/crates/turbo-rcstr" }
 turbo-esregex = { path = "turbopack/crates/turbo-esregex" }
 turbo-persistence = { path = "turbopack/crates/turbo-persistence" }
 turbo-tasks-malloc = { path = "turbopack/crates/turbo-tasks-malloc", default-features = false }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -98,7 +98,7 @@ swc_core = { workspace = true, features = [
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 lightningcss-napi = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-turbo-rcstr = { workspace = true }
+turbo-rcstr = { workspace = true, features = ["napi"] }
 turbo-tasks = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/packages/next/src/build/swc/generated-wasm.d.ts
+++ b/packages/next/src/build/swc/generated-wasm.d.ts
@@ -3,51 +3,11 @@
 
 /* tslint:disable */
 /* eslint-disable */
-/**
- * @param {string} s
- * @param {any} opts
- * @returns {any}
- */
 export function minifySync(s: string, opts: any): any
-/**
- * @param {string} s
- * @param {any} opts
- * @returns {Promise<any>}
- */
 export function minify(s: string, opts: any): Promise<any>
-/**
- * @param {any} s
- * @param {any} opts
- * @returns {any}
- */
 export function transformSync(s: any, opts: any): any
-/**
- * @param {any} s
- * @param {any} opts
- * @returns {Promise<any>}
- */
 export function transform(s: any, opts: any): Promise<any>
-/**
- * @param {string} s
- * @param {any} opts
- * @returns {any}
- */
 export function parseSync(s: string, opts: any): any
-/**
- * @param {string} s
- * @param {any} opts
- * @returns {Promise<any>}
- */
 export function parse(s: string, opts: any): Promise<any>
-/**
- * @param {string} value
- * @param {any} opts
- * @returns {any}
- */
 export function mdxCompileSync(value: string, opts: any): any
-/**
- * @param {string} value
- * @param {any} opts
- * @returns {Promise<any>}
- */
 export function mdxCompile(value: string, opts: any): Promise<any>

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -15,8 +15,10 @@ turbo-tasks-hash = { workspace = true }
 serde = { workspace = true }
 new_debug_unreachable = "1.0.6"
 shrink-to-fit = { workspace = true }
-napi = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+napi = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -361,7 +361,10 @@ impl ShrinkToFit for RcStr {
     fn shrink_to_fit(&mut self) {}
 }
 
-#[cfg(feature = "napi")]
+#[cfg(all(feature = "napi", target_family = "wasm"))]
+compile_error!("The napi feature cannot be enabled for wasm targets");
+
+#[cfg(all(feature = "napi", not(target_family = "wasm")))]
 mod napi_impl {
     use napi::{
         bindgen_prelude::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue},


### PR DESCRIPTION
Fixes https://vercel.slack.com/archives/C04KC8A53T7/p1749584921462879

```
pnpm swc-build-wasm
```

Closes PACK-4812