### PR TITLE
test(turbopack): Remove flaky benchmark

### DIFF
--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -26,29 +26,6 @@ env:
   TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
 
 jobs:
-  benchmark-tiny:
-    name: Benchmark Rust Crates (tiny)
-    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup-rust
-
-      - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-codspeed@2.10.1
-
-      - name: Build the benchmark target(s)
-        run: cargo codspeed build -p next-api
-
-      - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v3
-        with:
-          run: cargo codspeed run
-          token: ${{ secrets.CODSPEED_TOKEN }}
-
   benchmark-small-apps:
     name: Benchmark Rust Crates (small apps)
     runs-on: ['self-hosted', 'linux', 'x64', 'metal']


### PR DESCRIPTION
### What?

Remove a flaky benchmark.

### Why?

https://github.com/vercel/next.js/pull/80414#issuecomment-2963529621

This PR is not supposed to change performance greatly.



Closes PACK-4828