### PR TITLE
Respond with `404` for unknown server actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -625,7 +625,7 @@ export async function handleAction({
   }
 
   try {
-    await actionAsyncStorage.run({ isAction: true }, async () => {
+    return await actionAsyncStorage.run({ isAction: true }, async () => {
       if (
         // The type check here ensures that `req` is correctly typed, and the
         // environment variable check provides dead code elimination.
@@ -658,7 +658,21 @@ export async function handleAction({
               { temporaryReferences }
             )
           } else {
-            const action = await decodeAction(formData, serverModuleMap)
+            let action: (() => unknown) | null = null
+
+            try {
+              action = await decodeAction(formData, serverModuleMap)
+            } catch (err) {
+              const unknownActionId = getActionIdFromReactError(err)
+
+              if (unknownActionId) {
+                console.warn(createUnknownServerActionError(unknownActionId))
+                return { type: 'not-found' }
+              }
+
+              throw err
+            }
+
             if (typeof action === 'function') {
               // Only warn if it's a server action, otherwise skip for other post requests
               warnBadServerActionRequest()
@@ -678,15 +692,14 @@ export async function handleAction({
               )
             }
 
-            // Skip the fetch path
-            return
+            return { type: 'done', result: undefined, formState }
           }
         } else {
           try {
             actionModId = getActionModIdOrError(actionId, serverModuleMap)
           } catch (err) {
             if (actionId !== null) {
-              console.error(err)
+              console.warn(err)
             }
             return {
               type: 'not-found',
@@ -829,8 +842,23 @@ export async function handleAction({
               }),
               duplex: 'half',
             })
+
             const formData = await fakeRequest.formData()
-            const action = await decodeAction(formData, serverModuleMap)
+            let action: (() => unknown) | null = null
+
+            try {
+              action = await decodeAction(formData, serverModuleMap)
+            } catch (err) {
+              const unknownActionId = getActionIdFromReactError(err)
+
+              if (unknownActionId) {
+                console.warn(createUnknownServerActionError(unknownActionId))
+                return { type: 'not-found' }
+              }
+
+              throw err
+            }
+
             if (typeof action === 'function') {
               // Only warn if it's a server action, otherwise skip for other post requests
               warnBadServerActionRequest()
@@ -850,15 +878,14 @@ export async function handleAction({
               )
             }
 
-            // Skip the fetch path
-            return
+            return { type: 'done', result: undefined, formState }
           }
         } else {
           try {
             actionModId = getActionModIdOrError(actionId, serverModuleMap)
           } catch (err) {
             if (actionId !== null) {
-              console.error(err)
+              console.warn(err)
             }
             return {
               type: 'not-found',
@@ -904,11 +931,10 @@ export async function handleAction({
       // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
 
       try {
-        actionModId =
-          actionModId ?? getActionModIdOrError(actionId, serverModuleMap)
+        actionModId ??= getActionModIdOrError(actionId, serverModuleMap)
       } catch (err) {
         if (actionId !== null) {
-          console.error(err)
+          console.warn(err)
         }
         return {
           type: 'not-found',
@@ -942,13 +968,13 @@ export async function handleAction({
           temporaryReferences,
         })
       }
-    })
 
-    return {
-      type: 'done',
-      result: actionResult,
-      formState,
-    }
+      return {
+        type: 'done',
+        result: actionResult,
+        formState,
+      }
+    })
   } catch (err) {
     if (isRedirectError(err)) {
       const redirectUrl = getURLFromRedirectError(err)
@@ -1072,6 +1098,33 @@ async function executeActionAndPrepareForRender<
   }
 }
 
+function createUnknownServerActionError(actionId: string): Error {
+  return new Error(
+    `Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
+  )
+}
+
+const unknownServerActionErrorMessageRegExp =
+  /Could not find the module "(?<actionId>[0-9A-Fa-f]+)" in the React Server Manifest./
+
+/**
+ * Extract the action ID from a React error message that indicates the action ID
+ * could not be found in the server module map. Brand-checking the error message
+ * is a bit unfortunate, but there's currently no other way to detect this case
+ * for MPA server actions, unless we duplicate React's form data parsing.
+ */
+function getActionIdFromReactError(err: unknown): string | undefined {
+  if (err instanceof Error) {
+    const match = err.message.match(unknownServerActionErrorMessageRegExp)
+
+    if (match?.groups?.actionId) {
+      return match.groups.actionId
+    }
+  }
+
+  return undefined
+}
+
 /**
  * Attempts to find the module ID for the action from the module map. When this fails, it could be a deployment skew where
  * the action came from a different deployment. It could also simply be an invalid POST request that is not a server action.
@@ -1089,9 +1142,7 @@ function getActionModIdOrError(
   const actionModId = serverModuleMap[actionId]?.id
 
   if (!actionModId) {
-    throw new Error(
-      `Failed to find Server Action "${actionId}". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
-    )
+    throw createUnknownServerActionError(actionId)
   }
 
   return actionModId

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -50,7 +50,6 @@ import { RedirectStatusCode } from '../../client/components/redirect-status-code
 import { synchronizeMutableCookies } from '../async-storage/request-store'
 import type { TemporaryReferenceSet } from 'react-server-dom-webpack/server.edge'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
-import { InvariantError } from '../../shared/lib/invariant-error'
 import { executeRevalidates } from '../revalidation-utils'
 import { getRequestMeta } from '../request-meta'
 
@@ -695,15 +694,16 @@ export async function handleAction({
             return { type: 'done', result: undefined, formState }
           }
         } else {
+          if (!actionId) {
+            // We don't consider this a server action when there's no actionId.
+            return undefined
+          }
+
           try {
             actionModId = getActionModIdOrError(actionId, serverModuleMap)
           } catch (err) {
-            if (actionId !== null) {
-              console.warn(err)
-            }
-            return {
-              type: 'not-found',
-            }
+            console.warn(err)
+            return { type: 'not-found' }
           }
 
           const chunks: Buffer[] = []
@@ -881,15 +881,16 @@ export async function handleAction({
             return { type: 'done', result: undefined, formState }
           }
         } else {
+          if (!actionId) {
+            // We don't consider this a server action when there's no actionId.
+            return undefined
+          }
+
           try {
             actionModId = getActionModIdOrError(actionId, serverModuleMap)
           } catch (err) {
-            if (actionId !== null) {
-              console.warn(err)
-            }
-            return {
-              type: 'not-found',
-            }
+            console.warn(err)
+            return { type: 'not-found' }
           }
 
           const chunks: Buffer[] = []
@@ -930,15 +931,16 @@ export async function handleAction({
       // / -> fire action -> POST / -> appRender1 -> modId for the action file
       // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
 
+      if (!actionId) {
+        // We don't consider this a server action when there's no actionId.
+        return undefined
+      }
+
       try {
         actionModId ??= getActionModIdOrError(actionId, serverModuleMap)
       } catch (err) {
-        if (actionId !== null) {
-          console.warn(err)
-        }
-        return {
-          type: 'not-found',
-        }
+        console.warn(err)
+        return { type: 'not-found' }
       }
 
       const actionMod = (await ComponentMod.__next_app__.require(
@@ -1131,14 +1133,9 @@ function getActionIdFromReactError(err: unknown): string | undefined {
  * In either case, we'll throw an error to be handled by the caller.
  */
 function getActionModIdOrError(
-  actionId: string | null,
+  actionId: string,
   serverModuleMap: ServerModuleMap
 ): string {
-  // if we're missing the action ID header, we can't do any further processing
-  if (!actionId) {
-    throw new InvariantError("Missing 'next-action' header.")
-  }
-
   const actionModId = serverModuleMap[actionId]?.id
 
   if (!actionModId) {

--- a/test/e2e/app-dir/actions-deployment-skew/actions-deployment-skew.test.ts
+++ b/test/e2e/app-dir/actions-deployment-skew/actions-deployment-skew.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable jest/no-standalone-expect */
+import { nextTestSetup } from 'e2e-utils'
+
+const unknownActionId = 'abcdef1234567890'
+
+describe('actions-deployment-skew', () => {
+  const { next, isNextDeploy, isNextDev, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  let cliOutputLength = 0
+
+  beforeEach(() => {
+    cliOutputLength = next.cliOutput.length
+  })
+
+  describe.each(['node', 'edge'])('in the %s runtime', (runtime) => {
+    describe.each([
+      {
+        name: 'with a normal action',
+        page: 'action',
+        disableJavaScript: false,
+      },
+      {
+        name: 'with a form action and JavaScript enabled',
+        page: 'form-action',
+        disableJavaScript: false,
+      },
+      {
+        name: 'with a form action and JavaScript disabled',
+        page: 'form-action',
+        disableJavaScript: true,
+      },
+    ])('$name', ({ page, disableJavaScript }) => {
+      // TODO: In the Edge runtime with Turbopack in dev mode, there's a "use client" error
+      // in next/dist/esm/next-devtools/userspace/use-app-dev-rendering-indicator.js.
+      ;(runtime === 'edge' && isNextDev && isTurbopack ? it.skip : it)(
+        'should respond with a 404 for an unknown server action',
+        async () => {
+          const pathname = `/${runtime}/${page}`
+          const browser = await next.browser(pathname, {
+            disableJavaScript,
+            beforePageLoad(page) {
+              page.route(
+                (url) => url.pathname === pathname,
+                async (route, request) => {
+                  if (request.method() === 'POST') {
+                    const headers = request.headers()
+                    let postData = request.postData()
+
+                    if (headers['next-action']) {
+                      headers['next-action'] = unknownActionId
+                    }
+
+                    if (
+                      headers['content-type']?.startsWith('multipart/form-data')
+                    ) {
+                      // Currently not used because the form uses useActionState,
+                      // which makes React encode the action ID differently.
+                      postData = postData.replace(
+                        /\$ACTION_ID_[0-9A-Fa-f]+/,
+                        `$ACTION_ID_${unknownActionId}`
+                      )
+                      // Instead, this is required to be patched:
+                      postData = postData.replace(
+                        /"id":"[0-9A-Fa-f]+"/g,
+                        `"id":"${unknownActionId}"`
+                      )
+                    }
+
+                    return route.continue({ headers, postData })
+                  }
+
+                  return route.continue()
+                }
+              )
+
+              page.on('response', async (response) => {
+                const request = response.request()
+
+                if (
+                  request.url().endsWith(pathname) &&
+                  request.method() === 'POST'
+                ) {
+                  expect(response.status()).toBe(404)
+                }
+              })
+            },
+          })
+
+          const button = await browser.elementById('action-button')
+          await button.click()
+
+          if (disableJavaScript) {
+            expect(await browser.elementByCss('h2').text()).toBe(
+              'This page could not be found.'
+            )
+          } else {
+            expect(await browser.elementById('error-message').text()).toBe(
+              'An unexpected response was received from the server.'
+            )
+          }
+
+          if (!isNextDeploy) {
+            expect(next.cliOutput.slice(cliOutputLength)).toInclude(
+              `Error: Failed to find Server Action "${unknownActionId}". This request might be from an older or newer deployment.`
+            )
+          }
+        }
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/actions-deployment-skew/app/edge/action/page.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/edge/action/page.tsx
@@ -1,0 +1,2 @@
+export { default } from '../../node/action/page'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/actions-deployment-skew/app/edge/form-action/page.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/edge/form-action/page.tsx
@@ -1,0 +1,2 @@
+export { default } from '../../node/form-action/page'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/actions-deployment-skew/app/error-boundary.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/error-boundary.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Component } from 'react'
+
+export default class ErrorBoundary extends Component<
+  { children: React.ReactNode },
+  { message: null | string }
+> {
+  state = { message: null }
+
+  static getDerivedStateFromError(error: any) {
+    return { message: error.message }
+  }
+
+  render() {
+    return this.state.message !== null ? (
+      <p id="error-message">{this.state.message}</p>
+    ) : (
+      this.props.children
+    )
+  }
+}

--- a/test/e2e/app-dir/actions-deployment-skew/app/layout.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+import ErrorBoundary from './error-boundary'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/actions-deployment-skew/app/node/action/button.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/node/action/button.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useTransition } from 'react'
+
+export function Button({ action }: { action: () => Promise<void> }) {
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <button
+      id="action-button"
+      disabled={isPending}
+      onClick={() => startTransition(action)}
+    >
+      Submit
+    </button>
+  )
+}

--- a/test/e2e/app-dir/actions-deployment-skew/app/node/action/page.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/node/action/page.tsx
@@ -1,0 +1,12 @@
+import { Button } from './button'
+
+export default function Page() {
+  return (
+    <Button
+      action={async () => {
+        'use server'
+        console.log('Action!')
+      }}
+    />
+  )
+}

--- a/test/e2e/app-dir/actions-deployment-skew/app/node/form-action/form.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/node/form-action/form.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useActionState } from 'react'
+
+export function Form({ action }: { action: () => Promise<string> }) {
+  const [result, formAction, isPending] = useActionState(action, 'initial')
+
+  return (
+    <form action={formAction}>
+      <p id="result">{result}</p>
+      <button id="action-button" disabled={isPending}>
+        Submit Form
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/actions-deployment-skew/app/node/form-action/page.tsx
+++ b/test/e2e/app-dir/actions-deployment-skew/app/node/form-action/page.tsx
@@ -1,0 +1,12 @@
+import { Form } from './form'
+
+export default function Page() {
+  return (
+    <Form
+      action={async () => {
+        'use server'
+        return 'result'
+      }}
+    />
+  )
+}

--- a/test/e2e/app-dir/actions-deployment-skew/next.config.js
+++ b/test/e2e/app-dir/actions-deployment-skew/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1778,7 +1778,7 @@ describe('app-dir action handling', () => {
     })
 
     it.each(['307', '308'])(
-      `redirects properly when server action handler redirects with a %s status code`,
+      `redirects properly when route handler redirects with a %s status code`,
       async (statusCode) => {
         const postRequests = []
         const responseCodes = []


### PR DESCRIPTION
When a server action is sent from an older deployment and skew protection is not enabled or implemented, we intended to return a `404` response.

However, this behavior was never properly tested and was accidentally broken in #48626 when `actionAsyncStorage` was added to the action handler without a `return`, preventing the early `'not-found'` returns from taking effect.

This PR restores the `404` response handling and adds end-to-end tests for all server action variations. It also changes logs from errors to warnings to reflect that this scenario is expected to occur occasionally. Warnings remain useful (instead of silent failures), as users may want to tune their skew protection settings based on how often they see them.

fixes #75541