### PR TITLE
[test] unflake turbopack dev navigation test case

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -897,7 +897,15 @@ describe('app-dir action handling', () => {
       await browser
         .elementByCss(`[href='/delayed-action/${runtime}/other']`)
         .click()
-        .waitForElementByCss('#other-page')
+
+      // wait for url to change
+      await retry(async () => {
+        expect(await browser.url()).toBe(
+          `${next.url}/delayed-action/${runtime}/other`
+        )
+      })
+
+      await browser.waitForElementByCss('#other-page')
 
       await retry(async () => {
         expect(


### PR DESCRIPTION
Unflake turbopack dev test

```
pnpm test-dev-turbo test/e2e/app-dir/actions/app-action.test.ts (turbopack)

app-dir action handling > should forward action request to a worker that contains the action handler (node)
app-dir action handling > should forward action request to a worker that contains the action handler (edge)
```

x-ref: https://github.com/vercel/next.js/actions/runs/15581296918/job/43881444430?pr=80392