### PR TITLE
perf(turbopack): Load `is_immutable` flag dynamically

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -26,7 +26,7 @@ impl ConnectChildOperation {
     pub fn run(
         parent_task_id: TaskId,
         child_task_id: TaskId,
-        is_immutable: bool,
+        mut is_immutable: bool,
         mut ctx: impl ExecuteContext,
     ) {
         if !ctx.should_track_children() {
@@ -44,6 +44,12 @@ impl ConnectChildOperation {
             }
             return;
         }
+
+        if !is_immutable {
+            let task = ctx.task(child_task_id, TaskDataCategory::All);
+            is_immutable = task.is_immutable();
+        }
+
         let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
         let Some(InProgressState::InProgress(box InProgressStateInner { new_children, .. })) =
             get_mut!(parent_task, InProgress)

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -26,12 +26,12 @@ impl ConnectChildOperation {
     pub fn run(
         parent_task_id: TaskId,
         child_task_id: TaskId,
-        mut is_immutable: bool,
+        mut is_child_immutable: bool,
         mut ctx: impl ExecuteContext,
     ) {
         if !ctx.should_track_children() {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
-            if is_immutable {
+            if is_child_immutable {
                 task.mark_as_immutable();
             }
             if !task.has_key(&CachedDataItemKey::Output {}) {
@@ -45,9 +45,9 @@ impl ConnectChildOperation {
             return;
         }
 
-        if !is_immutable {
+        if !is_child_immutable {
             let task = ctx.task(child_task_id, TaskDataCategory::All);
-            is_immutable = task.is_immutable();
+            is_child_immutable = task.is_immutable();
         }
 
         let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
@@ -58,7 +58,10 @@ impl ConnectChildOperation {
         };
 
         // Quick skip if the child was already connected before
-        if new_children.insert(child_task_id, is_immutable).is_some() {
+        if new_children
+            .insert(child_task_id, is_child_immutable)
+            .is_some()
+        {
             return;
         }
 
@@ -82,13 +85,13 @@ impl ConnectChildOperation {
         }
 
         // Immutable tasks cannot be invalidated, meaning that we never reschedule them.
-        if !is_immutable && ctx.should_track_activeness() {
+        if !is_child_immutable && ctx.should_track_activeness() {
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
             });
         } else {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
-            if is_immutable {
+            if is_child_immutable {
                 task.mark_as_immutable();
             }
 


### PR DESCRIPTION
### What?

Load `is_immutable` flag from the task state instead of only relying on the static flag.

### Why?

It would allow determining more tasks as `immutable`


Closes PACK-4855