### PR TITLE
Fix: Rules of Hooks violation in AppRouter

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React, {
-  use,
   useEffect,
   useMemo,
   startTransition,
@@ -329,7 +328,10 @@ function Router({
     // TODO-APP: Should we listen to navigateerror here to catch failed
     // navigations somehow? And should we call window.stop() if a SPA navigation
     // should interrupt an MPA one?
-    use(unresolvedThenable)
+    // NOTE: This is intentionally using `throw` instead of `use` because we're
+    // inside an externally mutable condition (pushRef.mpaNavigation), which
+    // violates the rules of hooks.
+    throw unresolvedThenable
   }
 
   useEffect(() => {


### PR DESCRIPTION
There's some sketchy logic in AppRouter that (intentionally) violates the rules of hooks by reading an externally mutable condition. The rationalization is that it's OK to do this if the result is to infinitely suspend the component.

However, the mechanism used to infinitely suspend the component is `use(infinitePromise)` — this can lead to subtle bugs because even though `use` can be called conditionally, it relies on the assumption that its invocation is idempotent for the same props and state, i.e. you must still follow the rules of React regarding mutability and side effects.

Ideally we should refactor this block to not rely on external state at all, but in the meantime, we can switch from `use` to `throw` to suspend the component, since `throw` is lower level and isn't modeled as a hook.