### PR TITLE
refactor(turbopack): Make invalidator flag explicit

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -423,7 +423,7 @@ impl ProjectContainer {
 
 #[turbo_tasks::value_impl]
 impl ProjectContainer {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     pub async fn project(&self) -> Result<Vc<Project>> {
         let env_map: Vc<EnvMap>;
         let next_config;

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -219,7 +219,7 @@ impl VersionedContentMap {
         Ok(Vc::cell(None))
     }
 
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     pub async fn keys_in_path(&self, root: Vc<FileSystemPath>) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
             let map = &self.map_path_to_op.get().0;

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -234,7 +234,7 @@ impl VersionedContentMap {
         Ok(Vc::cell(keys))
     }
 
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     fn raw_get(&self, path: ResolvedVc<FileSystemPath>) -> Vc<OptionMapEntry> {
         let assets = {
             let map = &self.map_path_to_op.get().0;

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -551,7 +551,7 @@ impl Debug for DiskFileSystem {
 
 #[turbo_tasks::value_impl]
 impl FileSystem for DiskFileSystem {
-    #[turbo_tasks::function(fs)]
+    #[turbo_tasks::function(fs, invalidator)]
     async fn read(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
@@ -577,7 +577,7 @@ impl FileSystem for DiskFileSystem {
         Ok(content.cell())
     }
 
-    #[turbo_tasks::function(fs)]
+    #[turbo_tasks::function(fs, invalidator)]
     async fn raw_read_dir(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
@@ -632,7 +632,7 @@ impl FileSystem for DiskFileSystem {
         Ok(RawDirectoryContent::new(entries))
     }
 
-    #[turbo_tasks::function(fs)]
+    #[turbo_tasks::function(fs, invalidator)]
     async fn read_link(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<LinkContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
@@ -718,7 +718,7 @@ impl FileSystem for DiskFileSystem {
         .cell())
     }
 
-    #[turbo_tasks::function(fs)]
+    #[turbo_tasks::function(fs, invalidator)]
     async fn write(&self, fs_path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Result<()> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
@@ -843,7 +843,7 @@ impl FileSystem for DiskFileSystem {
         Ok(())
     }
 
-    #[turbo_tasks::function(fs)]
+    #[turbo_tasks::function(fs, invalidator)]
     async fn write_link(&self, fs_path: Vc<FileSystemPath>, target: Vc<LinkContent>) -> Result<()> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
@@ -962,7 +962,7 @@ impl FileSystem for DiskFileSystem {
         Ok(())
     }
 
-    #[turbo_tasks::function(fs)]
+    #[turbo_tasks::function(fs, invalidator)]
     async fn metadata(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", "operation", "local"
+error: unexpected token, expected one of: "fs", "network", "operation", "local", "invalidator"
  --> tests/function/fail_attribute_invalid_args.rs:9:25
   |
 9 | #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", "operation", "local"
+error: unexpected token, expected one of: "fs", "network", "operation", "local", "invalidator"
   --> tests/function/fail_attribute_invalid_args_inherent_impl.rs:14:29
    |
 14 |     #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -733,6 +733,9 @@ pub struct FunctionArguments {
     /// task-local state. The function call itself will not be cached, but cells will be created on
     /// the parent task.
     pub local: Option<Span>,
+    /// If true, the function will be allowed to call `get_invalidator` . If this is false, the
+    /// `get_invalidator` function will panic on calls.
+    pub invalidator: Option<Span>,
 }
 
 impl Parse for FunctionArguments {
@@ -760,11 +763,14 @@ impl Parse for FunctionArguments {
                 ("local", Meta::Path(_)) => {
                     parsed_args.local = Some(meta.span());
                 }
+                ("invalidator", Meta::Path(_)) => {
+                    parsed_args.invalidator = Some(meta.span());
+                }
                 (_, meta) => {
                     return Err(syn::Error::new_spanned(
                         meta,
                         "unexpected token, expected one of: \"fs\", \"network\", \"operation\", \
-                         \"local\"",
+                         \"local\", \"invalidator\"",
                     ));
                 }
             }
@@ -1092,6 +1098,7 @@ pub struct NativeFn {
     pub is_self_used: bool,
     pub filter_trait_call_args: Option<FilterTraitCallArgsTokens>,
     pub local: bool,
+    pub invalidator: bool,
 }
 
 impl NativeFn {
@@ -1107,6 +1114,7 @@ impl NativeFn {
             is_self_used,
             filter_trait_call_args,
             local,
+            invalidator,
         } = self;
 
         if *is_method {
@@ -1133,6 +1141,7 @@ impl NativeFn {
                             #function_path_string.to_owned(),
                             turbo_tasks::macro_helpers::FunctionMeta {
                                 local: #local,
+                                invalidator: #invalidator,
                             },
                             #arg_filter,
                             #function_path,
@@ -1147,6 +1156,7 @@ impl NativeFn {
                             #function_path_string.to_owned(),
                             turbo_tasks::macro_helpers::FunctionMeta {
                                 local: #local,
+                                invalidator: #invalidator,
                             },
                             #arg_filter,
                             #function_path,
@@ -1162,6 +1172,7 @@ impl NativeFn {
                         #function_path_string.to_owned(),
                         turbo_tasks::macro_helpers::FunctionMeta {
                             local: #local,
+                            invalidator: #invalidator,
                         },
                         #function_path,
                     )

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -42,6 +42,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         .inspect_err(|err| errors.push(err.to_compile_error()))
         .unwrap_or_default();
     let local = args.local.is_some();
+    let invalidator = args.invalidator.is_some();
     let is_self_used = args.operation.is_some() || is_self_used(&block);
 
     let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args) else {
@@ -65,6 +66,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         is_self_used,
         filter_trait_call_args: None, // not a trait method
         local,
+        invalidator,
     };
     let native_function_ident = get_native_function_ident(ident);
     let native_function_ty = native_fn.ty();

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -84,6 +84,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     continue;
                 };
                 let local = func_args.local.is_some();
+                let invalidator = func_args.invalidator.is_some();
                 let is_self_used = func_args.operation.is_some() || is_self_used(block);
 
                 let Some(turbo_fn) =
@@ -106,6 +107,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     is_self_used,
                     filter_trait_call_args: None, // not a trait method
                     local,
+                    invalidator,
                 };
 
                 let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
@@ -191,6 +193,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 };
 
                 let local = func_args.local.is_some();
+                let invalidator = func_args.invalidator.is_some();
                 let is_self_used = func_args.operation.is_some() || is_self_used(block);
 
                 let Some(turbo_fn) =
@@ -223,6 +226,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     is_self_used,
                     filter_trait_call_args: turbo_fn.filter_trait_call_args(),
                     local,
+                    invalidator,
                 };
 
                 let native_function_ident =

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -139,6 +139,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 //   argument. (This could be fixed)
                 // - This only makes sense when a default implementation is present.
                 local: false,
+                invalidator: func_args.invalidator.is_some(),
             };
 
             let native_function_ident = get_trait_default_impl_function_ident(trait_ident, ident);

--- a/turbopack/crates/turbo-tasks-testing/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/detached.rs
@@ -163,7 +163,7 @@ async fn spawns_detached_changing(
 }
 
 // spawns_detached should take a dependency on this function for each input
-#[turbo_tasks::function]
+#[turbo_tasks::function(invalidator)]
 async fn read_changing_input(changing_input: Vc<ChangingInput>) -> Vc<u32> {
     // when changing_input.set is called, it will trigger an invalidator for this task
     Vc::cell(*changing_input.await.unwrap().state.get())

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -71,7 +71,7 @@ impl ValueToString for Collectible {
     }
 }
 
-#[turbo_tasks::function(operation)]
+#[turbo_tasks::function(operation, invalidator)]
 async fn inner_compute(input: ResolvedVc<ChangingInput>) -> Result<Vc<u32>> {
     println!("start inner_compute");
     let value = *input.await?.state.get();

--- a/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/emptied_cells.rs
@@ -56,7 +56,7 @@ async fn compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
     Ok(Vc::cell(value))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(invalidator)]
 async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
     println!("inner_compute()");
     let state_value = *input.await?.state.get();

--- a/turbopack/crates/turbo-tasks-testing/tests/random_change.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/random_change.rs
@@ -48,7 +48,7 @@ fn make_state() -> Vc<ValueContainer> {
     .cell()
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(invalidator)]
 async fn func2(input: Vc<ValueContainer>) -> Result<Vc<Value>> {
     let state = input.await?;
     let value = state.state.get();
@@ -56,7 +56,7 @@ async fn func2(input: Vc<ValueContainer>) -> Result<Vc<Value>> {
     Ok(func(input, -*value))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(invalidator)]
 async fn func(input: Vc<ValueContainer>, nesting: i32) -> Result<Vc<Value>> {
     let state = input.await?;
     let value = state.state.get();

--- a/turbopack/crates/turbo-tasks-testing/tests/read_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/read_ref_cell.rs
@@ -70,7 +70,7 @@ impl Counter {
 
 #[turbo_tasks::value_impl]
 impl Counter {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     async fn get_value(&self) -> Result<Vc<CounterValue>> {
         let mut lock = self.value.lock().unwrap();
         lock.1 = Some(get_invalidator());

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute.rs
@@ -70,7 +70,7 @@ struct Output {
     random_value: u32,
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(invalidator)]
 async fn compute(input: Vc<ChangingInput>, input2: Vc<ChangingInput>) -> Result<Vc<Output>> {
     let state_value = *input.await?.state.get();
     let state_value2 = if state_value < 5 {
@@ -88,7 +88,7 @@ async fn compute(input: Vc<ChangingInput>, input2: Vc<ChangingInput>) -> Result<
     .cell())
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(invalidator)]
 async fn compute2(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
     let state_value = *input.await?.state.get();
     Ok(Vc::cell(state_value))

--- a/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/recompute_collectibles.rs
@@ -76,7 +76,7 @@ impl ValueToString for Collectible {
     }
 }
 
-#[turbo_tasks::function(operation)]
+#[turbo_tasks::function(operation, invalidator)]
 async fn inner_compute(
     input: ResolvedVc<ChangingInput>,
     input2: ResolvedVc<ChangingInput>,
@@ -85,7 +85,7 @@ async fn inner_compute(
     Ok(inner_compute2(*input, *input2.await?.state.get()))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(invalidator)]
 async fn inner_compute2(input: Vc<ChangingInput>, innerness: u32) -> Result<Vc<u32>> {
     println!("inner_compute2({innerness})");
     if innerness > 0 {

--- a/turbopack/crates/turbo-tasks-testing/tests/trait_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/trait_ref_cell.rs
@@ -85,7 +85,7 @@ trait CounterTrait {
 
 #[turbo_tasks::value_impl]
 impl CounterTrait for Counter {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     async fn get_value(&self) -> Result<Vc<CounterValue>> {
         let mut lock = self.value.lock().unwrap();
         lock.1 = Some(get_invalidator());

--- a/turbopack/crates/turbo-tasks/src/invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/invalidation.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Result;
 use indexmap::map::Entry;
 use serde::{Deserialize, Serialize, de::Visitor};
-use tokio::runtime::Handle;
+use tokio::{runtime::Handle, task_local};
 
 use crate::{
     FxIndexMap, FxIndexSet, TaskId, TurboTasksApi,
@@ -19,9 +19,27 @@ use crate::{
     util::StaticOrArc,
 };
 
+#[cfg(debug_assertions)]
+task_local! {
+    static ALLOW_INVALIDATOR: ();
+}
+
+#[cfg(debug_assertions)]
+pub fn allow_invalidator<R>(f: impl Future<Output = R>) -> impl Future<Output = R> {
+    ALLOW_INVALIDATOR.scope((), f)
+}
+
 /// Get an [`Invalidator`] that can be used to invalidate the current task
 /// based on external events.
 pub fn get_invalidator() -> Invalidator {
+    #[cfg(debug_assertions)]
+    if ALLOW_INVALIDATOR.try_with(|_| {}).is_err() {
+        panic!(
+            "Invalidator can only be used in the turbo-tasks function that has \
+             #[turbo_tasks::function(invalidator)] attribute"
+        );
+    }
+
     let handle = Handle::current();
     Invalidator {
         task: current_task("turbo_tasks::get_invalidator()"),

--- a/turbopack/crates/turbo-tasks/src/invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/invalidation.rs
@@ -19,21 +19,18 @@ use crate::{
     util::StaticOrArc,
 };
 
-#[cfg(debug_assertions)]
 task_local! {
-    static ALLOW_INVALIDATOR: ();
+    static DISALLOW_INVALIDATOR: ();
 }
 
-#[cfg(debug_assertions)]
-pub fn allow_invalidator<R>(f: impl Future<Output = R>) -> impl Future<Output = R> {
-    ALLOW_INVALIDATOR.scope((), f)
+pub fn disallow_invalidator<R>(f: impl Future<Output = R>) -> impl Future<Output = R> {
+    DISALLOW_INVALIDATOR.scope((), f)
 }
 
 /// Get an [`Invalidator`] that can be used to invalidate the current task
 /// based on external events.
 pub fn get_invalidator() -> Invalidator {
-    #[cfg(debug_assertions)]
-    if ALLOW_INVALIDATOR.try_with(|_| {}).is_err() {
+    if DISALLOW_INVALIDATOR.try_with(|_| {}).is_ok() {
         panic!(
             "Invalidator can only be used in the turbo-tasks function that has \
              #[turbo_tasks::function(invalidator)] attribute"

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -144,6 +144,10 @@ pub struct FunctionMeta {
     /// task-local state. The function call itself will not be cached, but cells will be created on
     /// the parent task.
     pub local: bool,
+
+    /// If true, the function will be allowed to call `get_invalidator` . If this is false, the
+    /// `get_invalidator` function will panic on calls.
+    pub invalidator: bool,
 }
 
 /// A native (rust) turbo-tasks function. It's used internally by
@@ -235,7 +239,14 @@ impl NativeFunction {
     /// Executed the function
     pub fn execute(&'static self, this: Option<RawVc>, arg: &dyn MagicAny) -> NativeTaskFuture {
         match (self.implementation).functor(this, arg) {
-            Ok(functor) => functor,
+            Ok(functor) => {
+                #[cfg(debug_assertions)]
+                if self.function_meta.invalidator {
+                    return Box::pin(crate::invalidation::allow_invalidator(functor));
+                }
+
+                functor
+            }
             Err(err) => Box::pin(async { Err(err) }),
         }
     }

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -240,9 +240,8 @@ impl NativeFunction {
     pub fn execute(&'static self, this: Option<RawVc>, arg: &dyn MagicAny) -> NativeTaskFuture {
         match (self.implementation).functor(this, arg) {
             Ok(functor) => {
-                #[cfg(debug_assertions)]
-                if self.function_meta.invalidator {
-                    return Box::pin(crate::invalidation::allow_invalidator(functor));
+                if !self.function_meta.invalidator {
+                    return Box::pin(crate::invalidation::disallow_invalidator(functor));
                 }
 
                 functor

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -272,7 +272,7 @@ pub struct VersionState {
 
 #[turbo_tasks::value_impl]
 impl VersionState {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     pub fn get(&self) -> Vc<Box<dyn Version>> {
         TraitRef::cell(self.version.get().0.clone())
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -88,7 +88,7 @@ impl AssetGraphContentSource {
         })
     }
 
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     async fn all_assets_map(&self) -> Result<Vc<OutputAssetsMap>> {
         Ok(Vc::cell(
             expand(

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -395,7 +395,7 @@ impl ModuleTypeResult {
 
 #[turbo_tasks::value_impl]
 impl EcmascriptParsable for EcmascriptModuleAsset {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(invalidator)]
     async fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>> {
         let real_result = self.parse();
         let this = self.await?;


### PR DESCRIPTION
### What?

Retry https://github.com/vercel/next.js/pull/80414.

This time, I added `invalidator` required only for turbo tasks function, and made it real assertion.

### Why?

We need it.

### How?

Closes PACK-4826