### PR TITLE
overwrite redirect SSG meta.status to 200 for RSC requests

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -83,6 +83,7 @@ export const __next_app__ = {
 }
 
 import * as entryBase from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
+import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 
 export * from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
 
@@ -997,6 +998,16 @@ export async function handler(
       // behind the experimental PPR flag.
       if (cachedData.status && (!isRSCRequest || !isRoutePPREnabled)) {
         res.statusCode = cachedData.status
+      }
+
+      // Redirect information is encoded in RSC payload, so we don't need to use redirect status codes
+      if (
+        !minimalMode &&
+        cachedData.status &&
+        RedirectStatusCode[cachedData.status] &&
+        isRSCRequest
+      ) {
+        res.statusCode = 200
       }
 
       // Mark that the request did postpone.

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -170,6 +170,7 @@ import { NoFallbackError } from '../shared/lib/no-fallback-error.external'
 import { getCacheHandlers } from './use-cache/handlers'
 import { fixMojibake } from './lib/fix-mojibake'
 import { computeCacheBustingSearchParam } from '../shared/lib/router/utils/cache-busting-search-param'
+import { RedirectStatusCode } from '../client/components/redirect-status-code'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -3503,6 +3504,16 @@ export default abstract class Server<
       // behind the experimental PPR flag.
       if (cachedData.status && (!isRSCRequest || !isRoutePPREnabled)) {
         res.statusCode = cachedData.status
+      }
+
+      // Redirect information is encoded in RSC payload, so we don't need to use redirect status codes
+      if (
+        !this.minimalMode &&
+        cachedData.status &&
+        RedirectStatusCode[cachedData.status] &&
+        isRSCRequest
+      ) {
+        res.statusCode = 200
       }
 
       // Mark that the request did postpone.

--- a/test/e2e/app-dir/rsc-redirect/app/dest/page.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/dest/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Destination</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-redirect/app/layout.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/layout.tsx
@@ -1,0 +1,9 @@
+import React, { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rsc-redirect/app/origin/page.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/origin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/dest')
+}

--- a/test/e2e/app-dir/rsc-redirect/app/page.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Home</h1>
+      <Link href="/origin">Go to Origin</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
+++ b/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+import { fetchViaHTTP } from 'next-test-utils'
+
+describe('rsc-redirect', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should get 307 status code for document request', async () => {
+    const response = await fetchViaHTTP(next.url, '/origin', undefined, {
+      redirect: 'manual',
+    })
+    expect(response.status).toBe(307)
+  })
+
+  it('should get 200 status code for rsc request', async () => {
+    // TODO: add RSC cache busting query param
+    const response = await fetchViaHTTP(next.url, '/origin', undefined, {
+      redirect: 'manual',
+      headers: {
+        RSC: '1',
+      },
+    })
+    expect(response.status).toBe(200)
+  })
+})


### PR DESCRIPTION
For a static route that simply returns a `redirect`:
```
export default function Page() {
  redirect("/about");
}
```
the SSG generates a `.meta` file for the route at build time, that looks like:
```
{
  "status": 307,
  "headers": {
    "location": "/about"
  }
}
```
On `next start`, if a request matches this route, the status code is retrieved from the file and returned to the response. This is perfectly fine for DOC requests. However, if the request is an RSC request, its RSC payload should have already encoded the redirect instruction:
```
1:"$Sreact.fragment"
2:I[657,[],""]
3:I[8597,[],""]
5:I[5975,[],"OutletBoundary"]
8:I[4429,[],"AsyncMetadataOutlet"]
a:I[5975,[],"ViewportBoundary"]
c:I[5975,[],"MetadataBoundary"]
e:I[1363,[],""]
0:{"P":null,"b":"gelhztYnmFGzccJ4F6F4T","p":"","c":["","rsc-redirect"],"i":false,"f":[[["",{"children":["rsc-redirect",{"children":["__PAGE__",{}]}]},"$undefined","$undefined",true],["",["$","$1","c",{"children":[null,["$","html",null,{"lang":"en","children":["$","body",null,{"children":["$","$L2",null,{"parallelRouterKey":"children","error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L3",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":[[["$","title",null,{"children":"404: This page could not be found."}],["$","div",null,{"style":{"fontFamily":"system-ui,\"Segoe UI\",Roboto,Helvetica,Arial,sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\"","height":"100vh","textAlign":"center","display":"flex","flexDirection":"column","alignItems":"center","justifyContent":"center"},"children":["$","div",null,{"children":[["$","style",null,{"dangerouslySetInnerHTML":{"__html":"body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}"}}],["$","h1",null,{"className":"next-error-h1","style":{"display":"inline-block","margin":"0 20px 0 0","padding":"0 23px 0 0","fontSize":24,"fontWeight":500,"verticalAlign":"top","lineHeight":"49px"},"children":404}],["$","div",null,{"style":{"display":"inline-block"},"children":["$","h2",null,{"style":{"fontSize":14,"fontWeight":400,"lineHeight":"49px","margin":0},"children":"This page could not be found."}]}]]}]}]],[]],"forbidden":"$undefined","unauthorized":"$undefined"}]}]}]]}],{"children":["rsc-redirect",["$","$1","c",{"children":[null,["$","$L2",null,{"parallelRouterKey":"children","error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L3",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","forbidden":"$undefined","unauthorized":"$undefined"}]]}],{"children":["__PAGE__",["$","$1","c",{"children":["$L4",null,["$","$L5",null,{"children":["$L6","$L7",["$","$L8",null,{"promise":"$@9"}]]}]]}],{},null,false]},null,false]},null,false],["$","$1","h",{"children":[null,["$","$1","0db7ba866b0656c433aa56ad545d5b104626108ev",{"children":[["$","$La",null,{"children":"$Lb"}],null]}],["$","$Lc",null,{"children":"$Ld"}]]}],false]],"m":"$undefined","G":["$e","$undefined"],"s":false,"S":true}
4:E{"digest":"NEXT_REDIRECT;replace;/about;307;"}
f:"$Sreact.suspense"
10:I[4429,[],"AsyncMetadata"]
d:["$","div",null,{"hidden":true,"children":["$","$f",null,{"fallback":null,"children":["$","$L10",null,{"promise":"$@11"}]}]}]
7:null
b:[["$","meta","0",{"charSet":"utf-8"}],["$","meta","1",{"name":"viewport","content":"width=device-width, initial-scale=1"}]]
6:null
9:{"metadata":[],"error":null,"digest":"$undefined"}
11:{"metadata":"$9:metadata","error":null,"digest":"$undefined"}
```

Specifically,
```
4:E{"digest":"NEXT_REDIRECT;replace;/about;307;"}
```

Hence, it would be fine to simply return 200 status code.

There are two motivations for this change:
1. This new behaviour is consistent with Next.js apps hosted on Vercel. (I.e., it returns 200 for static RSC even if the `meta.status = 307`)
2. 307 redirect on RSC payload is an obstacle to enabling [RSC validation](https://github.com/vercel/next.js/pull/80157)