### PR TITLE
[fix] clone the config module to avoid mutation

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1268,9 +1268,12 @@ export default async function loadConfig(
     }
 
     // Clone a new userConfig each time to avoid mutating the original
-    const userConfig = structuredClone(
-      await normalizeConfig(phase, userConfigModule.default || userConfigModule)
-    ) as NextConfig
+    const userConfig = {
+      ...(await normalizeConfig(
+        phase,
+        userConfigModule.default || userConfigModule
+      )),
+    } as NextConfig
 
     if (!process.env.NEXT_MINIMAL) {
       // We only validate the config against schema in non minimal mode

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1268,12 +1268,9 @@ export default async function loadConfig(
     }
 
     // Clone a new userConfig each time to avoid mutating the original
-    const userConfig = {
-      ...(await normalizeConfig(
-        phase,
-        userConfigModule.default || userConfigModule
-      )),
-    } as NextConfig
+    const userConfig = cloneObject(
+      await normalizeConfig(phase, userConfigModule.default || userConfigModule)
+    ) as NextConfig
 
     if (!process.env.NEXT_MINIMAL) {
       // We only validate the config against schema in non minimal mode
@@ -1478,4 +1475,23 @@ export function getConfiguredExperimentalFeatures(
     }
   }
   return configuredExperimentalFeatures
+}
+
+function cloneObject(obj: any): any {
+  if (obj === null || typeof obj !== 'object') {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(cloneObject)
+  }
+  const keys = Object.keys(obj)
+  if (keys.length === 0) {
+    return obj
+  }
+
+  return keys.reduce((acc, key) => {
+    ;(acc as any)[key] = cloneObject(obj[key])
+    return acc
+  }, {})
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1268,9 +1268,11 @@ export default async function loadConfig(
     }
 
     // Clone a new userConfig each time to avoid mutating the original
-    const userConfig = cloneObject(
-      await normalizeConfig(phase, userConfigModule.default || userConfigModule)
-    ) as NextConfig
+    const loadedConfig = (await normalizeConfig(
+      phase,
+      interopDefault(userConfigModule)
+    )) as NextConfig
+    const userConfig = cloneObject(loadedConfig) as NextConfig
 
     if (!process.env.NEXT_MINIMAL) {
       // We only validate the config against schema in non minimal mode
@@ -1388,7 +1390,7 @@ export default async function loadConfig(
       userConfig.htmlLimitedBots = userConfig.htmlLimitedBots.source
     }
 
-    onLoadUserConfig?.(userConfig)
+    onLoadUserConfig?.(Object.freeze(loadedConfig))
     const completeConfig = assignDefaults(
       dir,
       {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1267,10 +1267,10 @@ export default async function loadConfig(
       throw err
     }
 
-    const userConfig = (await normalizeConfig(
-      phase,
-      userConfigModule.default || userConfigModule
-    )) as NextConfig
+    // Clone a new userConfig each time to avoid mutating the original
+    const userConfig = structuredClone(
+      await normalizeConfig(phase, userConfigModule.default || userConfigModule)
+    ) as NextConfig
 
     if (!process.env.NEXT_MINIMAL) {
       // We only validate the config against schema in non minimal mode

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming-customized-rule.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming-customized-rule.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - metadata-streaming-customized-rule', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     overrideFiles: {
       'next.config.js': `
@@ -39,4 +39,12 @@ describe('app-dir - metadata-streaming-customized-rule', () => {
     expect(await $('head title').length).toBe(0)
     expect(await $('body title').length).toBe(1)
   })
+
+  if (isNextDev) {
+    it('should not have schema issue', () => {
+      expect(next.cliOutput).not.toContain(
+        'Invalid next.config.js options detected'
+      )
+    })
+  }
 })

--- a/test/integration/config-experimental-warning/next.config.js
+++ b/test/integration/config-experimental-warning/next.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  experimental: {
-    staticGenerationRetryCount: 2,
-    staticGenerationMaxConcurrency: 4,
-  },
-}


### PR DESCRIPTION
### Issue

When you specify a proper regex for `htmlLimitedBots` config Next.js still complain the schema is not fixed.

### Fix

The problem is because the module has been loaded, and `userConfig` will be the same instance in the same process. Since we'll also mutate the userConfig object, when we load it later it will return the mutated version which will cause schema change for `htmlLimitedBots` since it turns from `RegExp` to `string`

Closes NEXT-4527