### PR TITLE
perf(turbopack): Do not allocate vectors if we are not going to use it

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -852,26 +852,31 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 return (None, None);
             }
             let len = inner.len();
-            let mut meta = Vec::with_capacity(len);
-            let mut data = Vec::with_capacity(len);
+
+            let meta_restored = inner.state().meta_restored();
+            let data_restored = inner.state().data_restored();
+
+            let mut meta = Vec::with_capacity(if meta_restored { len } else { 0 });
+            let mut data = Vec::with_capacity(if data_restored { len } else { 0 });
             for (key, value) in inner.iter_all() {
                 if key.is_persistent() && value.is_persistent() {
                     match key.category() {
                         TaskDataCategory::Meta => {
-                            meta.push(CachedDataItem::from_key_and_value_ref(key, value))
+                            if meta_restored {
+                                meta.push(CachedDataItem::from_key_and_value_ref(key, value))
+                            }
                         }
                         TaskDataCategory::Data => {
-                            data.push(CachedDataItem::from_key_and_value_ref(key, value))
+                            if data_restored {
+                                data.push(CachedDataItem::from_key_and_value_ref(key, value))
+                            }
                         }
                         _ => {}
                     }
                 }
             }
 
-            (
-                inner.state().meta_restored().then_some(meta),
-                inner.state().data_restored().then_some(data),
-            )
+            (meta_restored.then_some(meta), data_restored.then_some(data))
         };
         let process = |task_id: TaskId, (meta, data): (Option<Vec<_>>, Option<Vec<_>>)| {
             (

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -856,18 +856,18 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             let meta_restored = inner.state().meta_restored();
             let data_restored = inner.state().data_restored();
 
-            let mut meta = Vec::with_capacity(if meta_restored { len } else { 0 });
-            let mut data = Vec::with_capacity(if data_restored { len } else { 0 });
+            let mut meta = meta_restored.then(|| Vec::with_capacity(len));
+            let mut data = data_restored.then(|| Vec::with_capacity(len));
             for (key, value) in inner.iter_all() {
                 if key.is_persistent() && value.is_persistent() {
                     match key.category() {
                         TaskDataCategory::Meta => {
-                            if meta_restored {
+                            if let Some(meta) = &mut meta {
                                 meta.push(CachedDataItem::from_key_and_value_ref(key, value))
                             }
                         }
                         TaskDataCategory::Data => {
-                            if data_restored {
+                            if let Some(data) = &mut data {
                                 data.push(CachedDataItem::from_key_and_value_ref(key, value))
                             }
                         }
@@ -876,7 +876,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 }
             }
 
-            (meta_restored.then_some(meta), data_restored.then_some(data))
+            (meta, data)
         };
         let process = |task_id: TaskId, (meta, data): (Option<Vec<_>>, Option<Vec<_>>)| {
             (


### PR DESCRIPTION
### What?

Avoid allocations when we are not going to use it


### Why?



I think static tools can technically analyze all of these kinds of needless allocations, but I'm not sure, so I'll try to find them by hand.

Closes PACK-4845