### PR TITLE
Turbopack: scope hoist tree shaking modules as well

### DIFF
--- a/test/e2e/app-dir/dynamic-io-errors/utils.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/utils.ts
@@ -35,13 +35,10 @@ export function getPrerenderOutput(
       lines.push(
         isMinified
           ? line
-              .replace(/at [\w.]+ \(.next[^)]+\)/, replaceNextDistStackFrame)
-              .replace(
-                /at ([\w.]+) \(<anonymous>\)/,
-                replaceAnonymousStackFrame
-              )
+              .replace(/at \S+ \(.next[^)]+\)/, replaceNextDistStackFrame)
+              .replace(/at (\S+) \(<anonymous>\)/, replaceAnonymousStackFrame)
           : line.replace(
-              /at ([\w.]+) \((webpack:\/\/)\/src[^)]+\)/,
+              /at (\S+) \((webpack:\/\/)\/src[^)]+\)/,
               `at $1 ($2<next-src>)`
             )
       )

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -746,28 +746,14 @@ impl MergeableModule for EcmascriptModuleAsset {
         modules: Vc<MergeableModulesExposed>,
         entry_points: Vc<MergeableModules>,
     ) -> Result<Vc<Box<dyn ChunkableModule>>> {
-        Ok(Vc::upcast(*MergedEcmascriptModule::new(
-            modules
-                .await?
-                .iter()
-                .map(|(m, exposed)| {
-                    Ok((
-                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(*m)
-                            .context("expected EcmascriptAnalyzable")?,
-                        *exposed,
-                    ))
-                })
-                .collect::<Result<Vec<_>>>()?,
-            entry_points
-                .await?
-                .iter()
-                .map(|m| {
-                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(*m)
-                        .context("expected EcmascriptAnalyzable")
-                })
-                .collect::<Result<Vec<_>>>()?,
-            self.options().to_resolved().await?,
-        )))
+        Ok(Vc::upcast(
+            *MergedEcmascriptModule::new(
+                modules,
+                entry_points,
+                self.options().to_resolved().await?,
+            )
+            .await?,
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -966,7 +966,7 @@ impl EcmascriptModuleContentOptions {
 
             let part_code_gens = part_references
                 .iter()
-                .map(|r| r.code_generation(**chunking_context))
+                .map(|r| r.code_generation(**chunking_context, scope_hoisting_context))
                 .try_join()
                 .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -261,6 +261,9 @@ impl EcmascriptAnalyzable for EcmascriptModuleFacadeModule {
             part_references,
             code_generation: CodeGens::empty().to_resolved().await?,
             async_module: ResolvedVc::cell(Some(self.async_module().to_resolved().await?)),
+            // The facade module cannot generate source maps, because the inserted references
+            // contain spans from the original module, but the facade module itself doesn't have the
+            // original module's swc_common::SourceMap in `parsed`.
             generate_source_map: false,
             original_source_map: None,
             exports: self.get_exports().to_resolved().await?,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, glob::Glob};
@@ -465,27 +465,13 @@ impl MergeableModule for EcmascriptModuleFacadeModule {
         modules: Vc<MergeableModulesExposed>,
         entry_points: Vc<MergeableModules>,
     ) -> Result<Vc<Box<dyn ChunkableModule>>> {
-        Ok(Vc::upcast(*MergedEcmascriptModule::new(
-            modules
-                .await?
-                .iter()
-                .map(|(m, exposed)| {
-                    Ok((
-                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(*m)
-                            .context("expected EcmascriptAnalyzable")?,
-                        *exposed,
-                    ))
-                })
-                .collect::<Result<Vec<_>>>()?,
-            entry_points
-                .await?
-                .iter()
-                .map(|m| {
-                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(*m)
-                        .context("expected EcmascriptAnalyzable")
-                })
-                .collect::<Result<Vec<_>>>()?,
-            EcmascriptOptions::default().resolved_cell(),
-        )))
+        Ok(Vc::upcast(
+            *MergedEcmascriptModule::new(
+                modules,
+                entry_points,
+                EcmascriptOptions::default().resolved_cell(),
+            )
+            .await?,
+        ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
@@ -217,27 +217,8 @@ impl MergeableModule for EcmascriptModuleLocalsModule {
         modules: Vc<MergeableModulesExposed>,
         entry_points: Vc<MergeableModules>,
     ) -> Result<Vc<Box<dyn ChunkableModule>>> {
-        Ok(Vc::upcast(*MergedEcmascriptModule::new(
-            modules
-                .await?
-                .iter()
-                .map(|(m, exposed)| {
-                    Ok((
-                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(*m)
-                            .context("expected EcmascriptAnalyzable")?,
-                        *exposed,
-                    ))
-                })
-                .collect::<Result<Vec<_>>>()?,
-            entry_points
-                .await?
-                .iter()
-                .map(|m| {
-                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptAnalyzable>>(*m)
-                        .context("expected EcmascriptAnalyzable")
-                })
-                .collect::<Result<Vec<_>>>()?,
-            self.module.await?.options,
-        )))
+        Ok(Vc::upcast(
+            *MergedEcmascriptModule::new(modules, entry_points, self.module.await?.options).await?,
+        ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
-use swc_core::{common::DUMMY_SP, quote};
+use swc_core::{common::DUMMY_SP, ecma::ast::Lit, quote};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, ValueToString, Vc, trace::TraceRawVcs};
 use turbopack_core::{
@@ -17,8 +17,11 @@ use super::{
     facade::module::EcmascriptModuleFacadeModule, locals::module::EcmascriptModuleLocalsModule,
 };
 use crate::{
-    ScopeHoistingContext, chunk::EcmascriptChunkPlaceable, code_gen::CodeGeneration,
-    references::esm::base::ReferencedAsset, runtime_functions::TURBOPACK_IMPORT,
+    ScopeHoistingContext,
+    chunk::EcmascriptChunkPlaceable,
+    code_gen::{CodeGeneration, CodeGenerationHoistedStmt},
+    references::esm::base::ReferencedAsset,
+    runtime_functions::TURBOPACK_IMPORT,
     utils::module_id_to_lit,
 };
 
@@ -152,29 +155,65 @@ impl EcmascriptModulePartReference {
     pub async fn code_generation(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
+        scope_hoisting_context: ScopeHoistingContext<'_>,
     ) -> Result<CodeGeneration> {
         let referenced_asset = ReferencedAsset::from_resolve_result(self.resolve_reference());
         let referenced_asset = referenced_asset.await?;
-        let ident = referenced_asset
-            .get_ident(chunking_context, None, ScopeHoistingContext::None)
-            .await?
-            .context("part module reference should have an ident")?
-            .as_expr_individual(DUMMY_SP)
-            .unwrap_left();
+        let part = &self.await?.part;
 
         let ReferencedAsset::Some(module) = *referenced_asset else {
             bail!("part module reference should have an module reference");
         };
-        let id = module.chunk_item_id(Vc::upcast(chunking_context)).await?;
 
-        Ok(CodeGeneration::hoisted_stmt(
-            ident.sym.as_str().into(),
-            quote!(
-                "var $name = $turbopack_import($id);" as Stmt,
-                name = ident,
-                turbopack_import: Expr = TURBOPACK_IMPORT.into(),
-                id: Expr = module_id_to_lit(&id),
-            ),
-        ))
+        let mut result = vec![];
+
+        let merged_index = scope_hoisting_context.get_module_index(module);
+        if let Some(merged_index) = merged_index {
+            // Insert a placeholder to inline the merged module at the right place
+            // relative to the other references (so to keep reference order).
+            result.push(CodeGenerationHoistedStmt::new(
+                format!("hoisted {merged_index}").into(),
+                quote!(
+                    "__turbopack_merged_esm__($id);" as Stmt,
+                    id: Expr = Lit::Num(merged_index.into()).into(),
+                ),
+            ));
+        }
+
+        let needs_namespace = match part {
+            ModulePart::Export(_) | ModulePart::RenamedExport { .. } | ModulePart::Evaluation => {
+                false
+            }
+            ModulePart::RenamedNamespace { .. }
+            | ModulePart::Internal(_)
+            | ModulePart::Locals
+            | ModulePart::Exports
+            | ModulePart::Facade => true,
+        };
+
+        if merged_index.is_some() && !needs_namespace {
+            // No need to import, the module was already executed and is available in the same scope
+            // hoisting group (unless it's a namespace import)
+        } else {
+            let ident = referenced_asset
+                .get_ident(chunking_context, None, scope_hoisting_context)
+                .await?
+                .context("part module reference should have an ident")?
+                .as_expr_individual(DUMMY_SP)
+                .unwrap_left();
+            let id = module.chunk_item_id(Vc::upcast(chunking_context)).await?;
+
+            result.push(CodeGenerationHoistedStmt::new(
+                ident.sym.as_str().into(),
+                quote!(
+                    "var $name = $turbopack_import($id);" as Stmt,
+                    name = ident,
+                    turbopack_import: Expr = TURBOPACK_IMPORT.into(),
+                    id: Expr = module_id_to_lit(&id),
+                ),
+            ));
+        }
+
+        Ok(CodeGeneration::hoisted_stmts(result))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
-use swc_core::{common::DUMMY_SP, ecma::ast::Lit, quote};
+use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{Ident, Lit},
+    quote,
+};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, ValueToString, Vc, trace::TraceRawVcs};
 use turbopack_core::{
@@ -20,7 +24,7 @@ use crate::{
     ScopeHoistingContext,
     chunk::EcmascriptChunkPlaceable,
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt},
-    references::esm::base::ReferencedAsset,
+    references::esm::base::{ReferencedAsset, ReferencedAssetIdent},
     runtime_functions::TURBOPACK_IMPORT,
     utils::module_id_to_lit,
 };
@@ -180,38 +184,53 @@ impl EcmascriptModulePartReference {
             ));
         }
 
-        let needs_namespace = match part {
-            ModulePart::Export(_) | ModulePart::RenamedExport { .. } | ModulePart::Evaluation => {
-                false
-            }
-            ModulePart::RenamedNamespace { .. }
-            | ModulePart::Internal(_)
-            | ModulePart::Locals
-            | ModulePart::Exports
-            | ModulePart::Facade => true,
-        };
-
-        if merged_index.is_some() && !needs_namespace {
+        if merged_index.is_some() && part == &ModulePart::Evaluation {
             // No need to import, the module was already executed and is available in the same scope
             // hoisting group (unless it's a namespace import)
         } else {
             let ident = referenced_asset
-                .get_ident(chunking_context, None, scope_hoisting_context)
+                .get_ident(
+                    chunking_context,
+                    match part {
+                        ModulePart::Export(export)
+                        | ModulePart::RenamedExport {
+                            original_export: export,
+                            ..
+                        }
+                        | ModulePart::RenamedNamespace { export } => Some(export.clone()),
+                        ModulePart::Internal(_)
+                        | ModulePart::Locals
+                        | ModulePart::Exports
+                        | ModulePart::Facade
+                        | ModulePart::Evaluation => None,
+                    },
+                    scope_hoisting_context,
+                )
                 .await?
-                .context("part module reference should have an ident")?
-                .as_expr_individual(DUMMY_SP)
-                .unwrap_left();
-            let id = module.chunk_item_id(Vc::upcast(chunking_context)).await?;
+                .context("part module reference should have an ident")?;
 
-            result.push(CodeGenerationHoistedStmt::new(
-                ident.sym.as_str().into(),
-                quote!(
-                    "var $name = $turbopack_import($id);" as Stmt,
-                    name = ident,
-                    turbopack_import: Expr = TURBOPACK_IMPORT.into(),
-                    id: Expr = module_id_to_lit(&id),
-                ),
-            ));
+            match ident {
+                ReferencedAssetIdent::LocalBinding { .. } => {
+                    // no need to import
+                }
+                ReferencedAssetIdent::Module { .. } => {
+                    let (sym, ctxt) = ident.into_module_namespace_ident().unwrap();
+                    let key = sym.as_str().into();
+                    let name = Ident::new(sym.into(), DUMMY_SP, ctxt.unwrap_or_default());
+
+                    let id = module.chunk_item_id(Vc::upcast(chunking_context)).await?;
+
+                    result.push(CodeGenerationHoistedStmt::new(
+                        key,
+                        quote!(
+                            "var $name = $turbopack_import($id);" as Stmt,
+                            name = name,
+                            turbopack_import: Expr = TURBOPACK_IMPORT.into(),
+                            id: Expr = module_id_to_lit(&id),
+                        ),
+                    ));
+                }
+            }
         }
 
         Ok(CodeGeneration::hoisted_stmts(result))

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/index.js
@@ -1,3 +1,10 @@
 it('should error when importing an invalid export', () => {
-  expect(require('./invalid-export').default).toBe(undefined)
+  // Either requiring should throw, or return undefined
+  let ns
+  try {
+    ns = require('./invalid-export')
+  } catch {
+    return
+  }
+  expect(ns.default).toBe(undefined)
 })


### PR DESCRIPTION
Scope hoist the facade and the locals module (which are the only ones used in reexports-only tree shaking mode?) as well:

![Bildschirmfoto 2025-06-14 um 14.13.36.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sjZSbv6AFeuDg7Gb9rma/419a611c-f814-48d9-908c-980f2c6791bd.png)

Closes PACK-2960
Builds on top of https://github.com/vercel/next.js/pull/79459