### PR TITLE
docs(fetch): update wording on conflicting cache and revalidate options

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/fetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/fetch.mdx
@@ -72,7 +72,7 @@ Set the cache lifetime of a resource (in seconds).
 > - If an individual `fetch()` request sets a `revalidate` number lower than the [default `revalidate`](/docs/app/api-reference/file-conventions/route-segment-config#revalidate) of a route, the whole route revalidation interval will be decreased.
 > - If two fetch requests with the same URL in the same route have different `revalidate` values, the lower value will be used.
 > - As a convenience, it is not necessary to set the `cache` option if `revalidate` is set to a number.
-> - Conflicting options such as `{ revalidate: 3600, cache: 'no-store' }` will cause an error.
+> - Conflicting options such as `{ revalidate: 3600, cache: 'no-store' }` will result in a warning in the terminal.
 
 ### `options.next.tags`
 


### PR DESCRIPTION
Clarifies that using conflicting options such as `{ revalidate: 3600, cache: 'no-store' }` results in a warning in the terminal rather than an error.

This change helps accurately reflect the current runtime behavior and avoids misleading readers into expecting a hard failure.

The update improves developer understanding when configuring fetch/cache strategies in their applications.