### PR TITLE
[segment explorer] handle builtin not-found

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -79,10 +79,11 @@ const GLOBAL_NOT_FOUND_FILE_TYPE = 'global-not-found'
 const PAGE_SEGMENT = 'page$'
 const PARALLEL_CHILDREN_SEGMENT = 'children$'
 
-const defaultGlobalErrorPath = 'next/dist/client/components/global-error'
-const defaultNotFoundPath = 'next/dist/client/components/not-found-error'
-const defaultLayoutPath = 'next/dist/client/components/default-layout'
-const defaultGlobalNotFoundPath = 'next/dist/client/components/global-not-found'
+const defaultGlobalErrorPath = 'next/dist/client/components/global-error.js'
+const defaultNotFoundPath = 'next/dist/client/components/not-found-error.js'
+const defaultLayoutPath = 'next/dist/client/components/default-layout.js'
+const defaultGlobalNotFoundPath =
+  'next/dist/client/components/global-not-found.js'
 
 type DirResolver = (pathToResolve: string) => string
 type PathResolver = (

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -39,7 +39,6 @@ function PageSegmentTreeLayerPresentation({
   node: SegmentTrieNode
   level: number
 }) {
-  const nodeName = node.value?.type
   const childrenKeys = Object.keys(node.children)
 
   const sortedChildrenKeys = childrenKeys.sort((a, b) => {
@@ -99,43 +98,46 @@ function PageSegmentTreeLayerPresentation({
           className="segment-explorer-item"
           data-nextjs-devtool-segment-explorer-segment={segment + '-' + level}
         >
-          <div className="segment-explorer-line">
-            <div
-              className={`segment-explorer-line-text-${nodeName ?? '<folder>'}`}
-            >
-              <div className="segment-explorer-filename">
-                {folderName && (
-                  <span className="segment-explorer-filename--path">
-                    {folderName}
-                    {/* hidden slashes for testing snapshots */}
-                    <small>{'/'}</small>
-                  </span>
-                )}
-                {/* display all the file segments in this level */}
-                {filesChildrenKeys.length > 0 && (
-                  <span className="segment-explorer-files">
-                    {filesChildrenKeys.map((fileChildSegment) => {
-                      const childNode = node.children[fileChildSegment]
-                      if (!childNode || !childNode.value) {
-                        return null
-                      }
-                      const fileName =
-                        childNode.value.pagePath.split('/').pop() || ''
-                      return (
-                        <span
-                          key={fileChildSegment}
-                          className={cx(
-                            'segment-explorer-file-label',
-                            `segment-explorer-file-label--${childNode.value.type}`
-                          )}
-                        >
-                          {fileName}
-                        </span>
-                      )
-                    })}
-                  </span>
-                )}
-              </div>
+          <div
+            className="segment-explorer-item-row"
+            style={{
+              // If it's children levels, show indents if there's any file at that level.
+              // Otherwise it's empty folder, no need to show indents.
+              ...{ paddingLeft: `${(level + 1) * 8}px` },
+            }}
+          >
+            <div className="segment-explorer-filename">
+              {folderName && (
+                <span className="segment-explorer-filename--path">
+                  {folderName}
+                  {/* hidden slashes for testing snapshots */}
+                  <small>{'/'}</small>
+                </span>
+              )}
+              {/* display all the file segments in this level */}
+              {filesChildrenKeys.length > 0 && (
+                <span className="segment-explorer-files">
+                  {filesChildrenKeys.map((fileChildSegment) => {
+                    const childNode = node.children[fileChildSegment]
+                    if (!childNode || !childNode.value) {
+                      return null
+                    }
+                    const fileName =
+                      childNode.value.pagePath.split('/').pop() || ''
+                    return (
+                      <span
+                        key={fileChildSegment}
+                        className={cx(
+                          'segment-explorer-file-label',
+                          `segment-explorer-file-label--${childNode.value.type}`
+                        )}
+                      >
+                        {fileName}
+                      </span>
+                    )
+                  })}
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -202,6 +204,9 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     padding-top: 10px;
     padding-bottom: 10px;
     padding-right: 4px;
+    white-space: pre;
+    cursor: default;
+    color: var(--color-gray-1000);
   }
 
   .segment-explorer-children--intended {
@@ -222,15 +227,6 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
   }
   .segment-explorer-filename--name {
     color: var(--color-gray-800);
-  }
-
-  .segment-explorer-line {
-    white-space: pre;
-    cursor: default;
-  }
-
-  .segment-explorer-line {
-    color: var(--color-gray-1000);
   }
 
   .segment-explorer-files {

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -99,49 +99,42 @@ function PageSegmentTreeLayerPresentation({
           className="segment-explorer-item"
           data-nextjs-devtool-segment-explorer-segment={segment + '-' + level}
         >
-          <div
-            className="segment-explorer-item-row"
-            style={{
-              // If it's children levels, show indents if there's any file at that level.
-              // Otherwise it's empty folder, no need to show indents.
-              ...{ paddingLeft: `${(level + 1) * 8}px` },
-            }}
-          >
-            <div className="segment-explorer-line">
-              <div className={`segment-explorer-line-text-${nodeName}`}>
-                <div className="segment-explorer-filename">
-                  {folderName && (
-                    <span className="segment-explorer-filename--path">
-                      {folderName}
-                      {/* hidden slashes for testing snapshots */}
-                      <small>{'/'}</small>
-                    </span>
-                  )}
-                  {/* display all the file segments in this level */}
-                  {filesChildrenKeys.length > 0 && (
-                    <span className="segment-explorer-files">
-                      {filesChildrenKeys.map((fileChildSegment) => {
-                        const childNode = node.children[fileChildSegment]
-                        if (!childNode || !childNode.value) {
-                          return null
-                        }
-                        const fileName =
-                          childNode.value.pagePath.split('/').pop() || ''
-                        return (
-                          <span
-                            key={fileChildSegment}
-                            className={cx(
-                              'segment-explorer-file-label',
-                              `segment-explorer-file-label--${childNode.value.type}`
-                            )}
-                          >
-                            {fileName}
-                          </span>
-                        )
-                      })}
-                    </span>
-                  )}
-                </div>
+          <div className="segment-explorer-line">
+            <div
+              className={`segment-explorer-line-text-${nodeName ?? '<folder>'}`}
+            >
+              <div className="segment-explorer-filename">
+                {folderName && (
+                  <span className="segment-explorer-filename--path">
+                    {folderName}
+                    {/* hidden slashes for testing snapshots */}
+                    <small>{'/'}</small>
+                  </span>
+                )}
+                {/* display all the file segments in this level */}
+                {filesChildrenKeys.length > 0 && (
+                  <span className="segment-explorer-files">
+                    {filesChildrenKeys.map((fileChildSegment) => {
+                      const childNode = node.children[fileChildSegment]
+                      if (!childNode || !childNode.value) {
+                        return null
+                      }
+                      const fileName =
+                        childNode.value.pagePath.split('/').pop() || ''
+                      return (
+                        <span
+                          key={fileChildSegment}
+                          className={cx(
+                            'segment-explorer-file-label',
+                            `segment-explorer-file-label--${childNode.value.type}`
+                          )}
+                        >
+                          {fileName}
+                        </span>
+                      )
+                    })}
+                  </span>
+                )}
               </div>
             </div>
           </div>
@@ -190,7 +183,6 @@ export function SegmentsExplorer({
 
 export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
   .segment-explorer-content {
-    overflow-y: auto;
     font-size: var(--size-14);
     margin: -12px -8px;
   }

--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer.ts
@@ -141,7 +141,7 @@ const trie: SegmentTrie = createTrie({
     if (!a || !b) return false
     return a.pagePath === b.pagePath && a.type === b.type
   },
-  getCharacters: (item) => item.pagePath.split('/'),
+  getCharacters: (item) => item.pagePath.split('/').filter(Boolean),
 })
 export const insertSegmentNode = trie.insert
 export const removeSegmentNode = trie.remove

--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer.ts
@@ -141,7 +141,7 @@ const trie: SegmentTrie = createTrie({
     if (!a || !b) return false
     return a.pagePath === b.pagePath && a.type === b.type
   },
-  getCharacters: (item) => item.pagePath.split('/').filter(Boolean),
+  getCharacters: (item) => item.pagePath.split('/'),
 })
 export const insertSegmentNode = trie.insert
 export const removeSegmentNode = trie.remove

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1033,7 +1033,8 @@ function normalizeConventionFilePath(
   conventionPath: string | undefined
 ) {
   const cwd = process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd()
-  const nextInternalPrefixRegex = /^next[\\/]dist[\\/]client[\\/]components[\\/]/
+  const nextInternalPrefixRegex =
+    /^(.*[\\/])?next[\\/]dist[\\/]client[\\/]components[\\/]/
 
   let relativePath = (conventionPath || '')
     // remove turbopack [project] prefix
@@ -1045,13 +1046,9 @@ function normalizeConventionFilePath(
     // remove /(src/)?app/ dir prefix
     .replace(/^([\\/])*(src[\\/])?app[\\/]/, '')
 
+  // If it's internal file only keep the filename, strip nextjs internal prefix
   if (nextInternalPrefixRegex.test(relativePath)) {
     relativePath = relativePath.replace(nextInternalPrefixRegex, '')
-    if (relativePath === 'not-found-error') {
-      // Special case for the built-in not-found-error convention file
-      // which is used to render the 404 page.
-      relativePath = '*not-found'
-    }
   }
 
   return relativePath

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1033,7 +1033,9 @@ function normalizeConventionFilePath(
   conventionPath: string | undefined
 ) {
   const cwd = process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd()
-  const relativePath = (conventionPath || '')
+  const nextInternalPrefixRegex = /^next[\\/]dist[\\/]client[\\/]components[\\/]/
+
+  let relativePath = (conventionPath || '')
     // remove turbopack [project] prefix
     .replace(/^\[project\][\\/]/, '')
     // remove the project root from the path
@@ -1042,6 +1044,15 @@ function normalizeConventionFilePath(
     .replace(cwd, '')
     // remove /(src/)?app/ dir prefix
     .replace(/^([\\/])*(src[\\/])?app[\\/]/, '')
+
+  if (nextInternalPrefixRegex.test(relativePath)) {
+    relativePath = relativePath.replace(nextInternalPrefixRegex, '')
+    if (relativePath === 'not-found-error') {
+      // Special case for the built-in not-found-error convention file
+      // which is used to render the 404 page.
+      relativePath = '*not-found'
+    }
+  }
 
   return relativePath
 }

--- a/test/development/app-dir/segment-explorer/app/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/page.tsx
@@ -4,7 +4,7 @@ const hrefs = [
   '/parallel-routes',
   '/blog/~/grid',
   '/soft-navigation/a',
-  '/file-system-routes',
+  '/file-segments',
 ]
 
 export default function Page() {

--- a/test/development/app-dir/segment-explorer/app/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+const hrefs = [
+  '/parallel-routes',
+  '/blog/~/grid',
+  '/soft-navigation/a',
+  '/file-system-routes',
+]
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Segment Explorer</h1>
+      <p>Examples</p>
+      <div>
+        {hrefs.map((href) => (
+          <div key={href}>
+            <Link href={href}>{href}</Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/runtime-error/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/runtime-error/page.tsx
@@ -2,7 +2,7 @@
 
 export default function Page() {
   if (typeof window !== 'undefined') {
-    throw new Error('This page should only be rendered on the client side.')
+    throw new Error('Error on client')
   }
   return <p>page</p>
 }

--- a/test/development/app-dir/segment-explorer/app/runtime-error/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/runtime-error/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+export default function Page() {
+  if (typeof window !== 'undefined') {
+    throw new Error('This page should only be rendered on the client side.')
+  }
+  return <p>page</p>
+}

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -120,7 +120,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
-     *not-found"
+     not-found-error"
     `)
   })
 })

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -120,7 +120,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
-     not-found-error"
+     not-found-error.js"
     `)
   })
 })

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -114,4 +114,13 @@ describe('segment-explorer', () => {
       `"Route Info currently is only available for the App Router."`
     )
   })
+
+  it('should handle special built-in not-found segments', async () => {
+    const browser = await next.browser('/404')
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
+     "app/
+     layout.tsx
+     *not-found"
+    `)
+  })
 })


### PR DESCRIPTION
Let segment explorer display the default 404 page. When there's a Next.js built-in component occurred, remove the next.js pattern prefix `next/dist/client/components/...` including the paths before it, such as `<cwd>/node_modules/...`.

Adding `.js` extension to the file path in Webpack loader to make it align with Turbopack. As Turbopack will show the *resolved* and *bundled* path `[project]/../next/dist/client/components/not-found-error.js`

NEXT-4540