### PR TITLE
perf(turbopack): Detect more immutable tasks

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1636,8 +1636,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // take the children from the task to process them
         let mut new_children = take(new_children);
 
-        new_children.retain(|_, is_immutable| !*is_immutable);
-
         // handle stateful
         if stateful {
             let _ = task.add(CachedDataItem::Stateful { value: () });
@@ -1672,10 +1670,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let mut old_edges = Vec::new();
 
         let has_children = !new_children.is_empty();
+        let has_mutable_chidlren =
+            has_children && new_children.values().any(|is_immutable| !*is_immutable);
 
         // If the task is not stateful and has no children, it does not have a way to be invalidated
         // and we can mark it as immutable.
-        if !stateful && !has_children {
+        if !stateful && !has_mutable_chidlren {
             task.mark_as_immutable();
         }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1670,12 +1670,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let mut old_edges = Vec::new();
 
         let has_children = !new_children.is_empty();
-        let has_mutable_chidlren =
+        let has_mutable_children =
             has_children && new_children.values().any(|is_immutable| !*is_immutable);
 
         // If the task is not stateful and has no children, it does not have a way to be invalidated
         // and we can mark it as immutable.
-        if !stateful && !has_mutable_chidlren {
+        if !stateful && !has_mutable_children {
             task.mark_as_immutable();
         }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1673,7 +1673,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let has_mutable_children =
             has_children && new_children.values().any(|is_immutable| !*is_immutable);
 
-        // If the task is not stateful and has no children, it does not have a way to be invalidated
+        // If the task is not stateful and has no mutable children, it does not have a way to be invalidated
         // and we can mark it as immutable.
         if !stateful && !has_mutable_children {
             task.mark_as_immutable();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1673,8 +1673,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let has_mutable_children =
             has_children && new_children.values().any(|is_immutable| !*is_immutable);
 
-        // If the task is not stateful and has no mutable children, it does not have a way to be invalidated
-        // and we can mark it as immutable.
+        // If the task is not stateful and has no mutable children, it does not have a way to be
+        // invalidated and we can mark it as immutable.
         if !stateful && !has_mutable_children {
             task.mark_as_immutable();
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -52,9 +52,10 @@ impl ConnectChildOperation {
         };
 
         // Quick skip if the child was already connected before
-        if !new_children.insert(child_task_id) {
+        if new_children.insert(child_task_id, is_immutable).is_some() {
             return;
         }
+
         if parent_task.has_key(&CachedDataItemKey::Child {
             task: child_task_id,
         }) {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashSet;
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use turbo_tasks::TaskId;
 
@@ -14,7 +14,7 @@ use crate::{
 pub fn connect_children(
     parent_task_id: TaskId,
     parent_task: &mut impl TaskGuard,
-    new_children: FxHashSet<TaskId>,
+    new_children: FxHashMap<TaskId, bool>,
     queue: &mut AggregationUpdateQueue,
     has_active_count: bool,
     should_track_activeness: bool,
@@ -25,14 +25,14 @@ pub fn connect_children(
 
     let parent_aggregation = get_aggregation_number(parent_task);
 
-    for &new_child in new_children.iter() {
+    for &new_child in new_children.keys() {
         parent_task.add_new(CachedDataItem::Child {
             task: new_child,
             value: (),
         });
     }
 
-    let new_follower_ids: SmallVec<_> = new_children.iter().copied().collect();
+    let new_follower_ids: SmallVec<_> = new_children.keys().copied().collect();
 
     let aggregating_node = is_aggregating_node(parent_aggregation);
     let upper_ids = (!aggregating_node).then(|| get_uppers(&*parent_task));

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/prepare_new_children.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, num::NonZeroU32};
 
-use rustc_hash::FxHashSet;
+use rustc_hash::FxHashMap;
 use turbo_tasks::TaskId;
 
 use crate::backend::{
@@ -15,7 +15,7 @@ const AGGREGATION_NUMBER_BUFFER_SPACE: u32 = 3;
 pub fn prepare_new_children(
     parent_task_id: TaskId,
     parent_task: &mut impl TaskGuard,
-    new_children: &FxHashSet<TaskId>,
+    new_children: &FxHashMap<TaskId, bool>,
     queue: &mut AggregationUpdateQueue,
 ) {
     if new_children.is_empty() {
@@ -48,7 +48,7 @@ pub fn prepare_new_children(
     if !is_aggregating_node(future_parent_aggregation) {
         let child_base_aggregation_number =
             future_parent_aggregation + AGGREGATION_NUMBER_BUFFER_SPACE;
-        for &new_child in new_children.iter() {
+        for &new_child in new_children.keys() {
             queue.push(AggregationUpdateJob::UpdateAggregationNumber {
                 task_id: new_child,
                 base_aggregation_number: child_base_aggregation_number,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -61,7 +61,7 @@ impl UpdateOutputOperation {
             return;
         }
         let children = if ctx.should_track_children() {
-            new_children.iter().copied().collect()
+            new_children.keys().copied().collect()
         } else {
             Default::default()
         };

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use rustc_hash::FxHashSet;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     CellId, KeyValuePair, SessionId, TaskId, TraitTypeId, TypedSharedReference, ValueTypeId,
@@ -315,7 +315,9 @@ pub struct InProgressStateInner {
     pub done_event: Event,
     /// Children that should be connected to the task and have their active_count decremented
     /// once the task completes.
-    pub new_children: FxHashSet<TaskId>,
+    ///
+    /// The bool value is `is_immutable` of the child task.
+    pub new_children: FxHashMap<TaskId, bool>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
### What?

Skip the dependency tracking for tasks that are analyzed to be immutable turbo tasks.

### Why?

We can do so!

Closes PACK-4846