### PR TITLE
[perf] cache load config results

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -219,7 +219,9 @@ const nextDev = async (
   // some set-ups that rely on listening on other interfaces
   const host = options.hostname
 
-  config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir)
+  config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, {
+    silent: false,
+  })
 
   if (
     options.experimentalUploadTrace &&

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -1,6 +1,15 @@
-import loadConfig from './config'
-
 describe('loadConfig', () => {
+  let loadConfig: typeof import('./config').default
+
+  beforeEach(async () => {
+    // Reset the module cache to ensure each test gets a fresh config load
+    // This is important because config.ts now has a module-level configCache
+    jest.resetModules()
+
+    // Dynamically import the module after reset to get a fresh instance
+    const configModule = await import('./config')
+    loadConfig = configModule.default
+  })
   describe('nextConfig.images defaults', () => {
     it('should assign a `images.remotePatterns` when using assetPrefix', async () => {
       const result = await loadConfig('', __dirname, {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -39,6 +39,7 @@ import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot
 import { findDir } from '../lib/find-pages-dir'
 import { CanaryOnlyError, isStableBuild } from '../shared/lib/canary-only'
 import { interopDefault } from '../lib/interop-default'
+import { djb2Hash } from '../shared/lib/hash'
 
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
@@ -1164,12 +1165,37 @@ async function applyModifyConfig(
   return config
 }
 
-// Single config cache to keep one copy containing rawConfig, complete config, and experimental features
-let configCache: {
-  rawConfig: any
-  config: NextConfigComplete
-  configuredExperimentalFeatures: ConfiguredExperimentalFeature[]
-} | null = null
+// Config cache with keys to handle multiple configurations (e.g., multi-zone)
+const configCache = new Map<
+  string,
+  {
+    rawConfig: any
+    config: NextConfigComplete
+    configuredExperimentalFeatures: ConfiguredExperimentalFeature[]
+  }
+>()
+
+// Generate cache key based on parameters that affect config output
+// We need a unique key for cache because there can be multiple values for
+function getCacheKey(
+  phase: string,
+  dir: string,
+  customConfig?: object | null,
+  reactProductionProfiling?: boolean,
+  debugPrerender?: boolean
+): string {
+  // The next.config.js is unique per project, so we can use the dir as the major key
+  // to generate the unique config key.
+  const keyData = JSON.stringify({
+    dir,
+    phase,
+    hasCustomConfig: Boolean(customConfig),
+    reactProductionProfiling: Boolean(reactProductionProfiling),
+    debugPrerender: Boolean(debugPrerender),
+  })
+
+  return djb2Hash(keyData).toString(36)
+}
 
 export default async function loadConfig(
   phase: string,
@@ -1192,19 +1218,29 @@ export default async function loadConfig(
     debugPrerender?: boolean
   } = {}
 ): Promise<NextConfigComplete> {
+  // Generate cache key based on parameters that affect config output
+  const cacheKey = getCacheKey(
+    phase,
+    dir,
+    customConfig,
+    reactProductionProfiling,
+    debugPrerender
+  )
+
   // Check if we have a cached result
-  if (configCache) {
+  const cachedResult = configCache.get(cacheKey)
+  if (cachedResult) {
     // Call the experimental features callback if provided
     if (reportExperimentalFeatures) {
-      reportExperimentalFeatures(configCache.configuredExperimentalFeatures)
+      reportExperimentalFeatures(cachedResult.configuredExperimentalFeatures)
     }
 
     // Return raw config if requested and available
-    if (rawConfig && configCache.rawConfig) {
-      return configCache.rawConfig
+    if (rawConfig && cachedResult.rawConfig) {
+      return cachedResult.rawConfig
     }
 
-    return configCache.config
+    return cachedResult.config
   }
 
   // Original implementation continues below...
@@ -1228,11 +1264,11 @@ export default async function loadConfig(
     )
 
     // Cache the standalone config
-    configCache = {
+    configCache.set(cacheKey, {
       config: standaloneConfig,
       rawConfig: standaloneConfig,
       configuredExperimentalFeatures: [],
-    }
+    })
 
     return standaloneConfig
   }
@@ -1266,15 +1302,13 @@ export default async function loadConfig(
     )
 
     // Cache the custom config result
-    configCache = {
+    configCache.set(cacheKey, {
       config,
       rawConfig: customConfig,
       configuredExperimentalFeatures,
-    }
+    })
 
-    if (reportExperimentalFeatures) {
-      reportExperimentalFeatures(configuredExperimentalFeatures)
-    }
+    reportExperimentalFeatures?.(configuredExperimentalFeatures)
 
     return config
   }
@@ -1317,15 +1351,13 @@ export default async function loadConfig(
 
       if (rawConfig) {
         // Cache the raw config
-        configCache = {
+        configCache.set(cacheKey, {
           config: userConfigModule as NextConfigComplete,
           rawConfig: userConfigModule,
           configuredExperimentalFeatures,
-        }
+        })
 
-        if (reportExperimentalFeatures) {
-          reportExperimentalFeatures(configuredExperimentalFeatures)
-        }
+        reportExperimentalFeatures?.(configuredExperimentalFeatures)
 
         return userConfigModule
       }
@@ -1506,11 +1538,11 @@ export default async function loadConfig(
     const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
 
     // Cache the final result
-    configCache = {
+    configCache.set(cacheKey, {
       config: finalConfig,
       rawConfig: userConfigModule, // Store the original user config module
       configuredExperimentalFeatures,
-    }
+    })
 
     if (reportExperimentalFeatures) {
       reportExperimentalFeatures(configuredExperimentalFeatures)
@@ -1561,11 +1593,11 @@ export default async function loadConfig(
   const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
 
   // Cache the default config result
-  configCache = {
+  configCache.set(cacheKey, {
     config: finalConfig,
     rawConfig: clonedDefaultConfig,
     configuredExperimentalFeatures,
-  }
+  })
 
   if (reportExperimentalFeatures) {
     reportExperimentalFeatures(configuredExperimentalFeatures)

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1165,7 +1165,7 @@ async function applyModifyConfig(
   return config
 }
 
-// Config cache with keys to handle multiple configurations (e.g., multi-zone)
+// Cache config with keys to handle multiple configurations (e.g., multi-zone)
 const configCache = new Map<
   string,
   {
@@ -1176,7 +1176,7 @@ const configCache = new Map<
 >()
 
 // Generate cache key based on parameters that affect config output
-// We need a unique key for cache because there can be multiple values for
+// We need a unique key for cache because there can be multiple values
 function getCacheKey(
   phase: string,
   dir: string,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1164,6 +1164,13 @@ async function applyModifyConfig(
   return config
 }
 
+// Single config cache to keep one copy containing rawConfig, complete config, and experimental features
+let configCache: {
+  rawConfig: any
+  config: NextConfigComplete
+  configuredExperimentalFeatures: ConfiguredExperimentalFeature[]
+} | null = null
+
 export default async function loadConfig(
   phase: string,
   dir: string,
@@ -1185,6 +1192,22 @@ export default async function loadConfig(
     debugPrerender?: boolean
   } = {}
 ): Promise<NextConfigComplete> {
+  // Check if we have a cached result
+  if (configCache) {
+    // Call the experimental features callback if provided
+    if (reportExperimentalFeatures) {
+      reportExperimentalFeatures(configCache.configuredExperimentalFeatures)
+    }
+
+    // Return raw config if requested and available
+    if (rawConfig && configCache.rawConfig) {
+      return configCache.rawConfig
+    }
+
+    return configCache.config
+  }
+
+  // Original implementation continues below...
   if (!process.env.__NEXT_PRIVATE_RENDER_WORKER) {
     try {
       loadWebpackHook()
@@ -1200,7 +1223,18 @@ export default async function loadConfig(
   if (process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
     // we don't apply assignDefaults or modifyConfig here as it
     // has already been applied
-    return JSON.parse(process.env.__NEXT_PRIVATE_STANDALONE_CONFIG)
+    const standaloneConfig = JSON.parse(
+      process.env.__NEXT_PRIVATE_STANDALONE_CONFIG
+    )
+
+    // Cache the standalone config
+    configCache = {
+      config: standaloneConfig,
+      rawConfig: standaloneConfig,
+      configuredExperimentalFeatures: [],
+    }
+
+    return standaloneConfig
   }
 
   const curLog = silent
@@ -1214,9 +1248,10 @@ export default async function loadConfig(
   loadEnvConfig(dir, phase === PHASE_DEVELOPMENT_SERVER, curLog)
 
   let configFileName = 'next.config.js'
+  const configuredExperimentalFeatures: ConfiguredExperimentalFeature[] = []
 
   if (customConfig) {
-    return await applyModifyConfig(
+    const config = await applyModifyConfig(
       assignDefaults(
         dir,
         {
@@ -1229,10 +1264,22 @@ export default async function loadConfig(
       phase,
       silent
     )
+
+    // Cache the custom config result
+    configCache = {
+      config,
+      rawConfig: customConfig,
+      configuredExperimentalFeatures,
+    }
+
+    if (reportExperimentalFeatures) {
+      reportExperimentalFeatures(configuredExperimentalFeatures)
+    }
+
+    return config
   }
 
   const path = await findUp(CONFIG_FILES, { cwd: dir })
-  const configuredExperimentalFeatures: ConfiguredExperimentalFeature[] = []
 
   // If config file was found
   if (path?.length) {
@@ -1269,6 +1316,17 @@ export default async function loadConfig(
       updateInitialEnv(newEnv)
 
       if (rawConfig) {
+        // Cache the raw config
+        configCache = {
+          config: userConfigModule as NextConfigComplete,
+          rawConfig: userConfigModule,
+          configuredExperimentalFeatures,
+        }
+
+        if (reportExperimentalFeatures) {
+          reportExperimentalFeatures(configuredExperimentalFeatures)
+        }
+
         return userConfigModule
       }
     } catch (err) {
@@ -1286,7 +1344,7 @@ export default async function loadConfig(
       )) as NextConfig
     )
 
-    if (reportExperimentalFeatures && loadedConfig.experimental) {
+    if (loadedConfig.experimental) {
       for (const name of Object.keys(
         loadedConfig.experimental
       ) as (keyof ExperimentalConfig)[]) {
@@ -1308,13 +1366,16 @@ export default async function loadConfig(
     // Clone a new userConfig each time to avoid mutating the original
     const userConfig = cloneObject(loadedConfig) as NextConfig
 
-    if (!process.env.NEXT_MINIMAL) {
+    // Always validate the config against schema in non minimal mode.
+    // Only validate once in the root Next.js process, not in forked processes.
+    const isRootProcess = typeof process.send !== 'function'
+    if (!process.env.NEXT_MINIMAL && isRootProcess) {
       // We only validate the config against schema in non minimal mode
       const { configSchema } =
         require('./config-schema') as typeof import('./config-schema')
       const state = configSchema.safeParse(userConfig)
 
-      if (state.success === false) {
+      if (!state.success) {
         // error message header
         const messages = [`Invalid ${configFileName} options detected: `]
 
@@ -1426,9 +1487,7 @@ export default async function loadConfig(
 
     enforceExperimentalFeatures(userConfig, {
       isDefaultConfig: false,
-      configuredExperimentalFeatures: reportExperimentalFeatures
-        ? configuredExperimentalFeatures
-        : undefined,
+      configuredExperimentalFeatures,
       debugPrerender,
       phase,
     })
@@ -1444,11 +1503,20 @@ export default async function loadConfig(
       silent
     ) as NextConfigComplete
 
+    const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
+
+    // Cache the final result
+    configCache = {
+      config: finalConfig,
+      rawConfig: userConfigModule, // Store the original user config module
+      configuredExperimentalFeatures,
+    }
+
     if (reportExperimentalFeatures) {
       reportExperimentalFeatures(configuredExperimentalFeatures)
     }
 
-    return await applyModifyConfig(completeConfig, phase, silent)
+    return finalConfig
   } else {
     const configBaseName = basename(CONFIG_FILES[0], extname(CONFIG_FILES[0]))
     const unsupportedConfig = findUp.sync(
@@ -1475,9 +1543,7 @@ export default async function loadConfig(
 
   enforceExperimentalFeatures(clonedDefaultConfig, {
     isDefaultConfig: true,
-    configuredExperimentalFeatures: reportExperimentalFeatures
-      ? configuredExperimentalFeatures
-      : undefined,
+    configuredExperimentalFeatures,
     debugPrerender,
     phase,
   })
@@ -1492,11 +1558,20 @@ export default async function loadConfig(
 
   setHttpClientAndAgentOptions(completeConfig)
 
+  const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
+
+  // Cache the default config result
+  configCache = {
+    config: finalConfig,
+    rawConfig: clonedDefaultConfig,
+    configuredExperimentalFeatures,
+  }
+
   if (reportExperimentalFeatures) {
     reportExperimentalFeatures(configuredExperimentalFeatures)
   }
 
-  return await applyModifyConfig(completeConfig, phase, silent)
+  return finalConfig
 }
 
 export type ConfiguredExperimentalFeature = {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -100,7 +100,9 @@ export async function initialize(opts: {
   const config = await loadConfig(
     opts.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,
     opts.dir,
-    { silent: false }
+    {
+      silent: opts.dev,
+    }
   )
 
   let compress: ReturnType<typeof setupCompression> | undefined

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -100,9 +100,7 @@ export async function initialize(opts: {
   const config = await loadConfig(
     opts.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,
     opts.dir,
-    {
-      silent: opts.dev,
-    }
+    { silent: false }
   )
 
   let compress: ReturnType<typeof setupCompression> | undefined

--- a/test/development/config-validation/index.test.ts
+++ b/test/development/config-validation/index.test.ts
@@ -1,0 +1,54 @@
+import stripAnsi from 'strip-ansi'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('config validation - validation only runs once', () => {
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+    export default function Page() {
+      return <p>hello world</p>
+    }
+    `,
+      'next.config.js': `
+    module.exports = {
+      invalidOption: 'shouldTriggerValidation',
+      anotherBadKey: 'anotherBadValue'
+    }
+    `,
+    },
+  })
+
+  it('should validate config only once in root process', async () => {
+    await next.fetch('/')
+    const output = stripAnsi(next.cliOutput)
+    const validationHeaderMatches = output.match(
+      /Invalid next\.config\.js options detected:/g
+    )
+    const validationHeaderCount = validationHeaderMatches
+      ? validationHeaderMatches.length
+      : 0
+
+    // Count occurrences of specific invalid option mentions
+    const invalidOptionMatches = output.match(/invalidOption/g)
+    const invalidOptionCount = invalidOptionMatches
+      ? invalidOptionMatches.length
+      : 0
+
+    const anotherBadKeyMatches = output.match(/anotherBadKey/g)
+    const anotherBadKeyCount = anotherBadKeyMatches
+      ? anotherBadKeyMatches.length
+      : 0
+
+    // Expect validation to have occurred
+    expect(output).toContain('Invalid next.config.js options detected')
+    expect(output).toContain('invalidOption')
+    expect(output).toContain('anotherBadKey')
+
+    // Expect validation header to appear only once (not multiple times from different processes)
+    expect(validationHeaderCount).toBe(1)
+
+    // Each invalid option should also appear only once in the validation output
+    expect(invalidOptionCount).toBe(1)
+    expect(anotherBadKeyCount).toBe(1)
+  })
+})

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 import { join } from 'path'
-import loadConfig from 'next/dist/server/config'
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
 
 const pathToConfig = join(__dirname, '_resolvedata', 'without-function')
@@ -11,6 +10,17 @@ const pathToConfigFn = join(__dirname, '_resolvedata', 'with-function')
 process.env.__NEXT_TEST_MODE = 'jest'
 
 describe('config', () => {
+  let loadConfig: typeof import('next/dist/server/config').default
+
+  beforeEach(async () => {
+    // Reset the module cache to ensure each test gets a fresh config load
+    // This is important because config.ts now has a module-level configCache
+    jest.resetModules()
+
+    // Dynamically import the module after reset to get a fresh instance
+    const configModule = await import('next/dist/server/config')
+    loadConfig = configModule.default
+  })
   it('Should get the configuration', async () => {
     const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig)
     expect(config.customConfig).toBe(true)
@@ -33,7 +43,7 @@ describe('config', () => {
   })
 
   it('Should pass the customConfig correctly', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
       customConfig: {
         customConfigKey: 'customConfigValue',
       },
@@ -42,7 +52,7 @@ describe('config', () => {
   })
 
   it('Should assign object defaults deeply to customConfig', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
       customConfig: {
         customConfig: true,
         onDemandEntries: { custom: true },
@@ -53,7 +63,7 @@ describe('config', () => {
   })
 
   it('Should allow setting objects which do not have defaults', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
       customConfig: {
         bogusSetting: { custom: true },
       },
@@ -63,7 +73,7 @@ describe('config', () => {
   })
 
   it('Should override defaults for arrays from user arrays', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
       customConfig: {
         pageExtensions: ['.bogus'],
       },


### PR DESCRIPTION
This PR is a perf improvement that we only need to load Next.js config once per process. For config schema validation we also only execute once. I noticed that config-schema is executed 3 times, in the 1st root process, and twice when the router-server load configs.

* For `loadConfig` it needs module loading, config parsing, save the expensive effort to only execute once
* Always validate config schema if possible and don't be silent, but only do it once is the parent process. We use `process.send` to check if it's in the root or forked process.