### PR TITLE
Normalize filepaths when parsing patterns from js values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,12 @@ opt-level = 3
 [profile.release.package.serde]
 opt-level = 3
 
+# Use a custom profile for CI where many tests are performance sensitive but we still want the additional validation of debug-assertions
+[profile.dev-optimized]
+inherits = "release"
+debug-assertions = true
+overflow-checks = true
+
 [workspace.dependencies]
 # Workspace crates
 next-api = { path = "crates/next-api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,7 @@ opt-level = 3
 opt-level = 3
 
 # Use a custom profile for CI where many tests are performance sensitive but we still want the additional validation of debug-assertions
-[profile.dev-optimized]
+[profile.release-with-assertions]
 inherits = "release"
 debug-assertions = true
 overflow-checks = true

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -17,7 +17,7 @@
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
     "rust-check-napi": "cargo check -p next-swc-napi",
-    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --exclude turbo-tasks-macros --release --no-fail-fast"
+    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --exclude turbo-tasks-macros --profile=dev-optimized --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -17,7 +17,7 @@
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
     "rust-check-napi": "cargo check -p next-swc-napi",
-    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --exclude turbo-tasks-macros --profile=dev-optimized --no-fail-fast"
+    "test-cargo-unit": "cargo nextest run --workspace --exclude next-swc-napi --exclude turbo-tasks-macros --cargo-profile release-with-assertions --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -532,17 +532,9 @@ impl Pattern {
     /// Order into Alternatives -> Concatenation -> Constant/Dynamic
     /// Merge when possible
     pub fn normalize(&mut self) {
-        let mut alternatives = [Vec::new()];
         match self {
-            Pattern::Constant(c) => {
-                for alt in alternatives.iter_mut() {
-                    alt.push(Pattern::Constant(c.clone()));
-                }
-            }
-            Pattern::Dynamic => {
-                for alt in alternatives.iter_mut() {
-                    alt.push(Pattern::Dynamic);
-                }
+            Pattern::Dynamic | Pattern::Constant(_) => {
+                // already normalized
             }
             Pattern::Alternatives(list) => {
                 for alt in list.iter_mut() {
@@ -630,6 +622,7 @@ impl Pattern {
                             })
                             .collect(),
                     );
+                    // The recursive call will deduplicate the alternatives after simplifying them
                     self.normalize();
                 } else {
                     let mut new_parts = Vec::new();

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -111,6 +111,13 @@ impl ConstantString {
         }
     }
 
+    pub fn as_rcstr(&self) -> RcStr {
+        match self {
+            Self::Atom(s) => RcStr::from(s.as_str()),
+            Self::RcStr(s) => s.clone(),
+        }
+    }
+
     pub fn as_atom(&self) -> Cow<Atom> {
         match self {
             Self::Atom(s) => Cow::Borrowed(s),

--- a/turbopack/crates/turbopack-ecmascript/src/utils.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/utils.rs
@@ -25,8 +25,9 @@ pub fn unparen(expr: &Expr) -> &Expr {
     expr
 }
 
+/// Converts a js-value into a Pattern for matching resources.
 pub fn js_value_to_pattern(value: &JsValue) -> Pattern {
-    let mut result = match value {
+    match value {
         JsValue::Constant(v) => Pattern::Constant(match v {
             ConstantValue::Str(str) => {
                 // Normalize windows file paths when constructing the pattern.
@@ -50,9 +51,16 @@ pub fn js_value_to_pattern(value: &JsValue) -> Pattern {
             total_nodes: _,
             values,
             logical_property: _,
-        } => Pattern::Alternatives(values.iter().map(js_value_to_pattern).collect()),
+        } => {
+            let mut alts = Pattern::Alternatives(values.iter().map(js_value_to_pattern).collect());
+            alts.normalize();
+            alts
+        }
         JsValue::Concat(_, parts) => {
-            Pattern::Concatenation(parts.iter().map(js_value_to_pattern).collect())
+            let mut concats =
+                Pattern::Concatenation(parts.iter().map(js_value_to_pattern).collect());
+            concats.normalize();
+            concats
         }
         JsValue::Add(..) => {
             // TODO do we need to handle that here
@@ -60,9 +68,7 @@ pub fn js_value_to_pattern(value: &JsValue) -> Pattern {
             Pattern::Dynamic
         }
         _ => Pattern::Dynamic,
-    };
-    result.normalize();
-    result
+    }
 }
 
 const JS_MAX_SAFE_INTEGER: u64 = (1u64 << 53) - 1;
@@ -208,4 +214,33 @@ pub fn module_value_to_well_known_object(module_value: &ModuleValue) -> Option<J
         "@grpc/proto-loader" => JsValue::WellKnownObject(WellKnownObjectKind::NodeProtobufLoader),
         _ => return None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use turbo_rcstr::rcstr;
+    use turbopack_core::resolve::pattern::Pattern;
+
+    use crate::{
+        analyzer::{ConstantString, ConstantValue, JsValue},
+        utils::js_value_to_pattern,
+    };
+
+    #[test]
+    fn test_path_normalization_in_pattern() {
+        assert_eq!(
+            Pattern::Constant(rcstr!("hello/world")),
+            js_value_to_pattern(&JsValue::Constant(ConstantValue::Str(
+                ConstantString::RcStr(rcstr!("hello\\world"))
+            )))
+        );
+
+        assert_eq!(
+            Pattern::Constant(rcstr!("hello/world")),
+            js_value_to_pattern(&JsValue::Concat(
+                1,
+                vec!["hello".into(), "\\".into(), "world".into()]
+            ))
+        );
+    }
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -492,7 +492,7 @@ async fn walk_asset(
             .await?
             .iter()
             .copied()
-            .flat_map(|asset| ResolvedVc::try_downcast::<Box<dyn OutputAsset>>(asset)),
+            .flat_map(ResolvedVc::try_downcast::<Box<dyn OutputAsset>>),
     );
 
     Ok(())

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -12,8 +12,7 @@ use serde::Deserialize;
 use serde_json::json;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    ReadConsistency, ReadRef, ResolvedVc, TryJoinIterExt, TurboTasks, ValueToString, Vc,
-    apply_effects,
+    ReadConsistency, ReadRef, ResolvedVc, TurboTasks, ValueToString, Vc, apply_effects,
 };
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_env::DotenvProcessEnv;
@@ -493,11 +492,7 @@ async fn walk_asset(
             .await?
             .iter()
             .copied()
-            .map(|asset| async move { Ok(ResolvedVc::try_downcast::<Box<dyn OutputAsset>>(asset)) })
-            .try_join()
-            .await?
-            .into_iter()
-            .flatten(),
+            .flat_map(|asset| ResolvedVc::try_downcast::<Box<dyn OutputAsset>>(asset)),
     );
 
     Ok(())


### PR DESCRIPTION
## Normalize Windows file paths in pattern construction

When interpreting js_values as `Pattern` objects for interpretation, normalize windows file endings away.

Also enable debug_assertions in unit tests.

### Why?
Enabling debug assertions on CI will prevent us from making mistakes

### Alternates?

Honestly, i am kind of confused about where to put this logic
https://vercel.slack.com/archives/C03EWR7LGEN/p1749854016509599?thread_ts=1749833045.978729&cid=C03EWR7LGEN

`Pattern::normalize` and `Pattern::with_normalized_path` are both reasonable alternatives.  However, the fact that `normalize` doesn't call `with_normalized_path` was a bit concerning, as was the complex nature of the Pattern type.

Fixes PACK-3279
Fixes PACK-414