### PR TITLE
Turbopack: don't revisit nodes

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -233,7 +233,7 @@ impl SingleModuleGraph {
             .await?;
 
         let (children_nodes_iter, visited_nodes) = AdjacencyMap::new()
-            .skip_duplicates()
+            .skip_duplicates_with_key(|node: &(SingleModuleGraphBuilderNode, ExportUsage)| &node.0)
             .visit(
                 root_edges,
                 SingleModuleGraphBuilder {
@@ -1669,6 +1669,8 @@ impl Visit<(SingleModuleGraphBuilderNode, ExportUsage)> for SingleModuleGraphBui
 
     fn edges(
         &mut self,
+        // The `skip_duplicates_with_key()` above ensures only a single `edges()` call per module
+        // (and not per `(module, export)` pair), so the export must not be read here!
         (node, _): &(SingleModuleGraphBuilderNode, ExportUsage),
     ) -> Self::EdgesFuture {
         // Destructure beforehand to not have to clone the whole node when entering the async block

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -290,7 +290,7 @@ type ModulesVec = Vec<ResolvedVc<Box<dyn Module>>>;
 pub struct ModulesWithRefData(Vec<(ChunkingType, ExportUsage, ModulesVec)>);
 
 /// Aggregates all primary [Module]s referenced by an [Module] via [ChunkableModuleReference]s.
-/// This does not include transitively references [Module]s, only includes
+/// This does not include transitively referenced [Module]s, only includes
 /// primary [Module]s referenced.
 ///
 /// [Module]: crate::module::Module


### PR DESCRIPTION
Don't revisit the nodes repeatedly because of differing `ExportUsage`.

A regression from https://github.com/vercel/next.js/pull/78286

Closes PACK-4832