### PR TITLE
[segment explorer] fix soft navigation case

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -80,6 +80,8 @@ function PageSegmentTreeLayerPresentation({
                   {folderName && (
                     <span className="segment-explorer-filename--path">
                       {folderName}
+                      {/* hidden slashes for testing snapshots */}
+                      <small>{'/'}</small>
                     </span>
                   )}
                   <span className="segment-explorer-filename--name">
@@ -150,6 +152,9 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
 
   .segment-explorer-filename--path {
     margin-right: 8px;
+  }
+  .segment-explorer-filename--path small {
+    width: 0;
   }
   .segment-explorer-filename--name {
     color: var(--color-gray-800);

--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer.test.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer.test.tsx
@@ -75,7 +75,7 @@ describe('Segment Explorer', () => {
     })
   })
 
-  test.failing('remove node in the middle', () => {
+  test('remove node in the middle', () => {
     insertSegmentNode({ pagePath: '/a/b/@sidebar/page.js', type: 'page' })
     insertSegmentNode({ pagePath: '/a/b/page.js', type: 'page' })
     insertSegmentNode({ pagePath: '/a/b/layout.js', type: 'layout' })

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -26,32 +26,32 @@ describe('segment-explorer', () => {
   it('should render the segment explorer for parallel routes', async () => {
     const browser = await next.browser('/parallel-routes')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "applayout.tsx
-     parallel-routeslayout.tsx
-     parallel-routespage.tsx
-     @barlayout.tsx
-     @barpage.tsx
-     @foolayout.tsx
-     @foopage.tsx"
+     "app/layout.tsx
+     parallel-routes/layout.tsx
+     parallel-routes/page.tsx
+     @bar/layout.tsx
+     @bar/page.tsx
+     @foo/layout.tsx
+     @foo/page.tsx"
     `)
   })
 
   it('should render the segment explorer for nested routes', async () => {
     const browser = await next.browser('/blog/~/grid')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "applayout.tsx
-     (v2)layout.tsx
-     (team)layout.tsx
-     (overview)layout.tsx
-     gridpage.tsx"
+     "app/layout.tsx
+     (v2)/layout.tsx
+     (team)/layout.tsx
+     (overview)/layout.tsx
+     grid/page.tsx"
     `)
   })
 
   it('should cleanup on soft navigation', async () => {
     const browser = await next.browser('/soft-navigation/a')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "applayout.tsx
-     apage.tsx"
+     "app/layout.tsx
+     a/page.tsx"
     `)
 
     await browser.elementByCss('[href="/soft-navigation/b"]').click()
@@ -59,11 +59,9 @@ describe('segment-explorer', () => {
       expect(await browser.elementByCss('body').text()).toContain('Page B')
     })
 
-    // FIXME: Should no longer contain /soft-navigation/a/page.js
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
-     "applayout.tsx
-     apage.tsx
-     bpage.tsx"
+     "app/layout.tsx
+     b/page.tsx"
     `)
   })
 })


### PR DESCRIPTION
Adding `remove` function for trie in segment explorer to address the trie updates for soft navigation case to ensure the nodes from previous page is removed after nav.
