### PR TITLE
build(turbopack): Update `swc_core` to `v27.0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6964,9 +6964,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "12.0.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c376d04a9e50083b31962550590199c78a1c0f6b88e48ea9f46c95623074dc"
+checksum = "fd2adffdd9f42af6cfefa16b1aaa8a0984a21854637ef9d89332dd29420d4b23"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -7061,9 +7061,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "27.0.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44216725e29a980e3081bb4afea465f486121af281114f6218d448aba9fc81f3"
+checksum = "0041e206e665457382fdd594bf18ae983d08ac5bf535b6351ca902b5e06e79b1"
 dependencies = [
  "binding_macros",
  "par-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,7 +292,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "27.0.1", features = [
+swc_core = { version = "27.0.2", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",


### PR DESCRIPTION
### What?

Update swc_core to v27.0.2

### Why?

https://github.com/swc-project/swc/pull/10599 is requried for further work

### How?


Closes PACK-4822