### PR TITLE
Remove `turbo_tasks::function` from `AssetContext::layer`

### DIFF
--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -3,7 +3,7 @@ use std::{io::Write, iter::once};
 use anyhow::{Context, Result, bail};
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{IntoTraitRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -187,7 +187,7 @@ impl Module for EcmascriptClientReferenceModule {
         Ok(self
             .server_ident
             .with_modifier(rcstr!("client reference proxy"))
-            .with_layer(self.server_asset_context.layer().owned().await?))
+            .with_layer(self.server_asset_context.into_trait_ref().await?.layer()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -64,8 +64,7 @@ pub trait AssetContext {
     fn compile_time_info(self: Vc<Self>) -> Vc<CompileTimeInfo>;
 
     /// Gets the layer of the asset context.
-    #[turbo_tasks::function]
-    fn layer(self: Vc<Self>) -> Vc<RcStr>;
+    fn layer(&self) -> RcStr;
 
     /// Gets the resolve options for a given path.
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{IntoTraitRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -121,7 +121,7 @@ impl Module for CssModuleAsset {
             .source
             .ident()
             .with_modifier(rcstr!("css"))
-            .with_layer(self.asset_context.layer().owned().await?);
+            .with_layer(self.asset_context.into_trait_ref().await?.layer());
         if let Some(import_context) = self.import_context {
             ident = ident.with_modifier(import_context.modifier().owned().await?)
         }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -5,7 +5,7 @@ use indoc::formatdoc;
 use lightningcss::css_modules::CssModuleReference;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, IntoTraitRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -64,7 +64,7 @@ impl Module for ModuleCssAsset {
             .source
             .ident()
             .with_modifier(rcstr!("css module"))
-            .with_layer(self.asset_context.layer().owned().await?))
+            .with_layer(self.asset_context.into_trait_ref().await?.layer()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -71,8 +71,8 @@ pub use transform::{
 };
 use turbo_rcstr::rcstr;
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc,
-    trace::TraceRawVcs,
+    FxIndexMap, IntoTraitRef, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt,
+    ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
@@ -645,7 +645,7 @@ impl Module for EcmascriptModuleAsset {
             }
         }
         ident.add_modifier(rcstr!("ecmascript"));
-        ident.layer = Some(self.asset_context.layer().owned().await?);
+        ident.layer = Some(self.asset_context.into_trait_ref().await?.layer());
         Ok(AssetIdent::new(ident))
     }
 

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
+use turbo_tasks::{IntoTraitRef, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -127,7 +127,7 @@ impl Module for WebAssemblyModuleAsset {
             .source
             .ident()
             .with_modifier(rcstr!("wasm module"))
-            .with_layer(self.asset_context.layer().owned().await?))
+            .with_layer(self.asset_context.into_trait_ref().await?.layer()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{IntoTraitRef, ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
@@ -57,7 +57,7 @@ impl Module for RawWebAssemblyModuleAsset {
             .source
             .ident()
             .with_modifier(rcstr!("wasm raw"))
-            .with_layer(self.asset_context.layer().owned().await?))
+            .with_layer(self.asset_context.into_trait_ref().await?.layer()))
     }
 }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -701,9 +701,8 @@ impl AssetContext for ModuleAssetContext {
         *self.compile_time_info
     }
 
-    #[turbo_tasks::function]
-    fn layer(&self) -> Vc<RcStr> {
-        Vc::cell(self.layer.clone())
+    fn layer(&self) -> RcStr {
+        self.layer.clone()
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
## Refactor `AssetContext.layer()` from a task function to a regular method

### Why?
This eliminates a turbo task and a cell, but does not change invalidation behavior.

I don't really anticipate a performance delta in any direction, but this this means in  https://github.com/vercel/next.js/pull/80388 the new `LayerName` struct would not need to be a `turbo_tasks::value`

Closes PACK-4849