### PR TITLE
perf(turbopack): Introduce static analysis for immutable tasks

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1135,6 +1135,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         &self,
         task_type: CachedTaskType,
         parent_task: TaskId,
+        is_immutable: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> TaskId {
         if let Some(task_id) = self.task_cache.lookup_forward(&task_type) {
@@ -1188,6 +1189,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         &self,
         task_type: CachedTaskType,
         parent_task: TaskId,
+        is_immutable: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> TaskId {
         if !parent_task.is_transient() {
@@ -2584,6 +2586,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         &self,
         task_type: CachedTaskType,
         parent_task: TaskId,
+        is_immutable: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId {
         self.0
@@ -2594,6 +2597,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         &self,
         task_type: CachedTaskType,
         parent_task: TaskId,
+        is_immutable: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId {
         self.0

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -29,7 +29,7 @@ impl ConnectChildOperation {
         is_immutable: bool,
         mut ctx: impl ExecuteContext,
     ) {
-        if !ctx.should_track_children() || is_immutable {
+        if !ctx.should_track_children() {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
             if !task.has_key(&CachedDataItemKey::Output {}) {
                 let description = ctx.get_task_desc_fn(child_task_id);
@@ -71,7 +71,7 @@ impl ConnectChildOperation {
             });
         }
 
-        if ctx.should_track_activeness() {
+        if ctx.should_track_activeness() && !is_immutable {
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
             });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -71,6 +71,7 @@ impl ConnectChildOperation {
             });
         }
 
+        // Immutable tasks cannot be invalidated, meaning that we never reschedule them.
         if !is_immutable && ctx.should_track_activeness() {
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -71,7 +71,7 @@ impl ConnectChildOperation {
             });
         }
 
-        if ctx.should_track_activeness() && !is_immutable {
+        if !is_immutable && ctx.should_track_activeness() {
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
             });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -23,8 +23,13 @@ pub enum ConnectChildOperation {
 }
 
 impl ConnectChildOperation {
-    pub fn run(parent_task_id: TaskId, child_task_id: TaskId, mut ctx: impl ExecuteContext) {
-        if !ctx.should_track_children() {
+    pub fn run(
+        parent_task_id: TaskId,
+        child_task_id: TaskId,
+        is_immutable: bool,
+        mut ctx: impl ExecuteContext,
+    ) {
+        if !ctx.should_track_children() || is_immutable {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
             if !task.has_key(&CachedDataItemKey::Output {}) {
                 let description = ctx.get_task_desc_fn(child_task_id);

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -1099,6 +1099,7 @@ pub struct NativeFn {
     pub filter_trait_call_args: Option<FilterTraitCallArgsTokens>,
     pub local: bool,
     pub invalidator: bool,
+    pub immutable: bool,
 }
 
 impl NativeFn {
@@ -1115,6 +1116,7 @@ impl NativeFn {
             filter_trait_call_args,
             local,
             invalidator,
+            immutable,
         } = self;
 
         if *is_method {
@@ -1142,6 +1144,7 @@ impl NativeFn {
                             turbo_tasks::macro_helpers::FunctionMeta {
                                 local: #local,
                                 invalidator: #invalidator,
+                                immutable: #immutable,
                             },
                             #arg_filter,
                             #function_path,
@@ -1157,6 +1160,7 @@ impl NativeFn {
                             turbo_tasks::macro_helpers::FunctionMeta {
                                 local: #local,
                                 invalidator: #invalidator,
+                                immutable: #immutable,
                             },
                             #arg_filter,
                             #function_path,
@@ -1173,6 +1177,7 @@ impl NativeFn {
                         turbo_tasks::macro_helpers::FunctionMeta {
                             local: #local,
                             invalidator: #invalidator,
+                            immutable: #immutable,
                         },
                         #function_path,
                     )

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -67,6 +67,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         filter_trait_call_args: None, // not a trait method
         local,
         invalidator,
+        immutable: sig.asyncness.is_none() && !invalidator,
     };
     let native_function_ident = get_native_function_ident(ident);
     let native_function_ty = native_fn.ty();

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -119,6 +119,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     filter_trait_call_args: None, // not a trait method
                     local,
                     invalidator,
+                    immutable: sig.asyncness.is_none() && !invalidator,
                 };
 
                 let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
@@ -248,6 +249,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     filter_trait_call_args: turbo_fn.filter_trait_call_args(),
                     local,
                     invalidator,
+                    immutable: sig.asyncness.is_none() && !invalidator,
                 };
 
                 let native_function_ident =

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -194,6 +194,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 // - This only makes sense when a default implementation is present.
                 local: false,
                 invalidator: func_args.invalidator.is_some(),
+                immutable: sig.asyncness.is_none() && func_args.invalidator.is_none(),
             };
 
             let native_function_ident = get_trait_default_impl_function_ident(trait_ident, ident);

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -667,6 +667,7 @@ pub trait Backend: Sync + Send {
         &self,
         task_type: CachedTaskType,
         parent_task: TaskId,
+        is_immutable: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId;
 
@@ -674,6 +675,7 @@ pub trait Backend: Sync + Send {
         &self,
         task_type: CachedTaskType,
         parent_task: TaskId,
+        is_immutable: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId;
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -603,18 +603,24 @@ impl<B: Backend + 'static> TurboTasks<B> {
                 self.schedule_local_task(task_type, persistence)
             }
             TaskPersistence::Transient => {
+                let immutable = registry::get_function(fn_type).function_meta.immutable;
                 let task_type = CachedTaskType { fn_type, this, arg };
+
                 RawVc::TaskOutput(self.backend.get_or_create_transient_task(
                     task_type,
                     current_task("turbo_function calls"),
+                    immutable,
                     self,
                 ))
             }
             TaskPersistence::Persistent => {
+                let immutable = registry::get_function(fn_type).function_meta.immutable;
                 let task_type = CachedTaskType { fn_type, this, arg };
+
                 RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
                     task_type,
                     current_task("turbo_function calls"),
+                    immutable,
                     self,
                 ))
             }

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -145,7 +145,7 @@ pub struct FunctionMeta {
     /// the parent task.
     pub local: bool,
 
-    /// If true, the function will be allowed to call `get_invalidator` . If this is false, the
+    /// If true, the function will be allowed to call `get_invalidator`. If this is false, the
     /// `get_invalidator` function will panic on calls.
     pub invalidator: bool,
 

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -148,6 +148,9 @@ pub struct FunctionMeta {
     /// If true, the function will be allowed to call `get_invalidator` . If this is false, the
     /// `get_invalidator` function will panic on calls.
     pub invalidator: bool,
+
+    /// If true, the function is statically analyzable immutable.
+    pub immutable: bool,
 }
 
 /// A native (rust) turbo-tasks function. It's used internally by


### PR DESCRIPTION
### What?

Implement a basic form of Immutable turbo tasks. At this stage, we only detect statically analyzble turbo tasks, and handle them specially. We only skip activeness tracking with this PR.


Closes PACK-4838