### PR TITLE
chore: Remove useActionState from auto wrapping list

### DIFF
--- a/docs/01-app/01-getting-started/08-updating-data.mdx
+++ b/docs/01-app/01-getting-started/08-updating-data.mdx
@@ -22,7 +22,6 @@ By convention, a Server Action is an async function used with [`startTransition`
 
 - Passed to a `<form>` using the `action` prop.
 - Passed to a `<button>` using the `formAction` prop.
-- Passed to `useActionState`.
 
 In Next.js, Server Actions integrate with the framework's [caching](/docs/app/deep-dive/caching) architecture. When an action is invoked, Next.js can return both the updated UI and new data in a single server roundtrip.
 


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/80419