### PR TITLE
[devtools] fix: error overlay closes when footer is clicked

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
@@ -18,6 +18,7 @@ const CSS_SELECTORS_TO_EXCLUDE_ON_CLICK_OUTSIDE = [
   '[data-info-popover]',
   '[data-nextjs-devtools-panel-overlay]',
   '[data-nextjs-devtools-panel-footer]',
+  '[data-nextjs-error-overlay-footer]',
 ]
 
 const Dialog: React.FC<DialogProps> = function Dialog({

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-footer/error-overlay-footer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-footer/error-overlay-footer.tsx
@@ -7,7 +7,7 @@ export type ErrorOverlayFooterProps = {
 
 export function ErrorOverlayFooter({ errorCode }: ErrorOverlayFooterProps) {
   return (
-    <footer className="error-overlay-footer">
+    <footer data-nextjs-error-overlay-footer className="error-overlay-footer">
       {errorCode ? (
         <ErrorFeedback className="error-feedback" errorCode={errorCode} />
       ) : null}


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/77327 should've added the footer to the dialog's click outside exclude list as is moving out from the dialog.

#### Before

https://github.com/user-attachments/assets/3ee79982-acc7-4783-b629-7132361463fd

#### After

https://github.com/user-attachments/assets/172e413d-5276-4dd5-a13c-936ba4bd5e6a