### PR TITLE
Use new `browserWithResponse()` method in `empty-fallback-shells` tests

### DIFF
--- a/test/e2e/app-dir/empty-fallback-shells/app/with-cached-io/last-modified.jsx
+++ b/test/e2e/app-dir/empty-fallback-shells/app/with-cached-io/last-modified.jsx
@@ -1,9 +1,12 @@
+import { getSentinelValue } from './sentinel'
+
 export async function LastModified({ params }) {
   const { slug } = await params
 
   return (
-    <p data-testid={`page-${slug}`}>
-      Page /{slug} last modified: {new Date().toISOString()}
+    <p id="last-modified">
+      Page /{slug} last modified: {new Date().toISOString()} (
+      {getSentinelValue()})
     </p>
   )
 }

--- a/test/e2e/app-dir/empty-fallback-shells/app/with-cached-io/with-suspense/layout.jsx
+++ b/test/e2e/app-dir/empty-fallback-shells/app/with-cached-io/with-suspense/layout.jsx
@@ -7,8 +7,8 @@ export default async function Layout({ children }) {
   return (
     <html>
       <body>
-        <div data-testid={`layout-${getSentinelValue()}`}>
-          Layout: {new Date().toISOString()}
+        <div id="layout">
+          Layout: {new Date().toISOString()} ({getSentinelValue()})
         </div>
         <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
       </body>

--- a/test/e2e/app-dir/empty-fallback-shells/app/with-cached-io/without-suspense/layout.jsx
+++ b/test/e2e/app-dir/empty-fallback-shells/app/with-cached-io/without-suspense/layout.jsx
@@ -6,8 +6,8 @@ export default async function Layout({ children }) {
   return (
     <html>
       <body>
-        <div data-testid={`layout-${getSentinelValue()}`}>
-          Layout: {new Date().toISOString()}
+        <div id="layout">
+          Layout: {new Date().toISOString()} ({getSentinelValue()})
         </div>
         {children}
       </body>

--- a/test/e2e/app-dir/empty-fallback-shells/app/without-io/[slug]/page.jsx
+++ b/test/e2e/app-dir/empty-fallback-shells/app/without-io/[slug]/page.jsx
@@ -1,6 +1,6 @@
 export default async function Page({ params }) {
   const { slug } = await params
-  return <div data-testid={`hello-${slug}`}>Hello /{slug}</div>
+  return <div id="slug">Hello /{slug}</div>
 }
 
 export async function generateStaticParams() {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -680,7 +680,6 @@ export class NextInstance {
   public async browserWithResponse(
     ...args: Parameters<OmitFirstArgument<typeof webdriver>>
   ): Promise<{ browser: Playwright; response: Response }> {
-    console.log('browserWithResponse', args)
     const [url, options = {}] = args
 
     let resolveResponse: (response: Response) => void

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -13,6 +13,7 @@ import cheerio from 'cheerio'
 import { once } from 'events'
 import { Playwright } from 'next-webdriver'
 import escapeStringRegexp from 'escape-string-regexp'
+import { Page, Response } from 'playwright'
 
 type Event = 'stdout' | 'stderr' | 'error' | 'destroy'
 export type InstallCommand =
@@ -664,12 +665,56 @@ export class NextInstance {
   }
 
   /**
-   * Create new browser window for the Next.js app.
+   * Create a new browser window for the Next.js app.
    */
   public async browser(
     ...args: Parameters<OmitFirstArgument<typeof webdriver>>
   ): Promise<Playwright> {
     return webdriver(this.url, ...args)
+  }
+
+  /**
+   * Create a new browser window for the Next.js app, and also return the page's
+   * response.
+   */
+  public async browserWithResponse(
+    ...args: Parameters<OmitFirstArgument<typeof webdriver>>
+  ): Promise<{ browser: Playwright; response: Response }> {
+    console.log('browserWithResponse', args)
+    const [url, options = {}] = args
+
+    let resolveResponse: (response: Response) => void
+
+    const responsePromise = new Promise<Response>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(`Timed out waiting for the response of ${url}`)
+      }, 10_000)
+
+      resolveResponse = (response: Response) => {
+        clearTimeout(timer)
+        resolve(response)
+      }
+    })
+
+    const absoluteUrl = new URL(url, this.url).href
+
+    const [browser, response] = await Promise.all([
+      webdriver(this.url, url, {
+        ...options,
+        beforePageLoad(page: Page) {
+          options.beforePageLoad?.(page)
+
+          page.on('response', async (response) => {
+            if (response.url() === absoluteUrl) {
+              resolveResponse(response)
+            }
+          })
+        },
+      }),
+      responsePromise,
+    ])
+
+    return { browser, response }
   }
 
   /**


### PR DESCRIPTION
In e2e tests, we sometimes want to assert on the response headers and on the rendered HTML within the same test. For the former, we usually use `next.fetch()`, but this doesn't allow us to use the Playwright browser API to assert on the rendered HTML, which is available through `next.browser()`. This is especially tricky when a PPR shell is resumed, where asserting on the response text is error-prone, as the streamed-in HTML may change the elements that we want to assert on.

To avoid the maintenance and runtime overhead of splitting the test into two separate tests, we introduce a new `next.browserWithResponse()` method that allows us to use the Playwright browser API while also exposing the response to check the headers and other properties.