### PR TITLE
Turbopack: make another callback return a result

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -348,7 +348,7 @@ impl ClientReferencesGraph {
                 },
                 |parent_info, node, state_map| {
                     let Some((parent_node, _)) = parent_info else {
-                        return;
+                        return Ok(());
                     };
                     let parent_module = parent_node.module;
 
@@ -378,6 +378,7 @@ impl ClientReferencesGraph {
                         }
                         _ => {}
                     };
+                    Ok(())
                 },
             )?;
 

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -80,7 +80,7 @@ async fn compute_async_module_info_single(
         |parent_info, module, _| {
             let Some((parent_module, ref_data)) = parent_info else {
                 // An entry module
-                return;
+                return Ok(());
             };
             let module = module.module();
             let parent_module = parent_module.module;
@@ -88,6 +88,7 @@ async fn compute_async_module_info_single(
             if ref_data.chunking_type.is_inherit_async() && async_modules.contains(&module) {
                 async_modules.insert(parent_module);
             }
+            Ok(())
         },
     )?;
 

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -567,7 +567,7 @@ impl SingleModuleGraph {
             Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
             &'a SingleModuleGraphNode,
             &mut S,
-        ),
+        ) -> Result<()>,
     ) -> Result<()> {
         let graph = &self.graph;
         let entries = entries.into_iter().map(|e| self.get_module(e).unwrap());
@@ -596,7 +596,7 @@ impl SingleModuleGraph {
             });
             match pass {
                 TopologicalPass::Visit => {
-                    visit_postorder(parent_arg, graph.node_weight(current).unwrap(), state);
+                    visit_postorder(parent_arg, graph.node_weight(current).unwrap(), state)?;
                 }
                 TopologicalPass::ExpandAndVisit => match graph.node_weight(current).unwrap() {
                     current_node @ SingleModuleGraphNode::Module(_) => {
@@ -619,7 +619,7 @@ impl SingleModuleGraph {
                     }
                     current_node @ SingleModuleGraphNode::VisitedModule { .. } => {
                         visit_preorder(parent_arg, current_node, state)?;
-                        visit_postorder(parent_arg, current_node, state);
+                        visit_postorder(parent_arg, current_node, state)?;
                     }
                 },
             }
@@ -1307,7 +1307,7 @@ impl ModuleGraph {
             Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
             &'_ SingleModuleGraphModuleNode,
             &mut S,
-        ),
+        ) -> Result<()>,
     ) -> Result<()> {
         let graphs = self.get_graphs().await?;
 
@@ -1345,7 +1345,7 @@ impl ModuleGraph {
             let current_node = get_node!(graphs, current)?;
             match pass {
                 TopologicalPass::Visit => {
-                    visit_postorder(parent_arg, current_node, state);
+                    visit_postorder(parent_arg, current_node, state)?;
                 }
                 TopologicalPass::ExpandAndVisit => {
                     let action = visit_preorder(parent_arg, current_node, state)?;

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -330,6 +330,7 @@ impl PreBatches {
                 |_, node, state| {
                     let item = PreBatchItem::ParallelModule(node.module);
                     state.items.push(item);
+                    Ok(())
                 },
             )
             .await?;


### PR DESCRIPTION
We already do this in a bunch of these callbacks, because sometimes you have some `Option<>` in there that you know is always set. Except for eventual consistency, unfortunately. That's the main usecase for a result here.

Closes PACK-4848