### PR TITLE
Turn on clientSegmentCache during PPR CI runs

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1323,7 +1323,19 @@ export const defaultConfig = {
     serverSourceMaps: false,
     linkNoTouchStart: false,
     caseSensitiveRoutes: false,
-    clientSegmentCache: false,
+    clientSegmentCache:
+      // TODO: Remove once we've made clientSegmentCache the default. We're
+      // piggybacking on the PPR test flag, instead of introducing a separate
+      // CI run.
+      //
+      // If we're testing, and the `__NEXT_EXPERIMENTAL_PPR` environment
+      // variable has been set to `true`, enable the experimental
+      // clientSegmentCache feature so long as it wasn't explicitly disabled in
+      // the config.
+      !!(
+        process.env.__NEXT_TEST_MODE &&
+        process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+      ),
     dynamicOnHover: false,
     appDocumentPreloading: undefined,
     preloadEntriesOnStart: true,

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -72,6 +72,68 @@
         "unexpected-error should set response status to 500 for unexpected errors in ssr app route",
         "unexpected-error should set response status to 500 for unexpected errors in isr app route"
       ]
+    },
+    "test/e2e/next-form/default/app-dir.test.ts": {
+      "failed": [
+        "next-form - app dir should soft-navigate on submit and show the prefetched loading state"
+      ]
+    },
+    "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts": {
+      "failed": [
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: false should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: false should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: true should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: true should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: false should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: false should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: true should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation router.refresh (regular) - searchParams: true should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation server action revalidation should not trigger a refresh for the page that is being redirected to"
+      ]
+    },
+    "test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts": {
+      "failed": [
+        "router autoscrolling on navigation bugs Should apply scroll when loading.js is used"
+      ]
+    },
+    "test/e2e/app-dir/actions/app-action-node-middleware.test.ts": {
+      "failed": [
+        "app-dir action handling fetch actions should invalidate client cache when path is revalidated",
+        "app-dir action handling fetch actions should store revalidation data in the prefetch cache",
+        "app-dir action handling should only submit action once when resubmitting an action after navigation",
+        "app-dir action handling should reset the form state when the action redirects to itself"
+      ]
+    },
+    "test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts": {
+      "failed": [
+        "searchparams-reuse-loading should re-use loading from \"full\" prefetch for param-full URL when navigating to param-full route",
+        "searchparams-reuse-loading should re-use loading from \"full\" prefetch for param-full URL when navigating to param-less route",
+        "searchparams-reuse-loading should re-use loading from \"full\" prefetch for param-less URL when navigating to param-full route"
+      ]
+    },
+    "test/production/app-dir/browser-chunks/browser-chunks.test.ts": {
+      "failed": [
+        "browser-chunks must not bundle any server modules into browser chunks"
+      ]
+    },
+    "test/e2e/next-form/default/next-form-prefetch.test.ts": {
+      "failed": [
+        "app dir - form prefetching should not prefetch when prefetch is set to false`",
+        "app dir - form prefetching should prefetch a loading state for the form's target"
+      ]
+    },
+    "test/e2e/app-dir/actions/app-action.test.ts": {
+      "failed": [
+        "app-dir action handling fetch actions should store revalidation data in the prefetch cache",
+        "app-dir action handling should only submit action once when resubmitting an action after navigation",
+        "app-dir action handling should reset the form state when the action redirects to itself"
+      ]
+    },
+    "test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts": {
+      "failed": [
+        "parallel-routes-and-interception route intercepting should support intercepting local dynamic sibling routes",
+        "parallel-routes-and-interception parallel routes should handle a loading state"
+      ]
     }
   },
   "rules": {


### PR DESCRIPTION
This sets the `clientSegmentCache` flag to `true` during PPR CI runs, so we can test the entire test suite with the feature enabled.

There are a few tests that are coupled to the old implementation details that I'll need to either rewrite or (temporarily) disable.