### PR TITLE
Turbopack: CSS Global Import Validation for Pages

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 use either::Either;
@@ -16,9 +16,11 @@ use turbo_tasks::{
     CollectiblesSource, FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt,
     TryJoinIterExt, Vc,
 };
+use turbo_tasks_fs::FileSystemPath;
+use turbopack::css::{CssModuleAsset, ModuleCssAsset};
 use turbopack_core::{
     context::AssetContext,
-    issue::Issue,
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     module::Module,
     module_graph::{GraphTraversalAction, ModuleGraph, SingleModuleGraph},
 };
@@ -399,6 +401,142 @@ impl ClientReferencesGraph {
     }
 }
 
+#[turbo_tasks::value(shared)]
+pub struct CssGlobalImportIssue {
+    parent_module: ResolvedVc<Box<dyn Module>>,
+    module: ResolvedVc<Box<dyn Module>>,
+}
+
+#[turbo_tasks::value_impl]
+impl CssGlobalImportIssue {
+    #[turbo_tasks::function]
+    pub fn new(
+        parent_module: ResolvedVc<Box<dyn Module>>,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Vc<Self> {
+        Self {
+            parent_module,
+            module,
+        }
+        .cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for CssGlobalImportIssue {
+    #[turbo_tasks::function]
+    async fn title(&self) -> Vc<StyledString> {
+        StyledString::Text(
+            format!(
+                "CSS global import in {}",
+                self.parent_module.ident().path().await.unwrap().path
+            )
+            .into(),
+        )
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    async fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(
+            StyledString::Text(
+                format!(
+                    "CSS global import in {}, cannot import {}",
+                    self.parent_module.ident().path().await.unwrap().path,
+                    self.module.ident().path().await.unwrap().path
+                )
+                .into(),
+            )
+            .resolved_cell(),
+        ))
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Warning.into()
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.parent_module.ident().path()
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::ProcessModule.into()
+    }
+}
+
+#[turbo_tasks::function]
+async fn validate_pages_css_imports(
+    graph: Vc<SingleModuleGraph>,
+    is_single_page: bool,
+    entry: Vc<Box<dyn Module>>,
+    // TODO potentially more arguments
+) -> Result<()> {
+    let graph = &*graph.await?;
+    let entry = entry.to_resolved().await?;
+
+    let entries = if !is_single_page {
+        if !graph.entry_modules().any(|m| m == entry) {
+            // the graph doesn't contain the entry, e.g. for the additional module graph
+            return Ok(());
+        }
+        Either::Left(std::iter::once(entry))
+    } else {
+        Either::Right(graph.entry_modules())
+    };
+
+    let issues = Rc::new(RefCell::new(Vec::new()));
+    let issues_ref = issues.clone();
+
+    graph.traverse_edges_from_entries(entries, |parent_info, node| {
+        let module = node.module;
+        let Some((parent_node, _)) = parent_info else {
+            // root node, no parent
+            return GraphTraversalAction::Continue;
+        };
+        let parent_module = parent_node.module;
+
+        // TODO validate parent_module -> module import
+
+        if parent_module == entry
+            && ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some()
+        {
+            println!("css import found");
+        }
+        if parent_module != entry
+            && ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some()
+        {
+            issues_ref
+                .borrow_mut()
+                .push(CssGlobalImportIssue::new(*parent_module, *module));
+            println!("css invalid global import found");
+        }
+        if parent_module != entry
+            && ResolvedVc::try_downcast_type::<ModuleCssAsset>(module).is_some()
+        {
+            println!("css valid module import found");
+        }
+
+        GraphTraversalAction::Continue
+    })?;
+
+    CssGlobalImportIssue::new(*entry, *entry)
+        .to_resolved()
+        .await;
+
+    // resolve_issues(&issues.borrow()).await?;
+
+    Ok(())
+}
+
+async fn resolve_issues(issues: &[Vc<CssGlobalImportIssue>]) -> Result<()> {
+    for issue in issues.iter() {
+        issue.to_resolved().await?.emit();
+    }
+    Ok(())
+}
+
 /// The consumers of this shouldn't need to care about the exact contents since it's abstracted away
 /// by the accessor functions, but
 /// - In dev, contains information about the modules of the current endpoint only
@@ -408,6 +546,9 @@ pub struct ReducedGraphs {
     next_dynamic: Vec<ResolvedVc<NextDynamicGraph>>,
     server_actions: Vec<ResolvedVc<ServerActionsGraph>>,
     client_references: Vec<ResolvedVc<ClientReferencesGraph>>,
+    // Data for some more ad-hoc operations
+    bare_graphs: ResolvedVc<ModuleGraph>,
+    is_single_page: bool,
     // TODO add other graphs
 }
 
@@ -415,9 +556,9 @@ pub struct ReducedGraphs {
 impl ReducedGraphs {
     #[turbo_tasks::function]
     pub async fn new(graphs: Vc<ModuleGraph>, is_single_page: bool) -> Result<Vc<Self>> {
-        let graphs = &graphs.await?.graphs;
+        let graphs_ref = &graphs.await?.graphs;
         let next_dynamic = async {
-            graphs
+            graphs_ref
                 .iter()
                 .map(|graph| {
                     NextDynamicGraph::new_with_entries(**graph, is_single_page).to_resolved()
@@ -428,7 +569,7 @@ impl ReducedGraphs {
         .instrument(tracing::info_span!("generating next/dynamic graphs"));
 
         let server_actions = async {
-            graphs
+            graphs_ref
                 .iter()
                 .map(|graph| {
                     ServerActionsGraph::new_with_entries(**graph, is_single_page).to_resolved()
@@ -439,7 +580,7 @@ impl ReducedGraphs {
         .instrument(tracing::info_span!("generating server actions graphs"));
 
         let client_references = async {
-            graphs
+            graphs_ref
                 .iter()
                 .map(|graph| {
                     ClientReferencesGraph::new_with_entries(**graph, is_single_page).to_resolved()
@@ -456,6 +597,8 @@ impl ReducedGraphs {
             next_dynamic: next_dynamic?,
             server_actions: server_actions?,
             client_references: client_references?,
+            bare_graphs: graphs.to_resolved().await?,
+            is_single_page,
         }
         .cell())
     }
@@ -575,6 +718,29 @@ impl ReducedGraphs {
             }
 
             Ok(result.cell())
+        }
+        .instrument(span)
+        .await
+    }
+
+    #[turbo_tasks::function]
+    pub async fn validate_pages_css_imports(
+        &self,
+        entry: Vc<Box<dyn Module>>,
+        // TODO potentially more arguments
+    ) -> Result<()> {
+        let span = tracing::info_span!("validate pages css imports");
+        async move {
+            let _ = self
+                .bare_graphs
+                .await?
+                .graphs
+                .iter()
+                .map(|graph| validate_pages_css_imports(**graph, self.is_single_page, entry))
+                .try_join()
+                .await?;
+
+            Ok(())
         }
         .instrument(span)
         .await

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cell::RefCell, rc::Rc};
+use std::borrow::Cow;
 
 use anyhow::Result;
 use either::Either;
@@ -12,9 +12,10 @@ use next_core::{
 };
 use rustc_hash::FxHashMap;
 use tracing::Instrument;
+use turbo_rcstr::RcStr;
 use turbo_tasks::{
     CollectiblesSource, FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt,
-    TryJoinIterExt, Vc,
+    TryJoinIterExt, ValueToString, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::css::{CssModuleAsset, ModuleCssAsset};
@@ -402,23 +403,20 @@ impl ClientReferencesGraph {
 }
 
 #[turbo_tasks::value(shared)]
-pub struct CssGlobalImportIssue {
+struct CssGlobalImportIssue {
     parent_module: ResolvedVc<Box<dyn Module>>,
     module: ResolvedVc<Box<dyn Module>>,
 }
 
-#[turbo_tasks::value_impl]
 impl CssGlobalImportIssue {
-    #[turbo_tasks::function]
-    pub fn new(
+    fn new(
         parent_module: ResolvedVc<Box<dyn Module>>,
         module: ResolvedVc<Box<dyn Module>>,
-    ) -> Vc<Self> {
+    ) -> Self {
         Self {
             parent_module,
             module,
         }
-        .cell()
     }
 }
 
@@ -426,33 +424,49 @@ impl CssGlobalImportIssue {
 impl Issue for CssGlobalImportIssue {
     #[turbo_tasks::function]
     async fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(
-            format!(
-                "CSS global import in {}",
-                self.parent_module.ident().path().await.unwrap().path
-            )
-            .into(),
-        )
+        StyledString::Stack(vec![
+            StyledString::Text("Failed to compile".into()),
+            StyledString::Text(
+                "Global CSS cannot be imported from files other than your Custom <App>. Due to \
+                 the Global nature of stylesheets, and to avoid conflicts, Please move all \
+                 first-party global CSS imports to pages/_app.js. Or convert the import to \
+                 Component-Level CSS (CSS Modules)."
+                    .into(),
+            ),
+            StyledString::Text("Read more: https://nextjs.org/docs/messages/css-global".into()),
+        ])
         .cell()
     }
 
     #[turbo_tasks::function]
-    async fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(
-                format!(
-                    "CSS global import in {}, cannot import {}",
-                    self.parent_module.ident().path().await.unwrap().path,
-                    self.module.ident().path().await.unwrap().path
-                )
-                .into(),
-            )
+    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+        let parent_path = &self.parent_module.ident().path();
+        let module_path = &self.module.ident().path();
+        let relative_import_location = parent_path.parent().await?;
+
+        let import_path = match relative_import_location.get_relative_path_to(&*module_path.await?)
+        {
+            Some(path) => path,
+            None => module_path.await?.path.clone(),
+        };
+        let cleaned_import_path =
+            if import_path.ends_with(".scss.css") || import_path.ends_with(".sass.css") {
+                RcStr::from(import_path.trim_end_matches(".css"))
+            } else {
+                import_path
+            };
+
+        Ok(Vc::cell(Some(
+            StyledString::Stack(vec![
+                StyledString::Text(format!("Location: {}", parent_path.await?.path).into()),
+                StyledString::Text(format!("Import path: {cleaned_import_path}",).into()),
+            ])
             .resolved_cell(),
-        ))
+        )))
     }
 
     fn severity(&self) -> IssueSeverity {
-        IssueSeverity::Warning.into()
+        IssueSeverity::Error
     }
 
     #[turbo_tasks::function]
@@ -466,17 +480,26 @@ impl Issue for CssGlobalImportIssue {
     }
 }
 
+type FxModuleNameMap = FxIndexMap<ResolvedVc<Box<dyn Module>>, RcStr>;
+
+#[turbo_tasks::value(transparent)]
+struct ModuleNameMap(pub FxModuleNameMap);
+
 #[turbo_tasks::function]
 async fn validate_pages_css_imports(
     graph: Vc<SingleModuleGraph>,
     is_single_page: bool,
     entry: Vc<Box<dyn Module>>,
-    // TODO potentially more arguments
+    app_module: ResolvedVc<Box<dyn Module>>,
+    module_name_map: ResolvedVc<ModuleNameMap>,
 ) -> Result<()> {
     let graph = &*graph.await?;
     let entry = entry.to_resolved().await?;
+    let module_name_map = module_name_map.await?;
 
     let entries = if !is_single_page {
+        // TODO: Optimize this code by checking if the node is an entry using `get_module` and then
+        // checking if the node is an entry in the graph by looking for the reverse edges.
         if !graph.entry_modules().any(|m| m == entry) {
             // the graph doesn't contain the entry, e.g. for the additional module graph
             return Ok(());
@@ -486,54 +509,47 @@ async fn validate_pages_css_imports(
         Either::Right(graph.entry_modules())
     };
 
-    let issues = Rc::new(RefCell::new(Vec::new()));
-    let issues_ref = issues.clone();
-
     graph.traverse_edges_from_entries(entries, |parent_info, node| {
         let module = node.module;
+
+        let module_name_contains_node_modules = module_name_map
+            .get(&module)
+            .is_some_and(|s| s.contains("node_modules"));
+
+        if module_name_contains_node_modules {
+            return GraphTraversalAction::Continue;
+        }
+
         let Some((parent_node, _)) = parent_info else {
             // root node, no parent
             return GraphTraversalAction::Continue;
         };
+
         let parent_module = parent_node.module;
+        let parent_is_css_module = ResolvedVc::try_downcast_type::<ModuleCssAsset>(parent_module)
+            .is_some()
+            || ResolvedVc::try_downcast_type::<CssModuleAsset>(parent_module).is_some();
 
-        // TODO validate parent_module -> module import
+        if parent_is_css_module {
+            return GraphTraversalAction::Continue;
+        }
 
-        if parent_module == entry
-            && ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some()
-        {
-            println!("css import found");
+        let module_is_global_css =
+            ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some();
+
+        if !module_is_global_css {
+            return GraphTraversalAction::Continue;
         }
-        if parent_module != entry
-            && ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some()
-        {
-            issues_ref
-                .borrow_mut()
-                .push(CssGlobalImportIssue::new(*parent_module, *module));
-            println!("css invalid global import found");
-        }
-        if parent_module != entry
-            && ResolvedVc::try_downcast_type::<ModuleCssAsset>(module).is_some()
-        {
-            println!("css valid module import found");
+
+        if parent_module != app_module {
+            CssGlobalImportIssue::new(parent_module, module)
+                .resolved_cell()
+                .emit();
         }
 
         GraphTraversalAction::Continue
     })?;
 
-    CssGlobalImportIssue::new(*entry, *entry)
-        .to_resolved()
-        .await;
-
-    // resolve_issues(&issues.borrow()).await?;
-
-    Ok(())
-}
-
-async fn resolve_issues(issues: &[Vc<CssGlobalImportIssue>]) -> Result<()> {
-    for issue in issues.iter() {
-        issue.to_resolved().await?.emit();
-    }
     Ok(())
 }
 
@@ -727,16 +743,42 @@ impl ReducedGraphs {
     pub async fn validate_pages_css_imports(
         &self,
         entry: Vc<Box<dyn Module>>,
-        // TODO potentially more arguments
+        app_module: Vc<Box<dyn Module>>,
     ) -> Result<()> {
         let span = tracing::info_span!("validate pages css imports");
         async move {
+            let mut ident_vec = Vec::new();
+            for graph in self.bare_graphs.await?.graphs.iter() {
+                let inputs = graph
+                    .await?
+                    .graph
+                    .node_weights()
+                    .map(async |n| {
+                        Ok((
+                            n.module(),
+                            RcStr::from(n.module().ident().to_string().await?.as_str()),
+                        ))
+                    })
+                    .try_join()
+                    .await?;
+                ident_vec.extend(inputs);
+            }
+            let idents = ModuleNameMap(ident_vec.into_iter().collect::<FxIndexMap<_, _>>()).cell();
+
             let _ = self
                 .bare_graphs
                 .await?
                 .graphs
                 .iter()
-                .map(|graph| validate_pages_css_imports(**graph, self.is_single_page, entry))
+                .map(|graph| {
+                    validate_pages_css_imports(
+                        **graph,
+                        self.is_single_page,
+                        entry,
+                        app_module,
+                        idents,
+                    )
+                })
                 .try_join()
                 .await?;
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1002,14 +1002,27 @@ impl PageEndpoint {
                     *project.per_page_module_graph().await?,
                 );
 
-                let client_module_assets = &self.client_module().ident().await?.assets;
-                for (_key, asset) in client_module_assets {
-                    println!("Client module asset: {:?}", asset.path().await?.path);
+                // We only validate the global css imports when there is not a `app` folder at the
+                // root of the project.
+                if project.app_project().await?.is_none() {
+                    let app_module = project
+                        .pages_project()
+                        .client_module_context()
+                        .process(
+                            Vc::upcast(FileSource::new(
+                                this.pages_structure.await?.app.file_path(),
+                            )),
+                            ReferenceType::Entry(EntryReferenceSubType::Page),
+                        )
+                        .to_resolved()
+                        .await?
+                        .module();
+
+                    reduced_graphs
+                        .validate_pages_css_imports(self.client_module(), app_module)
+                        .await?;
                 }
 
-                reduced_graphs
-                    .validate_pages_css_imports(self.client_module())
-                    .await?;
                 let next_dynamic_imports = reduced_graphs
                     .get_next_dynamic_imports_for_endpoint(self.client_module())
                     .await?;

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1001,6 +1001,15 @@ impl PageEndpoint {
                     client_module_graph,
                     *project.per_page_module_graph().await?,
                 );
+
+                let client_module_assets = &self.client_module().ident().await?.assets;
+                for (_key, asset) in client_module_assets {
+                    println!("Client module asset: {:?}", asset.path().await?.path);
+                }
+
+                reduced_graphs
+                    .validate_pages_css_imports(self.client_module())
+                    .await?;
                 let next_dynamic_imports = reduced_graphs
                     .get_next_dynamic_imports_for_endpoint(self.client_module())
                     .await?;

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -3,31 +3,24 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
 
 describe('Invalid Global CSS with Custom App', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+  })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('styles/global.scss')
-        expect(stderr).toMatch(
-          /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-      })
-    }
-  )
+  it('should fail to build', async () => {
+    const { code, stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+    })
+    expect(code).not.toBe(0)
+    expect(stderr).toContain('Failed to compile')
+    expect(stderr).toContain('styles/global.scss')
+    expect(stderr).toMatch(
+      /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+    )
+    expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+  })
 })

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -3,31 +3,24 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
 
 describe('Invalid Global CSS', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+  })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('styles/global.scss')
-        expect(stderr).toMatch(
-          /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-      })
-    }
-  )
+  it('should fail to build', async () => {
+    const { code, stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+    })
+    expect(code).not.toBe(0)
+    expect(stderr).toContain('Failed to compile')
+    expect(stderr).toContain('styles/global.scss')
+    expect(stderr).toMatch(
+      /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+    )
+    expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+  })
 })

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -3,31 +3,22 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
 
 describe('Valid and Invalid Global CSS with Custom App', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+  })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('styles/global.scss')
-        expect(stderr).toContain(
-          'Please move all first-party global CSS imports'
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-      })
-    }
-  )
+  it('should fail to build', async () => {
+    const { code, stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+    })
+    expect(code).not.toBe(0)
+    expect(stderr).toContain('Failed to compile')
+    expect(stderr).toContain('styles/global.scss')
+    expect(stderr).toContain('Please move all first-party global CSS imports')
+    expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+  })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5176,17 +5176,15 @@
     "runtimeError": false
   },
   "test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts": {
-    "passed": [],
-    "failed": [
-      "Invalid Global CSS with Custom App production only should fail to build"
-    ],
+    "passed": ["Invalid Global CSS with Custom App should fail to build"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false
   },
   "test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts": {
-    "passed": [],
-    "failed": ["Invalid Global CSS production only should fail to build"],
+    "passed": ["Invalid Global CSS should fail to build"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false
@@ -5408,10 +5406,10 @@
     "runtimeError": false
   },
   "test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts": {
-    "passed": [],
-    "failed": [
-      "Valid and Invalid Global CSS with Custom App production only should fail to build"
+    "passed": [
+      "Valid and Invalid Global CSS with Custom App should fail to build"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -176,7 +176,7 @@ impl GraphEntries {
 #[turbo_tasks::value(cell = "new", eq = "manual", into = "new")]
 #[derive(Clone, Default)]
 pub struct SingleModuleGraph {
-    graph: TracedDiGraph<SingleModuleGraphNode, RefData>,
+    pub graph: TracedDiGraph<SingleModuleGraphNode, RefData>,
 
     /// The number of modules in the graph (excluding VisitedModule nodes)
     pub number_of_modules: usize,


### PR DESCRIPTION
## Implement CSS Global Import Validation for Pages

This PR adds validation for CSS imports in the Pages Router to prevent global CSS imports in invalid modules.

Fixes #

Closes PACK-4895