### PR TITLE
Ensure we normalize .rsc/.prefetch.rsc

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2637,7 +2637,7 @@ export default abstract class Server<
             const parsedInitUrl = parseUrl(
               getRequestMeta(req, 'initURL') || req.url
             )
-            request.url = `${parsedInitUrl.pathname}${parsedInitUrl.search || ''}`
+            request.url = `${parsedInitUrl.pathname?.replace(/(\.prefetch\.rsc|\.rsc)$/, '')}${parsedInitUrl.search || ''}`
 
             // propagate the request context for dev
             setRequestMeta(request, getRequestMeta(req))


### PR DESCRIPTION
When we match a `.rsc` or `.prefetch.rsc` path we need to normalize the URL used to not include this as it could leak through to the canonical URL used for rendering and with `usePathname()`. 

x-ref: [slack thread](https://vercel.slack.com/archives/C08VDSLKNVC/p1749551233763969)