### PR TITLE
feat(turbopack): Print a warning about performance when starting with an invalidated cache

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -712,13 +712,14 @@ function bindingToApi(
       )
     }
 
-    compilationEventsSubscribe() {
+    compilationEventsSubscribe(eventTypes?: string[]) {
       return subscribe<TurbopackResult<CompilationEvent>>(
         true,
         async (callback) => {
           binding.projectCompilationEventsSubscribe(
             this._nativeProject,
-            callback
+            callback,
+            eventTypes
           )
         }
       )

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -238,9 +238,9 @@ export interface Project {
     aggregationMs: number
   ): AsyncIterableIterator<TurbopackResult<UpdateMessage>>
 
-  compilationEventsSubscribe(): AsyncIterableIterator<
-    TurbopackResult<CompilationEvent>
-  >
+  compilationEventsSubscribe(
+    eventTypes?: string[]
+  ): AsyncIterableIterator<TurbopackResult<CompilationEvent>>
 
   invalidatePersistentCache(): Promise<void>
 

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -19,8 +19,8 @@ import loadConfig from '../../server/config'
 import { hasCustomExportOutput } from '../../export/utils'
 import { Telemetry } from '../../telemetry/storage'
 import { setGlobal } from '../../trace'
-import * as Log from '../output/log'
 import { isCI } from '../../server/ci-info'
+import { backgroundLogCompilationEvents } from '../../shared/lib/turbopack/compilation-events'
 
 export async function turbopackBuild(): Promise<{
   duration: number
@@ -91,32 +91,7 @@ export async function turbopackBuild(): Promise<{
     }
   )
   try {
-    ;(async function logCompilationEvents() {
-      for await (const event of project.compilationEventsSubscribe()) {
-        switch (event.severity) {
-          case 'EVENT':
-            Log.event(event.message)
-            break
-          case 'TRACE':
-            Log.trace(event.message)
-            break
-          case 'INFO':
-            Log.info(event.message)
-            break
-          case 'WARNING':
-            Log.warn(event.message)
-            break
-          case 'ERROR':
-            Log.error(event.message)
-            break
-          case 'FATAL':
-            Log.error(event.message)
-            break
-          default:
-            break
-        }
-      }
-    })()
+    backgroundLogCompilationEvents(project)
 
     // Write an empty file in a known location to signal this was built with Turbopack
     await fs.writeFile(path.join(distDir, 'turbopack'), '')

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -98,6 +98,7 @@ import { getDevOverlayFontMiddleware } from '../../next-devtools/server/font/get
 import { devIndicatorServerState } from './dev-indicator-server-state'
 import { getDisableDevIndicatorMiddleware } from '../../next-devtools/server/dev-indicator-middleware'
 import { getRestartDevServerMiddleware } from '../../next-devtools/server/restart-dev-server-middleware'
+import { backgroundLogCompilationEvents } from '../../shared/lib/turbopack/compilation-events'
 // import { getSupportedBrowsers } from '../../build/utils'
 
 const wsServer = new ws.Server({ noServer: true })
@@ -248,6 +249,9 @@ export async function createHotReloaderTurbopack(
       memoryLimit: opts.nextConfig.experimental?.turbopackMemoryLimit,
     }
   )
+  backgroundLogCompilationEvents(project, {
+    eventTypes: ['StartupCacheInvalidationEvent'],
+  })
   setBundlerFindSourceMapImplementation(
     getSourceMapFromTurbopack.bind(null, project, projectPath)
   )

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -1,0 +1,44 @@
+import type { Project } from '../../../build/swc/types'
+import * as Log from '../../../build/output/log'
+
+/**
+ * Subscribes to compilation events for `project` and prints them using the
+ * `Log` library.
+ *
+ * The `signal` argument is partially implemented. The abort may not happen until the next
+ * compilation event arrives.
+ */
+export function backgroundLogCompilationEvents(
+  project: Project,
+  { eventTypes, signal }: { eventTypes?: string[]; signal?: AbortSignal } = {}
+) {
+  ;(async function () {
+    for await (const event of project.compilationEventsSubscribe(eventTypes)) {
+      if (signal?.aborted) {
+        return
+      }
+      switch (event.severity) {
+        case 'EVENT':
+          Log.event(event.message)
+          break
+        case 'TRACE':
+          Log.trace(event.message)
+          break
+        case 'INFO':
+          Log.info(event.message)
+          break
+        case 'WARNING':
+          Log.warn(event.message)
+          break
+        case 'ERROR':
+          Log.error(event.message)
+          break
+        case 'FATAL':
+          Log.error(event.message)
+          break
+        default:
+          break
+      }
+    }
+  })()
+}

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -41,6 +41,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
 smallvec = { workspace = true }
 tokio = { workspace = true }
@@ -54,7 +55,6 @@ turbo-tasks-testing = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 regex = { workspace = true }
-serde_json = { workspace = true }
 tempfile = { workspace = true }
 rstest = { workspace = true }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -210,8 +210,8 @@ impl<B: BackingStorage> TurboTasksBackend<B> {
         )))
     }
 
-    pub fn invalidate_storage(&self) -> Result<()> {
-        self.0.backing_storage.invalidate()
+    pub fn backing_storage(&self) -> &B {
+        &self.0.backing_storage
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/database/db_invalidation.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/db_invalidation.rs
@@ -1,14 +1,73 @@
 use std::{
-    fs::{self, read_dir},
-    io::{self, ErrorKind},
+    borrow::Cow,
+    fs::{self, File, read_dir},
+    io::{self, BufReader, BufWriter, ErrorKind, Write},
     path::Path,
 };
 
 use anyhow::Context;
+use serde::{Deserialize, Serialize};
 
 const INVALIDATION_MARKER: &str = "__turbo_tasks_invalidated_db";
 
-/// Atomically write an invalidation marker.
+const EXPLANATION: &str = "The cache database has been invalidated. The existence of this file \
+                           will cause the cache directory to be cleaned up the next time \
+                           Turbopack starts up.";
+const EASTER_EGG: &str =
+    "you just wrote me, and this is crazy, but if you see me, delete everything maybe?";
+
+/// The data written to the file at [`INVALIDATION_MARKER`].
+#[derive(Serialize, Deserialize)]
+struct InvalidationFile<'a> {
+    #[serde(skip_deserializing)]
+    _explanation: Option<&'static str>,
+    #[serde(skip_deserializing)]
+    _easter_egg: Option<&'static str>,
+    /// See [`StartupCacheState::Invalidated::reason_code`].
+    reason_code: Cow<'a, str>,
+}
+
+/// Information about if there's was a pre-existing cache or if the cache was detected as
+/// invalidated during startup.
+///
+/// If the cache was invalidated, the application may choose to show a warning to the user or log it
+/// to telemetry.
+///
+/// This value is returned by [`crate::turbo_backing_storage`] and
+/// [`crate::default_backing_storage`].
+pub enum StartupCacheState {
+    NoCache,
+    Cached,
+    Invalidated {
+        /// A short code passed to [`BackingStorage::invalidate`]. This value is
+        /// application-specific.
+        ///
+        /// If the value is `None` or doesn't match an expected value, the application should just
+        /// treat this reason as unknown. The invalidation file may have been corrupted or
+        /// modified by an external tool.
+        ///
+        /// See [`invalidation_reasons`] for some common reason codes.
+        ///
+        /// [`BackingStorage::invalidate`]: crate::BackingStorage::invalidate
+        reason_code: Option<String>,
+    },
+}
+
+/// Common invalidation reason codes. The application or libraries it uses may choose to use these
+/// reasons, or it may define it's own reasons.
+pub mod invalidation_reasons {
+    /// This invalidation reason is used by [`crate::turbo_backing_storage`] when the database was
+    /// invalidated by a panic.
+    pub const PANIC: &str = concat!(module_path!(), "::PANIC");
+    /// Indicates that the user explicitly clicked a button or ran a command that invalidates the
+    /// cache.
+    pub const USER_REQUEST: &str = concat!(module_path!(), "::USER_REQUEST");
+}
+
+/// Atomically create an invalidation marker.
+///
+/// Makes a best-effort attempt to write `reason_code` to the file, but ignores any failure with
+/// writing to the file.
 ///
 /// Because attempting to delete currently open database files could cause issues, actual deletion
 /// of files is deferred until the next start-up (in [`check_db_invalidation_and_cleanup`]).
@@ -18,9 +77,29 @@ const INVALIDATION_MARKER: &str = "__turbo_tasks_invalidated_db";
 ///
 /// This should be run with the base (non-versioned) path, as that likely aligns closest with user
 /// expectations (e.g. if they're clearing the cache for disk space reasons).
-pub fn invalidate_db(base_path: &Path) -> anyhow::Result<()> {
-    match fs::write(base_path.join(INVALIDATION_MARKER), [0u8; 0]) {
-        Ok(_) => Ok(()),
+///
+/// In most cases, you should prefer a higher-level API like [`crate::BackingStorage::invalidate`]
+/// to this one.
+pub(crate) fn invalidate_db(base_path: &Path, reason_code: &str) -> anyhow::Result<()> {
+    match File::create_new(base_path.join(INVALIDATION_MARKER)) {
+        Ok(file) => {
+            let mut writer = BufWriter::new(file);
+            // ignore errors: We've already successfully invalidated the cache just by creating the
+            // marker file, writing the reason_code is best-effort.
+            let _ = serde_json::to_writer_pretty(
+                &mut writer,
+                &InvalidationFile {
+                    _explanation: Some(EXPLANATION),
+                    _easter_egg: Some(EASTER_EGG),
+                    reason_code: Cow::Borrowed(reason_code),
+                },
+            );
+            let _ = writer.flush();
+            Ok(())
+        }
+        // the database was already invalidated, avoid overwriting that reason or risking concurrent
+        // writes to the same file.
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => Ok(()),
         // just ignore if the cache directory doesn't exist at all
         Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err).context("Failed to invalidate database"),
@@ -31,13 +110,37 @@ pub fn invalidate_db(base_path: &Path) -> anyhow::Result<()> {
 /// delete any invalidated database files.
 ///
 /// This should be run with the base (non-versioned) path.
-pub fn check_db_invalidation_and_cleanup(base_path: &Path) -> anyhow::Result<()> {
-    if fs::exists(base_path.join(INVALIDATION_MARKER))? {
-        // if this cleanup fails, we might try to open an invalid database later, so it's best to
-        // just propagate the error here.
-        cleanup_db(base_path)?;
-    };
-    Ok(())
+///
+/// In most cases, you should prefer a higher-level API like
+/// [`crate::KeyValueDatabaseBackingStorage::open_versioned_on_disk`] to this one.
+pub(crate) fn check_db_invalidation_and_cleanup(
+    base_path: &Path,
+) -> anyhow::Result<StartupCacheState> {
+    match File::open(base_path.join(INVALIDATION_MARKER)) {
+        Ok(file) => {
+            // Best-effort: Try to read the reason_code from the file, if the file format is
+            // corrupted (or anything else) just use `None`.
+            let reason_code = serde_json::from_reader::<_, InvalidationFile>(BufReader::new(file))
+                .ok()
+                .map(|contents| contents.reason_code.into_owned());
+            // `file` is dropped at this point: That's important for Windows where we can't delete
+            // open files.
+
+            // if this cleanup fails, we might try to open an invalid database later, so it's best
+            // to just propagate the error here.
+            cleanup_db(base_path)?;
+            Ok(StartupCacheState::Invalidated { reason_code })
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            if fs::exists(base_path)? {
+                Ok(StartupCacheState::Cached)
+            } else {
+                Ok(StartupCacheState::NoCache)
+            }
+        }
+        Err(err) => Err(err)
+            .with_context(|| format!("Failed to check for {INVALIDATION_MARKER} in {base_path:?}")),
+    }
 }
 
 /// Helper for [`check_db_invalidation_and_cleanup`]. You can call this to explicitly clean up a
@@ -45,7 +148,7 @@ pub fn check_db_invalidation_and_cleanup(base_path: &Path) -> anyhow::Result<()>
 ///
 /// You should not run this if the database has not yet been invalidated, as this operation is not
 /// atomic and could result in a partially-deleted and corrupted database.
-pub fn cleanup_db(base_path: &Path) -> anyhow::Result<()> {
+pub(crate) fn cleanup_db(base_path: &Path) -> anyhow::Result<()> {
     cleanup_db_inner(base_path).with_context(|| {
         format!(
             "Unable to remove invalid database. If this issue persists you can work around by \

--- a/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
+++ b/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
@@ -17,7 +17,7 @@
           dirty: false,
         },
         false
-      ).unwrap()
+      ).unwrap().0
     )
   )
 }

--- a/turbopack/crates/turbo-tasks-fetch/tests/test_config.trs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/test_config.trs
@@ -17,7 +17,7 @@
           dirty: false,
         },
         false
-      ).unwrap()
+      ).unwrap().0
     )
   )
 }

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -284,7 +284,8 @@ fn node_file_trace_persistent(#[case] input: CaseInput) {
                 },
                 false,
             )
-            .unwrap(),
+            .unwrap()
+            .0,
         ))
     });
 }


### PR DESCRIPTION
We want to show a warning to the user when we start up with an invalidated cache, letting them know why `next dev` might be a little slower than usual.

This is done by writing a JSON-encoded `reason_code` value to the invalidation marker file that's then read when starting back up.

I'm using @Cy-Tek's compilation event logging to log this from the JS side, so that log styling matches other Next.js warnings. This is a little tricky because of a chicken-and-egg dependency on turbo-tasks. We must invalidate the cache before constructing the turbo-tasks backend, and then emit the event after turbo-tasks is constructed.

## Testing

Reset the cache using the web UI:

<img src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/ac47b80d-d09c-48a8-bdcf-6f6f1bfd8288.png" width="500">

And see a warning logged to the terminal:

<img src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/e1860d1a-defd-46c2-9a85-a0c64e26f634.png" width="700">

This user-requested use-case is a bit contrived, we mostly care about automatic invalidation upon panic, as those are the ones that may be surprising to the user.

Closes PACK-4869