### PR TITLE
Fix typo in data-security.mdx

### DIFF
--- a/docs/01-app/02-guides/data-security.mdx
+++ b/docs/01-app/02-guides/data-security.mdx
@@ -121,7 +121,7 @@ import { getProfile } from '../../data/user'
 export async function Page({ params: { slug } }) {
   // This page can now safely pass around this profile knowing
   // that it shouldn't contain anything sensitive.
-  const profile = await getProfile(slug);
+  const profile = await getProfileDTO(slug);
   ...
 }
 ```


### PR DESCRIPTION
This PR fixes a typo.
**Problem**: This code block contains function `Page` and it uses `getProfile`. But code block above contain only `getProfileDTO`.
**Solution**: I guess, it should use `getProfileDTO` instead of `getProfile`.