### PR TITLE
[segment-explorer] optimize tree view

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -154,13 +154,14 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
   .segment-explorer-content {
     overflow-y: auto;
     font-size: var(--size-14);
-    margin: -8px -16px;
+    margin: -12px -8px;
   }
 
   .segment-explorer-item-row {
     display: flex;
     align-items: center;
-    padding: 2px 24px;
+    padding: 4px 24px;
+    border-radius: 6px;
   }
 
   .segment-explorer-children--intended {
@@ -185,8 +186,5 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
 
   [data-nextjs-devtool-segment-explorer-level='odd'] {
     background-color: var(--color-gray-100);
-  }
-  [data-nextjs-devtool-segment-explorer-level='even'] {
-    background-color: var(--color-gray-50);
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -66,10 +66,8 @@ function PageSegmentTreeLayerPresentation({
     return !!childNode?.value?.type
   })
 
-  const folderName =
-    parentSegment ||
-    // If it's the 1st level and contains a file, use 'app' as the folder name
-    (level === 1 && isFile ? 'app' : '')
+  // If it's the 1st level and contains a file, use 'app' as the folder name
+  const folderName = level === 1 && isFile ? 'app' : parentSegment
 
   return (
     <>
@@ -83,7 +81,6 @@ function PageSegmentTreeLayerPresentation({
             style={{
               // If it's children levels, show indents if there's any file at that level.
               // Otherwise it's empty folder, no need to show indents.
-              // level > 0 && hasFileChildren && 'segment-explorer-children--intended'
               ...(level > 0 && isFile && { paddingLeft: `${level * 8}px` }),
             }}
           >

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -1,5 +1,5 @@
-import { useRef, type HTMLProps } from 'react'
-import { css } from '../../../utils/css'
+import type { HTMLProps } from 'react'
+import { css } from '../../utils/css'
 import type { DevToolsInfoPropsCore } from '../errors/dev-tools-indicator/dev-tools-info/dev-tools-info'
 import { DevToolsInfo } from '../errors/dev-tools-indicator/dev-tools-info/dev-tools-info'
 import {
@@ -9,7 +9,6 @@ import {
 import type { Trie, TrieNode } from '../../../../shared/lib/devtool/trie'
 
 function PageSegmentTree({ tree }: { tree: Trie<SegmentNode> | undefined }) {
-  const nodeCountRef = useRef(0)
   if (!tree) {
     return null
   }
@@ -24,7 +23,6 @@ function PageSegmentTree({ tree }: { tree: Trie<SegmentNode> | undefined }) {
         level={0}
         segment=""
         parentSegment=""
-        nodeCountRef={nodeCountRef}
       />
     </div>
   )
@@ -36,14 +34,12 @@ function PageSegmentTreeLayerPresentation({
   parentSegment,
   node,
   level,
-  nodeCountRef,
 }: {
   tree: Trie<SegmentNode>
   segment: string
   parentSegment: string
   node: TrieNode<SegmentNode>
   level: number
-  nodeCountRef: React.RefObject<number>
 }) {
   const pagePath = node.value?.pagePath || ''
   const nodeName = node.value?.type
@@ -64,10 +60,6 @@ function PageSegmentTreeLayerPresentation({
     return a.localeCompare(b)
   })
 
-  if (isFile) {
-    nodeCountRef.current++
-  }
-
   // check if it has file children
   const hasFileChildren = sortedChildrenKeys.some((key) => {
     const childNode = node.children[key]
@@ -79,41 +71,39 @@ function PageSegmentTreeLayerPresentation({
     // If it's the 1st level and contains a file, use 'app' as the folder name
     (level === 1 && isFile ? 'app' : '')
 
-  const segLevel = nodeCountRef.current % 2 === 0 ? 'even' : 'odd'
-
   return (
-    <div
-      className="segment-explorer-item"
-      data-nextjs-devtool-segment-explorer-segment={segment}
-    >
+    <>
       {isFile ? (
         <div
-          className="segment-explorer-item-row"
-          data-nextjs-devtool-segment-explorer-level={segLevel}
-          style={{
-            // If it's children levels, show indents if there's any file at that level.
-            // Otherwise it's empty folder, no need to show indents.
-            // level > 0 && hasFileChildren && 'segment-explorer-children--intended'
-            ...(level > 0 && isFile && { paddingLeft: `${level * 8}px` }),
-          }}
+          className="segment-explorer-item"
+          data-nextjs-devtool-segment-explorer-segment={segment}
         >
-          <div className="segment-explorer-line">
-            <div className={`segment-explorer-line-text-${nodeName}`}>
-              <div className="segment-explorer-filename">
-                {folderName && (
-                  <span className="segment-explorer-filename--path">
-                    {folderName}
+          <div
+            className="segment-explorer-item-row"
+            style={{
+              // If it's children levels, show indents if there's any file at that level.
+              // Otherwise it's empty folder, no need to show indents.
+              // level > 0 && hasFileChildren && 'segment-explorer-children--intended'
+              ...(level > 0 && isFile && { paddingLeft: `${level * 8}px` }),
+            }}
+          >
+            <div className="segment-explorer-line">
+              <div className={`segment-explorer-line-text-${nodeName}`}>
+                <div className="segment-explorer-filename">
+                  {folderName && (
+                    <span className="segment-explorer-filename--path">
+                      {folderName}
+                    </span>
+                  )}
+                  <span className="segment-explorer-filename--name">
+                    {fileName}
                   </span>
-                )}
-                <span className="segment-explorer-filename--name">
-                  {fileName}
-                </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
       ) : null}
-
       {sortedChildrenKeys.map((childSegment) => {
         const child = node.children[childSegment]
         if (!child) {
@@ -127,11 +117,10 @@ function PageSegmentTreeLayerPresentation({
             tree={tree}
             node={child}
             level={hasFileChildren ? level + 1 : level}
-            nodeCountRef={nodeCountRef}
           />
         )
       })}
-    </div>
+    </>
   )
 }
 
@@ -155,6 +144,14 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     overflow-y: auto;
     font-size: var(--size-14);
     margin: -12px -8px;
+  }
+
+  .segment-explorer-item {
+    margin: 4px 0;
+  }
+
+  .segment-explorer-item:nth-child(odd) {
+    background-color: var(--color-gray-100);
   }
 
   .segment-explorer-item-row {

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -26,35 +26,24 @@ describe('segment-explorer', () => {
   it('should render the segment explorer for parallel routes', async () => {
     const browser = await next.browser('/parallel-routes')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "app/
-     layout.tsx
-     parallel-routes/
-     layout.tsx
-     page.tsx
-     @bar/
-     layout.tsx
-     page.tsx
-     @foo/
-     layout.tsx
-     page.tsx"
+     "applayout.tsx
+     parallel-routeslayout.tsx
+     parallel-routespage.tsx
+     @barlayout.tsx
+     @barpage.tsx
+     @foolayout.tsx
+     @foopage.tsx"
     `)
   })
 
   it('should render the segment explorer for nested routes', async () => {
     const browser = await next.browser('/blog/~/grid')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "app/
-     layout.tsx
-     (v2)/
-     layout.tsx
-     blog/
-     (team)/
-     layout.tsx
-     ~/
-     (overview)/
-     layout.tsx
-     grid/
-     page.tsx"
+     "applayout.tsx
+     (v2)layout.tsx
+     (team)layout.tsx
+     (overview)layout.tsx
+     gridpage.tsx"
     `)
   })
 })


### PR DESCRIPTION
### What

Optimize the display of segment explorer tree views, show the filename along with parent folder. This way it's easier to capture where roughly the file locate.

😌
| parallel routes | nested routes |
|:--|:--|
| ![image](https://github.com/user-attachments/assets/08af9465-6c7b-4040-bdb2-2a4b5d442deb) | ![image](https://github.com/user-attachments/assets/4bbeb7e3-ce1c-4c40-aa19-b7eb21f87e1b) |

This is intended to improve cases where the tree is extremely large and complex. 
See this bad base ❌

<img height="400" alt="image" src="https://github.com/user-attachments/assets/cf458755-6707-48c2-b51c-8b9d5ecd79ab">

This also improves the indentation and styling:

Indentation: when there's no file children under the folder, but only other folders, no need to give extra indentation. This wil avoid too many indentation when multi folders nested together.
Styling: Show the route path and route file in different colors, getting closer to what we want to have.
