### PR TITLE
perf(turbopack): Remove needless alloc for AQMF

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1,5 +1,6 @@
 use std::{
     any::{Any, TypeId},
+    borrow::Cow,
     collections::HashSet,
     fs::{self, File, OpenOptions, ReadDir},
     io::{BufWriter, Write},
@@ -1050,7 +1051,7 @@ impl TurboPersistence {
                     let index_in_meta = ssts_with_ranges[index].index_in_meta;
                     let meta_file = &meta_files[meta_index];
                     let entry = meta_file.entry(index_in_meta);
-                    let aqmf = entry.raw_aqmf(meta_file.aqmf_data()).to_vec();
+                    let aqmf = Cow::Borrowed(entry.raw_aqmf(meta_file.aqmf_data()));
                     let meta = StaticSortedFileBuilderMeta {
                         min_hash: entry.min_hash(),
                         max_hash: entry.max_hash(),

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -9,15 +9,15 @@ use byteorder::{BE, WriteBytesExt};
 
 use crate::static_sorted_file_builder::StaticSortedFileBuilderMeta;
 
-pub struct MetaFileBuilder {
+pub struct MetaFileBuilder<'a> {
     family: u32,
     /// Entries in the meta file, tuples of (sequence_number, StaticSortedFileBuilderMetaResult)
-    entries: Vec<(u32, StaticSortedFileBuilderMeta)>,
+    entries: Vec<(u32, StaticSortedFileBuilderMeta<'a>)>,
     /// Obsolete SST files, represented by their sequence numbers
     obsolete_sst_files: Vec<u32>,
 }
 
-impl MetaFileBuilder {
+impl<'a> MetaFileBuilder<'a> {
     pub fn new(family: u32) -> Self {
         Self {
             family,
@@ -26,7 +26,7 @@ impl MetaFileBuilder {
         }
     }
 
-    pub fn add(&mut self, sequence_number: u32, sst: StaticSortedFileBuilderMeta) {
+    pub fn add(&mut self, sequence_number: u32, sst: StaticSortedFileBuilderMeta<'a>) {
         self.entries.push((sequence_number, sst));
     }
 

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -78,7 +78,7 @@ pub struct WriteBatch<K: StoreKey + Send, const FAMILIES: usize> {
     /// Collectors in use. The thread local collectors flush into these when they are full.
     collectors: [Mutex<GlobalCollectorState<K>>; FAMILIES],
     /// Meta file builders for each family.
-    meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMeta)>>; FAMILIES],
+    meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMeta<'static>)>>; FAMILIES],
     /// The list of new SST files that have been created.
     /// Tuple of (sequence number, file).
     new_sst_files: Mutex<Vec<(u32, File)>>,


### PR DESCRIPTION
### What?

Trivial `Cow` optimization for AQMF data

### Why?

We can avoid calling `to_vec()` on this data, and according to the profiling result, compression was a memory hog.

Closes PACK-4833