### PR TITLE
[turbopack] Simplify `Request::parse(Pattern)` the recursive portion doesn't need to be async

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -143,7 +143,7 @@ impl Request {
     }
 
     /// Internal construction function.  Should only be called with normalized patterns, or
-    /// recursively. Most users should call [Self::parse]` instead.
+    /// recursively. Most users should call [Self::parse] instead.
     fn parse_ref(request: Pattern) -> Self {
         match request {
             Pattern::Dynamic => Request::Dynamic,

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -142,65 +142,68 @@ impl Request {
         })
     }
 
-    pub async fn parse_ref(mut request: Pattern) -> Result<Self> {
-        request.normalize();
-        Ok(match request {
+    /// Internal construction function.  Should only be called with normalized patterns, or recursively.
+    /// Most users should call [Self::parse]` instead.
+    fn parse_ref(request: Pattern) -> Self {
+        match request {
             Pattern::Dynamic => Request::Dynamic,
-            Pattern::Constant(r) => Request::parse_constant_pattern(r).await?,
-            Pattern::Concatenation(list) => Request::parse_concatenation_pattern(list).await?,
-            Pattern::Alternatives(list) => Request::parse_alternatives_pattern(list).await?,
-        })
+            Pattern::Constant(r) => Request::parse_constant_pattern(r),
+            Pattern::Concatenation(list) => Request::parse_concatenation_pattern(list),
+            Pattern::Alternatives(_) => panic!(
+                "request should be normalized and alternatives should have already been handled.",
+            ),
+        }
     }
 
-    async fn parse_constant_pattern(r: RcStr) -> Result<Self> {
+    fn parse_constant_pattern(r: RcStr) -> Self {
         if r.is_empty() {
-            return Ok(Request::Empty);
+            return Request::Empty;
         }
 
         if let Some(remainder) = r.strip_prefix("//") {
-            return Ok(Request::Uri {
+            return Request::Uri {
                 protocol: rcstr!("//"),
                 remainder: remainder.into(),
                 query: RcStr::default(),
                 fragment: RcStr::default(),
-            });
+            };
         }
 
         if r.starts_with('/') {
             let (path, query, fragment) = split_off_query_fragment(&r);
 
-            return Ok(Request::ServerRelative {
+            return Request::ServerRelative {
                 path,
                 query,
                 fragment,
-            });
+            };
         }
 
         if r.starts_with('#') {
-            return Ok(Request::PackageInternal {
+            return Request::PackageInternal {
                 path: Pattern::Constant(r),
-            });
+            };
         }
 
         if r.starts_with("./") || r.starts_with("../") || r == "." || r == ".." {
             let (path, query, fragment) = split_off_query_fragment(&r);
 
-            return Ok(Request::Relative {
+            return Request::Relative {
                 path,
                 force_in_lookup_dir: false,
                 query,
                 fragment,
-            });
+            };
         }
 
         if WINDOWS_PATH.is_match(&r) {
             let (path, query, fragment) = split_off_query_fragment(&r);
 
-            return Ok(Request::Windows {
+            return Request::Windows {
                 path,
                 query,
                 fragment,
-            });
+            };
         }
 
         if let Some(caps) = URI_PATH.captures(&r)
@@ -211,19 +214,19 @@ impl Request {
                 let encoding = caps.get(2).map_or("", |e| e.as_str()).into();
                 let data = caps.get(3).map_or("", |d| d.as_str()).into();
 
-                return Ok(Request::DataUri {
+                return Request::DataUri {
                     media_type,
                     encoding,
                     data: ResolvedVc::cell(data),
-                });
+                };
             }
 
-            return Ok(Request::Uri {
+            return Request::Uri {
                 protocol: protocol.as_str().into(),
                 remainder: remainder.as_str().into(),
                 query: RcStr::default(),
                 fragment: RcStr::default(),
-            });
+            };
         }
 
         if let Some((module, path)) = MODULE_PATH
@@ -232,25 +235,25 @@ impl Request {
         {
             let (path, query, fragment) = split_off_query_fragment(path.as_str());
 
-            return Ok(Request::Module {
+            return Request::Module {
                 module: module.as_str().into(),
                 path,
                 query,
                 fragment,
-            });
+            };
         }
 
-        Ok(Request::Unknown {
+        Request::Unknown {
             path: Pattern::Constant(r),
-        })
+        }
     }
 
-    async fn parse_concatenation_pattern(list: Vec<Pattern>) -> Result<Self> {
+    fn parse_concatenation_pattern(list: Vec<Pattern>) -> Self {
         if list.is_empty() {
-            return Ok(Request::Empty);
+            return Request::Empty;
         }
 
-        let mut result = Box::pin(Self::parse_ref(list[0].clone())).await?;
+        let mut result = Self::parse_ref(list[0].clone());
 
         for item in list.into_iter().skip(1) {
             match &mut result {
@@ -270,7 +273,7 @@ impl Request {
                     path.push(item);
                 }
                 Request::Empty => {
-                    result = Box::pin(Self::parse_ref(item)).await?;
+                    result = Self::parse_ref(item);
                 }
                 Request::PackageInternal { path } => {
                     path.push(item);
@@ -289,14 +292,15 @@ impl Request {
             };
         }
 
-        Ok(result)
+        result
     }
 
     async fn parse_alternatives_pattern(list: Vec<Pattern>) -> Result<Self> {
         Ok(Request::Alternatives {
             requests: list
                 .into_iter()
-                .map(Request::parse)
+                // We can call parse_inner directly because these patterns are already normalized.
+                .map(Request::parse_inner)
                 .map(|v| async move { v.to_resolved().await })
                 .try_join()
                 .await?,
@@ -306,13 +310,24 @@ impl Request {
     pub fn parse_string(request: RcStr) -> Vc<Self> {
         Self::parse(request.into())
     }
+
+    pub fn parse(mut request: Pattern) -> Vc<Self> {
+        // Call normalize before parse_inner to improve cache hits.
+        request.normalize();
+        Self::parse_inner(request)
+    }
 }
 
 #[turbo_tasks::value_impl]
 impl Request {
     #[turbo_tasks::function]
-    pub async fn parse(request: Pattern) -> Result<Vc<Self>> {
-        Ok(Self::cell(Request::parse_ref(request).await?))
+    async fn parse_inner(request: Pattern) -> Result<Vc<Self>> {
+        // Because we are normalized, we should handle alternatives here
+        if let Pattern::Alternatives(alts) = request {
+            Ok(Self::cell(Self::parse_alternatives_pattern(alts).await?))
+        } else {
+            Ok(Self::cell(Request::parse_ref(request)))
+        }
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
## Optimize Request parsing in Turbopack core resolver

### What?
Refactored the `Request::parse_ref` method and related functions to improve performance by:
- Converting async functions to synchronous where possible
- Normalizing patterns before parsing to improve cache hits
- Handling alternatives pattern separately in the async `parse_inner` function
- Adopt `rcstr!` in a few places

### Why?
This should be a small perf enhancement, basically just noticed the `Box::pin` calls and decided to track down what was fundamentally async.

Closes PACK-4841