### PR TITLE
[third-party] Add gtm script strategy

### DIFF
--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -16,6 +16,7 @@ export function GoogleTagManager(props: GTMParams) {
     preview,
     dataLayer,
     nonce,
+    strategy,
   } = props
 
   currDataLayerName = dataLayerName
@@ -56,6 +57,7 @@ export function GoogleTagManager(props: GTMParams) {
         data-ntpc="GTM"
         src={`${gtmScriptUrl}?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
         nonce={nonce}
+        strategy={strategy}
       />
     </>
   )

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -1,3 +1,5 @@
+import type { ScriptProps } from 'next/script'
+
 declare global {
   interface Window {
     dataLayer?: Object[]
@@ -20,6 +22,7 @@ export type GTMParams = {
   auth?: string
   preview?: string
   nonce?: string
+  strategy?: ScriptProps['strategy']
 }
 
 export type GAParams = {


### PR DESCRIPTION
### Adding a feature

- Let users specify the strategy for loading the GTM script, allowing users to set different priorities. ie: Not having the GTM script as high priority