### PR TITLE
Disable fetch cache size limit for implicit caching during build

### DIFF
--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -35,7 +35,7 @@ export interface WorkStore {
   readonly cacheLifeProfiles?: { [profile: string]: CacheLife }
 
   readonly isOnDemandRevalidate?: boolean
-  readonly isPrerendering?: boolean
+  readonly isBuildTimePrerendering?: boolean
   readonly isRevalidate?: boolean
 
   forceDynamic?: boolean

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -122,7 +122,7 @@ export function createWorkStore({
       renderOpts.incrementalCache || (globalThis as any).__incrementalCache,
     cacheLifeProfiles: renderOpts.cacheLifeProfiles,
     isRevalidate: renderOpts.isRevalidate,
-    isPrerendering: renderOpts.nextExport,
+    isBuildTimePrerendering: renderOpts.nextExport,
     fetchCache: renderOpts.fetchCache,
     isOnDemandRevalidate: renderOpts.isOnDemandRevalidate,
 

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -562,10 +562,13 @@ export class IncrementalCache implements IncrementalCacheType {
     const itemSize = JSON.stringify(data).length
     if (
       ctx.fetchCache &&
-      // we don't show this error/warning when a custom cache handler is being used
-      // as it might not have this limit
+      itemSize > 2 * 1024 * 1024 &&
+      // We ignore the size limit when custom cache handler is being used, as it
+      // might not have this limit
       !this.hasCustomCacheHandler &&
-      itemSize > 2 * 1024 * 1024
+      // We also ignore the size limit when it's an implicit build-time-only
+      // caching that the user isn't even aware of.
+      !ctx.isImplicitBuildTimeCache
     ) {
       const warningText = `Failed to set Next.js data cache for ${ctx.fetchUrl || pathname}, items over 2MB can not be cached (${itemSize} bytes)`
 

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -87,6 +87,7 @@ describe('createPatchedFetcher', () => {
           fetchIdx: 1,
           fetchUrl: 'https://example.com/',
           tags: [],
+          isImplicitBuildTimeCache: false,
         }
       )
     })

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -226,6 +226,7 @@ export interface SetIncrementalFetchCacheContext {
   fetchUrl?: string
   fetchIdx?: number
   tags?: string[]
+  isImplicitBuildTimeCache?: boolean
 }
 
 export interface SetIncrementalResponseCacheContext {

--- a/test/e2e/app-dir/app-fetch-deduping/app/layout.js
+++ b/test/e2e/app-dir/app-fetch-deduping/app/layout.js
@@ -1,5 +1,3 @@
-export const fetchCache = 'default-cache'
-
 export default function Layout({ children }) {
   return (
     <html lang="en">


### PR DESCRIPTION
During build-time prerendering, when we're only caching `fetch` calls implicitly to improve build performance, and not because the user has explicitly opted into fetch caching, we should not enforce the 2MB size limit.

1. The size limit is not required of the file-system-based cache that's used at build time.
2. The warning is not helpful to users, as they are not aware of the implicit caching behavior.

Related PRs:

- https://github.com/vercel/next.js/pull/68546
- https://github.com/vercel/next.js/pull/79384