### PR TITLE
[turbopack] Optimize PartialEq for RcStr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,10 @@ opt-level = 3
 [profile.release.package.serde]
 opt-level = 3
 
+[profile.profiling]
+inherits = "release"
+debug = true
+
 [workspace.dependencies]
 # Workspace crates
 next-api = { path = "crates/next-api" }

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -63,7 +63,6 @@ pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
 
 /// Attempts to construct an RcStr but only if it can be constructed inline.
 /// This is primarily useful in constant contexts.
-#[doc(hidden)]
 pub(crate) const fn inline_atom(text: &str) -> Option<RcStr> {
     let len = text.len();
     if len < MAX_INLINE_LEN {

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -21,8 +21,8 @@ pub(crate) unsafe fn restore_arc(v: TaggedValue) -> ManuallyDrop<ThinArc<Prehash
 
 /// This can create any kind of [Atom], although this lives in the `dynamic`
 /// module.
-pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
-    let bytes = text.as_ref().as_bytes();
+pub(crate) fn new_atom(text: &str) -> RcStr {
+    let bytes = text.as_bytes();
     let len = bytes.len();
 
     if len < MAX_INLINE_LEN {
@@ -35,7 +35,7 @@ pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
         return RcStr { unsafe_data };
     }
 
-    let hash = hash_bytes(text.as_ref().as_bytes());
+    let hash = hash_bytes(bytes);
 
     let entry = ThinArc::from_header_and_slice(PrehashedString { hash }, bytes);
     let entry = ThinArc::into_raw(entry);

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -185,28 +185,25 @@ impl From<BytesStr> for RcStr {
 
 impl From<Arc<String>> for RcStr {
     fn from(s: Arc<String>) -> Self {
-        match Arc::try_unwrap(s) {
-            Ok(v) => new_atom(Cow::Owned(v)),
-            Err(arc) => new_atom(Cow::Borrowed(&**arc)),
-        }
+        new_atom(s.as_str())
     }
 }
 
 impl From<String> for RcStr {
     fn from(s: String) -> Self {
-        new_atom(Cow::Owned(s))
+        new_atom(s.as_str())
     }
 }
 
 impl From<&'_ str> for RcStr {
     fn from(s: &str) -> Self {
-        new_atom(Cow::Borrowed(s))
+        new_atom(s)
     }
 }
 
 impl From<Cow<'_, str>> for RcStr {
     fn from(s: Cow<str>) -> Self {
-        new_atom(s)
+        new_atom(s.as_ref())
     }
 }
 


### PR DESCRIPTION
# Optimize RcStr implementation for better performance

## What?
This PR optimizes the `RcStr` implementation in the `turbo-rcstr` crate to improve performance and memory usage.

## Why?
The changes aim to make the code more efficient by:
- Ensuring RcStr triggers the non-zero size optimization
- Improving string comparison performance
- Optimizing string access patterns

## How?
- Added compile-time assertion to verify RcStr triggers non-zero size optimization
- Refactored `as_str()` implementation to use dedicated inline methods for dynamic and inline cases
- Optimized `PartialEq` implementation to first check for identical instances before comparing contents
- Removed `#[doc(hidden)]` from `inline_atom` function
- Fixed namespace references in the `rcstr!` macro to use fully qualified paths

Fixes #

Closes PACK-5136