### PR TITLE
Avoid timeout error when transformed params are passed to `"use cache"`

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -669,7 +669,11 @@ async function warmupDevRender(
     workStore,
   } = ctx
 
-  const { dev, onInstrumentationRequestError } = renderOpts
+  const {
+    allowEmptyStaticShell = false,
+    dev,
+    onInstrumentationRequestError,
+  } = renderOpts
 
   if (!dev) {
     throw new InvariantError(
@@ -711,6 +715,7 @@ async function warmupDevRender(
     controller: prerenderController,
     cacheSignal,
     dynamicTracking: null,
+    allowEmptyStaticShell,
     revalidate: INFINITE_CACHE,
     expire: INFINITE_CACHE,
     stale: INFINITE_CACHE,
@@ -2263,7 +2268,8 @@ async function spawnDynamicValidationInDev(
     renderOpts,
     workStore,
   } = ctx
-  const { botType } = renderOpts
+
+  const { allowEmptyStaticShell = false, botType } = renderOpts
 
   // These values are placeholder values for this validating render
   // that are provided during the actual prerenderToStream.
@@ -2311,6 +2317,7 @@ async function spawnDynamicValidationInDev(
     // the final prerender.
     cacheSignal,
     dynamicTracking: null,
+    allowEmptyStaticShell,
     revalidate: INFINITE_CACHE,
     expire: INFINITE_CACHE,
     stale: INFINITE_CACHE,
@@ -2418,6 +2425,7 @@ async function spawnDynamicValidationInDev(
       // is module loading, which has it's own cache signal
       cacheSignal: null,
       dynamicTracking: null,
+      allowEmptyStaticShell,
       revalidate: INFINITE_CACHE,
       expire: INFINITE_CACHE,
       stale: INFINITE_CACHE,
@@ -2504,6 +2512,7 @@ async function spawnDynamicValidationInDev(
     // All caches we could read must already be filled so no tracking is necessary
     cacheSignal: null,
     dynamicTracking: serverDynamicTracking,
+    allowEmptyStaticShell,
     revalidate: INFINITE_CACHE,
     expire: INFINITE_CACHE,
     stale: INFINITE_CACHE,
@@ -2567,6 +2576,7 @@ async function spawnDynamicValidationInDev(
     // No APIs require a cacheSignal through the workUnitStore during the HTML prerender
     cacheSignal: null,
     dynamicTracking: clientDynamicTracking,
+    allowEmptyStaticShell,
     revalidate: INFINITE_CACHE,
     expire: INFINITE_CACHE,
     stale: INFINITE_CACHE,
@@ -2906,6 +2916,7 @@ async function prerenderToStream(
         // the final prerender.
         cacheSignal,
         dynamicTracking: null,
+        allowEmptyStaticShell,
         revalidate: INFINITE_CACHE,
         expire: INFINITE_CACHE,
         stale: INFINITE_CACHE,
@@ -3029,6 +3040,7 @@ async function prerenderToStream(
           // is module loading, which has it's own cache signal
           cacheSignal: null,
           dynamicTracking: null,
+          allowEmptyStaticShell,
           revalidate: INFINITE_CACHE,
           expire: INFINITE_CACHE,
           stale: INFINITE_CACHE,
@@ -3115,6 +3127,7 @@ async function prerenderToStream(
         // All caches we could read must already be filled so no tracking is necessary
         cacheSignal: null,
         dynamicTracking: serverDynamicTracking,
+        allowEmptyStaticShell,
         revalidate: INFINITE_CACHE,
         expire: INFINITE_CACHE,
         stale: INFINITE_CACHE,
@@ -3186,6 +3199,7 @@ async function prerenderToStream(
         // No APIs require a cacheSignal through the workUnitStore during the HTML prerender
         cacheSignal: null,
         dynamicTracking: clientDynamicTracking,
+        allowEmptyStaticShell,
         revalidate: INFINITE_CACHE,
         expire: INFINITE_CACHE,
         stale: INFINITE_CACHE,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -194,7 +194,6 @@ import {
   trackPendingImport,
   trackPendingModules,
 } from './module-loading/track-module-loading.external'
-import { isUseCacheTimeoutError } from '../use-cache/use-cache-errors'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -2980,29 +2979,6 @@ async function prerenderToStream(
       // We don't need to continue the prerender process if we already
       // detected invalid dynamic usage in the initial prerender phase.
       if (workStore.invalidDynamicUsageError) {
-        if (
-          isUseCacheTimeoutError(workStore.invalidDynamicUsageError) &&
-          allowEmptyStaticShell
-        ) {
-          // If this is a "use cache" timeout error, and empty shells are
-          // allowed (i.e. we're prerendering a fallback shell, and there are
-          // also more specific routes prerendered) we return an empty shell.
-          return {
-            digestErrorsMap: reactServerErrorsByDigest,
-            ssrErrors: allCapturedErrors,
-            stream: new ReadableStream({
-              start(controller) {
-                controller.close()
-              },
-            }),
-            collectedRevalidate: INFINITE_CACHE,
-            collectedExpire: INFINITE_CACHE,
-            collectedStale: selectStaleTime(INFINITE_CACHE),
-            collectedTags: null,
-          }
-        }
-
-        // Otherwise we throw the error to fail the build.
         throw workStore.invalidDynamicUsageError
       }
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -109,6 +109,14 @@ export interface PrerenderStoreModern extends CommonWorkUnitStore {
 
   readonly rootParams: Params
 
+  /**
+   * When true, the page is prerendered as a fallback shell, while allowing any
+   * dynamic accesses to result in an empty shell. This is the case when there
+   * are also routes prerendered with a more complete set of params.
+   * Prerendering those routes would catch any invalid dynamic accesses.
+   */
+  readonly allowEmptyStaticShell: boolean
+
   // Collected revalidate times and tags for this document during the prerender.
   revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
   expire: number // server expiration time

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -391,6 +391,7 @@ export class AppRouteRouteModule extends RouteModule<
               // During prospective render we don't use a controller
               // because we need to let all caches fill.
               dynamicTracking,
+              allowEmptyStaticShell: false,
               revalidate: defaultRevalidate,
               expire: INFINITE_CACHE,
               stale: INFINITE_CACHE,
@@ -481,6 +482,7 @@ export class AppRouteRouteModule extends RouteModule<
             controller: finalController,
             cacheSignal: null,
             dynamicTracking,
+            allowEmptyStaticShell: false,
             revalidate: defaultRevalidate,
             expire: INFINITE_CACHE,
             stale: INFINITE_CACHE,

--- a/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-static-params/with-suspense/params-transformed/[slug]/page.jsx
+++ b/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-static-params/with-suspense/params-transformed/[slug]/page.jsx
@@ -1,0 +1,15 @@
+import { CachedLastModified } from '../../../../last-modified'
+
+async function transformParams(params) {
+  const { slug } = await params
+
+  return { slug }
+}
+
+export default async function Page({ params }) {
+  return <CachedLastModified params={transformParams(params)} />
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'foo' }]
+}

--- a/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-static-params/without-suspense/params-transformed/[slug]/page.jsx
+++ b/test/e2e/app-dir/fallback-shells/app/with-cached-io/with-static-params/without-suspense/params-transformed/[slug]/page.jsx
@@ -1,0 +1,15 @@
+import { CachedLastModified } from '../../../../last-modified'
+
+async function transformParams(params) {
+  const { slug } = await params
+
+  return { slug }
+}
+
+export default async function Page({ params }) {
+  return <CachedLastModified params={transformParams(params)} />
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'foo' }]
+}

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -30,8 +30,7 @@ describe('fallback-shells', () => {
         describe('and the params accessed in the cached page', () => {
           it('resumes a postponed fallback shell', async () => {
             const { browser, response } = await next.browserWithResponse(
-              '/with-cached-io/with-static-params/with-suspense/params-in-page/bar',
-              { pushErrorAsConsoleLog: true }
+              '/with-cached-io/with-static-params/with-suspense/params-in-page/bar'
             )
 
             const lastModified = await browser
@@ -54,11 +53,21 @@ describe('fallback-shells', () => {
             }
           })
 
-          // TODO: To be implemented in NAR-136.
-          it.skip('does not produce hydration errors when resuming a fallback shell containing a layout with unused params', async () => {
+          it('does not produce hydration errors when resuming a fallback shell containing a layout with unused params', async () => {
             const browser = await next.browser(
               '/with-cached-io/with-static-params/with-suspense/params-in-page/bar',
               { pushErrorAsConsoleLog: true }
+            )
+
+            // There should also be no hydration errors due to a buildtime date
+            // being replaced by a new runtime date.
+            await assertNoConsoleErrors(browser)
+          })
+
+          // TODO: To be implemented in NAR-136.
+          it.skip('includes a cached layout with unused params in the fallback shell', async () => {
+            const browser = await next.browser(
+              '/with-cached-io/with-static-params/with-suspense/params-in-page/bar'
             )
 
             const layout = await browser.elementById('layout').text()
@@ -67,10 +76,6 @@ describe('fallback-shells', () => {
             // resume of the fallback shell, so it should be "buildtime". If the
             // layout is unexpectedly a cache miss, then it will be "runtime".
             expect(layout).toInclude(isNextDev ? 'runtime' : 'buildtime')
-
-            // There should also be no hydration errors due to a buildtime date
-            // being replaced by a new runtime date.
-            await assertNoConsoleErrors(browser)
           })
 
           // TODO: Activate for deploy tests once background revalidation for
@@ -361,8 +366,7 @@ describe('fallback-shells', () => {
       describe('and the params accessed in the cached page', () => {
         it('resumes a postponed fallback shell', async () => {
           const { browser, response } = await next.browserWithResponse(
-            '/with-cached-io/without-static-params/params-in-page/foo',
-            { pushErrorAsConsoleLog: true }
+            '/with-cached-io/without-static-params/params-in-page/foo'
           )
 
           const lastModified = await browser.elementById('last-modified').text()
@@ -381,6 +385,32 @@ describe('fallback-shells', () => {
           } else if (isNextStart) {
             expect(headers['x-nextjs-postponed']).toBe('1')
           }
+        })
+
+        // TODO: To be implemented in NAR-136.
+        it.skip('does not produce hydration errors when resuming a fallback shell containing a layout with unused params', async () => {
+          const browser = await next.browser(
+            '/with-cached-io/without-static-params/params-in-page/bar',
+            { pushErrorAsConsoleLog: true }
+          )
+
+          // There should also be no hydration errors due to a buildtime date
+          // being replaced by a new runtime date.
+          await assertNoConsoleErrors(browser)
+        })
+
+        // TODO: To be implemented in NAR-136.
+        it.skip('includes a cached layout with unused params in the fallback shell', async () => {
+          const browser = await next.browser(
+            '/with-cached-io/without-static-params/params-in-page/bar'
+          )
+
+          const layout = await browser.elementById('layout').text()
+
+          // When prerendered, this should be restored from the RDC during the
+          // resume of the fallback shell, so it should be "buildtime". If the
+          // layout is unexpectedly a cache miss, then it will be "runtime".
+          expect(layout).toInclude(isNextDev ? 'runtime' : 'buildtime')
         })
       })
 

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -198,6 +198,33 @@ describe('fallback-shells', () => {
             }
           })
         })
+
+        describe('and the params transformed with an async function and then passed to a cached function', () => {
+          it('resumes a postponed fallback shell', async () => {
+            const { browser, response } = await next.browserWithResponse(
+              '/with-cached-io/with-static-params/with-suspense/params-transformed/bar'
+            )
+
+            const lastModified = await browser
+              .elementById('last-modified')
+              .text()
+            expect(lastModified).toInclude('Page /bar')
+            expect(lastModified).toInclude('runtime')
+
+            const layout = await browser.elementById('root-layout').text()
+            expect(layout).toInclude(isNextDev ? 'runtime' : 'buildtime')
+
+            const headers = response.headers()
+
+            if (isNextDeploy) {
+              expect(headers['x-matched-path']).toBe(
+                '/with-cached-io/with-static-params/with-suspense/params-transformed/[slug]'
+              )
+            } else if (isNextStart) {
+              expect(headers['x-nextjs-postponed']).toBe('1')
+            }
+          })
+        })
       })
 
       describe('and the page not wrapped in Suspense', () => {
@@ -294,6 +321,33 @@ describe('fallback-shells', () => {
             if (isNextDeploy) {
               expect(headers['x-matched-path']).toBe(
                 '/with-cached-io/with-static-params/without-suspense/params-then-in-page/[slug]'
+              )
+            } else if (isNextStart) {
+              expect(headers['x-nextjs-postponed']).not.toBe('1')
+            }
+          })
+        })
+
+        describe('and the params transformed with an async function and then passed to a cached function', () => {
+          it('does not resume a postponed fallback shell', async () => {
+            const { browser, response } = await next.browserWithResponse(
+              '/with-cached-io/with-static-params/without-suspense/params-transformed/bar'
+            )
+
+            const lastModified = await browser
+              .elementById('last-modified')
+              .text()
+            expect(lastModified).toInclude('Page /bar')
+            expect(lastModified).toInclude('runtime')
+
+            const layout = await browser.elementById('root-layout').text()
+            expect(layout).toInclude('runtime')
+
+            const headers = response.headers()
+
+            if (isNextDeploy) {
+              expect(headers['x-matched-path']).toBe(
+                '/with-cached-io/with-static-params/without-suspense/params-transformed/[slug]'
               )
             } else if (isNextStart) {
               expect(headers['x-nextjs-postponed']).not.toBe('1')

--- a/test/e2e/app-dir/use-cache-hanging-inputs/app/transformed-params/[slug]/page.jsx
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/app/transformed-params/[slug]/page.jsx
@@ -20,6 +20,5 @@ export default async function Page({ params }) {
   return <LastModified params={transformParams(params)} />
 }
 
-export async function generateStaticParams() {
-  return [{ slug: 'foo' }]
-}
+// Explicitly not defining `generateStaticParams` here. Otherwise, no timeout
+// error would be triggered.


### PR DESCRIPTION
With #79743, we're now providing a filled Resume Data Cache (RDC) when prerendering optional fallback shells for routes that have some params defined in `generateStaticParams`.

This allows us to treat a cache miss in the RDC as an indication that params were part of the cache key. In this case, we can make the cache function a dynamic hole in the shell (or produce an empty shell if there's no parent suspense boundary).

Currently, this also includes layouts and pages that don't read params, which will be improved when we implement NAR-136. Otherwise, we assume that if params are passed explicitly into a `"use cache"` function, that the params are also accessed (same as in #78882). This allows us to abort early, and treat the function as dynamic, instead of waiting for the timeout to be reached, even when params are transformed with an async function, before being passed into the "use cache" function, e.g.:

```js
import { CachedComponent } from './cached-component'

async function getSlug(params) {
  const { slug } = await params

  return slug
}

export default function Page({ params }) {
  return <CachedComponent slugPromise={getSlug(params)} />
}

export async function generateStaticParams() {
  return [{ slug: 'foo' }]
}
```

This escapes the instrumentation we do to bailout early on fallback params access. That handling is still needed though when prerendering fallback shells of routes that don't have any params defined in `generateStaticParams`, as we don't have a prefilled RDC in that case.