### PR TITLE
fix(next-swc): Update `styled-jsx` SWC plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6807,9 +6807,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.91.1"
+version = "0.91.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeb6bc4423bb2f48d3aad71b09e37ac704fa509b9ddb36540ca321cfb8e91da"
+checksum = "9388c45d387e6d34f19be52a63451517f6bd1e94be2bb9c03163b34e4c37b671"
 dependencies = [
  "anyhow",
  "lightningcss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,7 +302,7 @@ browserslist-rs = { version = "0.18.0" }
 mdxjs = "1.0.3"
 modularize_imports = { version = "0.87.0" }
 styled_components = { version = "0.115.0" }
-styled_jsx = { version = "0.91.1" }
+styled_jsx = { version = "0.91.2" }
 swc_emotion = { version = "0.91.0" }
 swc_relay = { version = "0.61.0" }
 


### PR DESCRIPTION
### What?

Apply https://github.com/swc-project/plugins/pull/471


### Why?

To fix the content escaping bug of `styled-jsx`



Closes PACK-4827