### PR TITLE
docs: fix broken link to good first issues in README

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -39,7 +39,8 @@ Contributions to Next.js are welcome and highly appreciated. However, before you
 
 ### Good First Issues:
 
-We have a list of **[good first issues](https://github.com/vercel/next.js/labels/"good first issue")** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
+We have a list of **[good first issues](https://github.com/vercel/next.js/labels/%22good%20first%20issue%22
+)** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
 
 ---
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -39,7 +39,7 @@ Contributions to Next.js are welcome and highly appreciated. However, before you
 
 ### Good First Issues:
 
-We have a list of **[good first issues](https://github.com/vercel/next.js/labels/good%20first%20issue)** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
+We have a list of **[good first issues](https://github.com/vercel/next.js/labels/"good first issue")** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
 
 ---
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -39,8 +39,8 @@ Contributions to Next.js are welcome and highly appreciated. However, before you
 
 ### Good First Issues:
 
-We have a list of **[good first issues](https://github.com/vercel/next.js/labels/%22good%20first%20issue%22
-)** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
+We have a list of
+**[good first issues](https://github.com/vercel/next.js/labels/%22good%20first%20issue%22)** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
 
 ---
 


### PR DESCRIPTION
The previous link to the "good first issues" label was incorrect, update it to point to the correct Github label url to help new contributors (like myself)