### PR TITLE
refactor(turbopack): Use `FileSystemPath` instead of `Vc<T>`

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -494,7 +494,7 @@ impl CompilationEvent for SlowFilesystemEvent {
 #[tracing::instrument(skip(turbo_tasks))]
 async fn benchmark_file_io(
     turbo_tasks: NextTurboTasks,
-    directory: Vc<FileSystemPath>,
+    directory: FileSystemPath,
 ) -> Result<Vc<Completion>> {
     // try to get the real file path on disk so that we can use it with tokio
     let fs = Vc::try_resolve_downcast_type::<DiskFileSystem>(directory.fs())

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -441,9 +441,12 @@ pub async fn project_new(
 
     let tasks_ref = turbo_tasks.clone();
     turbo_tasks.spawn_once_task(async move {
-        benchmark_file_io(tasks_ref, container.project().node_root())
-            .await
-            .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
+        benchmark_file_io(
+            tasks_ref,
+            container.project().node_root().await?.clone_value(),
+        )
+        .await
+        .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
     });
     Ok(External::new_with_size_hint(
         ProjectInstance {
@@ -1403,12 +1406,13 @@ pub async fn get_source_map_rope(
         return Ok(OptionStringifiedSourceMap::none());
     };
 
-    let server_path = container.project().node_root().join(chunk_base.into());
+    let server_path = container.project().node_root().await?.join(chunk_base)?;
 
     let client_path = container
         .project()
         .client_relative_path()
-        .join(chunk_base.into());
+        .await?
+        .join(chunk_base)?;
 
     let mut map = container.get_source_map(server_path, module.clone());
 
@@ -1476,8 +1480,12 @@ pub async fn project_trace_source_operation(
         }
     };
 
-    let project_root_uri =
-        uri_from_file(container.project().project_root_path(), None).await? + "/";
+    let project_root_uri = uri_from_file(
+        container.project().project_root_path().await?.clone_value(),
+        None,
+    )
+    .await?
+        + "/";
     let (file, original_file, is_internal) =
         if let Some(source_file) = original_file.strip_prefix(&project_root_uri) {
             // Client code uses file://
@@ -1563,9 +1571,11 @@ pub async fn project_get_source_for_asset(
                 .container
                 .project()
                 .project_path()
+                .await?
                 .fs()
                 .root()
-                .join(file_path.clone())
+                .await?
+                .join(&file_path)?
                 .read()
                 .await?;
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -91,7 +91,7 @@ use crate::{
 #[turbo_tasks::value]
 pub struct AppProject {
     project: ResolvedVc<Project>,
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
 }
 
 #[turbo_tasks::value(transparent)]
@@ -138,7 +138,7 @@ impl AppProject {
 #[turbo_tasks::value_impl]
 impl AppProject {
     #[turbo_tasks::function]
-    pub fn new(project: ResolvedVc<Project>, app_dir: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project: ResolvedVc<Project>, app_dir: FileSystemPath) -> Vc<Self> {
         AppProject { project, app_dir }.cell()
     }
 
@@ -1055,7 +1055,7 @@ enum AppEndpointType {
         loader_tree: ResolvedVc<AppPageLoaderTree>,
     },
     Route {
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         root_layouts: ResolvedVc<FileSystemPathVec>,
     },
     Metadata {
@@ -1087,7 +1087,7 @@ impl AppEndpoint {
     #[turbo_tasks::function]
     async fn app_route_entry(
         &self,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         root_layouts: Vc<FileSystemPathVec>,
         next_config: Vc<NextConfig>,
     ) -> Result<Vc<AppEntry>> {
@@ -1716,7 +1716,7 @@ impl AppEndpoint {
         self: Vc<Self>,
         client_references: Vc<ClientReferenceGraphResult>,
         server_action_manifest_loader: ResolvedVc<Box<dyn EvaluatableAsset>>,
-        server_path: Vc<FileSystemPath>,
+        server_path: FileSystemPath,
         process_client_assets: bool,
         module_graph: Vc<ModuleGraph>,
     ) -> Result<Vc<OutputAssets>> {
@@ -1874,7 +1874,7 @@ impl AppEndpoint {
 }
 
 async fn create_app_paths_manifest(
-    node_root: Vc<FileSystemPath>,
+    node_root: FileSystemPath,
     original_name: &str,
     filename: RcStr,
 ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -149,13 +149,13 @@ impl AppProject {
 
     #[turbo_tasks::function]
     fn app_dir(&self) -> Vc<FileSystemPath> {
-        *self.app_dir
+        self.app_dir.clone().cell()
     }
 
     #[turbo_tasks::function]
     fn client_ty(&self) -> Vc<ClientContextType> {
         ClientContextType::App {
-            app_dir: self.app_dir,
+            app_dir: self.app_dir.clone(),
         }
         .cell()
     }
@@ -164,7 +164,7 @@ impl AppProject {
     async fn rsc_ty(self: Vc<Self>) -> Result<Vc<ServerContextType>> {
         let this = self.await?;
         Ok(ServerContextType::AppRSC {
-            app_dir: this.app_dir,
+            app_dir: this.app_dir.clone(),
             client_transition: Some(ResolvedVc::upcast(
                 self.client_transition().to_resolved().await?,
             )),
@@ -177,7 +177,7 @@ impl AppProject {
     async fn route_ty(self: Vc<Self>) -> Result<Vc<ServerContextType>> {
         let this = self.await?;
         Ok(ServerContextType::AppRoute {
-            app_dir: this.app_dir,
+            app_dir: this.app_dir.clone(),
             ecmascript_client_reference_transition_name: Some(Self::client_transition_name()),
         }
         .cell())
@@ -186,7 +186,7 @@ impl AppProject {
     #[turbo_tasks::function]
     fn ssr_ty(&self) -> Vc<ServerContextType> {
         ServerContextType::AppSSR {
-            app_dir: self.app_dir,
+            app_dir: self.app_dir.clone(),
         }
         .cell()
     }
@@ -195,7 +195,7 @@ impl AppProject {
     fn app_entrypoints(&self) -> Vc<AppEntrypoints> {
         let conf = self.project.next_config();
         get_entrypoints(
-            *self.app_dir,
+            self.app_dir.clone(),
             conf.page_extensions(),
             conf.is_global_not_found_enabled(),
         )
@@ -204,7 +204,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_client_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
             self.client_ty().owned().await?,
@@ -218,7 +218,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.client_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -235,7 +235,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
@@ -249,7 +249,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
@@ -263,7 +263,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.route_ty().owned().await?,
             self.project().next_mode(),
@@ -277,7 +277,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.route_ty().owned().await?,
             self.project().next_mode(),
@@ -291,7 +291,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -302,7 +302,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -313,7 +313,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -326,7 +326,7 @@ impl AppProject {
         self: Vc<Self>,
     ) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -595,7 +595,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
@@ -609,7 +609,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
@@ -623,7 +623,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -634,7 +634,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -798,7 +798,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         Ok(get_client_runtime_entries(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.client_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -836,7 +836,7 @@ impl AppProject {
         let client_main_module = cjs_resolve(
             Vc::upcast(PlainResolveOrigin::new(
                 client_module_context,
-                self.project().project_path().join(rcstr!("_")),
+                self.project().project_path().await?.join("_")?,
             )),
             Request::parse(Pattern::Constant(rcstr!(
                 "next/dist/client/app-next-turbopack.js"
@@ -916,8 +916,7 @@ impl AppProject {
                             should_trace,
                         );
                         graphs.push(graph);
-                        let is_layout =
-                            module.server_path().file_stem().await?.as_deref() == Some("layout");
+                        let is_layout = module.server_path().await?.file_stem() == Some("layout");
                         visited_modules = if is_layout {
                             // Only propagate the visited_modules of the parent layout(s), not
                             // across siblings such as loading.js and
@@ -1048,7 +1047,7 @@ enum AppPageEndpointType {
     Rsc,
 }
 
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue)]
 enum AppEndpointType {
     Page {
         ty: AppPageEndpointType,
@@ -1073,15 +1072,19 @@ struct AppEndpoint {
 #[turbo_tasks::value_impl]
 impl AppEndpoint {
     #[turbo_tasks::function]
-    fn app_page_entry(&self, loader_tree: Vc<AppPageLoaderTree>) -> Vc<AppEntry> {
-        get_app_page_entry(
+    async fn app_page_entry(&self, loader_tree: Vc<AppPageLoaderTree>) -> Result<Vc<AppEntry>> {
+        Ok(get_app_page_entry(
             self.app_project.rsc_module_context(),
             self.app_project.edge_rsc_module_context(),
             loader_tree,
             self.page.clone(),
-            self.app_project.project().project_path(),
+            self.app_project
+                .project()
+                .project_path()
+                .await?
+                .clone_value(),
             self.app_project.project().next_config(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -1098,7 +1101,7 @@ impl AppEndpoint {
             let mut config = NextSegmentConfig::default();
 
             for layout in root_layouts.iter().rev() {
-                let source = Vc::upcast(FileSource::new(**layout));
+                let source = Vc::upcast(FileSource::new(layout.clone()));
                 let layout_config = parse_segment_config_from_source(source);
                 config.apply_parent_config(&*layout_config.await?);
             }
@@ -1111,7 +1114,11 @@ impl AppEndpoint {
             self.app_project.edge_route_module_context(),
             Vc::upcast(FileSource::new(path)),
             self.page.clone(),
-            self.app_project.project().project_path(),
+            self.app_project
+                .project()
+                .project_path()
+                .await?
+                .clone_value(),
             config,
             next_config,
         ))
@@ -1126,7 +1133,11 @@ impl AppEndpoint {
         Ok(get_app_metadata_route_entry(
             self.app_project.rsc_module_context(),
             self.app_project.edge_rsc_module_context(),
-            self.app_project.project().project_path(),
+            self.app_project
+                .project()
+                .project_path()
+                .await?
+                .clone_value(),
             self.page.clone(),
             *self.app_project.project().next_mode().await?,
             metadata,
@@ -1139,13 +1150,13 @@ impl AppEndpoint {
         let this = self.await?;
 
         let next_config = self.await?.app_project.project().next_config();
-        let app_entry = match this.ty {
-            AppEndpointType::Page { loader_tree, .. } => self.app_page_entry(*loader_tree),
+        let app_entry = match &this.ty {
+            AppEndpointType::Page { loader_tree, .. } => self.app_page_entry(**loader_tree),
             AppEndpointType::Route { path, root_layouts } => {
-                self.app_route_entry(*path, *root_layouts, next_config)
+                self.app_route_entry(path.clone(), **root_layouts, next_config)
             }
             AppEndpointType::Metadata { metadata } => {
-                self.app_metadata_entry(metadata, next_config)
+                self.app_metadata_entry(metadata.clone(), next_config)
             }
         };
 
@@ -1168,7 +1179,7 @@ impl AppEndpoint {
             /// All manifests: `Minimal` plus client-references, next-dynamic, ...
             Full,
         }
-        let (process_client_assets, process_ssr, emit_manifests) = match this.ty {
+        let (process_client_assets, process_ssr, emit_manifests) = match &this.ty {
             AppEndpointType::Page { ty, .. } => (
                 true,
                 matches!(ty, AppPageEndpointType::Html),
@@ -1190,9 +1201,9 @@ impl AppEndpoint {
             ),
         };
 
-        let node_root = project.node_root().to_resolved().await?;
-        let client_relative_path = project.client_relative_path().to_resolved().await?;
-        let server_path = node_root.join(rcstr!("server"));
+        let node_root = project.node_root().await?.clone_value();
+        let client_relative_path = project.client_relative_path().await?.clone_value();
+        let server_path = node_root.join("server")?;
 
         let mut server_assets = fxindexset![];
         let mut client_assets = fxindexset![];
@@ -1231,7 +1242,7 @@ impl AppEndpoint {
         };
 
         let client_shared_chunk_group = get_app_client_shared_chunk_group(
-            AssetIdent::from_path(project.project_path())
+            AssetIdent::from_path(project.project_path().await?.clone_value())
                 .with_modifier(rcstr!("client-shared-chunks")),
             this.app_project.client_runtime_entries(),
             *module_graphs.full,
@@ -1317,10 +1328,10 @@ impl AppEndpoint {
             };
             let app_build_manifest_output = app_build_manifest
                 .build_output(
-                    node_root.join(
-                        format!("server/app{manifest_path_prefix}/app-build-manifest.json",).into(),
-                    ),
-                    *client_relative_path,
+                    node_root.join(&format!(
+                        "server/app{manifest_path_prefix}/app-build-manifest.json",
+                    ))?,
+                    client_relative_path.clone(),
                 )
                 .await?
                 .to_resolved()
@@ -1331,14 +1342,19 @@ impl AppEndpoint {
 
         // polyfill-nomodule.js is a pre-compiled asset distributed as part of next,
         // load it as a RawModule.
-        let next_package = get_next_package(project.project_path());
+        let next_package = get_next_package(project.project_path().await?.clone_value())
+            .await?
+            .clone_value();
         let polyfill_source =
-            FileSource::new(next_package.join(rcstr!("dist/build/polyfills/polyfill-nomodule.js")));
-        let polyfill_output_path = client_chunking_context.chunk_path(
-            Some(Vc::upcast(polyfill_source)),
-            polyfill_source.ident(),
-            rcstr!(".js"),
-        );
+            FileSource::new(next_package.join("dist/build/polyfills/polyfill-nomodule.js")?);
+        let polyfill_output_path = client_chunking_context
+            .chunk_path(
+                Some(Vc::upcast(polyfill_source)),
+                polyfill_source.ident(),
+                rcstr!(".js"),
+            )
+            .await?
+            .clone_value();
         let polyfill_output_asset = ResolvedVc::upcast(
             RawOutput::new(polyfill_output_path, Vc::upcast(polyfill_source))
                 .to_resolved()
@@ -1356,9 +1372,9 @@ impl AppEndpoint {
                 let webpack_stats =
                     generate_webpack_stats(app_entry.original_name.clone(), &client_assets).await?;
                 let stats_output = VirtualOutputAsset::new(
-                    node_root.join(
-                        format!("server/app{manifest_path_prefix}/webpack-stats.json",).into(),
-                    ),
+                    node_root.join(&format!(
+                        "server/app{manifest_path_prefix}/webpack-stats.json",
+                    ))?,
                     AssetContent::file(
                         File::from(serde_json::to_string_pretty(&webpack_stats)?).into(),
                     ),
@@ -1376,10 +1392,10 @@ impl AppEndpoint {
             let build_manifest_output = ResolvedVc::upcast(
                 build_manifest
                     .build_output(
-                        node_root.join(
-                            format!("server/app{manifest_path_prefix}/build-manifest.json",).into(),
-                        ),
-                        *client_relative_path,
+                        node_root.join(&format!(
+                            "server/app{manifest_path_prefix}/build-manifest.json",
+                        ))?,
+                        client_relative_path.clone(),
                     )
                     .await?
                     .to_resolved()
@@ -1413,8 +1429,8 @@ impl AppEndpoint {
 
         let server_action_manifest = create_server_actions_manifest(
             actions,
-            project.project_path(),
-            *node_root,
+            project.project_path().await?.clone_value(),
+            node_root.clone(),
             app_entry.original_name.clone(),
             runtime,
             match runtime {
@@ -1437,7 +1453,7 @@ impl AppEndpoint {
             .app_entry_chunks(
                 *client_references,
                 *server_action_manifest_loader,
-                server_path,
+                server_path.clone(),
                 process_client_assets,
                 *module_graphs.full,
             )
@@ -1456,8 +1472,8 @@ impl AppEndpoint {
         if emit_manifests == EmitManifests::Full {
             let entry_manifest =
                 ClientReferenceManifest::build_output(ClientReferenceManifestOptions {
-                    node_root,
-                    client_relative_path,
+                    node_root: node_root.clone(),
+                    client_relative_path: client_relative_path.clone(),
                     entry_name: app_entry.original_name.clone(),
                     client_references,
                     client_references_chunks,
@@ -1477,9 +1493,9 @@ impl AppEndpoint {
             client_reference_manifest = Some(entry_manifest);
 
             let next_font_manifest_output = create_font_manifest(
-                project.client_root(),
-                *node_root,
-                this.app_project.app_dir(),
+                project.client_root().await?.clone_value(),
+                node_root.clone(),
+                this.app_project.app_dir().await?.clone_value(),
                 &app_entry.original_name,
                 &app_entry.original_name,
                 &app_entry.original_name,
@@ -1504,7 +1520,7 @@ impl AppEndpoint {
                 ];
                 let mut wasm_paths_from_root = fxindexset![];
 
-                let node_root_value = node_root.await?;
+                let node_root_value = node_root.clone();
 
                 file_paths_from_root
                     .extend(get_js_paths_from_root(&node_root_value, &middleware_assets).await?);
@@ -1536,14 +1552,11 @@ impl AppEndpoint {
 
                     let loadable_manifest_output = create_react_loadable_manifest(
                         *dynamic_import_entries,
-                        *client_relative_path,
-                        node_root.join(
-                            format!(
-                                "server/app{}/react-loadable-manifest",
-                                &app_entry.original_name
-                            )
-                            .into(),
-                        ),
+                        client_relative_path.clone(),
+                        node_root.join(&format!(
+                            "server/app{}/react-loadable-manifest",
+                            &app_entry.original_name
+                        ))?,
                         NextRuntime::Edge,
                     )
                     .await?;
@@ -1585,12 +1598,9 @@ impl AppEndpoint {
                     let manifest_path_prefix = &app_entry.original_name;
                     let middleware_manifest_v2 = ResolvedVc::upcast(
                         VirtualOutputAsset::new(
-                            node_root.join(
-                                format!(
-                                    "server/app{manifest_path_prefix}/middleware-manifest.json",
-                                )
-                                .into(),
-                            ),
+                            node_root.join(&format!(
+                                "server/app{manifest_path_prefix}/middleware-manifest.json",
+                            ))?,
                             AssetContent::file(
                                 FileContent::Content(File::from(serde_json::to_string_pretty(
                                     &middleware_manifest_v2,
@@ -1605,9 +1615,12 @@ impl AppEndpoint {
                 }
                 if emit_manifests != EmitManifests::None {
                     // create app paths manifest
-                    let app_paths_manifest_output =
-                        create_app_paths_manifest(*node_root, &app_entry.original_name, entry_file)
-                            .await?;
+                    let app_paths_manifest_output = create_app_paths_manifest(
+                        node_root.clone(),
+                        &app_entry.original_name,
+                        entry_file,
+                    )
+                    .await?;
                     server_assets.insert(app_paths_manifest_output);
                 }
 
@@ -1626,10 +1639,9 @@ impl AppEndpoint {
                 if emit_manifests != EmitManifests::None {
                     // create app paths manifest
                     let app_paths_manifest_output = create_app_paths_manifest(
-                        *node_root,
+                        node_root.clone(),
                         &app_entry.original_name,
                         server_path
-                            .await?
                             .get_path_to(&*rsc_chunk.path().await?)
                             .context(
                                 "RSC chunk path should be within app paths manifest directory",
@@ -1654,14 +1666,11 @@ impl AppEndpoint {
 
                     let loadable_manifest_output = create_react_loadable_manifest(
                         *dynamic_import_entries,
-                        *client_relative_path,
-                        node_root.join(
-                            format!(
-                                "server/app{}/react-loadable-manifest",
-                                &app_entry.original_name
-                            )
-                            .into(),
-                        ),
+                        client_relative_path.clone(),
+                        node_root.join(&format!(
+                            "server/app{}/react-loadable-manifest",
+                            &app_entry.original_name
+                        ))?,
                         NextRuntime::NodeJs,
                     )
                     .await?;
@@ -1788,8 +1797,14 @@ impl AppEndpoint {
                             .await?;
                         let chunk_group = chunking_context
                             .chunk_group(
-                                AssetIdent::from_path(this.app_project.project().project_path())
-                                    .with_modifier(rcstr!("server-utils")),
+                                AssetIdent::from_path(
+                                    this.app_project
+                                        .project()
+                                        .project_path()
+                                        .await?
+                                        .clone_value(),
+                                )
+                                .with_modifier(rcstr!("server-utils")),
                                 // TODO this should be ChunkGroup::Shared
                                 ChunkGroup::Entry(server_utils),
                                 module_graph,
@@ -1850,13 +1865,10 @@ impl AppEndpoint {
                     anyhow::Ok(Vc::cell(vec![
                         chunking_context
                             .entry_chunk_group_asset(
-                                server_path.join(
-                                    format!(
-                                        "app{original_name}.js",
-                                        original_name = app_entry.original_name
-                                    )
-                                    .into(),
-                                ),
+                                server_path.join(&format!(
+                                    "app{original_name}.js",
+                                    original_name = app_entry.original_name
+                                ))?,
                                 Vc::cell(evaluatable_assets),
                                 module_graph,
                                 current_chunks,
@@ -1879,8 +1891,9 @@ async fn create_app_paths_manifest(
     filename: RcStr,
 ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
     let manifest_path_prefix = original_name;
-    let path =
-        node_root.join(format!("server/app{manifest_path_prefix}/app-paths-manifest.json",).into());
+    let path = node_root.join(&format!(
+        "server/app{manifest_path_prefix}/app-paths-manifest.json",
+    ))?;
     let app_paths_manifest = AppPathsManifest {
         node_server_app_paths: PagesManifest {
             pages: [(original_name.into(), filename)].into_iter().collect(),
@@ -1939,10 +1952,15 @@ impl Endpoint for AppEndpoint {
                 .await?
                 .is_development()
             {
-                let node_root = this.app_project.project().node_root();
+                let node_root = this.app_project.project().node_root().await?.clone_value();
                 let server_paths = all_server_paths(output_assets, node_root).owned().await?;
 
-                let client_relative_root = this.app_project.project().client_relative_path();
+                let client_relative_root = this
+                    .app_project
+                    .project()
+                    .client_relative_path()
+                    .await?
+                    .clone_value();
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
                     .owned()
                     .instrument(tracing::info_span!("client_paths"))
@@ -2040,7 +2058,11 @@ impl Endpoint for AppEndpoint {
 
         let server_actions_loader = ResolvedVc::upcast(
             build_server_actions_loader(
-                this.app_project.project().project_path(),
+                this.app_project
+                    .project()
+                    .project_path()
+                    .await?
+                    .clone_value(),
                 app_entry.original_name.clone(),
                 actions,
                 match runtime {

--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -12,9 +12,9 @@ use turbopack_core::{
 use crate::paths::get_font_paths_from_root;
 
 pub(crate) async fn create_font_manifest(
-    client_root: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
-    dir: Vc<FileSystemPath>,
+    client_root: FileSystemPath,
+    node_root: FileSystemPath,
+    dir: FileSystemPath,
     original_name: &str,
     manifest_path_prefix: &str,
     pathname: &str,

--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use next_core::{all_assets_from_entries, next_manifests::NextFontManifest};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -25,17 +25,20 @@ pub(crate) async fn create_font_manifest(
 
     // `_next` gets added again later, so we "strip" it here via
     // `get_font_paths_from_root`.
-    let font_paths: Vec<String> =
-        get_font_paths_from_root(&*client_root.await?, &all_client_output_assets)
-            .await?
-            .iter()
-            .filter_map(|p| p.split("_next/").last().map(|f| f.to_string()))
-            .collect();
+    let font_paths: Vec<String> = get_font_paths_from_root(&client_root, &all_client_output_assets)
+        .await?
+        .iter()
+        .filter_map(|p| p.split("_next/").last().map(|f| f.to_string()))
+        .collect();
 
     let path = if app_dir {
-        node_root.join(format!("server/app{manifest_path_prefix}/next-font-manifest.json",).into())
+        node_root.join(&format!(
+            "server/app{manifest_path_prefix}/next-font-manifest.json",
+        ))?
     } else {
-        node_root.join(format!("server/pages{manifest_path_prefix}/next-font-manifest.json").into())
+        node_root.join(&format!(
+            "server/pages{manifest_path_prefix}/next-font-manifest.json",
+        ))?
     };
 
     let has_fonts = !font_paths.is_empty();
@@ -50,7 +53,7 @@ pub(crate) async fn create_font_manifest(
     let next_font_manifest = if !has_fonts {
         Default::default()
     } else if app_dir {
-        let dir_str = dir.to_string().await?;
+        let dir_str = dir.value_to_string().await?;
         let page_path = format!("{dir_str}{original_name}").into();
 
         NextFontManifest {

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -43,7 +43,7 @@ pub struct InstrumentationEndpoint {
     source: ResolvedVc<Box<dyn Source>>,
     is_edge: bool,
 
-    app_dir: Option<ResolvedVc<FileSystemPath>>,
+    app_dir: Option<FileSystemPath>,
     ecmascript_client_reference_transition_name: Option<RcStr>,
 }
 
@@ -55,7 +55,7 @@ impl InstrumentationEndpoint {
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
         source: ResolvedVc<Box<dyn Source>>,
         is_edge: bool,
-        app_dir: Option<ResolvedVc<FileSystemPath>>,
+        app_dir: Option<FileSystemPath>,
         ecmascript_client_reference_transition_name: Option<RcStr>,
     ) -> Vc<Self> {
         Self {

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -83,7 +83,7 @@ impl InstrumentationEndpoint {
 
         let edge_entry_module = wrap_edge_entry(
             *self.asset_context,
-            self.project.project_path(),
+            self.project.project_path().await?.clone_value(),
             *userland_module,
             rcstr!("instrumentation"),
         )
@@ -106,7 +106,7 @@ impl InstrumentationEndpoint {
 
         let evaluatable_assets = get_server_runtime_entries(
             ServerContextType::Instrumentation {
-                app_dir: this.app_dir,
+                app_dir: this.app_dir.clone(),
                 ecmascript_client_reference_transition_name: this
                     .ecmascript_client_reference_transition_name
                     .clone(),
@@ -148,10 +148,11 @@ impl InstrumentationEndpoint {
             .entry_chunk_group(
                 this.project
                     .node_root()
-                    .join(rcstr!("server/instrumentation.js")),
+                    .await?
+                    .join("server/instrumentation.js")?,
                 get_server_runtime_entries(
                     ServerContextType::Instrumentation {
-                        app_dir: this.app_dir,
+                        app_dir: this.app_dir.clone(),
                         ecmascript_client_reference_transition_name: this
                             .ecmascript_client_reference_transition_name
                             .clone(),
@@ -176,8 +177,8 @@ impl InstrumentationEndpoint {
             let edge_files = self.edge_files();
             let mut output_assets = edge_files.owned().await?;
 
-            let node_root = this.project.node_root();
-            let node_root_value = node_root.await?;
+            let node_root = this.project.node_root().await?.clone_value();
+            let node_root_value = node_root.clone();
 
             let file_paths_from_root =
                 get_js_paths_from_root(&node_root_value, &output_assets).await?;
@@ -198,7 +199,7 @@ impl InstrumentationEndpoint {
                 ..Default::default()
             };
             let middleware_manifest_v2 = VirtualOutputAsset::new(
-                node_root.join(rcstr!("server/instrumentation/middleware-manifest.json")),
+                node_root.join("server/instrumentation/middleware-manifest.json")?,
                 AssetContent::file(
                     FileContent::Content(File::from(serde_json::to_string_pretty(
                         &middleware_manifest_v2,
@@ -242,7 +243,7 @@ impl Endpoint for InstrumentationEndpoint {
             let output_assets = self.output_assets();
 
             let server_paths = if this.project.next_mode().await?.is_development() {
-                let node_root = this.project.node_root();
+                let node_root = this.project.node_root().await?.clone_value();
                 all_server_paths(output_assets, node_root).owned().await?
             } else {
                 vec![]

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -15,8 +15,8 @@ use crate::dynamic_imports::DynamicImportedChunks;
 #[turbo_tasks::function]
 pub async fn create_react_loadable_manifest(
     dynamic_import_entries: Vc<DynamicImportedChunks>,
-    client_relative_path: Vc<FileSystemPath>,
-    output_path: Vc<FileSystemPath>,
+    client_relative_path: FileSystemPath,
+    output_path: FileSystemPath,
     runtime: NextRuntime,
 ) -> Result<Vc<OutputAssets>> {
     let dynamic_import_entries = &*dynamic_import_entries.await?;

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -28,7 +28,7 @@ pub async fn create_react_loadable_manifest(
 
         let id = &*module_id.await?;
 
-        let client_relative_path_value = client_relative_path.await?;
+        let client_relative_path_value = client_relative_path.clone();
         let files = chunk_output
             .iter()
             .map(move |&file| {
@@ -55,7 +55,7 @@ pub async fn create_react_loadable_manifest(
     Ok(Vc::cell(match runtime {
         NextRuntime::NodeJs => vec![ResolvedVc::upcast(
             VirtualOutputAsset::new(
-                output_path.with_extension("json".into()),
+                output_path.with_extension("json"),
                 AssetContent::file(FileContent::Content(File::from(manifest_json)).cell()),
             )
             .to_resolved()
@@ -64,7 +64,7 @@ pub async fn create_react_loadable_manifest(
         NextRuntime::Edge => vec![
             ResolvedVc::upcast(
                 VirtualOutputAsset::new(
-                    output_path.with_extension("js".into()),
+                    output_path.with_extension("js"),
                     AssetContent::file(
                         FileContent::Content(File::from(format!(
                             "self.__REACT_LOADABLE_MANIFEST={};",
@@ -78,7 +78,7 @@ pub async fn create_react_loadable_manifest(
             ),
             ResolvedVc::upcast(
                 VirtualOutputAsset::new(
-                    output_path.with_extension("json".into()),
+                    output_path.with_extension("json"),
                     AssetContent::file(FileContent::Content(File::from(manifest_json)).cell()),
                 )
                 .to_resolved()

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -46,7 +46,7 @@ pub struct MiddlewareEndpoint {
     project: ResolvedVc<Project>,
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
     source: ResolvedVc<Box<dyn Source>>,
-    app_dir: Option<ResolvedVc<FileSystemPath>>,
+    app_dir: Option<FileSystemPath>,
     ecmascript_client_reference_transition_name: Option<RcStr>,
 }
 
@@ -57,7 +57,7 @@ impl MiddlewareEndpoint {
         project: ResolvedVc<Project>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
         source: ResolvedVc<Box<dyn Source>>,
-        app_dir: Option<ResolvedVc<FileSystemPath>>,
+        app_dir: Option<FileSystemPath>,
         ecmascript_client_reference_transition_name: Option<RcStr>,
     ) -> Vc<Self> {
         Self {

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -82,7 +82,7 @@ impl MiddlewareEndpoint {
 
         let module = get_middleware_module(
             *self.asset_context,
-            self.project.project_path(),
+            self.project.project_path().await?.clone_value(),
             userland_module,
         );
 
@@ -93,7 +93,7 @@ impl MiddlewareEndpoint {
         }
         Ok(wrap_edge_entry(
             *self.asset_context,
-            self.project.project_path(),
+            self.project.project_path().await?.clone_value(),
             module,
             rcstr!("middleware"),
         ))
@@ -108,7 +108,7 @@ impl MiddlewareEndpoint {
 
         let evaluatable_assets = get_server_runtime_entries(
             ServerContextType::Middleware {
-                app_dir: this.app_dir,
+                app_dir: this.app_dir.clone(),
                 ecmascript_client_reference_transition_name: this
                     .ecmascript_client_reference_transition_name
                     .clone(),
@@ -149,10 +149,11 @@ impl MiddlewareEndpoint {
             .entry_chunk_group(
                 this.project
                     .node_root()
-                    .join(rcstr!("server/middleware.js")),
+                    .await?
+                    .join("server/middleware.js")?,
                 get_server_runtime_entries(
                     ServerContextType::Middleware {
-                        app_dir: this.app_dir,
+                        app_dir: this.app_dir.clone(),
                         ecmascript_client_reference_transition_name: this
                             .ecmascript_client_reference_transition_name
                             .clone(),
@@ -260,7 +261,8 @@ impl MiddlewareEndpoint {
             let middleware_manifest_v2 = VirtualOutputAsset::new(
                 this.project
                     .node_root()
-                    .join(rcstr!("server/middleware/middleware-manifest.json")),
+                    .await?
+                    .join("server/middleware/middleware-manifest.json")?,
                 AssetContent::file(
                     FileContent::Content(File::from(serde_json::to_string_pretty(
                         &middleware_manifest_v2,
@@ -277,8 +279,8 @@ impl MiddlewareEndpoint {
             let edge_files = self.edge_files();
             let mut output_assets = edge_files.owned().await?;
 
-            let node_root = this.project.node_root();
-            let node_root_value = node_root.await?;
+            let node_root = this.project.node_root().await?.clone_value();
+            let node_root_value = node_root.clone();
 
             let file_paths_from_root =
                 get_js_paths_from_root(&node_root_value, &output_assets).await?;
@@ -320,7 +322,7 @@ impl MiddlewareEndpoint {
                 ..Default::default()
             };
             let middleware_manifest_v2 = VirtualOutputAsset::new(
-                node_root.join(rcstr!("server/middleware/middleware-manifest.json")),
+                node_root.join("server/middleware/middleware-manifest.json")?,
                 AssetContent::file(
                     FileContent::Content(File::from(serde_json::to_string_pretty(
                         &middleware_manifest_v2,
@@ -357,11 +359,11 @@ impl Endpoint for MiddlewareEndpoint {
             let output_assets = self.output_assets();
 
             let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
-                let node_root = this.project.node_root();
+                let node_root = this.project.node_root().await?.clone_value();
                 let server_paths = all_server_paths(output_assets, node_root).owned().await?;
 
                 // Middleware could in theory have a client path (e.g. `new URL`).
-                let client_relative_root = this.project.client_relative_path();
+                let client_relative_root = this.project.client_relative_path().await?.clone_value();
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
                     .into_future()
                     .owned()

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -440,14 +440,13 @@ impl Issue for CssGlobalImportIssue {
 
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        let parent_path = &self.parent_module.ident().path();
-        let module_path = &self.module.ident().path();
-        let relative_import_location = parent_path.parent().await?;
+        let parent_path = self.parent_module.ident().path().await?.clone_value();
+        let module_path = self.module.ident().path().await?.clone_value();
+        let relative_import_location = parent_path.parent();
 
-        let import_path = match relative_import_location.get_relative_path_to(&*module_path.await?)
-        {
+        let import_path = match relative_import_location.get_relative_path_to(&module_path) {
             Some(path) => path,
-            None => module_path.await?.path.clone(),
+            None => module_path.path.clone(),
         };
         let cleaned_import_path =
             if import_path.ends_with(".scss.css") || import_path.ends_with(".sass.css") {
@@ -458,7 +457,7 @@ impl Issue for CssGlobalImportIssue {
 
         Ok(Vc::cell(Some(
             StyledString::Stack(vec![
-                StyledString::Text(format!("Location: {}", parent_path.await?.path).into()),
+                StyledString::Text(format!("Location: {}", parent_path.path).into()),
                 StyledString::Text(format!("Import path: {cleaned_import_path}",).into()),
             ])
             .resolved_cell(),

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -969,7 +969,7 @@ impl PageEndpoint {
     async fn internal_ssr_chunk(
         self: Vc<Self>,
         ty: SsrChunkType,
-        node_path: Vc<FileSystemPath>,
+        node_path: FileSystemPath,
         node_chunking_context: Vc<NodeJsChunkingContext>,
         edge_chunking_context: Vc<Box<dyn ChunkingContext>>,
         runtime_entries: Vc<EvaluatableAssets>,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -119,9 +119,9 @@ impl PagesProject {
                 next_router_path,
                 original_path,
                 ..
-            } = *page.await?;
-            let pathname: RcStr = format!("/{}", next_router_path.await?.path).into();
-            let original_name = format!("/{}", original_path.await?.path).into();
+            } = &*page.await?;
+            let pathname: RcStr = format!("/{}", next_router_path.path).into();
+            let original_name = format!("/{}", original_path.path).into();
             let route = make_route(pathname.clone(), original_name, page).await?;
             routes.insert(pathname, route);
             Ok(())
@@ -224,9 +224,9 @@ impl PagesProject {
             next_router_path,
             original_path,
             ..
-        } = *item.await?;
-        let pathname: RcStr = format!("/{}", next_router_path.await?.path).into();
-        let original_name = format!("/{}", original_path.await?.path).into();
+        } = &*item.await?;
+        let pathname: RcStr = format!("/{}", next_router_path.path).into();
+        let original_name = format!("/{}", original_path.path).into();
         let endpoint = Vc::upcast(PageEndpoint::new(
             ty,
             self,
@@ -262,14 +262,14 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    fn pages_structure(&self) -> Vc<PagesStructure> {
+    async fn pages_structure(&self) -> Result<Vc<PagesStructure>> {
         let next_router_fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new());
-        let next_router_root = next_router_fs.root();
-        find_pages_structure(
-            self.project.project_path(),
+        let next_router_root = next_router_fs.root().await?.clone_value();
+        Ok(find_pages_structure(
+            self.project.project_path().await?.clone_value(),
             next_router_root,
             self.project.next_config().page_extensions(),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -277,7 +277,7 @@ impl PagesProject {
         Ok(if let Some(pages) = self.pages_structure().await?.pages {
             pages.project_path()
         } else {
-            self.project().project_path().join(rcstr!("pages"))
+            self.project().project_path().await?.join("pages")?.cell()
         })
     }
 
@@ -333,11 +333,11 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_client_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
             ClientContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -349,9 +349,9 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             ClientContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -441,10 +441,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -457,10 +457,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -473,10 +473,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             ServerContextType::PagesApi {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -489,10 +489,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn edge_api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             ServerContextType::PagesApi {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -505,10 +505,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             ServerContextType::PagesData {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -523,10 +523,10 @@ impl PagesProject {
         self: Vc<Self>,
     ) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             self.project().execution_context(),
             ServerContextType::PagesData {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -539,12 +539,12 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -555,12 +555,12 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -571,9 +571,9 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         let client_runtime_entries = get_client_runtime_entries(
-            self.project().project_path(),
+            self.project().project_path().await?.clone_value(),
             ClientContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -586,7 +586,7 @@ impl PagesProject {
     async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
         ))
@@ -596,7 +596,7 @@ impl PagesProject {
     async fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
             ServerContextType::PagesData {
-                pages_dir: self.pages_dir().to_resolved().await?,
+                pages_dir: self.pages_dir().await?.clone_value(),
             },
             self.project().next_mode(),
         ))
@@ -633,7 +633,7 @@ impl PagesProject {
         let client_main_module = esm_resolve(
             Vc::upcast(PlainResolveOrigin::new(
                 client_module_context,
-                self.project().project_path().join(rcstr!("_")),
+                self.project().project_path().await?.join("_")?,
             )),
             Request::parse(Pattern::Constant(
                 match *self.project().next_mode().await? {
@@ -726,8 +726,10 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn source(&self) -> Vc<Box<dyn Source>> {
-        Vc::upcast(FileSource::new(self.page.file_path()))
+    async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
+        Ok(Vc::upcast(FileSource::new(
+            self.page.file_path().await?.clone_value(),
+        )))
     }
 
     #[turbo_tasks::function]
@@ -744,7 +746,7 @@ impl PageEndpoint {
         ) && let Some(chunkable) = Vc::try_resolve_downcast(page_loader).await?
         {
             return Ok(Vc::upcast(HmrEntryModule::new(
-                AssetIdent::from_path(*this.page.await?.base_path),
+                AssetIdent::from_path(this.page.await?.base_path.clone()),
                 chunkable,
             )));
         }
@@ -844,7 +846,7 @@ impl PageEndpoint {
                 .map(|m| ResolvedVc::upcast(*m))
                 .collect();
             let client_chunk_group = client_chunking_context.evaluated_chunk_group(
-                AssetIdent::from_path(*this.page.await?.base_path),
+                AssetIdent::from_path(this.page.await?.base_path.clone()),
                 ChunkGroup::Entry(evaluatable_assets),
                 module_graph,
                 AvailabilityInfo::Root,
@@ -863,7 +865,7 @@ impl PageEndpoint {
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let this = self.await?;
         let project = this.pages_project.project();
-        let node_root = project.client_root();
+        let node_root = project.client_root().await?.clone_value();
         let client_relative_path = self.client_relative_path();
         let page_loader = PageLoaderAsset::new(
             node_root,
@@ -881,19 +883,31 @@ impl PageEndpoint {
         let (reference_type, project_root, module_context, edge_module_context) = match this.ty {
             PageEndpointType::Html | PageEndpointType::SsrOnly => (
                 ReferenceType::Entry(EntryReferenceSubType::Page),
-                this.pages_project.project().project_path(),
+                this.pages_project
+                    .project()
+                    .project_path()
+                    .await?
+                    .clone_value(),
                 this.pages_project.ssr_module_context(),
                 this.pages_project.edge_ssr_module_context(),
             ),
             PageEndpointType::Data => (
                 ReferenceType::Entry(EntryReferenceSubType::Page),
-                this.pages_project.project().project_path(),
+                this.pages_project
+                    .project()
+                    .project_path()
+                    .await?
+                    .clone_value(),
                 this.pages_project.ssr_data_module_context(),
                 this.pages_project.edge_ssr_data_module_context(),
             ),
             PageEndpointType::Api => (
                 ReferenceType::Entry(EntryReferenceSubType::PagesApi),
-                this.pages_project.project().project_path(),
+                this.pages_project
+                    .project()
+                    .project_path()
+                    .await?
+                    .clone_value(),
                 this.pages_project.api_module_context(),
                 this.pages_project.edge_api_module_context(),
             ),
@@ -1015,7 +1029,12 @@ impl PageEndpoint {
                         .client_module_context()
                         .process(
                             Vc::upcast(FileSource::new(
-                                this.pages_structure.await?.app.file_path(),
+                                this.pages_structure
+                                    .await?
+                                    .app
+                                    .file_path()
+                                    .await?
+                                    .clone_value(),
                             )),
                             ReferenceType::Entry(EntryReferenceSubType::Page),
                         )
@@ -1114,8 +1133,8 @@ impl PageEndpoint {
 
                 let asset_path = get_asset_path_from_pathname(pathname, ".js");
 
-                let ssr_entry_chunk_path_string: RcStr = format!("pages{asset_path}").into();
-                let ssr_entry_chunk_path = node_path.join(ssr_entry_chunk_path_string);
+                let ssr_entry_chunk_path_string = format!("pages{asset_path}");
+                let ssr_entry_chunk_path = node_path.join(&ssr_entry_chunk_path_string)?;
                 let ssr_entry_chunk = node_chunking_context
                     .entry_chunk_group_asset(
                         ssr_entry_chunk_path,
@@ -1180,7 +1199,8 @@ impl PageEndpoint {
             this.pages_project
                 .project()
                 .node_root()
-                .join(rcstr!("server")),
+                .await?
+                .join("server")?,
             project.server_chunking_context(true),
             project.edge_chunking_context(true),
             this.pages_project.ssr_runtime_entries(),
@@ -1196,7 +1216,8 @@ impl PageEndpoint {
             this.pages_project
                 .project()
                 .node_root()
-                .join(rcstr!("server/data")),
+                .await?
+                .join("server/data")?,
             this.pages_project.project().server_chunking_context(true),
             this.pages_project.project().edge_chunking_context(true),
             this.pages_project.ssr_data_runtime_entries(),
@@ -1212,7 +1233,8 @@ impl PageEndpoint {
             this.pages_project
                 .project()
                 .node_root()
-                .join(rcstr!("server")),
+                .await?
+                .join("server")?,
             this.pages_project.project().server_chunking_context(false),
             this.pages_project.project().edge_chunking_context(false),
             this.pages_project.ssr_runtime_entries(),
@@ -1225,12 +1247,11 @@ impl PageEndpoint {
         &self,
         entry_chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let node_root = self.pages_project.project().node_root();
+        let node_root = self.pages_project.project().node_root().await?;
         let chunk_path = entry_chunk.path().await?;
 
         let asset_path = node_root
-            .join(rcstr!("server"))
-            .await?
+            .join("server")?
             .get_path_to(&chunk_path)
             .context("ssr chunk entry path must be inside the node root")?;
 
@@ -1241,27 +1262,39 @@ impl PageEndpoint {
         };
         let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
         let asset = Vc::upcast(VirtualOutputAsset::new(
-            node_root
-                .join(format!("server/pages{manifest_path_prefix}/pages-manifest.json",).into()),
+            node_root.join(&format!(
+                "server/pages{manifest_path_prefix}/pages-manifest.json",
+            ))?,
             AssetContent::file(File::from(serde_json::to_string_pretty(&pages_manifest)?).into()),
         ));
         Ok(asset)
     }
 
     #[turbo_tasks::function]
-    fn react_loadable_manifest(
+    async fn react_loadable_manifest(
         &self,
         dynamic_import_entries: Vc<DynamicImportedChunks>,
         runtime: NextRuntime,
     ) -> Result<Vc<OutputAssets>> {
-        let node_root = self.pages_project.project().node_root();
-        let client_relative_path = self.pages_project.project().client_relative_path();
+        let node_root = self
+            .pages_project
+            .project()
+            .node_root()
+            .await?
+            .clone_value();
+        let client_relative_path = self
+            .pages_project
+            .project()
+            .client_relative_path()
+            .await?
+            .clone_value();
         let loadable_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
         Ok(create_react_loadable_manifest(
             dynamic_import_entries,
             client_relative_path,
-            node_root
-                .join(format!("server/pages{loadable_path_prefix}/react-loadable-manifest").into()),
+            node_root.join(&format!(
+                "server/pages{loadable_path_prefix}/react-loadable-manifest",
+            ))?,
             runtime,
         ))
     }
@@ -1271,8 +1304,18 @@ impl PageEndpoint {
         &self,
         client_chunks: ResolvedVc<OutputAssets>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let node_root = self.pages_project.project().node_root();
-        let client_relative_path = self.pages_project.project().client_relative_path();
+        let node_root = self
+            .pages_project
+            .project()
+            .node_root()
+            .await?
+            .clone_value();
+        let client_relative_path = self
+            .pages_project
+            .project()
+            .client_relative_path()
+            .await?
+            .clone_value();
         let build_manifest = BuildManifest {
             pages: fxindexmap!(self.pathname.clone() => client_chunks),
             ..Default::default()
@@ -1281,9 +1324,9 @@ impl PageEndpoint {
         Ok(Vc::upcast(
             build_manifest
                 .build_output(
-                    node_root.join(
-                        format!("server/pages{manifest_path_prefix}/build-manifest.json",).into(),
-                    ),
+                    node_root.join(&format!(
+                        "server/pages{manifest_path_prefix}/build-manifest.json",
+                    ))?,
                     client_relative_path,
                 )
                 .await?,
@@ -1319,11 +1362,20 @@ impl PageEndpoint {
         let client_assets = OutputAssets::new(client_assets).to_resolved().await?;
 
         let manifest_path_prefix = get_asset_prefix_from_pathname(pathname);
-        let node_root = this.pages_project.project().node_root();
+        let node_root = this
+            .pages_project
+            .project()
+            .node_root()
+            .await?
+            .clone_value();
         let next_font_manifest_output = create_font_manifest(
-            this.pages_project.project().client_root(),
-            node_root,
-            this.pages_project.pages_dir(),
+            this.pages_project
+                .project()
+                .client_root()
+                .await?
+                .clone_value(),
+            node_root.clone(),
+            this.pages_project.pages_dir().await?.clone_value(),
             original_name,
             &manifest_path_prefix,
             pathname,
@@ -1342,8 +1394,9 @@ impl PageEndpoint {
             let webpack_stats =
                 generate_webpack_stats(original_name.to_owned(), &client_assets.await?).await?;
             let stats_output = VirtualOutputAsset::new(
-                node_root
-                    .join(format!("server/pages{manifest_path_prefix}/webpack-stats.json",).into()),
+                node_root.join(&format!(
+                    "server/pages{manifest_path_prefix}/webpack-stats.json",
+                ))?,
                 AssetContent::file(
                     File::from(serde_json::to_string_pretty(&webpack_stats)?).into(),
                 ),
@@ -1384,7 +1437,12 @@ impl PageEndpoint {
                 dynamic_import_entries,
                 ref regions,
             } => {
-                let node_root = this.pages_project.project().node_root();
+                let node_root = this
+                    .pages_project
+                    .project()
+                    .node_root()
+                    .await?
+                    .clone_value();
                 if emit_manifests {
                     let files_value = files.await?;
                     if let Some(&file) = files_value.first() {
@@ -1409,7 +1467,7 @@ impl PageEndpoint {
                     ];
                     let mut wasm_paths_from_root = fxindexset![];
 
-                    let node_root_value = node_root.await?;
+                    let node_root_value = node_root.clone();
 
                     file_paths_from_root.extend(
                         get_js_paths_from_root(&node_root_value, &loadable_manifest_output).await?,
@@ -1464,10 +1522,9 @@ impl PageEndpoint {
                     };
                     let manifest_path_prefix = get_asset_prefix_from_pathname(&this.pathname);
                     let middleware_manifest_v2 = VirtualOutputAsset::new(
-                        node_root.join(
-                            format!("server/pages{manifest_path_prefix}/middleware-manifest.json")
-                                .into(),
-                        ),
+                        node_root.join(&format!(
+                            "server/pages{manifest_path_prefix}/middleware-manifest.json",
+                        ))?,
                         AssetContent::file(
                             FileContent::Content(File::from(serde_json::to_string_pretty(
                                 &middleware_manifest_v2,
@@ -1497,8 +1554,8 @@ impl PageEndpoint {
             self.pages_project
                 .project()
                 .client_relative_path()
-                .to_resolved()
-                .await?,
+                .await?
+                .clone_value(),
         )))
     }
 }
@@ -1538,7 +1595,12 @@ impl Endpoint for PageEndpoint {
             let output = self.output().await?;
             let output_assets = self.output().output_assets();
 
-            let node_root = this.pages_project.project().node_root();
+            let node_root = this
+                .pages_project
+                .project()
+                .node_root()
+                .await?
+                .clone_value();
 
             let (server_paths, client_paths) = if this
                 .pages_project
@@ -1547,9 +1609,16 @@ impl Endpoint for PageEndpoint {
                 .await?
                 .is_development()
             {
-                let server_paths = all_server_paths(output_assets, node_root).owned().await?;
+                let server_paths = all_server_paths(output_assets, node_root.clone())
+                    .owned()
+                    .await?;
 
-                let client_relative_root = this.pages_project.project().client_relative_path();
+                let client_relative_root = this
+                    .pages_project
+                    .project()
+                    .client_relative_path()
+                    .await?
+                    .clone_value();
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
                     .owned()
                     .instrument(tracing::info_span!("client_paths"))
@@ -1559,7 +1628,7 @@ impl Endpoint for PageEndpoint {
                 (vec![], vec![])
             };
 
-            let node_root = &node_root.await?;
+            let node_root = node_root.clone();
             let written_endpoint = match *output {
                 PageEndpointOutput::NodeJs { entry_chunk, .. } => EndpointOutputPaths::NodeJs {
                     server_entry_path: node_root

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -31,7 +31,7 @@ pub struct ServerPaths(Vec<ServerPath>);
 #[turbo_tasks::function]
 pub async fn all_server_paths(
     assets: Vc<OutputAssets>,
-    node_root: Vc<FileSystemPath>,
+    node_root: FileSystemPath,
 ) -> Result<Vc<ServerPaths>> {
     let span = tracing::info_span!("all_server_paths");
     async move {
@@ -69,7 +69,7 @@ pub async fn all_server_paths(
 #[turbo_tasks::function]
 pub async fn all_paths_in_root(
     assets: Vc<OutputAssets>,
-    root: Vc<FileSystemPath>,
+    root: FileSystemPath,
 ) -> Result<Vc<Vec<RcStr>>> {
     let all_assets = &*all_assets_from_entries(assets).await?;
     let root = &*root.await?;

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -36,25 +36,29 @@ pub async fn all_server_paths(
     let span = tracing::info_span!("all_server_paths");
     async move {
         let all_assets = all_assets_from_entries(assets).await?;
-        let node_root = &node_root.await?;
+        let node_root = node_root.clone();
         Ok(Vc::cell(
             all_assets
                 .iter()
-                .map(|&asset| async move {
-                    Ok(
-                        if let Some(path) = node_root.get_path_to(&*asset.path().await?) {
-                            let content_hash = match *asset.content().await? {
-                                AssetContent::File(file) => *file.hash().await?,
-                                AssetContent::Redirect { .. } => 0,
-                            };
-                            Some(ServerPath {
-                                path: path.to_string(),
-                                content_hash,
-                            })
-                        } else {
-                            None
-                        },
-                    )
+                .map(|&asset| {
+                    let node_root = node_root.clone();
+
+                    async move {
+                        Ok(
+                            if let Some(path) = node_root.get_path_to(&*asset.path().await?) {
+                                let content_hash = match *asset.content().await? {
+                                    AssetContent::File(file) => *file.hash().await?,
+                                    AssetContent::Redirect { .. } => 0,
+                                };
+                                Some(ServerPath {
+                                    path: path.to_string(),
+                                    content_hash,
+                                })
+                            } else {
+                                None
+                            },
+                        )
+                    }
                 })
                 .try_flat_join()
                 .await?,
@@ -72,10 +76,9 @@ pub async fn all_paths_in_root(
     root: FileSystemPath,
 ) -> Result<Vc<Vec<RcStr>>> {
     let all_assets = &*all_assets_from_entries(assets).await?;
-    let root = &*root.await?;
 
     Ok(Vc::cell(
-        get_paths_from_root(root, all_assets, |_| true).await?,
+        get_paths_from_root(&root, all_assets, |_| true).await?,
     ))
 }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -627,7 +627,7 @@ impl Issue for ConflictIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -645,10 +645,12 @@ impl Issue for ConflictIssue {
 impl Project {
     #[turbo_tasks::function]
     pub async fn app_project(self: Vc<Self>) -> Result<Vc<OptionAppProject>> {
-        let app_dir = find_app_dir(self.project_path()).await?;
+        let app_dir = find_app_dir(self.project_path().await?.clone_value()).await?;
 
-        Ok(match *app_dir {
-            Some(app_dir) => Vc::cell(Some(AppProject::new(self, *app_dir).to_resolved().await?)),
+        Ok(match &*app_dir {
+            Some(app_dir) => Vc::cell(Some(
+                AppProject::new(self, app_dir.clone()).to_resolved().await?,
+            )),
             None => Vc::cell(None),
         })
     }
@@ -691,8 +693,10 @@ impl Project {
         Ok(self
             .output_fs()
             .root()
-            .join(relative_from_root_to_project_path.into())
-            .join(this.dist_dir.clone()))
+            .await?
+            .join(&relative_from_root_to_project_path)?
+            .join(&this.dist_dir.clone())?
+            .cell())
     }
 
     #[turbo_tasks::function]
@@ -708,13 +712,14 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn client_relative_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let next_config = self.next_config().await?;
-        Ok(self.client_root().join(
-            format!(
+        Ok(self
+            .client_root()
+            .await?
+            .join(&format!(
                 "{}/_next",
                 next_config.base_path.clone().unwrap_or_default(),
-            )
-            .into(),
-        ))
+            ))?
+            .cell())
     }
 
     #[turbo_tasks::function]
@@ -722,8 +727,8 @@ impl Project {
         let this = self.await?;
         let output_root_to_root_path = self
             .project_path()
-            .join(this.dist_dir.clone())
             .await?
+            .join(&this.dist_dir.clone())?
             .get_relative_path_to(&*self.project_root_path().await?)
             .context("Project path need to be in root path")?;
         Ok(Vc::cell(output_root_to_root_path))
@@ -732,13 +737,13 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn project_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let root = self.project_root_path();
+        let root = self.project_root_path().await?;
         let project_relative = this.project_path.strip_prefix(&*this.root_path).unwrap();
         let project_relative = project_relative
             .strip_prefix(MAIN_SEPARATOR)
             .unwrap_or(project_relative)
             .replace(MAIN_SEPARATOR, "/");
-        Ok(root.join(project_relative.into()))
+        Ok(root.join(&project_relative)?.cell())
     }
 
     #[turbo_tasks::function]
@@ -795,17 +800,17 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) async fn execution_context(self: Vc<Self>) -> Result<Vc<ExecutionContext>> {
-        let node_root = self.node_root().to_resolved().await?;
+        let node_root = self.node_root().await?.clone_value();
         let next_mode = self.next_mode().await?;
 
         let node_execution_chunking_context = Vc::upcast(
             NodeJsChunkingContext::builder(
-                self.project_root_path().to_resolved().await?,
-                node_root,
+                self.project_root_path().await?.clone_value(),
+                node_root.clone(),
                 self.node_root_to_root_path().owned().await?,
-                node_root,
-                node_root.join(rcstr!("build/chunks")).to_resolved().await?,
-                node_root.join(rcstr!("build/assets")).to_resolved().await?,
+                node_root.clone(),
+                node_root.join("build/chunks")?,
+                node_root.join("build/assets")?,
                 node_build_environment().to_resolved().await?,
                 next_mode.runtime_type(),
             )
@@ -818,7 +823,7 @@ impl Project {
         );
 
         Ok(ExecutionContext::new(
-            self.project_path(),
+            self.project_path().await?.clone_value(),
             node_execution_chunking_context,
             self.env(),
         ))
@@ -999,7 +1004,7 @@ impl Project {
     pub(super) async fn edge_compile_time_info(self: Vc<Self>) -> Result<Vc<CompileTimeInfo>> {
         let this = self.await?;
         Ok(get_edge_compile_time_info(
-            self.project_path(),
+            self.project_path().await?.clone_value(),
             this.define_env.edge(),
             self.current_node_js_version(),
         ))
@@ -1022,8 +1027,8 @@ impl Project {
         self: Vc<Self>,
     ) -> Result<Vc<Box<dyn ChunkingContext>>> {
         Ok(get_client_chunking_context(
-            self.project_root_path(),
-            self.client_relative_path(),
+            self.project_root_path().await?.clone_value(),
+            self.client_relative_path().await?.clone_value(),
             rcstr!("/ROOT"),
             self.next_config().computed_asset_prefix(),
             self.next_config().chunk_suffix_path(),
@@ -1045,10 +1050,10 @@ impl Project {
         Ok(if client_assets {
             get_server_chunking_context_with_client_assets(
                 self.next_mode(),
-                self.project_root_path(),
-                self.node_root(),
+                self.project_root_path().await?.clone_value(),
+                self.node_root().await?.clone_value(),
                 self.node_root_to_root_path().owned().await?,
-                self.client_relative_path(),
+                self.client_relative_path().await?.clone_value(),
                 self.next_config().computed_asset_prefix().owned().await?,
                 self.server_compile_time_info().environment(),
                 self.module_ids(),
@@ -1060,8 +1065,8 @@ impl Project {
         } else {
             get_server_chunking_context(
                 self.next_mode(),
-                self.project_root_path(),
-                self.node_root(),
+                self.project_root_path().await?.clone_value(),
+                self.node_root().await?.clone_value(),
                 self.node_root_to_root_path().owned().await?,
                 self.server_compile_time_info().environment(),
                 self.module_ids(),
@@ -1081,10 +1086,10 @@ impl Project {
         Ok(if client_assets {
             get_edge_chunking_context_with_client_assets(
                 self.next_mode(),
-                self.project_root_path(),
-                self.node_root(),
+                self.project_root_path().await?.clone_value(),
+                self.node_root().await?.clone_value(),
                 self.node_root_to_root_path(),
-                self.client_relative_path(),
+                self.client_relative_path().await?.clone_value(),
                 self.next_config().computed_asset_prefix(),
                 self.edge_compile_time_info().environment(),
                 self.module_ids(),
@@ -1096,8 +1101,8 @@ impl Project {
         } else {
             get_edge_chunking_context(
                 self.next_mode(),
-                self.project_root_path(),
-                self.node_root(),
+                self.project_root_path().await?.clone_value(),
+                self.node_root().await?.clone_value(),
                 self.node_root_to_root_path(),
                 self.edge_compile_time_info().environment(),
                 self.module_ids(),
@@ -1225,7 +1230,7 @@ impl Project {
             match routes.entry(pathname.clone()) {
                 Entry::Occupied(mut entry) => {
                     ConflictIssue {
-                        path: self.project_path().to_resolved().await?,
+                        path: self.project_path().await?.clone_value(),
                         title: StyledString::Text(
                             format!("App Router and Pages Router both match path: {pathname}")
                                 .into(),
@@ -1292,7 +1297,7 @@ impl Project {
     async fn edge_middleware_context(self: Vc<Self>) -> Result<Vc<Box<dyn AssetContext>>> {
         let mut transitions = vec![];
 
-        let app_dir = *find_app_dir(self.project_path()).await?;
+        let app_dir = (*find_app_dir(self.project_path().await?.clone_value()).await?).clone();
         let app_project = *self.app_project().await?;
 
         let ecmascript_client_reference_transition_name =
@@ -1316,10 +1321,10 @@ impl Project {
             .cell(),
             self.edge_compile_time_info(),
             get_server_module_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 self.execution_context(),
                 ServerContextType::Middleware {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
                 },
@@ -1330,9 +1335,9 @@ impl Project {
                 self.edge_compile_time_info().environment(),
             ),
             get_edge_resolve_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 ServerContextType::Middleware {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
                 },
@@ -1351,7 +1356,7 @@ impl Project {
     async fn node_middleware_context(self: Vc<Self>) -> Result<Vc<Box<dyn AssetContext>>> {
         let mut transitions = vec![];
 
-        let app_dir = *find_app_dir(self.project_path()).await?;
+        let app_dir = (*find_app_dir(self.project_path().await?.clone_value()).await?).clone();
         let app_project = *self.app_project().await?;
 
         let ecmascript_client_reference_transition_name =
@@ -1375,10 +1380,10 @@ impl Project {
             .cell(),
             self.server_compile_time_info(),
             get_server_module_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 self.execution_context(),
                 ServerContextType::Middleware {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
                 },
@@ -1389,9 +1394,9 @@ impl Project {
                 self.server_compile_time_info().environment(),
             ),
             get_server_resolve_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 ServerContextType::Middleware {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name,
                 },
                 self.next_mode(),
@@ -1407,10 +1412,10 @@ impl Project {
         let edge_module_context = self.edge_middleware_context();
 
         let middleware = self.find_middleware();
-        let FindContextFileResult::Found(fs_path, _) = *middleware.await? else {
+        let FindContextFileResult::Found(fs_path, _) = &*middleware.await? else {
             return Ok(Vc::upcast(edge_module_context));
         };
-        let source = Vc::upcast(FileSource::new(*fs_path));
+        let source = Vc::upcast(FileSource::new(fs_path.clone()));
 
         let module = edge_module_context
             .process(
@@ -1429,21 +1434,21 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    fn find_middleware(self: Vc<Self>) -> Vc<FindContextFileResult> {
-        find_context_file(
-            self.project_path(),
+    async fn find_middleware(self: Vc<Self>) -> Result<Vc<FindContextFileResult>> {
+        Ok(find_context_file(
+            self.project_path().await?.clone_value(),
             middleware_files(self.next_config().page_extensions()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
     async fn middleware_endpoint(self: Vc<Self>) -> Result<Vc<Box<dyn Endpoint>>> {
         let middleware = self.find_middleware();
-        let FindContextFileResult::Found(fs_path, _) = *middleware.await? else {
+        let FindContextFileResult::Found(fs_path, _) = &*middleware.await? else {
             return Ok(Vc::upcast(EmptyEndpoint::new()));
         };
-        let source = Vc::upcast(FileSource::new(*fs_path));
-        let app_dir = *find_app_dir(self.project_path()).await?;
+        let source = Vc::upcast(FileSource::new(fs_path.clone()));
+        let app_dir = (*find_app_dir(self.project_path().await?.clone_value()).await?).clone();
         let ecmascript_client_reference_transition_name = (*self.app_project().await?)
             .as_ref()
             .map(|_| AppProject::client_transition_name());
@@ -1454,7 +1459,7 @@ impl Project {
             self,
             middleware_asset_context,
             source,
-            app_dir.as_deref().copied(),
+            app_dir.clone(),
             ecmascript_client_reference_transition_name,
         )))
     }
@@ -1463,7 +1468,7 @@ impl Project {
     async fn node_instrumentation_context(self: Vc<Self>) -> Result<Vc<Box<dyn AssetContext>>> {
         let mut transitions = vec![];
 
-        let app_dir = *find_app_dir(self.project_path()).await?;
+        let app_dir = (*find_app_dir(self.project_path().await?.clone_value()).await?).clone();
         let app_project = &*self.app_project().await?;
 
         let ecmascript_client_reference_transition_name = app_project
@@ -1488,10 +1493,10 @@ impl Project {
             .cell(),
             self.server_compile_time_info(),
             get_server_module_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 self.execution_context(),
                 ServerContextType::Instrumentation {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
                 },
@@ -1502,9 +1507,9 @@ impl Project {
                 self.server_compile_time_info().environment(),
             ),
             get_server_resolve_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 ServerContextType::Instrumentation {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name,
                 },
                 self.next_mode(),
@@ -1522,7 +1527,7 @@ impl Project {
     async fn edge_instrumentation_context(self: Vc<Self>) -> Result<Vc<Box<dyn AssetContext>>> {
         let mut transitions = vec![];
 
-        let app_dir = *find_app_dir(self.project_path()).await?;
+        let app_dir = (*find_app_dir(self.project_path().await?.clone_value()).await?).clone();
         let app_project = &*self.app_project().await?;
 
         let ecmascript_client_reference_transition_name = app_project
@@ -1547,10 +1552,10 @@ impl Project {
             .cell(),
             self.edge_compile_time_info(),
             get_server_module_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 self.execution_context(),
                 ServerContextType::Instrumentation {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name:
                         ecmascript_client_reference_transition_name.clone(),
                 },
@@ -1561,9 +1566,9 @@ impl Project {
                 self.edge_compile_time_info().environment(),
             ),
             get_edge_resolve_options_context(
-                self.project_path(),
+                self.project_path().await?.clone_value(),
                 ServerContextType::Instrumentation {
-                    app_dir,
+                    app_dir: app_dir.clone(),
                     ecmascript_client_reference_transition_name,
                 },
                 self.next_mode(),
@@ -1578,11 +1583,11 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    fn find_instrumentation(self: Vc<Self>) -> Vc<FindContextFileResult> {
-        find_context_file(
-            self.project_path(),
+    async fn find_instrumentation(self: Vc<Self>) -> Result<Vc<FindContextFileResult>> {
+        Ok(find_context_file(
+            self.project_path().await?.clone_value(),
             instrumentation_files(self.next_config().page_extensions()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -1591,11 +1596,11 @@ impl Project {
         is_edge: bool,
     ) -> Result<Vc<Box<dyn Endpoint>>> {
         let instrumentation = self.find_instrumentation();
-        let FindContextFileResult::Found(fs_path, _) = *instrumentation.await? else {
+        let FindContextFileResult::Found(fs_path, _) = &*instrumentation.await? else {
             return Ok(Vc::upcast(EmptyEndpoint::new()));
         };
-        let source = Vc::upcast(FileSource::new(*fs_path));
-        let app_dir = *find_app_dir(self.project_path()).await?;
+        let source = Vc::upcast(FileSource::new(fs_path.clone()));
+        let app_dir = (*find_app_dir(self.project_path().await?.clone_value()).await?).clone();
         let ecmascript_client_reference_transition_name = (*self.app_project().await?)
             .as_ref()
             .map(|_| AppProject::client_transition_name());
@@ -1611,7 +1616,7 @@ impl Project {
             instrumentation_asset_context,
             source,
             is_edge,
-            app_dir.as_deref().copied(),
+            app_dir.clone(),
             ecmascript_client_reference_transition_name,
         )))
     }
@@ -1625,16 +1630,16 @@ impl Project {
         async move {
             let all_output_assets = all_assets_from_entries_operation(output_assets);
 
-            let client_relative_path = self.client_relative_path();
-            let node_root = self.node_root();
+            let client_relative_path = self.client_relative_path().await?.clone_value();
+            let node_root = self.node_root().await?.clone_value();
 
             if let Some(map) = self.await?.versioned_content_map {
                 let _ = map
                     .insert_output_assets(
                         all_output_assets,
-                        node_root,
-                        client_relative_path,
-                        node_root,
+                        node_root.clone(),
+                        client_relative_path.clone(),
+                        node_root.clone(),
                     )
                     .resolve()
                     .await?;
@@ -1643,9 +1648,9 @@ impl Project {
             } else {
                 let _ = emit_assets(
                     all_output_assets.connect(),
-                    node_root,
-                    client_relative_path,
-                    node_root,
+                    node_root.clone(),
+                    client_relative_path.clone(),
+                    node_root.clone(),
                 )
                 .resolve()
                 .await?;
@@ -1660,7 +1665,7 @@ impl Project {
     #[turbo_tasks::function]
     async fn hmr_content(self: Vc<Self>, identifier: RcStr) -> Result<Vc<OptionVersionedContent>> {
         if let Some(map) = self.await?.versioned_content_map {
-            let content = map.get(self.client_relative_path().join(identifier.clone()));
+            let content = map.get(self.client_relative_path().await?.join(&identifier)?);
             Ok(content)
         } else {
             bail!("must be in dev mode to hmr")
@@ -1727,7 +1732,7 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn hmr_identifiers(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
         if let Some(map) = self.await?.versioned_content_map {
-            Ok(map.keys_in_path(self.client_relative_path()))
+            Ok(map.keys_in_path(self.client_relative_path().await?.clone_value()))
         } else {
             bail!("must be in dev mode to hmr")
         }
@@ -1736,17 +1741,17 @@ impl Project {
     /// Completion when server side changes are detected in output assets
     /// referenced from the roots
     #[turbo_tasks::function]
-    pub fn server_changed(self: Vc<Self>, roots: Vc<OutputAssets>) -> Vc<Completion> {
-        let path = self.node_root();
-        any_output_changed(roots, path, true)
+    pub async fn server_changed(self: Vc<Self>, roots: Vc<OutputAssets>) -> Result<Vc<Completion>> {
+        let path = self.node_root().await?.clone_value();
+        Ok(any_output_changed(roots, path, true))
     }
 
     /// Completion when client side changes are detected in output assets
     /// referenced from the roots
     #[turbo_tasks::function]
-    pub fn client_changed(self: Vc<Self>, roots: Vc<OutputAssets>) -> Vc<Completion> {
-        let path = self.client_root();
-        any_output_changed(roots, path, false)
+    pub async fn client_changed(self: Vc<Self>, roots: Vc<OutputAssets>) -> Result<Vc<Completion>> {
+        let path = self.client_root().await?.clone_value();
+        Ok(any_output_changed(roots, path, false))
     }
 
     #[turbo_tasks::function]
@@ -1823,7 +1828,6 @@ async fn any_output_changed(
     path: FileSystemPath,
     server: bool,
 ) -> Result<Vc<Completion>> {
-    let path = &path.await?;
     let completions = AdjacencyMap::new()
         .skip_duplicates()
         .visit(roots.await?.iter().copied(), get_referenced_output_assets)
@@ -1831,15 +1835,19 @@ async fn any_output_changed(
         .completed()?
         .into_inner()
         .into_postorder_topological()
-        .map(|m| async move {
-            let asset_path = m.path().await?;
-            if !asset_path.path.ends_with(".map")
-                && (!server || !asset_path.path.ends_with(".css"))
-                && asset_path.is_inside_ref(path)
-            {
-                anyhow::Ok(Some(content_changed(*ResolvedVc::upcast(m))))
-            } else {
-                Ok(None)
+        .map(|m| {
+            let path = path.clone();
+
+            async move {
+                let asset_path = m.path().await?;
+                if !asset_path.path.ends_with(".map")
+                    && (!server || !asset_path.path.ends_with(".css"))
+                    && asset_path.is_inside_ref(&path)
+                {
+                    anyhow::Ok(Some(content_changed(*ResolvedVc::upcast(m))))
+                } else {
+                    Ok(None)
+                }
             }
         })
         .map(|v| async move {

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -521,7 +521,7 @@ impl ProjectContainer {
     #[turbo_tasks::function]
     pub fn get_source_map(
         &self,
-        file_path: Vc<FileSystemPath>,
+        file_path: FileSystemPath,
         section: Option<RcStr>,
     ) -> Vc<OptionStringifiedSourceMap> {
         if let Some(map) = self.versioned_content_map {
@@ -608,7 +608,7 @@ impl ProjectDefineEnv {
 
 #[turbo_tasks::value(shared)]
 struct ConflictIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     title: ResolvedVc<StyledString>,
     description: ResolvedVc<StyledString>,
     severity: IssueSeverity,
@@ -1820,7 +1820,7 @@ pub struct ModuleGraphs {
 #[turbo_tasks::function]
 async fn any_output_changed(
     roots: Vc<OutputAssets>,
-    path: Vc<FileSystemPath>,
+    path: FileSystemPath,
     server: bool,
 ) -> Result<Vc<Completion>> {
     let path = &path.await?;

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -59,8 +59,8 @@ pub(crate) struct ServerActionsManifest {
 #[turbo_tasks::function]
 pub(crate) async fn create_server_actions_manifest(
     actions: Vc<AllActions>,
-    project_path: Vc<FileSystemPath>,
-    node_root: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
+    node_root: FileSystemPath,
     page_name: RcStr,
     runtime: NextRuntime,
     rsc_asset_context: Vc<Box<dyn AssetContext>>,
@@ -100,7 +100,7 @@ pub(crate) async fn create_server_actions_manifest(
 /// client and present inside the paired manifest.
 #[turbo_tasks::function]
 pub(crate) async fn build_server_actions_loader(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     page_name: RcStr,
     actions: Vc<AllActions>,
     asset_context: Vc<Box<dyn AssetContext>>,
@@ -150,7 +150,7 @@ pub(crate) async fn build_server_actions_loader(
 /// Builds a manifest containing every action's hashed id, with an internal
 /// module id which exports a function using that hashed name.
 async fn build_manifest(
-    node_root: Vc<FileSystemPath>,
+    node_root: FileSystemPath,
     page_name: RcStr,
     runtime: NextRuntime,
     actions: Vc<AllActions>,

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -124,7 +124,7 @@ pub(crate) async fn build_server_actions_loader(
         )?;
     }
 
-    let path = project_path.join(format!(".next-internal/server/app{page_name}/actions.js").into());
+    let path = project_path.join(&format!(".next-internal/server/app{page_name}/actions.js"))?;
     let file = File::from(contents.build());
     let source = VirtualSource::new_with_ident(
         AssetIdent::from_path(path).with_modifier(rcstr!("server actions loader")),
@@ -158,8 +158,9 @@ async fn build_manifest(
     async_module_info: Vc<AsyncModulesInfo>,
 ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
     let manifest_path_prefix = &page_name;
-    let manifest_path = node_root
-        .join(format!("server/app{manifest_path_prefix}/server-reference-manifest.json",).into());
+    let manifest_path = node_root.join(&format!(
+        "server/app{manifest_path_prefix}/server-reference-manifest.json",
+    ))?;
     let mut manifest = ServerReferenceManifest {
         ..Default::default()
     };
@@ -207,7 +208,13 @@ pub async fn to_rsc_context(
     // opposed to the following hack to construct the RSC module corresponding to this client
     // module.
     let source = FileSource::new_with_query(
-        client_module.ident().path().root().join(entry_path.into()),
+        client_module
+            .ident()
+            .path()
+            .await?
+            .root()
+            .await?
+            .join(entry_path)?,
         entry_query.into(),
     );
     let module = asset_context

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -29,7 +29,7 @@ use turbopack_core::{
 struct MapEntry {
     assets_operation: OperationVc<OutputAssets>,
     /// Precomputed map for quick access to output asset by filepath
-    path_to_asset: FxHashMap<ResolvedVc<FileSystemPath>, ResolvedVc<Box<dyn OutputAsset>>>,
+    path_to_asset: FxHashMap<FileSystemPath, ResolvedVc<Box<dyn OutputAsset>>>,
 }
 
 // HACK: This is technically incorrect because `path_to_asset` contains `ResolvedVc`...
@@ -47,7 +47,7 @@ pub struct PathToOutputOperation(
     /// It may not be 100% correct for the key (`FileSystemPath`) to be in a `ResolvedVc` here, but
     /// it's impractical to make it an `OperationVc`/`OperationValue`, and it's unlikely to
     /// change/break?
-    FxHashMap<ResolvedVc<FileSystemPath>, FxIndexSet<OperationVc<OutputAssets>>>,
+    FxHashMap<FileSystemPath, FxIndexSet<OperationVc<OutputAssets>>>,
 );
 
 // HACK: This is technically incorrect because the map's key is a `ResolvedVc`...
@@ -91,9 +91,9 @@ impl VersionedContentMap {
         self: ResolvedVc<Self>,
         // Output assets to emit
         assets_operation: OperationVc<OutputAssets>,
-        node_root: ResolvedVc<FileSystemPath>,
-        client_relative_path: ResolvedVc<FileSystemPath>,
-        client_output_path: ResolvedVc<FileSystemPath>,
+        node_root: FileSystemPath,
+        client_relative_path: FileSystemPath,
+        client_output_path: FileSystemPath,
     ) -> Result<()> {
         let this = self.await?;
         let compute_entry = compute_entry_operation(
@@ -115,9 +115,9 @@ impl VersionedContentMap {
     async fn compute_entry(
         &self,
         assets_operation: OperationVc<OutputAssets>,
-        node_root: Vc<FileSystemPath>,
-        client_relative_path: Vc<FileSystemPath>,
-        client_output_path: Vc<FileSystemPath>,
+        node_root: FileSystemPath,
+        client_relative_path: FileSystemPath,
+        client_output_path: FileSystemPath,
     ) -> Result<Vc<OptionMapEntry>> {
         let entries = get_entries(assets_operation)
             .read_strongly_consistent()
@@ -167,10 +167,7 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    pub async fn get(
-        self: Vc<Self>,
-        path: Vc<FileSystemPath>,
-    ) -> Result<Vc<OptionVersionedContent>> {
+    pub async fn get(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<OptionVersionedContent>> {
         Ok(Vc::cell(match *self.get_asset(path).await? {
             Some(asset) => Some(asset.versioned_content().to_resolved().await?),
             None => None,
@@ -180,7 +177,7 @@ impl VersionedContentMap {
     #[turbo_tasks::function]
     pub async fn get_source_map(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         section: Option<RcStr>,
     ) -> Result<Vc<OptionStringifiedSourceMap>> {
         let Some(asset) = &*self.get_asset(path).await? else {
@@ -202,10 +199,7 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    pub async fn get_asset(
-        self: Vc<Self>,
-        path: ResolvedVc<FileSystemPath>,
-    ) -> Result<Vc<OptionOutputAsset>> {
+    pub async fn get_asset(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<OptionOutputAsset>> {
         let result = self.raw_get(*path).await?;
         if let Some(MapEntry {
             assets_operation: _,
@@ -220,7 +214,7 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function(invalidator)]
-    pub async fn keys_in_path(&self, root: Vc<FileSystemPath>) -> Result<Vc<Vec<RcStr>>> {
+    pub async fn keys_in_path(&self, root: FileSystemPath) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
             let map = &self.map_path_to_op.get().0;
             map.keys().copied().collect::<Vec<_>>()
@@ -235,7 +229,7 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function(invalidator)]
-    fn raw_get(&self, path: ResolvedVc<FileSystemPath>) -> Vc<OptionMapEntry> {
+    fn raw_get(&self, path: FileSystemPath) -> Vc<OptionMapEntry> {
         let assets = {
             let map = &self.map_path_to_op.get().0;
             map.get(&path).and_then(|m| m.iter().next().copied())
@@ -257,7 +251,7 @@ impl VersionedContentMap {
     }
 }
 
-type GetEntriesResultT = Vec<(ResolvedVc<FileSystemPath>, ResolvedVc<Box<dyn OutputAsset>>)>;
+type GetEntriesResultT = Vec<(FileSystemPath, ResolvedVc<Box<dyn OutputAsset>>)>;
 
 #[turbo_tasks::value(transparent)]
 struct GetEntriesResult(GetEntriesResultT);
@@ -280,9 +274,9 @@ async fn get_entries(assets: OperationVc<OutputAssets>) -> Result<Vc<GetEntriesR
 fn compute_entry_operation(
     map: ResolvedVc<VersionedContentMap>,
     assets_operation: OperationVc<OutputAssets>,
-    node_root: ResolvedVc<FileSystemPath>,
-    client_relative_path: ResolvedVc<FileSystemPath>,
-    client_output_path: ResolvedVc<FileSystemPath>,
+    node_root: FileSystemPath,
+    client_relative_path: FileSystemPath,
+    client_output_path: FileSystemPath,
 ) -> Vc<OptionMapEntry> {
     map.compute_entry(
         assets_operation,

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueDefault, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    TryJoinIterExt, ValueDefault, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -129,10 +129,10 @@ impl VersionedContentMap {
             let mut changed = false;
 
             // get current map's keys, subtract keys that don't exist in operation
-            let mut stale_assets = map.0.keys().copied().collect::<FxHashSet<_>>();
+            let mut stale_assets = map.0.keys().cloned().collect::<FxHashSet<_>>();
 
             for (k, _) in entries.iter().flatten() {
-                let res = map.0.entry(*k).or_default().insert(assets_operation);
+                let res = map.0.entry(k.clone()).or_default().insert(assets_operation);
                 stale_assets.remove(k);
                 changed = changed || res;
             }
@@ -161,7 +161,7 @@ impl VersionedContentMap {
         .await?;
         let map_entry = Vc::cell(Some(MapEntry {
             assets_operation,
-            path_to_asset: entries.iter().flatten().copied().collect(),
+            path_to_asset: entries.iter().flatten().cloned().collect(),
         }));
         Ok(map_entry)
     }
@@ -180,7 +180,7 @@ impl VersionedContentMap {
         path: FileSystemPath,
         section: Option<RcStr>,
     ) -> Result<Vc<OptionStringifiedSourceMap>> {
-        let Some(asset) = &*self.get_asset(path).await? else {
+        let Some(asset) = &*self.get_asset(path.clone()).await? else {
             return Ok(Vc::cell(None));
         };
 
@@ -193,14 +193,14 @@ impl VersionedContentMap {
                 generate_source_map.generate_source_map()
             })
         } else {
-            let path = path.to_string().await?;
+            let path = path.value_to_string().await?;
             bail!("no source map for path {}", path);
         }
     }
 
     #[turbo_tasks::function]
     pub async fn get_asset(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<OptionOutputAsset>> {
-        let result = self.raw_get(*path).await?;
+        let result = self.raw_get(path.clone()).await?;
         if let Some(MapEntry {
             assets_operation: _,
             path_to_asset,
@@ -217,12 +217,14 @@ impl VersionedContentMap {
     pub async fn keys_in_path(&self, root: FileSystemPath) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
             let map = &self.map_path_to_op.get().0;
-            map.keys().copied().collect::<Vec<_>>()
+            map.keys().cloned().collect::<Vec<_>>()
         };
-        let root = &root.await?;
         let keys = keys
             .into_iter()
-            .map(|path| async move { Ok(root.get_path_to(&*path.await?).map(RcStr::from)) })
+            .map(|path| {
+                let root = root.clone();
+                async move { Ok(root.get_path_to(&path).map(RcStr::from)) }
+            })
             .try_flat_join()
             .await?;
         Ok(Vc::cell(keys))
@@ -262,7 +264,7 @@ async fn get_entries(assets: OperationVc<OutputAssets>) -> Result<Vc<GetEntriesR
     let entries = assets_ref
         .iter()
         .map(|&asset| async move {
-            let path = asset.path().to_resolved().await?;
+            let path = asset.path().await?.clone_value();
             Ok((path, asset))
         })
         .try_join()
@@ -280,8 +282,8 @@ fn compute_entry_operation(
 ) -> Vc<OptionMapEntry> {
     map.compute_entry(
         assets_operation,
-        *node_root,
-        *client_relative_path,
-        *client_output_path,
+        node_root,
+        client_relative_path,
+        client_output_path,
     )
 }

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -55,7 +55,13 @@ where
     }
 
     for (chunk_item, chunks) in chunk_items {
-        let size = *chunk_item.content_ident().path().read().len().await?;
+        let size = *chunk_item
+            .content_ident()
+            .path()
+            .await?
+            .read()
+            .len()
+            .await?;
         let path = chunk_item.asset_ident().path().await?.path.clone();
         modules.push(WebpackStatsModule {
             name: path.clone(),

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct AppPageLoaderTreeBuilder {
     base: BaseLoaderTreeBuilder,
     loader_tree_code: String,
-    pages: Vec<ResolvedVc<FileSystemPath>>,
+    pages: Vec<FileSystemPath>,
     /// next.config.js' basePath option to construct og metadata.
     base_path: Option<RcStr>,
 }
@@ -49,7 +49,7 @@ impl AppPageLoaderTreeBuilder {
     async fn write_modules_entry(
         &mut self,
         module_type: AppDirModuleType,
-        path: Option<ResolvedVc<FileSystemPath>>,
+        path: Option<FileSystemPath>,
     ) -> Result<()> {
         if let Some(path) = path {
             if matches!(module_type, AppDirModuleType::Page) {
@@ -218,8 +218,8 @@ impl AppPageLoaderTreeBuilder {
         app_page: &AppPage,
         name: &str,
         item: &MetadataWithAltItem,
-        path: Vc<FileSystemPath>,
-        alt_path: Option<Vc<FileSystemPath>>,
+        path: FileSystemPath,
+        alt_path: Option<FileSystemPath>,
     ) -> Result<()> {
         let i = self.base.unique_number();
 
@@ -437,7 +437,7 @@ pub struct AppPageLoaderTreeModule {
     pub imports: Vec<RcStr>,
     pub loader_tree_code: RcStr,
     pub inner_assets: FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>,
-    pub pages: Vec<ResolvedVc<FileSystemPath>>,
+    pub pages: Vec<FileSystemPath>,
 }
 
 impl AppPageLoaderTreeModule {

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -53,7 +53,7 @@ impl AppPageLoaderTreeBuilder {
     ) -> Result<()> {
         if let Some(path) = path {
             if matches!(module_type, AppDirModuleType::Page) {
-                self.pages.push(path);
+                self.pages.push(path.clone());
             }
 
             let tuple_code = self
@@ -96,7 +96,7 @@ impl AppPageLoaderTreeBuilder {
 
         // naively convert metadataitem -> metadatawithaltitem to iterate along with
         // other icon items
-        let icon = if let Some(favicon) = global_metadata.and_then(|m| m.favicon) {
+        let icon = if let Some(favicon) = global_metadata.and_then(|m| m.favicon.clone()) {
             let item = match favicon {
                 MetadataItem::Static { path } => MetadataWithAltItem::Static {
                     path,
@@ -105,7 +105,7 @@ impl AppPageLoaderTreeBuilder {
                 MetadataItem::Dynamic { path } => MetadataWithAltItem::Dynamic { path },
             };
             let mut item = vec![item];
-            item.extend(icon.iter());
+            item.extend(icon.iter().cloned());
             item
         } else {
             icon.clone()
@@ -121,7 +121,7 @@ impl AppPageLoaderTreeBuilder {
             .await?;
 
         if let Some(global_metadata) = global_metadata {
-            self.write_metadata_manifest(global_metadata.manifest)
+            self.write_metadata_manifest(global_metadata.manifest.clone())
                 .await?;
         }
         self.loader_tree_code += "  },";
@@ -180,8 +180,8 @@ impl AppPageLoaderTreeBuilder {
                     app_page,
                     name,
                     item,
-                    **path,
-                    alt_path.as_deref().copied(),
+                    path.clone(),
+                    alt_path.clone(),
                 )
                 .await?;
             }
@@ -196,7 +196,7 @@ impl AppPageLoaderTreeBuilder {
 
                 let source = dynamic_image_metadata_source(
                     *ResolvedVc::upcast(self.base.module_asset_context),
-                    **path,
+                    path.clone(),
                     name.into(),
                     app_page.clone(),
                 );
@@ -238,7 +238,7 @@ impl AppPageLoaderTreeBuilder {
             .imports
             .push(format!("import {identifier} from \"{inner_module_id}\";").into());
         let module = Vc::upcast(StructuredImageModuleType::create_module(
-            Vc::upcast(FileSource::new(path)),
+            Vc::upcast(FileSource::new(path.clone())),
             BlurPlaceholderMode::None,
             *self.base.module_asset_context,
         ));
@@ -254,7 +254,7 @@ impl AppPageLoaderTreeBuilder {
         } else {
             app_page.to_string()
         };
-        let metadata_route = &*get_metadata_route_name((*item).into()).await?;
+        let metadata_route = &*get_metadata_route_name(item.clone().into()).await?;
         writeln!(
             self.loader_tree_code,
             "{s}  url: fillMetadataSegment({}, await props.params, {}) + \
@@ -268,7 +268,7 @@ impl AppPageLoaderTreeBuilder {
             writeln!(self.loader_tree_code, "{s}  width: {identifier}.width,")?;
             writeln!(self.loader_tree_code, "{s}  height: {identifier}.height,")?;
         } else {
-            let ext = &*path.extension().await?;
+            let ext = path.extension();
             // For SVGs, skip sizes and use "any" to let it scale automatically based on viewport,
             // For the images doesn't provide the size properly, use "any" as well.
             // If the size is presented, use the actual size for the image.
@@ -356,27 +356,27 @@ impl AppPageLoaderTreeBuilder {
         )
         .await?;
 
-        self.write_modules_entry(AppDirModuleType::Layout, *layout)
+        self.write_modules_entry(AppDirModuleType::Layout, layout.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::Error, *error)
+        self.write_modules_entry(AppDirModuleType::Error, error.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::Loading, *loading)
+        self.write_modules_entry(AppDirModuleType::Loading, loading.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::Template, *template)
+        self.write_modules_entry(AppDirModuleType::Template, template.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::NotFound, *not_found)
+        self.write_modules_entry(AppDirModuleType::NotFound, not_found.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::Forbidden, *forbidden)
+        self.write_modules_entry(AppDirModuleType::Forbidden, forbidden.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::Unauthorized, *unauthorized)
+        self.write_modules_entry(AppDirModuleType::Unauthorized, unauthorized.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::Page, *page)
+        self.write_modules_entry(AppDirModuleType::Page, page.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::DefaultPage, *default)
+        self.write_modules_entry(AppDirModuleType::DefaultPage, default.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::GlobalError, *global_error)
+        self.write_modules_entry(AppDirModuleType::GlobalError, global_error.clone())
             .await?;
-        self.write_modules_entry(AppDirModuleType::GlobalNotFound, *global_not_found)
+        self.write_modules_entry(AppDirModuleType::GlobalNotFound, global_not_found.clone())
             .await?;
 
         let modules_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);
@@ -403,19 +403,19 @@ impl AppPageLoaderTreeBuilder {
 
         let modules = &loader_tree.modules;
         // load global-error module
-        if let Some(global_error) = modules.global_error {
+        if let Some(global_error) = &modules.global_error {
             let module = self
                 .base
-                .process_source(Vc::upcast(FileSource::new(*global_error)))
+                .process_source(Vc::upcast(FileSource::new(global_error.clone())))
                 .to_resolved()
                 .await?;
             self.base.inner_assets.insert(GLOBAL_ERROR.into(), module);
         };
         // load global-not-found module
-        if let Some(global_not_found) = modules.global_not_found {
+        if let Some(global_not_found) = &modules.global_not_found {
             let module = self
                 .base
-                .process_source(Vc::upcast(FileSource::new(*global_not_found)))
+                .process_source(Vc::upcast(FileSource::new(global_not_found.clone())))
                 .to_resolved()
                 .await?;
             self.base

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -583,11 +583,15 @@ pub async fn parse_segment_config_from_loader_tree_internal(
     }
 
     let modules = &loader_tree.modules;
-    for path in [modules.page, modules.default, modules.layout]
-        .into_iter()
-        .flatten()
+    for path in [
+        modules.page.clone(),
+        modules.default.clone(),
+        modules.layout.clone(),
+    ]
+    .into_iter()
+    .flatten()
     {
-        let source = Vc::upcast(FileSource::new(*path));
+        let source = Vc::upcast(FileSource::new(path.clone()));
         config.apply_parent_config(&*parse_segment_config_from_source(source).await?);
     }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -37,29 +37,29 @@ fn normalize_underscore(string: &str) -> String {
 #[derive(Default, Debug, Clone)]
 pub struct AppDirModules {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub page: Option<ResolvedVc<FileSystemPath>>,
+    pub page: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layout: Option<ResolvedVc<FileSystemPath>>,
+    pub layout: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<ResolvedVc<FileSystemPath>>,
+    pub error: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub global_error: Option<ResolvedVc<FileSystemPath>>,
+    pub global_error: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub global_not_found: Option<ResolvedVc<FileSystemPath>>,
+    pub global_not_found: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub loading: Option<ResolvedVc<FileSystemPath>>,
+    pub loading: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub template: Option<ResolvedVc<FileSystemPath>>,
+    pub template: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub forbidden: Option<ResolvedVc<FileSystemPath>>,
+    pub forbidden: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unauthorized: Option<ResolvedVc<FileSystemPath>>,
+    pub unauthorized: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_found: Option<ResolvedVc<FileSystemPath>>,
+    pub not_found: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<ResolvedVc<FileSystemPath>>,
+    pub default: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub route: Option<ResolvedVc<FileSystemPath>>,
+    pub route: Option<FileSystemPath>,
     #[serde(skip_serializing_if = "Metadata::is_empty", default)]
     pub metadata: Metadata,
 }
@@ -88,11 +88,11 @@ impl AppDirModules {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, TraceRawVcs, NonLocalValue)]
 pub enum MetadataWithAltItem {
     Static {
-        path: ResolvedVc<FileSystemPath>,
-        alt_path: Option<ResolvedVc<FileSystemPath>>,
+        path: FileSystemPath,
+        alt_path: Option<FileSystemPath>,
     },
     Dynamic {
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
     },
 }
 
@@ -111,8 +111,8 @@ pub enum MetadataWithAltItem {
     NonLocalValue,
 )]
 pub enum MetadataItem {
-    Static { path: ResolvedVc<FileSystemPath> },
-    Dynamic { path: ResolvedVc<FileSystemPath> },
+    Static { path: FileSystemPath },
+    Dynamic { path: FileSystemPath },
 }
 
 #[turbo_tasks::function]
@@ -139,7 +139,7 @@ pub async fn get_metadata_route_name(meta: MetadataItem) -> Result<Vc<RcStr>> {
 }
 
 impl MetadataItem {
-    pub fn into_path(self) -> ResolvedVc<FileSystemPath> {
+    pub fn into_path(self) -> Vc<FileSystemPath> {
         match self {
             MetadataItem::Static { path } => path,
             MetadataItem::Dynamic { path } => path,
@@ -258,11 +258,11 @@ impl DirectoryTree {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionAppDir(Option<ResolvedVc<FileSystemPath>>);
+pub struct OptionAppDir(Option<FileSystemPath>);
 
 /// Finds and returns the [DirectoryTree] of the app directory if existing.
 #[turbo_tasks::function]
-pub async fn find_app_dir(project_path: Vc<FileSystemPath>) -> Result<Vc<OptionAppDir>> {
+pub async fn find_app_dir(project_path: FileSystemPath) -> Result<Vc<OptionAppDir>> {
     let app = project_path.join(rcstr!("app"));
     let src_app = project_path.join(rcstr!("src/app"));
     let app_dir = if *app.get_type().await? == FileSystemEntryType::Directory {
@@ -280,7 +280,7 @@ pub async fn find_app_dir(project_path: Vc<FileSystemPath>) -> Result<Vc<OptionA
 
 #[turbo_tasks::function]
 async fn get_directory_tree(
-    dir: Vc<FileSystemPath>,
+    dir: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<DirectoryTree>> {
     let span = {
@@ -293,7 +293,7 @@ async fn get_directory_tree(
 }
 
 async fn get_directory_tree_internal(
-    dir: Vc<FileSystemPath>,
+    dir: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<DirectoryTree>> {
     let DirectoryContent::Entries(entries) = &*dir.read_dir().await? else {
@@ -501,7 +501,7 @@ impl AppPageLoaderTree {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct FileSystemPathVec(Vec<ResolvedVc<FileSystemPath>>);
+pub struct FileSystemPathVec(Vec<FileSystemPath>);
 
 #[turbo_tasks::value_impl]
 impl ValueDefault for FileSystemPathVec {
@@ -531,7 +531,7 @@ pub enum Entrypoint {
     },
     AppRoute {
         page: AppPage,
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         root_layouts: ResolvedVc<FileSystemPathVec>,
     },
     AppMetadata {
@@ -566,7 +566,7 @@ fn match_parallel_route(name: &str) -> Option<&str> {
 }
 
 fn conflict_issue(
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
     e: &'_ OccupiedEntry<'_, AppPath, Entrypoint>,
     a: &str,
     b: &str,
@@ -597,7 +597,7 @@ fn conflict_issue(
 }
 
 fn add_app_page(
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
     result: &mut FxIndexMap<AppPath, Entrypoint>,
     page: AppPage,
     loader_tree: ResolvedVc<AppPageLoaderTree>,
@@ -656,10 +656,10 @@ fn add_app_page(
 }
 
 fn add_app_route(
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
     result: &mut FxIndexMap<AppPath, Entrypoint>,
     page: AppPage,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     root_layouts: ResolvedVc<FileSystemPathVec>,
 ) {
     let e = match result.entry(page.clone().into()) {
@@ -699,7 +699,7 @@ fn add_app_route(
 }
 
 fn add_app_metadata_route(
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
     result: &mut FxIndexMap<AppPath, Entrypoint>,
     page: AppPage,
     metadata: MetadataItem,
@@ -738,7 +738,7 @@ fn add_app_metadata_route(
 
 #[turbo_tasks::function]
 pub fn get_entrypoints(
-    app_dir: Vc<FileSystemPath>,
+    app_dir: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
     is_global_not_found_enabled: Vc<bool>,
 ) -> Vc<Entrypoints> {
@@ -753,7 +753,7 @@ pub fn get_entrypoints(
 
 #[turbo_tasks::function]
 fn directory_tree_to_entrypoints(
-    app_dir: Vc<FileSystemPath>,
+    app_dir: FileSystemPath,
     directory_tree: Vc<DirectoryTree>,
     global_metadata: Vc<GlobalMetadata>,
     is_global_not_found_enabled: Vc<bool>,
@@ -772,7 +772,7 @@ fn directory_tree_to_entrypoints(
 
 #[turbo_tasks::value]
 struct DuplicateParallelRouteIssue {
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
     previously_inserted_page: AppPage,
     page: AppPage,
 }
@@ -830,7 +830,7 @@ fn page_path_except_parallel(loader_tree: &AppPageLoaderTree) -> Option<AppPage>
 async fn check_duplicate(
     duplicate: &mut FxHashMap<AppPath, AppPage>,
     loader_tree: &AppPageLoaderTree,
-    app_dir: Vc<FileSystemPath>,
+    app_dir: FileSystemPath,
 ) -> Result<()> {
     let page_path = page_path_except_parallel(loader_tree);
 
@@ -856,7 +856,7 @@ struct AppPageLoaderTreeOption(Option<ResolvedVc<AppPageLoaderTree>>);
 /// creates the loader tree for a specific route (pathname / [AppPath])
 #[turbo_tasks::function]
 async fn directory_tree_to_loader_tree(
-    app_dir: Vc<FileSystemPath>,
+    app_dir: FileSystemPath,
     global_metadata: Vc<GlobalMetadata>,
     directory_name: RcStr,
     directory_tree: Vc<DirectoryTree>,
@@ -880,7 +880,7 @@ async fn directory_tree_to_loader_tree(
 }
 
 async fn directory_tree_to_loader_tree_internal(
-    app_dir: Vc<FileSystemPath>,
+    app_dir: FileSystemPath,
     global_metadata: Vc<GlobalMetadata>,
     directory_name: RcStr,
     directory_tree: &PlainDirectoryTree,
@@ -1119,10 +1119,10 @@ async fn directory_tree_to_loader_tree_internal(
 }
 
 async fn default_route_tree(
-    app_dir: Vc<FileSystemPath>,
+    app_dir: FileSystemPath,
     global_metadata: Vc<GlobalMetadata>,
     app_page: AppPage,
-    default_component: Option<Vc<FileSystemPath>>,
+    default_component: Option<FileSystemPath>,
 ) -> Result<AppPageLoaderTree> {
     Ok(AppPageLoaderTree {
         page: app_page.clone(),
@@ -1151,7 +1151,7 @@ async fn default_route_tree(
 
 #[turbo_tasks::function]
 async fn directory_tree_to_entrypoints_internal(
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
     global_metadata: Vc<GlobalMetadata>,
     is_global_not_found_enabled: Vc<bool>,
     directory_name: RcStr,
@@ -1174,7 +1174,7 @@ async fn directory_tree_to_entrypoints_internal(
 }
 
 async fn directory_tree_to_entrypoints_internal_untraced(
-    app_dir: ResolvedVc<FileSystemPath>,
+    app_dir: FileSystemPath,
     global_metadata: Vc<GlobalMetadata>,
     is_global_not_found_enabled: Vc<bool>,
     directory_name: RcStr,
@@ -1496,7 +1496,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
 /// Returns the global metadata for an app directory.
 #[turbo_tasks::function]
 pub async fn get_global_metadata(
-    app_dir: Vc<FileSystemPath>,
+    app_dir: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<GlobalMetadata>> {
     let DirectoryContent::Entries(entries) = &*app_dir.read_dir().await? else {
@@ -1538,7 +1538,7 @@ pub async fn get_global_metadata(
 #[turbo_tasks::value(shared)]
 struct DirectoryTreeIssue {
     pub severity: IssueSeverity,
-    pub app_dir: ResolvedVc<FileSystemPath>,
+    pub app_dir: FileSystemPath,
     pub message: ResolvedVc<StyledString>,
 }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueDefault, ValueToString,
-    Vc, debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
+    FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueDefault, Vc,
+    debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath};
 use turbopack_core::issue::{
@@ -68,15 +68,15 @@ impl AppDirModules {
     fn without_leafs(&self) -> Self {
         Self {
             page: None,
-            layout: self.layout,
-            error: self.error,
-            global_error: self.global_error,
-            global_not_found: self.global_not_found,
-            loading: self.loading,
-            template: self.template,
-            not_found: self.not_found,
-            forbidden: self.forbidden,
-            unauthorized: self.unauthorized,
+            layout: self.layout.clone(),
+            error: self.error.clone(),
+            global_error: self.global_error.clone(),
+            global_not_found: self.global_not_found.clone(),
+            loading: self.loading.clone(),
+            template: self.template.clone(),
+            not_found: self.not_found.clone(),
+            forbidden: self.forbidden.clone(),
+            unauthorized: self.unauthorized.clone(),
             default: None,
             route: None,
             metadata: self.metadata.clone(),
@@ -85,7 +85,7 @@ impl AppDirModules {
 }
 
 /// A single metadata file plus an optional "alt" text file.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, TraceRawVcs, NonLocalValue)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, TraceRawVcs, NonLocalValue)]
 pub enum MetadataWithAltItem {
     Static {
         path: FileSystemPath,
@@ -98,17 +98,7 @@ pub enum MetadataWithAltItem {
 
 /// A single metadata file.
 #[derive(
-    Copy,
-    Clone,
-    Debug,
-    Hash,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Eq,
-    TaskInput,
-    TraceRawVcs,
-    NonLocalValue,
+    Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, TaskInput, TraceRawVcs, NonLocalValue,
 )]
 pub enum MetadataItem {
     Static { path: FileSystemPath },
@@ -118,28 +108,25 @@ pub enum MetadataItem {
 #[turbo_tasks::function]
 pub async fn get_metadata_route_name(meta: MetadataItem) -> Result<Vc<RcStr>> {
     Ok(match meta {
-        MetadataItem::Static { path } => {
-            let path_value = path.await?;
-            Vc::cell(path_value.file_name().into())
-        }
+        MetadataItem::Static { path } => Vc::cell(path.file_name().into()),
         MetadataItem::Dynamic { path } => {
-            let Some(stem) = &*path.file_stem().await? else {
+            let Some(stem) = path.file_stem() else {
                 bail!(
                     "unable to resolve file stem for metadata item at {}",
-                    path.to_string().await?
+                    path.value_to_string().await?
                 );
             };
 
-            match stem.as_str() {
+            match stem {
                 "manifest" => Vc::cell(rcstr!("manifest.webmanifest")),
-                _ => Vc::cell(stem.clone()),
+                _ => Vc::cell(RcStr::from(stem)),
             }
         }
     })
 }
 
 impl MetadataItem {
-    pub fn into_path(self) -> Vc<FileSystemPath> {
+    pub fn into_path(self) -> FileSystemPath {
         match self {
             MetadataItem::Static { path } => path,
             MetadataItem::Dynamic { path } => path,
@@ -263,17 +250,15 @@ pub struct OptionAppDir(Option<FileSystemPath>);
 /// Finds and returns the [DirectoryTree] of the app directory if existing.
 #[turbo_tasks::function]
 pub async fn find_app_dir(project_path: FileSystemPath) -> Result<Vc<OptionAppDir>> {
-    let app = project_path.join(rcstr!("app"));
-    let src_app = project_path.join(rcstr!("src/app"));
+    let app = project_path.join("app")?;
+    let src_app = project_path.join("src/app")?;
     let app_dir = if *app.get_type().await? == FileSystemEntryType::Directory {
         app
     } else if *src_app.get_type().await? == FileSystemEntryType::Directory {
         src_app
     } else {
         return Ok(Vc::cell(None));
-    }
-    .to_resolved()
-    .await?;
+    };
 
     Ok(Vc::cell(Some(app_dir)))
 }
@@ -284,7 +269,7 @@ async fn get_directory_tree(
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<DirectoryTree>> {
     let span = {
-        let dir = dir.to_string().await?.to_string();
+        let dir = dir.value_to_string().await?.to_string();
         tracing::info_span!("read app directory tree", name = dir)
     };
     get_directory_tree_internal(dir, page_extensions)
@@ -317,7 +302,7 @@ async fn get_directory_tree_internal(
     let mut metadata_twitter = Vec::new();
 
     for (basename, entry) in entries {
-        let entry = entry.resolve_symlink().await?;
+        let entry = entry.clone().resolve_symlink().await?;
         match entry {
             DirectoryEntry::File(file) => {
                 // Do not process .d.ts files as routes
@@ -328,18 +313,18 @@ async fn get_directory_tree_internal(
                     && page_extensions_value.iter().any(|e| e == ext)
                 {
                     match stem {
-                        "page" => modules.page = Some(file),
-                        "layout" => modules.layout = Some(file),
-                        "error" => modules.error = Some(file),
-                        "global-error" => modules.global_error = Some(file),
-                        "global-not-found" => modules.global_not_found = Some(file),
-                        "loading" => modules.loading = Some(file),
-                        "template" => modules.template = Some(file),
-                        "forbidden" => modules.forbidden = Some(file),
-                        "unauthorized" => modules.unauthorized = Some(file),
-                        "not-found" => modules.not_found = Some(file),
-                        "default" => modules.default = Some(file),
-                        "route" => modules.route = Some(file),
+                        "page" => modules.page = Some(file.clone()),
+                        "layout" => modules.layout = Some(file.clone()),
+                        "error" => modules.error = Some(file.clone()),
+                        "global-error" => modules.global_error = Some(file.clone()),
+                        "global-not-found" => modules.global_not_found = Some(file.clone()),
+                        "loading" => modules.loading = Some(file.clone()),
+                        "template" => modules.template = Some(file.clone()),
+                        "forbidden" => modules.forbidden = Some(file.clone()),
+                        "unauthorized" => modules.unauthorized = Some(file.clone()),
+                        "not-found" => modules.not_found = Some(file.clone()),
+                        "default" => modules.default = Some(file.clone()),
+                        "route" => modules.route = Some(file.clone()),
                         _ => {}
                     }
                 }
@@ -374,16 +359,11 @@ async fn get_directory_tree_internal(
                     continue;
                 }
 
-                let file_value = file.await?;
-                let file_name = file_value.file_name();
+                let file_name = file.file_name();
                 let basename = file_name
                     .rsplit_once('.')
                     .map_or(file_name, |(basename, _)| basename);
-                let alt_path = file
-                    .parent()
-                    .join(format!("{basename}.alt.txt").into())
-                    .to_resolved()
-                    .await?;
+                let alt_path = file.parent().join(&format!("{basename}.alt.txt"))?;
                 let alt_path = matches!(&*alt_path.get_type().await?, FileSystemEntryType::File)
                     .then_some(alt_path);
 
@@ -398,7 +378,7 @@ async fn get_directory_tree_internal(
             DirectoryEntry::Directory(dir) => {
                 // appDir ignores paths starting with an underscore
                 if !basename.starts_with('_') {
-                    let result = get_directory_tree(*dir, page_extensions)
+                    let result = get_directory_tree(dir.clone(), page_extensions)
                         .to_resolved()
                         .await?;
                     subdirectories.insert(basename.clone(), result);
@@ -743,8 +723,8 @@ pub fn get_entrypoints(
     is_global_not_found_enabled: Vc<bool>,
 ) -> Vc<Entrypoints> {
     directory_tree_to_entrypoints(
-        app_dir,
-        get_directory_tree(app_dir, page_extensions),
+        app_dir.clone(),
+        get_directory_tree(app_dir.clone(), page_extensions),
         get_global_metadata(app_dir, page_extensions),
         is_global_not_found_enabled,
         Default::default(),
@@ -780,8 +760,8 @@ struct DuplicateParallelRouteIssue {
 #[turbo_tasks::value_impl]
 impl Issue for DuplicateParallelRouteIssue {
     #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.app_dir.join(self.page.to_string().into())
+    fn file_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.app_dir.join(&self.page.to_string())?.cell())
     }
 
     #[turbo_tasks::function]
@@ -839,7 +819,7 @@ async fn check_duplicate(
         && prev != page_path
     {
         DuplicateParallelRouteIssue {
-            app_dir: app_dir.to_resolved().await?,
+            app_dir: app_dir.clone(),
             previously_inserted_page: prev.clone(),
             page: loader_tree.page.clone(),
         }
@@ -909,34 +889,30 @@ async fn directory_tree_to_loader_tree_internal(
     if is_root_directory || is_root_layout {
         if modules.not_found.is_none() {
             modules.not_found = Some(
-                get_next_package(app_dir)
-                    .join(rcstr!("dist/client/components/builtin/not-found.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/not-found.js")?,
             );
         }
         if modules.forbidden.is_none() {
             modules.forbidden = Some(
-                get_next_package(app_dir)
-                    .join(rcstr!("dist/client/components/builtin/forbidden.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/forbidden.js")?,
             );
         }
         if modules.unauthorized.is_none() {
             modules.unauthorized = Some(
-                get_next_package(app_dir)
-                    .join(rcstr!("dist/client/components/builtin/unauthorized.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/unauthorized.js")?,
             );
         }
         if modules.global_error.is_none() {
             modules.global_error = Some(
-                get_next_package(app_dir)
-                    .join(rcstr!("dist/client/components/builtin/global-error.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/global-error.js")?,
             );
         }
     }
@@ -995,7 +971,7 @@ async fn directory_tree_to_loader_tree_internal(
         }
 
         let subtree = Box::pin(directory_tree_to_loader_tree_internal(
-            app_dir,
+            app_dir.clone(),
             global_metadata,
             subdir_name.clone(),
             subdirectory,
@@ -1020,7 +996,7 @@ async fn directory_tree_to_loader_tree_internal(
             }
 
             if subtree.has_page() {
-                check_duplicate(&mut duplicate, &subtree, app_dir).await?;
+                check_duplicate(&mut duplicate, &subtree, app_dir.clone()).await?;
             }
 
             if let Some(current_tree) = tree.parallel_routes.get("children") {
@@ -1062,22 +1038,17 @@ async fn directory_tree_to_loader_tree_internal(
             let subdir_name: RcStr = format!("@{key}").into();
 
             let default = if key == "children" {
-                modules.default
+                modules.default.clone()
             } else if let Some(subdirectory) = directory_tree.subdirectories.get(&subdir_name) {
-                subdirectory.modules.default
+                subdirectory.modules.default.clone()
             } else {
                 None
             };
 
             tree.parallel_routes.insert(
                 key,
-                default_route_tree(
-                    app_dir,
-                    global_metadata,
-                    app_page.clone(),
-                    default.map(|v| *v),
-                )
-                .await?,
+                default_route_tree(app_dir.clone(), global_metadata, app_page.clone(), default)
+                    .await?,
             );
         }
     }
@@ -1085,10 +1056,10 @@ async fn directory_tree_to_loader_tree_internal(
     if tree.parallel_routes.is_empty() {
         if modules.default.is_some() || current_level_is_parallel_route {
             tree = default_route_tree(
-                app_dir,
+                app_dir.clone(),
                 global_metadata,
                 app_page,
-                modules.default.map(|v| *v),
+                modules.default.clone(),
             )
             .await?;
         } else {
@@ -1098,10 +1069,10 @@ async fn directory_tree_to_loader_tree_internal(
         tree.parallel_routes.insert(
             rcstr!("children"),
             default_route_tree(
-                app_dir,
+                app_dir.clone(),
                 global_metadata,
                 app_page,
-                modules.default.map(|v| *v),
+                modules.default.clone(),
             )
             .await?,
         );
@@ -1130,7 +1101,7 @@ async fn default_route_tree(
         parallel_routes: FxIndexMap::default(),
         modules: if let Some(default) = default_component {
             AppDirModules {
-                default: Some(default.to_resolved().await?),
+                default: Some(default),
                 ..Default::default()
             }
         } else {
@@ -1138,9 +1109,8 @@ async fn default_route_tree(
             AppDirModules {
                 default: Some(
                     get_next_package(app_dir)
-                        .join(rcstr!("dist/client/components/builtin/default.js"))
-                        .to_resolved()
-                        .await?,
+                        .await?
+                        .join("dist/client/components/builtin/default.js")?,
                 ),
                 ..Default::default()
             }
@@ -1152,7 +1122,7 @@ async fn default_route_tree(
 #[turbo_tasks::function]
 async fn directory_tree_to_entrypoints_internal(
     app_dir: FileSystemPath,
-    global_metadata: Vc<GlobalMetadata>,
+    global_metadata: ResolvedVc<GlobalMetadata>,
     is_global_not_found_enabled: Vc<bool>,
     directory_name: RcStr,
     directory_tree: Vc<DirectoryTree>,
@@ -1175,7 +1145,7 @@ async fn directory_tree_to_entrypoints_internal(
 
 async fn directory_tree_to_entrypoints_internal_untraced(
     app_dir: FileSystemPath,
-    global_metadata: Vc<GlobalMetadata>,
+    global_metadata: ResolvedVc<GlobalMetadata>,
     is_global_not_found_enabled: Vc<bool>,
     directory_name: RcStr,
     directory_tree: Vc<DirectoryTree>,
@@ -1192,9 +1162,9 @@ async fn directory_tree_to_entrypoints_internal_untraced(
     // Route can have its own segment config, also can inherit from the layout root
     // segment config. https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes#segment-runtime-option
     // Pass down layouts from each tree to apply segment config when adding route.
-    let root_layouts = if let Some(layout) = modules.layout {
+    let root_layouts = if let Some(layout) = &modules.layout {
         let mut layouts = root_layouts.owned().await?;
-        layouts.push(layout);
+        layouts.push(layout.clone());
         ResolvedVc::cell(layouts)
     } else {
         root_layouts
@@ -1204,8 +1174,8 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         let app_path = AppPath::from(app_page.clone());
 
         let loader_tree = *directory_tree_to_loader_tree(
-            *app_dir,
-            global_metadata,
+            app_dir.clone(),
+            *global_metadata,
             directory_name.clone(),
             directory_tree_vc,
             app_page.clone(),
@@ -1214,19 +1184,19 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         .await?;
 
         add_app_page(
-            app_dir,
+            app_dir.clone(),
             &mut result,
             app_page.complete(PageType::Page)?,
             loader_tree.context("loader tree should be created for a page/default")?,
         );
     }
 
-    if let Some(route) = modules.route {
+    if let Some(route) = &modules.route {
         add_app_route(
-            app_dir,
+            app_dir.clone(),
             &mut result,
             app_page.complete(PageType::Route)?,
-            route,
+            route.clone(),
             root_layouts,
         );
     }
@@ -1242,16 +1212,16 @@ async fn directory_tree_to_entrypoints_internal_untraced(
 
     for meta in sitemap
         .iter()
-        .copied()
-        .chain(icon.iter().copied().map(MetadataItem::from))
-        .chain(apple.iter().copied().map(MetadataItem::from))
-        .chain(twitter.iter().copied().map(MetadataItem::from))
-        .chain(open_graph.iter().copied().map(MetadataItem::from))
+        .cloned()
+        .chain(icon.iter().cloned().map(MetadataItem::from))
+        .chain(apple.iter().cloned().map(MetadataItem::from))
+        .chain(twitter.iter().cloned().map(MetadataItem::from))
+        .chain(open_graph.iter().cloned().map(MetadataItem::from))
     {
-        let app_page = app_page.clone_push_str(&get_metadata_route_name(meta).await?)?;
+        let app_page = app_page.clone_push_str(&get_metadata_route_name(meta.clone()).await?)?;
 
         add_app_metadata_route(
-            app_dir,
+            app_dir.clone(),
             &mut result,
             normalize_metadata_route(app_page)?,
             meta,
@@ -1267,13 +1237,14 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         } = &*global_metadata.await?;
 
         for meta in favicon.iter().chain(robots.iter()).chain(manifest.iter()) {
-            let app_page = app_page.clone_push_str(&get_metadata_route_name(*meta).await?)?;
+            let app_page =
+                app_page.clone_push_str(&get_metadata_route_name(meta.clone()).await?)?;
 
             add_app_metadata_route(
-                app_dir,
+                app_dir.clone(),
                 &mut result,
                 normalize_metadata_route(app_page)?,
-                *meta,
+                meta.clone(),
             );
         }
 
@@ -1282,35 +1253,31 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         // fill in the default modules for the not-found entrypoint
         if modules.layout.is_none() {
             modules.layout = Some(
-                get_next_package(*app_dir)
-                    .join(rcstr!("dist/client/components/builtin/layout.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/layout.js")?,
             );
         }
 
         if modules.not_found.is_none() {
             modules.not_found = Some(
-                get_next_package(*app_dir)
-                    .join(rcstr!("dist/client/components/builtin/not-found.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/not-found.js")?,
             );
         }
         if modules.forbidden.is_none() {
             modules.forbidden = Some(
-                get_next_package(*app_dir)
-                    .join(rcstr!("dist/client/components/builtin/forbidden.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/forbidden.js")?,
             );
         }
         if modules.unauthorized.is_none() {
             modules.unauthorized = Some(
-                get_next_package(*app_dir)
-                    .join(rcstr!("dist/client/components/builtin/unauthorized.js"))
-                    .to_resolved()
-                    .await?,
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/unauthorized.js")?,
             );
         }
 
@@ -1342,10 +1309,10 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                                     layout: None,
                                     page: match modules.global_not_found {
                                         Some(v) => Some(v),
-                                        None => Some(get_next_package(*app_dir)
-                                            .join(rcstr!("dist/client/components/builtin/global-not-found.js"))
-                                            .to_resolved()
-                                            .await?),
+                                        None =>  Some(get_next_package(app_dir.clone())
+                                            .await?
+                                            .join("dist/client/components/builtin/global-not-found.js")?,
+                                        ),
                                     },
                                     ..Default::default()
                                 }
@@ -1355,27 +1322,28 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                                 AppDirModules {
                                     page: match modules.not_found {
                                         Some(v) => Some(v),
-                                        None => Some(get_next_package(*app_dir)
-                                            .join(rcstr!("dist/client/components/builtin/not-found.js"))
-                                            .to_resolved()
-                                            .await?),
+                                        None => Some(get_next_package(app_dir.clone())
+                                            .await?
+                                            .join("dist/client/components/builtin/not-found.js")?,
+                                        ),
                                     },
                                     ..Default::default()
                                 }
                             },
-                            global_metadata: global_metadata.to_resolved().await?,
+                            global_metadata,
                         }
                     },
                     modules: AppDirModules {
                         ..Default::default()
                     },
-                    global_metadata: global_metadata.to_resolved().await?,
+                    global_metadata,
                 },
             },
             modules: AppDirModules {
                 // `global-not-found.js` does not need a layout since it's included.
                 // Skip it if it's present.
-                // Otherwise, we need to compose it with the root layout to compose with not-found.js boundary.
+                // Otherwise, we need to compose it with the root layout to compose with
+                // not-found.js boundary.
                 layout: if use_global_not_found {
                     None
                 } else {
@@ -1383,7 +1351,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                 },
                 ..not_found_root_modules
             },
-            global_metadata: global_metadata.to_resolved().await?,
+            global_metadata,
         }
         .resolved_cell();
 
@@ -1392,7 +1360,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                 .clone_push_str("_not-found")?
                 .complete(PageType::Page)?;
 
-            add_app_page(app_dir, &mut result, app_page, not_found_tree);
+            add_app_page(app_dir.clone(), &mut result, app_page, not_found_tree);
         }
     }
 
@@ -1400,58 +1368,62 @@ async fn directory_tree_to_entrypoints_internal_untraced(
     let directory_name = &directory_name;
     let subdirectories = subdirectories
         .iter()
-        .map(|(subdir_name, &subdirectory)| async move {
-            let mut child_app_page = app_page.clone();
-            let mut illegal_path = None;
+        .map(|(subdir_name, &subdirectory)| {
+            let app_dir = app_dir.clone();
 
-            // When constructing the app_page fails (e. g. due to limitations of the order),
-            // we only want to emit the error when there are actual pages below that
-            // directory.
-            if let Err(e) = child_app_page.push_str(&normalize_underscore(subdir_name)) {
-                illegal_path = Some(e);
-            }
+            async move {
+                let mut child_app_page = app_page.clone();
+                let mut illegal_path = None;
 
-            let map = directory_tree_to_entrypoints_internal(
-                *app_dir,
-                global_metadata,
-                is_global_not_found_enabled,
-                subdir_name.clone(),
-                *subdirectory,
-                child_app_page.clone(),
-                *root_layouts,
-            )
-            .await?;
+                // When constructing the app_page fails (e. g. due to limitations of the order),
+                // we only want to emit the error when there are actual pages below that
+                // directory.
+                if let Err(e) = child_app_page.push_str(&normalize_underscore(subdir_name)) {
+                    illegal_path = Some(e);
+                }
 
-            if let Some(illegal_path) = illegal_path
-                && !map.is_empty()
-            {
-                return Err(illegal_path);
-            }
+                let map = directory_tree_to_entrypoints_internal(
+                    app_dir.clone(),
+                    *global_metadata,
+                    is_global_not_found_enabled,
+                    subdir_name.clone(),
+                    *subdirectory,
+                    child_app_page.clone(),
+                    *root_layouts,
+                )
+                .await?;
 
-            let mut loader_trees = Vec::new();
-
-            for (_, entrypoint) in map.iter() {
-                if let Entrypoint::AppPage {
-                    ref pages,
-                    loader_tree: _,
-                } = *entrypoint
+                if let Some(illegal_path) = illegal_path
+                    && !map.is_empty()
                 {
-                    for page in pages {
-                        let app_path = AppPath::from(page.clone());
+                    return Err(illegal_path);
+                }
 
-                        let loader_tree = directory_tree_to_loader_tree(
-                            *app_dir,
-                            global_metadata,
-                            directory_name.clone(),
-                            directory_tree_vc,
-                            app_page.clone(),
-                            app_path,
-                        );
-                        loader_trees.push(loader_tree);
+                let mut loader_trees = Vec::new();
+
+                for (_, entrypoint) in map.iter() {
+                    if let Entrypoint::AppPage {
+                        ref pages,
+                        loader_tree: _,
+                    } = *entrypoint
+                    {
+                        for page in pages {
+                            let app_path = AppPath::from(page.clone());
+
+                            let loader_tree = directory_tree_to_loader_tree(
+                                app_dir.clone(),
+                                *global_metadata,
+                                directory_name.clone(),
+                                directory_tree_vc,
+                                app_page.clone(),
+                                app_path,
+                            );
+                            loader_trees.push(loader_tree);
+                        }
                     }
                 }
+                Ok((map, loader_trees))
             }
-            Ok((map, loader_trees))
         })
         .try_join()
         .await?;
@@ -1459,9 +1431,9 @@ async fn directory_tree_to_entrypoints_internal_untraced(
     for (map, loader_trees) in subdirectories.iter() {
         let mut i = 0;
         for (_, entrypoint) in map.iter() {
-            match *entrypoint {
+            match entrypoint {
                 Entrypoint::AppPage {
-                    ref pages,
+                    pages,
                     loader_tree: _,
                 } => {
                     for page in pages {
@@ -1469,7 +1441,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                         i += 1;
 
                         add_app_page(
-                            app_dir,
+                            app_dir.clone(),
                             &mut result,
                             page.clone(),
                             loader_tree
@@ -1478,14 +1450,25 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                     }
                 }
                 Entrypoint::AppRoute {
-                    ref page,
+                    page,
                     path,
                     root_layouts,
                 } => {
-                    add_app_route(app_dir, &mut result, page.clone(), path, root_layouts);
+                    add_app_route(
+                        app_dir.clone(),
+                        &mut result,
+                        page.clone(),
+                        path.clone(),
+                        *root_layouts,
+                    );
                 }
-                Entrypoint::AppMetadata { ref page, metadata } => {
-                    add_app_metadata_route(app_dir, &mut result, page.clone(), metadata);
+                Entrypoint::AppMetadata { page, metadata } => {
+                    add_app_metadata_route(
+                        app_dir.clone(),
+                        &mut result,
+                        page.clone(),
+                        metadata.clone(),
+                    );
                 }
             }
         }
@@ -1505,7 +1488,7 @@ pub async fn get_global_metadata(
     let mut metadata = GlobalMetadata::default();
 
     for (basename, entry) in entries {
-        let DirectoryEntry::File(file) = *entry else {
+        let DirectoryEntry::File(file) = entry else {
             continue;
         };
 
@@ -1525,9 +1508,9 @@ pub async fn get_global_metadata(
         };
 
         if dynamic {
-            *entry = Some(MetadataItem::Dynamic { path: file });
+            *entry = Some(MetadataItem::Dynamic { path: file.clone() });
         } else {
-            *entry = Some(MetadataItem::Static { path: file });
+            *entry = Some(MetadataItem::Static { path: file.clone() });
         }
         // TODO(WEB-952) handle symlinks in app dir
     }
@@ -1560,7 +1543,7 @@ impl Issue for DirectoryTreeIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.app_dir
+        self.app_dir.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -90,7 +90,7 @@ impl BaseLoaderTreeBuilder {
     pub async fn create_module_tuple_code(
         &mut self,
         module_type: AppDirModuleType,
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
     ) -> Result<String> {
         let name = module_type.name();
         let i = self.unique_number();

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -108,7 +108,7 @@ impl BaseLoaderTreeBuilder {
         );
 
         let module = self
-            .process_source(Vc::upcast(FileSource::new(*path)))
+            .process_source(Vc::upcast(FileSource::new(path.clone())))
             .to_resolved()
             .await?;
 

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -16,7 +16,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 pub fn route_bootstrap(
     asset: Vc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
-    base_path: Vc<FileSystemPath>,
+    base_path: FileSystemPath,
     bootstrap_asset: Vc<Box<dyn Source>>,
     config: Vc<BootstrapConfig>,
 ) -> Vc<Box<dyn EvaluatableAsset>> {
@@ -45,7 +45,7 @@ impl BootstrapConfig {
 pub async fn bootstrap(
     asset: ResolvedVc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
-    base_path: Vc<FileSystemPath>,
+    base_path: FileSystemPath,
     bootstrap_asset: Vc<Box<dyn Source>>,
     inner_assets: Vc<InnerAssets>,
     config: Vc<BootstrapConfig>,

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -51,11 +51,11 @@ pub async fn bootstrap(
     config: Vc<BootstrapConfig>,
 ) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
     let path = asset.ident().path().await?;
-    let Some(path) = base_path.await?.get_path_to(&path) else {
+    let Some(path) = base_path.get_path_to(&path) else {
         bail!(
             "asset {} is not in base path {}",
             asset.ident().to_string().await?,
-            base_path.to_string().await?
+            base_path.value_to_string().await?
         );
     };
     let path = if let Some((name, ext)) = path.rsplit_once('.') {
@@ -73,7 +73,7 @@ pub async fn bootstrap(
     let config_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                asset.ident().path().join("bootstrap-config.ts".into()),
+                asset.ident().path().await?.join("bootstrap-config.ts")?,
                 AssetContent::file(
                     File::from(
                         config

--- a/crates/next-core/src/embed_js.rs
+++ b/crates/next-core/src/embed_js.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath};
@@ -12,16 +13,18 @@ pub(crate) fn next_js_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_js_file(path: RcStr) -> Vc<FileContent> {
-    next_js_fs().root().join(path).read()
+pub(crate) async fn next_js_file(path: RcStr) -> Result<Vc<FileContent>> {
+    Ok(next_js_fs().root().await?.join(&path)?.read())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_js_file_path(path: RcStr) -> Vc<FileSystemPath> {
-    next_js_fs().root().join(path)
+pub(crate) async fn next_js_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(next_js_fs().root().await?.join(&path)?.cell())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_asset(path: RcStr) -> Vc<Box<dyn Source>> {
-    Vc::upcast(FileSource::new(next_js_file_path(path)))
+pub(crate) async fn next_asset(path: RcStr) -> Result<Vc<Box<dyn Source>>> {
+    Ok(Vc::upcast(FileSource::new(
+        next_js_file_path(path).await?.clone_value(),
+    )))
 }

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -18,9 +18,9 @@ use turbopack_core::{
 #[turbo_tasks::function]
 pub async fn emit_all_assets(
     assets: Vc<OutputAssets>,
-    node_root: Vc<FileSystemPath>,
-    client_relative_path: Vc<FileSystemPath>,
-    client_output_path: Vc<FileSystemPath>,
+    node_root: FileSystemPath,
+    client_relative_path: FileSystemPath,
+    client_output_path: FileSystemPath,
 ) -> Result<()> {
     let _ = emit_assets(
         all_assets_from_entries(assets),
@@ -41,9 +41,9 @@ pub async fn emit_all_assets(
 #[turbo_tasks::function]
 pub async fn emit_assets(
     assets: Vc<OutputAssets>,
-    node_root: Vc<FileSystemPath>,
-    client_relative_path: Vc<FileSystemPath>,
-    client_output_path: Vc<FileSystemPath>,
+    node_root: FileSystemPath,
+    client_relative_path: FileSystemPath,
+    client_output_path: FileSystemPath,
 ) -> Result<()> {
     let _: Vec<Vc<()>> = assets
         .await?
@@ -86,8 +86,8 @@ async fn emit(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
 #[turbo_tasks::function]
 async fn emit_rebase(
     asset: Vc<Box<dyn OutputAsset>>,
-    from: Vc<FileSystemPath>,
-    to: Vc<FileSystemPath>,
+    from: FileSystemPath,
+    to: FileSystemPath,
 ) -> Result<()> {
     let path = rebase(asset.path(), from, to);
     let content = asset.content();

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use tracing::Instrument;
 use turbo_tasks::{
-    FxIndexSet, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
+    FxIndexSet, ResolvedVc, TryFlatJoinIterExt, Vc,
     graph::{AdjacencyMap, GraphTraversal},
 };
 use turbo_tasks_fs::{FileSystemPath, rebase};
@@ -49,28 +49,33 @@ pub async fn emit_assets(
         .await?
         .iter()
         .copied()
-        .map(|asset| async move {
-            let path = asset.path();
-            let span = tracing::info_span!("emit asset", name = %path.to_string().await?);
+        .map(|asset| {
+            let node_root = node_root.clone();
+            let client_relative_path = client_relative_path.clone();
+            let client_output_path = client_output_path.clone();
+
             async move {
-                let path = path.await?;
-                Ok(if path.is_inside_ref(&*node_root.await?) {
-                    Some(emit(*asset))
-                } else if path.is_inside_ref(&*client_relative_path.await?) {
-                    // Client assets are emitted to the client output path, which is prefixed
-                    // with _next. We need to rebase them to remove that
-                    // prefix.
-                    Some(emit_rebase(
-                        *asset,
-                        client_relative_path,
-                        client_output_path,
-                    ))
-                } else {
-                    None
-                })
+                let path = asset.path().await?.clone_value();
+                let span = tracing::info_span!("emit asset", name = %path.value_to_string().await?);
+                async move {
+                    Ok(if path.is_inside_ref(&node_root) {
+                        Some(emit(*asset))
+                    } else if path.is_inside_ref(&client_relative_path) {
+                        // Client assets are emitted to the client output path, which is prefixed
+                        // with _next. We need to rebase them to remove that
+                        // prefix.
+                        Some(emit_rebase(
+                            *asset,
+                            client_relative_path,
+                            client_output_path,
+                        ))
+                    } else {
+                        None
+                    })
+                }
+                .instrument(span)
+                .await
             }
-            .instrument(span)
-            .await
         })
         .try_flat_join()
         .await?;
@@ -79,7 +84,11 @@ pub async fn emit_assets(
 
 #[turbo_tasks::function]
 async fn emit(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
-    let _ = asset.content().write(asset.path()).resolve().await?;
+    let _ = asset
+        .content()
+        .write(asset.path().await?.clone_value())
+        .resolve()
+        .await?;
     Ok(())
 }
 
@@ -89,14 +98,11 @@ async fn emit_rebase(
     from: FileSystemPath,
     to: FileSystemPath,
 ) -> Result<()> {
-    let path = rebase(asset.path(), from, to);
-    let content = asset.content();
-    let _ = content
-        .resolve()
+    let path = rebase(asset.path().await?.clone_value(), from, to)
         .await?
-        .write(path.resolve().await?)
-        .resolve()
-        .await?;
+        .clone_value();
+    let content = asset.content();
+    let _ = content.resolve().await?.write(path).resolve().await?;
     Ok(())
 }
 

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -28,12 +28,13 @@ use turbopack_ecmascript::{
 /// Each entry point in the HMR system has an ident with a different nested asset.
 /// This produces the 'base' ident for the HMR entry point, which is then modified
 #[turbo_tasks::function]
-fn hmr_entry_point_base_ident() -> Vc<AssetIdent> {
-    AssetIdent::from_path(
+async fn hmr_entry_point_base_ident() -> Result<Vc<AssetIdent>> {
+    Ok(AssetIdent::from_path(
         VirtualFileSystem::new_with_name(rcstr!("hmr-entry"))
             .root()
-            .join(rcstr!("hmr-entry.js")),
-    )
+            .await?
+            .join("hmr-entry.js")?,
+    ))
 }
 
 #[turbo_tasks::value(shared)]

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -24,7 +24,7 @@ pub async fn middleware_files(page_extensions: Vc<Vec<RcStr>>) -> Result<Vc<Vec<
 #[turbo_tasks::function]
 pub async fn get_middleware_module(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     userland_module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_MIDDLEWARE_MODULE";

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{ChunkingContext, availability_info::AvailabilityInfo},
     module::Module,
@@ -179,9 +179,9 @@ pub async fn get_app_client_references_chunks(
 
                 let base_ident = server_component.ident();
 
-                let server_path = server_component.server_path();
-                let is_layout = server_path.file_stem().await?.as_deref() == Some("layout");
-                let server_component_path = server_path.to_string().await?;
+                let server_path = server_component.server_path().await?.clone_value();
+                let is_layout = server_path.file_stem() == Some("layout");
+                let server_component_path = server_path.value_to_string().await?;
 
                 let ssr_modules = client_reference_types
                     .iter()

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -37,7 +37,7 @@ pub async fn get_app_page_entry(
     edge_context: ResolvedVc<ModuleAssetContext>,
     loader_tree: Vc<AppPageLoaderTree>,
     page: AppPage,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<AppEntry>> {
     let config = parse_segment_config_from_loader_tree(loader_tree);
@@ -142,7 +142,7 @@ pub async fn get_app_page_entry(
 #[turbo_tasks::function]
 async fn wrap_edge_page(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     page: AppPage,
     next_config: Vc<NextConfig>,

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, fxindexmap};
 use turbo_tasks_fs::{self, File, FileSystemPath, rope::RopeBuilder};
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -73,7 +73,11 @@ pub async fn get_app_page_entry(
         writeln!(result, "{import}")?;
     }
 
-    let pages = pages.iter().map(|page| page.to_string()).try_join().await?;
+    let pages = pages
+        .iter()
+        .map(|page| page.value_to_string())
+        .try_join()
+        .await?;
 
     let original_name: RcStr = page.to_string().into();
     let pathname: RcStr = AppPath::from(page.clone()).to_string().into();
@@ -81,7 +85,7 @@ pub async fn get_app_page_entry(
     // Load the file from the next.js codebase.
     let source = load_next_js_template(
         "app-page.js",
-        project_root,
+        project_root.clone(),
         fxindexmap! {
             "VAR_DEFINITION_PAGE" => page.to_string().into(),
             "VAR_DEFINITION_PATHNAME" => pathname.clone(),
@@ -123,7 +127,7 @@ pub async fn get_app_page_entry(
     if is_edge {
         rsc_entry = wrap_edge_page(
             *ResolvedVc::upcast(module_asset_context),
-            project_root,
+            project_root.clone(),
             rsc_entry,
             page,
             next_config,
@@ -169,7 +173,7 @@ async fn wrap_edge_page(
 
     let source = load_next_js_template(
         "edge-ssr-app.js",
-        project_root,
+        project_root.clone(),
         fxindexmap! {
             "VAR_USERLAND" => INNER.into(),
             "VAR_PAGE" => page.to_string().into(),

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -32,7 +32,7 @@ pub async fn get_app_route_entry(
     edge_context: Vc<ModuleAssetContext>,
     source: Vc<Box<dyn Source>>,
     page: AppPage,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     original_segment_config: Option<Vc<NextSegmentConfig>>,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<AppEntry>> {
@@ -132,7 +132,7 @@ pub async fn get_app_route_entry(
 #[turbo_tasks::function]
 async fn wrap_edge_route(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     page: AppPage,
     next_config: Vc<NextConfig>,

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, ValueToString, Vc, fxindexmap};
+use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -55,7 +55,7 @@ pub async fn get_app_route_entry(
     let original_name: RcStr = page.to_string().into();
     let pathname: RcStr = AppPath::from(page.clone()).to_string().into();
 
-    let path = source.ident().path();
+    let path = source.ident().path().await?.clone_value();
 
     const INNER: &str = "INNER_APP_ROUTE";
 
@@ -73,14 +73,14 @@ pub async fn get_app_route_entry(
     // Load the file from the next.js codebase.
     let virtual_source = load_next_js_template(
         "app-route.js",
-        project_root,
+        project_root.clone(),
         fxindexmap! {
             "VAR_DEFINITION_PAGE" => page.to_string().into(),
             "VAR_DEFINITION_PATHNAME" => pathname.clone(),
-            "VAR_DEFINITION_FILENAME" => path.file_stem().await?.as_ref().unwrap().as_str().into(),
+            "VAR_DEFINITION_FILENAME" => path.file_stem().unwrap().into(),
             // TODO(alexkirsz) Is this necessary?
             "VAR_DEFINITION_BUNDLE_PATH" => "".to_string().into(),
-            "VAR_RESOLVED_PAGE_PATH" => path.to_string().owned().await?,
+            "VAR_RESOLVED_PAGE_PATH" => path.value_to_string().owned().await?,
             "VAR_USERLAND" => INNER.into(),
         },
         fxindexmap! {
@@ -143,7 +143,7 @@ async fn wrap_edge_route(
 
     let source = load_next_js_template(
         "edge-app-route.js",
-        project_root,
+        project_root.clone(),
         fxindexmap! {
             "VAR_USERLAND" => INNER.into(),
             "VAR_PAGE" => page.to_string().into(),
@@ -168,7 +168,7 @@ async fn wrap_edge_route(
 
     Ok(wrap_edge_entry(
         asset_context,
-        project_root,
+        project_root.clone(),
         wrapped,
         AppPath::from(page).to_string().into(),
     ))

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -24,7 +24,7 @@ use turbopack_ecmascript::{
 
 use crate::next_app::AppPage;
 
-async fn hash_file_content(path: Vc<FileSystemPath>) -> Result<u64> {
+async fn hash_file_content(path: FileSystemPath) -> Result<u64> {
     let original_file_content = path.read().await?;
 
     Ok(match &*original_file_content {
@@ -41,7 +41,7 @@ async fn hash_file_content(path: Vc<FileSystemPath>) -> Result<u64> {
 #[turbo_tasks::function]
 pub async fn dynamic_image_metadata_source(
     asset_context: Vc<Box<dyn AssetContext>>,
-    path: Vc<FileSystemPath>,
+    path: FileSystemPath,
     ty: RcStr,
     page: AppPage,
 ) -> Result<Vc<Box<dyn Source>>> {

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -5,7 +5,7 @@
 use anyhow::{Result, bail};
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ValueToString, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
@@ -33,7 +33,10 @@ async fn hash_file_content(path: FileSystemPath) -> Result<u64> {
             hash_xxh3_hash64(&*content)
         }
         FileContent::NotFound => {
-            bail!("metadata file not found: {}", &path.to_string().await?);
+            bail!(
+                "metadata file not found: {}",
+                &path.value_to_string().await?
+            );
         }
     })
 }
@@ -45,11 +48,11 @@ pub async fn dynamic_image_metadata_source(
     ty: RcStr,
     page: AppPage,
 ) -> Result<Vc<Box<dyn Source>>> {
-    let stem = path.file_stem().await?;
-    let stem = stem.as_deref().unwrap_or_default();
-    let ext = &*path.extension().await?;
+    let stem = path.file_stem();
+    let stem = stem.unwrap_or_default();
+    let ext = path.extension();
 
-    let hash_query = format!("?{:x}", hash_file_content(path).await?);
+    let hash_query = format!("?{:x}", hash_file_content(path.clone()).await?);
 
     let use_numeric_sizes = ty == "twitter" || ty == "openGraph";
     let sizes = if use_numeric_sizes {
@@ -71,7 +74,7 @@ pub async fn dynamic_image_metadata_source(
         format!("data.sizes = `{sizes}`;")
     };
 
-    let source = Vc::upcast(FileSource::new(path));
+    let source = Vc::upcast(FileSource::new(path.clone()));
     let module = asset_context
         .process(
             source,
@@ -133,7 +136,7 @@ pub async fn dynamic_image_metadata_source(
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--metadata.js").into()),
+        path.parent().join(&format!("{stem}--metadata.js"))?,
         AssetContent::file(file.into()),
     );
 

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -83,7 +83,7 @@ fn match_metadata_file<'a>(
     })
 }
 
-pub(crate) async fn get_content_type(path: Vc<FileSystemPath>) -> Result<String> {
+pub(crate) async fn get_content_type(path: FileSystemPath) -> Result<String> {
     let stem = &*path.file_stem().await?;
     let ext = &*path.extension().await?;
 

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::next_app::{AppPage, PageSegment, PageType};
@@ -84,11 +83,10 @@ fn match_metadata_file<'a>(
 }
 
 pub(crate) async fn get_content_type(path: FileSystemPath) -> Result<String> {
-    let stem = &*path.file_stem().await?;
-    let ext = &*path.extension().await?;
+    let stem = path.file_stem();
+    let mut ext = path.extension();
 
-    let name = stem.as_deref().unwrap_or_default();
-    let mut ext = ext.as_str();
+    let name = stem.unwrap_or_default();
     if ext == "jpg" {
         ext = "jpeg"
     }

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -52,7 +52,7 @@ pub async fn get_app_metadata_route_source(
 pub async fn get_app_metadata_route_entry(
     nodejs_context: Vc<ModuleAssetContext>,
     edge_context: Vc<ModuleAssetContext>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     mut page: AppPage,
     mode: NextMode,
     metadata: MetadataItem,
@@ -112,7 +112,7 @@ const CACHE_HEADER_NONE: &str = "no-cache, no-store";
 const CACHE_HEADER_LONG_CACHE: &str = "public, immutable, no-transform, max-age=31536000";
 const CACHE_HEADER_REVALIDATE: &str = "public, max-age=0, must-revalidate";
 
-async fn get_base64_file_content(path: Vc<FileSystemPath>) -> Result<String> {
+async fn get_base64_file_content(path: FileSystemPath) -> Result<String> {
     let original_file_content = path.read().await?;
 
     Ok(match &*original_file_content {
@@ -127,10 +127,7 @@ async fn get_base64_file_content(path: Vc<FileSystemPath>) -> Result<String> {
 }
 
 #[turbo_tasks::function]
-async fn static_route_source(
-    mode: NextMode,
-    path: Vc<FileSystemPath>,
-) -> Result<Vc<Box<dyn Source>>> {
+async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem().await?;
     let stem = stem.as_deref().unwrap_or_default();
 
@@ -204,7 +201,7 @@ async fn static_route_source(
 }
 
 #[turbo_tasks::function]
-async fn dynamic_text_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<dyn Source>>> {
+async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem().await?;
     let stem = stem.as_deref().unwrap_or_default();
     let ext = &*path.extension().await?;
@@ -260,7 +257,7 @@ async fn dynamic_text_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<dy
 #[turbo_tasks::function]
 async fn dynamic_site_map_route_source(
     mode: NextMode,
-    path: Vc<FileSystemPath>,
+    path: FileSystemPath,
     is_multi_dynamic: bool,
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem().await?;
@@ -353,7 +350,7 @@ async fn dynamic_site_map_route_source(
 }
 
 #[turbo_tasks::function]
-async fn dynamic_image_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<dyn Source>>> {
+async fn dynamic_image_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem().await?;
     let stem = stem.as_deref().unwrap_or_default();
     let ext = &*path.extension().await?;

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -5,7 +5,7 @@
 use anyhow::{Ok, Result, bail};
 use base64::{display::Base64Display, engine::general_purpose::STANDARD};
 use indoc::{formatdoc, indoc};
-use turbo_tasks::{ValueToString, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -32,17 +32,17 @@ pub async fn get_app_metadata_route_source(
     is_multi_dynamic: bool,
 ) -> Result<Vc<Box<dyn Source>>> {
     Ok(match metadata {
-        MetadataItem::Static { path } => static_route_source(mode, *path),
+        MetadataItem::Static { path } => static_route_source(mode, path),
         MetadataItem::Dynamic { path } => {
-            let stem = path.file_stem().await?;
-            let stem = stem.as_deref().unwrap_or_default();
+            let stem = path.file_stem();
+            let stem = stem.unwrap_or_default();
 
             if stem == "robots" || stem == "manifest" {
-                dynamic_text_route_source(*path)
+                dynamic_text_route_source(path)
             } else if stem == "sitemap" {
-                dynamic_site_map_route_source(mode, *path, is_multi_dynamic)
+                dynamic_site_map_route_source(mode, path, is_multi_dynamic)
             } else {
-                dynamic_image_route_source(*path)
+                dynamic_image_route_source(path)
             }
         }
     })
@@ -60,9 +60,9 @@ pub async fn get_app_metadata_route_entry(
 ) -> Vc<AppEntry> {
     // Read original source's segment config before replacing source into
     // dynamic|static metadata route handler.
-    let original_path = metadata.into_path();
+    let original_path = metadata.clone().into_path();
 
-    let source = Vc::upcast(FileSource::new(*original_path));
+    let source = Vc::upcast(FileSource::new(original_path));
     let segment_config = parse_segment_config_from_source(source);
     let is_dynamic_metadata = matches!(metadata, MetadataItem::Dynamic { .. });
     let is_multi_dynamic: bool = if Some(segment_config).is_some() {
@@ -121,17 +121,20 @@ async fn get_base64_file_content(path: FileSystemPath) -> Result<String> {
             Base64Display::new(&content, &STANDARD).to_string()
         }
         FileContent::NotFound => {
-            bail!("metadata file not found: {}", &path.to_string().await?);
+            bail!(
+                "metadata file not found: {}",
+                &path.value_to_string().await?
+            );
         }
     })
 }
 
 #[turbo_tasks::function]
 async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
-    let stem = path.file_stem().await?;
-    let stem = stem.as_deref().unwrap_or_default();
+    let stem = path.file_stem();
+    let stem = stem.unwrap_or_default();
 
-    let content_type = get_content_type(path).await?;
+    let content_type = get_content_type(path.clone()).await?;
 
     let cache_control = if stem == "favicon" {
         CACHE_HEADER_REVALIDATE
@@ -141,7 +144,7 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
         CACHE_HEADER_NONE
     };
 
-    let original_file_content_b64 = get_base64_file_content(path).await?;
+    let original_file_content_b64 = get_base64_file_content(path.clone()).await?;
 
     let is_twitter = stem == "twitter-image";
     let is_open_graph = stem == "opengraph-image";
@@ -188,12 +191,12 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
         is_open_graph = is_open_graph,
         file_size_limit = file_size_limit,
         img_name = img_name,
-        path = StringifyJs(&path.to_string().await?),
+        path = StringifyJs(&path.value_to_string().await?),
     };
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js").into()),
+        path.parent().join(&format!("{stem}--route-entry.js"))?,
         AssetContent::file(file.into()),
     );
 
@@ -202,11 +205,11 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
 
 #[turbo_tasks::function]
 async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
-    let stem = path.file_stem().await?;
-    let stem = stem.as_deref().unwrap_or_default();
-    let ext = &*path.extension().await?;
+    let stem = path.file_stem();
+    let stem = stem.unwrap_or_default();
+    let ext = path.extension();
 
-    let content_type = get_content_type(path).await?;
+    let content_type = get_content_type(path.clone()).await?;
 
     // refer https://github.com/vercel/next.js/blob/7b2b9823432fb1fa28ae0ac3878801d638d93311/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts#L84
     // for the original template.
@@ -247,7 +250,7 @@ async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn So
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js").into()),
+        path.parent().join(&format!("{stem}--route-entry.js"))?,
         AssetContent::file(file.into()),
     );
 
@@ -260,10 +263,10 @@ async fn dynamic_site_map_route_source(
     path: FileSystemPath,
     is_multi_dynamic: bool,
 ) -> Result<Vc<Box<dyn Source>>> {
-    let stem = path.file_stem().await?;
-    let stem = stem.as_deref().unwrap_or_default();
-    let ext = &*path.extension().await?;
-    let content_type = get_content_type(path).await?;
+    let stem = path.file_stem();
+    let stem = stem.unwrap_or_default();
+    let ext = path.extension();
+    let content_type = get_content_type(path.clone()).await?;
     let mut static_generation_code = "";
 
     if mode.is_production() && is_multi_dynamic {
@@ -342,7 +345,7 @@ async fn dynamic_site_map_route_source(
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js").into()),
+        path.parent().join(&format!("{stem}--route-entry.js"))?,
         AssetContent::file(file.into()),
     );
 
@@ -351,9 +354,9 @@ async fn dynamic_site_map_route_source(
 
 #[turbo_tasks::function]
 async fn dynamic_image_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
-    let stem = path.file_stem().await?;
-    let stem = stem.as_deref().unwrap_or_default();
-    let ext = &*path.extension().await?;
+    let stem = path.file_stem();
+    let stem = stem.unwrap_or_default();
+    let ext = path.extension();
 
     let code = formatdoc! {
         r#"
@@ -404,7 +407,7 @@ async fn dynamic_image_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn S
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js").into()),
+        path.parent().join(&format!("{stem}--route-entry.js"))?,
         AssetContent::file(file.into()),
     );
 

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -8,7 +8,7 @@ use crate::next_import_map::get_next_package;
 
 #[turbo_tasks::function]
 pub async fn get_postcss_package_mapping(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Vc<ImportMapping>> {
     Ok(ImportMapping::Alternatives(vec![
         // Prefer the local installed version over the next.js version

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::resolve::{ExternalTraced, ExternalType, options::ImportMapping};
 
@@ -12,10 +12,11 @@ pub async fn get_postcss_package_mapping(
 ) -> Result<Vc<ImportMapping>> {
     Ok(ImportMapping::Alternatives(vec![
         // Prefer the local installed version over the next.js version
-        ImportMapping::PrimaryAlternative("postcss".into(), Some(project_path)).resolved_cell(),
+        ImportMapping::PrimaryAlternative("postcss".into(), Some(project_path.clone()))
+            .resolved_cell(),
         ImportMapping::PrimaryAlternative(
             "postcss".into(),
-            Some(get_next_package(*project_path).to_resolved().await?),
+            Some(get_next_package(project_path.clone()).await?.clone_value()),
         )
         .resolved_cell(),
     ])

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -142,19 +142,15 @@ pub async fn get_client_compile_time_info(
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Copy, Clone, Hash, TaskInput)]
 pub enum ClientContextType {
-    Pages {
-        pages_dir: ResolvedVc<FileSystemPath>,
-    },
-    App {
-        app_dir: ResolvedVc<FileSystemPath>,
-    },
+    Pages { pages_dir: FileSystemPath },
+    App { app_dir: FileSystemPath },
     Fallback,
     Other,
 }
 
 #[turbo_tasks::function]
 pub async fn get_client_resolve_options_context(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ClientContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
@@ -228,7 +224,7 @@ pub async fn get_client_resolve_options_context(
 
 #[turbo_tasks::function]
 pub async fn get_client_module_options_context(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: ResolvedVc<ExecutionContext>,
     env: ResolvedVc<Environment>,
     ty: ClientContextType,
@@ -424,8 +420,8 @@ pub async fn get_client_module_options_context(
 
 #[turbo_tasks::function]
 pub async fn get_client_chunking_context(
-    root_path: ResolvedVc<FileSystemPath>,
-    client_root: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
+    client_root: FileSystemPath,
     client_root_to_root_path: RcStr,
     asset_prefix: ResolvedVc<Option<RcStr>>,
     chunk_suffix_path: ResolvedVc<Option<RcStr>>,
@@ -499,13 +495,13 @@ pub async fn get_client_chunking_context(
 }
 
 #[turbo_tasks::function]
-pub fn get_client_assets_path(client_root: Vc<FileSystemPath>) -> Vc<FileSystemPath> {
+pub fn get_client_assets_path(client_root: FileSystemPath) -> Vc<FileSystemPath> {
     client_root.join(rcstr!("static/media"))
 }
 
 #[turbo_tasks::function]
 pub async fn get_client_runtime_entries(
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     ty: ClientContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TaskInput, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
@@ -140,7 +140,7 @@ pub async fn get_client_compile_time_info(
 }
 
 #[turbo_tasks::value(shared)]
-#[derive(Debug, Copy, Clone, Hash, TaskInput)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub enum ClientContextType {
     Pages { pages_dir: FileSystemPath },
     App { app_dir: FileSystemPath },
@@ -156,20 +156,25 @@ pub async fn get_client_resolve_options_context(
     next_config: Vc<NextConfig>,
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
-    let next_client_import_map =
-        get_next_client_import_map(*project_path, ty, next_config, mode, execution_context)
-            .to_resolved()
-            .await?;
-    let next_client_fallback_import_map = get_next_client_fallback_import_map(ty)
+    let next_client_import_map = get_next_client_import_map(
+        project_path.clone(),
+        ty.clone(),
+        next_config,
+        mode,
+        execution_context,
+    )
+    .to_resolved()
+    .await?;
+    let next_client_fallback_import_map = get_next_client_fallback_import_map(ty.clone())
         .to_resolved()
         .await?;
     let next_client_resolved_map =
-        get_next_client_resolved_map(*project_path, project_path, *mode.await?)
+        get_next_client_resolved_map(project_path.clone(), project_path.clone(), *mode.await?)
             .to_resolved()
             .await?;
     let custom_conditions = vec![mode.await?.condition().into()];
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().to_resolved().await?),
+        enable_node_modules: Some(project_path.root().await?.clone_value()),
         custom_conditions,
         import_map: Some(next_client_import_map),
         fallback_import_map: Some(next_client_fallback_import_map),
@@ -178,23 +183,23 @@ pub async fn get_client_resolve_options_context(
         module: true,
         before_resolve_plugins: vec![
             ResolvedVc::upcast(
-                get_invalid_server_only_resolve_plugin(project_path)
+                get_invalid_server_only_resolve_plugin(project_path.clone())
                     .to_resolved()
                     .await?,
             ),
             ResolvedVc::upcast(
-                ModuleFeatureReportResolvePlugin::new(*project_path)
+                ModuleFeatureReportResolvePlugin::new(project_path.clone())
                     .to_resolved()
                     .await?,
             ),
             ResolvedVc::upcast(
-                NextFontLocalResolvePlugin::new(*project_path)
+                NextFontLocalResolvePlugin::new(project_path.clone())
                     .to_resolved()
                     .await?,
             ),
         ],
         after_resolve_plugins: vec![ResolvedVc::upcast(
-            NextSharedRuntimeResolvePlugin::new(*project_path)
+            NextSharedRuntimeResolvePlugin::new(project_path.clone())
                 .to_resolved()
                 .await?,
         )],
@@ -210,9 +215,8 @@ pub async fn get_client_resolve_options_context(
             .typescript_tsconfig_path()
             .await?
             .as_ref()
-            .map(|p| project_path.join(p.to_owned()))
-            .to_resolved()
-            .await?,
+            .map(|p| project_path.join(p))
+            .transpose()?,
         rules: vec![(
             foreign_code_context_condition(next_config, project_path).await?,
             resolve_options_context.clone().resolved_cell(),
@@ -235,20 +239,20 @@ pub async fn get_client_module_options_context(
 ) -> Result<Vc<ModuleOptionsContext>> {
     let next_mode = mode.await?;
     let resolve_options_context = get_client_resolve_options_context(
-        *project_path,
-        ty,
+        project_path.clone(),
+        ty.clone(),
         mode,
         next_config,
         *execution_context,
     );
 
-    let tsconfig = get_typescript_transform_options(*project_path)
+    let tsconfig = get_typescript_transform_options(project_path.clone())
         .to_resolved()
         .await?;
-    let decorators_options = get_decorators_transform_options(*project_path);
+    let decorators_options = get_decorators_transform_options(project_path.clone());
     let enable_mdx_rs = *next_config.mdx_rs().await?;
     let jsx_runtime_options = get_jsx_transform_options(
-        *project_path,
+        project_path.clone(),
         mode,
         Some(resolve_options_context),
         false,
@@ -263,7 +267,7 @@ pub async fn get_client_module_options_context(
     // does by default.
     let conditions = vec![rcstr!("browser"), mode.await?.condition().into()];
     let foreign_enable_webpack_loaders = webpack_loader_options(
-        project_path,
+        project_path.clone(),
         next_config,
         true,
         conditions
@@ -276,7 +280,7 @@ pub async fn get_client_module_options_context(
 
     // Now creates a webpack rules that applies to all codes.
     let enable_webpack_loaders =
-        webpack_loader_options(project_path, next_config, false, conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, false, conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
         .tree_shaking_mode_for_user_code(next_mode.is_development())
@@ -287,12 +291,14 @@ pub async fn get_client_module_options_context(
     let target_browsers = env.runtime_versions();
 
     let mut next_client_rules =
-        get_next_client_transforms_rules(next_config, ty, mode, false, encryption_key).await?;
+        get_next_client_transforms_rules(next_config, ty.clone(), mode, false, encryption_key)
+            .await?;
     let foreign_next_client_rules =
-        get_next_client_transforms_rules(next_config, ty, mode, true, encryption_key).await?;
+        get_next_client_transforms_rules(next_config, ty.clone(), mode, true, encryption_key)
+            .await?;
     let additional_rules: Vec<ModuleRule> = vec![
-        get_swc_ecma_transform_plugin_rule(next_config, project_path).await?,
-        get_relay_transform_rule(next_config, project_path).await?,
+        get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?,
+        get_relay_transform_rule(next_config, project_path.clone()).await?,
         get_emotion_transform_rule(next_config).await?,
         get_styled_components_transform_rule(next_config).await?,
         get_styled_jsx_transform_rule(next_config, target_browsers).await?,
@@ -307,7 +313,7 @@ pub async fn get_client_module_options_context(
 
     let postcss_transform_options = PostCssTransformOptions {
         postcss_package: Some(
-            get_postcss_package_mapping(*project_path)
+            get_postcss_package_mapping(project_path.clone())
                 .to_resolved()
                 .await?,
         ),
@@ -438,14 +444,13 @@ pub async fn get_client_chunking_context(
     let chunk_suffix_path = chunk_suffix_path.owned().await?;
     let mut builder = BrowserChunkingContext::builder(
         root_path,
-        client_root,
+        client_root.clone(),
         client_root_to_root_path,
-        client_root,
-        client_root
-            .join(rcstr!("static/chunks"))
-            .to_resolved()
-            .await?,
-        get_client_assets_path(*client_root).to_resolved().await?,
+        client_root.clone(),
+        client_root.join("static/chunks")?,
+        get_client_assets_path(client_root.clone())
+            .await?
+            .clone_value(),
         environment,
         next_mode.runtime_type(),
     )
@@ -495,8 +500,8 @@ pub async fn get_client_chunking_context(
 }
 
 #[turbo_tasks::function]
-pub fn get_client_assets_path(client_root: FileSystemPath) -> Vc<FileSystemPath> {
-    client_root.join(rcstr!("static/media"))
+pub fn get_client_assets_path(client_root: FileSystemPath) -> Result<Vc<FileSystemPath>> {
+    Ok(client_root.join("static/media")?.cell())
 }
 
 #[turbo_tasks::function]
@@ -508,12 +513,17 @@ pub async fn get_client_runtime_entries(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<RuntimeEntries>> {
     let mut runtime_entries = vec![];
-    let resolve_options_context =
-        get_client_resolve_options_context(project_root, ty, mode, next_config, execution_context);
+    let resolve_options_context = get_client_resolve_options_context(
+        project_root.clone(),
+        ty.clone(),
+        mode,
+        next_config,
+        execution_context,
+    );
 
     if mode.await?.is_development() {
         let enable_react_refresh =
-            assert_can_resolve_react_refresh(project_root, resolve_options_context)
+            assert_can_resolve_react_refresh(project_root.clone(), resolve_options_context)
                 .await?
                 .as_request();
 
@@ -522,11 +532,8 @@ pub async fn get_client_runtime_entries(
         // functions to be available.
         if let Some(request) = enable_react_refresh {
             runtime_entries.push(
-                RuntimeEntry::Request(
-                    request.to_resolved().await?,
-                    project_root.join(rcstr!("_")).to_resolved().await?,
-                )
-                .resolved_cell(),
+                RuntimeEntry::Request(request.to_resolved().await?, project_root.join("_")?)
+                    .resolved_cell(),
             )
         };
     }
@@ -539,7 +546,7 @@ pub async fn get_client_runtime_entries(
                 )))
                 .to_resolved()
                 .await?,
-                project_root.join(rcstr!("_")).to_resolved().await?,
+                project_root.join("_")?,
             )
             .resolved_cell(),
         );

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -12,7 +12,7 @@ use turbopack_ecmascript::resolve::cjs_resolve;
 
 #[turbo_tasks::value(shared)]
 pub enum RuntimeEntry {
-    Request(ResolvedVc<Request>, ResolvedVc<FileSystemPath>),
+    Request(ResolvedVc<Request>, FileSystemPath),
     Evaluatable(ResolvedVc<Box<dyn EvaluatableAsset>>),
     Source(ResolvedVc<Box<dyn Source>>),
 }

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -24,16 +24,16 @@ impl RuntimeEntry {
         self: Vc<Self>,
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
-        let (request, path) = match *self.await? {
-            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(*e)),
+        let (request, path) = match &*self.await? {
+            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(**e)),
             RuntimeEntry::Source(source) => {
                 return Ok(EvaluatableAssets::one(source.to_evaluatable(asset_context)));
             }
-            RuntimeEntry::Request(r, path) => (r, path),
+            RuntimeEntry::Request(r, path) => (*r, path.clone()),
         };
 
         let modules = cjs_resolve(
-            Vc::upcast(PlainResolveOrigin::new(asset_context, *path)),
+            Vc::upcast(PlainResolveOrigin::new(asset_context, path.clone())),
             *request,
             None,
             false,

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -53,12 +53,12 @@ pub async fn get_next_client_transforms_rules(
     let cache_kinds = next_config.cache_kinds().to_resolved().await?;
     let mut is_app_dir = false;
 
-    match context_ty {
+    match &context_ty {
         ClientContextType::Pages { pages_dir } => {
             if !foreign_code {
                 rules.push(
                     get_next_pages_transforms_rule(
-                        *pages_dir,
+                        pages_dir.clone(),
                         ExportFilter::StripDataExports,
                         enable_mdx_rs,
                     )
@@ -66,9 +66,9 @@ pub async fn get_next_client_transforms_rules(
                 );
                 rules.push(get_next_disallow_export_all_in_page_rule(
                     enable_mdx_rs,
-                    pages_dir.await?,
+                    pages_dir.clone(),
                 ));
-                rules.push(get_next_page_config_rule(enable_mdx_rs, pages_dir.await?));
+                rules.push(get_next_page_config_rule(enable_mdx_rs, pages_dir.clone()));
             }
         }
         ClientContextType::App { .. } => {

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -148,13 +148,13 @@ impl EcmascriptClientReferenceModule {
             AssetContent::file(File::from(code.source_code().clone()).into());
 
         let proxy_source = VirtualSource::new(
-            self.server_ident.path().join(
+            self.server_ident.path().await?.join(
                 // Depending on the original format, we call the file `proxy.mjs` or `proxy.cjs`.
                 // This is because we're placing the virtual module next to the original code, so
                 // its parsing will be affected by `type` fields in package.json --
                 // a bare `proxy.js` may end up being unexpectedly parsed as the wrong format.
-                format!("proxy.{}", if is_esm { "mjs" } else { "cjs" }).into(),
-            ),
+                &format!("proxy.{}", if is_esm { "mjs" } else { "cjs" }),
+            )?,
             proxy_module_content,
         );
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -57,14 +57,13 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             None => source.ident(),
         };
         let ident_ref = ident.await?;
-        let ident_path = ident_ref.path.await?;
+        let ident_path = ident_ref.path.clone();
         let client_source = if ident_path.path.contains("next/dist/esm/") {
-            let path = ident_ref.path.root().join(
-                ident_path
-                    .path
-                    .replace("next/dist/esm/", "next/dist/")
-                    .into(),
-            );
+            let path = ident_ref
+                .path
+                .root()
+                .await?
+                .join(&ident_path.path.replace("next/dist/esm/", "next/dist/"))?;
             Vc::upcast(FileSource::new_with_query_and_fragment(
                 path,
                 ident_ref.query.clone(),

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -240,7 +240,7 @@ struct VisitClientReferenceNode {
 )]
 enum VisitClientReferenceNodeState {
     Entry {
-        entry_path: ResolvedVc<FileSystemPath>,
+        entry_path: FileSystemPath,
     },
     InServerComponent {
         server_component: ResolvedVc<NextServerComponentModule>,

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -156,7 +156,7 @@ pub async fn find_server_entries(
     include_traced: bool,
 ) -> Result<Vc<ServerEntries>> {
     async move {
-        let entry_path = entry.ident().path().to_resolved().await?;
+        let entry_path = entry.ident().path().await?.clone_value();
         let graph = AdjacencyMap::new()
             .skip_duplicates()
             .visit(
@@ -227,7 +227,6 @@ struct VisitClientReferenceNode {
 
 #[derive(
     Clone,
-    Copy,
     Eq,
     PartialEq,
     Hash,
@@ -331,74 +330,79 @@ impl Visit<VisitClientReferenceNode> for VisitClientReference {
                     _ => Some(modules.iter()),
                 })
                 .flatten()
-                .map(|module| async move {
-                    if let Some(client_reference_module) =
-                        ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(*module)
-                    {
-                        return Ok(VisitClientReferenceNode {
-                            state: node.state,
-                            ty: VisitClientReferenceNodeType::ClientReference(
-                                ClientReference {
-                                    server_component: node.state.server_component(),
-                                    ty: ClientReferenceType::EcmascriptClientReference(
-                                        client_reference_module,
-                                    ),
+                .map(|module| {
+                    let node_state = node.state.clone();
+
+                    async move {
+                        if let Some(client_reference_module) = ResolvedVc::try_downcast_type::<
+                            EcmascriptClientReferenceModule,
+                        >(*module)
+                        {
+                            return Ok(VisitClientReferenceNode {
+                                state: node_state.clone(),
+                                ty: VisitClientReferenceNodeType::ClientReference(
+                                    ClientReference {
+                                        server_component: node_state.clone().server_component(),
+                                        ty: ClientReferenceType::EcmascriptClientReference(
+                                            client_reference_module,
+                                        ),
+                                    },
+                                    client_reference_module.ident().to_string().await?,
+                                ),
+                            });
+                        }
+
+                        if let Some(client_reference_module) =
+                            ResolvedVc::try_downcast_type::<CssClientReferenceModule>(*module)
+                        {
+                            return Ok(VisitClientReferenceNode {
+                                state: node_state.clone(),
+                                ty: VisitClientReferenceNodeType::ClientReference(
+                                    ClientReference {
+                                        server_component: node_state.clone().server_component(),
+                                        ty: ClientReferenceType::CssClientReference(
+                                            client_reference_module.await?.client_module,
+                                        ),
+                                    },
+                                    client_reference_module.ident().to_string().await?,
+                                ),
+                            });
+                        }
+
+                        if let Some(server_component_asset) =
+                            ResolvedVc::try_downcast_type::<NextServerComponentModule>(*module)
+                        {
+                            return Ok(VisitClientReferenceNode {
+                                state: VisitClientReferenceNodeState::InServerComponent {
+                                    server_component: server_component_asset,
                                 },
-                                client_reference_module.ident().to_string().await?,
-                            ),
-                        });
-                    }
+                                ty: VisitClientReferenceNodeType::ServerComponentEntry(
+                                    server_component_asset,
+                                    server_component_asset.ident().to_string().await?,
+                                ),
+                            });
+                        }
 
-                    if let Some(client_reference_module) =
-                        ResolvedVc::try_downcast_type::<CssClientReferenceModule>(*module)
-                    {
-                        return Ok(VisitClientReferenceNode {
-                            state: node.state,
-                            ty: VisitClientReferenceNodeType::ClientReference(
-                                ClientReference {
-                                    server_component: node.state.server_component(),
-                                    ty: ClientReferenceType::CssClientReference(
-                                        client_reference_module.await?.client_module,
-                                    ),
-                                },
-                                client_reference_module.ident().to_string().await?,
-                            ),
-                        });
-                    }
+                        if let Some(server_util_module) =
+                            ResolvedVc::try_downcast_type::<NextServerUtilityModule>(*module)
+                        {
+                            return Ok(VisitClientReferenceNode {
+                                state: VisitClientReferenceNodeState::InServerUtil,
+                                ty: VisitClientReferenceNodeType::ServerUtilEntry(
+                                    server_util_module,
+                                    module.ident().to_string().await?,
+                                ),
+                            });
+                        }
 
-                    if let Some(server_component_asset) =
-                        ResolvedVc::try_downcast_type::<NextServerComponentModule>(*module)
-                    {
-                        return Ok(VisitClientReferenceNode {
-                            state: VisitClientReferenceNodeState::InServerComponent {
-                                server_component: server_component_asset,
-                            },
-                            ty: VisitClientReferenceNodeType::ServerComponentEntry(
-                                server_component_asset,
-                                server_component_asset.ident().to_string().await?,
-                            ),
-                        });
-                    }
-
-                    if let Some(server_util_module) =
-                        ResolvedVc::try_downcast_type::<NextServerUtilityModule>(*module)
-                    {
-                        return Ok(VisitClientReferenceNode {
-                            state: VisitClientReferenceNodeState::InServerUtil,
-                            ty: VisitClientReferenceNodeType::ServerUtilEntry(
-                                server_util_module,
+                        Ok(VisitClientReferenceNode {
+                            state: node_state,
+                            ty: VisitClientReferenceNodeType::Internal(
+                                *module,
                                 module.ident().to_string().await?,
                             ),
-                        });
+                        })
                     }
-
-                    Ok(VisitClientReferenceNode {
-                        state: node.state,
-                        ty: VisitClientReferenceNodeType::Internal(
-                            *module,
-                            module.ident().to_string().await?,
-                        ),
-                    })
                 });
 
             let assets = referenced_modules.try_join().await?;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1671,7 +1671,7 @@ impl JsConfig {
 
 #[turbo_tasks::value]
 struct OutdatedConfigIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     old_name: RcStr,
     new_name: RcStr,
     description: RcStr,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1690,7 +1690,7 @@ impl Issue for OutdatedConfigIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{css::chunk::CssChunkType, resolve_options_context::ResolveOptionsContext};
@@ -111,7 +111,7 @@ pub async fn get_edge_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_edge_import_map = get_next_edge_import_map(
-        *project_path,
+        project_path.clone(),
         ty.clone(),
         next_config,
         mode,
@@ -121,7 +121,7 @@ pub async fn get_edge_resolve_options_context(
     .await?;
 
     let mut before_resolve_plugins = vec![ResolvedVc::upcast(
-        ModuleFeatureReportResolvePlugin::new(*project_path)
+        ModuleFeatureReportResolvePlugin::new(project_path.clone())
             .to_resolved()
             .await?,
     )];
@@ -132,7 +132,7 @@ pub async fn get_edge_resolve_options_context(
             | ServerContextType::AppRSC { .. }
     ) {
         before_resolve_plugins.push(ResolvedVc::upcast(
-            NextFontLocalResolvePlugin::new(*project_path)
+            NextFontLocalResolvePlugin::new(project_path.clone())
                 .to_resolved()
                 .await?,
         ));
@@ -147,19 +147,19 @@ pub async fn get_edge_resolve_options_context(
             | ServerContextType::Instrumentation { .. }
     ) {
         before_resolve_plugins.push(ResolvedVc::upcast(
-            get_invalid_client_only_resolve_plugin(project_path)
+            get_invalid_client_only_resolve_plugin(project_path.clone())
                 .to_resolved()
                 .await?,
         ));
         before_resolve_plugins.push(ResolvedVc::upcast(
-            get_invalid_styled_jsx_resolve_plugin(project_path)
+            get_invalid_styled_jsx_resolve_plugin(project_path.clone())
                 .to_resolved()
                 .await?,
         ));
     }
 
     let after_resolve_plugins = vec![ResolvedVc::upcast(
-        NextSharedRuntimeResolvePlugin::new(*project_path)
+        NextSharedRuntimeResolvePlugin::new(project_path.clone())
             .to_resolved()
             .await?,
     )];
@@ -179,7 +179,7 @@ pub async fn get_edge_resolve_options_context(
     };
 
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().to_resolved().await?),
+        enable_node_modules: Some(project_path.root().await?.clone_value()),
         enable_edge_node_externals: true,
         custom_conditions,
         import_map: Some(next_edge_import_map),
@@ -201,9 +201,8 @@ pub async fn get_edge_resolve_options_context(
             .typescript_tsconfig_path()
             .await?
             .as_ref()
-            .map(|p| project_path.join(p.to_owned()))
-            .to_resolved()
-            .await?,
+            .map(|p| project_path.join(p))
+            .transpose()?,
         rules: vec![(
             foreign_code_context_condition(next_config, project_path).await?,
             resolve_options_context.clone().resolved_cell(),
@@ -228,18 +227,15 @@ pub async fn get_edge_chunking_context_with_client_assets(
     no_mangling: Vc<bool>,
     scope_hoisting: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
-    let output_root = node_root.join(rcstr!("server/edge")).to_resolved().await?;
+    let output_root = node_root.join("server/edge")?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
         root_path,
-        output_root,
+        output_root.clone(),
         output_root_to_root_path.owned().await?,
-        client_root,
-        output_root.join(rcstr!("chunks/ssr")).to_resolved().await?,
-        client_root
-            .join(rcstr!("static/media"))
-            .to_resolved()
-            .await?,
+        client_root.clone(),
+        output_root.join("chunks/ssr")?,
+        client_root.join("static/media")?,
         environment,
         next_mode.runtime_type(),
     )
@@ -294,15 +290,15 @@ pub async fn get_edge_chunking_context(
     no_mangling: Vc<bool>,
     scope_hoisting: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
-    let output_root = node_root.join(rcstr!("server/edge")).to_resolved().await?;
+    let output_root = node_root.join("server/edge")?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
         root_path,
-        output_root,
+        output_root.clone(),
         node_root_to_root_path.owned().await?,
-        output_root,
-        output_root.join(rcstr!("chunks")).to_resolved().await?,
-        output_root.join(rcstr!("assets")).to_resolved().await?,
+        output_root.clone(),
+        output_root.join("chunks")?,
+        output_root.join("assets")?,
         environment,
         next_mode.runtime_type(),
     )

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -65,7 +65,7 @@ async fn next_edge_defines(define_env: Vc<EnvMap>) -> Result<Vc<CompileTimeDefin
 /// See [here](https://github.com/vercel/next.js/blob/160bb99b06e9c049f88e25806fd995f07f4cc7e1/packages/next/src/build/webpack-config.ts#L1715-L1718) how webpack configures it.
 #[turbo_tasks::function]
 async fn next_edge_free_vars(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     define_env: Vc<EnvMap>,
 ) -> Result<Vc<FreeVarReferences>> {
     Ok(free_var_references!(
@@ -81,7 +81,7 @@ async fn next_edge_free_vars(
 
 #[turbo_tasks::function]
 pub async fn get_edge_compile_time_info(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     define_env: Vc<EnvMap>,
     node_version: ResolvedVc<NodeJsVersion>,
 ) -> Result<Vc<CompileTimeInfo>> {
@@ -104,7 +104,7 @@ pub async fn get_edge_compile_time_info(
 
 #[turbo_tasks::function]
 pub async fn get_edge_resolve_options_context(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
@@ -216,10 +216,10 @@ pub async fn get_edge_resolve_options_context(
 #[turbo_tasks::function]
 pub async fn get_edge_chunking_context_with_client_assets(
     mode: Vc<NextMode>,
-    root_path: ResolvedVc<FileSystemPath>,
-    node_root: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
+    node_root: FileSystemPath,
     output_root_to_root_path: ResolvedVc<RcStr>,
-    client_root: ResolvedVc<FileSystemPath>,
+    client_root: FileSystemPath,
     asset_prefix: ResolvedVc<Option<RcStr>>,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
@@ -284,8 +284,8 @@ pub async fn get_edge_chunking_context_with_client_assets(
 #[turbo_tasks::function]
 pub async fn get_edge_chunking_context(
     mode: Vc<NextMode>,
-    root_path: ResolvedVc<FileSystemPath>,
-    node_root: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
+    node_root: FileSystemPath,
     node_root_to_root_path: ResolvedVc<RcStr>,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -11,7 +11,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 #[turbo_tasks::function]
 pub fn wrap_edge_entry(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     pathname: RcStr,
 ) -> Vc<Box<dyn Module>> {

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
@@ -14,7 +15,7 @@ pub fn wrap_edge_entry(
     project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     pathname: RcStr,
-) -> Vc<Box<dyn Module>> {
+) -> Result<Vc<Box<dyn Module>>> {
     // The wrapped module could be an async module, we handle that with the proxy
     // here. The comma expression makes sure we don't call the function with the
     // module as the "this" arg.
@@ -45,7 +46,7 @@ pub fn wrap_edge_entry(
 
     // TODO(alexkirsz) Figure out how to name this virtual asset.
     let virtual_source = VirtualSource::new(
-        project_root.join("edge-wrapper.js".into()),
+        project_root.join("edge-wrapper.js")?,
         AssetContent::file(file.into()),
     );
 
@@ -53,10 +54,10 @@ pub fn wrap_edge_entry(
         "MODULE".into() => entry
     };
 
-    asset_context
+    Ok(asset_context
         .process(
             Vc::upcast(virtual_source),
             ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
-        .module()
+        .module())
 }

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -42,7 +42,7 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
     #[turbo_tasks::function]
     async fn result(
         &self,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -60,7 +60,7 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
 }
 
 #[turbo_tasks::function]
-fn unsupported_module_source(root_path: Vc<FileSystemPath>, module: RcStr) -> Vc<VirtualSource> {
+fn unsupported_module_source(root_path: FileSystemPath, module: RcStr) -> Vc<VirtualSource> {
     // packages/next/src/server/web/globals.ts augments global with
     // `__import_unsupported` and necessary functions.
     let code = formatdoc! {

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -49,9 +49,10 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
         if let Request::Module { module, .. } = request {
             // Call out to separate `unsupported_module_source` to only have a single Source cell
             // for requests with different subpaths: `fs` and `fs/promises`.
-            let source = unsupported_module_source(lookup_path.root(), module.clone())
-                .to_resolved()
-                .await?;
+            let source =
+                unsupported_module_source(lookup_path.root().await?.clone_value(), module.clone())
+                    .to_resolved()
+                    .await?;
             Ok(ImportMapResult::Result(ResolveResult::source(ResolvedVc::upcast(source))).cell())
         } else {
             Ok(ImportMapResult::NoEntry.cell())

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -44,7 +44,7 @@ struct Fallback {
 
 #[turbo_tasks::function]
 pub(super) async fn get_font_fallback(
-    lookup_path: ResolvedVc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     options_vc: Vc<NextFontGoogleOptions>,
 ) -> Result<Vc<FontFallback>> {
     let options = options_vc.await?;

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{IssueExt, IssueSeverity, StyledString};
 
@@ -52,7 +52,7 @@ pub(super) async fn get_font_fallback(
         Some(fallback) => FontFallback::Manual(fallback.clone()).cell(),
         None => {
             let metrics_json = load_next_js_templateon(
-                lookup_path,
+                lookup_path.clone(),
                 rcstr!("dist/server/capsize-font-metrics.json"),
             )
             .await?;
@@ -74,7 +74,7 @@ pub(super) async fn get_font_fallback(
                 .cell(),
                 Err(_) => {
                     NextFontIssue {
-                        path: lookup_path,
+                        path: lookup_path.clone(),
                         title: StyledString::Text(
                             format!(
                                 "Failed to find font override values for font `{}`",

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -75,13 +75,13 @@ struct FontData(FxIndexMap<RcStr, FontDataEntry>);
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontGoogleReplacer {
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontGoogleReplacer {
     #[turbo_tasks::function]
-    pub fn new(project_path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project_path: FileSystemPath) -> Vc<Self> {
         Self::cell(NextFontGoogleReplacer { project_path })
     }
 
@@ -153,7 +153,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
     #[turbo_tasks::function]
     async fn result(
         self: Vc<Self>,
-        _context: Vc<FileSystemPath>,
+        _context: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -178,7 +178,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
 
 #[turbo_tasks::value(shared)]
 pub struct NextFontGoogleCssModuleReplacer {
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: ResolvedVc<ExecutionContext>,
     next_mode: ResolvedVc<NextMode>,
 }
@@ -187,7 +187,7 @@ pub struct NextFontGoogleCssModuleReplacer {
 impl NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: ResolvedVc<FileSystemPath>,
+        project_path: FileSystemPath,
         execution_context: ResolvedVc<ExecutionContext>,
         next_mode: ResolvedVc<NextMode>,
     ) -> Vc<Self> {
@@ -332,7 +332,7 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
     async fn result(
         self: Vc<Self>,
-        _context: Vc<FileSystemPath>,
+        _context: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -359,13 +359,13 @@ struct NextFontGoogleFontFileOptions {
 
 #[turbo_tasks::value(shared)]
 pub struct NextFontGoogleFontFileReplacer {
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontGoogleFontFileReplacer {
     #[turbo_tasks::function]
-    pub fn new(project_path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project_path: FileSystemPath) -> Vc<Self> {
         Self::cell(NextFontGoogleFontFileReplacer { project_path })
     }
 }
@@ -383,7 +383,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
     #[turbo_tasks::function]
     async fn result(
         &self,
-        _context: Vc<FileSystemPath>,
+        _context: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -436,7 +436,7 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
 }
 
 #[turbo_tasks::function]
-async fn load_font_data(project_root: ResolvedVc<FileSystemPath>) -> Result<Vc<FontData>> {
+async fn load_font_data(project_root: FileSystemPath) -> Result<Vc<FontData>> {
     let data: FontData = load_next_js_templateon(
         project_root,
         rcstr!("dist/compiled/@next/font/dist/google/font-data.json"),
@@ -642,7 +642,7 @@ fn font_file_options_from_query_map(query: &RcStr) -> Result<NextFontGoogleFontF
 
 async fn fetch_real_stylesheet(
     stylesheet_url: RcStr,
-    css_virtual_path: Vc<FileSystemPath>,
+    css_virtual_path: FileSystemPath,
 ) -> Result<Option<Vc<RcStr>>> {
     let body = fetch_from_google_fonts(stylesheet_url, css_virtual_path).await?;
 
@@ -651,7 +651,7 @@ async fn fetch_real_stylesheet(
 
 async fn fetch_from_google_fonts(
     url: RcStr,
-    virtual_path: Vc<FileSystemPath>,
+    virtual_path: FileSystemPath,
 ) -> Result<Option<Vc<HttpResponseBody>>> {
     let result = fetch(
         url,

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -90,14 +90,15 @@ impl NextFontGoogleReplacer {
         let request_hash = get_request_hash(&query);
         let qstr = qstring::QString::from(query.as_str());
 
-        let font_data = load_font_data(*self.project_path);
+        let font_data = load_font_data(self.project_path.clone());
         let options = font_options_from_query_map(query, font_data);
 
-        let fallback = get_font_fallback(*self.project_path, options);
+        let fallback = get_font_fallback(self.project_path.clone(), options);
         let properties = get_font_css_properties(options, fallback).await?;
         let js_asset = VirtualSource::new(
             next_js_file_path(rcstr!("internal/font/google"))
-                .join(format!("{}.js", get_request_id(options.font_family().await?, request_hash)).into()),
+                .await?
+                .join(&format!("{}.js", get_request_id(options.font_family().await?, request_hash)))?,
             AssetContent::file(FileContent::Content(
                 formatdoc!(
                     r#"
@@ -168,7 +169,7 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
         };
 
         let this = &*self.await?;
-        if can_use_next_font(*this.project_path, query).await? {
+        if can_use_next_font(this.project_path.clone(), query).await? {
             Ok(self.import_map_result(query.clone()))
         } else {
             Ok(ImportMapResult::NoEntry.into())
@@ -201,7 +202,7 @@ impl NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
     async fn import_map_result(&self, query: RcStr) -> Result<Vc<ImportMapResult>> {
         let request_hash = get_request_hash(&query);
-        let font_data = load_font_data(*self.project_path);
+        let font_data = load_font_data(self.project_path.clone());
         let options = font_options_from_query_map(query, font_data);
         let stylesheet_url = get_stylesheet_url_from_options(options, font_data)
             .owned()
@@ -210,7 +211,11 @@ impl NextFontGoogleCssModuleReplacer {
         let scoped_font_family =
             get_scoped_font_family(FontFamilyType::WebFont, font_family.clone());
         let css_virtual_path = next_js_file_path(rcstr!("internal/font/google"))
-            .join(format!("/{}.module.css", get_request_id(font_family, request_hash)).into());
+            .await?
+            .join(&format!(
+                "/{}.module.css",
+                get_request_id(font_family, request_hash)
+            ))?;
 
         // When running Next.js integration tests, use the mock data available in
         // process.env.NEXT_FONT_GOOGLE_MOCKED_RESPONSES instead of making real
@@ -223,12 +228,12 @@ impl NextFontGoogleCssModuleReplacer {
         let stylesheet_str = mocked_responses_path
             .as_ref()
             .map_or_else(
-                || fetch_real_stylesheet(stylesheet_url.clone(), css_virtual_path).boxed(),
+                || fetch_real_stylesheet(stylesheet_url.clone(), css_virtual_path.clone()).boxed(),
                 |p| get_mock_stylesheet(stylesheet_url.clone(), p, *self.execution_context).boxed(),
             )
             .await?;
 
-        let font_fallback = get_font_fallback(*self.project_path, options);
+        let font_fallback = get_font_fallback(self.project_path.clone(), options);
         let stylesheet = match stylesheet_str {
             Some(s) => Some(
                 update_google_stylesheet(
@@ -246,7 +251,7 @@ impl NextFontGoogleCssModuleReplacer {
                     // rendering.
                     NextMode::Build => {
                         NextFontIssue {
-                            path: css_virtual_path.to_resolved().await?,
+                            path: css_virtual_path.clone(),
                             title: StyledString::Line(vec![
                                 StyledString::Code(rcstr!("next/font:")),
                                 StyledString::Text(rcstr!(" error:")),
@@ -270,7 +275,7 @@ impl NextFontGoogleCssModuleReplacer {
                     // renders during development.
                     NextMode::Development => {
                         NextFontIssue {
-                            path: css_virtual_path.to_resolved().await?,
+                            path: css_virtual_path.clone(),
                             title: StyledString::Line(vec![
                                 StyledString::Code(rcstr!("next/font:")),
                                 StyledString::Text(rcstr!(" warning:")),
@@ -415,12 +420,14 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
             name.push_str(".p")
         }
 
-        let font_virtual_path =
-            next_js_file_path(rcstr!("internal/font/google")).join(format!("/{name}.{ext}").into());
+        let font_virtual_path = next_js_file_path(rcstr!("internal/font/google"))
+            .await?
+            .join(&format!("/{name}.{ext}"))?;
 
         // doesn't seem ideal to download the font into a string, but probably doesn't
         // really matter either.
-        let Some(font) = fetch_from_google_fonts(url.into(), font_virtual_path).await? else {
+        let Some(font) = fetch_from_google_fonts(url.into(), font_virtual_path.clone()).await?
+        else {
             return Ok(ImportMapResult::Result(ResolveResult::unresolvable()).cell());
         };
 
@@ -702,11 +709,11 @@ async fn get_mock_stylesheet(
         Layer::new(rcstr!("next_font")),
         false,
     );
-    let loader_path = mock_fs.root().join(rcstr!("loader.js"));
+    let loader_path = mock_fs.root().await?.join("loader.js")?;
     let mocked_response_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                loader_path,
+                loader_path.clone(),
                 AssetContent::file(
                     File::from(format!(
                         "import data from './{}'; export default function load() {{ return data; \
@@ -723,7 +730,7 @@ async fn get_mock_stylesheet(
         )
         .module();
 
-    let root = mock_fs.root();
+    let root = mock_fs.root().await?.clone_value();
     let val = evaluate(
         mocked_response_asset,
         root,

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -4,7 +4,7 @@ use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontIssue {
-    pub(crate) path: ResolvedVc<FileSystemPath>,
+    pub(crate) path: FileSystemPath,
     pub(crate) title: ResolvedVc<StyledString>,
     pub(crate) description: ResolvedVc<StyledString>,
     pub(crate) severity: IssueSeverity,

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -23,7 +23,7 @@ impl Issue for NextFontIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -34,7 +34,7 @@ static BOLD_WEIGHT: f64 = 700.0;
 
 #[turbo_tasks::function]
 pub(super) async fn get_font_fallbacks(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     options_vc: Vc<NextFontLocalOptions>,
 ) -> Result<Vc<FontFallbackResult>> {
     let options = &*options_vc.await?;
@@ -90,7 +90,7 @@ pub(super) async fn get_font_fallbacks(
 }
 
 async fn get_font_adjustment(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     options: Vc<NextFontLocalOptions>,
     fallback_font: &DefaultFallbackFont,
 ) -> Result<FontResult<FontAdjustment>> {

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -96,10 +96,7 @@ async fn get_font_adjustment(
 ) -> Result<FontResult<FontAdjustment>> {
     let options = &*options.await?;
     let main_descriptor = pick_font_for_fallback_generation(&options.fonts)?;
-    let font_file = &*lookup_path
-        .join(main_descriptor.path.clone())
-        .read()
-        .await?;
+    let font_file = &*lookup_path.join(&main_descriptor.path)?.read().await?;
     let font_file_rope = match font_file {
         FileContent::NotFound => {
             return Ok(FontResult::FontFileNotFound(FontFileNotFound(

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -53,13 +53,13 @@ struct NextFontLocalFontFileOptions {
 
 #[turbo_tasks::value]
 pub(crate) struct NextFontLocalResolvePlugin {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: FileSystemPath) -> Vc<Self> {
         NextFontLocalResolvePlugin { root }.cell()
     }
 }
@@ -76,7 +76,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
     async fn before_resolve(
         self: Vc<Self>,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         request_vc: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
@@ -323,7 +323,7 @@ fn font_file_options_from_query_map(query: &RcStr) -> Result<NextFontLocalFontFi
 #[turbo_tasks::value(shared)]
 struct FontResolvingIssue {
     font_path: ResolvedVc<RcStr>,
-    origin_path: ResolvedVc<FileSystemPath>,
+    origin_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -99,7 +99,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
 
         match request_key.as_str() {
             "next/font/local/target.css" => {
-                if !can_use_next_font(*this.root, query).await? {
+                if !can_use_next_font(this.root.clone(), query).await? {
                     return Ok(ResolveResultOption::none());
                 }
 
@@ -107,12 +107,11 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let qstr = qstring::QString::from(query.as_str());
                 let options_vc = font_options_from_query_map(query.clone());
 
-                let font_fallbacks = &*get_font_fallbacks(lookup_path, options_vc).await?;
-                let lookup_path = lookup_path.to_resolved().await?;
+                let font_fallbacks = &*get_font_fallbacks(lookup_path.clone(), options_vc).await?;
                 let font_fallbacks = match font_fallbacks {
                     FontFallbackResult::FontFileNotFound(err) => {
                         FontResolvingIssue {
-                            origin_path: lookup_path,
+                            origin_path: lookup_path.clone(),
                             font_path: ResolvedVc::cell(err.0.clone()),
                         }
                         .resolved_cell()
@@ -160,13 +159,10 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                         .unwrap_or_else(|| "".to_owned()),
                 );
                 let js_asset = VirtualSource::new(
-                    lookup_path.join(
-                        format!(
-                            "{}.js",
-                            get_request_id(options_vc.font_family().await?, request_hash)
-                        )
-                        .into(),
-                    ),
+                    lookup_path.join(&format!(
+                        "{}.js",
+                        get_request_id(options_vc.font_family().await?, request_hash)
+                    ))?,
                     AssetContent::file(FileContent::Content(file_content.into()).into()),
                 )
                 .to_resolved()
@@ -179,18 +175,15 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
             "@vercel/turbopack-next/internal/font/local/cssmodule.module.css" => {
                 let request_hash = get_request_hash(query);
                 let options = font_options_from_query_map(query.clone());
-                let css_virtual_path = lookup_path.join(
-                    format!(
-                        "/{}.module.css",
-                        get_request_id(options.font_family().await?, request_hash)
-                    )
-                    .into(),
-                );
-                let fallback = &*get_font_fallbacks(lookup_path, options).await?;
+                let css_virtual_path = lookup_path.join(&format!(
+                    "/{}.module.css",
+                    get_request_id(options.font_family().await?, request_hash)
+                ))?;
+                let fallback = &*get_font_fallbacks(lookup_path.clone(), options).await?;
                 let fallback = match fallback {
                     FontFallbackResult::FontFileNotFound(err) => {
                         FontResolvingIssue {
-                            origin_path: lookup_path.to_resolved().await?,
+                            origin_path: lookup_path.clone(),
                             font_path: ResolvedVc::cell(err.0.clone()),
                         }
                         .resolved_cell()
@@ -240,9 +233,9 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                     name.push_str(".p")
                 }
 
-                let font_virtual_path = lookup_path.join(format!("/{name}.{ext}").into());
+                let font_virtual_path = lookup_path.join(&format!("/{name}.{ext}"))?;
 
-                let font_file = lookup_path.join(path.clone()).read();
+                let font_file = lookup_path.join(&path)?.read();
 
                 let font_source =
                     VirtualSource::new(font_virtual_path, AssetContent::file(font_file))
@@ -334,7 +327,7 @@ impl Issue for FontResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.origin_path
+        self.origin_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -68,10 +68,7 @@ struct HasPath {
     path: RcStr,
 }
 
-pub(crate) async fn can_use_next_font(
-    project_path: Vc<FileSystemPath>,
-    query: &RcStr,
-) -> Result<bool> {
+pub(crate) async fn can_use_next_font(project_path: FileSystemPath, query: &RcStr) -> Result<bool> {
     let query_map = qstring::QString::from(query.as_str());
     let request: HasPath = parse_json_with_source_context(
         query_map

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::{FileSystemPath, json::parse_json_with_source_context};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::issue::{IssueExt, IssueSeverity, StyledString};
@@ -79,11 +79,11 @@ pub(crate) async fn can_use_next_font(project_path: FileSystemPath, query: &RcSt
     )?;
 
     let document_re = lazy_regex::regex!("^(src/)?_document\\.[^/]+$");
-    let path = project_path.join(request.path.clone());
+    let path = project_path.join(&request.path)?;
     let can_use = !document_re.is_match(&request.path);
     if !can_use {
         NextFontIssue {
-            path: path.to_resolved().await?,
+            path: path.clone(),
             title: StyledString::Line(vec![
                 StyledString::Code(rcstr!("next/font:")),
                 StyledString::Text(rcstr!(" error:")),

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -90,7 +90,7 @@ const EDGE_UNSUPPORTED_NODE_INTERNALS: [&str; 44] = [
 /// Computes the Next-specific client import map.
 #[turbo_tasks::function]
 pub async fn get_next_client_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ClientContextType,
     next_config: Vc<NextConfig>,
     next_mode: Vc<NextMode>,
@@ -286,7 +286,7 @@ pub async fn get_next_client_fallback_import_map(ty: ClientContextType) -> Resul
 /// Computes the Next-specific server-side import map.
 #[turbo_tasks::function]
 pub async fn get_next_server_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     next_config: Vc<NextConfig>,
     next_mode: Vc<NextMode>,
@@ -381,7 +381,7 @@ pub async fn get_next_server_import_map(
 /// Computes the Next-specific edge-side import map.
 #[turbo_tasks::function]
 pub async fn get_next_edge_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     next_config: Vc<NextConfig>,
     next_mode: Vc<NextMode>,
@@ -523,8 +523,8 @@ async fn insert_unsupported_node_internal_aliases(import_map: &mut ImportMap) ->
 }
 
 pub fn get_next_client_resolved_map(
-    _context: Vc<FileSystemPath>,
-    _root: ResolvedVc<FileSystemPath>,
+    _context: FileSystemPath,
+    _root: FileSystemPath,
     _mode: NextMode,
 ) -> Vc<ResolvedMap> {
     let glob_mappings = vec![];
@@ -562,21 +562,19 @@ static NEXT_ALIASES: [(&str, &str); 23] = [
 
 async fn insert_next_server_special_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
 ) -> Result<()> {
-    let external_cjs_if_node =
-        move |context_dir: ResolvedVc<FileSystemPath>, request: &str| match runtime {
-            NextRuntime::Edge => request_to_import_mapping(context_dir, request),
-            NextRuntime::NodeJs => external_request_to_cjs_import_mapping(context_dir, request),
-        };
-    let external_esm_if_node =
-        move |context_dir: ResolvedVc<FileSystemPath>, request: &str| match runtime {
-            NextRuntime::Edge => request_to_import_mapping(context_dir, request),
-            NextRuntime::NodeJs => external_request_to_esm_import_mapping(context_dir, request),
-        };
+    let external_cjs_if_node = move |context_dir: FileSystemPath, request: &str| match runtime {
+        NextRuntime::Edge => request_to_import_mapping(context_dir, request),
+        NextRuntime::NodeJs => external_request_to_cjs_import_mapping(context_dir, request),
+    };
+    let external_esm_if_node = move |context_dir: FileSystemPath, request: &str| match runtime {
+        NextRuntime::Edge => request_to_import_mapping(context_dir, request),
+        NextRuntime::NodeJs => external_request_to_esm_import_mapping(context_dir, request),
+    };
 
     import_map.insert_exact_alias(
         "next/dist/compiled/@vercel/og/index.node.js",
@@ -696,7 +694,7 @@ async fn get_react_client_package(next_config: Vc<NextConfig>) -> Result<&'stati
 
 async fn rsc_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
@@ -819,7 +817,7 @@ pub fn mdx_import_source_file() -> RcStr {
 // Keep in sync with getOptimizedModuleAliases in webpack-config.ts
 async fn insert_optimized_module_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<()> {
     insert_exact_alias_map(
         import_map,
@@ -843,7 +841,7 @@ async fn insert_optimized_module_aliases(
 // Make sure to not add any external requests here.
 async fn insert_next_shared_aliases(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: Vc<ExecutionContext>,
     next_config: Vc<NextConfig>,
     next_mode: Vc<NextMode>,
@@ -1006,7 +1004,7 @@ async fn insert_next_shared_aliases(
 }
 
 #[turbo_tasks::function]
-pub async fn get_next_package(context_directory: Vc<FileSystemPath>) -> Result<Vc<FileSystemPath>> {
+pub async fn get_next_package(context_directory: FileSystemPath) -> Result<Vc<FileSystemPath>> {
     let result = resolve(
         context_directory,
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
@@ -1022,7 +1020,7 @@ pub async fn get_next_package(context_directory: Vc<FileSystemPath>) -> Result<V
 
 pub async fn insert_alias_option<const N: usize>(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     alias_options: Vc<ResolveAliasMap>,
     conditions: [&'static str; N],
 ) -> Result<()> {
@@ -1038,7 +1036,7 @@ pub async fn insert_alias_option<const N: usize>(
 fn export_value_to_import_mapping(
     value: &SubpathValue,
     conditions: &BTreeMap<RcStr, ConditionValue>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Option<ResolvedVc<ImportMapping>> {
     let mut result = Vec::new();
     value.add_results(
@@ -1070,7 +1068,7 @@ fn export_value_to_import_mapping(
 
 fn insert_exact_alias_map(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
@@ -1080,7 +1078,7 @@ fn insert_exact_alias_map(
 
 fn insert_wildcard_alias_map(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
@@ -1102,11 +1100,7 @@ fn insert_alias_to_alternatives<'a>(
 }
 
 /// Inserts an alias to an import mapping into an import map.
-fn insert_package_alias(
-    import_map: &mut ImportMap,
-    prefix: &str,
-    package_root: ResolvedVc<FileSystemPath>,
-) {
+fn insert_package_alias(import_map: &mut ImportMap, prefix: &str, package_root: FileSystemPath) {
     import_map.insert_wildcard_alias(
         prefix,
         ImportMapping::PrimaryAlternative(rcstr!("./*"), Some(package_root)).resolved_cell(),
@@ -1129,7 +1123,7 @@ async fn insert_turbopack_dev_alias(import_map: &mut ImportMap) -> Result<()> {
 /// Handles instrumentation-client.ts bundling logic
 async fn insert_instrumentation_client_alias(
     import_map: &mut ImportMap,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<()> {
     insert_alias_to_alternatives(
         import_map,
@@ -1159,7 +1153,7 @@ fn insert_exact_alias_or_js(
 /// Creates a direct import mapping to the result of resolving a request
 /// in a context.
 fn request_to_import_mapping(
-    context_path: ResolvedVc<FileSystemPath>,
+    context_path: FileSystemPath,
     request: &str,
 ) -> ResolvedVc<ImportMapping> {
     ImportMapping::PrimaryAlternative(request.into(), Some(context_path)).resolved_cell()
@@ -1168,7 +1162,7 @@ fn request_to_import_mapping(
 /// Creates a direct import mapping to the result of resolving an external
 /// request.
 fn external_request_to_cjs_import_mapping(
-    context_dir: ResolvedVc<FileSystemPath>,
+    context_dir: FileSystemPath,
     request: &str,
 ) -> ResolvedVc<ImportMapping> {
     ImportMapping::PrimaryAlternativeExternal {
@@ -1183,7 +1177,7 @@ fn external_request_to_cjs_import_mapping(
 /// Creates a direct import mapping to the result of resolving an external
 /// request.
 fn external_request_to_esm_import_mapping(
-    context_dir: ResolvedVc<FileSystemPath>,
+    context_dir: FileSystemPath,
     request: &str,
 ) -> ResolvedVc<ImportMapping> {
     ImportMapping::PrimaryAlternativeExternal {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -100,7 +100,7 @@ pub async fn get_next_client_import_map(
 
     insert_next_shared_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         execution_context,
         next_config,
         next_mode,
@@ -108,17 +108,17 @@ pub async fn get_next_client_import_map(
     )
     .await?;
 
-    insert_optimized_module_aliases(&mut import_map, project_path).await?;
+    insert_optimized_module_aliases(&mut import_map, project_path.clone()).await?;
 
     insert_alias_option(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         next_config.resolve_alias_options(),
         ["browser"],
     )
     .await?;
 
-    match ty {
+    match &ty {
         ClientContextType::Pages { .. } => {}
         ClientContextType::App { app_dir } => {
             let react_flavor = if *next_config.enable_ppr().await?
@@ -134,42 +134,42 @@ pub async fn get_next_client_import_map(
             import_map.insert_exact_alias(
                 "react",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react{react_flavor}"),
                 ),
             );
             import_map.insert_wildcard_alias(
                 "react/",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react{react_flavor}/*"),
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-dom{react_flavor}"),
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom/static",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     "next/dist/compiled/react-dom-experimental/static",
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom/static.edge",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     "next/dist/compiled/react-dom-experimental/static.edge",
                 ),
             );
             import_map.insert_exact_alias(
                 "react-dom/static.browser",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     "next/dist/compiled/react-dom-experimental/static.browser",
                 ),
             );
@@ -177,47 +177,50 @@ pub async fn get_next_client_import_map(
             import_map.insert_exact_alias(
                 "react-dom/client",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-dom{react_flavor}/{react_client_package}"),
                 ),
             );
             import_map.insert_wildcard_alias(
                 "react-dom/",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-dom{react_flavor}/*"),
                 ),
             );
             import_map.insert_wildcard_alias(
                 "react-server-dom-webpack/",
-                request_to_import_mapping(app_dir, "react-server-dom-turbopack/*"),
+                request_to_import_mapping(app_dir.clone(), "react-server-dom-turbopack/*"),
             );
             import_map.insert_wildcard_alias(
                 "react-server-dom-turbopack/",
                 request_to_import_mapping(
-                    app_dir,
+                    app_dir.clone(),
                     &format!("next/dist/compiled/react-server-dom-turbopack{react_flavor}/*"),
                 ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/head",
-                request_to_import_mapping(project_path, "next/dist/client/components/noop-head"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    "next/dist/client/components/noop-head",
+                ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/dynamic",
-                request_to_import_mapping(project_path, "next/dist/shared/lib/app-dynamic"),
+                request_to_import_mapping(project_path.clone(), "next/dist/shared/lib/app-dynamic"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/link",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/link"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/link"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/form",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/form"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/form"),
             );
         }
         ClientContextType::Fallback => {}
@@ -227,7 +230,7 @@ pub async fn get_next_client_import_map(
     // see https://github.com/vercel/next.js/blob/8013ef7372fc545d49dbd060461224ceb563b454/packages/next/src/build/webpack-config.ts#L1449-L1531
     insert_exact_alias_map(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         fxindexmap! {
             "server-only" => "next/dist/compiled/server-only/index".to_string(),
             "client-only" => "next/dist/compiled/client-only/index".to_string(),
@@ -243,7 +246,7 @@ pub async fn get_next_client_import_map(
             for (original, alias) in NEXT_ALIASES {
                 import_map.insert_exact_alias(
                     format!("node:{original}"),
-                    request_to_import_mapping(project_path, alias),
+                    request_to_import_mapping(project_path.clone(), alias),
                 );
             }
         }
@@ -270,8 +273,10 @@ pub async fn get_next_client_fallback_import_map(ty: ClientContextType) -> Resul
             app_dir: context_dir,
         } => {
             for (original, alias) in NEXT_ALIASES {
-                import_map
-                    .insert_exact_alias(original, request_to_import_mapping(context_dir, alias));
+                import_map.insert_exact_alias(
+                    original,
+                    request_to_import_mapping(context_dir.clone(), alias),
+                );
             }
         }
         ClientContextType::Fallback => {}
@@ -296,7 +301,7 @@ pub async fn get_next_server_import_map(
 
     insert_next_shared_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         execution_context,
         next_config,
         next_mode,
@@ -306,7 +311,7 @@ pub async fn get_next_server_import_map(
 
     insert_alias_option(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         next_config.resolve_alias_options(),
         [],
     )
@@ -345,22 +350,25 @@ pub async fn get_next_server_import_map(
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/head",
-                request_to_import_mapping(project_path, "next/dist/client/components/noop-head"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    "next/dist/client/components/noop-head",
+                ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/dynamic",
-                request_to_import_mapping(project_path, "next/dist/shared/lib/app-dynamic"),
+                request_to_import_mapping(project_path.clone(), "next/dist/shared/lib/app-dynamic"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/link",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/link"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/link"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/form",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/form"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/form"),
             );
         }
         ServerContextType::Middleware { .. } | ServerContextType::Instrumentation { .. } => {}
@@ -368,7 +376,7 @@ pub async fn get_next_server_import_map(
 
     insert_next_server_special_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         ty,
         NextRuntime::NodeJs,
         next_config,
@@ -394,7 +402,7 @@ pub async fn get_next_edge_import_map(
     // Alias next/dist imports to next/dist/esm assets
     insert_wildcard_alias_map(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         fxindexmap! {
             "next/dist/build/" => "next/dist/esm/build/*".to_string(),
             "next/dist/client/" => "next/dist/esm/client/*".to_string(),
@@ -409,7 +417,7 @@ pub async fn get_next_edge_import_map(
     // Alias the usage of next public APIs
     insert_exact_alias_map(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         fxindexmap! {
             "next/app" => "next/dist/api/app".to_string(),
             "next/document" => "next/dist/api/document".to_string(),
@@ -433,7 +441,7 @@ pub async fn get_next_edge_import_map(
 
     insert_next_shared_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         execution_context,
         next_config,
         next_mode,
@@ -441,11 +449,11 @@ pub async fn get_next_edge_import_map(
     )
     .await?;
 
-    insert_optimized_module_aliases(&mut import_map, project_path).await?;
+    insert_optimized_module_aliases(&mut import_map, project_path.clone()).await?;
 
     insert_alias_option(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         next_config.resolve_alias_options(),
         [],
     )
@@ -463,24 +471,27 @@ pub async fn get_next_edge_import_map(
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/head",
-                request_to_import_mapping(project_path, "next/dist/client/components/noop-head"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    "next/dist/client/components/noop-head",
+                ),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/dynamic",
-                request_to_import_mapping(project_path, "next/dist/shared/lib/app-dynamic"),
+                request_to_import_mapping(project_path.clone(), "next/dist/shared/lib/app-dynamic"),
             );
             insert_exact_alias_or_js(
                 &mut import_map,
                 "next/link",
-                request_to_import_mapping(project_path, "next/dist/client/app-dir/link"),
+                request_to_import_mapping(project_path.clone(), "next/dist/client/app-dir/link"),
             );
         }
     }
 
     insert_next_server_special_aliases(
         &mut import_map,
-        project_path,
+        project_path.clone(),
         ty.clone(),
         NextRuntime::Edge,
         next_config,
@@ -578,14 +589,17 @@ async fn insert_next_server_special_aliases(
 
     import_map.insert_exact_alias(
         "next/dist/compiled/@vercel/og/index.node.js",
-        external_esm_if_node(project_path, "next/dist/compiled/@vercel/og/index.node.js"),
+        external_esm_if_node(
+            project_path.clone(),
+            "next/dist/compiled/@vercel/og/index.node.js",
+        ),
     );
 
     import_map.insert_exact_alias(
         "next/dist/server/ReactDOMServerPages",
         ImportMapping::Alternatives(vec![
-            request_to_import_mapping(project_path, "react-dom/server.edge"),
-            request_to_import_mapping(project_path, "react-dom/server.browser"),
+            request_to_import_mapping(project_path.clone(), "react-dom/server.edge"),
+            request_to_import_mapping(project_path.clone(), "react-dom/server.browser"),
         ])
         .resolved_cell(),
     );
@@ -594,8 +608,11 @@ async fn insert_next_server_special_aliases(
         "@opentelemetry/api",
         // It needs to prefer the local version of @opentelemetry/api
         ImportMapping::Alternatives(vec![
-            external_cjs_if_node(project_path, "@opentelemetry/api"),
-            external_cjs_if_node(project_path, "next/dist/compiled/@opentelemetry/api"),
+            external_cjs_if_node(project_path.clone(), "@opentelemetry/api"),
+            external_cjs_if_node(
+                project_path.clone(),
+                "next/dist/compiled/@opentelemetry/api",
+            ),
         ])
         .resolved_cell(),
     );
@@ -607,20 +624,34 @@ async fn insert_next_server_special_aliases(
         ServerContextType::AppSSR { app_dir }
         | ServerContextType::AppRSC { app_dir, .. }
         | ServerContextType::AppRoute { app_dir, .. } => {
-            let next_package = get_next_package(**app_dir).to_resolved().await?;
+            let next_package = get_next_package(app_dir.clone()).await?.clone_value();
             import_map.insert_exact_alias(
                 "styled-jsx",
-                request_to_import_mapping(next_package, "styled-jsx"),
+                request_to_import_mapping(next_package.clone(), "styled-jsx"),
             );
             import_map.insert_wildcard_alias(
                 "styled-jsx/",
-                request_to_import_mapping(next_package, "styled-jsx/*"),
+                request_to_import_mapping(next_package.clone(), "styled-jsx/*"),
             );
 
-            rsc_aliases(import_map, project_path, ty.clone(), runtime, next_config).await?;
+            rsc_aliases(
+                import_map,
+                project_path.clone(),
+                ty.clone(),
+                runtime,
+                next_config,
+            )
+            .await?;
         }
         ServerContextType::Middleware { .. } | ServerContextType::Instrumentation { .. } => {
-            rsc_aliases(import_map, project_path, ty.clone(), runtime, next_config).await?;
+            rsc_aliases(
+                import_map,
+                project_path.clone(),
+                ty.clone(),
+                runtime,
+                next_config,
+            )
+            .await?;
         }
     }
 
@@ -633,7 +664,7 @@ async fn insert_next_server_special_aliases(
         ServerContextType::Pages { .. } => {
             insert_exact_alias_map(
                 import_map,
-                project_path,
+                project_path.clone(),
                 fxindexmap! {
                     "server-only" => "next/dist/compiled/server-only/empty".to_string(),
                     "client-only" => "next/dist/compiled/client-only/index".to_string(),
@@ -650,7 +681,7 @@ async fn insert_next_server_special_aliases(
         | ServerContextType::Instrumentation { .. } => {
             insert_exact_alias_map(
                 import_map,
-                project_path,
+                project_path.clone(),
                 fxindexmap! {
                     "server-only" => "next/dist/compiled/server-only/empty".to_string(),
                     "client-only" => "next/dist/compiled/client-only/error".to_string(),
@@ -662,7 +693,7 @@ async fn insert_next_server_special_aliases(
         ServerContextType::AppSSR { .. } => {
             insert_exact_alias_map(
                 import_map,
-                project_path,
+                project_path.clone(),
                 fxindexmap! {
                     "server-only" => "next/dist/compiled/server-only/index".to_string(),
                     "client-only" => "next/dist/compiled/client-only/index".to_string(),
@@ -675,7 +706,7 @@ async fn insert_next_server_special_aliases(
 
     import_map.insert_exact_alias(
         "@vercel/og",
-        external_cjs_if_node(project_path, "next/dist/server/og/image-response"),
+        external_cjs_if_node(project_path.clone(), "next/dist/server/og/image-response"),
     );
 
     Ok(())
@@ -804,7 +835,7 @@ async fn rsc_aliases(
         })
     }
 
-    insert_exact_alias_map(import_map, project_path, alias);
+    insert_exact_alias_map(import_map, project_path.clone(), alias);
 
     Ok(())
 }
@@ -847,16 +878,16 @@ async fn insert_next_shared_aliases(
     next_mode: Vc<NextMode>,
     is_runtime_edge: bool,
 ) -> Result<()> {
-    let package_root = next_js_fs().root().to_resolved().await?;
+    let package_root = next_js_fs().root().await?.clone_value();
 
     insert_alias_to_alternatives(
         import_map,
         mdx_import_source_file(),
         vec![
-            request_to_import_mapping(project_path, "./mdx-components"),
-            request_to_import_mapping(project_path, "./src/mdx-components"),
-            request_to_import_mapping(project_path, "@mdx-js/react"),
-            request_to_import_mapping(project_path, "@next/mdx/mdx-components.js"),
+            request_to_import_mapping(project_path.clone(), "./mdx-components"),
+            request_to_import_mapping(project_path.clone(), "./src/mdx-components"),
+            request_to_import_mapping(project_path.clone(), "@mdx-js/react"),
+            request_to_import_mapping(project_path.clone(), "@next/mdx/mdx-components.js"),
         ],
     );
 
@@ -872,7 +903,7 @@ async fn insert_next_shared_aliases(
     // TODO: Add BeforeResolve plugins for `@next/font/google`
 
     let next_font_google_replacer_mapping = ImportMapping::Dynamic(ResolvedVc::upcast(
-        NextFontGoogleReplacer::new(*project_path)
+        NextFontGoogleReplacer::new(project_path.clone())
             .to_resolved()
             .await?,
     ))
@@ -893,9 +924,13 @@ async fn insert_next_shared_aliases(
     import_map.insert_alias(
         AliasPattern::exact("@vercel/turbopack-next/internal/font/google/cssmodule.module.css"),
         ImportMapping::Dynamic(ResolvedVc::upcast(
-            NextFontGoogleCssModuleReplacer::new(*project_path, execution_context, next_mode)
-                .to_resolved()
-                .await?,
+            NextFontGoogleCssModuleReplacer::new(
+                project_path.clone(),
+                execution_context,
+                next_mode,
+            )
+            .to_resolved()
+            .await?,
         ))
         .resolved_cell(),
     );
@@ -903,23 +938,26 @@ async fn insert_next_shared_aliases(
     import_map.insert_alias(
         AliasPattern::exact(GOOGLE_FONTS_INTERNAL_PREFIX),
         ImportMapping::Dynamic(ResolvedVc::upcast(
-            NextFontGoogleFontFileReplacer::new(*project_path)
+            NextFontGoogleFontFileReplacer::new(project_path.clone())
                 .to_resolved()
                 .await?,
         ))
         .resolved_cell(),
     );
 
-    let next_package = get_next_package(*project_path).to_resolved().await?;
-    import_map.insert_singleton_alias("@swc/helpers", next_package);
-    import_map.insert_singleton_alias("styled-jsx", next_package);
-    import_map.insert_singleton_alias("next", project_path);
-    import_map.insert_singleton_alias("react", project_path);
-    import_map.insert_singleton_alias("react-dom", project_path);
+    let next_package = get_next_package(project_path.clone()).await?.clone_value();
+    import_map.insert_singleton_alias("@swc/helpers", next_package.clone());
+    import_map.insert_singleton_alias("styled-jsx", next_package.clone());
+    import_map.insert_singleton_alias("next", project_path.clone());
+    import_map.insert_singleton_alias("react", project_path.clone());
+    import_map.insert_singleton_alias("react-dom", project_path.clone());
     let react_client_package = get_react_client_package(next_config).await?;
     import_map.insert_exact_alias(
         "react-dom/client",
-        request_to_import_mapping(project_path, &format!("react-dom/{react_client_package}")),
+        request_to_import_mapping(
+            project_path.clone(),
+            &format!("react-dom/{react_client_package}"),
+        ),
     );
 
     import_map.insert_alias(
@@ -932,45 +970,48 @@ async fn insert_next_shared_aliases(
     //https://github.com/vercel/next.js/blob/f94d4f93e4802f951063cfa3351dd5a2325724b3/packages/next/src/build/webpack-config.ts#L1196
     import_map.insert_exact_alias(
         "setimmediate",
-        request_to_import_mapping(project_path, "next/dist/compiled/setimmediate"),
+        request_to_import_mapping(project_path.clone(), "next/dist/compiled/setimmediate"),
     );
 
     import_map.insert_exact_alias(
         "private-next-rsc-server-reference",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/server-reference",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-action-client-wrapper",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/action-client-wrapper",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-action-validate",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/action-validate",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-action-encryption",
-        request_to_import_mapping(project_path, "next/dist/server/app-render/encryption"),
+        request_to_import_mapping(
+            project_path.clone(),
+            "next/dist/server/app-render/encryption",
+        ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-cache-wrapper",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/cache-wrapper",
         ),
     );
     import_map.insert_exact_alias(
         "private-next-rsc-track-dynamic-import",
         request_to_import_mapping(
-            project_path,
+            project_path.clone(),
             "next/dist/build/webpack/loaders/next-flight-loader/track-dynamic-import",
         ),
     );
@@ -981,21 +1022,21 @@ async fn insert_next_shared_aliases(
         "@vercel/turbopack-node/",
         turbopack_node::embed_js::embed_fs()
             .root()
-            .to_resolved()
-            .await?,
+            .await?
+            .clone_value(),
     );
 
     let image_config = next_config.image_config().await?;
     if let Some(loader_file) = image_config.loader_file.as_deref() {
         import_map.insert_exact_alias(
             "next/dist/shared/lib/image-loader",
-            request_to_import_mapping(project_path, loader_file),
+            request_to_import_mapping(project_path.clone(), loader_file),
         );
 
         if is_runtime_edge {
             import_map.insert_exact_alias(
                 "next/dist/esm/shared/lib/image-loader",
-                request_to_import_mapping(project_path, loader_file),
+                request_to_import_mapping(project_path.clone(), loader_file),
             );
         }
     }
@@ -1006,16 +1047,16 @@ async fn insert_next_shared_aliases(
 #[turbo_tasks::function]
 pub async fn get_next_package(context_directory: FileSystemPath) -> Result<Vc<FileSystemPath>> {
     let result = resolve(
-        context_directory,
+        context_directory.clone(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
-        node_cjs_resolve_options(context_directory.root()),
+        node_cjs_resolve_options(context_directory.root().await?.clone_value()),
     );
     let source = result
         .first_source()
         .await?
         .context("Next.js package not found")?;
-    Ok(source.ident().path().parent())
+    Ok(source.ident().path().await?.parent().cell())
 }
 
 pub async fn insert_alias_option<const N: usize>(
@@ -1026,7 +1067,9 @@ pub async fn insert_alias_option<const N: usize>(
 ) -> Result<()> {
     let conditions = BTreeMap::from(conditions.map(|c| (c.into(), ConditionValue::Set)));
     for (alias, value) in &alias_options.await? {
-        if let Some(mapping) = export_value_to_import_mapping(value, &conditions, project_path) {
+        if let Some(mapping) =
+            export_value_to_import_mapping(value, &conditions, project_path.clone())
+        {
             import_map.insert_alias(alias, mapping);
         }
     }
@@ -1056,7 +1099,7 @@ fn export_value_to_import_mapping(
                 result
                     .iter()
                     .map(|(m, _)| {
-                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path))
+                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path.clone()))
                             .resolved_cell()
                     })
                     .collect(),
@@ -1072,7 +1115,10 @@ fn insert_exact_alias_map(
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
-        import_map.insert_exact_alias(pattern, request_to_import_mapping(project_path, &request));
+        import_map.insert_exact_alias(
+            pattern,
+            request_to_import_mapping(project_path.clone(), &request),
+        );
     }
 }
 
@@ -1082,8 +1128,10 @@ fn insert_wildcard_alias_map(
     map: FxIndexMap<&'static str, String>,
 ) {
     for (pattern, request) in map {
-        import_map
-            .insert_wildcard_alias(pattern, request_to_import_mapping(project_path, &request));
+        import_map.insert_wildcard_alias(
+            pattern,
+            request_to_import_mapping(project_path.clone(), &request),
+        );
     }
 }
 
@@ -1114,8 +1162,8 @@ async fn insert_turbopack_dev_alias(import_map: &mut ImportMap) -> Result<()> {
         "@vercel/turbopack-ecmascript-runtime/",
         turbopack_ecmascript_runtime::embed_fs()
             .root()
-            .to_resolved()
-            .await?,
+            .await?
+            .clone_value(),
     );
     Ok(())
 }
@@ -1129,10 +1177,10 @@ async fn insert_instrumentation_client_alias(
         import_map,
         "private-next-instrumentation-client",
         vec![
-            request_to_import_mapping(project_path, "./src/instrumentation-client"),
-            request_to_import_mapping(project_path, "./src/instrumentation-client.ts"),
-            request_to_import_mapping(project_path, "./instrumentation-client"),
-            request_to_import_mapping(project_path, "./instrumentation-client.ts"),
+            request_to_import_mapping(project_path.clone(), "./src/instrumentation-client"),
+            request_to_import_mapping(project_path.clone(), "./src/instrumentation-client.ts"),
+            request_to_import_mapping(project_path.clone(), "./instrumentation-client"),
+            request_to_import_mapping(project_path.clone(), "./instrumentation-client.ts"),
             ImportMapping::Ignore.resolved_cell(),
         ],
     );

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -32,8 +32,8 @@ use crate::{
 
 #[derive(TaskInput, Clone, Hash, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 pub struct ClientReferenceManifestOptions {
-    pub node_root: ResolvedVc<FileSystemPath>,
-    pub client_relative_path: ResolvedVc<FileSystemPath>,
+    pub node_root: FileSystemPath,
+    pub client_relative_path: FileSystemPath,
     pub entry_name: RcStr,
     pub client_references: ResolvedVc<ClientReferenceGraphResult>,
     pub client_references_chunks: ResolvedVc<ClientReferencesChunks>,
@@ -128,11 +128,10 @@ impl ClientReferenceManifest {
                 .await?;
 
             async fn cached_chunk_paths(
-                cache: &mut FxHashMap<ResolvedVc<Box<dyn OutputAsset>>, ReadRef<FileSystemPath>>,
+                cache: &mut FxHashMap<ResolvedVc<Box<dyn OutputAsset>>, FileSystemPath>,
                 chunks: impl Iterator<Item = ResolvedVc<Box<dyn OutputAsset>>>,
-            ) -> Result<
-                impl Iterator<Item = (ResolvedVc<Box<dyn OutputAsset>>, ReadRef<FileSystemPath>)>,
-            > {
+            ) -> Result<impl Iterator<Item = (ResolvedVc<Box<dyn OutputAsset>>, FileSystemPath)>>
+            {
                 let results = chunks
                     .into_iter()
                     .map(|chunk| (chunk, cache.get(&chunk).cloned()))
@@ -158,11 +157,11 @@ impl ClientReferenceManifest {
             }
             let mut client_chunk_path_cache: FxHashMap<
                 ResolvedVc<Box<dyn OutputAsset>>,
-                ReadRef<FileSystemPath>,
+                FileSystemPath,
             > = FxHashMap::default();
             let mut ssr_chunk_path_cache: FxHashMap<
                 ResolvedVc<Box<dyn OutputAsset>>,
-                ReadRef<FileSystemPath>,
+                FileSystemPath,
             > = FxHashMap::default();
 
             for (client_reference_module, client_reference_module_ref) in

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt, ValueToString,
-    Vc, trace::TraceRawVcs,
+    FxIndexSet, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
@@ -96,8 +96,8 @@ impl ClientReferenceManifest {
                 layout_segment_client_chunks,
                 client_component_ssr_chunks,
             } = &*client_references_chunks.await?;
-            let client_relative_path = &*client_relative_path.await?;
-            let node_root_ref = &*node_root.await?;
+            let client_relative_path = client_relative_path.clone();
+            let node_root_ref = node_root.clone();
 
             let client_references_ecmascript = client_references
                 .await?
@@ -139,7 +139,7 @@ impl ClientReferenceManifest {
                         Ok(if let Some(path) = path {
                             (chunk, Either::Left(path))
                         } else {
-                            (chunk, Either::Right(chunk.path().await?))
+                            (chunk, Either::Right(chunk.path().await?.clone_value()))
                         })
                     })
                     .try_join()
@@ -326,8 +326,9 @@ impl ClientReferenceManifest {
             for (server_component, client_chunks) in layout_segment_client_chunks.iter() {
                 let server_component_name = server_component
                     .server_path()
-                    .with_extension("".into())
-                    .to_string()
+                    .await?
+                    .with_extension("")
+                    .value_to_string()
                     .owned()
                     .await?;
                 let mut entry_css_files_with_chunk = Vec::new();
@@ -395,10 +396,9 @@ impl ClientReferenceManifest {
             // path still (same as webpack does)
             let normalized_manifest_entry = entry_name.replace("%5F", "_");
             Ok(Vc::upcast(VirtualOutputAsset::new_with_references(
-                node_root.join(
-                    format!("server/app{normalized_manifest_entry}_client-reference-manifest.js",)
-                        .into(),
-                ),
+                node_root.join(&format!(
+                    "server/app{normalized_manifest_entry}_client-reference-manifest.js",
+                ))?,
                 AssetContent::file(
                     File::from(formatdoc! {
                         r#"

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -35,8 +35,8 @@ pub struct BuildManifest {
 impl BuildManifest {
     pub async fn build_output(
         self,
-        output_path: Vc<FileSystemPath>,
-        client_relative_path: Vc<FileSystemPath>,
+        output_path: FileSystemPath,
+        client_relative_path: FileSystemPath,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let client_relative_path_ref = &*client_relative_path.await?;
 
@@ -421,8 +421,8 @@ pub struct AppBuildManifest {
 impl AppBuildManifest {
     pub async fn build_output(
         self,
-        output_path: Vc<FileSystemPath>,
-        client_relative_path: Vc<FileSystemPath>,
+        output_path: FileSystemPath,
+        client_relative_path: FileSystemPath,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let client_relative_path_ref = &*client_relative_path.await?;
 

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -38,7 +38,7 @@ impl BuildManifest {
         output_path: FileSystemPath,
         client_relative_path: FileSystemPath,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let client_relative_path_ref = &*client_relative_path.await?;
+        let client_relative_path_ref = client_relative_path.clone();
 
         #[derive(Serialize, Default, Debug)]
         #[serde(rename_all = "camelCase")]
@@ -55,23 +55,33 @@ impl BuildManifest {
         let pages: Vec<(RcStr, Vec<RcStr>)> = self
             .pages
             .iter()
-            .map(|(k, chunks)| async move {
-                Ok((
-                    k.clone(),
-                    chunks
-                        .await?
-                        .iter()
-                        .copied()
-                        .map(|chunk| async move {
-                            let chunk_path = chunk.path().await?;
-                            Ok(client_relative_path_ref
-                                .get_path_to(&chunk_path)
-                                .context("client chunk entry path must be inside the client root")?
-                                .into())
-                        })
-                        .try_join()
-                        .await?,
-                ))
+            .map(|(k, chunks)| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    Ok((
+                        k.clone(),
+                        chunks
+                            .await?
+                            .iter()
+                            .copied()
+                            .map(|chunk| {
+                                let client_relative_path_ref = client_relative_path_ref.clone();
+                                async move {
+                                    let chunk_path = chunk.path().await?;
+                                    Ok(client_relative_path_ref
+                                        .get_path_to(&chunk_path)
+                                        .context(
+                                            "client chunk entry path must be inside the client \
+                                             root",
+                                        )?
+                                        .into())
+                                }
+                            })
+                            .try_join()
+                            .await?,
+                    ))
+                }
             })
             .try_join()
             .await?;
@@ -80,12 +90,16 @@ impl BuildManifest {
             .polyfill_files
             .iter()
             .copied()
-            .map(|chunk| async move {
-                let chunk_path = chunk.path().await?;
-                Ok(client_relative_path_ref
-                    .get_path_to(&chunk_path)
-                    .context("failed to resolve client-relative path to polyfill")?
-                    .into())
+            .map(|chunk| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    let chunk_path = chunk.path().await?;
+                    Ok(client_relative_path_ref
+                        .get_path_to(&chunk_path)
+                        .context("failed to resolve client-relative path to polyfill")?
+                        .into())
+                }
             })
             .try_join()
             .await?;
@@ -94,12 +108,16 @@ impl BuildManifest {
             .root_main_files
             .iter()
             .copied()
-            .map(|chunk| async move {
-                let chunk_path = chunk.path().await?;
-                Ok(client_relative_path_ref
-                    .get_path_to(&chunk_path)
-                    .context("failed to resolve client-relative path to root_main_file")?
-                    .into())
+            .map(|chunk| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    let chunk_path = chunk.path().await?;
+                    Ok(client_relative_path_ref
+                        .get_path_to(&chunk_path)
+                        .context("failed to resolve client-relative path to root_main_file")?
+                        .into())
+                }
             })
             .try_join()
             .await?;
@@ -424,7 +442,7 @@ impl AppBuildManifest {
         output_path: FileSystemPath,
         client_relative_path: FileSystemPath,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let client_relative_path_ref = &*client_relative_path.await?;
+        let client_relative_path_ref = client_relative_path.clone();
 
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -435,23 +453,34 @@ impl AppBuildManifest {
         let pages: Vec<(RcStr, Vec<RcStr>)> = self
             .pages
             .iter()
-            .map(|(k, chunks)| async move {
-                Ok((
-                    k.clone(),
-                    chunks
-                        .await?
-                        .iter()
-                        .copied()
-                        .map(|chunk| async move {
-                            let chunk_path = chunk.path().await?;
-                            Ok(client_relative_path_ref
-                                .get_path_to(&chunk_path)
-                                .context("client chunk entry path must be inside the client root")?
-                                .into())
-                        })
-                        .try_join()
-                        .await?,
-                ))
+            .map(|(k, chunks)| {
+                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                async move {
+                    Ok((
+                        k.clone(),
+                        chunks
+                            .await?
+                            .iter()
+                            .copied()
+                            .map(|chunk| {
+                                let client_relative_path_ref = client_relative_path_ref.clone();
+
+                                async move {
+                                    let chunk_path = chunk.path().await?;
+                                    Ok(client_relative_path_ref
+                                        .get_path_to(&chunk_path)
+                                        .context(
+                                            "client chunk entry path must be inside the client \
+                                             root",
+                                        )?
+                                        .into())
+                                }
+                            })
+                            .try_join()
+                            .await?,
+                    ))
+                }
             })
             .try_join()
             .await?;

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -34,7 +34,7 @@ pub struct PageSsrEntryModule {
 pub async fn create_page_ssr_entry_module(
     pathname: RcStr,
     reference_type: ReferenceType,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     ssr_module_context: Vc<Box<dyn AssetContext>>,
     source: Vc<Box<dyn Source>>,
     next_original_name: RcStr,
@@ -196,7 +196,7 @@ fn process_global_item(
 #[turbo_tasks::function]
 async fn wrap_edge_page(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     page: RcStr,
     pathname: RcStr,

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -86,7 +86,7 @@ pub async fn create_page_ssr_entry_module(
     // Load the file from the next.js codebase.
     let mut source = load_next_js_template(
         template_file,
-        project_root,
+        project_root.clone(),
         replacements,
         FxIndexMap::default(),
         FxIndexMap::default(),
@@ -112,7 +112,7 @@ pub async fn create_page_ssr_entry_module(
         let file = File::from(result.build());
 
         source = Vc::upcast(VirtualSource::new(
-            source.ident().path(),
+            source.ident().path().await?.clone_value(),
             AssetContent::file(file.into()),
         ));
     }
@@ -184,13 +184,13 @@ pub async fn create_page_ssr_entry_module(
 }
 
 #[turbo_tasks::function]
-fn process_global_item(
+async fn process_global_item(
     item: Vc<PagesStructureItem>,
     reference_type: ReferenceType,
     module_context: Vc<Box<dyn AssetContext>>,
-) -> Vc<Box<dyn Module>> {
-    let source = Vc::upcast(FileSource::new(item.file_path()));
-    module_context.process(source, reference_type).module()
+) -> Result<Vc<Box<dyn Module>>> {
+    let source = Vc::upcast(FileSource::new(item.file_path().await?.clone_value()));
+    Ok(module_context.process(source, reference_type).module())
 }
 
 #[turbo_tasks::function]
@@ -226,7 +226,7 @@ async fn wrap_edge_page(
 
     let source = load_next_js_template(
         "edge-ssr.js",
-        project_root,
+        project_root.clone(),
         fxindexmap! {
             "VAR_USERLAND" => INNER.into(),
             "VAR_PAGE" => pathname.clone(),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -82,32 +82,32 @@ use crate::{
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub enum ServerContextType {
     Pages {
-        pages_dir: ResolvedVc<FileSystemPath>,
+        pages_dir: FileSystemPath,
     },
     PagesApi {
-        pages_dir: ResolvedVc<FileSystemPath>,
+        pages_dir: FileSystemPath,
     },
     PagesData {
-        pages_dir: ResolvedVc<FileSystemPath>,
+        pages_dir: FileSystemPath,
     },
     AppSSR {
-        app_dir: ResolvedVc<FileSystemPath>,
+        app_dir: FileSystemPath,
     },
     AppRSC {
-        app_dir: ResolvedVc<FileSystemPath>,
+        app_dir: FileSystemPath,
         ecmascript_client_reference_transition_name: Option<RcStr>,
         client_transition: Option<ResolvedVc<Box<dyn Transition>>>,
     },
     AppRoute {
-        app_dir: ResolvedVc<FileSystemPath>,
+        app_dir: FileSystemPath,
         ecmascript_client_reference_transition_name: Option<RcStr>,
     },
     Middleware {
-        app_dir: Option<ResolvedVc<FileSystemPath>>,
+        app_dir: Option<FileSystemPath>,
         ecmascript_client_reference_transition_name: Option<RcStr>,
     },
     Instrumentation {
-        app_dir: Option<ResolvedVc<FileSystemPath>>,
+        app_dir: Option<FileSystemPath>,
         ecmascript_client_reference_transition_name: Option<RcStr>,
     },
 }
@@ -127,7 +127,7 @@ impl ServerContextType {
 
 #[turbo_tasks::function]
 pub async fn get_server_resolve_options_context(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     ty: ServerContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
@@ -405,7 +405,7 @@ pub async fn get_server_compile_time_info(
 
 #[turbo_tasks::function]
 pub async fn get_server_module_options_context(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: ResolvedVc<ExecutionContext>,
     ty: ServerContextType,
     mode: Vc<NextMode>,
@@ -986,10 +986,10 @@ pub fn get_server_runtime_entries(
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context_with_client_assets(
     mode: Vc<NextMode>,
-    root_path: ResolvedVc<FileSystemPath>,
-    node_root: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
+    node_root: FileSystemPath,
     node_root_to_root_path: RcStr,
-    client_root: ResolvedVc<FileSystemPath>,
+    client_root: FileSystemPath,
     asset_prefix: Option<RcStr>,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
@@ -1064,8 +1064,8 @@ pub async fn get_server_chunking_context_with_client_assets(
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context(
     mode: Vc<NextMode>,
-    root_path: ResolvedVc<FileSystemPath>,
-    node_root: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
+    node_root: FileSystemPath,
     node_root_to_root_path: RcStr,
     environment: ResolvedVc<Environment>,
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, TaskInput, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
@@ -134,7 +134,7 @@ pub async fn get_server_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_server_import_map = get_next_server_import_map(
-        *project_path,
+        project_path.clone(),
         ty.clone(),
         next_config,
         mode,
@@ -143,27 +143,29 @@ pub async fn get_server_resolve_options_context(
     .to_resolved()
     .await?;
     let foreign_code_context_condition =
-        foreign_code_context_condition(next_config, project_path).await?;
-    let root_dir = project_path.root().to_resolved().await?;
-    let module_feature_report_resolve_plugin = ModuleFeatureReportResolvePlugin::new(*project_path)
-        .to_resolved()
-        .await?;
-    let invalid_client_only_resolve_plugin = get_invalid_client_only_resolve_plugin(project_path)
-        .to_resolved()
-        .await?;
+        foreign_code_context_condition(next_config, project_path.clone()).await?;
+    let root_dir = project_path.root().await?.clone_value();
+    let module_feature_report_resolve_plugin =
+        ModuleFeatureReportResolvePlugin::new(project_path.clone())
+            .to_resolved()
+            .await?;
+    let invalid_client_only_resolve_plugin =
+        get_invalid_client_only_resolve_plugin(project_path.clone())
+            .to_resolved()
+            .await?;
     let invalid_styled_jsx_client_only_resolve_plugin =
-        get_invalid_styled_jsx_resolve_plugin(project_path)
+        get_invalid_styled_jsx_resolve_plugin(project_path.clone())
             .to_resolved()
             .await?;
 
     // Always load these predefined packages as external.
     let mut external_packages: Vec<RcStr> = load_next_js_templateon(
-        project_path,
+        project_path.clone(),
         rcstr!("dist/lib/server-external-packages.json"),
     )
     .await?;
 
-    let mut transpiled_packages = get_transpiled_packages(next_config, *project_path)
+    let mut transpiled_packages = get_transpiled_packages(next_config, project_path.clone())
         .owned()
         .await?;
 
@@ -194,8 +196,8 @@ pub async fn get_server_resolve_options_context(
     external_packages.retain(|item| !transpiled_packages.contains(item));
 
     let server_external_packages_plugin = ExternalCjsModulesResolvePlugin::new(
-        *project_path,
-        project_path.root(),
+        project_path.clone(),
+        project_path.root().await?.clone_value(),
         ExternalPredicate::Only(ResolvedVc::cell(external_packages)).cell(),
         *next_config.import_externals().await?,
     )
@@ -219,8 +221,8 @@ pub async fn get_server_resolve_options_context(
         server_external_packages_plugin
     } else {
         ExternalCjsModulesResolvePlugin::new(
-            *project_path,
-            project_path.root(),
+            project_path.clone(),
+            project_path.root().await?.clone_value(),
             ExternalPredicate::AllExcept(ResolvedVc::cell(transpiled_packages)).cell(),
             *next_config.import_externals().await?,
         )
@@ -228,11 +230,11 @@ pub async fn get_server_resolve_options_context(
         .await?
     };
 
-    let next_external_plugin = NextExternalResolvePlugin::new(*project_path)
+    let next_external_plugin = NextExternalResolvePlugin::new(project_path.clone())
         .to_resolved()
         .await?;
     let next_node_shared_runtime_plugin =
-        NextNodeSharedRuntimeResolvePlugin::new(*project_path, ty.clone())
+        NextNodeSharedRuntimeResolvePlugin::new(project_path.clone(), ty.clone())
             .to_resolved()
             .await?;
 
@@ -242,7 +244,7 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::AppRSC { .. } => {
             vec![
                 ResolvedVc::upcast(
-                    NextFontLocalResolvePlugin::new(*project_path)
+                    NextFontLocalResolvePlugin::new(project_path.clone())
                         .to_resolved()
                         .await?,
                 ),
@@ -314,7 +316,7 @@ pub async fn get_server_resolve_options_context(
     }
 
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(root_dir),
+        enable_node_modules: Some(root_dir.clone()),
         enable_node_externals: true,
         enable_node_native_modules: true,
         module: true,
@@ -334,9 +336,8 @@ pub async fn get_server_resolve_options_context(
             .typescript_tsconfig_path()
             .await?
             .as_ref()
-            .map(|p| project_path.join(p.to_owned()))
-            .to_resolved()
-            .await?,
+            .map(|p| project_path.join(p))
+            .transpose()?,
         rules: vec![(
             foreign_code_context_condition,
             resolve_options_context.clone().resolved_cell(),
@@ -440,10 +441,10 @@ pub async fn get_server_module_options_context(
     .await?;
 
     let foreign_code_context_condition =
-        foreign_code_context_condition(next_config, project_path).await?;
+        foreign_code_context_condition(next_config, project_path.clone()).await?;
     let postcss_transform_options = PostCssTransformOptions {
         postcss_package: Some(
-            get_postcss_package_mapping(*project_path)
+            get_postcss_package_mapping(project_path.clone())
                 .to_resolved()
                 .await?,
         ),
@@ -474,7 +475,7 @@ pub async fn get_server_module_options_context(
     // node_modules that requires webpack loaders, which next-dev implicitly
     // does by default.
     let foreign_enable_webpack_loaders = webpack_loader_options(
-        project_path,
+        project_path.clone(),
         next_config,
         true,
         conditions
@@ -487,7 +488,7 @@ pub async fn get_server_module_options_context(
 
     // Now creates a webpack rules that applies to all codes.
     let enable_webpack_loaders =
-        webpack_loader_options(project_path, next_config, false, conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, false, conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
         .tree_shaking_mode_for_user_code(next_mode.is_development())
@@ -498,10 +499,10 @@ pub async fn get_server_module_options_context(
     let versions = RuntimeVersions(Default::default()).cell();
 
     // ModuleOptionsContext related options
-    let tsconfig = get_typescript_transform_options(*project_path)
+    let tsconfig = get_typescript_transform_options(project_path.clone())
         .to_resolved()
         .await?;
-    let decorators_options = get_decorators_transform_options(*project_path);
+    let decorators_options = get_decorators_transform_options(project_path.clone());
     let enable_mdx_rs = *next_config.mdx_rs().await?;
 
     // Get the jsx transform options for the `client` side.
@@ -512,18 +513,18 @@ pub async fn get_server_module_options_context(
     // This enables correct emotion transform and other hydration between server and
     // client bundles. ref: https://github.com/vercel/next.js/blob/4bbf9b6c70d2aa4237defe2bebfa790cdb7e334e/packages/next/src/build/webpack-config.ts#L1421-L1426
     let jsx_runtime_options =
-        get_jsx_transform_options(*project_path, mode, None, false, next_config)
+        get_jsx_transform_options(project_path.clone(), mode, None, false, next_config)
             .to_resolved()
             .await?;
     let rsc_jsx_runtime_options =
-        get_jsx_transform_options(*project_path, mode, None, true, next_config)
+        get_jsx_transform_options(project_path.clone(), mode, None, true, next_config)
             .to_resolved()
             .await?;
 
     // A set of custom ecma transform rules being applied to server context.
     let source_transform_rules: Vec<ModuleRule> = vec![
-        get_swc_ecma_transform_plugin_rule(next_config, project_path).await?,
-        get_relay_transform_rule(next_config, project_path).await?,
+        get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?,
+        get_relay_transform_rule(next_config, project_path.clone()).await?,
         get_emotion_transform_rule(next_config).await?,
         get_react_remove_properties_transform_rule(next_config).await?,
         get_remove_console_transform_rule(next_config).await?,
@@ -1004,17 +1005,11 @@ pub async fn get_server_chunking_context_with_client_assets(
     // support both production and development modes.
     let mut builder = NodeJsChunkingContext::builder(
         root_path,
-        node_root,
+        node_root.clone(),
         node_root_to_root_path,
-        client_root,
-        node_root
-            .join(rcstr!("server/chunks/ssr"))
-            .to_resolved()
-            .await?,
-        client_root
-            .join(rcstr!("static/media"))
-            .to_resolved()
-            .await?,
+        client_root.clone(),
+        node_root.join("server/chunks/ssr")?,
+        client_root.join("static/media")?,
         environment,
         next_mode.runtime_type(),
     )
@@ -1080,17 +1075,11 @@ pub async fn get_server_chunking_context(
     // support both production and development modes.
     let mut builder = NodeJsChunkingContext::builder(
         root_path,
-        node_root,
+        node_root.clone(),
         node_root_to_root_path,
-        node_root,
-        node_root
-            .join(rcstr!("server/chunks"))
-            .to_resolved()
-            .await?,
-        node_root
-            .join(rcstr!("server/assets"))
-            .to_resolved()
-            .await?,
+        node_root.clone(),
+        node_root.join("server/chunks")?,
+        node_root.join("server/assets")?,
         environment,
         next_mode.runtime_type(),
     )

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -37,8 +37,8 @@ pub enum ExternalPredicate {
 /// possible to resolve them at runtime.
 #[turbo_tasks::value]
 pub(crate) struct ExternalCjsModulesResolvePlugin {
-    project_path: ResolvedVc<FileSystemPath>,
-    root: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
+    root: FileSystemPath,
     predicate: ResolvedVc<ExternalPredicate>,
     import_externals: bool,
 }
@@ -47,8 +47,8 @@ pub(crate) struct ExternalCjsModulesResolvePlugin {
 impl ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: ResolvedVc<FileSystemPath>,
-        root: ResolvedVc<FileSystemPath>,
+        project_path: FileSystemPath,
+        root: FileSystemPath,
         predicate: ResolvedVc<ExternalPredicate>,
         import_externals: bool,
     ) -> Vc<Self> {
@@ -63,7 +63,7 @@ impl ExternalCjsModulesResolvePlugin {
 }
 
 #[turbo_tasks::function]
-fn condition(root: Vc<FileSystemPath>) -> Vc<AfterResolvePluginCondition> {
+fn condition(root: FileSystemPath) -> Vc<AfterResolvePluginCondition> {
     AfterResolvePluginCondition::new(root, Glob::new("**/node_modules/**".into()))
 }
 
@@ -77,8 +77,8 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: ResolvedVc<FileSystemPath>,
-        lookup_path: ResolvedVc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: ResolvedVc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
@@ -161,7 +161,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         }
 
         async fn get_file_type(
-            fs_path: Vc<FileSystemPath>,
+            fs_path: FileSystemPath,
             raw_fs_path: &FileSystemPath,
         ) -> Result<FileType> {
             // node.js only supports these file extensions
@@ -451,7 +451,7 @@ async fn packages_glob(packages: Vc<Vec<RcStr>>) -> Result<Vc<OptionPackagesGlob
 
 #[turbo_tasks::value]
 struct ExternalizeIssue {
-    file_path: ResolvedVc<FileSystemPath>,
+    file_path: FileSystemPath,
     package: RcStr,
     request_str: RcStr,
     reason: Vec<StyledString>,

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -71,7 +71,7 @@ fn condition(root: FileSystemPath) -> Vc<AfterResolvePluginCondition> {
 impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
     fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        condition(*self.root)
+        condition(self.root.clone())
     }
 
     #[turbo_tasks::function]
@@ -103,12 +103,15 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             return Ok(ResolveResultOption::none());
         }
 
-        let raw_fs_path = &*fs_path.await?;
+        let raw_fs_path = fs_path.clone();
 
         let predicate = self.predicate.await?;
         let must_be_external = match &*predicate {
             ExternalPredicate::AllExcept(exceptions) => {
-                if *condition(*self.root).matches(*lookup_path).await? {
+                if *condition(self.root.clone())
+                    .matches(lookup_path.clone())
+                    .await?
+                {
                     return Ok(ResolveResultOption::none());
                 }
 
@@ -177,7 +180,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 // for .js extension in cjs context, we need to check the actual module type via
                 // package.json
                 let FindContextFileResult::Found(package_json, _) =
-                    *find_context_file(fs_path.parent(), package_json()).await?
+                    &*find_context_file(fs_path.parent(), package_json()).await?
                 else {
                     // can't find package.json
                     return Ok(FileType::CommonJs);
@@ -200,7 +203,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         let unable_to_externalize = |reason: Vec<StyledString>| {
             if must_be_external {
                 ExternalizeIssue {
-                    file_path: lookup_path,
+                    file_path: lookup_path.clone(),
                     package: package.clone(),
                     request_str: request_str.clone(),
                     reason,
@@ -215,13 +218,13 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         let mut request_str = request_str.to_string();
 
         let node_resolve_options = if is_esm {
-            node_esm_resolve_options(lookup_path.root())
+            node_esm_resolve_options(lookup_path.root().await?.clone_value())
         } else {
-            node_cjs_resolve_options(lookup_path.root())
+            node_cjs_resolve_options(lookup_path.root().await?.clone_value())
         };
         let result_from_original_location = loop {
             let node_resolved_from_original_location = resolve(
-                *lookup_path,
+                lookup_path.clone(),
                 reference_type.clone(),
                 request,
                 node_resolve_options,
@@ -254,7 +257,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             break result_from_original_location;
         };
         let node_resolved = resolve(
-            *self.project_path,
+            self.project_path.clone(),
             reference_type.clone(),
             request,
             node_resolve_options,
@@ -276,20 +279,13 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         };
 
         if result_from_original_location != result {
-            let package_json_file = find_context_file(
-                result.ident().path().parent().resolve().await?,
-                package_json(),
-            );
+            let package_json_file =
+                find_context_file(result.ident().path().await?.parent(), package_json());
             let package_json_from_original_location = find_context_file(
-                result_from_original_location
-                    .ident()
-                    .path()
-                    .parent()
-                    .resolve()
-                    .await?,
+                result_from_original_location.ident().path().await?.parent(),
                 package_json(),
             );
-            let FindContextFileResult::Found(package_json_file, _) = *package_json_file.await?
+            let FindContextFileResult::Found(package_json_file, _) = &*package_json_file.await?
             else {
                 return unable_to_externalize(vec![StyledString::Text(
                     "The package.json of the package resolved from the project directory can't be \
@@ -298,7 +294,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 )]);
             };
             let FindContextFileResult::Found(package_json_from_original_location, _) =
-                *package_json_from_original_location.await?
+                &*package_json_from_original_location.await?
             else {
                 return unable_to_externalize(vec![StyledString::Text(
                     "The package.json of the package can't be found.".into(),
@@ -355,8 +351,8 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 )]);
             }
         }
-        let path = result.ident().path().resolve().await?;
-        let file_type = get_file_type(path, &*path.await?).await?;
+        let path = result.ident().path().await?.clone_value();
+        let file_type = get_file_type(path.clone(), &path).await?;
 
         let external_type = match (file_type, is_esm) {
             (FileType::UnsupportedExtension, _) => {
@@ -376,16 +372,17 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             (FileType::CommonJs, true) => {
                 // It would be more efficient to use an CJS external instead of an ESM external,
                 // but we need to verify if that would be correct (as in resolves to the same file).
-                let node_resolve_options = node_cjs_resolve_options(lookup_path.root());
+                let node_resolve_options =
+                    node_cjs_resolve_options(lookup_path.root().await?.clone_value());
                 let node_resolved = resolve(
-                    *self.project_path,
+                    self.project_path.clone(),
                     reference_type.clone(),
                     request,
                     node_resolve_options,
                 );
                 let resolves_equal = if let Some(result) = *node_resolved.first_source().await? {
-                    let cjs_path = result.ident().path();
-                    cjs_path.resolve().await? == path
+                    let cjs_path = result.ident().path().await?.clone_value();
+                    cjs_path == path
                 } else {
                     false
                 };
@@ -480,7 +477,7 @@ impl Issue for ExternalizeIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -100,7 +100,7 @@ pub async fn get_next_server_transforms_rules(
             if !foreign_code {
                 rules.push(get_next_disallow_export_all_in_page_rule(
                     mdx_rs,
-                    pages_dir.await?,
+                    pages_dir.clone(),
                 ));
             }
             false
@@ -109,7 +109,7 @@ pub async fn get_next_server_transforms_rules(
             if !foreign_code {
                 rules.push(
                     get_next_pages_transforms_rule(
-                        **pages_dir,
+                        pages_dir.clone(),
                         ExportFilter::StripDefaultExport,
                         mdx_rs,
                     )
@@ -117,7 +117,7 @@ pub async fn get_next_server_transforms_rules(
                 );
                 rules.push(get_next_disallow_export_all_in_page_rule(
                     mdx_rs,
-                    pages_dir.await?,
+                    pages_dir.clone(),
                 ));
             }
             false

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -45,7 +45,7 @@ static FEATURE_MODULES: LazyLock<FxHashMap<&'static str, Vec<&'static str>>> =
 
 #[turbo_tasks::value(shared)]
 pub struct InvalidImportModuleIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub messages: Vec<RcStr>,
     pub skip_context_message: bool,
 }
@@ -101,7 +101,7 @@ impl Issue for InvalidImportModuleIssue {
 /// configured when each context sets up its resolve options.
 #[turbo_tasks::value]
 pub(crate) struct InvalidImportResolvePlugin {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
     invalid_import: RcStr,
     message: Vec<RcStr>,
 }
@@ -109,11 +109,7 @@ pub(crate) struct InvalidImportResolvePlugin {
 #[turbo_tasks::value_impl]
 impl InvalidImportResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(
-        root: ResolvedVc<FileSystemPath>,
-        invalid_import: RcStr,
-        message: Vec<RcStr>,
-    ) -> Vc<Self> {
+    pub fn new(root: FileSystemPath, invalid_import: RcStr, message: Vec<RcStr>) -> Vc<Self> {
         InvalidImportResolvePlugin {
             root,
             invalid_import,
@@ -133,7 +129,7 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
     #[turbo_tasks::function]
     fn before_resolve(
         &self,
-        lookup_path: ResolvedVc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Vc<ResolveResultOption> {
@@ -156,7 +152,7 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
 /// Only the contexts that alises `client-only` to
 /// `next/dist/compiled/client-only/error` should use this.
 pub(crate) fn get_invalid_client_only_resolve_plugin(
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
         *root,
@@ -173,7 +169,7 @@ pub(crate) fn get_invalid_client_only_resolve_plugin(
 /// Only the contexts that alises `server-only` to
 /// `next/dist/compiled/server-only/index` should use this.
 pub(crate) fn get_invalid_server_only_resolve_plugin(
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
         *root,
@@ -188,7 +184,7 @@ pub(crate) fn get_invalid_server_only_resolve_plugin(
 
 /// Returns a resolve plugin if context have imports to `styled-jsx`.
 pub(crate) fn get_invalid_styled_jsx_resolve_plugin(
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
         *root,
@@ -207,13 +203,13 @@ pub(crate) fn get_invalid_styled_jsx_resolve_plugin(
 
 #[turbo_tasks::value]
 pub(crate) struct NextExternalResolvePlugin {
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextExternalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(project_path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(project_path: FileSystemPath) -> Vc<Self> {
         NextExternalResolvePlugin { project_path }.cell()
     }
 }
@@ -231,8 +227,8 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: Vc<FileSystemPath>,
-        _lookup_path: Vc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
@@ -256,17 +252,14 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextNodeSharedRuntimeResolvePlugin {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
     server_context_type: ServerContextType,
 }
 
 #[turbo_tasks::value_impl]
 impl NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(
-        root: ResolvedVc<FileSystemPath>,
-        server_context_type: ServerContextType,
-    ) -> Vc<Self> {
+    pub fn new(root: FileSystemPath, server_context_type: ServerContextType) -> Vc<Self> {
         NextNodeSharedRuntimeResolvePlugin {
             root,
             server_context_type,
@@ -288,8 +281,8 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: Vc<FileSystemPath>,
-        _lookup_path: Vc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
@@ -331,13 +324,13 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
 /// telemetry events if there is a match.
 #[turbo_tasks::value]
 pub(crate) struct ModuleFeatureReportResolvePlugin {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl ModuleFeatureReportResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: FileSystemPath) -> Vc<Self> {
         ModuleFeatureReportResolvePlugin { root }.cell()
     }
 }
@@ -357,7 +350,7 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
     #[turbo_tasks::function]
     async fn before_resolve(
         &self,
-        _lookup_path: Vc<FileSystemPath>,
+        _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
@@ -388,13 +381,13 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextSharedRuntimeResolvePlugin {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: FileSystemPath) -> Vc<Self> {
         NextSharedRuntimeResolvePlugin { root }.cell()
     }
 }
@@ -412,8 +405,8 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: Vc<FileSystemPath>,
-        _lookup_path: Vc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -68,12 +68,12 @@ impl Issue for InvalidImportModuleIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        let raw_context = &*self.file_path.await?;
+        let raw_context = self.file_path.clone();
 
         let mut messages = self.messages.clone();
 
@@ -155,7 +155,7 @@ pub(crate) fn get_invalid_client_only_resolve_plugin(
     root: FileSystemPath,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
-        *root,
+        root,
         "client-only".into(),
         vec![
             "'client-only' cannot be imported from a Server Component module. It should only be \
@@ -172,7 +172,7 @@ pub(crate) fn get_invalid_server_only_resolve_plugin(
     root: FileSystemPath,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
-        *root,
+        root,
         "server-only".into(),
         vec![
             "'server-only' cannot be imported from a Client Component module. It should only be \
@@ -187,7 +187,7 @@ pub(crate) fn get_invalid_styled_jsx_resolve_plugin(
     root: FileSystemPath,
 ) -> Vc<InvalidImportResolvePlugin> {
     InvalidImportResolvePlugin::new(
-        *root,
+        root,
         "styled-jsx".into(),
         vec![
             "'client-only' cannot be imported from a Server Component module. It should only be \
@@ -217,11 +217,11 @@ impl NextExternalResolvePlugin {
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextExternalResolvePlugin {
     #[turbo_tasks::function]
-    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        AfterResolvePluginCondition::new(
-            self.project_path.root(),
+    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
+        Ok(AfterResolvePluginCondition::new(
+            self.project_path.root().await?.clone_value(),
             Glob::new("**/next/dist/**/*.{external,runtime.dev,runtime.prod}.js".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -232,7 +232,7 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
         _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
-        let path = fs_path.await?.path.to_string();
+        let path = fs_path.path.to_string();
         // Find the starting index of 'next/dist' and slice from that point. It should
         // always be found since the glob pattern above is specific enough.
         let starting_index = path.find("next/dist").unwrap();
@@ -271,11 +271,11 @@ impl NextNodeSharedRuntimeResolvePlugin {
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        AfterResolvePluginCondition::new(
-            self.root.root(),
+    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
+        Ok(AfterResolvePluginCondition::new(
+            self.root.root().await?.clone_value(),
             Glob::new("**/next/dist/**/*.shared-runtime.js".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -286,8 +286,8 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
         _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
-        let stem = fs_path.file_stem().await?;
-        let stem = stem.as_deref().unwrap_or_default();
+        let stem = fs_path.file_stem();
+        let stem = stem.unwrap_or_default();
         let stem = stem.replace(".shared-runtime", "");
 
         let resource_request = format!(
@@ -301,7 +301,7 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
             stem
         );
 
-        let raw_fs_path = &*fs_path.await?;
+        let raw_fs_path = fs_path.clone();
         let path = raw_fs_path.path.to_string();
 
         // Find the starting index of 'next/dist' and slice from that point. It should
@@ -312,7 +312,8 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
 
         let new_path = fs_path
             .root()
-            .join(format!("{base}/{resource_request}").into());
+            .await?
+            .join(&format!("{base}/{resource_request}"))?;
 
         Ok(Vc::cell(Some(ResolveResult::source(ResolvedVc::upcast(
             FileSource::new(new_path).to_resolved().await?,
@@ -395,11 +396,11 @@ impl NextSharedRuntimeResolvePlugin {
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        AfterResolvePluginCondition::new(
-            self.root.root(),
+    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
+        Ok(AfterResolvePluginCondition::new(
+            self.root.root().await?.clone_value(),
             Glob::new("**/next/dist/esm/**/*.shared-runtime.js".into()),
-        )
+        ))
     }
 
     #[turbo_tasks::function]
@@ -410,9 +411,9 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
         _reference_type: ReferenceType,
         _request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
-        let raw_fs_path = &*fs_path.await?;
+        let raw_fs_path = fs_path.clone();
         let modified_path = raw_fs_path.path.replace("next/dist/esm/", "next/dist/");
-        let new_path = fs_path.root().join(modified_path.into());
+        let new_path = fs_path.root().await?.join(&modified_path)?;
         Ok(Vc::cell(Some(ResolveResult::source(ResolvedVc::upcast(
             FileSource::new(new_path).to_resolved().await?,
         )))))

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -121,7 +121,7 @@ pub(crate) fn module_rule_match_js_no_url(enable_mdx_rs: bool) -> RuleCondition 
 
 pub(crate) fn module_rule_match_pages_page_file(
     enable_mdx_rs: bool,
-    pages_directory: ReadRef<FileSystemPath>,
+    pages_directory: FileSystemPath,
 ) -> RuleCondition {
     let conditions = match_js_extension(enable_mdx_rs);
 

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -33,7 +33,7 @@ pub use next_lint::get_next_lint_transform_rule;
 pub use next_strip_page_exports::get_next_pages_transforms_rule;
 pub use next_track_dynamic_imports::get_next_track_dynamic_imports_transform_rule;
 pub use server_actions::get_server_actions_transform_rule;
-use turbo_tasks::{ReadRef, ResolvedVc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
 use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -11,7 +11,7 @@ use super::module_rule_match_pages_page_file;
 
 pub fn get_next_disallow_export_all_in_page_rule(
     enable_mdx_rs: bool,
-    pages_dir: ReadRef<FileSystemPath>,
+    pages_dir: FileSystemPath,
 ) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
         NextDisallowReExportAllInPage,

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::disallow_re_export_all_in_page::disallow_re_export_all_in_page;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, ResolvedVc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -9,10 +9,7 @@ use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, Transfor
 
 use super::module_rule_match_pages_page_file;
 
-pub fn get_next_page_config_rule(
-    enable_mdx_rs: bool,
-    pages_dir: ReadRef<FileSystemPath>,
-) -> ModuleRule {
+pub fn get_next_page_config_rule(enable_mdx_rs: bool, pages_dir: FileSystemPath) -> ModuleRule {
     let transformer = EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextPageConfig {
         // [TODO]: update once turbopack build works
         is_development: true,

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use next_custom_transforms::transforms::page_config::page_config;
 use swc_core::ecma::ast::*;
-use turbo_tasks::{ReadRef, ResolvedVc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -145,7 +145,7 @@ impl CustomTransformer for NextPageStaticInfo {
 
 #[turbo_tasks::value(shared)]
 pub struct PageStaticInfoIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub messages: Vec<String>,
     pub severity: IssueSeverity,
 }

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -82,7 +82,7 @@ impl CustomTransformer for NextPageStaticInfo {
             if is_server_layer_page {
                 for warning in collected_exports.warnings.iter() {
                     PageStaticInfoIssue {
-                        file_path: ctx.file_path,
+                        file_path: ctx.file_path.clone(),
                         messages: vec![
                             format!(
                                 "Next.js can't recognize the exported `{}` field in \"{}\" as {}.",
@@ -117,7 +117,7 @@ impl CustomTransformer for NextPageStaticInfo {
                 messages.push("Visit https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config for more information.".to_string());
 
                 PageStaticInfoIssue {
-                    file_path: ctx.file_path,
+                    file_path: ctx.file_path.clone(),
                     messages,
                     severity: IssueSeverity::Warning,
                 }
@@ -130,7 +130,7 @@ impl CustomTransformer for NextPageStaticInfo {
                 && is_app_page
             {
                 PageStaticInfoIssue {
-                    file_path: ctx.file_path,
+                    file_path: ctx.file_path.clone(),
                     messages: vec![format!(r#"Page "{}" cannot use both "use client" and export function "generateStaticParams()"."#, ctx.file_path_str)],
                     severity: IssueSeverity::Error,
                 }
@@ -168,7 +168,7 @@ impl Issue for PageStaticInfoIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -31,7 +31,7 @@ use crate::next_config::NextConfig;
 pub async fn get_next_react_server_components_transform_rule(
     next_config: Vc<NextConfig>,
     is_react_server_layer: bool,
-    app_dir: Option<ResolvedVc<FileSystemPath>>,
+    app_dir: Option<FileSystemPath>,
 ) -> Result<ModuleRule> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let dynamic_io_enabled = *next_config.enable_dynamic_io().await?;
@@ -53,7 +53,7 @@ struct NextJsReactServerComponents {
     is_react_server_layer: bool,
     dynamic_io_enabled: bool,
     use_cache_enabled: bool,
-    app_dir: Option<ResolvedVc<FileSystemPath>>,
+    app_dir: Option<FileSystemPath>,
 }
 
 impl NextJsReactServerComponents {
@@ -61,7 +61,7 @@ impl NextJsReactServerComponents {
         is_react_server_layer: bool,
         dynamic_io_enabled: bool,
         use_cache_enabled: bool,
-        app_dir: Option<ResolvedVc<FileSystemPath>>,
+        app_dir: Option<FileSystemPath>,
     ) -> Self {
         Self {
             is_react_server_layer,

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -5,7 +5,7 @@ use swc_core::{
     common::FileName,
     ecma::{ast::Program, visit::VisitWith},
 };
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -89,10 +89,7 @@ impl CustomTransformer for NextJsReactServerComponents {
                 dynamic_io_enabled: self.dynamic_io_enabled,
                 use_cache_enabled: self.use_cache_enabled,
             }),
-            match self.app_dir {
-                None => None,
-                Some(path) => Some(path.await?.path.clone().into()),
-            },
+            self.app_dir.as_ref().map(|path| path.path.clone().into()),
         );
 
         program.visit_with(&mut visitor);

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -13,7 +13,7 @@ use super::module_rule_match_js_no_url;
 
 /// Returns a rule which applies the Next.js page export stripping transform.
 pub async fn get_next_pages_transforms_rule(
-    pages_dir: Vc<FileSystemPath>,
+    pages_dir: FileSystemPath,
     export_filter: ExportFilter,
     enable_mdx_rs: bool,
 ) -> Result<ModuleRule> {

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -4,7 +4,7 @@ use next_custom_transforms::transforms::strip_page_exports::{
     ExportFilter, next_transform_strip_page_exports,
 };
 use swc_core::ecma::ast::Program;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, TransformContext};
@@ -25,20 +25,16 @@ pub async fn get_next_pages_transforms_rule(
     Ok(ModuleRule::new(
         RuleCondition::all(vec![
             RuleCondition::all(vec![
-                RuleCondition::ResourcePathInExactDirectory(pages_dir.await?),
+                RuleCondition::ResourcePathInExactDirectory(pages_dir.clone()),
                 RuleCondition::not(RuleCondition::ResourcePathInExactDirectory(
-                    pages_dir.join("api".into()).await?,
+                    pages_dir.join("api")?,
                 )),
                 RuleCondition::not(RuleCondition::any(vec![
                     // TODO(alexkirsz): Possibly ignore _app as well?
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.js".into()).await?),
-                    RuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.jsx".into()).await?,
-                    ),
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.ts".into()).await?),
-                    RuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.tsx".into()).await?,
-                    ),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.js")?),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.jsx")?),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.ts")?),
+                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.tsx")?),
                 ])),
             ]),
             module_rule_match_js_no_url(enable_mdx_rs),

--- a/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/crates/next-core/src/next_shared/transforms/relay.rs
@@ -10,7 +10,7 @@ use crate::next_config::NextConfig;
 /// Returns a transform rule for the relay graphql transform.
 pub async fn get_relay_transform_rule(
     next_config: Vc<NextConfig>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Option<ModuleRule>> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let project_path = &*project_path.await?;

--- a/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/crates/next-core/src/next_shared/transforms/relay.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript_plugins::transform::relay::RelayTransformer;
@@ -13,10 +13,9 @@ pub async fn get_relay_transform_rule(
     project_path: FileSystemPath,
 ) -> Result<Option<ModuleRule>> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
-    let project_path = &*project_path.await?;
     let module_rule = next_config.compiler().await?.relay.as_ref().map(|config| {
         get_ecma_transform_rule(
-            Box::new(RelayTransformer::new(config, project_path)),
+            Box::new(RelayTransformer::new(config, &project_path)),
             enable_mdx_rs,
             true,
         )

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -9,7 +9,7 @@ use crate::next_config::NextConfig;
 
 pub async fn get_swc_ecma_transform_plugin_rule(
     next_config: Vc<NextConfig>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Option<ModuleRule>> {
     let plugin_configs = next_config.experimental_swc_plugins().await?;
     if !plugin_configs.is_empty() {
@@ -31,7 +31,7 @@ pub async fn get_swc_ecma_transform_plugin_rule(
 
 #[cfg(feature = "plugin")]
 pub async fn get_swc_ecma_transform_rule_impl(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     plugin_configs: &[(RcStr, serde_json::Value)],
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 #[allow(unused_imports)]
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
 
@@ -52,58 +52,63 @@ pub async fn get_swc_ecma_transform_rule_impl(
 
     let plugins = plugin_configs
         .iter()
-        .map(|(name, config)| async move {
-            // [TODO]: SWC's current experimental config supports
-            // two forms of plugin path,
-            // one for implicit package name resolves to node_modules,
-            // and one for explicit path to a .wasm binary.
-            // Current resolve will fail with latter.
-            let request = Request::parse_string(name.clone());
-            let resolve_options = resolve_options(
-                *project_path,
-                ResolveOptionsContext {
-                    enable_node_modules: Some(project_path.root().to_resolved().await?),
-                    enable_node_native_modules: true,
-                    ..Default::default()
-                }
-                .cell(),
-            );
+        .map(|(name, config)| {
+            let project_path = project_path.clone();
 
-            let plugin_wasm_module_resolve_result = handle_resolve_error(
-                resolve(
-                    *project_path,
+            async move {
+                // [TODO]: SWC's current experimental config supports
+                // two forms of plugin path,
+                // one for implicit package name resolves to node_modules,
+                // and one for explicit path to a .wasm binary.
+                // Current resolve will fail with latter.
+                let request = Request::parse_string(name.clone());
+                let resolve_options = resolve_options(
+                    project_path.clone(),
+                    ResolveOptionsContext {
+                        enable_node_modules: Some(project_path.root().await?.clone_value()),
+                        enable_node_native_modules: true,
+                        ..Default::default()
+                    }
+                    .cell(),
+                );
+
+                let plugin_wasm_module_resolve_result = handle_resolve_error(
+                    resolve(
+                        project_path.clone(),
+                        ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
+                        request,
+                        resolve_options,
+                    )
+                    .as_raw_module_result(),
                     ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
+                    // TODO proper error location
+                    project_path.clone(),
                     request,
                     resolve_options,
+                    false,
+                    // TODO proper error location
+                    None,
                 )
-                .as_raw_module_result(),
-                ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
-                // TODO proper error location
-                *project_path,
-                request,
-                resolve_options,
-                false,
-                // TODO proper error location
-                None,
-            )
-            .await?;
+                .await?;
 
-            let Some(plugin_module) = &*plugin_wasm_module_resolve_result.first_module().await?
-            else {
-                // Ignore unresolveable plugin modules, handle_resolve_error has already emitted an
-                // issue.
-                return Ok(None);
-            };
+                let Some(plugin_module) =
+                    &*plugin_wasm_module_resolve_result.first_module().await?
+                else {
+                    // Ignore unresolveable plugin modules, handle_resolve_error has already emitted
+                    // an issue.
+                    return Ok(None);
+                };
 
-            let content = &*plugin_module.content().file_content().await?;
-            let FileContent::Content(file) = content else {
-                bail!("Expected file content for plugin module");
-            };
+                let content = &*plugin_module.content().file_content().await?;
+                let FileContent::Content(file) = content else {
+                    bail!("Expected file content for plugin module");
+                };
 
-            Ok(Some((
-                SwcPluginModule::new(name, file.content().to_bytes().to_vec()).resolved_cell(),
-                config.clone(),
-            )))
+                Ok(Some((
+                    SwcPluginModule::new(name, file.content().to_bytes().to_vec()).resolved_cell(),
+                    config.clone(),
+                )))
+            }
         })
         .try_flat_join()
         .await?;

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -27,7 +27,7 @@ const BABEL_CONFIG_FILES: &[&str] = &[
 /// webpack loader for each eligible file type if it doesn't already exist.
 #[turbo_tasks::function]
 pub async fn maybe_add_babel_loader(
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     webpack_rules: Option<ResolvedVc<WebpackRules>>,
 ) -> Result<Vc<OptionWebpackRules>> {
     let has_babel_config = {
@@ -112,7 +112,7 @@ pub async fn maybe_add_babel_loader(
 }
 
 #[turbo_tasks::function]
-pub async fn is_babel_loader_available(project_path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+pub async fn is_babel_loader_available(project_path: FileSystemPath) -> Result<Vc<bool>> {
     let result = resolve(
         project_path,
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
@@ -125,7 +125,7 @@ pub async fn is_babel_loader_available(project_path: Vc<FileSystemPath>) -> Resu
 
 #[turbo_tasks::value]
 struct BabelIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     title: ResolvedVc<StyledString>,
     description: ResolvedVc<StyledString>,
     severity: IssueSeverity,

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -33,7 +33,7 @@ pub async fn maybe_add_babel_loader(
     let has_babel_config = {
         let mut has_babel_config = false;
         for &filename in BABEL_CONFIG_FILES {
-            let filetype = *project_root.join(filename.into()).get_type().await?;
+            let filetype = *project_root.join(filename)?.get_type().await?;
             if matches!(filetype, FileSystemEntryType::File) {
                 has_babel_config = true;
                 break;
@@ -63,10 +63,10 @@ pub async fn maybe_add_babel_loader(
 
             if !has_babel_loader {
                 if !has_emitted_babel_resolve_issue
-                    && !*is_babel_loader_available(project_root).await?
+                    && !*is_babel_loader_available(project_root.clone()).await?
                 {
                     BabelIssue {
-                        path: project_root.to_resolved().await?,
+                        path: project_root.clone(),
                         title: StyledString::Text(rcstr!(
                             "Unable to resolve babel-loader, but a babel config is present"
                         ))
@@ -114,7 +114,7 @@ pub async fn maybe_add_babel_loader(
 #[turbo_tasks::function]
 pub async fn is_babel_loader_available(project_path: FileSystemPath) -> Result<Vc<bool>> {
     let result = resolve(
-        project_path,
+        project_path.clone(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         Request::parse(Pattern::Constant("babel-loader/package.json".into())),
         node_cjs_resolve_options(project_path),
@@ -144,7 +144,7 @@ impl Issue for BabelIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod babel;
 pub(crate) mod sass;
 
 pub async fn webpack_loader_options(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     next_config: Vc<NextConfig>,
     foreign: bool,
     condition_strs: Vec<RcStr>,

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -22,7 +22,7 @@ pub async fn webpack_loader_options(
     let rules = if foreign {
         rules
     } else {
-        *maybe_add_babel_loader(*project_path, rules.map(|v| *v)).await?
+        *maybe_add_babel_loader(project_path.clone(), rules.map(|v| *v)).await?
     };
 
     let conditions = next_config.webpack_conditions().to_resolved().await?;

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -67,7 +67,7 @@ pub async fn create_page_loader_entry_module(
 
 #[turbo_tasks::value(shared)]
 pub struct PageLoaderAsset {
-    pub server_root: ResolvedVc<FileSystemPath>,
+    pub server_root: FileSystemPath,
     pub pathname: RcStr,
     pub rebase_prefix_path: ResolvedVc<FileSystemPathOption>,
     pub page_chunks: ResolvedVc<OutputAssets>,
@@ -77,7 +77,7 @@ pub struct PageLoaderAsset {
 impl PageLoaderAsset {
     #[turbo_tasks::function]
     pub fn new(
-        server_root: ResolvedVc<FileSystemPath>,
+        server_root: FileSystemPath,
         pathname: RcStr,
         rebase_prefix_path: ResolvedVc<FileSystemPathOption>,
         page_chunks: ResolvedVc<OutputAssets>,

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -30,7 +30,9 @@ pub async fn create_page_loader_entry_module(
     let mut result = RopeBuilder::default();
     writeln!(result, "const PAGE_PATH = {};\n", StringifyJs(&pathname))?;
 
-    let page_loader_path = next_js_file_path(rcstr!("entry/page-loader.ts"));
+    let page_loader_path = next_js_file_path(rcstr!("entry/page-loader.ts"))
+        .await?
+        .clone_value();
     let base_code = page_loader_path.read();
     if let FileContent::Content(base_file) = &*base_code.await? {
         result += base_file.content()
@@ -101,23 +103,34 @@ impl PageLoaderAsset {
         // If we are provided a prefix path, we need to rewrite our chunk paths to
         // remove that prefix.
         if let Some(rebase_path) = &*rebase_prefix_path.await? {
-            let root_path = rebase_path.root();
+            let root_path = rebase_path.root().await?.clone_value();
             let rebased = chunks
                 .await?
                 .iter()
                 .map(|&chunk| {
-                    Vc::upcast::<Box<dyn OutputAsset>>(ProxiedAsset::new(
-                        *chunk,
-                        FileSystemPath::rebase(chunk.path(), **rebase_path, root_path),
-                    ))
-                    .to_resolved()
+                    let root_path = root_path.clone();
+
+                    async move {
+                        Vc::upcast::<Box<dyn OutputAsset>>(ProxiedAsset::new(
+                            *chunk,
+                            FileSystemPath::rebase(
+                                chunk.path().await?.clone_value(),
+                                rebase_path.clone(),
+                                root_path.clone(),
+                            )
+                            .await?
+                            .clone_value(),
+                        ))
+                        .to_resolved()
+                        .await
+                    }
                 })
                 .try_join()
                 .await?;
             chunks = ResolvedVc::cell(rebased);
         };
 
-        Ok(ChunkData::from_assets(*self.server_root, *chunks))
+        Ok(ChunkData::from_assets(self.server_root.clone(), *chunks))
     }
 }
 
@@ -125,17 +138,15 @@ impl PageLoaderAsset {
 impl OutputAsset for PageLoaderAsset {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
-        let root = self
-            .rebase_prefix_path
-            .await?
-            .map_or(*self.server_root, |path| *path);
-        Ok(root.join(
-            format!(
+        let root = (*self.rebase_prefix_path.await?)
+            .clone()
+            .map_or(self.server_root.clone(), |path| path);
+        Ok(root
+            .join(&format!(
                 "static/chunks/pages{}",
                 get_asset_path_from_pathname(&self.pathname, ".js")
-            )
-            .into(),
-        ))
+            ))?
+            .cell())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -11,28 +11,28 @@ use crate::next_import_map::get_next_package;
 /// A final route in the pages directory.
 #[turbo_tasks::value]
 pub struct PagesStructureItem {
-    pub base_path: ResolvedVc<FileSystemPath>,
+    pub base_path: FileSystemPath,
     pub extensions: ResolvedVc<Vec<RcStr>>,
-    pub fallback_path: Option<ResolvedVc<FileSystemPath>>,
+    pub fallback_path: Option<FileSystemPath>,
 
     /// Pathname of this item in the Next.js router.
-    pub next_router_path: ResolvedVc<FileSystemPath>,
+    pub next_router_path: FileSystemPath,
     /// Unique path corresponding to this item. This differs from
     /// `next_router_path` in that it will include the trailing /index for index
     /// routes, which allows for differentiating with potential /index
     /// directories.
-    pub original_path: ResolvedVc<FileSystemPath>,
+    pub original_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl PagesStructureItem {
     #[turbo_tasks::function]
     fn new(
-        base_path: ResolvedVc<FileSystemPath>,
+        base_path: FileSystemPath,
         extensions: ResolvedVc<Vec<RcStr>>,
-        fallback_path: Option<ResolvedVc<FileSystemPath>>,
-        next_router_path: ResolvedVc<FileSystemPath>,
-        original_path: ResolvedVc<FileSystemPath>,
+        fallback_path: Option<FileSystemPath>,
+        next_router_path: FileSystemPath,
+        original_path: FileSystemPath,
     ) -> Vc<Self> {
         PagesStructureItem {
             base_path,
@@ -49,7 +49,7 @@ impl PagesStructureItem {
         // Check if the file path + extension exists in the filesystem, if so use that. If not fall
         // back to the base path.
         for ext in self.extensions.await?.into_iter() {
-            let file_path: Vc<FileSystemPath> = self.base_path.append(format!(".{ext}").into());
+            let file_path: FileSystemPath = self.base_path.append(format!(".{ext}").into());
             let ty = *file_path.get_type().await?;
             if matches!(ty, FileSystemEntryType::File | FileSystemEntryType::Symlink) {
                 return Ok(file_path);
@@ -80,8 +80,8 @@ pub struct PagesStructure {
 
 #[turbo_tasks::value]
 pub struct PagesDirectoryStructure {
-    pub project_path: ResolvedVc<FileSystemPath>,
-    pub next_router_path: ResolvedVc<FileSystemPath>,
+    pub project_path: FileSystemPath,
+    pub next_router_path: FileSystemPath,
     pub items: Vec<ResolvedVc<PagesStructureItem>>,
     pub children: Vec<ResolvedVc<PagesDirectoryStructure>>,
 }
@@ -99,8 +99,8 @@ impl PagesDirectoryStructure {
 /// Finds and returns the [PagesStructure] of the pages directory if existing.
 #[turbo_tasks::function]
 pub async fn find_pages_structure(
-    project_root: Vc<FileSystemPath>,
-    next_router_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
+    next_router_root: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesStructure>> {
     let pages_root = project_root
@@ -137,9 +137,9 @@ pub async fn find_pages_structure(
 /// Handles the root pages directory.
 #[turbo_tasks::function]
 async fn get_pages_structure_for_root_directory(
-    project_root: Vc<FileSystemPath>,
+    project_root: FileSystemPath,
     project_path: Vc<FileSystemPathOption>,
-    next_router_path: Vc<FileSystemPath>,
+    next_router_path: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesStructure>> {
     let page_extensions_raw = &*page_extensions.await?;
@@ -311,8 +311,8 @@ async fn get_pages_structure_for_root_directory(
 /// Calls itself recursively for sub directories.
 #[turbo_tasks::function]
 async fn get_pages_structure_for_directory(
-    project_path: Vc<FileSystemPath>,
-    next_router_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
+    next_router_path: FileSystemPath,
     position: u32,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesDirectoryStructure>> {
@@ -401,7 +401,7 @@ fn page_basename<'a>(name: &'a str, page_extensions: &'a [RcStr]) -> Option<&'a 
 }
 
 fn next_router_path_for_basename(
-    next_router_path: Vc<FileSystemPath>,
+    next_router_path: FileSystemPath,
     basename: &str,
 ) -> Vc<FileSystemPath> {
     if basename == "index" {

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{OptionVcExt, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{OptionVcExt, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{
     DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath, FileSystemPathOption,
 };
@@ -49,19 +49,19 @@ impl PagesStructureItem {
         // Check if the file path + extension exists in the filesystem, if so use that. If not fall
         // back to the base path.
         for ext in self.extensions.await?.into_iter() {
-            let file_path: FileSystemPath = self.base_path.append(format!(".{ext}").into());
+            let file_path = self.base_path.append(&format!(".{ext}"))?;
             let ty = *file_path.get_type().await?;
             if matches!(ty, FileSystemEntryType::File | FileSystemEntryType::Symlink) {
-                return Ok(file_path);
+                return Ok(file_path.cell());
             }
         }
-        if let Some(fallback_path) = self.fallback_path {
-            Ok(*fallback_path)
+        if let Some(fallback_path) = &self.fallback_path {
+            Ok(fallback_path.clone().cell())
         } else {
             // If the file path that was passed in already has an extension, for example
             // `pages/index.js` it won't match the extensions list above because it already had an
             // extension and for example `.js.js` obviously won't match
-            Ok(*self.base_path)
+            Ok(self.base_path.clone().cell())
         }
     }
 }
@@ -92,7 +92,7 @@ impl PagesDirectoryStructure {
     /// system.
     #[turbo_tasks::function]
     pub fn project_path(&self) -> Vc<FileSystemPath> {
-        *self.project_path
+        self.project_path.clone().cell()
     }
 }
 
@@ -103,19 +103,15 @@ pub async fn find_pages_structure(
     next_router_root: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesStructure>> {
-    let pages_root = project_root
-        .join("pages".into())
-        .realpath()
-        .to_resolved()
-        .await?;
+    let pages_root = project_root.join("pages")?.realpath().await?.clone_value();
     let pages_root = if *pages_root.get_type().await? == FileSystemEntryType::Directory {
         Some(pages_root)
     } else {
         let src_pages_root = project_root
-            .join("src/pages".into())
+            .join("src/pages")?
             .realpath()
-            .to_resolved()
-            .await?;
+            .await?
+            .clone_value();
         if *src_pages_root.get_type().await? == FileSystemEntryType::Directory {
             Some(src_pages_root)
         } else {
@@ -155,7 +151,7 @@ async fn get_pages_structure_for_root_directory(
         let dir_content = project_path.read_dir().await?;
         if let DirectoryContent::Entries(entries) = &*dir_content {
             for (name, entry) in entries.iter() {
-                let entry = entry.resolve_symlink().await?;
+                let entry = entry.clone().resolve_symlink().await?;
                 match entry {
                     DirectoryEntry::File(_) => {
                         // Do not process .d.ts files as routes
@@ -165,13 +161,15 @@ async fn get_pages_structure_for_root_directory(
                         let Some(basename) = page_basename(name, page_extensions_raw) else {
                             continue;
                         };
-                        let base_path = project_path.join(basename.into());
+                        let base_path = project_path.join(basename)?;
                         match basename {
                             "_app" | "_document" | "_error" => {}
                             "500" => {
-                                let item_next_router_path =
-                                    next_router_path_for_basename(next_router_path, basename);
-                                let item_original_path = next_router_path.join(basename.into());
+                                let item_next_router_path = next_router_path_for_basename(
+                                    next_router_path.clone(),
+                                    basename,
+                                )?;
+                                let item_original_path = next_router_path.join(basename)?;
                                 let item = PagesStructureItem::new(
                                     base_path,
                                     page_extensions,
@@ -186,9 +184,11 @@ async fn get_pages_structure_for_root_directory(
                             }
 
                             basename => {
-                                let item_next_router_path =
-                                    next_router_path_for_basename(next_router_path, basename);
-                                let item_original_path = next_router_path.join(basename.into());
+                                let item_next_router_path = next_router_path_for_basename(
+                                    next_router_path.clone(),
+                                    basename,
+                                )?;
+                                let item_original_path = next_router_path.join(basename)?;
                                 items.push((
                                     basename,
                                     PagesStructureItem::new(
@@ -206,8 +206,8 @@ async fn get_pages_structure_for_root_directory(
                         "api" => {
                             api_directory = Some(
                                 get_pages_structure_for_directory(
-                                    *dir_project_path,
-                                    next_router_path.join(name.clone()),
+                                    dir_project_path.clone(),
+                                    next_router_path.join(name)?,
                                     1,
                                     page_extensions,
                                 )
@@ -219,8 +219,8 @@ async fn get_pages_structure_for_root_directory(
                             children.push((
                                 name,
                                 get_pages_structure_for_directory(
-                                    *dir_project_path,
-                                    next_router_path.join(name.clone()),
+                                    dir_project_path.clone(),
+                                    next_router_path.join(name)?,
                                     1,
                                     page_extensions,
                                 ),
@@ -238,8 +238,8 @@ async fn get_pages_structure_for_root_directory(
 
         Some(
             PagesDirectoryStructure {
-                project_path: *project_path,
-                next_router_path: next_router_path.to_resolved().await?,
+                project_path: project_path.clone(),
+                next_router_path: next_router_path.clone(),
                 items: items
                     .into_iter()
                     .map(|(_, v)| async move { v.to_resolved().await })
@@ -257,41 +257,53 @@ async fn get_pages_structure_for_root_directory(
         None
     };
 
-    let pages_path = if let Some(project_path) = *project_path {
-        *project_path
+    let pages_path = if let Some(project_path) = &*project_path {
+        project_path.clone()
     } else {
-        project_root.join("pages".into())
+        project_root.join("pages")?
     };
 
     let app_item = {
-        let app_router_path = next_router_path.join("_app".into());
+        let app_router_path = next_router_path.join("_app")?;
         PagesStructureItem::new(
-            pages_path.join("_app".into()),
+            pages_path.join("_app")?,
             page_extensions,
-            Some(get_next_package(project_root).join("app.js".into())),
-            app_router_path,
+            Some(
+                get_next_package(project_root.clone())
+                    .await?
+                    .join("app.js")?,
+            ),
+            app_router_path.clone(),
             app_router_path,
         )
     };
 
     let document_item = {
-        let document_router_path = next_router_path.join("_document".into());
+        let document_router_path = next_router_path.join("_document")?;
         PagesStructureItem::new(
-            pages_path.join("_document".into()),
+            pages_path.join("_document")?,
             page_extensions,
-            Some(get_next_package(project_root).join("document.js".into())),
-            document_router_path,
+            Some(
+                get_next_package(project_root.clone())
+                    .await?
+                    .join("document.js")?,
+            ),
+            document_router_path.clone(),
             document_router_path,
         )
     };
 
     let error_item = {
-        let error_router_path = next_router_path.join("_error".into());
+        let error_router_path = next_router_path.join("_error")?;
         PagesStructureItem::new(
-            pages_path.join("_error".into()),
+            pages_path.join("_error")?,
             page_extensions,
-            Some(get_next_package(project_root).join("error.js".into())),
-            error_router_path,
+            Some(
+                get_next_package(project_root.clone())
+                    .await?
+                    .join("error.js")?,
+            ),
+            error_router_path.clone(),
             error_router_path,
         )
     };
@@ -317,7 +329,7 @@ async fn get_pages_structure_for_directory(
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesDirectoryStructure>> {
     let span = {
-        let path = project_path.to_string().await?.to_string();
+        let path = project_path.value_to_string().await?.to_string();
         tracing::info_span!("analyse pages structure", name = path)
     };
     async move {
@@ -334,11 +346,11 @@ async fn get_pages_structure_for_directory(
                             continue;
                         };
                         let item_next_router_path = match basename {
-                            "index" => next_router_path,
-                            _ => next_router_path.join(basename.into()),
+                            "index" => next_router_path.clone(),
+                            _ => next_router_path.join(basename)?,
                         };
-                        let base_path = project_path.join(name.clone());
-                        let item_original_name = next_router_path.join(basename.into());
+                        let base_path = project_path.join(name)?;
+                        let item_original_name = next_router_path.join(basename)?;
                         items.push((
                             basename,
                             PagesStructureItem::new(
@@ -354,8 +366,8 @@ async fn get_pages_structure_for_directory(
                         children.push((
                             name,
                             get_pages_structure_for_directory(
-                                **dir_project_path,
-                                next_router_path.join(name.clone()),
+                                dir_project_path.clone(),
+                                next_router_path.join(name)?,
                                 position + 1,
                                 page_extensions,
                             ),
@@ -373,8 +385,8 @@ async fn get_pages_structure_for_directory(
         children.sort_by_key(|(k, _)| *k);
 
         Ok(PagesDirectoryStructure {
-            project_path: project_path.to_resolved().await?,
-            next_router_path: next_router_path.to_resolved().await?,
+            project_path: project_path.clone(),
+            next_router_path: next_router_path.clone(),
             items: items
                 .into_iter()
                 .map(|(_, v)| v)
@@ -403,10 +415,10 @@ fn page_basename<'a>(name: &'a str, page_extensions: &'a [RcStr]) -> Option<&'a 
 fn next_router_path_for_basename(
     next_router_path: FileSystemPath,
     basename: &str,
-) -> Vc<FileSystemPath> {
-    if basename == "index" {
-        next_router_path
+) -> Result<FileSystemPath> {
+    Ok(if basename == "index" {
+        next_router_path.clone()
     } else {
-        next_router_path.join(basename.into())
-    }
+        next_router_path.join(basename)?
+    })
 }

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -18,7 +18,7 @@ use turbopack_ecmascript::typescript::resolve::{read_from_tsconfigs, read_tsconf
 use crate::{mode::NextMode, next_config::NextConfig};
 
 async fn get_typescript_options(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Option<Vec<(Vc<FileJsonContent>, ResolvedVc<Box<dyn Source>>)>>> {
     let tsconfig = find_context_file(project_path, tsconfig());
     Ok(match tsconfig.await.ok().as_deref() {
@@ -37,7 +37,7 @@ async fn get_typescript_options(
 /// outputs
 #[turbo_tasks::function]
 pub async fn get_typescript_transform_options(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Vc<TypescriptTransformOptions>> {
     let tsconfig = get_typescript_options(project_path).await?;
 
@@ -62,7 +62,7 @@ pub async fn get_typescript_transform_options(
 /// **TODO** Currnently only typescript's legacy decorators are supported
 #[turbo_tasks::function]
 pub async fn get_decorators_transform_options(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Vc<DecoratorsOptions>> {
     let tsconfig = get_typescript_options(project_path).await?;
 
@@ -129,7 +129,7 @@ pub async fn get_decorators_transform_options(
 
 #[turbo_tasks::function]
 pub async fn get_jsx_transform_options(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     mode: Vc<NextMode>,
     resolve_options_context: Option<Vc<ResolveOptionsContext>>,
     is_rsc_context: bool,

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -24,8 +24,8 @@ async fn get_typescript_options(
     Ok(match tsconfig.await.ok().as_deref() {
         Some(FindContextFileResult::Found(path, _)) => read_tsconfigs(
             path.read(),
-            ResolvedVc::upcast(FileSource::new(**path).to_resolved().await?),
-            node_cjs_resolve_options(path.root()),
+            ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
+            node_cjs_resolve_options(path.root().await?.clone_value()),
         )
         .await
         .ok(),
@@ -135,12 +135,12 @@ pub async fn get_jsx_transform_options(
     is_rsc_context: bool,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<JsxTransformOptions>> {
-    let tsconfig = get_typescript_options(project_path).await?;
+    let tsconfig = get_typescript_options(project_path.clone()).await?;
 
     let is_react_development = mode.await?.is_react_development();
     let enable_react_refresh = if is_react_development {
         if let Some(resolve_options_context) = resolve_options_context {
-            assert_can_resolve_react_refresh(project_path, resolve_options_context)
+            assert_can_resolve_react_refresh(project_path.clone(), resolve_options_context)
                 .await?
                 .is_found()
         } else {

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -52,8 +52,8 @@ pub enum PathType {
 /// Converts a filename within the server root into a next pathname.
 #[turbo_tasks::function]
 pub async fn pathname_for_path(
-    server_root: Vc<FileSystemPath>,
-    server_path: Vc<FileSystemPath>,
+    server_root: FileSystemPath,
+    server_path: FileSystemPath,
     path_ty: PathType,
 ) -> Result<Vc<RcStr>> {
     let server_path_value = &*server_path.await?;
@@ -98,7 +98,7 @@ pub fn get_asset_path_from_pathname(pathname: &str, ext: &str) -> String {
 #[turbo_tasks::function]
 pub async fn get_transpiled_packages(
     next_config: Vc<NextConfig>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<Vc<Vec<RcStr>>> {
     let mut transpile_packages: Vec<RcStr> = next_config.transpile_packages().owned().await?;
 
@@ -115,7 +115,7 @@ pub async fn get_transpiled_packages(
 
 pub async fn foreign_code_context_condition(
     next_config: Vc<NextConfig>,
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
 ) -> Result<ContextCondition> {
     let transpiled_packages = get_transpiled_packages(next_config, *project_path).await?;
 
@@ -675,7 +675,7 @@ async fn parse_config_from_js_value(
 /// sure there are none left over.
 pub async fn load_next_js_template(
     path: &str,
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     replacements: FxIndexMap<&'static str, RcStr>,
     injections: FxIndexMap<&'static str, RcStr>,
     imports: FxIndexMap<&'static str, Option<RcStr>>,
@@ -940,7 +940,7 @@ pub async fn file_content_rope(content: Vc<FileContent>) -> Result<Vc<Rope>> {
 }
 
 pub fn virtual_next_js_template_path(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     file: String,
 ) -> Vc<FileSystemPath> {
     debug_assert!(!file.contains('/'));
@@ -948,7 +948,7 @@ pub fn virtual_next_js_template_path(
 }
 
 pub async fn load_next_js_templateon<T: DeserializeOwned>(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     path: RcStr,
 ) -> Result<T> {
     let file_path = get_next_package(*project_path).join(path.clone());

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -8,7 +8,7 @@ use swc_core::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, ValueDefault, ValueToString, Vc,
+    FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, ValueDefault, Vc,
     trace::TraceRawVcs, util::WrapFuture,
 };
 use turbo_tasks_fs::{
@@ -56,14 +56,14 @@ pub async fn pathname_for_path(
     server_path: FileSystemPath,
     path_ty: PathType,
 ) -> Result<Vc<RcStr>> {
-    let server_path_value = &*server_path.await?;
-    let path = if let Some(path) = server_root.await?.get_path_to(server_path_value) {
+    let server_path_value = server_path.clone();
+    let path = if let Some(path) = server_root.get_path_to(&server_path_value) {
         path
     } else {
         bail!(
             "server_path ({}) is not in server_root ({})",
-            server_path.to_string().await?,
-            server_root.to_string().await?
+            server_path.value_to_string().await?,
+            server_root.value_to_string().await?
         )
     };
     let path = match (path_ty, path) {
@@ -117,17 +117,16 @@ pub async fn foreign_code_context_condition(
     next_config: Vc<NextConfig>,
     project_path: FileSystemPath,
 ) -> Result<ContextCondition> {
-    let transpiled_packages = get_transpiled_packages(next_config, *project_path).await?;
+    let transpiled_packages = get_transpiled_packages(next_config, project_path.clone()).await?;
 
     // The next template files are allowed to import the user's code via import
     // mapping, and imports must use the project-level [ResolveOptions] instead
     // of the `node_modules` specific resolve options (the template files are
     // technically node module files).
     let not_next_template_dir = ContextCondition::not(ContextCondition::InPath(
-        get_next_package(*project_path)
-            .join(NEXT_TEMPLATE_PATH.into())
-            .to_resolved()
-            .await?,
+        get_next_package(project_path.clone())
+            .await?
+            .join(NEXT_TEMPLATE_PATH)?,
     ));
 
     let result = ContextCondition::all(vec![
@@ -151,18 +150,18 @@ pub async fn foreign_code_context_condition(
 // subject to Next.js's configuration even if it's embedded assets.
 pub async fn internal_assets_conditions() -> Result<ContextCondition> {
     Ok(ContextCondition::any(vec![
-        ContextCondition::InPath(next_js_fs().root().to_resolved().await?),
+        ContextCondition::InPath(next_js_fs().root().await?.clone_value()),
         ContextCondition::InPath(
             turbopack_ecmascript_runtime::embed_fs()
                 .root()
-                .to_resolved()
-                .await?,
+                .await?
+                .clone_value(),
         ),
         ContextCondition::InPath(
             turbopack_node::embed_js::embed_fs()
                 .root()
-                .to_resolved()
-                .await?,
+                .await?
+                .clone_value(),
         ),
     ]))
 }
@@ -680,16 +679,16 @@ pub async fn load_next_js_template(
     injections: FxIndexMap<&'static str, RcStr>,
     imports: FxIndexMap<&'static str, Option<RcStr>>,
 ) -> Result<Vc<Box<dyn Source>>> {
-    let path = virtual_next_js_template_path(project_path, path.to_string());
+    let path = virtual_next_js_template_path(project_path.clone(), path.to_string()).await?;
 
     let content = &*file_content_rope(path.read()).await?;
     let content = content.to_str()?.into_owned();
 
     let parent_path = path.parent();
-    let parent_path_value = &*parent_path.await?;
+    let parent_path_value = parent_path.clone();
 
-    let package_root = get_next_package(project_path).parent();
-    let package_root_value = &*package_root.await?;
+    let package_root = get_next_package(project_path).await?.parent();
+    let package_root_value = package_root.clone();
 
     /// See [regex::Regex::replace_all].
     fn replace_all<E>(
@@ -939,24 +938,29 @@ pub async fn file_content_rope(content: Vc<FileContent>) -> Result<Vc<Rope>> {
     Ok(file.content().to_owned().cell())
 }
 
-pub fn virtual_next_js_template_path(
+pub async fn virtual_next_js_template_path(
     project_path: FileSystemPath,
     file: String,
-) -> Vc<FileSystemPath> {
+) -> Result<FileSystemPath> {
     debug_assert!(!file.contains('/'));
-    get_next_package(project_path).join(format!("{NEXT_TEMPLATE_PATH}/{file}").into())
+    get_next_package(project_path)
+        .await?
+        .join(&format!("{NEXT_TEMPLATE_PATH}/{file}"))
 }
 
 pub async fn load_next_js_templateon<T: DeserializeOwned>(
     project_path: FileSystemPath,
     path: RcStr,
 ) -> Result<T> {
-    let file_path = get_next_package(*project_path).join(path.clone());
+    let file_path = get_next_package(project_path.clone()).await?.join(&path)?;
 
     let content = &*file_path.read().await?;
 
     let FileContent::Content(file) = content else {
-        bail!("Expected file content at {}", file_path.to_string().await?);
+        bail!(
+            "Expected file content at {}",
+            file_path.value_to_string().await?
+        );
     };
 
     let result: T = parse_json_rope_with_source_context(file.content())?;

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -13,16 +13,13 @@ use crate::{EnvMap, GLOBAL_ENV_LOCK, ProcessEnv, sorted_env_vars};
 #[turbo_tasks::value]
 pub struct DotenvProcessEnv {
     prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl DotenvProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(
-        prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>,
-        path: ResolvedVc<FileSystemPath>,
-    ) -> Vc<Self> {
+    pub fn new(prior: Option<ResolvedVc<Box<dyn ProcessEnv>>>, path: FileSystemPath) -> Vc<Self> {
         DotenvProcessEnv { prior, path }.cell()
     }
 

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -2,7 +2,7 @@ use std::{env, sync::MutexGuard};
 
 use anyhow::{Context, Result, anyhow};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
 use crate::{EnvMap, GLOBAL_ENV_LOCK, ProcessEnv, sorted_env_vars};
@@ -62,7 +62,7 @@ impl DotenvProcessEnv {
             if let Err(e) = res {
                 return Err(e).context(anyhow!(
                     "unable to read {} for env vars",
-                    this.path.to_string().await?
+                    this.path.value_to_string().await?
                 ));
             }
 

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -142,7 +142,7 @@ impl FetchError {
     pub async fn to_issue(
         self: Vc<Self>,
         severity: IssueSeverity,
-        issue_context: ResolvedVc<FileSystemPath>,
+        issue_context: FileSystemPath,
     ) -> Result<Vc<FetchIssue>> {
         let this = &*self.await?;
         Ok(FetchIssue {
@@ -158,7 +158,7 @@ impl FetchError {
 
 #[turbo_tasks::value(shared)]
 pub struct FetchIssue {
-    pub issue_context: ResolvedVc<FileSystemPath>,
+    pub issue_context: FileSystemPath,
     pub severity: IssueSeverity,
     pub url: ResolvedVc<RcStr>,
     pub kind: ResolvedVc<FetchErrorKind>,

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -169,7 +169,7 @@ pub struct FetchIssue {
 impl Issue for FetchIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.issue_context
+        self.issue_context.clone().cell()
     }
 
     fn severity(&self) -> IssueSeverity {

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -125,7 +125,10 @@ async fn errors_on_failed_connection() {
         assert_eq!(*err.kind.await?, FetchErrorKind::Connect);
         assert_eq!(*err.url.await?, url);
 
-        let issue = err_vc.to_issue(IssueSeverity::Error, get_issue_context());
+        let issue = err_vc.to_issue(
+            IssueSeverity::Error,
+            get_issue_context().await?.clone_value(),
+        );
         assert_eq!(issue.await?.severity(), IssueSeverity::Error);
         assert_eq!(
             *issue.description().await?.unwrap().await?,
@@ -159,7 +162,10 @@ async fn errors_on_404() {
         assert!(matches!(*err.kind.await?, FetchErrorKind::Status(404)));
         assert_eq!(*err.url.await?, url);
 
-        let issue = err_vc.to_issue(IssueSeverity::Error, get_issue_context());
+        let issue = err_vc.to_issue(
+            IssueSeverity::Error,
+            get_issue_context().await?.clone_value(),
+        );
         assert_eq!(issue.await?.severity(), IssueSeverity::Error);
         assert_eq!(
             *issue.description().await?.unwrap().await?,

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -67,12 +67,12 @@ async fn print_hash(dir_hash: Vc<RcStr>) -> Result<Vc<()>> {
     Ok(Default::default())
 }
 
-async fn filename(path: Vc<FileSystemPath>) -> Result<String> {
+async fn filename(path: FileSystemPath) -> Result<String> {
     Ok(path.await?.path.split('/').next_back().unwrap().to_string())
 }
 
 #[turbo_tasks::function]
-async fn hash_directory(directory: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
+async fn hash_directory(directory: FileSystemPath) -> Result<Vc<RcStr>> {
     let dir_path = &directory.await?.path;
     let content = directory.read_dir();
     let mut hashes = BTreeMap::new();
@@ -108,7 +108,7 @@ async fn hash_directory(directory: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
 }
 
 #[turbo_tasks::function]
-async fn hash_file(file_path: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
+async fn hash_file(file_path: FileSystemPath) -> Result<Vc<RcStr>> {
     let content = file_path.read().await?;
     Ok(match &*content {
         FileContent::Content(file) => hash_content(&mut file.read()),

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);
-            let input = fs.root().join("demo".into());
+            let input = fs.root().await?.join("demo")?;
             let dir_hash = hash_directory(input);
             print_hash(dir_hash).await?;
             Ok::<Vc<()>, _>(Default::default())
@@ -68,12 +68,12 @@ async fn print_hash(dir_hash: Vc<RcStr>) -> Result<Vc<()>> {
 }
 
 async fn filename(path: FileSystemPath) -> Result<String> {
-    Ok(path.await?.path.split('/').next_back().unwrap().to_string())
+    Ok(path.path.split('/').next_back().unwrap().to_string())
 }
 
 #[turbo_tasks::function]
 async fn hash_directory(directory: FileSystemPath) -> Result<Vc<RcStr>> {
-    let dir_path = &directory.await?.path;
+    let dir_path = &directory.path;
     let content = directory.read_dir();
     let mut hashes = BTreeMap::new();
     match &*content.await? {
@@ -81,19 +81,19 @@ async fn hash_directory(directory: FileSystemPath) -> Result<Vc<RcStr>> {
             for entry in entries.values() {
                 match entry {
                     DirectoryEntry::File(path) => {
-                        let name = filename(**path).await?;
-                        hashes.insert(name, hash_file(**path).owned().await?);
+                        let name = filename(path.clone()).await?;
+                        hashes.insert(name, hash_file(path.clone()).owned().await?);
                     }
                     DirectoryEntry::Directory(path) => {
-                        let name = filename(**path).await?;
-                        hashes.insert(name, hash_directory(**path).owned().await?);
+                        let name = filename(path.clone()).await?;
+                        hashes.insert(name, hash_directory(path.clone()).owned().await?);
                     }
                     _ => {}
                 }
             }
         }
         DirectoryContent::NotFound => {
-            println!("{}: not found", directory.await?.path);
+            println!("{}: not found", directory.path);
         }
     };
     let hash = hash_content(

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -23,7 +23,7 @@ impl AttachedFileSystem {
     /// an invisible subdirectory of the `child_path`
     #[turbo_tasks::function]
     pub async fn new(
-        child_path: Vc<FileSystemPath>,
+        child_path: FileSystemPath,
         child_fs: ResolvedVc<Box<dyn FileSystem>>,
     ) -> Result<Vc<Self>> {
         let child_path = child_path.await?;
@@ -36,14 +36,14 @@ impl AttachedFileSystem {
         .cell())
     }
 
-    /// Converts the given [Vc<FileSystemPath>] to a path in this [FileSystem].
+    /// Converts the given [FileSystemPath] to a path in this [FileSystem].
     ///
     /// The given path has to be inside of the root [FileSystem], the child
     /// [FileSystem] or this [AttachedFileSystem].
     #[turbo_tasks::function]
     pub async fn convert_path(
         self: ResolvedVc<Self>,
-        contained_path_vc: Vc<FileSystemPath>,
+        contained_path_vc: FileSystemPath,
     ) -> Result<Vc<FileSystemPath>> {
         let contained_path = contained_path_vc.await?;
         let self_fs: ResolvedVc<Box<dyn FileSystem>> = ResolvedVc::upcast(self);
@@ -71,7 +71,7 @@ impl AttachedFileSystem {
         }
     }
 
-    /// Constructs a [Vc<FileSystemPath>] of the attachment point referencing
+    /// Constructs a [FileSystemPath] of the attachment point referencing
     /// this [AttachedFileSystem]
     #[turbo_tasks::function]
     async fn child_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
@@ -87,7 +87,7 @@ impl AttachedFileSystem {
     #[turbo_tasks::function]
     pub async fn get_inner_fs_path(
         self: ResolvedVc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
     ) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
         let path = path.await?;
@@ -119,32 +119,32 @@ impl AttachedFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for AttachedFileSystem {
     #[turbo_tasks::function(fs)]
-    fn read(self: Vc<Self>, path: Vc<FileSystemPath>) -> Vc<FileContent> {
+    fn read(self: Vc<Self>, path: FileSystemPath) -> Vc<FileContent> {
         self.get_inner_fs_path(path).read()
     }
 
     #[turbo_tasks::function(fs)]
-    fn read_link(self: Vc<Self>, path: Vc<FileSystemPath>) -> Vc<LinkContent> {
+    fn read_link(self: Vc<Self>, path: FileSystemPath) -> Vc<LinkContent> {
         self.get_inner_fs_path(path).read_link()
     }
 
     #[turbo_tasks::function(fs)]
-    fn raw_read_dir(self: Vc<Self>, path: Vc<FileSystemPath>) -> Vc<RawDirectoryContent> {
+    fn raw_read_dir(self: Vc<Self>, path: FileSystemPath) -> Vc<RawDirectoryContent> {
         self.get_inner_fs_path(path).raw_read_dir()
     }
 
     #[turbo_tasks::function(fs)]
-    fn write(self: Vc<Self>, path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Vc<()> {
+    fn write(self: Vc<Self>, path: FileSystemPath, content: Vc<FileContent>) -> Vc<()> {
         self.get_inner_fs_path(path).write(content)
     }
 
     #[turbo_tasks::function(fs)]
-    fn write_link(self: Vc<Self>, path: Vc<FileSystemPath>, target: Vc<LinkContent>) -> Vc<()> {
+    fn write_link(self: Vc<Self>, path: FileSystemPath, target: Vc<LinkContent>) -> Vc<()> {
         self.get_inner_fs_path(path).write_link(target)
     }
 
     #[turbo_tasks::function]
-    fn metadata(self: Vc<Self>, path: Vc<FileSystemPath>) -> Vc<FileMeta> {
+    fn metadata(self: Vc<Self>, path: FileSystemPath) -> Vc<FileMeta> {
         self.get_inner_fs_path(path).metadata()
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -26,8 +26,6 @@ impl AttachedFileSystem {
         child_path: FileSystemPath,
         child_fs: ResolvedVc<Box<dyn FileSystem>>,
     ) -> Result<Vc<Self>> {
-        let child_path = child_path.await?;
-
         Ok(AttachedFileSystem {
             root_fs: child_path.fs,
             child_path: child_path.path.clone(),
@@ -43,30 +41,23 @@ impl AttachedFileSystem {
     #[turbo_tasks::function]
     pub async fn convert_path(
         self: ResolvedVc<Self>,
-        contained_path_vc: FileSystemPath,
+        contained_path: FileSystemPath,
     ) -> Result<Vc<FileSystemPath>> {
-        let contained_path = contained_path_vc.await?;
         let self_fs: ResolvedVc<Box<dyn FileSystem>> = ResolvedVc::upcast(self);
         let this = self.await?;
 
         match contained_path.fs {
             // already on this filesystem
-            fs if fs == self_fs => Ok(contained_path_vc),
+            fs if fs == self_fs => Ok(contained_path.cell()),
             // in the root filesystem, just need to rebase on this filesystem
-            fs if fs == this.root_fs => Ok(self
-                .root()
-                .resolve()
-                .await?
-                .join(contained_path.path.clone())),
+            fs if fs == this.root_fs => Ok(self.root().await?.join(&contained_path.path)?.cell()),
             // in the child filesystem, so we expand to the full path by appending to child_path
-            fs if fs == this.child_fs => Ok(self
-                .child_path()
-                .resolve()
-                .await?
-                .join(contained_path.path.clone())),
+            fs if fs == this.child_fs => {
+                Ok(self.child_path().await?.join(&contained_path.path)?.cell())
+            }
             _ => bail!(
                 "path {} not part of self, the root fs or the child fs",
-                contained_path_vc.to_string().await?
+                contained_path.value_to_string().await?
             ),
         }
     }
@@ -75,11 +66,7 @@ impl AttachedFileSystem {
     /// this [AttachedFileSystem]
     #[turbo_tasks::function]
     async fn child_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self
-            .root()
-            .resolve()
-            .await?
-            .join(self.await?.child_path.clone()))
+        Ok(self.root().await?.join(&self.await?.child_path)?.cell())
     }
 
     /// Resolves the local path of the root or child filesystem from a path
@@ -90,7 +77,6 @@ impl AttachedFileSystem {
         path: FileSystemPath,
     ) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let path = path.await?;
         let self_fs: ResolvedVc<Box<dyn FileSystem>> = ResolvedVc::upcast(self);
 
         if path.fs != self_fs {
@@ -105,13 +91,9 @@ impl AttachedFileSystem {
 
         let child_path = self.child_path().await?;
         Ok(if let Some(inner_path) = child_path.get_path_to(&path) {
-            this.child_fs
-                .root()
-                .resolve()
-                .await?
-                .join(inner_path.into())
+            this.child_fs.root().await?.join(inner_path)?.cell()
         } else {
-            this.root_fs.root().resolve().await?.join(path.path.clone())
+            this.root_fs.root().await?.join(&path.path)?.cell()
         })
     }
 }
@@ -119,33 +101,41 @@ impl AttachedFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for AttachedFileSystem {
     #[turbo_tasks::function(fs)]
-    fn read(self: Vc<Self>, path: FileSystemPath) -> Vc<FileContent> {
-        self.get_inner_fs_path(path).read()
+    async fn read(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<FileContent>> {
+        Ok(self.get_inner_fs_path(path).await?.read())
     }
 
     #[turbo_tasks::function(fs)]
-    fn read_link(self: Vc<Self>, path: FileSystemPath) -> Vc<LinkContent> {
-        self.get_inner_fs_path(path).read_link()
+    async fn read_link(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<LinkContent>> {
+        Ok(self.get_inner_fs_path(path).await?.read_link())
     }
 
     #[turbo_tasks::function(fs)]
-    fn raw_read_dir(self: Vc<Self>, path: FileSystemPath) -> Vc<RawDirectoryContent> {
-        self.get_inner_fs_path(path).raw_read_dir()
+    async fn raw_read_dir(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
+        Ok(self.get_inner_fs_path(path).await?.raw_read_dir())
     }
 
     #[turbo_tasks::function(fs)]
-    fn write(self: Vc<Self>, path: FileSystemPath, content: Vc<FileContent>) -> Vc<()> {
-        self.get_inner_fs_path(path).write(content)
+    async fn write(
+        self: Vc<Self>,
+        path: FileSystemPath,
+        content: Vc<FileContent>,
+    ) -> Result<Vc<()>> {
+        Ok(self.get_inner_fs_path(path).await?.write(content))
     }
 
     #[turbo_tasks::function(fs)]
-    fn write_link(self: Vc<Self>, path: FileSystemPath, target: Vc<LinkContent>) -> Vc<()> {
-        self.get_inner_fs_path(path).write_link(target)
+    async fn write_link(
+        self: Vc<Self>,
+        path: FileSystemPath,
+        target: Vc<LinkContent>,
+    ) -> Result<Vc<()>> {
+        Ok(self.get_inner_fs_path(path).await?.write_link(target))
     }
 
     #[turbo_tasks::function]
-    fn metadata(self: Vc<Self>, path: FileSystemPath) -> Vc<FileMeta> {
-        self.get_inner_fs_path(path).metadata()
+    async fn metadata(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<FileMeta>> {
+        Ok(self.get_inner_fs_path(path).await?.metadata())
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -26,7 +26,7 @@ pub async fn content_from_relative_path(
     );
     disk_fs.await?.start_watching(None).await?;
 
-    let fs_path = disk_fs.root().join(path.into());
+    let fs_path = disk_fs.root().await?.join(path)?;
     Ok(fs_path.read())
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -25,7 +25,7 @@ impl EmbeddedFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for EmbeddedFileSystem {
     #[turbo_tasks::function]
-    async fn read(&self, path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
+    async fn read(&self, path: FileSystemPath) -> Result<Vc<FileContent>> {
         let file = match self.dir.get_file(&path.await?.path) {
             Some(file) => file,
             None => return Ok(FileContent::NotFound.cell()),
@@ -35,12 +35,12 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _path: Vc<FileSystemPath>) -> Vc<LinkContent> {
+    fn read_link(&self, _path: FileSystemPath) -> Vc<LinkContent> {
         LinkContent::NotFound.cell()
     }
 
     #[turbo_tasks::function]
-    async fn raw_read_dir(&self, path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
+    async fn raw_read_dir(&self, path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         let path_str = &path.await?.path;
         let dir = match (path_str.as_str(), self.dir.get_dir(path_str)) {
             ("", _) => self.dir,
@@ -70,17 +70,17 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 
     #[turbo_tasks::function]
-    async fn metadata(&self, path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
+    async fn metadata(&self, path: FileSystemPath) -> Result<Vc<FileMeta>> {
         if self.dir.get_entry(&path.await?.path).is_none() {
             bail!("path not found, can't read metadata");
         }

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -26,7 +26,7 @@ impl EmbeddedFileSystem {
 impl FileSystem for EmbeddedFileSystem {
     #[turbo_tasks::function]
     async fn read(&self, path: FileSystemPath) -> Result<Vc<FileContent>> {
-        let file = match self.dir.get_file(&path.await?.path) {
+        let file = match self.dir.get_file(&path.path) {
             Some(file) => file,
             None => return Ok(FileContent::NotFound.cell()),
         };
@@ -41,7 +41,7 @@ impl FileSystem for EmbeddedFileSystem {
 
     #[turbo_tasks::function]
     async fn raw_read_dir(&self, path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
-        let path_str = &path.await?.path;
+        let path_str = &path.path;
         let dir = match (path_str.as_str(), self.dir.get_dir(path_str)) {
             ("", _) => self.dir,
             (_, Some(dir)) => dir,
@@ -81,7 +81,7 @@ impl FileSystem for EmbeddedFileSystem {
 
     #[turbo_tasks::function]
     async fn metadata(&self, path: FileSystemPath) -> Result<Vc<FileMeta>> {
-        if self.dir.get_entry(&path.await?.path).is_none() {
+        if self.dir.get_entry(&path.path).is_none() {
             bail!("path not found, can't read metadata");
         }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -60,8 +60,8 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     ApplyEffectsContext, Completion, InvalidationReason, Invalidator, NonLocalValue, ReadRef,
-    ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, effect, mark_session_dependent,
-    mark_stateful, trace::TraceRawVcs,
+    ResolvedVc, TaskInput, ValueToString, Vc, debug::ValueDebugFormat, effect,
+    mark_session_dependent, mark_stateful, trace::TraceRawVcs,
 };
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher, hash_xxh3_hash64};
 use util::{extract_disk_access, join_path, normalize_path, sys_to_unix, unix_to_sys};
@@ -1023,8 +1023,8 @@ pub fn get_relative_path_to(path: &str, other_path: &str) -> String {
     result.join("/")
 }
 
-#[turbo_tasks::value]
-#[derive(Debug, Clone, Hash)]
+#[turbo_tasks::value(shared)]
+#[derive(Debug, Clone, Hash, TaskInput)]
 pub struct FileSystemPath {
     pub fs: ResolvedVc<Box<dyn FileSystem>>,
     pub path: RcStr,

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -201,17 +201,17 @@ pub trait FileSystem: ValueToString {
         FileSystemPath::new_normalized(self, RcStr::default())
     }
     #[turbo_tasks::function]
-    fn read(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<FileContent>;
+    fn read(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<FileContent>;
     #[turbo_tasks::function]
-    fn read_link(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<LinkContent>;
+    fn read_link(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<LinkContent>;
     #[turbo_tasks::function]
-    fn raw_read_dir(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<RawDirectoryContent>;
+    fn raw_read_dir(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<RawDirectoryContent>;
     #[turbo_tasks::function]
-    fn write(self: Vc<Self>, fs_path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Vc<()>;
+    fn write(self: Vc<Self>, fs_path: FileSystemPath, content: Vc<FileContent>) -> Vc<()>;
     #[turbo_tasks::function]
-    fn write_link(self: Vc<Self>, fs_path: Vc<FileSystemPath>, target: Vc<LinkContent>) -> Vc<()>;
+    fn write_link(self: Vc<Self>, fs_path: FileSystemPath, target: Vc<LinkContent>) -> Vc<()>;
     #[turbo_tasks::function]
-    fn metadata(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Vc<FileMeta>;
+    fn metadata(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<FileMeta>;
 }
 
 #[derive(Default)]
@@ -474,7 +474,7 @@ impl DiskFileSystem {
         self.inner.watcher.stop_watching();
     }
 
-    pub async fn to_sys_path(&self, fs_path: Vc<FileSystemPath>) -> Result<PathBuf> {
+    pub async fn to_sys_path(&self, fs_path: FileSystemPath) -> Result<PathBuf> {
         // just in case there's a windows unc path prefix we remove it with `dunce`
         let path = self.inner.root_path();
         let fs_path = fs_path.await?;
@@ -553,7 +553,7 @@ impl Debug for DiskFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for DiskFileSystem {
     #[turbo_tasks::function(fs, invalidator)]
-    async fn read(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
+    async fn read(&self, fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         self.inner.register_read_invalidator(&full_path)?;
@@ -579,7 +579,7 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs, invalidator)]
-    async fn raw_read_dir(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
+    async fn raw_read_dir(&self, fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         self.inner.register_dir_invalidator(&full_path)?;
@@ -634,7 +634,7 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs, invalidator)]
-    async fn read_link(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<LinkContent>> {
+    async fn read_link(&self, fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         self.inner.register_read_invalidator(&full_path)?;
@@ -720,7 +720,7 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs, invalidator)]
-    async fn write(&self, fs_path: Vc<FileSystemPath>, content: Vc<FileContent>) -> Result<()> {
+    async fn write(&self, fs_path: FileSystemPath, content: Vc<FileContent>) -> Result<()> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         let content = content.await?;
@@ -845,7 +845,7 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs, invalidator)]
-    async fn write_link(&self, fs_path: Vc<FileSystemPath>, target: Vc<LinkContent>) -> Result<()> {
+    async fn write_link(&self, fs_path: FileSystemPath, target: Vc<LinkContent>) -> Result<()> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         let content = target.await?;
@@ -964,7 +964,7 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs, invalidator)]
-    async fn metadata(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
+    async fn metadata(&self, fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
         mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         self.inner.register_read_invalidator(&full_path)?;
@@ -1145,7 +1145,7 @@ impl FileSystemPath {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct FileSystemPathOption(Option<ResolvedVc<FileSystemPath>>);
+pub struct FileSystemPathOption(Option<FileSystemPath>);
 
 #[turbo_tasks::value_impl]
 impl FileSystemPathOption {
@@ -1157,7 +1157,7 @@ impl FileSystemPathOption {
 
 #[turbo_tasks::value_impl]
 impl FileSystemPath {
-    /// Create a new Vc<FileSystemPath> from a path withing a FileSystem. The
+    /// Create a new FileSystemPath from a path withing a FileSystem. The
     /// /-separated path is expected to be already normalized (this is asserted
     /// in dev mode).
     #[turbo_tasks::function]
@@ -1186,7 +1186,7 @@ impl FileSystemPath {
             Ok(Self::new_normalized(*self.fs, path.into()))
         } else {
             bail!(
-                "Vc<FileSystemPath>(\"{}\").join(\"{}\") leaves the filesystem root",
+                "FileSystemPath(\"{}\").join(\"{}\") leaves the filesystem root",
                 self.path,
                 path
             );
@@ -1295,16 +1295,16 @@ impl FileSystemPath {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_inside(&self, other: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+    pub async fn is_inside(&self, other: FileSystemPath) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.is_inside_ref(&*other.await?)))
     }
 
     #[turbo_tasks::function]
-    pub async fn is_inside_or_equal(&self, other: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+    pub async fn is_inside_or_equal(&self, other: FileSystemPath) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.is_inside_or_equal_ref(&*other.await?)))
     }
 
-    /// Creates a new [`Vc<FileSystemPath>`] like `self` but with the given
+    /// Creates a new [`FileSystemPath`] like `self` but with the given
     /// extension.
     #[turbo_tasks::function]
     pub fn with_extension(&self, extension: RcStr) -> Vc<FileSystemPath> {
@@ -1346,9 +1346,9 @@ impl Display for FileSystemPath {
 
 #[turbo_tasks::function]
 pub async fn rebase(
-    fs_path: Vc<FileSystemPath>,
-    old_base: Vc<FileSystemPath>,
-    new_base: Vc<FileSystemPath>,
+    fs_path: FileSystemPath,
+    old_base: FileSystemPath,
+    new_base: FileSystemPath,
 ) -> Result<Vc<FileSystemPath>> {
     let fs_path = &*fs_path.await?;
     let old_base = &*old_base.await?;
@@ -1424,9 +1424,9 @@ impl FileSystemPath {
     }
 
     pub fn rebase(
-        fs_path: Vc<FileSystemPath>,
-        old_base: Vc<FileSystemPath>,
-        new_base: Vc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        old_base: FileSystemPath,
+        new_base: FileSystemPath,
     ) -> Vc<FileSystemPath> {
         rebase(fs_path, old_base, new_base)
     }
@@ -1520,7 +1520,7 @@ impl FileSystemPath {
     #[turbo_tasks::function]
     pub async fn realpath_with_links(self: ResolvedVc<Self>) -> Result<Vc<RealPathResult>> {
         let mut current_vc = self;
-        let mut symlinks: IndexSet<ResolvedVc<FileSystemPath>> = IndexSet::new();
+        let mut symlinks: IndexSet<FileSystemPath> = IndexSet::new();
         let mut visited: AutoSet<RcStr> = AutoSet::new();
         // Pick some arbitrary symlink depth limit... similar to the ELOOP logic for realpath(3).
         // SYMLOOP_MAX is 40 for Linux: https://unix.stackexchange.com/q/721724
@@ -1614,8 +1614,8 @@ impl ValueToString for FileSystemPath {
 #[derive(Clone, Debug)]
 #[turbo_tasks::value(shared)]
 pub struct RealPathResult {
-    pub path: ResolvedVc<FileSystemPath>,
-    pub symlinks: Vec<ResolvedVc<FileSystemPath>>,
+    pub path: FileSystemPath,
+    pub symlinks: Vec<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -1774,7 +1774,7 @@ bitflags! {
 pub enum LinkContent {
     // for the relative link, the target is raw value read from the link
     // for the absolute link, the target is stripped of the root path while reading
-    // We don't use the `Vc<FileSystemPath>` here for now, because the `FileSystemPath` is always
+    // We don't use the `FileSystemPath` here for now, because the `FileSystemPath` is always
     // normalized, which means in `fn write_link` we couldn't restore the raw value of the file
     // link because there is only **dist** path in `fn write_link`, and we need the raw path if
     // we want to restore the link value in `fn write_link`
@@ -2239,10 +2239,10 @@ pub enum RawDirectoryEntry {
     Hash, Clone, Copy, Debug, PartialEq, Eq, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
 )]
 pub enum DirectoryEntry {
-    File(ResolvedVc<FileSystemPath>),
-    Directory(ResolvedVc<FileSystemPath>),
-    Symlink(ResolvedVc<FileSystemPath>),
-    Other(ResolvedVc<FileSystemPath>),
+    File(FileSystemPath),
+    Directory(FileSystemPath),
+    Symlink(FileSystemPath),
+    Other(FileSystemPath),
     Error,
 }
 
@@ -2263,7 +2263,7 @@ impl DirectoryEntry {
         }
     }
 
-    pub fn path(self) -> Option<ResolvedVc<FileSystemPath>> {
+    pub fn path(self) -> Option<FileSystemPath> {
         match self {
             DirectoryEntry::File(path)
             | DirectoryEntry::Directory(path)
@@ -2374,32 +2374,32 @@ pub struct NullFileSystem;
 #[turbo_tasks::value_impl]
 impl FileSystem for NullFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: Vc<FileSystemPath>) -> Vc<FileContent> {
+    fn read(&self, _fs_path: FileSystemPath) -> Vc<FileContent> {
         FileContent::NotFound.cell()
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: Vc<FileSystemPath>) -> Vc<LinkContent> {
+    fn read_link(&self, _fs_path: FileSystemPath) -> Vc<LinkContent> {
         LinkContent::NotFound.into()
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Vc<RawDirectoryContent> {
+    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Vc<RawDirectoryContent> {
         RawDirectoryContent::not_found()
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Vc<()> {
+    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Vc<()> {
         Vc::default()
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Vc<()> {
+    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Vc<()> {
         Vc::default()
     }
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: Vc<FileSystemPath>) -> Vc<FileMeta> {
+    fn metadata(&self, _fs_path: FileSystemPath) -> Vc<FileMeta> {
         FileMeta::default().cell()
     }
 }
@@ -2412,7 +2412,7 @@ impl ValueToString for NullFileSystem {
     }
 }
 
-pub async fn to_sys_path(mut path: Vc<FileSystemPath>) -> Result<Option<PathBuf>> {
+pub async fn to_sys_path(mut path: FileSystemPath) -> Result<Option<PathBuf>> {
     loop {
         if let Some(fs) = Vc::try_resolve_downcast_type::<AttachedFileSystem>(path.fs()).await? {
             path = fs.get_inner_fs_path(path);

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1242,12 +1242,13 @@ impl FileSystemPath {
 
     /// Similar to [FileSystemPath::join], but returns an Option that will be
     /// None when the joined path would leave the filesystem root.
+    #[allow(clippy::needless_borrow)] // for windows build
     pub fn try_join(&self, path: &str) -> Result<Option<FileSystemPath>> {
         // TODO(PACK-3279): Remove this once we do not produce invalid paths at the first place.
         #[cfg(target_os = "windows")]
         let path = path.replace('\\', "/");
 
-        if let Some(path) = join_path(&self.path, path) {
+        if let Some(path) = join_path(&self.path, &path) {
             Ok(Some(Self::new_normalized(self.fs, path.into())))
         } else {
             Ok(None)
@@ -1265,9 +1266,8 @@ impl FileSystemPath {
         Ok(None)
     }
 
-    #[turbo_tasks::function]
-    pub async fn read_glob(self: Vc<Self>, glob: Vc<Glob>) -> Result<Vc<ReadGlobResult>> {
-        read_glob(self, glob).await
+    pub fn read_glob(&self, glob: Vc<Glob>) -> Vc<ReadGlobResult> {
+        read_glob(self.clone(), glob)
     }
 
     // Tracks all files and directories matching the glob
@@ -2386,8 +2386,9 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
             current_vc = if link_type.contains(LinkType::ABSOLUTE) {
                 (*current_vc.root().await?).clone()
             } else {
-                parent_result.path.join(target)?
-            };
+                parent_result.path
+            }
+            .join(target)?;
         } else {
             // get_type() and read_link() might disagree temporarily due to turbo-tasks
             // eventual consistency or if the file gets invalidated before the directory does

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1031,6 +1031,20 @@ pub struct FileSystemPath {
 }
 
 impl FileSystemPath {
+    /// Mimics `ValueToString::to_string`.
+    pub fn value_to_string(&self) -> Vc<RcStr> {
+        value_to_string(self.clone())
+    }
+}
+
+#[turbo_tasks::function]
+async fn value_to_string(path: FileSystemPath) -> Result<Vc<RcStr>> {
+    Ok(Vc::cell(
+        format!("[{}]/{}", path.fs.to_string().await?, path.path).into(),
+    ))
+}
+
+impl FileSystemPath {
     pub fn is_inside_ref(&self, other: &FileSystemPath) -> bool {
         if self.fs == other.fs && self.path.starts_with(&*other.path) {
             if other.path.is_empty() {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -197,8 +197,8 @@ fn create_semaphore() -> tokio::sync::Semaphore {
 pub trait FileSystem: ValueToString {
     /// Returns the path to the root of the file system.
     #[turbo_tasks::function]
-    fn root(self: Vc<Self>) -> Vc<FileSystemPath> {
-        FileSystemPath::new_normalized(self, RcStr::default())
+    fn root(self: ResolvedVc<Self>) -> Vc<FileSystemPath> {
+        FileSystemPath::new_normalized(self, RcStr::default()).cell()
     }
     #[turbo_tasks::function]
     fn read(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<FileContent>;
@@ -477,7 +477,6 @@ impl DiskFileSystem {
     pub async fn to_sys_path(&self, fs_path: FileSystemPath) -> Result<PathBuf> {
         // just in case there's a windows unc path prefix we remove it with `dunce`
         let path = self.inner.root_path();
-        let fs_path = fs_path.await?;
         Ok(if fs_path.path.is_empty() {
             path.to_path_buf()
         } else {
@@ -636,7 +635,7 @@ impl FileSystem for DiskFileSystem {
     #[turbo_tasks::function(fs, invalidator)]
     async fn read_link(&self, fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
         mark_session_dependent();
-        let full_path = self.to_sys_path(fs_path).await?;
+        let full_path = self.to_sys_path(fs_path.clone()).await?;
         self.inner.register_read_invalidator(&full_path)?;
 
         let _lock = self.inner.lock_path(&full_path).await;
@@ -690,7 +689,7 @@ impl FileSystem for DiskFileSystem {
             let target_string: RcStr = relative_to_root_path.to_string_lossy().into();
             (
                 target_string.clone(),
-                FileSystemPath::new_normalized(fs_path.fs(), target_string)
+                FileSystemPath::new_normalized(fs_path.fs().to_resolved().await?, target_string)
                     .get_type()
                     .await?,
             )
@@ -699,7 +698,7 @@ impl FileSystem for DiskFileSystem {
             let link_path_unix: RcStr = sys_to_unix(&link_path_string_cow).into();
             (
                 link_path_unix.clone(),
-                fs_path.parent().join(link_path_unix).get_type().await?,
+                fs_path.parent().join(&link_path_unix)?.get_type().await?,
             )
         };
 
@@ -1169,13 +1168,11 @@ impl FileSystemPathOption {
     }
 }
 
-#[turbo_tasks::value_impl]
 impl FileSystemPath {
     /// Create a new FileSystemPath from a path withing a FileSystem. The
     /// /-separated path is expected to be already normalized (this is asserted
     /// in dev mode).
-    #[turbo_tasks::function]
-    fn new_normalized(fs: ResolvedVc<Box<dyn FileSystem>>, path: RcStr) -> Vc<Self> {
+    fn new_normalized(fs: ResolvedVc<Box<dyn FileSystem>>, path: RcStr) -> Self {
         // On Windows, the path must be converted to a unix path before creating. But on
         // Unix, backslashes are a valid char in file names, and the path can be
         // provided by the user, so we allow it.
@@ -1188,16 +1185,15 @@ impl FileSystemPath {
             normalize_path(&path).as_deref() == Some(&*path),
             "path {path} must be normalized",
         );
-        Self::cell(FileSystemPath { fs, path })
+        FileSystemPath { fs, path }
     }
 
     /// Adds a subpath to the current path. The /-separate path argument might
     /// contain ".." or "." seqments, but it must not leave the root of the
     /// filesystem.
-    #[turbo_tasks::function]
-    pub fn join(&self, path: RcStr) -> Result<Vc<Self>> {
-        if let Some(path) = join_path(&self.path, &path) {
-            Ok(Self::new_normalized(*self.fs, path.into()))
+    pub fn join(&self, path: &str) -> Result<Self> {
+        if let Some(path) = join_path(&self.path, path) {
+            Ok(Self::new_normalized(self.fs, path.into()))
         } else {
             bail!(
                 "FileSystemPath(\"{}\").join(\"{}\") leaves the filesystem root",
@@ -1208,8 +1204,7 @@ impl FileSystemPath {
     }
 
     /// Adds a suffix to the filename. [path] must not contain `/`.
-    #[turbo_tasks::function]
-    pub fn append(&self, path: RcStr) -> Result<Vc<Self>> {
+    pub fn append(&self, path: &str) -> Result<Self> {
         if path.contains('/') {
             bail!(
                 "FileSystemPath(\"{}\").append(\"{}\") must not append '/'",
@@ -1218,15 +1213,14 @@ impl FileSystemPath {
             )
         }
         Ok(Self::new_normalized(
-            *self.fs,
+            self.fs,
             format!("{}{}", self.path, path).into(),
         ))
     }
 
     /// Adds a suffix to the basename of the filename. [appending] must not
     /// contain `/`. Extension will stay intact.
-    #[turbo_tasks::function]
-    pub fn append_to_stem(&self, appending: RcStr) -> Result<Vc<Self>> {
+    pub fn append_to_stem(&self, appending: &str) -> Result<Self> {
         if appending.contains('/') {
             bail!(
                 "FileSystemPath(\"{}\").append_to_stem(\"{}\") must not append '/'",
@@ -1236,49 +1230,39 @@ impl FileSystemPath {
         }
         if let (path, Some(ext)) = self.split_extension() {
             return Ok(Self::new_normalized(
-                *self.fs,
+                self.fs,
                 format!("{path}{appending}.{ext}").into(),
             ));
         }
         Ok(Self::new_normalized(
-            *self.fs,
+            self.fs,
             format!("{}{}", self.path, appending).into(),
         ))
     }
 
     /// Similar to [FileSystemPath::join], but returns an Option that will be
     /// None when the joined path would leave the filesystem root.
-    #[turbo_tasks::function]
-    pub async fn try_join(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
+    pub fn try_join(&self, path: &str) -> Result<Option<FileSystemPath>> {
         // TODO(PACK-3279): Remove this once we do not produce invalid paths at the first place.
         #[cfg(target_os = "windows")]
         let path = path.replace('\\', "/");
 
-        if let Some(path) = join_path(&self.path, &path) {
-            Ok(Vc::cell(Some(
-                Self::new_normalized(*self.fs, path.into())
-                    .to_resolved()
-                    .await?,
-            )))
+        if let Some(path) = join_path(&self.path, path) {
+            Ok(Some(Self::new_normalized(self.fs, path.into())))
         } else {
-            Ok(FileSystemPathOption::none())
+            Ok(None)
         }
     }
 
     /// Similar to [FileSystemPath::join], but returns an Option that will be
     /// None when the joined path would leave the current path.
-    #[turbo_tasks::function]
-    pub async fn try_join_inside(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
-        if let Some(path) = join_path(&self.path, &path)
+    pub fn try_join_inside(&self, path: &str) -> Result<Option<FileSystemPath>> {
+        if let Some(path) = join_path(&self.path, path)
             && path.starts_with(&*self.path)
         {
-            return Ok(Vc::cell(Some(
-                Self::new_normalized(*self.fs, path.into())
-                    .to_resolved()
-                    .await?,
-            )));
+            return Ok(Some(Self::new_normalized(self.fs, path.into())));
         }
-        Ok(FileSystemPathOption::none())
+        Ok(None)
     }
 
     #[turbo_tasks::function]
@@ -1288,43 +1272,38 @@ impl FileSystemPath {
 
     // Tracks all files and directories matching the glob
     // Follows symlinks as though they were part of the original hierarchy.
-    #[turbo_tasks::function]
-    pub fn track_glob(self: Vc<Self>, glob: Vc<Glob>, include_dot_files: bool) -> Vc<Completion> {
-        track_glob(self, glob, include_dot_files)
+    pub fn track_glob(&self, glob: Vc<Glob>, include_dot_files: bool) -> Vc<Completion> {
+        track_glob(self.clone(), glob, include_dot_files)
     }
 
-    #[turbo_tasks::function]
-    pub fn root(self: Vc<Self>) -> Vc<Self> {
+    pub fn root(&self) -> Vc<Self> {
         self.fs().root()
     }
+}
 
-    #[turbo_tasks::function]
+impl FileSystemPath {
     pub fn fs(&self) -> Vc<Box<dyn FileSystem>> {
         *self.fs
     }
 
-    #[turbo_tasks::function]
-    pub fn extension(&self) -> Vc<RcStr> {
-        Vc::cell(self.extension_ref().map(RcStr::from).unwrap_or_default())
+    pub fn extension(&self) -> &str {
+        self.extension_ref().unwrap_or_default()
     }
 
-    #[turbo_tasks::function]
-    pub async fn is_inside(&self, other: FileSystemPath) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.is_inside_ref(&*other.await?)))
+    pub fn is_inside(&self, other: &FileSystemPath) -> bool {
+        self.is_inside_ref(other)
     }
 
-    #[turbo_tasks::function]
-    pub async fn is_inside_or_equal(&self, other: FileSystemPath) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.is_inside_or_equal_ref(&*other.await?)))
+    pub fn is_inside_or_equal(&self, other: &FileSystemPath) -> bool {
+        self.is_inside_or_equal_ref(other)
     }
 
     /// Creates a new [`FileSystemPath`] like `self` but with the given
     /// extension.
-    #[turbo_tasks::function]
-    pub fn with_extension(&self, extension: RcStr) -> Vc<FileSystemPath> {
+    pub fn with_extension(&self, extension: &str) -> FileSystemPath {
         let (path_without_extension, _) = self.split_extension();
         Self::new_normalized(
-            *self.fs,
+            self.fs,
             // Like `Path::with_extension` and `PathBuf::set_extension`, if the extension is empty,
             // we remove the extension altogether.
             match extension.is_empty() {
@@ -1342,13 +1321,12 @@ impl FileSystemPath {
     /// * The entire file name if there is no embedded `.`;
     /// * The entire file name if the file name begins with `.` and has no other `.`s within;
     /// * Otherwise, the portion of the file name before the final `.`
-    #[turbo_tasks::function]
-    pub fn file_stem(&self) -> Vc<Option<RcStr>> {
+    pub fn file_stem(&self) -> Option<&str> {
         let (_, file_stem, _) = self.split_file_stem_extension();
         if file_stem.is_empty() {
-            return Vc::cell(None);
+            return None;
         }
-        Vc::cell(Some(file_stem.into()))
+        Some(file_stem)
     }
 }
 
@@ -1364,9 +1342,6 @@ pub async fn rebase(
     old_base: FileSystemPath,
     new_base: FileSystemPath,
 ) -> Result<Vc<FileSystemPath>> {
-    let fs_path = &*fs_path.await?;
-    let old_base = &*old_base.await?;
-    let new_base = &*new_base.await?;
     let new_path;
     if old_base.path.is_empty() {
         if new_base.path.is_empty() {
@@ -1392,48 +1367,48 @@ pub async fn rebase(
                 .into();
         }
     }
-    Ok(new_base.fs.root().join(new_path))
+    Ok(new_base.fs.root().await?.join(&new_path)?.cell())
 }
 
 // Not turbo-tasks functions, only delegating
 impl FileSystemPath {
-    pub fn read(self: Vc<Self>) -> Vc<FileContent> {
-        self.fs().read(self)
+    pub fn read(&self) -> Vc<FileContent> {
+        self.fs().read(self.clone())
     }
 
-    pub fn read_link(self: Vc<Self>) -> Vc<LinkContent> {
-        self.fs().read_link(self)
+    pub fn read_link(&self) -> Vc<LinkContent> {
+        self.fs().read_link(self.clone())
     }
 
-    pub fn read_json(self: Vc<Self>) -> Vc<FileJsonContent> {
-        self.fs().read(self).parse_json()
+    pub fn read_json(&self) -> Vc<FileJsonContent> {
+        self.fs().read(self.clone()).parse_json()
     }
 
-    pub fn read_json5(self: Vc<Self>) -> Vc<FileJsonContent> {
-        self.fs().read(self).parse_json5()
+    pub fn read_json5(&self) -> Vc<FileJsonContent> {
+        self.fs().read(self.clone()).parse_json5()
     }
 
     /// Reads content of a directory.
     ///
     /// DETERMINISM: Result is in random order. Either sort result or do not
     /// depend on the order.
-    pub fn raw_read_dir(self: Vc<Self>) -> Vc<RawDirectoryContent> {
-        self.fs().raw_read_dir(self)
+    pub fn raw_read_dir(&self) -> Vc<RawDirectoryContent> {
+        self.fs().raw_read_dir(self.clone())
     }
 
-    pub fn write(self: Vc<Self>, content: Vc<FileContent>) -> Vc<()> {
-        self.fs().write(self, content)
+    pub fn write(&self, content: Vc<FileContent>) -> Vc<()> {
+        self.fs().write(self.clone(), content)
     }
 
-    pub fn write_link(self: Vc<Self>, target: Vc<LinkContent>) -> Vc<()> {
-        self.fs().write_link(self, target)
+    pub fn write_link(&self, target: Vc<LinkContent>) -> Vc<()> {
+        self.fs().write_link(self.clone(), target)
     }
 
-    pub fn metadata(self: Vc<Self>) -> Vc<FileMeta> {
-        self.fs().metadata(self)
+    pub fn metadata(&self) -> Vc<FileMeta> {
+        self.fs().metadata(self.clone())
     }
 
-    pub fn realpath(self: Vc<Self>) -> Vc<FileSystemPath> {
+    pub fn realpath(&self) -> Vc<FileSystemPath> {
         self.realpath_with_links().path()
     }
 
@@ -1446,61 +1421,27 @@ impl FileSystemPath {
     }
 }
 
-#[turbo_tasks::value_impl]
 impl FileSystemPath {
     /// Reads content of a directory.
     ///
     /// DETERMINISM: Result is in random order. Either sort result or do not
     /// depend on the order.
-    #[turbo_tasks::function]
-    pub async fn read_dir(self: Vc<Self>) -> Result<Vc<DirectoryContent>> {
-        let this = self.await?;
-        let fs = this.fs;
-        match &*fs.raw_read_dir(self).await? {
-            RawDirectoryContent::NotFound => Ok(DirectoryContent::not_found()),
-            RawDirectoryContent::Entries(entries) => {
-                let mut normalized_entries = AutoMap::new();
-                let dir_path = &this.path;
-                for (name, entry) in entries {
-                    // Construct the path directly instead of going through `join`.
-                    // We do not need to normalize since the `name` is guaranteed to be a simple
-                    // path segment.
-                    let path = if dir_path.is_empty() {
-                        name.clone()
-                    } else {
-                        RcStr::from(format!("{dir_path}/{name}"))
-                    };
-
-                    let entry_path = Self::new_normalized(*fs, path).to_resolved().await?;
-                    let entry = match entry {
-                        RawDirectoryEntry::File => DirectoryEntry::File(entry_path),
-                        RawDirectoryEntry::Directory => DirectoryEntry::Directory(entry_path),
-                        RawDirectoryEntry::Symlink => DirectoryEntry::Symlink(entry_path),
-                        RawDirectoryEntry::Other => DirectoryEntry::Other(entry_path),
-                        RawDirectoryEntry::Error => DirectoryEntry::Error,
-                    };
-                    normalized_entries.insert(name.clone(), entry);
-                }
-                Ok(DirectoryContent::new(normalized_entries))
-            }
-        }
+    pub fn read_dir(&self) -> Vc<DirectoryContent> {
+        read_dir(self.clone())
     }
 
-    #[turbo_tasks::function]
-    pub async fn parent(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        let this = self.await?;
-        let path = &this.path;
+    pub fn parent(&self) -> FileSystemPath {
+        let path = &self.path;
         if path.is_empty() {
-            return Ok(self);
+            return self.clone();
         }
         let p = match str::rfind(path, '/') {
             Some(index) => path[..index].to_string(),
             None => "".to_string(),
         };
-        Ok(FileSystemPath::new_normalized(*this.fs, p.into()))
+        FileSystemPath::new_normalized(self.fs, p.into())
     }
 
-    #[turbo_tasks::function]
     // It is important that get_type uses read_dir and not stat/metadata.
     // - `get_type` is called very very often during resolving and stat would
     // make it 1 syscall per call, whereas read_dir would make it 1 syscall per
@@ -1509,109 +1450,12 @@ impl FileSystemPath {
     // case-insenstive filesystems, while read_dir gives you the "correct"
     // casing. We want to enforce "correct" casing to avoid broken builds on
     // Vercel deployments (case-sensitive).
-    pub async fn get_type(self: Vc<Self>) -> Result<Vc<FileSystemEntryType>> {
-        let this = self.await?;
-        if this.is_root() {
-            return Ok(FileSystemEntryType::cell(FileSystemEntryType::Directory));
-        }
-        let parent = self.parent().resolve().await?;
-        let dir_content = parent.raw_read_dir().await?;
-        match &*dir_content {
-            RawDirectoryContent::NotFound => {
-                Ok(FileSystemEntryType::cell(FileSystemEntryType::NotFound))
-            }
-            RawDirectoryContent::Entries(entries) => {
-                let (_, file_name) = this.split_file_name();
-                if let Some(entry) = entries.get(file_name) {
-                    Ok(FileSystemEntryType::cell(entry.into()))
-                } else {
-                    Ok(FileSystemEntryType::cell(FileSystemEntryType::NotFound))
-                }
-            }
-        }
+    pub fn get_type(&self) -> Vc<FileSystemEntryType> {
+        get_type(self.clone())
     }
 
-    #[turbo_tasks::function]
-    pub async fn realpath_with_links(self: ResolvedVc<Self>) -> Result<Vc<RealPathResult>> {
-        let mut current_vc = self;
-        let mut symlinks: IndexSet<FileSystemPath> = IndexSet::new();
-        let mut visited: AutoSet<RcStr> = AutoSet::new();
-        // Pick some arbitrary symlink depth limit... similar to the ELOOP logic for realpath(3).
-        // SYMLOOP_MAX is 40 for Linux: https://unix.stackexchange.com/q/721724
-        for _i in 0..40 {
-            let current = current_vc.await?;
-            if current.is_root() {
-                // fast path
-                return Ok(RealPathResult {
-                    path: self,
-                    symlinks: symlinks.into_iter().collect(),
-                }
-                .cell());
-            }
-
-            if !visited.insert(current.path.clone()) {
-                break; // we detected a cycle
-            }
-
-            // see if a parent segment of the path is a symlink and resolve that first
-            let parent = self.parent().to_resolved().await?;
-            let parent_result = parent.realpath_with_links().owned().await?;
-            let basename = current
-                .path
-                .rsplit_once('/')
-                .map_or(current.path.as_str(), |(_, name)| name);
-            if parent_result.path != parent {
-                current_vc = parent_result
-                    .path
-                    .join(basename.into())
-                    .to_resolved()
-                    .await?;
-            }
-            symlinks.extend(parent_result.symlinks);
-
-            // use `get_type` before trying `read_link`, as there's a good chance of a cache hit on
-            // `get_type`, and `read_link` isn't the common codepath.
-            if !matches!(*current_vc.get_type().await?, FileSystemEntryType::Symlink) {
-                return Ok(RealPathResult {
-                    path: current_vc,
-                    symlinks: symlinks.into_iter().collect(), // convert set to vec
-                }
-                .cell());
-            }
-
-            if let LinkContent::Link { target, link_type } = &*current_vc.read_link().await? {
-                symlinks.insert(current_vc);
-                current_vc = if link_type.contains(LinkType::ABSOLUTE) {
-                    current_vc.root()
-                } else {
-                    *parent_result.path
-                }
-                .join(target.clone())
-                .to_resolved()
-                .await?;
-            } else {
-                // get_type() and read_link() might disagree temporarily due to turbo-tasks
-                // eventual consistency or if the file gets invalidated before the directory does
-                return Ok(RealPathResult {
-                    path: current_vc,
-                    symlinks: symlinks.into_iter().collect(), // convert set to vec
-                }
-                .cell());
-            }
-        }
-
-        // Too many attempts or detected a cycle, we bailed out!
-        //
-        // TODO: There's no proper way to indicate an non-turbo-tasks error here, so just return the
-        // original path and all the symlinks we followed.
-        //
-        // Returning the followed symlinks is still important, even if there is an error! Otherwise
-        // we may never notice if the symlink loop is fixed.
-        Ok(RealPathResult {
-            path: self,
-            symlinks: symlinks.into_iter().collect(),
-        }
-        .cell())
+    pub fn realpath_with_links(&self) -> Vc<RealPathResult> {
+        realpath_with_links(self.clone())
     }
 }
 
@@ -1636,7 +1480,7 @@ pub struct RealPathResult {
 impl RealPathResult {
     #[turbo_tasks::function]
     pub fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 }
 
@@ -2249,9 +2093,7 @@ pub enum RawDirectoryEntry {
     Error,
 }
 
-#[derive(
-    Hash, Clone, Copy, Debug, PartialEq, Eq, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
-)]
+#[derive(Hash, Clone, Debug, PartialEq, Eq, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
 pub enum DirectoryEntry {
     File(FileSystemPath),
     Directory(FileSystemPath),
@@ -2265,8 +2107,8 @@ impl DirectoryEntry {
     /// type and replacing it with `DirectoryEntry::File` or
     /// `DirectoryEntry::Directory`.
     pub async fn resolve_symlink(self) -> Result<Self> {
-        if let DirectoryEntry::Symlink(symlink) = self {
-            let real_path = symlink.realpath().to_resolved().await?;
+        if let DirectoryEntry::Symlink(symlink) = &self {
+            let real_path = (*symlink.realpath().await?).clone();
             match *real_path.get_type().await? {
                 FileSystemEntryType::Directory => Ok(DirectoryEntry::Directory(real_path)),
                 FileSystemEntryType::File => Ok(DirectoryEntry::File(real_path)),
@@ -2429,7 +2271,7 @@ impl ValueToString for NullFileSystem {
 pub async fn to_sys_path(mut path: FileSystemPath) -> Result<Option<PathBuf>> {
     loop {
         if let Some(fs) = Vc::try_resolve_downcast_type::<AttachedFileSystem>(path.fs()).await? {
-            path = fs.get_inner_fs_path(path);
+            path = (*fs.get_inner_fs_path(path).await?).clone();
             continue;
         }
 
@@ -2440,6 +2282,135 @@ pub async fn to_sys_path(mut path: FileSystemPath) -> Result<Option<PathBuf>> {
 
         return Ok(None);
     }
+}
+
+#[turbo_tasks::function]
+async fn read_dir(path: FileSystemPath) -> Result<Vc<DirectoryContent>> {
+    let fs = path.fs().to_resolved().await?;
+    match &*fs.raw_read_dir(path.clone()).await? {
+        RawDirectoryContent::NotFound => Ok(DirectoryContent::not_found()),
+        RawDirectoryContent::Entries(entries) => {
+            let mut normalized_entries = AutoMap::new();
+            let dir_path = &path.path;
+            for (name, entry) in entries {
+                // Construct the path directly instead of going through `join`.
+                // We do not need to normalize since the `name` is guaranteed to be a simple
+                // path segment.
+                let path = if dir_path.is_empty() {
+                    name.clone()
+                } else {
+                    RcStr::from(format!("{dir_path}/{name}"))
+                };
+
+                let entry_path = FileSystemPath::new_normalized(fs, path);
+                let entry = match entry {
+                    RawDirectoryEntry::File => DirectoryEntry::File(entry_path),
+                    RawDirectoryEntry::Directory => DirectoryEntry::Directory(entry_path),
+                    RawDirectoryEntry::Symlink => DirectoryEntry::Symlink(entry_path),
+                    RawDirectoryEntry::Other => DirectoryEntry::Other(entry_path),
+                    RawDirectoryEntry::Error => DirectoryEntry::Error,
+                };
+                normalized_entries.insert(name.clone(), entry);
+            }
+            Ok(DirectoryContent::new(normalized_entries))
+        }
+    }
+}
+
+#[turbo_tasks::function]
+async fn get_type(path: FileSystemPath) -> Result<Vc<FileSystemEntryType>> {
+    if path.is_root() {
+        return Ok(FileSystemEntryType::Directory.cell());
+    }
+    let parent = path.parent();
+    let dir_content = parent.raw_read_dir().await?;
+    match &*dir_content {
+        RawDirectoryContent::NotFound => Ok(FileSystemEntryType::NotFound.cell()),
+        RawDirectoryContent::Entries(entries) => {
+            let (_, file_name) = path.split_file_name();
+            if let Some(entry) = entries.get(file_name) {
+                Ok(FileSystemEntryType::from(entry).cell())
+            } else {
+                Ok(FileSystemEntryType::NotFound.cell())
+            }
+        }
+    }
+}
+
+#[turbo_tasks::function]
+async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>> {
+    let mut current_vc = path.clone();
+    let mut symlinks: IndexSet<FileSystemPath> = IndexSet::new();
+    let mut visited: AutoSet<RcStr> = AutoSet::new();
+    // Pick some arbitrary symlink depth limit... similar to the ELOOP logic for realpath(3).
+    // SYMLOOP_MAX is 40 for Linux: https://unix.stackexchange.com/q/721724
+    for _i in 0..40 {
+        let current = current_vc.clone();
+        if current.is_root() {
+            // fast path
+            return Ok(RealPathResult {
+                path: current_vc,
+                symlinks: symlinks.into_iter().collect(),
+            }
+            .cell());
+        }
+
+        if !visited.insert(current.path.clone()) {
+            break; // we detected a cycle
+        }
+
+        // see if a parent segment of the path is a symlink and resolve that first
+        let parent = current_vc.parent();
+        let parent_result = parent.realpath_with_links().owned().await?;
+        let basename = current
+            .path
+            .rsplit_once('/')
+            .map_or(current.path.as_str(), |(_, name)| name);
+        if parent_result.path != parent {
+            current_vc = parent_result.path.join(basename)?;
+        }
+        symlinks.extend(parent_result.symlinks);
+
+        // use `get_type` before trying `read_link`, as there's a good chance of a cache hit on
+        // `get_type`, and `read_link` isn't the common codepath.
+        if !matches!(*current_vc.get_type().await?, FileSystemEntryType::Symlink) {
+            return Ok(RealPathResult {
+                path: current_vc,
+                symlinks: symlinks.into_iter().collect(), // convert set to vec
+            }
+            .cell());
+        }
+
+        if let LinkContent::Link { target, link_type } = &*current_vc.read_link().await? {
+            symlinks.insert(current_vc.clone());
+            current_vc = if link_type.contains(LinkType::ABSOLUTE) {
+                (*current_vc.root().await?).clone()
+            } else {
+                parent_result.path.join(target)?
+            };
+        } else {
+            // get_type() and read_link() might disagree temporarily due to turbo-tasks
+            // eventual consistency or if the file gets invalidated before the directory does
+            return Ok(RealPathResult {
+                path: current_vc,
+                symlinks: symlinks.into_iter().collect(), // convert set to vec
+            }
+            .cell());
+        }
+    }
+
+    // Too many attempts or detected a cycle, we bailed out!
+    //
+    // TODO: There's no proper way to indicate an non-turbo-tasks error here, so just return the
+    // original path and all the symlinks we followed.
+    //
+    // Returning the followed symlinks is still important, even if there is an error! Otherwise
+    // we may never notice if the symlink loop is fixed.
+    Ok(RealPathResult {
+        path,
+        symlinks: symlinks.into_iter().collect(),
+    }
+    .cell())
 }
 
 pub fn register() {
@@ -2474,32 +2445,31 @@ mod tests {
         crate::register();
 
         turbo_tasks_testing::VcStorage::with(async {
-            let fs = Vc::upcast(VirtualFileSystem::new());
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new())
+                .to_resolved()
+                .await?;
 
             let path_txt = FileSystemPath::new_normalized(fs, rcstr!("foo/bar.txt"));
 
-            let path_json = path_txt.with_extension(rcstr!("json"));
-            assert_eq!(&*path_json.await.unwrap().path, "foo/bar.json");
+            let path_json = path_txt.with_extension("json");
+            assert_eq!(&*path_json.path, "foo/bar.json");
 
-            let path_no_ext = path_txt.with_extension(rcstr!(""));
-            assert_eq!(&*path_no_ext.await.unwrap().path, "foo/bar");
+            let path_no_ext = path_txt.with_extension("");
+            assert_eq!(&*path_no_ext.path, "foo/bar");
 
-            let path_new_ext = path_no_ext.with_extension(rcstr!("json"));
-            assert_eq!(&*path_new_ext.await.unwrap().path, "foo/bar.json");
+            let path_new_ext = path_no_ext.with_extension("json");
+            assert_eq!(&*path_new_ext.path, "foo/bar.json");
 
             let path_no_slash_txt = FileSystemPath::new_normalized(fs, rcstr!("bar.txt"));
 
-            let path_no_slash_json = path_no_slash_txt.with_extension(rcstr!("json"));
-            assert_eq!(path_no_slash_json.await.unwrap().path.as_str(), "bar.json");
+            let path_no_slash_json = path_no_slash_txt.with_extension("json");
+            assert_eq!(path_no_slash_json.path.as_str(), "bar.json");
 
-            let path_no_slash_no_ext = path_no_slash_txt.with_extension(rcstr!(""));
-            assert_eq!(path_no_slash_no_ext.await.unwrap().path.as_str(), "bar");
+            let path_no_slash_no_ext = path_no_slash_txt.with_extension("");
+            assert_eq!(path_no_slash_no_ext.path.as_str(), "bar");
 
-            let path_no_slash_new_ext = path_no_slash_no_ext.with_extension(rcstr!("json"));
-            assert_eq!(
-                path_no_slash_new_ext.await.unwrap().path.as_str(),
-                "bar.json"
-            );
+            let path_no_slash_new_ext = path_no_slash_no_ext.with_extension("json");
+            assert_eq!(path_no_slash_new_ext.path.as_str(), "bar.json");
 
             anyhow::Ok(())
         })
@@ -2512,22 +2482,24 @@ mod tests {
         crate::register();
 
         turbo_tasks_testing::VcStorage::with(async {
-            let fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new());
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new())
+                .to_resolved()
+                .await?;
 
             let path = FileSystemPath::new_normalized(fs, rcstr!(""));
-            assert_eq!(path.file_stem().await.unwrap().as_deref(), None);
+            assert_eq!(path.file_stem(), None);
 
             let path = FileSystemPath::new_normalized(fs, rcstr!("foo/bar.txt"));
-            assert_eq!(path.file_stem().await.unwrap().as_deref(), Some("bar"));
+            assert_eq!(path.file_stem(), Some("bar"));
 
             let path = FileSystemPath::new_normalized(fs, rcstr!("bar.txt"));
-            assert_eq!(path.file_stem().await.unwrap().as_deref(), Some("bar"));
+            assert_eq!(path.file_stem(), Some("bar"));
 
             let path = FileSystemPath::new_normalized(fs, rcstr!("foo/bar"));
-            assert_eq!(path.file_stem().await.unwrap().as_deref(), Some("bar"));
+            assert_eq!(path.file_stem(), Some("bar"));
 
             let path = FileSystemPath::new_normalized(fs, rcstr!("foo/.bar"));
-            assert_eq!(path.file_stem().await.unwrap().as_deref(), Some(".bar"));
+            assert_eq!(path.file_stem(), Some(".bar"));
 
             anyhow::Ok(())
         })

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -106,7 +106,7 @@ async fn resolve_symlink_safely(entry: &DirectoryEntry) -> Result<DirectoryEntry
 ///  but unlike read_glob doesn't accumulate data.
 #[turbo_tasks::function(fs)]
 pub async fn track_glob(
-    directory: Vc<FileSystemPath>,
+    directory: FileSystemPath,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {
@@ -116,7 +116,7 @@ pub async fn track_glob(
 #[turbo_tasks::function(fs)]
 async fn track_glob_inner(
     prefix: RcStr,
-    directory: Vc<FileSystemPath>,
+    directory: FileSystemPath,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {
@@ -125,7 +125,7 @@ async fn track_glob_inner(
 
 async fn track_glob_internal(
     prefix: &str,
-    directory: Vc<FileSystemPath>,
+    directory: FileSystemPath,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {
@@ -328,13 +328,13 @@ pub mod tests {
     }
 
     #[turbo_tasks::function(operation)]
-    pub async fn delete(path: ResolvedVc<FileSystemPath>) -> anyhow::Result<()> {
+    pub async fn delete(path: FileSystemPath) -> anyhow::Result<()> {
         path.write(FileContent::NotFound.cell()).await?;
         Ok(())
     }
 
     #[turbo_tasks::function(operation)]
-    pub async fn write(path: ResolvedVc<FileSystemPath>, contents: RcStr) -> anyhow::Result<()> {
+    pub async fn write(path: FileSystemPath, contents: RcStr) -> anyhow::Result<()> {
         path.write(
             FileContent::Content(crate::File::from_bytes(contents.to_string().into_bytes())).cell(),
         )
@@ -343,7 +343,7 @@ pub mod tests {
     }
 
     #[turbo_tasks::function(operation)]
-    pub fn track_star_star_glob(path: ResolvedVc<FileSystemPath>) -> Vc<Completion> {
+    pub fn track_star_star_glob(path: FileSystemPath) -> Vc<Completion> {
         path.track_glob(Glob::new("**".into()), false)
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -17,17 +17,15 @@ pub struct ReadGlobResult {
 ///
 /// DETERMINISM: Result is in random order. Either sort result or do not depend
 /// on the order.
-pub async fn read_glob(
-    directory: Vc<FileSystemPath>,
-    glob: Vc<Glob>,
-) -> Result<Vc<ReadGlobResult>> {
+#[turbo_tasks::function(fs)]
+pub async fn read_glob(directory: FileSystemPath, glob: Vc<Glob>) -> Result<Vc<ReadGlobResult>> {
     read_glob_internal("", directory, glob).await
 }
 
 #[turbo_tasks::function(fs)]
 async fn read_glob_inner(
     prefix: RcStr,
-    directory: Vc<FileSystemPath>,
+    directory: FileSystemPath,
     glob: Vc<Glob>,
 ) -> Result<Vc<ReadGlobResult>> {
     read_glob_internal(&prefix, directory, glob).await
@@ -36,7 +34,7 @@ async fn read_glob_inner(
 // The `prefix` represents the relative directory path where symlinks are not resolve.
 async fn read_glob_internal(
     prefix: &str,
-    directory: Vc<FileSystemPath>,
+    directory: FileSystemPath,
     glob: Vc<Glob>,
 ) -> Result<Vc<ReadGlobResult>> {
     let dir = directory.read_dir().await?;
@@ -52,16 +50,16 @@ async fn read_glob_internal(
                 } else {
                     format!("{prefix}/{segment}").into()
                 };
-                let entry = resolve_symlink_safely(entry).await?;
+                let entry = resolve_symlink_safely(entry.clone()).await?;
                 if glob_value.matches(&entry_path) {
-                    result.results.insert(entry_path.to_string(), entry);
+                    result.results.insert(entry_path.to_string(), entry.clone());
                 }
                 if let DirectoryEntry::Directory(path) = entry
                     && glob_value.can_match_in_directory(&entry_path)
                 {
                     result.inner.insert(
                         entry_path.to_string(),
-                        read_glob_inner(entry_path, *path, glob)
+                        read_glob_inner(entry_path, path.clone(), glob)
                             .to_resolved()
                             .await?,
                     );
@@ -166,8 +164,7 @@ async fn track_glob_internal(
                         "resolve_symlink_safely() should have resolved all symlinks, but found \
                          unresolved symlink at path: '{}'. Found path: '{}'. Please report this \
                          as a bug.",
-                        entry_path,
-                        symlink_path.await?
+                        entry_path, symlink_path
                     ),
                     DirectoryEntry::Other(path) => {
                         if glob_value.matches(&entry_path) {
@@ -232,34 +229,34 @@ pub mod tests {
                 path,
                 Vec::new(),
             ));
-            let read_dir = fs.root().read_glob(Glob::new("**".into())).await.unwrap();
+            let read_dir = fs
+                .root()
+                .await?
+                .read_glob(Glob::new("**".into()))
+                .await
+                .unwrap();
             assert_eq!(read_dir.results.len(), 2);
             assert_eq!(
                 read_dir.results.get("foo"),
-                Some(&DirectoryEntry::File(
-                    fs.root().join("foo".into()).to_resolved().await?
-                ))
+                Some(&DirectoryEntry::File(fs.root().await?.join("foo")?))
             );
             assert_eq!(
                 read_dir.results.get("sub"),
-                Some(&DirectoryEntry::Directory(
-                    fs.root().join("sub".into()).to_resolved().await?
-                ))
+                Some(&DirectoryEntry::Directory(fs.root().await?.join("sub")?))
             );
             assert_eq!(read_dir.inner.len(), 1);
             let inner = &*read_dir.inner.get("sub").unwrap().await?;
             assert_eq!(inner.results.len(), 1);
             assert_eq!(
                 inner.results.get("sub/bar"),
-                Some(&DirectoryEntry::File(
-                    fs.root().join("sub/bar".into()).to_resolved().await?
-                ))
+                Some(&DirectoryEntry::File(fs.root().await?.join("sub/bar")?))
             );
             assert_eq!(inner.inner.len(), 0);
 
             // Now with a more specific pattern
             let read_dir = fs
                 .root()
+                .await?
                 .read_glob(Glob::new("**/bar".into()))
                 .await
                 .unwrap();
@@ -269,9 +266,7 @@ pub mod tests {
             assert_eq!(inner.results.len(), 1);
             assert_eq!(
                 inner.results.get("sub/bar"),
-                Some(&DirectoryEntry::File(
-                    fs.root().join("sub/bar".into()).to_resolved().await?
-                ))
+                Some(&DirectoryEntry::File(fs.root().await?.join("sub/bar")?))
             );
             assert_eq!(inner.inner.len(), 0);
 
@@ -308,13 +303,16 @@ pub mod tests {
                 path,
                 Vec::new(),
             ));
-            let read_dir = fs.root().read_glob(Glob::new("*.js".into())).await.unwrap();
+            let read_dir = fs
+                .root()
+                .await?
+                .read_glob(Glob::new("*.js".into()))
+                .await
+                .unwrap();
             assert_eq!(read_dir.results.len(), 1);
             assert_eq!(
                 read_dir.results.get("link.js"),
-                Some(&DirectoryEntry::File(
-                    fs.root().join("sub/foo.js".into()).to_resolved().await?
-                ))
+                Some(&DirectoryEntry::File(fs.root().await?.join("sub/foo.js")?))
             );
             assert_eq!(read_dir.inner.len(), 0);
 
@@ -526,6 +524,7 @@ pub mod tests {
             ));
             let err = fs
                 .root()
+                .await?
                 .read_glob(Glob::new("**".into()))
                 .await
                 .expect_err("Should have detected an infinite loop");
@@ -538,6 +537,7 @@ pub mod tests {
             // Same when calling track glob
             let err = fs
                 .root()
+                .await?
                 .track_glob(Glob::new("**".into()), false)
                 .await
                 .expect_err("Should have detected an infinite loop");

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -74,9 +74,9 @@ async fn read_glob_internal(
 }
 
 // Resolve a symlink checking for recursion.
-async fn resolve_symlink_safely(entry: &DirectoryEntry) -> Result<DirectoryEntry> {
-    let resolved_entry = entry.resolve_symlink().await?;
-    if resolved_entry != *entry && matches!(&resolved_entry, DirectoryEntry::Directory(_)) {
+async fn resolve_symlink_safely(entry: DirectoryEntry) -> Result<DirectoryEntry> {
+    let resolved_entry = entry.clone().resolve_symlink().await?;
+    if resolved_entry != entry && matches!(&resolved_entry, DirectoryEntry::Directory(_)) {
         // We followed a symlink to a directory
         // To prevent an infinite loop, which in the case of turbo-tasks would simply
         // exhaust RAM or go into an infinite loop with the GC we need to check for a
@@ -86,13 +86,10 @@ async fn resolve_symlink_safely(entry: &DirectoryEntry) -> Result<DirectoryEntry
         // ancestor of the current path, which can be detected via a simple prefix
         // match.
         let source_path = entry.path().unwrap();
-        if *source_path
-            .is_inside_or_equal(*resolved_entry.path().unwrap())
-            .await?
-        {
+        if source_path.is_inside_or_equal(&resolved_entry.clone().path().unwrap()) {
             bail!(
                 "'{}' is a symlink causes that causes an infinite loop!",
-                source_path.await?.path.to_string()
+                source_path.path.to_string()
             )
         }
     }
@@ -149,12 +146,12 @@ async fn track_glob_internal(
                     format!("{prefix}/{segment}").into()
                 };
 
-                match resolve_symlink_safely(entry).await? {
+                match resolve_symlink_safely(entry.clone()).await? {
                     DirectoryEntry::Directory(path) => {
                         if glob_value.can_match_in_directory(&entry_path) {
                             completions.push(track_glob_inner(
                                 entry_path,
-                                *path,
+                                path.clone(),
                                 glob,
                                 include_dot_files,
                             ));
@@ -162,7 +159,7 @@ async fn track_glob_internal(
                     }
                     DirectoryEntry::File(path) => {
                         if glob_value.matches(&entry_path) {
-                            reads.push(fs.read(*path))
+                            reads.push(fs.read(path.clone()))
                         }
                     }
                     DirectoryEntry::Symlink(symlink_path) => unreachable!(
@@ -200,7 +197,7 @@ pub mod tests {
     };
 
     use turbo_rcstr::RcStr;
-    use turbo_tasks::{Completion, ReadRef, ResolvedVc, Vc, apply_effects};
+    use turbo_tasks::{Completion, ReadRef, Vc, apply_effects};
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
     use crate::{
@@ -393,42 +390,42 @@ pub mod tests {
                 path,
                 Vec::new(),
             ));
-            let dir = fs.root().join("dir".into()).to_resolved().await?;
-            let read_dir = track_star_star_glob(dir).read_strongly_consistent().await?;
+            let dir = fs.root().await?.join("dir")?;
+            let read_dir = track_star_star_glob(dir.clone())
+                .read_strongly_consistent()
+                .await?;
 
             // Delete a file that we shouldn't be tracking
-            let delete_result = delete(
-                fs.root()
-                    .join("dir/sub/.vim/.gitignore".into())
-                    .to_resolved()
-                    .await?,
-            );
+            let delete_result = delete(fs.root().await?.join("dir/sub/.vim/.gitignore")?);
             delete_result.read_strongly_consistent().await?;
             apply_effects(delete_result).await?;
 
-            let read_dir2 = track_star_star_glob(dir).read_strongly_consistent().await?;
+            let read_dir2 = track_star_star_glob(dir.clone())
+                .read_strongly_consistent()
+                .await?;
             assert!(ReadRef::ptr_eq(&read_dir, &read_dir2));
 
             // Delete a file that we should be tracking
-            let delete_result = delete(fs.root().join("dir/foo".into()).to_resolved().await?);
+            let delete_result = delete(fs.root().await?.join("dir/foo")?);
             delete_result.read_strongly_consistent().await?;
             apply_effects(delete_result).await?;
 
-            let read_dir2 = track_star_star_glob(dir).read_strongly_consistent().await?;
+            let read_dir2 = track_star_star_glob(dir.clone())
+                .read_strongly_consistent()
+                .await?;
 
             assert!(!ReadRef::ptr_eq(&read_dir, &read_dir2));
 
             // Modify a symlink target file
             let write_result = write(
-                fs.root()
-                    .join("link_target.js".into())
-                    .to_resolved()
-                    .await?,
+                fs.root().await?.join("link_target.js")?,
                 "new_contents".into(),
             );
             write_result.read_strongly_consistent().await?;
             apply_effects(write_result).await?;
-            let read_dir3 = track_star_star_glob(dir).read_strongly_consistent().await?;
+            let read_dir3 = track_star_star_glob(dir.clone())
+                .read_strongly_consistent()
+                .await?;
 
             assert!(!ReadRef::ptr_eq(&read_dir3, &read_dir2));
 
@@ -469,6 +466,7 @@ pub mod tests {
             ));
             let err = fs
                 .root()
+                .await?
                 .track_glob(Glob::new("**".into()), false)
                 .await
                 .expect_err("Should have detected an infinite loop");
@@ -481,6 +479,7 @@ pub mod tests {
             // Same when calling track glob
             let err = fs
                 .root()
+                .await?
                 .track_glob(Glob::new("**".into()), false)
                 .await
                 .expect_err("Should have detected an infinite loop");

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -138,7 +138,7 @@ pub fn extract_disk_access<T>(value: io::Result<T>, path: &Path) -> Result<Optio
 }
 
 #[cfg(not(target_os = "windows"))]
-pub async fn uri_from_file(root: Vc<FileSystemPath>, path: Option<&str>) -> Result<String> {
+pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
     let root_fs = root.fs();
     let root_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(root_fs)
         .await?
@@ -164,7 +164,7 @@ pub async fn uri_from_file(root: Vc<FileSystemPath>, path: Option<&str>) -> Resu
 }
 
 #[cfg(target_os = "windows")]
-pub async fn uri_from_file(root: Vc<FileSystemPath>, path: Option<&str>) -> Result<String> {
+pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
     let root_fs = root.fs();
     let root_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(root_fs)
         .await?

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -150,7 +150,7 @@ pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<S
         &sys_to_unix(
             &root_fs
                 .to_sys_path(match path {
-                    Some(path) => root.join(path.into()),
+                    Some(path) => root.join(path)?,
                     None => root,
                 })
                 .await?

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -173,7 +173,7 @@ pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<S
 
     let sys_path = root_fs
         .to_sys_path(match path {
-            Some(path) => root.join(path.into()),
+            Some(path) => root.join(path.into())?,
             None => root,
         })
         .await?;

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -15,9 +15,9 @@ impl VirtualFileSystem {
     ///
     /// NOTE: This function is not a `turbo_tasks::function` to avoid instances
     /// being equivalent identity-wise. This ensures that a
-    /// [`Vc<FileSystemPath>`] created from this [`Vc<VirtualFileSystem>`]
+    /// [`FileSystemPath`] created from this [`Vc<VirtualFileSystem>`]
     /// will never be equivalent, nor be interoperable, with a
-    /// [`Vc<FileSystemPath>`] created from another
+    /// [`FileSystemPath`] created from another
     /// [`Vc<VirtualFileSystem>`].
     pub fn new() -> Vc<Self> {
         Self::cell(VirtualFileSystem {
@@ -29,9 +29,9 @@ impl VirtualFileSystem {
     ///
     /// NOTE: This function is not a `turbo_tasks::function` to avoid instances
     /// being equivalent identity-wise. This ensures that a
-    /// [`Vc<FileSystemPath>`] created from this [`Vc<VirtualFileSystem>`]
+    /// [`FileSystemPath`] created from this [`Vc<VirtualFileSystem>`]
     /// will never be equivalent, nor be interoperable, with a
-    /// [`Vc<FileSystemPath>`] created from another
+    /// [`FileSystemPath`] created from another
     /// [`Vc<VirtualFileSystem>`].
     pub fn new_with_name(name: RcStr) -> Vc<Self> {
         Self::cell(VirtualFileSystem { name })
@@ -47,32 +47,32 @@ impl ValueDefault for VirtualFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for VirtualFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
+    fn read(&self, _fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<LinkContent>> {
+    fn read_link(&self, _fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
+    fn metadata(&self, _fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
         bail!("Reading is not possible on the virtual file system")
     }
 }

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -153,7 +153,7 @@ fn disk_file_system_root_operation(fs: ResolvedVc<DiskFileSystem>) -> Vc<FileSys
 #[turbo_tasks::function]
 async fn read_path(
     invalidations: TransientInstance<PathInvalidations>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 ) -> anyhow::Result<()> {
     let path_str = path.await?.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
@@ -164,13 +164,13 @@ async fn read_path(
 #[turbo_tasks::function(operation)]
 async fn read_all_paths_operation(
     invalidations: TransientInstance<PathInvalidations>,
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
     depth: usize,
     width: usize,
 ) -> anyhow::Result<()> {
     async fn read_all_paths_inner(
         invalidations: TransientInstance<PathInvalidations>,
-        parent: ResolvedVc<FileSystemPath>,
+        parent: FileSystemPath,
         depth: usize,
         width: usize,
     ) -> anyhow::Result<()> {

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -82,9 +82,11 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
         let project_fs = disk_file_system_operation(fs_root_rcstr.clone())
             .resolve_strongly_consistent()
             .await?;
-        let project_root = disk_file_system_root_operation(project_fs)
+        let project_root = (*disk_file_system_root_operation(project_fs)
             .resolve_strongly_consistent()
-            .await?;
+            .await?
+            .await?)
+            .clone();
         create_directory_tree(&mut FxHashSet::default(), &fs_root, args.depth, args.width)?;
 
         project_fs.await?.start_watching(None).await?;
@@ -155,7 +157,7 @@ async fn read_path(
     invalidations: TransientInstance<PathInvalidations>,
     path: FileSystemPath,
 ) -> anyhow::Result<()> {
-    let path_str = path.await?.path.clone();
+    let path_str = path.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
     let _ = path.read().await?;
     Ok(())
@@ -175,10 +177,10 @@ async fn read_all_paths_operation(
         width: usize,
     ) -> anyhow::Result<()> {
         for child_id in 0..width {
-            let child_name = RcStr::from(child_id.to_string());
-            let child_path = parent.join(child_name).to_resolved().await?;
+            let child_name = child_id.to_string();
+            let child_path = parent.join(&child_name)?;
             if depth == 1 {
-                read_path(invalidations.clone(), *child_path).await?;
+                read_path(invalidations.clone(), child_path).await?;
             } else {
                 Box::pin(read_all_paths_inner(
                     invalidations.clone(),

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -42,6 +42,15 @@ where
     }
 }
 
+impl<T> ReadRef<T>
+where
+    T: VcValueType + Clone,
+{
+    pub fn clone_value(&self) -> VcReadTarget<T> {
+        T::Read::value_to_target((*self.0).clone())
+    }
+}
+
 impl<T> Display for ReadRef<T>
 where
     T: VcValueType,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -181,19 +181,19 @@ impl BrowserChunkingContextBuilder {
 pub struct BrowserChunkingContext {
     name: Option<RcStr>,
     /// The root path of the project
-    root_path: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
     /// Whether to write file sources as file:// paths in source maps
     should_use_file_source_map_uris: bool,
     /// This path is used to compute the url to request chunks from
-    output_root: ResolvedVc<FileSystemPath>,
+    output_root: FileSystemPath,
     /// The relative path from the output_root to the root_path.
     output_root_to_root_path: RcStr,
     /// This path is used to compute the url to request assets from
-    client_root: ResolvedVc<FileSystemPath>,
+    client_root: FileSystemPath,
     /// Chunks are placed at this path
-    chunk_root_path: ResolvedVc<FileSystemPath>,
+    chunk_root_path: FileSystemPath,
     /// Static assets are placed at this path
-    asset_root_path: ResolvedVc<FileSystemPath>,
+    asset_root_path: FileSystemPath,
     /// Base path that will be prepended to all chunk URLs when loading them.
     /// This path will not appear in chunk paths or chunk data.
     chunk_base_path: Option<RcStr>,
@@ -231,12 +231,12 @@ pub struct BrowserChunkingContext {
 
 impl BrowserChunkingContext {
     pub fn builder(
-        root_path: ResolvedVc<FileSystemPath>,
-        output_root: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
+        output_root: FileSystemPath,
         output_root_to_root_path: RcStr,
-        client_root: ResolvedVc<FileSystemPath>,
-        chunk_root_path: ResolvedVc<FileSystemPath>,
-        asset_root_path: ResolvedVc<FileSystemPath>,
+        client_root: FileSystemPath,
+        chunk_root_path: FileSystemPath,
+        asset_root_path: FileSystemPath,
         environment: ResolvedVc<Environment>,
         runtime_type: RuntimeType,
     ) -> BrowserChunkingContextBuilder {
@@ -439,7 +439,7 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn asset_url(&self, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
+    async fn asset_url(&self, ident: FileSystemPath) -> Result<Vc<RcStr>> {
         let asset_path = ident.await?.to_string();
         let asset_path = asset_path
             .strip_prefix(&format!("{}/", self.client_root.await?.path))
@@ -668,7 +668,7 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     fn entry_chunk_group(
         self: Vc<Self>,
-        _path: Vc<FileSystemPath>,
+        _path: FileSystemPath,
         _evaluatable_assets: Vc<EvaluatableAssets>,
         _module_graph: Vc<ModuleGraph>,
         _extra_chunks: Vc<OutputAssets>,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -376,12 +376,12 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     fn root_path(&self) -> Vc<FileSystemPath> {
-        *self.root_path
+        self.root_path.clone().cell()
     }
 
     #[turbo_tasks::function]
     fn output_root(&self) -> Vc<FileSystemPath> {
-        *self.output_root
+        self.output_root.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -396,7 +396,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     fn chunk_root_path(&self) -> Vc<FileSystemPath> {
-        *self.chunk_root_path
+        self.chunk_root_path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -410,11 +410,11 @@ impl ChunkingContext for BrowserChunkingContext {
             extension.starts_with("."),
             "`extension` should include the leading '.', got '{extension}'"
         );
-        let root_path = self.chunk_root_path;
+        let root_path = self.chunk_root_path.clone();
         let name = match self.content_hashing {
             None => {
                 ident
-                    .output_name(*self.root_path, extension)
+                    .output_name(self.root_path.clone(), extension)
                     .owned()
                     .await?
             }
@@ -435,14 +435,14 @@ impl ChunkingContext for BrowserChunkingContext {
                 }
             }
         };
-        Ok(root_path.join(name))
+        Ok(root_path.join(&name)?.cell())
     }
 
     #[turbo_tasks::function]
     async fn asset_url(&self, ident: FileSystemPath) -> Result<Vc<RcStr>> {
-        let asset_path = ident.await?.to_string();
+        let asset_path = ident.to_string();
         let asset_path = asset_path
-            .strip_prefix(&format!("{}/", self.client_root.await?.path))
+            .strip_prefix(&format!("{}/", self.client_root.path))
             .context("expected asset_path to contain client_root")?;
 
         Ok(Vc::cell(
@@ -493,7 +493,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 content_hash = &content_hash[..8]
             ),
         };
-        Ok(self.asset_root_path.join(asset_path.into()))
+        Ok(self.asset_root_path.join(&asset_path)?.cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -60,12 +60,12 @@ impl EcmascriptBrowserChunkContent {
 #[turbo_tasks::value_impl]
 impl EcmascriptBrowserChunkContent {
     #[turbo_tasks::function]
-    pub(crate) fn own_version(&self) -> Vc<EcmascriptBrowserChunkVersion> {
-        EcmascriptBrowserChunkVersion::new(
-            self.chunking_context.output_root(),
-            self.chunk.path(),
+    pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBrowserChunkVersion>> {
+        Ok(EcmascriptBrowserChunkVersion::new(
+            self.chunking_context.output_root().await?.clone_value(),
+            self.chunk.path().await?.clone_value(),
             *self.content,
-        )
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -68,8 +68,11 @@ impl EcmascriptBrowserEvaluateChunk {
     }
 
     #[turbo_tasks::function]
-    fn chunks_data(&self) -> Vc<ChunksData> {
-        ChunkData::from_assets(self.chunking_context.output_root(), *self.other_chunks)
+    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        Ok(ChunkData::from_assets(
+            self.chunking_context.output_root().await?.clone_value(),
+            *self.other_chunks,
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -18,8 +18,8 @@ pub(super) struct EcmascriptBrowserChunkVersion {
 impl EcmascriptBrowserChunkVersion {
     #[turbo_tasks::function]
     pub async fn new(
-        output_root: Vc<FileSystemPath>,
-        chunk_path: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
+        chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {
         let output_root = output_root.await?;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -22,8 +22,8 @@ impl EcmascriptBrowserChunkVersion {
         chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {
-        let output_root = output_root.await?;
-        let chunk_path = chunk_path.await?;
+        let output_root = output_root.clone();
+        let chunk_path = chunk_path.clone();
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -48,7 +48,7 @@ impl ResolveReactRefreshResult {
 /// given path. Emits an issue if we can't.
 #[turbo_tasks::function]
 pub async fn assert_can_resolve_react_refresh(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     resolve_options_context: Vc<ResolveOptionsContext>,
 ) -> Result<Vc<ResolveReactRefreshResult>> {
     let resolve_options = apply_cjs_specific_options(turbopack_resolve::resolve::resolve_options(
@@ -75,7 +75,7 @@ pub async fn assert_can_resolve_react_refresh(
 /// An issue that occurred while resolving the React Refresh runtime module.
 #[turbo_tasks::value(shared)]
 pub struct ReactRefreshResolvingIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -52,12 +52,12 @@ pub async fn assert_can_resolve_react_refresh(
     resolve_options_context: Vc<ResolveOptionsContext>,
 ) -> Result<Vc<ResolveReactRefreshResult>> {
     let resolve_options = apply_cjs_specific_options(turbopack_resolve::resolve::resolve_options(
-        *path,
+        path.clone(),
         resolve_options_context,
     ));
     for request in [react_refresh_request_in_next(), react_refresh_request()] {
         let result = turbopack_core::resolve::resolve(
-            *path,
+            path.clone(),
             ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
             request,
             resolve_options,
@@ -96,7 +96,7 @@ impl Issue for ReactRefreshResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -12,7 +12,7 @@ use turbopack_resolve::ecmascript::cjs_resolve;
 
 #[turbo_tasks::value(shared)]
 pub enum RuntimeEntry {
-    Request(ResolvedVc<Request>, ResolvedVc<FileSystemPath>),
+    Request(ResolvedVc<Request>, FileSystemPath),
     Evaluatable(ResolvedVc<Box<dyn EvaluatableAsset>>),
     Source(ResolvedVc<Box<dyn Source>>),
 }

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -21,11 +21,11 @@ pub enum RuntimeEntry {
 impl RuntimeEntry {
     #[turbo_tasks::function]
     pub async fn resolve_entry(
-        self: Vc<Self>,
+        &self,
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
-        let (request, path) = match *self.await? {
-            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(*e)),
+        let (request, path) = match self {
+            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(**e)),
             RuntimeEntry::Source(source) => {
                 return Ok(EvaluatableAssets::one(source.to_evaluatable(asset_context)));
             }
@@ -33,8 +33,8 @@ impl RuntimeEntry {
         };
 
         let modules = cjs_resolve(
-            Vc::upcast(PlainResolveOrigin::new(asset_context, *path)),
-            *request,
+            Vc::upcast(PlainResolveOrigin::new(asset_context, path.clone())),
+            **request,
             None,
             false,
         )

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -49,9 +49,7 @@ async fn foreign_code_context_condition() -> Result<ContextCondition> {
 }
 
 #[turbo_tasks::function]
-pub async fn get_client_import_map(
-    project_path: ResolvedVc<FileSystemPath>,
-) -> Result<Vc<ImportMap>> {
+pub async fn get_client_import_map(project_path: FileSystemPath) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
     import_map.insert_singleton_alias("@swc/helpers", project_path);
@@ -78,7 +76,7 @@ pub async fn get_client_import_map(
 
 #[turbo_tasks::function]
 pub async fn get_client_resolve_options_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_client_import_map = get_client_import_map(project_path).to_resolved().await?;
@@ -104,7 +102,7 @@ pub async fn get_client_resolve_options_context(
 
 #[turbo_tasks::function]
 async fn get_client_module_options_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: ResolvedVc<ExecutionContext>,
     env: ResolvedVc<Environment>,
     node_env: Vc<NodeEnv>,
@@ -173,7 +171,7 @@ async fn get_client_module_options_context(
 
 #[turbo_tasks::function]
 pub fn get_client_asset_context(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     execution_context: Vc<ExecutionContext>,
     compile_time_info: Vc<CompileTimeInfo>,
     node_env: Vc<NodeEnv>,

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -52,10 +52,10 @@ async fn foreign_code_context_condition() -> Result<ContextCondition> {
 pub async fn get_client_import_map(project_path: FileSystemPath) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
-    import_map.insert_singleton_alias("@swc/helpers", project_path);
-    import_map.insert_singleton_alias("styled-jsx", project_path);
-    import_map.insert_singleton_alias("react", project_path);
-    import_map.insert_singleton_alias("react-dom", project_path);
+    import_map.insert_singleton_alias("@swc/helpers", project_path.clone());
+    import_map.insert_singleton_alias("styled-jsx", project_path.clone());
+    import_map.insert_singleton_alias("react", project_path.clone());
+    import_map.insert_singleton_alias("react-dom", project_path.clone());
 
     import_map.insert_wildcard_alias(
         "@vercel/turbopack-ecmascript-runtime/",
@@ -64,8 +64,8 @@ pub async fn get_client_import_map(project_path: FileSystemPath) -> Result<Vc<Im
             Some(
                 turbopack_ecmascript_runtime::embed_fs()
                     .root()
-                    .to_resolved()
-                    .await?,
+                    .await?
+                    .clone_value(),
             ),
         )
         .resolved_cell(),
@@ -79,9 +79,11 @@ pub async fn get_client_resolve_options_context(
     project_path: FileSystemPath,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<ResolveOptionsContext>> {
-    let next_client_import_map = get_client_import_map(project_path).to_resolved().await?;
+    let next_client_import_map = get_client_import_map(project_path.clone())
+        .to_resolved()
+        .await?;
     let module_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().to_resolved().await?),
+        enable_node_modules: Some(project_path.root().await?.clone_value()),
         custom_conditions: vec![node_env.await?.to_string().into(), "browser".into()],
         import_map: Some(next_client_import_map),
         browser: true,
@@ -117,10 +119,11 @@ async fn get_client_module_options_context(
         ..Default::default()
     };
 
-    let resolve_options_context = get_client_resolve_options_context(project_path, node_env);
+    let resolve_options_context =
+        get_client_resolve_options_context(project_path.clone(), node_env);
 
     let enable_react_refresh = is_dev
-        && assert_can_resolve_react_refresh(project_path, resolve_options_context)
+        && assert_can_resolve_react_refresh(project_path.clone(), resolve_options_context)
             .await?
             .is_found();
 
@@ -177,7 +180,8 @@ pub fn get_client_asset_context(
     node_env: Vc<NodeEnv>,
     source_maps_type: SourceMapsType,
 ) -> Vc<Box<dyn AssetContext>> {
-    let resolve_options_context = get_client_resolve_options_context(project_path, node_env);
+    let resolve_options_context =
+        get_client_resolve_options_context(project_path.clone(), node_env);
     let module_options_context = get_client_module_options_context(
         project_path,
         execution_context,

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -34,8 +34,8 @@ use crate::{
 
 #[turbo_tasks::function]
 pub async fn get_client_chunking_context(
-    root_path: ResolvedVc<FileSystemPath>,
-    server_root: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
+    server_root: FileSystemPath,
     server_root_to_root_path: RcStr,
     environment: ResolvedVc<Environment>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
@@ -58,7 +58,7 @@ pub async fn get_client_chunking_context(
 
 #[turbo_tasks::function]
 pub async fn get_client_runtime_entries(
-    project_path: ResolvedVc<FileSystemPath>,
+    project_path: FileSystemPath,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<RuntimeEntries>> {
     let resolve_options_context = get_client_resolve_options_context(*project_path, node_env);
@@ -96,10 +96,10 @@ pub async fn get_client_runtime_entries(
 
 #[turbo_tasks::function]
 pub async fn create_web_entry_source(
-    root_path: Vc<FileSystemPath>,
+    root_path: FileSystemPath,
     execution_context: Vc<ExecutionContext>,
     entry_requests: Vec<Vc<Request>>,
-    server_root: Vc<FileSystemPath>,
+    server_root: FileSystemPath,
     server_root_to_root_path: RcStr,
     _env: Vc<Box<dyn ProcessEnv>>,
     eager_compile: bool,

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -42,11 +42,11 @@ pub async fn get_client_chunking_context(
     Ok(Vc::upcast(
         BrowserChunkingContext::builder(
             root_path,
-            server_root,
+            server_root.clone(),
             server_root_to_root_path,
-            server_root,
-            server_root.join(rcstr!("/_chunks")).to_resolved().await?,
-            server_root.join(rcstr!("/_assets")).to_resolved().await?,
+            server_root.clone(),
+            server_root.join("/_chunks")?,
+            server_root.join("/_assets")?,
             environment,
             RuntimeType::Development,
         )
@@ -61,12 +61,13 @@ pub async fn get_client_runtime_entries(
     project_path: FileSystemPath,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<RuntimeEntries>> {
-    let resolve_options_context = get_client_resolve_options_context(*project_path, node_env);
+    let resolve_options_context =
+        get_client_resolve_options_context(project_path.clone(), node_env);
 
     let mut runtime_entries = Vec::new();
 
     let enable_react_refresh =
-        assert_can_resolve_react_refresh(*project_path, resolve_options_context)
+        assert_can_resolve_react_refresh(project_path.clone(), resolve_options_context)
             .await?
             .as_request();
     // It's important that React Refresh come before the regular bootstrap file,
@@ -74,19 +75,20 @@ pub async fn get_client_runtime_entries(
     // functions to be available.
     if let Some(request) = enable_react_refresh {
         runtime_entries.push(
-            RuntimeEntry::Request(
-                request.to_resolved().await?,
-                project_path.join(rcstr!("_")).to_resolved().await?,
-            )
-            .resolved_cell(),
+            RuntimeEntry::Request(request.to_resolved().await?, project_path.join("_")?)
+                .resolved_cell(),
         )
     };
 
     runtime_entries.push(
         RuntimeEntry::Source(ResolvedVc::upcast(
-            FileSource::new(embed_file_path(rcstr!("entry/bootstrap.ts")))
-                .to_resolved()
-                .await?,
+            FileSource::new(
+                embed_file_path(rcstr!("entry/bootstrap.ts"))
+                    .await?
+                    .clone_value(),
+            )
+            .to_resolved()
+            .await?,
         ))
         .resolved_cell(),
     );
@@ -109,31 +111,31 @@ pub async fn create_web_entry_source(
 ) -> Result<Vc<Box<dyn ContentSource>>> {
     let compile_time_info = get_client_compile_time_info(browserslist_query, node_env);
     let asset_context = get_client_asset_context(
-        root_path,
+        root_path.clone(),
         execution_context,
         compile_time_info,
         node_env,
         source_maps_type,
     );
     let chunking_context = get_client_chunking_context(
-        root_path,
-        server_root,
+        root_path.clone(),
+        server_root.clone(),
         server_root_to_root_path,
         compile_time_info.environment(),
     )
     .to_resolved()
     .await?;
-    let entries = get_client_runtime_entries(root_path, node_env);
+    let entries = get_client_runtime_entries(root_path.clone(), node_env);
 
     let runtime_entries = entries.resolve_entries(asset_context);
 
-    let origin = PlainResolveOrigin::new(asset_context, root_path.join(rcstr!("_")));
+    let origin = PlainResolveOrigin::new(asset_context, root_path.join("_")?);
     let entries = entry_requests
         .into_iter()
         .map(|request| async move {
             let ty = ReferenceType::Entry(EntryReferenceSubType::Web);
             Ok(origin
-                .resolve_asset(request, origin.resolve_options(ty.clone()), ty)
+                .resolve_asset(request, origin.resolve_options(ty.clone()).await?, ty)
                 .await?
                 .resolve()
                 .await?
@@ -195,10 +197,7 @@ pub async fn create_web_entry_source(
         .try_join()
         .await?;
 
-    let entry_asset = Vc::upcast(DevHtmlAsset::new(
-        server_root.join(rcstr!("index.html")).to_resolved().await?,
-        entries,
-    ));
+    let entry_asset = Vc::upcast(DevHtmlAsset::new(server_root.join("index.html")?, entries));
 
     let graph = Vc::upcast(if eager_compile {
         AssetGraphContentSource::new_eager(server_root, entry_asset)

--- a/turbopack/crates/turbopack-cli/src/embed_js.rs
+++ b/turbopack/crates/turbopack-cli/src/embed_js.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath, embed_directory};
@@ -8,11 +9,11 @@ fn embed_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file(path: RcStr) -> Vc<FileContent> {
-    embed_fs().root().join(path).read()
+pub(crate) async fn embed_file(path: RcStr) -> Result<Vc<FileContent>> {
+    Ok(embed_fs().root().await?.join(&path)?.read())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file_path(path: RcStr) -> Vc<FileSystemPath> {
-    embed_fs().root().join(path)
+pub(crate) async fn embed_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(embed_fs().root().await?.join(&path)?.cell())
 }

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -88,7 +88,7 @@ impl AssetContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn write(self: Vc<Self>, path: Vc<FileSystemPath>) -> Result<()> {
+    pub async fn write(self: Vc<Self>, path: FileSystemPath) -> Result<()> {
         let this = self.await?;
         match &*this {
             AssetContent::File(file) => {

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -192,7 +192,7 @@ pub trait ChunkingContext {
     /// Returns a URL (relative or absolute, depending on the asset prefix) to
     /// the static asset based on its `ident`.
     #[turbo_tasks::function]
-    fn asset_url(self: Vc<Self>, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>>;
+    fn asset_url(self: Vc<Self>, ident: FileSystemPath) -> Result<Vc<RcStr>>;
 
     #[turbo_tasks::function]
     fn asset_path(
@@ -271,7 +271,7 @@ pub trait ChunkingContext {
     #[turbo_tasks::function]
     fn entry_chunk_group(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -325,7 +325,7 @@ pub trait ChunkingContextExt {
 
     fn entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -336,7 +336,7 @@ pub trait ChunkingContextExt {
 
     fn root_entry_chunk_group(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -346,7 +346,7 @@ pub trait ChunkingContextExt {
 
     fn root_entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -402,7 +402,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
 
     fn entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -420,7 +420,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
 
     fn root_entry_chunk_group(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -436,7 +436,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
 
     fn root_entry_chunk_group_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
@@ -498,7 +498,7 @@ async fn evaluated_chunk_group_assets(
 #[turbo_tasks::function]
 async fn entry_chunk_group_asset(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    path: Vc<FileSystemPath>,
+    path: FileSystemPath,
     evaluatable_assets: Vc<EvaluatableAssets>,
     module_graph: Vc<ModuleGraph>,
     extra_chunks: Vc<OutputAssets>,

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -63,7 +63,7 @@ impl ChunkData {
 
     #[turbo_tasks::function]
     pub async fn from_asset(
-        output_root: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
         chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<ChunkDataOption>> {
         let output_root = output_root.await?;
@@ -147,7 +147,7 @@ impl ChunkData {
 
     #[turbo_tasks::function]
     pub async fn from_assets(
-        output_root: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
         chunks: Vc<OutputAssets>,
     ) -> Result<Vc<ChunksData>> {
         Ok(Vc::cell(

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -66,7 +66,6 @@ impl ChunkData {
         output_root: FileSystemPath,
         chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<ChunkDataOption>> {
-        let output_root = output_root.await?;
         let path = chunk.path().await?;
         // The "path" in this case is the chunk's path, not the chunk item's path.
         // The difference is a chunk is a file served by the dev server, and an
@@ -154,7 +153,7 @@ impl ChunkData {
             chunks
                 .await?
                 .iter()
-                .map(|&chunk| ChunkData::from_asset(output_root, *chunk))
+                .map(|&chunk| ChunkData::from_asset(output_root.clone(), *chunk))
                 .try_join()
                 .await?
                 .into_iter()

--- a/turbopack/crates/turbopack-core/src/chunk/optimize.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/optimize.rs
@@ -10,10 +10,10 @@ use turbo_tasks_fs::{FileSystemPath, FileSystemPathOption};
 use crate::chunk::containment_tree::{ContainmentTree, ContainmentTreeKey};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-struct FileSystemPathKey(ResolvedVc<FileSystemPath>);
+struct FileSystemPathKey(FileSystemPath);
 
 impl FileSystemPathKey {
-    async fn new(path: Vc<FileSystemPath>) -> Result<Self> {
+    async fn new(path: FileSystemPath) -> Result<Self> {
         Ok(Self(path.to_resolved().await?))
     }
 }

--- a/turbopack/crates/turbopack-core/src/chunk/optimize.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/optimize.rs
@@ -4,7 +4,7 @@
 //! their size and eliminating duplicates between them.
 
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{TryJoinIterExt, Vc};
 use turbo_tasks_fs::{FileSystemPath, FileSystemPathOption};
 
 use crate::chunk::containment_tree::{ContainmentTree, ContainmentTreeKey};
@@ -14,7 +14,7 @@ struct FileSystemPathKey(FileSystemPath);
 
 impl FileSystemPathKey {
     async fn new(path: FileSystemPath) -> Result<Self> {
-        Ok(Self(path.to_resolved().await?))
+        Ok(Self(path))
     }
 }
 
@@ -45,7 +45,7 @@ where
 
                     Ok((
                         if let Some(common_parent) = &*common_parent {
-                            Some(FileSystemPathKey::new(**common_parent).await?)
+                            Some(FileSystemPathKey::new(common_parent.clone()).await?)
                         } else {
                             None
                         },

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -215,7 +215,7 @@ pub enum InputRelativeConstant {
 pub enum FreeVarReference {
     EcmaScriptModule {
         request: RcStr,
-        lookup_path: Option<ResolvedVc<FileSystemPath>>,
+        lookup_path: Option<FileSystemPath>,
         export: Option<RcStr>,
     },
     Ident(RcStr),

--- a/turbopack/crates/turbopack-core/src/condition.rs
+++ b/turbopack/crates/turbopack-core/src/condition.rs
@@ -10,7 +10,7 @@ pub enum ContextCondition {
     Any(Vec<ContextCondition>),
     Not(Box<ContextCondition>),
     InDirectory(String),
-    InPath(ResolvedVc<FileSystemPath>),
+    InPath(FileSystemPath),
 }
 
 impl ContextCondition {

--- a/turbopack/crates/turbopack-core/src/condition.rs
+++ b/turbopack/crates/turbopack-core/src/condition.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use futures::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{NonLocalValue, ResolvedVc, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 
 #[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue)]
@@ -52,9 +52,7 @@ impl ContextCondition {
                     .await
             }
             ContextCondition::Not(condition) => Box::pin(condition.matches(path)).await.map(|b| !b),
-            ContextCondition::InPath(other_path) => {
-                Ok(path.is_inside_or_equal_ref(&*other_path.await?))
-            }
+            ContextCondition::InPath(other_path) => Ok(path.is_inside_or_equal_ref(other_path)),
             ContextCondition::InDirectory(dir) => Ok(path.path.starts_with(&format!("{dir}/"))
                 || path.path.contains(&format!("/{dir}/"))
                 || path.path.ends_with(&format!("/{dir}"))

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -71,7 +71,7 @@ pub trait AssetContext {
     #[turbo_tasks::function]
     fn resolve_options(
         self: Vc<Self>,
-        origin_path: Vc<FileSystemPath>,
+        origin_path: FileSystemPath,
         reference_type: ReferenceType,
     ) -> Vc<ResolveOptions>;
 
@@ -79,7 +79,7 @@ pub trait AssetContext {
     #[turbo_tasks::function]
     fn resolve_asset(
         self: Vc<Self>,
-        origin_path: Vc<FileSystemPath>,
+        origin_path: FileSystemPath,
         request: Vc<Request>,
         resolve_options: Vc<ResolveOptions>,
         reference_type: ReferenceType,

--- a/turbopack/crates/turbopack-core/src/data_uri_source.rs
+++ b/turbopack/crates/turbopack-core/src/data_uri_source.rs
@@ -17,7 +17,7 @@ pub struct DataUriSource {
     media_type: RcStr,
     encoding: RcStr,
     data: ResolvedVc<RcStr>,
-    lookup_path: ResolvedVc<FileSystemPath>,
+    lookup_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -27,7 +27,7 @@ impl DataUriSource {
         media_type: RcStr,
         encoding: RcStr,
         data: ResolvedVc<RcStr>,
-        lookup_path: ResolvedVc<FileSystemPath>,
+        lookup_path: FileSystemPath,
     ) -> Vc<Self> {
         Self::cell(DataUriSource {
             media_type,

--- a/turbopack/crates/turbopack-core/src/data_uri_source.rs
+++ b/turbopack/crates/turbopack-core/src/data_uri_source.rs
@@ -52,7 +52,7 @@ impl Source for DataUriSource {
             )))[0..6]
         );
         Ok(
-            AssetIdent::from_path(self.lookup_path.join(filename.into()))
+            AssetIdent::from_path(self.lookup_path.join(&filename)?)
                 .with_content_type(content_type),
         )
     }

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -13,16 +13,16 @@ use crate::{
 /// references to other [Source]s.
 #[turbo_tasks::value]
 pub struct FileSource {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     query: RcStr,
     fragment: RcStr,
 }
 
 impl FileSource {
-    pub fn new(path: Vc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(path: FileSystemPath) -> Vc<Self> {
         FileSource::new_with_query_and_fragment(path, RcStr::default(), RcStr::default())
     }
-    pub fn new_with_query(path: Vc<FileSystemPath>, query: RcStr) -> Vc<Self> {
+    pub fn new_with_query(path: FileSystemPath, query: RcStr) -> Vc<Self> {
         FileSource::new_with_query_and_fragment(path, query, RcStr::default())
     }
 }
@@ -31,7 +31,7 @@ impl FileSource {
 impl FileSource {
     #[turbo_tasks::function]
     pub fn new_with_query_and_fragment(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         query: RcStr,
         fragment: RcStr,
     ) -> Vc<Self> {

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystemEntryType, FileSystemPath, LinkContent};
 
 use crate::{
@@ -47,7 +47,7 @@ impl FileSource {
 impl Source for FileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        let mut ident = AssetIdent::from_path(*self.path);
+        let mut ident = AssetIdent::from_path(self.path.clone());
         if !self.query.is_empty() {
             ident = ident.with_query(self.query.clone());
         }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -61,7 +61,7 @@ impl Layer {
 #[derive(Clone, Debug, Hash, TaskInput)]
 pub struct AssetIdent {
     /// The primary path of the asset
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     /// The query string of the asset this is either the empty string or a query string that starts
     /// with a `?` (e.g. `?foo=bar`)
     pub query: RcStr,
@@ -178,9 +178,9 @@ impl AssetIdent {
         ident.cell()
     }
 
-    /// Creates an [AssetIdent] from a [Vc<FileSystemPath>]
+    /// Creates an [AssetIdent] from a [FileSystemPath]
     #[turbo_tasks::function]
-    pub fn from_path(path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn from_path(path: FileSystemPath) -> Vc<Self> {
         Self::new(AssetIdent {
             path,
             query: RcStr::default(),
@@ -222,7 +222,7 @@ impl AssetIdent {
     }
 
     #[turbo_tasks::function]
-    pub fn with_path(&self, path: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn with_path(&self, path: FileSystemPath) -> Vc<Self> {
         let mut this = self.clone();
         this.path = path;
         Self::new(this)
@@ -268,7 +268,7 @@ impl AssetIdent {
     #[turbo_tasks::function]
     pub async fn output_name(
         &self,
-        context_path: Vc<FileSystemPath>,
+        context_path: FileSystemPath,
         expected_extension: RcStr,
     ) -> Result<Vc<RcStr>> {
         debug_assert!(

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -91,12 +91,9 @@ impl AssetIdent {
     }
 
     pub async fn rename_as_ref(&mut self, pattern: &str) -> Result<()> {
-        let root = self.path.root();
-        let path = self.path.await?;
-        self.path = root
-            .join(pattern.replace('*', &path.path).into())
-            .to_resolved()
-            .await?;
+        let root = self.path.root().await?;
+        let path = self.path.clone();
+        self.path = root.join(&pattern.replace('*', &path.path))?;
         Ok(())
     }
 }
@@ -105,7 +102,7 @@ impl AssetIdent {
 impl ValueToString for AssetIdent {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let mut s = self.path.to_string().owned().await?.into_owned();
+        let mut s = self.path.value_to_string().owned().await?.into_owned();
 
         // The query string is either empty or non-empty starting with `?` so we can just concat
         s.push_str(&self.query);
@@ -258,7 +255,7 @@ impl AssetIdent {
 
     #[turbo_tasks::function]
     pub fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     /// Computes a unique output asset name for the given asset identifier.
@@ -279,11 +276,11 @@ impl AssetIdent {
         // to be compatible with all operating systems + URLs.
 
         // For clippy -- This explicit deref is necessary
-        let path = &*self.path.await?;
-        let mut name = if let Some(inner) = context_path.await?.get_path_to(path) {
+        let path = &self.path;
+        let mut name = if let Some(inner) = context_path.get_path_to(path) {
             clean_separators(inner)
         } else {
-            clean_separators(&self.path.to_string().await?)
+            clean_separators(&self.path.value_to_string().await?)
         };
         let removed_extension = name.ends_with(&*expected_extension);
         if removed_extension {

--- a/turbopack/crates/turbopack-core/src/issue/code_gen.rs
+++ b/turbopack/crates/turbopack-core/src/issue/code_gen.rs
@@ -6,7 +6,7 @@ use super::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 #[turbo_tasks::value(shared)]
 pub struct CodeGenerationIssue {
     pub severity: IssueSeverity,
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub title: ResolvedVc<StyledString>,
     pub message: ResolvedVc<StyledString>,
 }

--- a/turbopack/crates/turbopack-core/src/issue/code_gen.rs
+++ b/turbopack/crates/turbopack-core/src/issue/code_gen.rs
@@ -29,7 +29,7 @@ impl Issue for CodeGenerationIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -161,7 +161,7 @@ pub trait Issue {
 #[turbo_tasks::value_trait]
 pub trait ImportTracer {
     #[turbo_tasks::function]
-    fn get_traces(self: Vc<Self>, path: ResolvedVc<FileSystemPath>) -> Vc<ImportTraces>;
+    fn get_traces(self: Vc<Self>, path: FileSystemPath) -> Vc<ImportTraces>;
 }
 
 #[turbo_tasks::value(shared)]
@@ -171,7 +171,7 @@ pub struct DelegatingImportTracer {
 }
 
 impl DelegatingImportTracer {
-    async fn get_traces(&self, path: Vc<FileSystemPath>) -> Result<Vec<ImportTrace>> {
+    async fn get_traces(&self, path: FileSystemPath) -> Result<Vec<ImportTrace>> {
         Ok(self
             .delegates
             .iter()
@@ -208,7 +208,7 @@ trait IssueProcessingPath {
 
 #[turbo_tasks::value]
 pub struct IssueProcessingPathItem {
-    pub file_path: Option<ResolvedVc<FileSystemPath>>,
+    pub file_path: Option<FileSystemPath>,
     pub description: ResolvedVc<RcStr>,
 }
 
@@ -988,7 +988,7 @@ where
     #[allow(unused_variables, reason = "behind feature flag")]
     async fn attach_file_path(
         self,
-        file_path: impl Into<Option<Vc<FileSystemPath>>> + Send,
+        file_path: impl Into<Option<FileSystemPath>> + Send,
         description: impl Into<String> + Send,
     ) -> Result<Self>;
 
@@ -997,7 +997,7 @@ where
 
     async fn issue_file_path(
         self,
-        file_path: impl Into<Option<Vc<FileSystemPath>>> + Send,
+        file_path: impl Into<Option<FileSystemPath>> + Send,
         description: impl Into<String> + Send,
     ) -> Result<Self>;
     async fn issue_description(self, description: impl Into<String> + Send) -> Result<Self>;
@@ -1021,7 +1021,7 @@ where
     #[allow(unused_variables, reason = "behind feature flag")]
     async fn attach_file_path(
         self,
-        file_path: impl Into<Option<Vc<FileSystemPath>>> + Send,
+        file_path: impl Into<Option<FileSystemPath>> + Send,
         description: impl Into<String> + Send,
     ) -> Result<Self> {
         #[cfg(feature = "issue_path")]
@@ -1054,7 +1054,7 @@ where
 
     async fn issue_file_path(
         self,
-        file_path: impl Into<Option<Vc<FileSystemPath>>> + Send,
+        file_path: impl Into<Option<FileSystemPath>> + Send,
         description: impl Into<String> + Send,
     ) -> Result<Self> {
         #[cfg(feature = "issue_path")]

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -175,7 +175,7 @@ impl DelegatingImportTracer {
         Ok(self
             .delegates
             .iter()
-            .map(|d| d.get_traces(path))
+            .map(|d| d.get_traces(path.clone()))
             .try_join()
             .await?
             .iter()
@@ -216,10 +216,10 @@ pub struct IssueProcessingPathItem {
 impl ValueToString for IssueProcessingPathItem {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        if let Some(context) = self.file_path {
+        if let Some(context) = &self.file_path {
             let description_str = self.description.await?;
             Ok(Vc::cell(
-                format!("{} ({})", context.to_string().await?, description_str).into(),
+                format!("{} ({})", context.value_to_string().await?, description_str).into(),
             ))
         } else {
             Ok(*self.description)
@@ -232,8 +232,8 @@ impl IssueProcessingPathItem {
     #[turbo_tasks::function]
     pub async fn into_plain(&self) -> Result<Vc<PlainIssueProcessingPathItem>> {
         Ok(PlainIssueProcessingPathItem {
-            file_path: if let Some(context) = self.file_path {
-                Some(context.to_string().await?)
+            file_path: if let Some(context) = &self.file_path {
+                Some(context.value_to_string().await?)
             } else {
                 None
             },
@@ -647,7 +647,7 @@ impl PlainTraceItem {
     async fn from_asset_ident(asset: ReadRef<AssetIdent>) -> Result<Self> {
         // TODO(lukesandberg): How should we display paths? it would be good to display all paths
         // relative to the cwd or the project root.
-        let fs_path = asset.path.await?;
+        let fs_path = asset.path.clone();
         let fs_name = fs_path.fs.to_string().owned().await?;
         let root_path = fs_path.fs.root().await?.path.clone();
         let path = fs_path.path.clone();
@@ -881,7 +881,13 @@ impl PlainIssue {
             processing_path: processing_path.into_plain().await?,
             import_traces: match import_tracer {
                 Some(tracer) => {
-                    into_plain_trace(tracer.await?.get_traces(issue.file_path()).await?).await?
+                    into_plain_trace(
+                        tracer
+                            .await?
+                            .get_traces(issue.file_path().await?.clone_value())
+                            .await?,
+                    )
+                    .await?
                 }
                 None => vec![],
             },
@@ -1032,10 +1038,7 @@ where
                     ItemIssueProcessingPath::resolved_cell(ItemIssueProcessingPath(
                         Some(IssueProcessingPathItem::resolved_cell(
                             IssueProcessingPathItem {
-                                file_path: match file_path.into() {
-                                    Some(path) => Some(path.to_resolved().await?),
-                                    None => None,
-                                },
+                                file_path: file_path.into(),
                                 description: ResolvedVc::cell(RcStr::from(description.into())),
                             },
                         )),
@@ -1065,10 +1068,7 @@ where
                     ItemIssueProcessingPath::resolved_cell(ItemIssueProcessingPath(
                         Some(IssueProcessingPathItem::resolved_cell(
                             IssueProcessingPathItem {
-                                file_path: match file_path.into() {
-                                    Some(path) => Some(path.to_resolved().await?),
-                                    None => None,
-                                },
+                                file_path: file_path.into(),
                                 description: ResolvedVc::cell(RcStr::from(description.into())),
                             },
                         )),

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -20,7 +20,7 @@ pub struct ResolvingIssue {
     pub severity: IssueSeverity,
     pub request_type: String,
     pub request: ResolvedVc<Request>,
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub resolve_options: ResolvedVc<ResolveOptions>,
     pub error_message: Option<String>,
     pub source: Option<IssueSource>,
@@ -128,7 +128,7 @@ impl Issue for ResolvingIssue {
 
 async fn lookup_import_map(
     import_map: Vc<ImportMap>,
-    file_path: Vc<FileSystemPath>,
+    file_path: FileSystemPath,
     request: Vc<Request>,
 ) -> Result<Option<ReadRef<RcStr>>> {
     let result = import_map.await?.lookup(file_path, request).await?;

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -50,7 +50,7 @@ impl Issue for ResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -67,7 +67,7 @@ impl Issue for ResolvingIssue {
 
         if let Some(import_map) = &self.resolve_options.await?.import_map {
             for request in request_parts {
-                match lookup_import_map(**import_map, *self.file_path, **request).await {
+                match lookup_import_map(**import_map, self.file_path.clone(), **request).await {
                     Ok(None) => {}
                     Ok(Some(str)) => writeln!(description, "Import map: {str}")?,
                     Err(err) => {
@@ -102,7 +102,7 @@ impl Issue for ResolvingIssue {
         writeln!(
             detail,
             "Path where resolving has started: {context}",
-            context = self.file_path.to_string().await?
+            context = self.file_path.value_to_string().await?
         )?;
         writeln!(
             detail,

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -877,10 +877,7 @@ impl ModuleGraphImportTracer {
 #[turbo_tasks::value_impl]
 impl ImportTracer for ModuleGraphImportTracer {
     #[turbo_tasks::function]
-    async fn get_traces(
-        self: Vc<Self>,
-        path: ResolvedVc<FileSystemPath>,
-    ) -> Result<Vc<ImportTraces>> {
+    async fn get_traces(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<ImportTraces>> {
         let path_to_modules = self.path_to_modules().await?;
         let Some(modules) = path_to_modules.map.get(&*path.await?) else {
             return Ok(Vc::default()); // This isn't unusual, the file just might not be in this

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -879,7 +879,7 @@ impl ImportTracer for ModuleGraphImportTracer {
     #[turbo_tasks::function]
     async fn get_traces(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<ImportTraces>> {
         let path_to_modules = self.path_to_modules().await?;
-        let Some(modules) = path_to_modules.map.get(&*path.await?) else {
+        let Some(modules) = path_to_modules.map.get(&path) else {
             return Ok(Vc::default()); // This isn't unusual, the file just might not be in this
             // graph.
         };

--- a/turbopack/crates/turbopack-core/src/package_json.rs
+++ b/turbopack/crates/turbopack-core/src/package_json.rs
@@ -33,7 +33,7 @@ pub struct OptionPackageJson(Option<PackageJson>);
 /// Reads a package.json file (if it exists). If the file is unparseable, it
 /// emits a useful [Issue] pointing to the invalid location.
 #[turbo_tasks::function]
-pub async fn read_package_json(path: ResolvedVc<FileSystemPath>) -> Result<Vc<OptionPackageJson>> {
+pub async fn read_package_json(path: FileSystemPath) -> Result<Vc<OptionPackageJson>> {
     let read = path.read_json().await?;
     match &*read {
         FileJsonContent::Content(_) => Ok(OptionPackageJson(Some(PackageJson(read))).cell()),
@@ -60,7 +60,7 @@ pub async fn read_package_json(path: ResolvedVc<FileSystemPath>) -> Result<Vc<Op
 /// Reusable Issue struct representing any problem with a `package.json`
 #[turbo_tasks::value(shared)]
 pub struct PackageJsonIssue {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub error_message: RcStr,
 }
 

--- a/turbopack/crates/turbopack-core/src/package_json.rs
+++ b/turbopack/crates/turbopack-core/src/package_json.rs
@@ -3,9 +3,7 @@ use std::{fmt::Write, ops::Deref};
 use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{
-    NonLocalValue, ReadRef, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
-};
+use turbo_tasks::{NonLocalValue, ReadRef, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbo_tasks_fs::{FileContent, FileJsonContent, FileSystemPath};
 
 use super::issue::Issue;
@@ -78,7 +76,7 @@ impl Issue for PackageJsonIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/proxied_asset.rs
+++ b/turbopack/crates/turbopack-core/src/proxied_asset.rs
@@ -15,17 +15,14 @@ use crate::{
 #[turbo_tasks::value]
 pub struct ProxiedAsset {
     asset: ResolvedVc<Box<dyn OutputAsset>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl ProxiedAsset {
     /// Creates a new [`ProxiedAsset`] from an [`Asset`] and a path.
     #[turbo_tasks::function]
-    pub fn new(
-        asset: ResolvedVc<Box<dyn OutputAsset>>,
-        path: ResolvedVc<FileSystemPath>,
-    ) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn OutputAsset>>, path: FileSystemPath) -> Vc<Self> {
         ProxiedAsset { asset, path }.cell()
     }
 }

--- a/turbopack/crates/turbopack-core/src/proxied_asset.rs
+++ b/turbopack/crates/turbopack-core/src/proxied_asset.rs
@@ -31,7 +31,7 @@ impl ProxiedAsset {
 impl OutputAsset for ProxiedAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/raw_output.rs
+++ b/turbopack/crates/turbopack-core/src/raw_output.rs
@@ -11,7 +11,7 @@ use crate::{
 /// This module has no references to other modules.
 #[turbo_tasks::value]
 pub struct RawOutput {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     source: ResolvedVc<Box<dyn Source>>,
 }
 
@@ -34,10 +34,7 @@ impl Asset for RawOutput {
 #[turbo_tasks::value_impl]
 impl RawOutput {
     #[turbo_tasks::function]
-    pub fn new(
-        path: ResolvedVc<FileSystemPath>,
-        source: ResolvedVc<Box<dyn Source>>,
-    ) -> Vc<RawOutput> {
+    pub fn new(path: FileSystemPath, source: ResolvedVc<Box<dyn Source>>) -> Vc<RawOutput> {
         RawOutput { path, source }.cell()
     }
 }

--- a/turbopack/crates/turbopack-core/src/raw_output.rs
+++ b/turbopack/crates/turbopack-core/src/raw_output.rs
@@ -19,7 +19,7 @@ pub struct RawOutput {
 impl OutputAsset for RawOutput {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -17,8 +17,8 @@ use crate::{
 #[derive(Hash)]
 pub struct RebasedAsset {
     module: ResolvedVc<Box<dyn Module>>,
-    input_dir: ResolvedVc<FileSystemPath>,
-    output_dir: ResolvedVc<FileSystemPath>,
+    input_dir: FileSystemPath,
+    output_dir: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -26,8 +26,8 @@ impl RebasedAsset {
     #[turbo_tasks::function]
     pub fn new(
         module: ResolvedVc<Box<dyn Module>>,
-        input_dir: ResolvedVc<FileSystemPath>,
-        output_dir: ResolvedVc<FileSystemPath>,
+        input_dir: FileSystemPath,
+        output_dir: FileSystemPath,
     ) -> Vc<Self> {
         Self::cell(RebasedAsset {
             module,

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -40,12 +40,12 @@ impl RebasedAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for RebasedAsset {
     #[turbo_tasks::function]
-    fn path(&self) -> Vc<FileSystemPath> {
-        FileSystemPath::rebase(
-            self.module.ident().path(),
-            *self.input_dir,
-            *self.output_dir,
-        )
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(FileSystemPath::rebase(
+            self.module.ident().path().await?.clone_value(),
+            self.input_dir.clone(),
+            self.output_dir.clone(),
+        ))
     }
 
     #[turbo_tasks::function]
@@ -55,7 +55,7 @@ impl OutputAsset for RebasedAsset {
             .iter()
             .map(|module| async move {
                 Ok(ResolvedVc::upcast(
-                    RebasedAsset::new(**module, *self.input_dir, *self.output_dir)
+                    RebasedAsset::new(**module, self.input_dir.clone(), self.output_dir.clone())
                         .to_resolved()
                         .await?,
                 ))

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -15,20 +15,20 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct SourceMapReference {
-    from: ResolvedVc<FileSystemPath>,
-    file: ResolvedVc<FileSystemPath>,
+    from: FileSystemPath,
+    file: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl SourceMapReference {
     #[turbo_tasks::function]
-    pub fn new(from: ResolvedVc<FileSystemPath>, file: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(from: FileSystemPath, file: FileSystemPath) -> Vc<Self> {
         Self::cell(SourceMapReference { from, file })
     }
 }
 
 impl SourceMapReference {
-    async fn get_file(&self) -> Option<Vc<FileSystemPath>> {
+    async fn get_file(&self) -> Option<FileSystemPath> {
         let file_type = self.file.get_type().await;
         if let Ok(file_type_result) = file_type.as_ref()
             && let FileSystemEntryType::File = &**file_type_result

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -33,7 +33,7 @@ impl SourceMapReference {
         if let Ok(file_type_result) = file_type.as_ref()
             && let FileSystemEntryType::File = &**file_type_result
         {
-            return Some(*self.file);
+            return Some(self.file.clone());
         }
         None
     }
@@ -64,7 +64,7 @@ impl GenerateSourceMap for SourceMapReference {
 
         let content = file.read().await?;
         let content = content.as_content().map(|file| file.content());
-        let source_map = resolve_source_map_sources(content, *self.from).await?;
+        let source_map = resolve_source_map_sources(content, self.from.clone()).await?;
         Ok(Vc::cell(source_map))
     }
 }
@@ -76,7 +76,7 @@ impl ValueToString for SourceMapReference {
         Ok(Vc::cell(
             format!(
                 "source map file is referenced by {}",
-                self.from.to_string().await?
+                self.from.value_to_string().await?
             )
             .into(),
         ))

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1148,24 +1148,24 @@ impl ResolveResultOption {
 }
 
 async fn exists(
-    fs_path: Vc<FileSystemPath>,
+    fs_path: FileSystemPath,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
-) -> Result<Option<ResolvedVc<FileSystemPath>>> {
+) -> Result<Option<FileSystemPath>> {
     type_exists(fs_path, FileSystemEntryType::File, refs).await
 }
 
 async fn dir_exists(
-    fs_path: Vc<FileSystemPath>,
+    fs_path: FileSystemPath,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
-) -> Result<Option<ResolvedVc<FileSystemPath>>> {
+) -> Result<Option<FileSystemPath>> {
     type_exists(fs_path, FileSystemEntryType::Directory, refs).await
 }
 
 async fn type_exists(
-    fs_path: Vc<FileSystemPath>,
+    fs_path: FileSystemPath,
     ty: FileSystemEntryType,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
-) -> Result<Option<ResolvedVc<FileSystemPath>>> {
+) -> Result<Option<FileSystemPath>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
     refs.extend(
         result
@@ -1188,9 +1188,9 @@ async fn type_exists(
 }
 
 async fn any_exists(
-    fs_path: Vc<FileSystemPath>,
+    fs_path: FileSystemPath,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
-) -> Result<Option<(FileSystemEntryType, Vc<FileSystemPath>)>> {
+) -> Result<Option<(FileSystemEntryType, FileSystemPath)>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
     refs.extend(
         result
@@ -1227,9 +1227,7 @@ enum ExportsFieldResult {
 /// Extracts the "exports" field out of the package.json, parsing it into an
 /// appropriate [AliasMap] for lookups.
 #[turbo_tasks::function]
-async fn exports_field(
-    package_json_path: ResolvedVc<FileSystemPath>,
-) -> Result<Vc<ExportsFieldResult>> {
+async fn exports_field(package_json_path: FileSystemPath) -> Result<Vc<ExportsFieldResult>> {
     let read = read_package_json(*package_json_path).await?;
     let package_json = match &*read {
         Some(json) => json,
@@ -1257,7 +1255,7 @@ async fn exports_field(
 enum ImportsFieldResult {
     Some(
         #[turbo_tasks(debug_ignore, trace_ignore)] ImportsField,
-        ResolvedVc<FileSystemPath>,
+        FileSystemPath,
     ),
     None,
 }
@@ -1265,7 +1263,7 @@ enum ImportsFieldResult {
 /// Extracts the "imports" field out of the nearest package.json, parsing it
 /// into an appropriate [AliasMap] for lookups.
 #[turbo_tasks::function]
-async fn imports_field(lookup_path: Vc<FileSystemPath>) -> Result<Vc<ImportsFieldResult>> {
+async fn imports_field(lookup_path: FileSystemPath) -> Result<Vc<ImportsFieldResult>> {
     let package_json_context = find_context_file(lookup_path, package_json()).await?;
     let FindContextFileResult::Found(package_json_path, _refs) = &*package_json_context else {
         return Ok(ImportsFieldResult::None.cell());
@@ -1301,13 +1299,13 @@ pub fn package_json() -> Vc<Vec<RcStr>> {
 
 #[turbo_tasks::value(shared)]
 pub enum FindContextFileResult {
-    Found(ResolvedVc<FileSystemPath>, Vec<ResolvedVc<Box<dyn Source>>>),
+    Found(FileSystemPath, Vec<ResolvedVc<Box<dyn Source>>>),
     NotFound(Vec<ResolvedVc<Box<dyn Source>>>),
 }
 
 #[turbo_tasks::function]
 pub async fn find_context_file(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     names: Vc<Vec<RcStr>>,
 ) -> Result<Vc<FindContextFileResult>> {
     let mut refs = Vec::new();
@@ -1347,7 +1345,7 @@ pub async fn find_context_file(
 // Same as find_context_file, but also stop for package.json with the specified key
 #[turbo_tasks::function]
 pub async fn find_context_file_or_package_key(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     names: Vc<Vec<RcStr>>,
     package_key: RcStr,
 ) -> Result<Vc<FindContextFileResult>> {
@@ -1392,8 +1390,8 @@ pub async fn find_context_file_or_package_key(
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Debug, NonLocalValue)]
 enum FindPackageItem {
-    PackageDirectory(ResolvedVc<FileSystemPath>),
-    PackageFile(ResolvedVc<FileSystemPath>),
+    PackageDirectory(FileSystemPath),
+    PackageFile(FileSystemPath),
 }
 
 #[turbo_tasks::value]
@@ -1404,7 +1402,7 @@ struct FindPackageResult {
 
 #[turbo_tasks::function]
 async fn find_package(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     package_name: RcStr,
     options: Vc<ResolveModulesOptions>,
 ) -> Result<Vc<FindPackageResult>> {
@@ -1511,14 +1509,11 @@ fn merge_results_with_affecting_sources(
 
 #[turbo_tasks::function]
 pub async fn resolve_raw(
-    lookup_dir: Vc<FileSystemPath>,
+    lookup_dir: FileSystemPath,
     path: Vc<Pattern>,
     force_in_lookup_dir: bool,
 ) -> Result<Vc<ResolveResult>> {
-    async fn to_result(
-        request: &str,
-        path: ResolvedVc<FileSystemPath>,
-    ) -> Result<Vc<ResolveResult>> {
+    async fn to_result(request: &str, path: FileSystemPath) -> Result<Vc<ResolveResult>> {
         let RealPathResult { path, symlinks } = &*path.realpath_with_links().await?;
         Ok(*ResolveResult::source_with_affecting_sources(
             RequestKey::new(request.into()),
@@ -1584,7 +1579,7 @@ pub async fn resolve_raw(
 
 #[turbo_tasks::function]
 pub async fn resolve(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     reference_type: ReferenceType,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
@@ -1593,7 +1588,7 @@ pub async fn resolve(
 }
 
 pub async fn resolve_inline(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     reference_type: ReferenceType,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
@@ -1682,7 +1677,7 @@ pub async fn url_resolve(
 
 #[tracing::instrument(level = "trace", skip_all)]
 async fn handle_before_resolve_plugins(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     reference_type: ReferenceType,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
@@ -1705,15 +1700,15 @@ async fn handle_before_resolve_plugins(
 
 #[tracing::instrument(level = "trace", skip_all)]
 async fn handle_after_resolve_plugins(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     reference_type: ReferenceType,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
     result: Vc<ResolveResult>,
 ) -> Result<Vc<ResolveResult>> {
     async fn apply_plugins_to_path(
-        path: Vc<FileSystemPath>,
-        lookup_path: Vc<FileSystemPath>,
+        path: FileSystemPath,
+        lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: Vc<Request>,
         options: Vc<ResolveOptions>,
@@ -1777,7 +1772,7 @@ async fn handle_after_resolve_plugins(
 
 #[turbo_tasks::function]
 async fn resolve_internal(
-    lookup_path: ResolvedVc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     request: ResolvedVc<Request>,
     options: ResolvedVc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
@@ -1785,7 +1780,7 @@ async fn resolve_internal(
 }
 
 async fn resolve_internal_inline(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
@@ -2120,7 +2115,7 @@ async fn resolve_internal_inline(
 
 #[turbo_tasks::function]
 async fn resolve_into_folder(
-    package_path: ResolvedVc<FileSystemPath>,
+    package_path: FileSystemPath,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let package_json_path = package_path.join(rcstr!("package.json"));
@@ -2191,7 +2186,7 @@ async fn resolve_into_folder(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_relative_request(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
@@ -2395,7 +2390,7 @@ async fn resolve_relative_request(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn apply_in_package(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     get_request: impl Fn(&FileSystemPath) -> Option<RcStr>,
@@ -2497,7 +2492,7 @@ async fn apply_in_package(
 enum FindSelfReferencePackageResult {
     Found {
         name: String,
-        package_path: ResolvedVc<FileSystemPath>,
+        package_path: FileSystemPath,
     },
     NotFound,
 }
@@ -2506,7 +2501,7 @@ enum FindSelfReferencePackageResult {
 /// Finds the nearest folder containing package.json that could be used for a
 /// self-reference (i.e. has an exports fields).
 async fn find_self_reference(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
 ) -> Result<Vc<FindSelfReferencePackageResult>> {
     let package_json_context = find_context_file(lookup_path, package_json()).await?;
     if let FindContextFileResult::Found(package_json_path, _refs) = &*package_json_context {
@@ -2527,7 +2522,7 @@ async fn find_self_reference(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_module_request(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
@@ -2650,7 +2645,7 @@ async fn resolve_module_request(
 #[turbo_tasks::function]
 async fn resolve_into_package(
     path: Pattern,
-    package_path: ResolvedVc<FileSystemPath>,
+    package_path: FileSystemPath,
     query: RcStr,
     fragment: RcStr,
     options: ResolvedVc<ResolveOptions>,
@@ -2731,8 +2726,8 @@ async fn resolve_into_package(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_import_map_result(
     result: &ImportMapResult,
-    lookup_path: Vc<FileSystemPath>,
-    original_lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
+    original_lookup_path: FileSystemPath,
     original_request: Vc<Request>,
     options: Vc<ResolveOptions>,
     query: RcStr,
@@ -2829,8 +2824,8 @@ async fn resolve_import_map_result(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolved(
     request_key: RequestKey,
-    fs_path: Vc<FileSystemPath>,
-    original_context: Vc<FileSystemPath>,
+    fs_path: FileSystemPath,
+    original_context: FileSystemPath,
     original_request: Vc<Request>,
     options_value: &ResolveOptions,
     options: Vc<ResolveOptions>,
@@ -2894,8 +2889,8 @@ async fn resolved(
 }
 
 async fn handle_exports_imports_field(
-    package_path: Vc<FileSystemPath>,
-    package_json_path: Vc<FileSystemPath>,
+    package_path: FileSystemPath,
+    package_json_path: FileSystemPath,
     options: Vc<ResolveOptions>,
     exports_imports_field: &AliasMap<SubpathValue>,
     path: &str,
@@ -2960,7 +2955,7 @@ async fn handle_exports_imports_field(
 /// static strings or conditions like `import` or `require` to handle ESM/CJS
 /// with differently compiled files.
 async fn resolve_package_internal_with_imports_field(
-    file_path: Vc<FileSystemPath>,
+    file_path: FileSystemPath,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     pattern: &Pattern,
@@ -3008,7 +3003,7 @@ async fn resolve_package_internal_with_imports_field(
 pub async fn handle_resolve_error(
     result: Vc<ModuleResolveResult>,
     reference_type: ReferenceType,
-    origin_path: Vc<FileSystemPath>,
+    origin_path: FileSystemPath,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
@@ -3052,7 +3047,7 @@ pub async fn handle_resolve_error(
 pub async fn handle_resolve_source_error(
     result: Vc<ResolveResult>,
     reference_type: ReferenceType,
-    origin_path: Vc<FileSystemPath>,
+    origin_path: FileSystemPath,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
@@ -3095,7 +3090,7 @@ pub async fn handle_resolve_source_error(
 
 async fn emit_resolve_error_issue(
     is_optional: bool,
-    origin_path: Vc<FileSystemPath>,
+    origin_path: FileSystemPath,
     reference_type: ReferenceType,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
@@ -3123,7 +3118,7 @@ async fn emit_resolve_error_issue(
 
 async fn emit_unresolvable_issue(
     is_optional: bool,
-    origin_path: Vc<FileSystemPath>,
+    origin_path: FileSystemPath,
     reference_type: ReferenceType,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1166,20 +1166,20 @@ async fn type_exists(
     ty: FileSystemEntryType,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<Option<FileSystemPath>> {
-    let result = fs_path.resolve().await?.realpath_with_links().await?;
+    let result = fs_path.realpath_with_links().await?;
     refs.extend(
         result
             .symlinks
             .iter()
             .map(|path| async move {
                 Ok(ResolvedVc::upcast(
-                    FileSource::new(**path).to_resolved().await?,
+                    FileSource::new(path.clone()).to_resolved().await?,
                 ))
             })
             .try_join()
             .await?,
     );
-    let path = result.path;
+    let path = result.clone_value().path;
     Ok(if *path.get_type().await? == ty {
         Some(path)
     } else {
@@ -1191,20 +1191,20 @@ async fn any_exists(
     fs_path: FileSystemPath,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<Option<(FileSystemEntryType, FileSystemPath)>> {
-    let result = fs_path.resolve().await?.realpath_with_links().await?;
+    let result = fs_path.realpath_with_links().await?;
     refs.extend(
         result
             .symlinks
             .iter()
             .map(|path| async move {
                 Ok(ResolvedVc::upcast(
-                    FileSource::new(**path).to_resolved().await?,
+                    FileSource::new(path.clone()).to_resolved().await?,
                 ))
             })
             .try_join()
             .await?,
     );
-    let path = result.path;
+    let path = result.clone_value().path;
     let ty = *path.get_type().await?;
     Ok(
         if matches!(
@@ -1213,7 +1213,7 @@ async fn any_exists(
         ) {
             None
         } else {
-            Some((ty, *path))
+            Some((ty, path))
         },
     )
 }
@@ -1228,7 +1228,7 @@ enum ExportsFieldResult {
 /// appropriate [AliasMap] for lookups.
 #[turbo_tasks::function]
 async fn exports_field(package_json_path: FileSystemPath) -> Result<Vc<ExportsFieldResult>> {
-    let read = read_package_json(*package_json_path).await?;
+    let read = read_package_json(package_json_path.clone()).await?;
     let package_json = match &*read {
         Some(json) => json,
         None => return Ok(ExportsFieldResult::None.cell()),
@@ -1269,7 +1269,7 @@ async fn imports_field(lookup_path: FileSystemPath) -> Result<Vc<ImportsFieldRes
         return Ok(ImportsFieldResult::None.cell());
     };
 
-    let read = read_package_json(**package_json_path).await?;
+    let read = read_package_json(package_json_path.clone()).await?;
     let package_json = match &*read {
         Some(json) => json,
         None => return Ok(ImportsFieldResult::None.cell()),
@@ -1279,10 +1279,10 @@ async fn imports_field(lookup_path: FileSystemPath) -> Result<Vc<ImportsFieldRes
         return Ok(ImportsFieldResult::None.cell());
     };
     match imports.try_into() {
-        Ok(imports) => Ok(ImportsFieldResult::Some(imports, *package_json_path).cell()),
+        Ok(imports) => Ok(ImportsFieldResult::Some(imports, package_json_path.clone()).cell()),
         Err(err) => {
             PackageJsonIssue {
-                path: *package_json_path,
+                path: package_json_path.clone(),
                 error_message: err.to_string().into(),
             }
             .resolved_cell()
@@ -1310,12 +1310,12 @@ pub async fn find_context_file(
 ) -> Result<Vc<FindContextFileResult>> {
     let mut refs = Vec::new();
     for name in &*names.await? {
-        let fs_path = lookup_path.join(name.clone());
+        let fs_path = lookup_path.join(name)?;
         if let Some(fs_path) = exists(fs_path, &mut refs).await? {
             return Ok(FindContextFileResult::Found(fs_path, refs).cell());
         }
     }
-    if lookup_path.await?.is_root() {
+    if lookup_path.is_root() {
         return Ok(FindContextFileResult::NotFound(refs).cell());
     }
     if refs.is_empty() {
@@ -1323,15 +1323,15 @@ pub async fn find_context_file(
         Ok(find_context_file(
             // Hot codepath optimization: resolve all arguments to avoid an automatically-created
             // intermediate task
-            lookup_path.parent().resolve().await?,
+            lookup_path.parent(),
             names,
         ))
     } else {
-        let parent_result = find_context_file(lookup_path.parent().resolve().await?, names).await?;
+        let parent_result = find_context_file(lookup_path.parent(), names).await?;
         Ok(match &*parent_result {
             FindContextFileResult::Found(p, r) => {
                 refs.extend(r.iter().copied());
-                FindContextFileResult::Found(*p, refs)
+                FindContextFileResult::Found(p.clone(), refs)
             }
             FindContextFileResult::NotFound(r) => {
                 refs.extend(r.iter().copied());
@@ -1350,34 +1350,31 @@ pub async fn find_context_file_or_package_key(
     package_key: RcStr,
 ) -> Result<Vc<FindContextFileResult>> {
     let mut refs = Vec::new();
-    let package_json_path = lookup_path.join(rcstr!("package.json"));
+    let package_json_path = lookup_path.join("package.json")?;
     if let Some(package_json_path) = exists(package_json_path, &mut refs).await?
-        && let Some(json) = &*read_package_json(*package_json_path).await?
+        && let Some(json) = &*read_package_json(package_json_path.clone()).await?
         && json.get(&*package_key).is_some()
     {
         return Ok(FindContextFileResult::Found(package_json_path, refs).into());
     }
     for name in &*names.await? {
-        let fs_path = lookup_path.join(name.clone());
+        let fs_path = lookup_path.join(name)?;
         if let Some(fs_path) = exists(fs_path, &mut refs).await? {
             return Ok(FindContextFileResult::Found(fs_path, refs).into());
         }
     }
-    if lookup_path.await?.is_root() {
+    if lookup_path.is_root() {
         return Ok(FindContextFileResult::NotFound(refs).into());
     }
     if refs.is_empty() {
         // Tailcall
-        Ok(find_context_file(
-            lookup_path.parent().resolve().await?,
-            names,
-        ))
+        Ok(find_context_file(lookup_path.parent(), names))
     } else {
-        let parent_result = find_context_file(lookup_path.parent().resolve().await?, names).await?;
+        let parent_result = find_context_file(lookup_path.parent(), names).await?;
         Ok(match &*parent_result {
             FindContextFileResult::Found(p, r) => {
                 refs.extend(r.iter().copied());
-                FindContextFileResult::Found(*p, refs)
+                FindContextFileResult::Found(p.clone(), refs)
             }
             FindContextFileResult::NotFound(r) => {
                 refs.extend(r.iter().copied());
@@ -1388,7 +1385,7 @@ pub async fn find_context_file_or_package_key(
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Debug, NonLocalValue)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Debug, NonLocalValue)]
 enum FindPackageItem {
     PackageDirectory(FileSystemPath),
     PackageFile(FileSystemPath),
@@ -1412,25 +1409,25 @@ async fn find_package(
     for resolve_modules in &options.modules {
         match resolve_modules {
             ResolveModules::Nested(root_vc, names) => {
-                let mut lookup_path = lookup_path;
-                let mut lookup_path_value = lookup_path.await?;
+                let mut lookup_path = lookup_path.clone();
+                let mut lookup_path_value = lookup_path.clone();
                 // For clippy -- This explicit deref is necessary
-                let root = &*root_vc.await?;
-                while lookup_path_value.is_inside_ref(root) {
+                let root = root_vc.clone();
+                while lookup_path_value.is_inside_ref(&root) {
                     for name in names.iter() {
-                        let fs_path = lookup_path.join(name.clone());
+                        let fs_path = lookup_path.join(name)?;
                         if let Some(fs_path) = dir_exists(fs_path, &mut affecting_sources).await? {
-                            let fs_path = fs_path.join(package_name.clone());
+                            let fs_path = fs_path.join(&package_name.clone())?;
                             if let Some(fs_path) =
-                                dir_exists(fs_path, &mut affecting_sources).await?
+                                dir_exists(fs_path.clone(), &mut affecting_sources).await?
                             {
                                 packages.push(FindPackageItem::PackageDirectory(fs_path));
                             }
                         }
                     }
-                    lookup_path = lookup_path.parent().resolve().await?;
-                    let new_context_value = lookup_path.await?;
-                    if *new_context_value == *lookup_path_value {
+                    lookup_path = lookup_path.parent();
+                    let new_context_value = lookup_path.clone();
+                    if new_context_value == lookup_path_value {
                         break;
                     }
                     lookup_path_value = new_context_value;
@@ -1441,20 +1438,16 @@ async fn find_package(
                 excluded_extensions,
             } => {
                 let excluded_extensions = excluded_extensions.await?;
-                let package_dir = dir.join(package_name.clone());
+                let package_dir = dir.join(&package_name)?;
                 if let Some((ty, package_dir)) =
-                    any_exists(package_dir, &mut affecting_sources).await?
+                    any_exists(package_dir.clone(), &mut affecting_sources).await?
                 {
                     match ty {
                         FileSystemEntryType::Directory => {
-                            packages.push(FindPackageItem::PackageDirectory(
-                                package_dir.to_resolved().await?,
-                            ));
+                            packages.push(FindPackageItem::PackageDirectory(package_dir.clone()));
                         }
                         FileSystemEntryType::File => {
-                            packages.push(FindPackageItem::PackageFile(
-                                package_dir.to_resolved().await?,
-                            ));
+                            packages.push(FindPackageItem::PackageFile(package_dir.clone()));
                         }
                         _ => {}
                     }
@@ -1463,7 +1456,7 @@ async fn find_package(
                     if excluded_extensions.contains(extension) {
                         continue;
                     }
-                    let package_file = package_dir.append(extension.clone());
+                    let package_file = package_dir.append(&extension.clone())?;
                     if let Some(package_file) = exists(package_file, &mut affecting_sources).await?
                     {
                         packages.push(FindPackageItem::PackageFile(package_file));
@@ -1517,12 +1510,12 @@ pub async fn resolve_raw(
         let RealPathResult { path, symlinks } = &*path.realpath_with_links().await?;
         Ok(*ResolveResult::source_with_affecting_sources(
             RequestKey::new(request.into()),
-            ResolvedVc::upcast(FileSource::new(**path).to_resolved().await?),
+            ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
             symlinks
                 .iter()
                 .map(|symlink| async move {
                     anyhow::Ok(ResolvedVc::upcast(
-                        FileSource::new(**symlink).to_resolved().await?,
+                        FileSource::new(symlink.clone()).to_resolved().await?,
                     ))
                 })
                 .try_join()
@@ -1532,14 +1525,20 @@ pub async fn resolve_raw(
 
     let mut results = Vec::new();
 
-    let lookup_dir_str = lookup_dir.to_string().await?;
+    let lookup_dir_str = lookup_dir.value_to_string().await?;
     let pat = path.await?;
     if let Some(pat) = pat
         .filter_could_match("/ROOT/")
         .and_then(|pat| pat.filter_could_not_match("/ROOT/fsd8nz8og54z"))
     {
         let path = Pattern::new(pat);
-        let matches = read_matches(lookup_dir.root(), rcstr!("/ROOT/"), true, path).await?;
+        let matches = read_matches(
+            lookup_dir.root().await?.clone_value(),
+            rcstr!("/ROOT/"),
+            true,
+            path,
+        )
+        .await?;
         if matches.len() > 10000 {
             let path_str = path.to_string().await?;
             println!(
@@ -1551,7 +1550,7 @@ pub async fn resolve_raw(
         } else {
             for m in matches.iter() {
                 if let PatternMatch::File(request, path) = m {
-                    results.push(to_result(request, *path).await?);
+                    results.push(to_result(request, path.clone()).await?);
                 }
             }
         }
@@ -1569,7 +1568,7 @@ pub async fn resolve_raw(
         }
         for m in matches.iter() {
             if let PatternMatch::File(request, path) = m {
-                results.push(to_result(request, *path).await?);
+                results.push(to_result(request, path.clone()).await?);
             }
         }
     }
@@ -1594,7 +1593,7 @@ pub async fn resolve_inline(
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let span = {
-        let lookup_path = lookup_path.to_string().await?.to_string();
+        let lookup_path = lookup_path.value_to_string().await?.to_string();
         let request = request.to_string().await?.to_string();
         tracing::info_span!(
             "resolving",
@@ -1604,14 +1603,18 @@ pub async fn resolve_inline(
         )
     };
     async {
-        let before_plugins_result =
-            handle_before_resolve_plugins(lookup_path, reference_type.clone(), request, options)
-                .await?;
+        let before_plugins_result = handle_before_resolve_plugins(
+            lookup_path.clone(),
+            reference_type.clone(),
+            request,
+            options,
+        )
+        .await?;
 
         let raw_result = match before_plugins_result {
             Some(result) => result,
             None => {
-                resolve_internal(lookup_path, request, options)
+                resolve_internal(lookup_path.clone(), request, options)
                     .resolve()
                     .await?
             }
@@ -1634,10 +1637,10 @@ pub async fn url_resolve(
     issue_source: Option<IssueSource>,
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
-    let resolve_options = origin.resolve_options(reference_type.clone());
+    let resolve_options = origin.resolve_options(reference_type.clone()).await?;
     let rel_request = request.as_relative();
     let rel_result = resolve(
-        origin.origin_path().parent(),
+        origin.origin_path().await?.parent(),
         reference_type.clone(),
         rel_request,
         resolve_options,
@@ -1645,7 +1648,7 @@ pub async fn url_resolve(
     let result = if *rel_result.is_unresolvable().await? && rel_request.resolve().await? != request
     {
         resolve(
-            origin.origin_path().parent(),
+            origin.origin_path().await?.parent(),
             reference_type.clone(),
             request,
             resolve_options,
@@ -1666,7 +1669,7 @@ pub async fn url_resolve(
     handle_resolve_error(
         result,
         reference_type,
-        origin.origin_path(),
+        origin.origin_path().await?.clone_value(),
         request,
         resolve_options,
         is_optional,
@@ -1689,7 +1692,7 @@ async fn handle_before_resolve_plugins(
         }
 
         if let Some(result) = *plugin
-            .before_resolve(lookup_path, reference_type.clone(), request)
+            .before_resolve(lookup_path.clone(), reference_type.clone(), request)
             .await?
         {
             return Ok(Some(*result));
@@ -1715,9 +1718,14 @@ async fn handle_after_resolve_plugins(
     ) -> Result<Option<Vc<ResolveResult>>> {
         for plugin in &options.await?.after_resolve_plugins {
             let after_resolve_condition = plugin.after_resolve_condition().resolve().await?;
-            if *after_resolve_condition.matches(path).await?
+            if *after_resolve_condition.matches(path.clone()).await?
                 && let Some(result) = *plugin
-                    .after_resolve(path, lookup_path, reference_type.clone(), request)
+                    .after_resolve(
+                        path.clone(),
+                        lookup_path.clone(),
+                        reference_type.clone(),
+                        request,
+                    )
                     .await?
             {
                 return Ok(Some(*result));
@@ -1734,10 +1742,15 @@ async fn handle_after_resolve_plugins(
 
     for (key, primary) in result_value.primary.iter() {
         if let &ResolveResultItem::Source(source) = primary {
-            let path = source.ident().path().resolve().await?;
-            if let Some(new_result) =
-                apply_plugins_to_path(path, lookup_path, reference_type.clone(), request, options)
-                    .await?
+            let path = source.ident().path().await?.clone_value();
+            if let Some(new_result) = apply_plugins_to_path(
+                path.clone(),
+                lookup_path.clone(),
+                reference_type.clone(),
+                request,
+                options,
+            )
+            .await?
             {
                 let new_result = new_result.await?;
                 changed = true;
@@ -1776,7 +1789,7 @@ async fn resolve_internal(
     request: ResolvedVc<Request>,
     options: ResolvedVc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    resolve_internal_inline(*lookup_path, *request, *options).await
+    resolve_internal_inline(lookup_path.clone(), *request, *options).await
 }
 
 async fn resolve_internal_inline(
@@ -1785,7 +1798,7 @@ async fn resolve_internal_inline(
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let span = {
-        let lookup_path = lookup_path.to_string().await?.to_string();
+        let lookup_path = lookup_path.value_to_string().await?.to_string();
         let request = request.to_string().await?.to_string();
         tracing::info_span!(
             "internal resolving",
@@ -1806,13 +1819,16 @@ async fn resolve_internal_inline(
                 _ => &[request.to_resolved().await?],
             };
             for &request in request_parts {
-                let result = import_map.await?.lookup(lookup_path, *request).await?;
+                let result = import_map
+                    .await?
+                    .lookup(lookup_path.clone(), *request)
+                    .await?;
                 if !matches!(result, ImportMapResult::NoEntry) {
                     has_alias = true;
                     let resolved_result = resolve_import_map_result(
                         &result,
-                        lookup_path,
-                        lookup_path,
+                        lookup_path.clone(),
+                        lookup_path.clone(),
                         *request,
                         options,
                         request.query().owned().await?,
@@ -1838,7 +1854,9 @@ async fn resolve_internal_inline(
             Request::Alternatives { requests } => {
                 let results = requests
                     .iter()
-                    .map(|req| async { resolve_internal_inline(lookup_path, **req, options).await })
+                    .map(|req| async {
+                        resolve_internal_inline(lookup_path.clone(), **req, options).await
+                    })
                     .try_join()
                     .await?;
 
@@ -1852,7 +1870,7 @@ async fn resolve_internal_inline(
             } => {
                 let mut results = Vec::new();
                 let matches = read_matches(
-                    lookup_path,
+                    lookup_path.clone(),
                     rcstr!(""),
                     *force_in_lookup_dir,
                     Pattern::new(path.clone()).resolve().await?,
@@ -1865,8 +1883,8 @@ async fn resolve_internal_inline(
                             results.push(
                                 resolved(
                                     RequestKey::new(matched_pattern.clone()),
-                                    **path,
-                                    lookup_path,
+                                    path.clone(),
+                                    lookup_path.clone(),
                                     request,
                                     options_value,
                                     options,
@@ -1878,7 +1896,7 @@ async fn resolve_internal_inline(
                         }
                         PatternMatch::Directory(matched_pattern, path) => {
                             results.push(
-                                resolve_into_folder(**path, options)
+                                resolve_into_folder(path.clone(), options)
                                     .with_request(matched_pattern.clone()),
                             );
                         }
@@ -1895,7 +1913,7 @@ async fn resolve_internal_inline(
             } => {
                 if !fragment.is_empty()
                     && let Ok(result) = resolve_relative_request(
-                        lookup_path,
+                        lookup_path.clone(),
                         request,
                         options,
                         options_value,
@@ -1910,7 +1928,7 @@ async fn resolve_internal_inline(
                 }
                 // Resolve without fragment
                 resolve_relative_request(
-                    lookup_path,
+                    lookup_path.clone(),
                     request,
                     options,
                     options_value,
@@ -1928,7 +1946,7 @@ async fn resolve_internal_inline(
                 fragment,
             } => {
                 resolve_module_request(
-                    lookup_path,
+                    lookup_path.clone(),
                     request,
                     options,
                     options_value,
@@ -1953,7 +1971,7 @@ async fn resolve_internal_inline(
                         severity: error_severity(options).await?,
                         request_type: "server relative import: not implemented yet".to_string(),
                         request: relative.to_resolved().await?,
-                        file_path: lookup_path.to_resolved().await?,
+                        file_path: lookup_path.clone(),
                         resolve_options: options.to_resolved().await?,
                         error_message: Some(
                             "server relative imports are not implemented yet. Please try an \
@@ -1967,7 +1985,7 @@ async fn resolve_internal_inline(
                 }
 
                 Box::pin(resolve_internal_inline(
-                    lookup_path.root(),
+                    lookup_path.root().await?.clone_value(),
                     relative,
                     options,
                 ))
@@ -1983,7 +2001,7 @@ async fn resolve_internal_inline(
                         severity: error_severity(options).await?,
                         request_type: "windows import: not implemented yet".to_string(),
                         request: request.to_resolved().await?,
-                        file_path: lookup_path.to_resolved().await?,
+                        file_path: lookup_path.clone(),
                         resolve_options: options.to_resolved().await?,
                         error_message: Some("windows imports are not implemented yet".to_string()),
                         source: None,
@@ -2009,7 +2027,7 @@ async fn resolve_internal_inline(
                     })
                     .unwrap_or_else(|| (Default::default(), ConditionValue::Unset));
                 resolve_package_internal_with_imports_field(
-                    lookup_path,
+                    lookup_path.clone(),
                     request,
                     options,
                     path,
@@ -2035,7 +2053,7 @@ async fn resolve_internal_inline(
                                 media_type.clone(),
                                 encoding.clone(),
                                 **data,
-                                lookup_path,
+                                lookup_path.clone(),
                             )
                             .to_resolved()
                             .await?,
@@ -2074,7 +2092,7 @@ async fn resolve_internal_inline(
                         severity: error_severity(options).await?,
                         request_type: format!("unknown import: `{path}`"),
                         request: request.to_resolved().await?,
-                        file_path: lookup_path.to_resolved().await?,
+                        file_path: lookup_path.clone(),
                         resolve_options: options.to_resolved().await?,
                         error_message: None,
                         source: None,
@@ -2090,11 +2108,14 @@ async fn resolve_internal_inline(
         if let Some(import_map) = &options_value.fallback_import_map
             && *result.is_unresolvable().await?
         {
-            let result = import_map.await?.lookup(lookup_path, request).await?;
+            let result = import_map
+                .await?
+                .lookup(lookup_path.clone(), request)
+                .await?;
             let resolved_result = resolve_import_map_result(
                 &result,
-                lookup_path,
-                lookup_path,
+                lookup_path.clone(),
+                lookup_path.clone(),
                 request,
                 options,
                 request.query().owned().await?,
@@ -2118,13 +2139,13 @@ async fn resolve_into_folder(
     package_path: FileSystemPath,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    let package_json_path = package_path.join(rcstr!("package.json"));
+    let package_json_path = package_path.join("package.json")?;
     let options_value = options.await?;
 
     for resolve_into_package in options_value.into_package.iter() {
         match resolve_into_package {
             ResolveIntoPackage::MainField { field: name } => {
-                if let Some(package_json) = &*read_package_json(package_json_path).await?
+                if let Some(package_json) = &*read_package_json(package_json_path.clone()).await?
                     && let Some(field_value) = package_json[name.as_str()].as_str()
                 {
                     let normalized_request: RcStr = normalize_request(field_value).into();
@@ -2142,7 +2163,7 @@ async fn resolve_into_folder(
                     } else {
                         options
                     };
-                    let result = &*resolve_internal_inline(*package_path, request, options)
+                    let result = &*resolve_internal_inline(package_path.clone(), request, options)
                         .await?
                         .await?;
                     // we are not that strict when a main field fails to resolve
@@ -2179,9 +2200,11 @@ async fn resolve_into_folder(
 
     let request = Request::parse(pattern);
 
-    Ok(resolve_internal_inline(*package_path, request, options)
-        .await?
-        .with_request(rcstr!(".")))
+    Ok(
+        resolve_internal_inline(package_path.clone(), request, options)
+            .await?
+            .with_request(rcstr!(".")),
+    )
 }
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
@@ -2196,14 +2219,14 @@ async fn resolve_relative_request(
     fragment: RcStr,
 ) -> Result<Vc<ResolveResult>> {
     // Check alias field for aliases first
-    let lookup_path_ref = &*lookup_path.await?;
+    let lookup_path_ref = lookup_path.clone();
     if let Some(result) = apply_in_package(
-        lookup_path,
+        lookup_path.clone(),
         options,
         options_value,
         |package_path| {
             let request = path_pattern.as_string()?;
-            let prefix_path = package_path.get_path_to(lookup_path_ref)?;
+            let prefix_path = package_path.get_path_to(&lookup_path_ref)?;
             let request = normalize_request(&format!("./{prefix_path}/{request}"));
             Some(request.into())
         },
@@ -2283,7 +2306,7 @@ async fn resolve_relative_request(
 
     let mut results = Vec::new();
     let matches = read_matches(
-        lookup_path,
+        lookup_path.clone(),
         rcstr!(""),
         force_in_lookup_dir,
         Pattern::new(new_path).resolve().await?,
@@ -2309,8 +2332,8 @@ async fn resolve_relative_request(
                             results.push(
                                 resolved(
                                     RequestKey::new(matched_pattern.into()),
-                                    **path,
-                                    lookup_path,
+                                    path.clone(),
+                                    lookup_path.clone(),
                                     request,
                                     options_value,
                                     options,
@@ -2326,8 +2349,8 @@ async fn resolve_relative_request(
                         results.push(
                             resolved(
                                 RequestKey::new(matched_pattern.into()),
-                                **path,
-                                lookup_path,
+                                path.clone(),
+                                lookup_path.clone(),
                                 request,
                                 options_value,
                                 options,
@@ -2346,8 +2369,8 @@ async fn resolve_relative_request(
                     results.push(
                         resolved(
                             RequestKey::new(matched_pattern.into()),
-                            **path,
-                            lookup_path,
+                            path.clone(),
+                            lookup_path.clone(),
                             request,
                             options_value,
                             options,
@@ -2364,8 +2387,8 @@ async fn resolve_relative_request(
                 results.push(
                     resolved(
                         RequestKey::new(matched_pattern.clone()),
-                        **path,
-                        lookup_path,
+                        path.clone(),
+                        lookup_path.clone(),
                         request,
                         options_value,
                         options,
@@ -2380,8 +2403,9 @@ async fn resolve_relative_request(
     // Directory matches must be resolved AFTER file matches
     for m in matches.iter() {
         if let PatternMatch::Directory(matched_pattern, path) = m {
-            results
-                .push(resolve_into_folder(**path, options).with_request(matched_pattern.clone()));
+            results.push(
+                resolve_into_folder(path.clone(), options).with_request(matched_pattern.clone()),
+            );
         }
     }
 
@@ -2407,12 +2431,12 @@ async fn apply_in_package(
         };
 
         let FindContextFileResult::Found(package_json_path, refs) =
-            &*find_context_file(lookup_path, package_json().resolve().await?).await?
+            &*find_context_file(lookup_path.clone(), package_json().resolve().await?).await?
         else {
             continue;
         };
 
-        let read = read_package_json(**package_json_path).await?;
+        let read = read_package_json(package_json_path.clone()).await?;
         let Some(package_json) = &*read else {
             continue;
         };
@@ -2421,9 +2445,9 @@ async fn apply_in_package(
             continue;
         };
 
-        let package_path = package_json_path.parent().resolve().await?;
+        let package_path = package_json_path.parent();
 
-        let Some(request) = get_request(&*package_path.await?) else {
+        let Some(request) = get_request(&package_path) else {
             continue;
         };
 
@@ -2469,7 +2493,7 @@ async fn apply_in_package(
 
         ResolvingIssue {
             severity: error_severity(options).await?,
-            file_path: *package_json_path,
+            file_path: package_json_path.clone(),
             request_type: format!("alias field ({field})"),
             request: Request::parse(Pattern::Constant(request))
                 .to_resolved()
@@ -2505,14 +2529,14 @@ async fn find_self_reference(
 ) -> Result<Vc<FindSelfReferencePackageResult>> {
     let package_json_context = find_context_file(lookup_path, package_json()).await?;
     if let FindContextFileResult::Found(package_json_path, _refs) = &*package_json_context {
-        let read = read_package_json(**package_json_path).await?;
+        let read = read_package_json(package_json_path.clone()).await?;
         if let Some(json) = &*read
             && json.get("exports").is_some()
             && let Some(name) = json["name"].as_str()
         {
             return Ok(FindSelfReferencePackageResult::Found {
                 name: name.to_string(),
-                package_path: package_json_path.parent().to_resolved().await?,
+                package_path: package_json_path.parent(),
             }
             .cell());
         }
@@ -2533,7 +2557,7 @@ async fn resolve_module_request(
 ) -> Result<Vc<ResolveResult>> {
     // Check alias field for module aliases first
     if let Some(result) = apply_in_package(
-        lookup_path,
+        lookup_path.clone(),
         options,
         options_value,
         |_| {
@@ -2552,12 +2576,12 @@ async fn resolve_module_request(
     // module. This should match only using the exports field and no other
     // fields/fallbacks.
     if let FindSelfReferencePackageResult::Found { name, package_path } =
-        &*find_self_reference(lookup_path).await?
+        &*find_self_reference(lookup_path.clone()).await?
         && name == module
     {
         let result = resolve_into_package(
             path.clone(),
-            **package_path,
+            package_path.clone(),
             query.clone(),
             fragment.clone(),
             options,
@@ -2568,7 +2592,7 @@ async fn resolve_module_request(
     }
 
     let result = find_package(
-        lookup_path,
+        lookup_path.clone(),
         module.into(),
         resolve_modules_options(options).resolve().await?,
     )
@@ -2588,11 +2612,11 @@ async fn resolve_module_request(
     // "[baseUrl]/foo/bar" or "[baseUrl]/node_modules/foo/bar", and we'll need to
     // try both.
     for item in &result.packages {
-        match *item {
+        match item {
             FindPackageItem::PackageDirectory(package_path) => {
                 results.push(resolve_into_package(
                     path.clone(),
-                    *package_path,
+                    package_path.clone(),
                     query.clone(),
                     fragment.clone(),
                     options,
@@ -2602,8 +2626,8 @@ async fn resolve_module_request(
                 if path.is_match("") {
                     let resolved = resolved(
                         RequestKey::new(rcstr!(".")),
-                        *package_path,
-                        lookup_path,
+                        package_path.clone(),
+                        lookup_path.clone(),
                         request,
                         options_value,
                         options,
@@ -2631,8 +2655,12 @@ async fn resolve_module_request(
         let relative = Request::relative(pattern, query, fragment, true)
             .to_resolved()
             .await?;
-        let relative_result =
-            Box::pin(resolve_internal_inline(lookup_path, *relative, options)).await?;
+        let relative_result = Box::pin(resolve_internal_inline(
+            lookup_path.clone(),
+            *relative,
+            options,
+        ))
+        .await?;
         let relative_result = relative_result
             .with_replaced_request_key(module_prefix, RequestKey::new(module.into()));
 
@@ -2664,9 +2692,9 @@ async fn resolve_into_package(
                 conditions,
                 unspecified_conditions,
             } => {
-                let package_json_path = package_path.join(rcstr!("package.json"));
+                let package_json_path = package_path.join("package.json")?;
                 let ExportsFieldResult::Some(exports_field) =
-                    &*exports_field(package_json_path).await?
+                    &*exports_field(package_json_path.clone()).await?
                 else {
                     continue;
                 };
@@ -2683,7 +2711,7 @@ async fn resolve_into_package(
 
                 results.push(
                     handle_exports_imports_field(
-                        *package_path,
+                        package_path.clone(),
                         package_json_path,
                         *options,
                         exports_field,
@@ -2705,7 +2733,7 @@ async fn resolve_into_package(
     // apply main field(s) or fallback to index.js if there's no subpath
     if is_root_match {
         results.push(resolve_into_folder(
-            *package_path,
+            package_path.clone(),
             options.with_fully_specified(false),
         ));
     }
@@ -2717,7 +2745,7 @@ async fn resolve_into_package(
         let relative = Request::relative(new_pat, query, fragment, true)
             .to_resolved()
             .await?;
-        results.push(resolve_internal_inline(*package_path, *relative, *options).await?);
+        results.push(resolve_internal_inline(package_path.clone(), *relative, *options).await?);
     }
 
     Ok(merge_results(results))
@@ -2737,7 +2765,7 @@ async fn resolve_import_map_result(
         ImportMapResult::Alias(request, alias_lookup_path) => {
             let request = **request;
             let lookup_path = match alias_lookup_path {
-                Some(path) => **path,
+                Some(path) => path.clone(),
                 None => lookup_path,
             };
             // We must avoid cycles during resolving
@@ -2768,20 +2796,20 @@ async fn resolve_import_map_result(
 
             // We must avoid cycles during resolving
             if request.resolve().await? == original_request
-                && **alias_lookup_path == original_lookup_path
+                && *alias_lookup_path == original_lookup_path
             {
                 None
             } else {
                 let is_external_resolvable = !resolve_internal(
-                    **alias_lookup_path,
+                    alias_lookup_path.clone(),
                     request,
                     match ty {
                         // TODO is that root correct?
                         ExternalType::CommonJs => {
-                            node_cjs_resolve_options(alias_lookup_path.root())
+                            node_cjs_resolve_options(alias_lookup_path.root().await?.clone_value())
                         }
                         ExternalType::EcmaScriptModule => {
-                            node_esm_resolve_options(alias_lookup_path.root())
+                            node_esm_resolve_options(alias_lookup_path.root().await?.clone_value())
                         }
                         ExternalType::Script | ExternalType::Url | ExternalType::Global => options,
                     },
@@ -2805,8 +2833,8 @@ async fn resolve_import_map_result(
                 .map(|result| {
                     Box::pin(resolve_import_map_result(
                         result,
-                        lookup_path,
-                        original_lookup_path,
+                        lookup_path.clone(),
+                        original_lookup_path.clone(),
                         original_request,
                         options,
                         query.clone(),
@@ -2834,13 +2862,13 @@ async fn resolved(
 ) -> Result<Vc<ResolveResult>> {
     let RealPathResult { path, symlinks } = &*fs_path.realpath_with_links().await?;
 
-    let path_ref = &*path.await?;
+    let path_ref = path.clone();
     // Check alias field for path aliases first
     if let Some(result) = apply_in_package(
-        path.parent().resolve().await?,
+        path.parent(),
         options,
         options_value,
-        |package_path| package_path.get_relative_path_to(path_ref),
+        |package_path| package_path.get_relative_path_to(&path_ref),
         query.clone(),
         fragment.clone(),
     )
@@ -2851,13 +2879,13 @@ async fn resolved(
 
     if let Some(resolved_map) = options_value.resolved_map {
         let result = resolved_map
-            .lookup(**path, original_context, original_request)
+            .lookup(path.clone(), original_context.clone(), original_request)
             .await?;
 
         let resolved_result = resolve_import_map_result(
             &result,
             path.parent(),
-            original_context,
+            original_context.clone(),
             original_request,
             options,
             query.clone(),
@@ -2872,7 +2900,7 @@ async fn resolved(
     Ok(*ResolveResult::source_with_affecting_sources(
         request_key,
         ResolvedVc::upcast(
-            FileSource::new_with_query_and_fragment(**path, query, fragment)
+            FileSource::new_with_query_and_fragment(path.clone(), query, fragment)
                 .to_resolved()
                 .await?,
         ),
@@ -2880,7 +2908,7 @@ async fn resolved(
             .iter()
             .map(|symlink| async move {
                 anyhow::Ok(ResolvedVc::upcast(
-                    FileSource::new(**symlink).to_resolved().await?,
+                    FileSource::new(symlink.clone()).to_resolved().await?,
                 ))
             })
             .try_join()
@@ -2929,8 +2957,12 @@ async fn handle_exports_imports_field(
             .to_resolved()
             .await?;
 
-            let resolve_result =
-                Box::pin(resolve_internal_inline(package_path, *request, options)).await?;
+            let resolve_result = Box::pin(resolve_internal_inline(
+                package_path.clone(),
+                *request,
+                options,
+            ))
+            .await?;
             if conditions.is_empty() {
                 resolved_results.push(resolve_result.with_request(path.into()));
             } else {
@@ -2969,7 +3001,7 @@ async fn resolve_package_internal_with_imports_field(
     if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with('/') {
         ResolvingIssue {
             severity: error_severity(resolve_options).await?,
-            file_path: file_path.to_resolved().await?,
+            file_path: file_path.clone(),
             request_type: format!("package imports request: `{specifier}`"),
             request: request.to_resolved().await?,
             resolve_options: resolve_options.to_resolved().await?,
@@ -2983,13 +3015,13 @@ async fn resolve_package_internal_with_imports_field(
 
     let imports_result = imports_field(file_path).await?;
     let (imports, package_json_path) = match &*imports_result {
-        ImportsFieldResult::Some(i, p) => (i, *p),
+        ImportsFieldResult::Some(i, p) => (i, p.clone()),
         ImportsFieldResult::None => return Ok(*ResolveResult::unresolvable()),
     };
 
     handle_exports_imports_field(
         package_json_path.parent(),
-        *package_json_path,
+        package_json_path.clone(),
         resolve_options,
         imports,
         specifier,
@@ -3104,7 +3136,7 @@ async fn emit_resolve_error_issue(
     };
     ResolvingIssue {
         severity,
-        file_path: origin_path.to_resolved().await?,
+        file_path: origin_path.clone(),
         request_type: format!("{reference_type} request"),
         request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,
@@ -3131,7 +3163,7 @@ async fn emit_unresolvable_issue(
     };
     ResolvingIssue {
         severity,
-        file_path: origin_path.to_resolved().await?,
+        file_path: origin_path.clone(),
         request_type: format!("{reference_type} request"),
         request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,

--- a/turbopack/crates/turbopack-core/src/resolve/node.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/node.rs
@@ -7,7 +7,7 @@ use super::options::{
 };
 
 #[turbo_tasks::function]
-pub fn node_cjs_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveOptions> {
+pub fn node_cjs_resolve_options(root: FileSystemPath) -> Vc<ResolveOptions> {
     let conditions: ResolutionConditions = [
         ("node".into(), ConditionValue::Set),
         ("require".into(), ConditionValue::Set),
@@ -37,7 +37,7 @@ pub fn node_cjs_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveO
 }
 
 #[turbo_tasks::function]
-pub fn node_esm_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveOptions> {
+pub fn node_esm_resolve_options(root: FileSystemPath) -> Vc<ResolveOptions> {
     let conditions: ResolutionConditions = [
         ("node".into(), ConditionValue::Set),
         ("import".into(), ConditionValue::Set),

--- a/turbopack/crates/turbopack-core/src/resolve/node.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/node.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
 use super::options::{

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -41,10 +41,10 @@ pub struct ExcludedExtensions(pub FxIndexSet<RcStr>);
 pub enum ResolveModules {
     /// when inside of path, use the list of directories to
     /// resolve inside these
-    Nested(ResolvedVc<FileSystemPath>, Vec<RcStr>),
+    Nested(FileSystemPath, Vec<RcStr>),
     /// look into that directory, unless the request has an excluded extension
     Path {
-        dir: ResolvedVc<FileSystemPath>,
+        dir: FileSystemPath,
         excluded_extensions: ResolvedVc<ExcludedExtensions>,
     },
 }
@@ -115,14 +115,14 @@ pub enum ImportMapping {
         name: Option<RcStr>,
         ty: ExternalType,
         traced: ExternalTraced,
-        lookup_dir: ResolvedVc<FileSystemPath>,
+        lookup_dir: FileSystemPath,
     },
     /// An already resolved result that will be returned directly.
     Direct(ResolvedVc<ResolveResult>),
     /// A request alias that will be resolved first, and fall back to resolving
     /// the original request if it fails. Useful for the tsconfig.json
     /// `compilerOptions.paths` option and Next aliases.
-    PrimaryAlternative(RcStr, Option<ResolvedVc<FileSystemPath>>),
+    PrimaryAlternative(RcStr, Option<FileSystemPath>),
     Ignore,
     Empty,
     Alternatives(Vec<ResolvedVc<ImportMapping>>),
@@ -139,10 +139,10 @@ pub enum ReplacedImportMapping {
         name: Option<RcStr>,
         ty: ExternalType,
         traced: ExternalTraced,
-        lookup_dir: ResolvedVc<FileSystemPath>,
+        lookup_dir: FileSystemPath,
     },
     Direct(ResolvedVc<ResolveResult>),
-    PrimaryAlternative(Pattern, Option<ResolvedVc<FileSystemPath>>),
+    PrimaryAlternative(Pattern, Option<FileSystemPath>),
     Ignore,
     Empty,
     Alternatives(Vec<ResolvedVc<ReplacedImportMapping>>),
@@ -152,7 +152,7 @@ pub enum ReplacedImportMapping {
 impl ImportMapping {
     pub fn primary_alternatives(
         list: Vec<RcStr>,
-        lookup_path: Option<ResolvedVc<FileSystemPath>>,
+        lookup_path: Option<FileSystemPath>,
     ) -> ImportMapping {
         if list.is_empty() {
             ImportMapping::Ignore
@@ -346,7 +346,7 @@ impl ImportMap {
     pub fn insert_singleton_alias<'a>(
         &mut self,
         prefix: impl Into<RcStr> + 'a,
-        context_path: ResolvedVc<FileSystemPath>,
+        context_path: FileSystemPath,
     ) {
         let prefix: RcStr = prefix.into();
         let wildcard_prefix: RcStr = (prefix.to_string() + "/").into();
@@ -376,11 +376,7 @@ impl ImportMap {
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Default)]
 pub struct ResolvedMap {
-    pub by_glob: Vec<(
-        ResolvedVc<FileSystemPath>,
-        ResolvedVc<Glob>,
-        ResolvedVc<ImportMapping>,
-    )>,
+    pub by_glob: Vec<(FileSystemPath, ResolvedVc<Glob>, ResolvedVc<ImportMapping>)>,
 }
 
 #[turbo_tasks::value(shared)]
@@ -392,16 +388,16 @@ pub enum ImportMapResult {
         name: RcStr,
         ty: ExternalType,
         traced: ExternalTraced,
-        lookup_dir: ResolvedVc<FileSystemPath>,
+        lookup_dir: FileSystemPath,
     },
-    Alias(ResolvedVc<Request>, Option<ResolvedVc<FileSystemPath>>),
+    Alias(ResolvedVc<Request>, Option<FileSystemPath>),
     Alternatives(Vec<ImportMapResult>),
     NoEntry,
 }
 
 async fn import_mapping_to_result(
     mapping: Vc<ReplacedImportMapping>,
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     request: Vc<Request>,
 ) -> Result<ImportMapResult> {
     Ok(match &*mapping.await? {
@@ -499,7 +495,7 @@ impl ImportMap {
     // lookup
     pub async fn lookup(
         &self,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<ImportMapResult> {
         // relative requests must not match global wildcard aliases.
@@ -547,8 +543,8 @@ impl ResolvedMap {
     #[turbo_tasks::function]
     pub async fn lookup(
         &self,
-        resolved: Vc<FileSystemPath>,
-        lookup_path: Vc<FileSystemPath>,
+        resolved: FileSystemPath,
+        lookup_path: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let resolved = resolved.await?;
@@ -695,7 +691,7 @@ pub trait ImportMappingReplacement {
     #[turbo_tasks::function]
     fn result(
         self: Vc<Self>,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         request: Vc<Request>,
     ) -> Vc<ImportMapResult>;
 }

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -161,7 +161,9 @@ impl ImportMapping {
         } else {
             ImportMapping::Alternatives(
                 list.into_iter()
-                    .map(|s| ImportMapping::PrimaryAlternative(s, lookup_path).resolved_cell())
+                    .map(|s| {
+                        ImportMapping::PrimaryAlternative(s, lookup_path.clone()).resolved_cell()
+                    })
                     .collect(),
             )
         }
@@ -200,10 +202,13 @@ impl AliasTemplate for Vc<ImportMapping> {
                     name: name.clone(),
                     ty: *ty,
                     traced: *traced,
-                    lookup_dir: *lookup_dir,
+                    lookup_dir: lookup_dir.clone(),
                 },
                 ImportMapping::PrimaryAlternative(name, lookup_dir) => {
-                    ReplacedImportMapping::PrimaryAlternative((*name).clone().into(), *lookup_dir)
+                    ReplacedImportMapping::PrimaryAlternative(
+                        (*name).clone().into(),
+                        lookup_dir.clone(),
+                    )
                 }
                 ImportMapping::Direct(v) => ReplacedImportMapping::Direct(*v),
                 ImportMapping::Ignore => ReplacedImportMapping::Ignore,
@@ -248,21 +253,21 @@ impl AliasTemplate for Vc<ImportMapping> {
                             name: capture.spread_into_star(name).as_string().map(|s| s.into()),
                             ty: *ty,
                             traced: *traced,
-                            lookup_dir: *lookup_dir,
+                            lookup_dir: lookup_dir.clone(),
                         }
                     } else {
                         ReplacedImportMapping::PrimaryAlternativeExternal {
                             name: None,
                             ty: *ty,
                             traced: *traced,
-                            lookup_dir: *lookup_dir,
+                            lookup_dir: lookup_dir.clone(),
                         }
                     }
                 }
                 ImportMapping::PrimaryAlternative(name, lookup_dir) => {
                     ReplacedImportMapping::PrimaryAlternative(
                         capture.spread_into_star(name),
-                        *lookup_dir,
+                        lookup_dir.clone(),
                     )
                 }
                 ImportMapping::Direct(v) => ReplacedImportMapping::Direct(*v),
@@ -353,7 +358,8 @@ impl ImportMap {
         let wildcard_alias: RcStr = (prefix.to_string() + "/*").into();
         self.insert_exact_alias(
             prefix.clone(),
-            ImportMapping::PrimaryAlternative(prefix.clone(), Some(context_path)).resolved_cell(),
+            ImportMapping::PrimaryAlternative(prefix.clone(), Some(context_path.clone()))
+                .resolved_cell(),
         );
         self.insert_wildcard_alias(
             wildcard_prefix,
@@ -428,7 +434,7 @@ async fn import_mapping_to_result(
             },
             ty: *ty,
             traced: *traced,
-            lookup_dir: *lookup_dir,
+            lookup_dir: lookup_dir.clone(),
         },
         ReplacedImportMapping::Ignore => {
             ImportMapResult::Result(ResolveResult::primary(ResolveResultItem::Ignore))
@@ -438,11 +444,17 @@ async fn import_mapping_to_result(
         }
         ReplacedImportMapping::PrimaryAlternative(name, context) => {
             let request = Request::parse(name.clone()).to_resolved().await?;
-            ImportMapResult::Alias(request, *context)
+            ImportMapResult::Alias(request, context.clone())
         }
         ReplacedImportMapping::Alternatives(list) => ImportMapResult::Alternatives(
             list.iter()
-                .map(|mapping| Box::pin(import_mapping_to_result(**mapping, lookup_path, request)))
+                .map(|mapping| {
+                    Box::pin(import_mapping_to_result(
+                        **mapping,
+                        lookup_path.clone(),
+                        request,
+                    ))
+                })
                 .try_join()
                 .await?,
         ),
@@ -462,7 +474,7 @@ impl ValueToString for ImportMapResult {
             ImportMapResult::AliasExternal { .. } => Ok(Vc::cell(rcstr!("TODO external"))),
             ImportMapResult::Alias(request, context) => {
                 let s = if let Some(path) = context {
-                    let path = path.to_string().await?;
+                    let path = path.value_to_string().await?;
                     format!(
                         "aliased to {} inside of {}",
                         request.to_string().await?,
@@ -524,8 +536,12 @@ impl ImportMap {
             .chain(lookup_rel_parent.into_iter())
             .chain(lookup.into_iter())
             .map(async |result| {
-                import_mapping_to_result(*result.try_join_into_self().await?, lookup_path, request)
-                    .await
+                import_mapping_to_result(
+                    *result.try_join_into_self().await?,
+                    lookup_path.clone(),
+                    request,
+                )
+                .await
             })
             .try_join()
             .await?;
@@ -547,9 +563,7 @@ impl ResolvedMap {
         lookup_path: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
-        let resolved = resolved.await?;
         for (root, glob, mapping) in self.by_glob.iter() {
-            let root = root.await?;
             if let Some(path) = root.get_path_to(&resolved)
                 && glob.await?.matches(path)
             {

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -107,7 +107,7 @@ async fn resolve_asset(
 #[turbo_tasks::value]
 pub struct PlainResolveOrigin {
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
-    origin_path: ResolvedVc<FileSystemPath>,
+    origin_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -115,7 +115,7 @@ impl PlainResolveOrigin {
     #[turbo_tasks::function]
     pub fn new(
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
-        origin_path: ResolvedVc<FileSystemPath>,
+        origin_path: FileSystemPath,
     ) -> Vc<Self> {
         PlainResolveOrigin {
             asset_context,

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -47,7 +47,10 @@ pub trait ResolveOriginExt: Send {
     ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send;
 
     /// Get the resolve options that apply for this origin.
-    fn resolve_options(self: Vc<Self>, reference_type: ReferenceType) -> Vc<ResolveOptions>;
+    fn resolve_options(
+        self: Vc<Self>,
+        reference_type: ReferenceType,
+    ) -> impl std::future::Future<Output = Result<Vc<ResolveOptions>>> + Send;
 
     /// Adds a transition that is used for resolved assets.
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>>;
@@ -66,9 +69,13 @@ where
         resolve_asset(Vc::upcast(self), request, options, reference_type)
     }
 
-    fn resolve_options(self: Vc<Self>, reference_type: ReferenceType) -> Vc<ResolveOptions> {
-        self.asset_context()
-            .resolve_options(self.origin_path(), reference_type)
+    async fn resolve_options(
+        self: Vc<Self>,
+        reference_type: ReferenceType,
+    ) -> Result<Vc<ResolveOptions>> {
+        Ok(self
+            .asset_context()
+            .resolve_options(self.origin_path().await?.clone_value(), reference_type))
     }
 
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>> {
@@ -96,7 +103,7 @@ async fn resolve_asset(
         .resolve()
         .await?
         .resolve_asset(
-            resolve_origin.origin_path().resolve().await?,
+            resolve_origin.origin_path().await?.clone_value(),
             request.resolve().await?,
             options.resolve().await?,
             reference_type,
@@ -129,7 +136,7 @@ impl PlainResolveOrigin {
 impl ResolveOrigin for PlainResolveOrigin {
     #[turbo_tasks::function]
     fn origin_path(&self) -> Vc<FileSystemPath> {
-        *self.origin_path
+        self.origin_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1326,12 +1326,12 @@ impl ValueToString for Pattern {
     NonLocalValue,
 )]
 pub enum PatternMatch {
-    File(RcStr, ResolvedVc<FileSystemPath>),
-    Directory(RcStr, ResolvedVc<FileSystemPath>),
+    File(RcStr, FileSystemPath),
+    Directory(RcStr, FileSystemPath),
 }
 
 impl PatternMatch {
-    pub fn path(&self) -> ResolvedVc<FileSystemPath> {
+    pub fn path(&self) -> Vc<FileSystemPath> {
         match *self {
             PatternMatch::File(_, path) | PatternMatch::Directory(_, path) => path,
         }
@@ -1359,7 +1359,7 @@ pub struct PatternMatches(Vec<PatternMatch>);
 /// symlinks when they are interested in that.
 #[turbo_tasks::function]
 pub async fn read_matches(
-    lookup_dir: ResolvedVc<FileSystemPath>,
+    lookup_dir: FileSystemPath,
     prefix: RcStr,
     force_in_lookup_dir: bool,
     pattern: Vc<Pattern>,

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -12,8 +12,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, debug::ValueDebugFormat,
-    trace::TraceRawVcs,
+    NonLocalValue, TaskInput, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
     FileSystemPath, LinkContent, LinkType, RawDirectoryContent, RawDirectoryEntry,
@@ -1332,8 +1331,8 @@ pub enum PatternMatch {
 
 impl PatternMatch {
     pub fn path(&self) -> Vc<FileSystemPath> {
-        match *self {
-            PatternMatch::File(_, path) | PatternMatch::Directory(_, path) => path,
+        match self {
+            PatternMatch::File(_, path) | PatternMatch::Directory(_, path) => path.clone().cell(),
         }
     }
 
@@ -1387,11 +1386,11 @@ pub async fn read_matches(
                     if last_segment.is_empty() {
                         // This means we don't have a last segment, so we just have a directory
                         let joined = if force_in_lookup_dir {
-                            lookup_dir.try_join_inside(parent_path.into()).await?
+                            lookup_dir.try_join_inside(parent_path)?
                         } else {
-                            lookup_dir.try_join(parent_path.into()).await?
+                            lookup_dir.try_join(parent_path)?
                         };
-                        let Some(fs_path) = *joined else {
+                        let Some(fs_path) = joined else {
                             continue;
                         };
                         results.push((
@@ -1404,10 +1403,10 @@ pub async fn read_matches(
                     let read_dir = match entry {
                         Entry::Occupied(e) => Some(e.into_mut()),
                         Entry::Vacant(e) => {
-                            let path_option = *if force_in_lookup_dir {
-                                lookup_dir.try_join_inside(parent_path.into()).await?
+                            let path_option = if force_in_lookup_dir {
+                                lookup_dir.try_join_inside(parent_path)?
                             } else {
-                                lookup_dir.try_join(parent_path.into()).await?
+                                lookup_dir.try_join(parent_path)?
                             };
                             if let Some(path) = path_option {
                                 Some(e.insert((path.raw_read_dir().await?, path)))
@@ -1431,10 +1430,7 @@ pub async fn read_matches(
                                 index,
                                 PatternMatch::File(
                                     concat(&prefix, str).into(),
-                                    parent_fs_path
-                                        .join(last_segment.into())
-                                        .to_resolved()
-                                        .await?,
+                                    parent_fs_path.join(last_segment)?,
                                 ),
                             ));
                         }
@@ -1442,17 +1438,11 @@ pub async fn read_matches(
                             index,
                             PatternMatch::Directory(
                                 concat(&prefix, str).into(),
-                                parent_fs_path
-                                    .join(last_segment.into())
-                                    .to_resolved()
-                                    .await?,
+                                parent_fs_path.join(last_segment)?,
                             ),
                         )),
                         RawDirectoryEntry::Symlink => {
-                            let fs_path = parent_fs_path
-                                .join(last_segment.into())
-                                .to_resolved()
-                                .await?;
+                            let fs_path = parent_fs_path.join(last_segment)?;
                             let LinkContent::Link { link_type, .. } = &*fs_path.read_link().await?
                             else {
                                 continue;
@@ -1470,17 +1460,17 @@ pub async fn read_matches(
                     let subpath = &str[..=str.rfind('/').unwrap()];
                     if handled.insert(subpath) {
                         let joined = if force_in_lookup_dir {
-                            lookup_dir.try_join_inside(subpath.into()).await?
+                            lookup_dir.try_join_inside(subpath)?
                         } else {
-                            lookup_dir.try_join(subpath.into()).await?
+                            lookup_dir.try_join(subpath)?
                         };
-                        let Some(fs_path) = *joined else {
+                        let Some(fs_path) = joined else {
                             continue;
                         };
                         nested.push((
                             0,
                             read_matches(
-                                *fs_path,
+                                fs_path.clone(),
                                 concat(&prefix, subpath).into(),
                                 force_in_lookup_dir,
                                 pattern,
@@ -1507,10 +1497,7 @@ pub async fn read_matches(
                 if let Some(pos) = pat.match_position(&prefix) {
                     results.push((
                         pos,
-                        PatternMatch::Directory(
-                            prefix.clone().into(),
-                            lookup_dir.parent().to_resolved().await?,
-                        ),
+                        PatternMatch::Directory(prefix.clone().into(), lookup_dir.parent()),
                     ));
                 }
 
@@ -1519,10 +1506,7 @@ pub async fn read_matches(
                 if let Some(pos) = pat.match_position(&prefix) {
                     results.push((
                         pos,
-                        PatternMatch::Directory(
-                            prefix.clone().into(),
-                            lookup_dir.parent().to_resolved().await?,
-                        ),
+                        PatternMatch::Directory(prefix.clone().into(), lookup_dir.parent()),
                     ));
                 }
                 if let Some(pos) = pat.could_match_position(&prefix) {
@@ -1541,17 +1525,23 @@ pub async fn read_matches(
                 if let Some(pos) = pat.match_position(&prefix) {
                     results.push((
                         pos,
-                        PatternMatch::Directory(prefix.clone().into(), lookup_dir),
+                        PatternMatch::Directory(prefix.clone().into(), lookup_dir.clone()),
                     ));
                 }
                 prefix.pop();
             }
             if prefix.is_empty() {
                 if let Some(pos) = pat.match_position("./") {
-                    results.push((pos, PatternMatch::Directory(rcstr!("./"), lookup_dir)));
+                    results.push((
+                        pos,
+                        PatternMatch::Directory(rcstr!("./"), lookup_dir.clone()),
+                    ));
                 }
                 if let Some(pos) = pat.could_match_position("./") {
-                    nested.push((pos, read_matches(*lookup_dir, rcstr!("./"), false, pattern)));
+                    nested.push((
+                        pos,
+                        read_matches(lookup_dir.clone(), rcstr!("./"), false, pattern),
+                    ));
                 }
             } else {
                 prefix.push('/');
@@ -1559,7 +1549,12 @@ pub async fn read_matches(
                 if let Some(pos) = pat.could_match_position(&prefix) {
                     nested.push((
                         pos,
-                        read_matches(*lookup_dir, prefix.to_string().into(), false, pattern),
+                        read_matches(
+                            lookup_dir.clone(),
+                            prefix.to_string().into(),
+                            false,
+                            pattern,
+                        ),
                     ));
                 }
                 prefix.pop();
@@ -1568,7 +1563,12 @@ pub async fn read_matches(
                 if let Some(pos) = pat.could_match_position(&prefix) {
                     nested.push((
                         pos,
-                        read_matches(*lookup_dir, prefix.to_string().into(), false, pattern),
+                        read_matches(
+                            lookup_dir.clone(),
+                            prefix.to_string().into(),
+                            false,
+                            pattern,
+                        ),
                     ));
                 }
                 prefix.pop();
@@ -1583,7 +1583,7 @@ pub async fn read_matches(
                                 prefix.push_str(key);
                                 // {prefix}{key}
                                 if let Some(pos) = pat.match_position(&prefix) {
-                                    let path = lookup_dir.join(key.clone()).to_resolved().await?;
+                                    let path = lookup_dir.join(key)?;
                                     results.push((
                                         pos,
                                         PatternMatch::File(prefix.clone().into(), path),
@@ -1599,7 +1599,7 @@ pub async fn read_matches(
                                     prefix.pop();
                                 }
                                 if let Some(pos) = pat.match_position(&prefix) {
-                                    let path = lookup_dir.join(key.clone()).to_resolved().await?;
+                                    let path = lookup_dir.join(key)?;
                                     results.push((
                                         pos,
                                         PatternMatch::Directory(prefix.clone().into(), path),
@@ -1608,17 +1608,17 @@ pub async fn read_matches(
                                 prefix.push('/');
                                 // {prefix}{key}/
                                 if let Some(pos) = pat.match_position(&prefix) {
-                                    let path = lookup_dir.join(key.clone()).to_resolved().await?;
+                                    let path = lookup_dir.join(key)?;
                                     results.push((
                                         pos,
                                         PatternMatch::Directory(prefix.clone().into(), path),
                                     ));
                                 }
                                 if let Some(pos) = pat.could_match_position(&prefix) {
-                                    let path = lookup_dir.join(key.clone()).to_resolved().await?;
+                                    let path = lookup_dir.join(key)?;
                                     nested.push((
                                         pos,
-                                        read_matches(*path, prefix.clone().into(), true, pattern),
+                                        read_matches(path, prefix.clone().into(), true, pattern),
                                     ));
                                 }
                                 prefix.truncate(len)
@@ -1631,8 +1631,7 @@ pub async fn read_matches(
                                     prefix.pop();
                                 }
                                 if let Some(pos) = pat.match_position(&prefix) {
-                                    let fs_path =
-                                        lookup_dir.join(key.clone()).to_resolved().await?;
+                                    let fs_path = lookup_dir.join(&key.clone())?;
                                     if let LinkContent::Link { link_type, .. } =
                                         &*fs_path.read_link().await?
                                     {
@@ -1654,8 +1653,7 @@ pub async fn read_matches(
                                 }
                                 prefix.push('/');
                                 if let Some(pos) = pat.match_position(&prefix) {
-                                    let fs_path =
-                                        lookup_dir.join(key.clone()).to_resolved().await?;
+                                    let fs_path = lookup_dir.join(&key.clone())?;
                                     if let LinkContent::Link { link_type, .. } =
                                         &*fs_path.read_link().await?
                                         && link_type.contains(LinkType::DIRECTORY)
@@ -1667,8 +1665,7 @@ pub async fn read_matches(
                                     }
                                 }
                                 if let Some(pos) = pat.could_match_position(&prefix) {
-                                    let fs_path =
-                                        lookup_dir.join(key.clone()).to_resolved().await?;
+                                    let fs_path = lookup_dir.join(&key.clone())?;
                                     if let LinkContent::Link { link_type, .. } =
                                         &*fs_path.read_link().await?
                                         && link_type.contains(LinkType::DIRECTORY)

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -12,19 +12,19 @@ use crate::{
 /// A condition which determines if the hooks of a resolve plugin gets called.
 #[turbo_tasks::value]
 pub struct AfterResolvePluginCondition {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
     glob: ResolvedVc<Glob>,
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
-    pub fn new(root: ResolvedVc<FileSystemPath>, glob: ResolvedVc<Glob>) -> Vc<Self> {
+    pub fn new(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Vc<Self> {
         AfterResolvePluginCondition { root, glob }.cell()
     }
 
     #[turbo_tasks::function]
-    pub async fn matches(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+    pub async fn matches(&self, fs_path: FileSystemPath) -> Result<Vc<bool>> {
         let root = self.root.await?;
         let glob = self.glob.await?;
 
@@ -88,7 +88,7 @@ pub trait BeforeResolvePlugin {
     #[turbo_tasks::function]
     fn before_resolve(
         self: Vc<Self>,
-        lookup_path: Vc<FileSystemPath>,
+        lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: Vc<Request>,
     ) -> Vc<ResolveResultOption>;
@@ -106,8 +106,8 @@ pub trait AfterResolvePlugin {
     #[turbo_tasks::function]
     fn after_resolve(
         self: Vc<Self>,
-        fs_path: Vc<FileSystemPath>,
-        lookup_path: Vc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: Vc<Request>,
     ) -> Vc<ResolveResultOption>;

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -25,10 +25,10 @@ impl AfterResolvePluginCondition {
 
     #[turbo_tasks::function]
     pub async fn matches(&self, fs_path: FileSystemPath) -> Result<Vc<bool>> {
-        let root = self.root.await?;
+        let root = self.root.clone();
         let glob = self.glob.await?;
 
-        let path = fs_path.await?;
+        let path = fs_path;
 
         if let Some(path) = root.get_path_to(&path)
             && glob.matches(path)

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -19,32 +19,32 @@ impl ServerFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for ServerFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
+    fn read(&self, _fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<LinkContent>> {
+    fn read_link(&self, _fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<RawDirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: Vc<FileSystemPath>, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: Vc<FileSystemPath>, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
+    fn metadata(&self, _fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 }

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -236,7 +236,7 @@ impl SourceMap {
         Ok(Some(SourceMap::Decoded(InnerSourceMap::new(map))))
     }
 
-    pub async fn new_from_file(file: Vc<FileSystemPath>) -> Result<Option<Self>> {
+    pub async fn new_from_file(file: FileSystemPath) -> Result<Option<Self>> {
         let read = file.read();
         Self::new_from_file_content(read).await
     }
@@ -409,11 +409,11 @@ impl SourceMap {
         })
     }
 
-    pub async fn with_resolved_sources(&self, origin: Vc<FileSystemPath>) -> Result<Self> {
+    pub async fn with_resolved_sources(&self, origin: FileSystemPath) -> Result<Self> {
         async fn resolve_source(
             source_request: BytesStr,
             source_content: Option<BytesStr>,
-            origin: Vc<FileSystemPath>,
+            origin: FileSystemPath,
         ) -> Result<(BytesStr, BytesStr)> {
             Ok(
                 if let Some(path) = *origin.parent().try_join((&*source_request).into()).await? {
@@ -450,7 +450,7 @@ impl SourceMap {
         }
         async fn regular_map_with_resolved_sources(
             map: &RegularMapWrapper,
-            origin: Vc<FileSystemPath>,
+            origin: FileSystemPath,
         ) -> Result<RegularMap> {
             let map = &map.0;
             let file = map.get_file().cloned();
@@ -478,7 +478,7 @@ impl SourceMap {
         }
         async fn decoded_map_with_resolved_sources(
             map: &CrateMapWrapper,
-            origin: Vc<FileSystemPath>,
+            origin: FileSystemPath,
         ) -> Result<CrateMapWrapper> {
             Ok(CrateMapWrapper(match &map.0 {
                 DecodedMap::Regular(map) => {

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use swc_sourcemap::{DecodedMap, SourceMap as RegularMap, SourceMapBuilder, SourceMapIndex};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{
     File, FileContent, FileSystem, FileSystemPath, VirtualFileSystem,
     rope::{Rope, RopeBuilder},
@@ -416,8 +416,8 @@ impl SourceMap {
             origin: FileSystemPath,
         ) -> Result<(BytesStr, BytesStr)> {
             Ok(
-                if let Some(path) = *origin.parent().try_join((&*source_request).into()).await? {
-                    let path_str = path.to_string().await?;
+                if let Some(path) = origin.parent().try_join(&source_request)? {
+                    let path_str = path.value_to_string().await?;
                     let source = format!("{SOURCE_URL_PROTOCOL}///{path_str}");
                     let source_content = if let Some(source_content) = source_content {
                         source_content
@@ -429,7 +429,7 @@ impl SourceMap {
                     };
                     (source.into(), source_content)
                 } else {
-                    let origin_str = origin.to_string().await?;
+                    let origin_str = origin.value_to_string().await?;
                     static INVALID_REGEX: Lazy<Regex> =
                         Lazy::new(|| Regex::new(r#"(?:^|/)(?:\.\.?(?:/|$))+"#).unwrap());
                     let source = INVALID_REGEX
@@ -465,7 +465,7 @@ impl SourceMap {
             let mut new_sources = Vec::with_capacity(count);
             let mut new_source_contents = Vec::with_capacity(count);
             for (source, source_content) in sources.into_iter().zip(source_contents.into_iter()) {
-                let (source, name) = resolve_source(source, source_content, origin).await?;
+                let (source, name) = resolve_source(source, source_content, origin.clone()).await?;
                 new_sources.push(source);
                 new_source_contents.push(Some(name));
             }
@@ -498,11 +498,18 @@ impl SourceMap {
                         .collect::<Vec<_>>();
                     let sections = sections
                         .into_iter()
-                        .map(|(offset, map)| async move {
-                            Ok((
-                                offset,
-                                Box::pin(decoded_map_with_resolved_sources(map, origin)).await?,
-                            ))
+                        .map(|(offset, map)| {
+                            let origin = origin.clone();
+                            async move {
+                                Ok((
+                                    offset,
+                                    Box::pin(decoded_map_with_resolved_sources(
+                                        map,
+                                        origin.clone(),
+                                    ))
+                                    .await?,
+                                ))
+                            }
                         })
                         .try_join()
                         .await?;
@@ -530,7 +537,7 @@ impl SourceMap {
             Self::Sectioned(m) => {
                 let mut sections = Vec::with_capacity(m.sections.len());
                 for section in &m.sections {
-                    let map = Box::pin(section.map.with_resolved_sources(origin)).await?;
+                    let map = Box::pin(section.map.with_resolved_sources(origin.clone())).await?;
                     sections.push(SourceMapSection::new(section.offset, map));
                 }
                 SourceMap::new_sectioned(sections)
@@ -545,10 +552,10 @@ fn sourcemap_content_fs_root() -> Vc<FileSystemPath> {
 }
 
 #[turbo_tasks::function]
-fn sourcemap_content_source(path: RcStr, content: RcStr) -> Vc<Box<dyn Source>> {
-    let path = sourcemap_content_fs_root().join(path);
+async fn sourcemap_content_source(path: RcStr, content: RcStr) -> Result<Vc<Box<dyn Source>>> {
+    let path = sourcemap_content_fs_root().await?.join(&path)?;
     let content = AssetContent::file(FileContent::new(File::from(content)).cell());
-    Vc::upcast(VirtualSource::new(path, content))
+    Ok(Vc::upcast(VirtualSource::new(path, content)))
 }
 
 impl SourceMap {

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -19,7 +19,7 @@ use crate::{
 #[derive(PartialEq, Eq, Serialize, Deserialize, NonLocalValue, TraceRawVcs, ValueDebugFormat)]
 enum PathType {
     Fixed {
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
     },
     FromIdent {
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
@@ -54,7 +54,7 @@ impl SourceMapAsset {
 
     #[turbo_tasks::function]
     pub fn new_fixed(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         generate_source_map: ResolvedVc<Box<dyn GenerateSourceMap>>,
     ) -> Vc<Self> {
         SourceMapAsset {

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -72,14 +72,16 @@ impl OutputAsset for SourceMapAsset {
         // NOTE(alexkirsz) We used to include the asset's version id in the path,
         // but this caused `all_assets_map` to be recomputed on every change.
         let this = self.await?;
-        Ok(match this.path_ty {
+        Ok(match &this.path_ty {
             PathType::FromIdent {
                 chunking_context,
                 ident_for_path,
             } => chunking_context
-                .chunk_path(Some(Vc::upcast(self)), *ident_for_path, rcstr!(".js"))
-                .append(rcstr!(".map")),
-            PathType::Fixed { path } => path.append(rcstr!(".map")),
+                .chunk_path(Some(Vc::upcast(self)), **ident_for_path, rcstr!(".js"))
+                .await?
+                .append(".map")?
+                .cell(),
+            PathType::Fixed { path } => path.append(".map")?.cell(),
         })
     }
 }

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -73,12 +73,12 @@ struct SourceMapJson {
 /// `sourceContent`s from disk.
 pub async fn resolve_source_map_sources(
     map: Option<&Rope>,
-    origin: Vc<FileSystemPath>,
+    origin: FileSystemPath,
 ) -> Result<Option<Rope>> {
     async fn resolve_source(
         original_source: &mut String,
         original_content: Option<&mut Option<String>>,
-        origin: Vc<FileSystemPath>,
+        origin: FileSystemPath,
     ) -> Result<()> {
         if let Some(path) = *origin
             .parent()
@@ -119,7 +119,7 @@ pub async fn resolve_source_map_sources(
         anyhow::Ok(())
     }
 
-    async fn resolve_map(map: &mut SourceMapJson, origin: Vc<FileSystemPath>) -> Result<()> {
+    async fn resolve_map(map: &mut SourceMapJson, origin: FileSystemPath) -> Result<()> {
         if let Some(sources) = &mut map.sources {
             let mut contents = if let Some(mut contents) = map.sources_content.take() {
                 contents.resize(sources.len(), None);
@@ -165,7 +165,7 @@ pub async fn resolve_source_map_sources(
 /// is useful for debugging environments.
 pub async fn fileify_source_map(
     map: Option<&Rope>,
-    context_path: Vc<FileSystemPath>,
+    context_path: FileSystemPath,
 ) -> Result<Option<Rope>> {
     let Some(map) = map else {
         return Ok(None);

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -5,7 +5,7 @@ use const_format::concatcp;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{ValueToString, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{
     DiskFileSystem, FileContent, FileSystemPath, rope::Rope, util::uri_from_file,
 };
@@ -80,12 +80,8 @@ pub async fn resolve_source_map_sources(
         original_content: Option<&mut Option<String>>,
         origin: FileSystemPath,
     ) -> Result<()> {
-        if let Some(path) = *origin
-            .parent()
-            .try_join((&**original_source).into())
-            .await?
-        {
-            let path_str = path.to_string().await?;
+        if let Some(path) = origin.parent().try_join(original_source)? {
+            let path_str = path.value_to_string().await?;
             let source = format!("{SOURCE_URL_PROTOCOL}///{path_str}");
             *original_source = source;
 
@@ -100,7 +96,7 @@ pub async fn resolve_source_map_sources(
                 }
             }
         } else {
-            let origin_str = origin.to_string().await?;
+            let origin_str = origin.value_to_string().await?;
             static INVALID_REGEX: Lazy<Regex> =
                 Lazy::new(|| Regex::new(r#"(?:^|/)(?:\.\.?(?:/|$))+"#).unwrap());
             let source = INVALID_REGEX.replace_all(original_source, |s: &regex::Captures<'_>| {
@@ -130,7 +126,7 @@ pub async fn resolve_source_map_sources(
 
             for (source, content) in sources.iter_mut().zip(contents.iter_mut()) {
                 if let Some(source) = source {
-                    resolve_source(source, Some(content), origin).await?;
+                    resolve_source(source, Some(content), origin.clone()).await?;
                 }
             }
 
@@ -149,12 +145,12 @@ pub async fn resolve_source_map_sources(
     };
 
     if let Some(file) = &mut map.file {
-        resolve_source(file, None, origin).await?;
+        resolve_source(file, None, origin.clone()).await?;
     }
 
-    resolve_map(&mut map, origin).await?;
+    resolve_map(&mut map, origin.clone()).await?;
     for section in map.sections.iter_mut().flatten() {
-        resolve_map(&mut section.map, origin).await?;
+        resolve_map(&mut section.map, origin.clone()).await?;
     }
 
     let map = Rope::from(serde_json::to_vec(&map)?);
@@ -187,7 +183,7 @@ pub async fn fileify_source_map(
         if let Some(src) = src
             && let Some(src_rest) = src.strip_prefix(&prefix)
         {
-            *src = uri_from_file(context_path, Some(src_rest)).await?;
+            *src = uri_from_file(context_path.clone(), Some(src_rest)).await?;
         }
         anyhow::Ok(())
     };

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -10,7 +10,7 @@ use crate::{
 /// to other assets.
 #[turbo_tasks::value]
 pub struct VirtualOutputAsset {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub content: ResolvedVc<AssetContent>,
     pub references: ResolvedVc<OutputAssets>,
 }
@@ -18,7 +18,7 @@ pub struct VirtualOutputAsset {
 #[turbo_tasks::value_impl]
 impl VirtualOutputAsset {
     #[turbo_tasks::function]
-    pub fn new(path: ResolvedVc<FileSystemPath>, content: ResolvedVc<AssetContent>) -> Vc<Self> {
+    pub fn new(path: FileSystemPath, content: ResolvedVc<AssetContent>) -> Vc<Self> {
         VirtualOutputAsset {
             path,
             content,
@@ -29,7 +29,7 @@ impl VirtualOutputAsset {
 
     #[turbo_tasks::function]
     pub fn new_with_references(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         content: ResolvedVc<AssetContent>,
         references: ResolvedVc<OutputAssets>,
     ) -> Vc<Self> {

--- a/turbopack/crates/turbopack-core/src/virtual_output.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_output.rs
@@ -46,7 +46,7 @@ impl VirtualOutputAsset {
 impl OutputAsset for VirtualOutputAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/virtual_source.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_source.rs
@@ -18,10 +18,7 @@ pub struct VirtualSource {
 #[turbo_tasks::value_impl]
 impl VirtualSource {
     #[turbo_tasks::function]
-    pub async fn new(
-        path: Vc<FileSystemPath>,
-        content: ResolvedVc<AssetContent>,
-    ) -> Result<Vc<Self>> {
+    pub async fn new(path: FileSystemPath, content: ResolvedVc<AssetContent>) -> Result<Vc<Self>> {
         Ok(Self::cell(VirtualSource {
             ident: AssetIdent::from_path(path).to_resolved().await?,
             content,

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -82,9 +82,11 @@ impl SingleItemCssChunk {
 #[turbo_tasks::value_impl]
 impl Chunk for SingleItemCssChunk {
     #[turbo_tasks::function]
-    fn ident(self: Vc<Self>) -> Vc<AssetIdent> {
+    async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
         let self_as_output_asset: Vc<Box<dyn OutputAsset>> = Vc::upcast(self);
-        AssetIdent::from_path(self_as_output_asset.path())
+        Ok(AssetIdent::from_path(
+            self_as_output_asset.path().await?.clone_value(),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -38,7 +38,9 @@ impl OutputAsset for SingleItemCssChunkSourceMapAsset {
                 this.chunk.ident_for_path(),
                 ".single.css".into(),
             )
-            .append(".map".into()))
+            .await?
+            .append(".map")?
+            .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -35,7 +35,9 @@ impl OutputAsset for CssChunkSourceMapAsset {
             .await?
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, ".css".into())
-            .append(".map".into()))
+            .await?
+            .append(".map")?
+            .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -402,7 +402,7 @@ pub async fn parse_css(
 async fn process_content(
     content_vc: ResolvedVc<FileContent>,
     code: String,
-    fs_path_vc: ResolvedVc<FileSystemPath>,
+    fs_path_vc: FileSystemPath,
     filename: &str,
     source: ResolvedVc<Box<dyn Source>>,
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
@@ -577,7 +577,7 @@ enum CssError {
 }
 
 impl CssError {
-    fn report(self, file: ResolvedVc<FileSystemPath>) {
+    fn report(self, file: FileSystemPath) {
         match self {
             CssError::CssSelectorInModuleNotPure { selector } => {
                 ParsingIssue {
@@ -685,7 +685,7 @@ fn generate_css_source_map(source_map: &parcel_sourcemap::SourceMap) -> Result<R
 #[turbo_tasks::value]
 struct ParsingIssue {
     msg: RcStr,
-    file: ResolvedVc<FileSystemPath>,
+    file: FileSystemPath,
     source: Option<IssueSource>,
 }
 

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -381,7 +381,7 @@ pub async fn parse_css(
                         process_content(
                             *file_content,
                             string.into_owned(),
-                            fs_path.to_resolved().await?,
+                            fs_path.await?.clone_value(),
                             ident_str,
                             source,
                             origin,
@@ -463,7 +463,7 @@ async fn process_content(
                     ss.visit(&mut validator).unwrap();
 
                     for err in validator.errors {
-                        err.report(fs_path_vc);
+                        err.report(fs_path_vc.clone());
                     }
                 }
 
@@ -488,7 +488,7 @@ async fn process_content(
                             };
 
                             ParsingIssue {
-                                file: fs_path_vc,
+                                file: fs_path_vc.clone(),
                                 msg: err.to_string().into(),
                                 source,
                             }
@@ -693,7 +693,7 @@ struct ParsingIssue {
 impl Issue for ParsingIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file
+        self.file.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -35,7 +35,7 @@ pub struct DevHtmlEntry {
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct DevHtmlAsset {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     entries: Vec<DevHtmlEntry>,
     body: Option<RcStr>,
 }
@@ -68,7 +68,7 @@ impl Asset for DevHtmlAsset {
 
 impl DevHtmlAsset {
     /// Create a new dev HTML asset.
-    pub fn new(path: ResolvedVc<FileSystemPath>, entries: Vec<DevHtmlEntry>) -> Vc<Self> {
+    pub fn new(path: FileSystemPath, entries: Vec<DevHtmlEntry>) -> Vc<Self> {
         DevHtmlAsset {
             path,
             entries,
@@ -79,7 +79,7 @@ impl DevHtmlAsset {
 
     /// Create a new dev HTML asset.
     pub fn new_with_body(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         entries: Vec<DevHtmlEntry>,
         body: RcStr,
     ) -> Vc<Self> {
@@ -95,7 +95,7 @@ impl DevHtmlAsset {
 #[turbo_tasks::value_impl]
 impl DevHtmlAsset {
     #[turbo_tasks::function]
-    pub async fn with_path(self: Vc<Self>, path: ResolvedVc<FileSystemPath>) -> Result<Vc<Self>> {
+    pub async fn with_path(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<Self>> {
         let mut html: DevHtmlAsset = self.owned().await?;
         html.path = path;
         Ok(html.cell())

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -44,7 +44,7 @@ pub struct DevHtmlAsset {
 impl OutputAsset for DevHtmlAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -114,7 +114,7 @@ impl DevHtmlAsset {
     #[turbo_tasks::function]
     async fn html_content(self: Vc<Self>) -> Result<Vc<DevHtmlAssetContent>> {
         let this = self.await?;
-        let context_path = this.path.parent().await?;
+        let context_path = this.path.parent();
         let mut chunk_paths = vec![];
         for chunk in &*self.chunks().await? {
             let chunk_path = &*chunk.path().await?;

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -27,7 +27,7 @@ type ExpandedState = State<FxHashSet<RcStr>>;
 
 #[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 pub struct AssetGraphContentSource {
-    root_path: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
     root_assets: ResolvedVc<OutputAssetsSet>,
     expanded: Option<ExpandedState>,
 }
@@ -37,7 +37,7 @@ impl AssetGraphContentSource {
     /// Serves all assets references by root_asset.
     #[turbo_tasks::function]
     pub fn new_eager(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -51,7 +51,7 @@ impl AssetGraphContentSource {
     /// asset when it has served its content before.
     #[turbo_tasks::function]
     pub fn new_lazy(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -64,7 +64,7 @@ impl AssetGraphContentSource {
     /// Serves all assets references by all root_assets.
     #[turbo_tasks::function]
     pub fn new_eager_multiple(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_assets: ResolvedVc<OutputAssetsSet>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {
@@ -78,7 +78,7 @@ impl AssetGraphContentSource {
     /// of an asset when it has served its content before.
     #[turbo_tasks::function]
     pub fn new_lazy_multiple(
-        root_path: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
         root_assets: ResolvedVc<OutputAssetsSet>,
     ) -> Vc<Self> {
         Self::cell(AssetGraphContentSource {

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -4,8 +4,7 @@ use anyhow::Result;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexMap, FxIndexSet, ResolvedVc, State, TryJoinIterExt, ValueToString, Vc,
-    fxindexset,
+    Completion, FxIndexMap, FxIndexSet, ResolvedVc, State, TryJoinIterExt, Vc, fxindexset,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -93,7 +92,7 @@ impl AssetGraphContentSource {
         Ok(Vc::cell(
             expand(
                 &*self.root_assets.await?,
-                &*self.root_path.await?,
+                &self.root_path,
                 self.expanded.as_ref(),
             )
             .await?,
@@ -302,7 +301,7 @@ impl Introspectable for AssetGraphContentSource {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<RcStr> {
-        self.root_path.to_string()
+        self.root_path.value_to_string()
     }
 
     #[turbo_tasks::function]
@@ -372,15 +371,14 @@ impl Introspectable for FullyExpanded {
 
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<RcStr>> {
-        Ok(self.0.await?.root_path.to_string())
+        Ok(self.0.await?.root_path.value_to_string())
     }
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let source = self.0.await?;
 
-        let expanded_assets =
-            expand(&*source.root_assets.await?, &*source.root_path.await?, None).await?;
+        let expanded_assets = expand(&*source.root_assets.await?, &source.root_path, None).await?;
         let children = expanded_assets
             .iter()
             .map(|(_k, &v)| async move {

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -15,7 +15,7 @@ use super::{
 
 #[turbo_tasks::value]
 pub struct IssueFilePathContentSource {
-    file_path: Option<ResolvedVc<FileSystemPath>>,
+    file_path: Option<FileSystemPath>,
     description: RcStr,
     source: ResolvedVc<Box<dyn ContentSource>>,
 }
@@ -24,7 +24,7 @@ pub struct IssueFilePathContentSource {
 impl IssueFilePathContentSource {
     #[turbo_tasks::function]
     pub fn new_file_path(
-        file_path: ResolvedVc<FileSystemPath>,
+        file_path: FileSystemPath,
         description: RcStr,
         source: ResolvedVc<Box<dyn ContentSource>>,
     ) -> Vc<Self> {

--- a/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/issue_context.rs
@@ -56,7 +56,7 @@ impl ContentSource for IssueFilePathContentSource {
     async fn get_routes(self: ResolvedVc<Self>) -> Result<Vc<RouteTree>> {
         let this = self.await?;
         let routes = content_source_get_routes_operation(this.source)
-            .issue_file_path(this.file_path.map(|v| *v), &*this.description)
+            .issue_file_path(this.file_path.clone(), &*this.description)
             .await?
             .connect();
         Ok(routes.map_routes(Vc::upcast(
@@ -111,7 +111,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
     async fn vary(&self) -> Result<Vc<ContentSourceDataVary>> {
         let source = self.source.await?;
         Ok(get_content_source_vary_operation(self.get_content)
-            .issue_file_path(source.file_path.map(|v| *v), &*source.description)
+            .issue_file_path(source.file_path.clone(), &*source.description)
             .await?
             .connect())
     }
@@ -121,7 +121,7 @@ impl GetContentSourceContent for IssueContextGetContentSourceContent {
         let source = self.source.await?;
         Ok(
             get_content_source_get_operation(self.get_content, path, data)
-                .issue_file_path(source.file_path.map(|v| *v), &*source.description)
+                .issue_file_path(source.file_path.clone(), &*source.description)
                 .await?
                 .connect(),
         )

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -433,7 +433,7 @@ pub trait ContentSource {
 pub trait ContentSourceExt {
     fn issue_file_path(
         self: Vc<Self>,
-        file_path: Vc<FileSystemPath>,
+        file_path: FileSystemPath,
         description: RcStr,
     ) -> Vc<Box<dyn ContentSource>>;
 }
@@ -444,7 +444,7 @@ where
 {
     fn issue_file_path(
         self: Vc<Self>,
-        file_path: Vc<FileSystemPath>,
+        file_path: FileSystemPath,
         description: RcStr,
     ) -> Vc<Box<dyn ContentSource>> {
         Vc::upcast(IssueFilePathContentSource::new_file_path(

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -17,21 +17,21 @@ use super::{
 #[turbo_tasks::value(shared)]
 pub struct StaticAssetsContentSource {
     pub prefix: ResolvedVc<RcStr>,
-    pub dir: ResolvedVc<FileSystemPath>,
+    pub dir: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl StaticAssetsContentSource {
     // TODO(WEB-1151): Remove this method and migrate users to `with_prefix`.
     #[turbo_tasks::function]
-    pub fn new(prefix: RcStr, dir: Vc<FileSystemPath>) -> Vc<StaticAssetsContentSource> {
+    pub fn new(prefix: RcStr, dir: FileSystemPath) -> Vc<StaticAssetsContentSource> {
         StaticAssetsContentSource::with_prefix(Vc::cell(prefix), dir)
     }
 
     #[turbo_tasks::function]
     pub async fn with_prefix(
         prefix: ResolvedVc<RcStr>,
-        dir: ResolvedVc<FileSystemPath>,
+        dir: FileSystemPath,
     ) -> Result<Vc<StaticAssetsContentSource>> {
         if cfg!(debug_assertions) {
             let prefix_string = prefix.await?;
@@ -44,7 +44,7 @@ impl StaticAssetsContentSource {
 
 // TODO(WEB-1251) It would be better to lazily enumerate the directory
 #[turbo_tasks::function]
-async fn get_routes_from_directory(dir: Vc<FileSystemPath>) -> Result<Vc<RouteTree>> {
+async fn get_routes_from_directory(dir: FileSystemPath) -> Result<Vc<RouteTree>> {
     let dir = dir.read_dir().await?;
     let DirectoryContent::Entries(entries) = &*dir else {
         return Ok(RouteTree::empty());
@@ -84,13 +84,13 @@ impl ContentSource for StaticAssetsContentSource {
 
 #[turbo_tasks::value]
 struct StaticAssetsContentSourceItem {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl StaticAssetsContentSourceItem {
     #[turbo_tasks::function]
-    pub fn new(path: ResolvedVc<FileSystemPath>) -> Vc<StaticAssetsContentSourceItem> {
+    pub fn new(path: FileSystemPath) -> Vc<StaticAssetsContentSourceItem> {
         StaticAssetsContentSourceItem { path }.cell()
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -57,11 +57,11 @@ async fn get_routes_from_directory(dir: FileSystemPath) -> Result<Vc<RouteTree>>
                 Some(RouteTree::new_route(
                     vec![BaseSegment::Static(name.clone())],
                     RouteType::Exact,
-                    Vc::upcast(StaticAssetsContentSourceItem::new(**path)),
+                    Vc::upcast(StaticAssetsContentSourceItem::new(path.clone())),
                 ))
             }
             DirectoryEntry::Directory(path) => Some(
-                get_routes_from_directory(**path)
+                get_routes_from_directory(path.clone())
                     .with_prepended_base(vec![BaseSegment::Static(name.clone())]),
             ),
             _ => None,
@@ -78,7 +78,7 @@ impl ContentSource for StaticAssetsContentSource {
     async fn get_routes(&self) -> Result<Vc<RouteTree>> {
         let prefix = self.prefix.await?;
         let prefix = BaseSegment::from_static_pathname(prefix.as_str()).collect::<Vec<_>>();
-        Ok(get_routes_from_directory(*self.dir).with_prepended_base(prefix))
+        Ok(get_routes_from_directory(self.dir.clone()).with_prepended_base(prefix))
     }
 }
 
@@ -99,7 +99,7 @@ impl StaticAssetsContentSourceItem {
 impl GetContentSourceContent for StaticAssetsContentSourceItem {
     #[turbo_tasks::function]
     fn get(&self, _path: RcStr, _data: ContentSourceData) -> Vc<ContentSourceContent> {
-        let content = Vc::upcast::<Box<dyn Asset>>(FileSource::new(*self.path)).content();
+        let content = Vc::upcast::<Box<dyn Asset>>(FileSource::new(self.path.clone())).content();
         ContentSourceContent::static_content(content.versioned())
     }
 }
@@ -127,15 +127,17 @@ impl Introspectable for StaticAssetsContentSource {
                     let child = match entry {
                         DirectoryEntry::File(path) | DirectoryEntry::Symlink(path) => {
                             ResolvedVc::upcast(
-                                IntrospectableSource::new(Vc::upcast(FileSource::new(**path)))
-                                    .to_resolved()
-                                    .await?,
+                                IntrospectableSource::new(Vc::upcast(FileSource::new(
+                                    path.clone(),
+                                )))
+                                .to_resolved()
+                                .await?,
                             )
                         }
                         DirectoryEntry::Directory(path) => ResolvedVc::upcast(
                             StaticAssetsContentSource::with_prefix(
                                 Vc::cell(format!("{}{name}/", &*prefix).into()),
-                                **path,
+                                path.clone(),
                             )
                             .to_resolved()
                             .await?,

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -389,8 +389,12 @@ impl Issue for FatalStreamIssue {
     }
 
     #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        ServerFileSystem::new().root().join(self.resource.clone())
+    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(ServerFileSystem::new()
+            .root()
+            .await?
+            .join(&self.resource)?
+            .cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/server.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/server.rs
@@ -41,7 +41,7 @@ impl CustomTransformer for ServerDirectiveTransformer {
                 Program::Script(s) => s.body = vec![stmt],
             }
             UnsupportedServerActionIssue {
-                file_path: ctx.file_path,
+                file_path: ctx.file_path.clone(),
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
@@ -66,7 +66,6 @@ impl CustomTransformer for RelayTransformer {
         let path_to_proj = PathBuf::from(
             ctx.file_path
                 .parent()
-                .await?
                 .get_relative_path_to(&self.project_path)
                 .context("Expected relative path to relay artifact")?,
         );

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -50,7 +50,7 @@ impl SwcPluginModule {
 
 #[turbo_tasks::value(shared)]
 struct UnsupportedSwcEcmaTransformPluginsIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::ecma::ast::Program;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
@@ -74,7 +74,7 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -228,7 +228,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
             use turbopack_core::issue::IssueExt;
 
             UnsupportedSwcEcmaTransformPluginsIssue {
-                file_path: ctx.file_path,
+                file_path: ctx.file_path.clone(),
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath, embed_directory};
@@ -10,20 +11,25 @@ pub fn embed_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub fn embed_file(path: RcStr) -> Vc<FileContent> {
-    embed_fs().root().join(path).read()
+pub async fn embed_file(path: RcStr) -> Result<Vc<FileContent>> {
+    Ok(embed_fs().root().await?.join(&path)?.read())
 }
 
 #[turbo_tasks::function]
-pub fn embed_file_path(path: RcStr) -> Vc<FileSystemPath> {
-    embed_fs().root().join(path)
+pub async fn embed_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(embed_fs().root().await?.join(&path)?.cell())
 }
 
 #[turbo_tasks::function]
-pub fn embed_static_code(
+pub async fn embed_static_code(
     asset_context: Vc<Box<dyn AssetContext>>,
     path: RcStr,
     generate_source_map: bool,
-) -> Vc<Code> {
-    StaticEcmascriptCode::new(asset_context, embed_file_path(path), generate_source_map).code()
+) -> Result<Vc<Code>> {
+    Ok(StaticEcmascriptCode::new(
+        asset_context,
+        embed_file_path(path).await?.clone_value(),
+        generate_source_map,
+    )
+    .code())
 }

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -62,7 +62,7 @@ impl AsyncLoaderChunkItem {
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root(),
+            this.chunking_context.output_root().await?.clone_value(),
             self.chunks(),
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -30,7 +30,7 @@ pub struct EcmascriptChunkItemContent {
     pub source_map: Option<Rope>,
     pub additional_ids: SmallVec<[ResolvedVc<ModuleId>; 1]>,
     pub options: EcmascriptChunkItemOptions,
-    pub rewrite_source_path: Option<ResolvedVc<FileSystemPath>>,
+    pub rewrite_source_path: Option<FileSystemPath>,
     pub placeholder_for_future_extensions: (),
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -55,7 +55,7 @@ impl EcmascriptChunkItemContent {
 
         Ok(EcmascriptChunkItemContent {
             rewrite_source_path: if *chunking_context.should_use_file_source_map_uris().await? {
-                Some(chunking_context.root_path().to_resolved().await?)
+                Some(chunking_context.root_path().await?.clone_value())
             } else {
                 None
             },
@@ -134,8 +134,8 @@ impl EcmascriptChunkItemContent {
             code += "{\n";
         }
 
-        let source_map = if let Some(rewrite_source_path) = self.rewrite_source_path {
-            fileify_source_map(self.source_map.as_ref(), *rewrite_source_path).await?
+        let source_map = if let Some(rewrite_source_path) = &self.rewrite_source_path {
+            fileify_source_map(self.source_map.as_ref(), rewrite_source_path.clone()).await?
         } else {
             self.source_map.clone()
         };
@@ -279,7 +279,7 @@ async fn module_factory_with_code_generation_issue(
                 let js_error_message = serde_json::to_string(&error_message)?;
                 CodeGenerationIssue {
                     severity: IssueSeverity::Error,
-                    path: chunk_item.asset_ident().path().to_resolved().await?,
+                    path: chunk_item.asset_ident().path().await?.clone_value(),
                     title: StyledString::Text(rcstr!("Code generation for chunk item errored"))
                         .resolved_cell(),
                     message: StyledString::Text(error_message).resolved_cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -72,24 +72,23 @@ impl Chunk for EcmascriptChunk {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let chunk_items = &*self.content.included_chunk_items().await?;
         let mut common_path = if let Some(chunk_item) = chunk_items.first() {
-            let path = chunk_item.asset_ident().path().to_resolved().await?;
-            Some((path, path.await?))
+            let path = chunk_item.asset_ident().path().await?.clone_value();
+            Some(path)
         } else {
             None
         };
 
         // The included chunk items describe the chunk uniquely
         for &chunk_item in chunk_items.iter() {
-            if let Some((common_path_vc, common_path_ref)) = common_path.as_mut() {
+            if let Some(common_path_ref) = common_path.as_mut() {
                 let path = chunk_item.asset_ident().path().await?;
                 while !path.is_inside_or_equal_ref(common_path_ref) {
-                    let parent = common_path_vc.parent().to_resolved().await?;
-                    if parent == *common_path_vc {
+                    let parent = common_path_ref.parent();
+                    if parent == *common_path_ref {
                         common_path = None;
                         break;
                     }
-                    *common_path_vc = parent;
-                    *common_path_ref = (*common_path_vc).await?;
+                    *common_path_ref = parent;
                 }
             }
         }
@@ -106,10 +105,10 @@ impl Chunk for EcmascriptChunk {
             .await?;
 
         let ident = AssetIdent {
-            path: if let Some((common_path, _)) = common_path {
+            path: if let Some(common_path) = common_path {
                 common_path
             } else {
-                ServerFileSystem::new().root().to_resolved().await?
+                ServerFileSystem::new().root().await?.clone_value()
             },
             query: RcStr::default(),
             fragment: RcStr::default(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -42,7 +42,7 @@ enum SideEffectsValue {
 
 #[turbo_tasks::function]
 async fn side_effects_from_package_json(
-    package_json: ResolvedVc<FileSystemPath>,
+    package_json: FileSystemPath,
 ) -> Result<Vc<SideEffectsValue>> {
     if let FileJsonContent::Content(content) = &*package_json.read_json().await?
         && let Some(side_effects) = content.get("sideEffects")
@@ -130,7 +130,7 @@ async fn side_effects_from_package_json(
 
 #[turbo_tasks::value]
 struct SideEffectsInPackageJsonIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     description: Option<ResolvedVc<StyledString>>,
 }
 
@@ -163,7 +163,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 
 #[turbo_tasks::function]
 pub async fn is_marked_as_side_effect_free(
-    path: Vc<FileSystemPath>,
+    path: FileSystemPath,
     side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<bool>> {
     if side_effect_free_packages.await?.matches(&path.await?.path) {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -25,11 +25,14 @@ pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
         Vc::cell(None)
     }
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
+    async fn is_marked_as_side_effect_free(
         self: Vc<Self>,
         side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        is_marked_as_side_effect_free(self.ident().path(), side_effect_free_packages)
+    ) -> Result<Vc<bool>> {
+        Ok(is_marked_as_side_effect_free(
+            self.ident().path().await?.clone_value(),
+            side_effect_free_packages,
+        ))
     }
 }
 
@@ -63,7 +66,7 @@ async fn side_effects_from_package_json(
                         }
                     } else {
                         SideEffectsInPackageJsonIssue {
-                            path: package_json,
+                            path: package_json.clone(),
                             description: Some(
                                 StyledString::Text(
                                     format!(
@@ -80,26 +83,29 @@ async fn side_effects_from_package_json(
                         None
                     }
                 })
-                .map(|glob| async move {
-                    match glob.resolve().await {
-                        Ok(glob) => Ok(Some(glob)),
-                        Err(err) => {
-                            SideEffectsInPackageJsonIssue {
-                                path: package_json,
-                                description: Some(
-                                    StyledString::Text(
-                                        format!(
-                                            "Invalid glob in sideEffects: {}",
-                                            PrettyPrintError(&err)
+                .map(|glob| {
+                    let package_json = package_json.clone();
+                    async move {
+                        match glob.resolve().await {
+                            Ok(glob) => Ok(Some(glob)),
+                            Err(err) => {
+                                SideEffectsInPackageJsonIssue {
+                                    path: package_json.clone(),
+                                    description: Some(
+                                        StyledString::Text(
+                                            format!(
+                                                "Invalid glob in sideEffects: {}",
+                                                PrettyPrintError(&err)
+                                            )
+                                            .into(),
                                         )
-                                        .into(),
-                                    )
-                                    .resolved_cell(),
-                                ),
+                                        .resolved_cell(),
+                                    ),
+                                }
+                                .resolved_cell()
+                                .emit();
+                                Ok(None)
                             }
-                            .resolved_cell()
-                            .emit();
-                            Ok(None)
                         }
                     }
                 })
@@ -110,7 +116,7 @@ async fn side_effects_from_package_json(
             );
         } else {
             SideEffectsInPackageJsonIssue {
-                path: package_json,
+                path: package_json.clone(),
                 description: Some(
                     StyledString::Text(
                         format!(
@@ -147,7 +153,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -166,22 +172,18 @@ pub async fn is_marked_as_side_effect_free(
     path: FileSystemPath,
     side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<bool>> {
-    if side_effect_free_packages.await?.matches(&path.await?.path) {
+    if side_effect_free_packages.await?.matches(&path.path) {
         return Ok(Vc::cell(true));
     }
 
     let find_package_json = find_context_file(path.parent(), package_json()).await?;
 
-    if let FindContextFileResult::Found(package_json, _) = *find_package_json {
-        match *side_effects_from_package_json(*package_json).await? {
+    if let FindContextFileResult::Found(package_json, _) = &*find_package_json {
+        match *side_effects_from_package_json(package_json.clone()).await? {
             SideEffectsValue::None => {}
             SideEffectsValue::Constant(side_effects) => return Ok(Vc::cell(!side_effects)),
             SideEffectsValue::Glob(glob) => {
-                if let Some(rel_path) = package_json
-                    .parent()
-                    .await?
-                    .get_relative_path_to(&*path.await?)
-                {
+                if let Some(rel_path) = package_json.parent().get_relative_path_to(&path) {
                     let rel_path = rel_path.strip_prefix("./").unwrap_or(&rel_path);
                     return Ok(Vc::cell(!glob.await?.matches(rel_path)));
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -384,7 +384,7 @@ impl EcmascriptModuleAsset {
 #[derive(Copy, Clone)]
 pub(crate) struct ModuleTypeResult {
     pub module_type: SpecifiedModuleType,
-    pub referenced_package_json: Option<ResolvedVc<FileSystemPath>>,
+    pub referenced_package_json: Option<FileSystemPath>,
 }
 
 #[turbo_tasks::value_impl]
@@ -400,7 +400,7 @@ impl ModuleTypeResult {
     #[turbo_tasks::function]
     fn new_with_package_json(
         module_type: SpecifiedModuleType,
-        package_json: ResolvedVc<FileSystemPath>,
+        package_json: FileSystemPath,
     ) -> Vc<Self> {
         Self::cell(ModuleTypeResult {
             module_type,
@@ -517,7 +517,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
 
 #[turbo_tasks::function]
 async fn determine_module_type_for_directory(
-    context_path: Vc<FileSystemPath>,
+    context_path: FileSystemPath,
 ) -> Result<Vc<ModuleTypeResult>> {
     let find_package_json =
         find_context_file(context_path, package_json().resolve().await?).await?;

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -381,7 +381,7 @@ impl EcmascriptModuleAsset {
 }
 
 #[turbo_tasks::value]
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub(crate) struct ModuleTypeResult {
     pub module_type: SpecifiedModuleType,
     pub referenced_package_json: Option<FileSystemPath>,
@@ -479,7 +479,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleAsset {
         let analyze = self.analyze();
         let analyze_ref = analyze.await?;
 
-        let module_type_result = *self.determine_module_type().await?;
+        let module_type_result = self.determine_module_type().await?;
         let generate_source_map = *chunking_context
             .reference_module_source_maps(Vc::upcast(*self))
             .await?;
@@ -521,7 +521,7 @@ async fn determine_module_type_for_directory(
 ) -> Result<Vc<ModuleTypeResult>> {
     let find_package_json =
         find_context_file(context_path, package_json().resolve().await?).await?;
-    let FindContextFileResult::Found(package_json, _) = *find_package_json else {
+    let FindContextFileResult::Found(package_json, _) = &*find_package_json else {
         return Ok(ModuleTypeResult::new(SpecifiedModuleType::Automatic));
     };
 
@@ -535,13 +535,13 @@ async fn determine_module_type_for_directory(
                 Some("commonjs") => SpecifiedModuleType::CommonJs,
                 _ => SpecifiedModuleType::Automatic,
             },
-            *package_json,
+            package_json.clone(),
         ));
     }
 
     Ok(ModuleTypeResult::new_with_package_json(
         SpecifiedModuleType::Automatic,
-        *package_json,
+        package_json.clone(),
     ))
 }
 
@@ -638,15 +638,7 @@ impl EcmascriptModuleAsset {
             SpecifiedModuleType::Automatic => {}
         }
 
-        determine_module_type_for_directory(
-            self.origin_path()
-                .resolve()
-                .await?
-                .parent()
-                .resolve()
-                .await?,
-        )
-        .await
+        determine_module_type_for_directory(self.origin_path().await?.parent()).await
     }
 }
 
@@ -722,8 +714,10 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleAsset {
         side_effect_free_packages: Vc<Glob>,
     ) -> Result<Vc<bool>> {
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
-        let pkg_side_effect_free =
-            is_marked_as_side_effect_free(self.ident().path(), side_effect_free_packages);
+        let pkg_side_effect_free = is_marked_as_side_effect_free(
+            self.ident().path().await?.clone_value(),
+            side_effect_free_packages,
+        );
         Ok(if *pkg_side_effect_free.await? {
             pkg_side_effect_free
         } else {

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -30,8 +30,11 @@ pub(super) struct ManifestChunkItem {
 #[turbo_tasks::value_impl]
 impl ManifestChunkItem {
     #[turbo_tasks::function]
-    fn chunks_data(&self) -> Vc<ChunksData> {
-        ChunkData::from_assets(self.chunking_context.output_root(), self.manifest.chunks())
+    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        Ok(ChunkData::from_assets(
+            self.chunking_context.output_root().await?.clone_value(),
+            self.manifest.chunks(),
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -66,9 +66,12 @@ impl ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    pub fn chunks_data(&self) -> Vc<ChunksData> {
+    pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         let chunks = self.manifest.manifest_chunks();
-        ChunkData::from_assets(self.chunking_context.output_root(), chunks)
+        Ok(ChunkData::from_assets(
+            self.chunking_context.output_root().await?.clone_value(),
+            chunks,
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -291,7 +291,7 @@ async fn parse_internal(
 
 async fn parse_file_content(
     string: BytesStr,
-    fs_path_vc: Vc<FileSystemPath>,
+    fs_path_vc: FileSystemPath,
     fs_path: &FileSystemPath,
     ident: &str,
     query: RcStr,

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -215,8 +215,8 @@ async fn parse_internal(
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
     let content = source.content();
-    let fs_path_vc = source.ident().path();
-    let fs_path = &*fs_path_vc.await?;
+    let fs_path_vc = source.ident().path().await?.clone_value();
+    let fs_path = fs_path_vc.clone();
     let ident = &*source.ident().to_string().await?;
     let file_path_hash = hash_xxh3_hash64(&*source.ident().to_string().await?) as u128;
     let content = match content.await {
@@ -245,8 +245,8 @@ async fn parse_internal(
                         let transforms = &*transforms.await?;
                         match parse_file_content(
                             string,
-                            fs_path_vc,
-                            fs_path,
+                            fs_path_vc.clone(),
+                            &fs_path,
                             ident,
                             source.ident().await?.query.clone(),
                             file_path_hash,
@@ -452,7 +452,7 @@ async fn parse_file_content(
                 file_name_str: fs_path.file_name(),
                 file_name_hash: file_path_hash,
                 query_str: query,
-                file_path: fs_path_vc.to_resolved().await?,
+                file_path: fs_path_vc.clone(),
             };
             let span = tracing::trace_span!("transforms");
             async {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -28,11 +28,11 @@ use crate::{
 /// This singleton behavior must be enforced by the caller!
 #[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
 pub struct ImportMetaBinding {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 impl ImportMetaBinding {
-    pub fn new(path: ResolvedVc<FileSystemPath>) -> Self {
+    pub fn new(path: FileSystemPath) -> Self {
         ImportMetaBinding { path }
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -8,7 +8,7 @@ use swc_core::{
     quote,
 };
 use turbo_rcstr::rcstr;
-use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
 
@@ -44,7 +44,7 @@ impl ImportMetaBinding {
         let rel_path = chunking_context
             .root_path()
             .await?
-            .get_relative_path_to(&*self.path.await?);
+            .get_relative_path_to(&self.path);
         let path = rel_path.map_or_else(
             || {
                 quote!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -192,13 +192,13 @@ impl CachedExternalModule {
 #[turbo_tasks::value_impl]
 impl Module for CachedExternalModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let fs = VirtualFileSystem::new_with_name(rcstr!("externals"));
 
-        AssetIdent::from_path(fs.root().join(self.request.clone()))
+        Ok(AssetIdent::from_path(fs.root().await?.join(&self.request)?)
             .with_layer(Layer::new(rcstr!("external")))
             .with_modifier(self.request.clone())
-            .with_modifier(self.external_type.to_string().into())
+            .with_modifier(self.external_type.to_string().into()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -526,7 +526,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let origin = ResolvedVc::upcast::<Box<dyn ResolveOrigin>>(module);
 
     let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new();
-    let path = origin.origin_path();
+    let path = origin.origin_path().await?.clone_value();
 
     // Is this a typescript file that requires analzying type references?
     let analyze_types = match &ty {
@@ -546,13 +546,13 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let ModuleTypeResult {
         module_type: specified_type,
         referenced_package_json,
-    } = *module.determine_module_type().await?;
+    } = module.determine_module_type().await?.clone_value();
 
     if let Some(package_json) = referenced_package_json {
         let span = tracing::info_span!("package.json reference");
         async {
             analysis.add_reference(
-                PackageJsonReference::new(*package_json)
+                PackageJsonReference::new(package_json.clone())
                     .to_resolved()
                     .await?,
             );
@@ -568,7 +568,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             match &*find_context_file(path.parent(), tsconfig()).await? {
                 FindContextFileResult::Found(tsconfig, _) => {
                     analysis.add_reference(
-                        TsConfigReference::new(*origin, **tsconfig)
+                        TsConfigReference::new(*origin, tsconfig.clone())
                             .to_resolved()
                             .await?,
                     );
@@ -581,7 +581,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         .await?;
     }
 
-    special_cases(&path.await?.path, &mut analysis);
+    special_cases(&path.path, &mut analysis);
 
     let parsed = parsed.await?;
 
@@ -692,9 +692,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 static JSON_DATA_URL_BASE64: LazyLock<Regex> = LazyLock::new(|| {
                     Regex::new(r"^data:application\/json;(?:charset=utf-8;)?base64").unwrap()
                 });
-                let origin_path = origin.origin_path();
+                let origin_path = origin.origin_path().await?.clone_value();
                 if path.ends_with(".map") {
-                    let source_map_origin = origin_path.parent().join(path.into());
+                    let source_map_origin = origin_path.parent().join(path)?;
                     let reference = SourceMapReference::new(origin_path, source_map_origin)
                         .to_resolved()
                         .await?;
@@ -704,7 +704,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 } else if JSON_DATA_URL_BASE64.is_match(path) {
                     analysis.set_source_map(ResolvedVc::upcast(
                         InlineSourceMap {
-                            origin_path: origin_path.to_resolved().await?,
+                            origin_path,
                             source_map: path.into(),
                         }
                         .resolved_cell(),
@@ -841,7 +841,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         let exports = if !esm_exports.is_empty() || !esm_star_exports.is_empty() {
             if specified_type == SpecifiedModuleType::CommonJs {
                 SpecifiedModuleTypeIssue {
-                    path: source.ident().path().to_resolved().await?,
+                    path: source.ident().path().await?.clone_value(),
                     specified_type,
                 }
                 .resolved_cell()
@@ -859,7 +859,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
             match detect_dynamic_export(program) {
                 DetectedDynamicExportType::CommonJs => {
                     SpecifiedModuleTypeIssue {
-                        path: source.ident().path().to_resolved().await?,
+                        path: source.ident().path().await?.clone_value(),
                         specified_type,
                     }
                     .resolved_cell()
@@ -1419,7 +1419,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     if analysis_state.first_import_meta {
                         analysis_state.first_import_meta = false;
                         analysis.add_code_gen(ImportMetaBinding::new(
-                            source.ident().path().to_resolved().await?,
+                            source.ident().path().await?.clone_value(),
                         ));
                     }
 
@@ -1946,7 +1946,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         }
 
         JsValue::WellKnownFunction(WellKnownFunctionKind::PathResolve(..)) => {
-            let parent_path = origin.origin_path().parent().await?;
+            let parent_path = origin.origin_path().await?.clone_value().parent();
             let args = linked_args(args).await?;
 
             let linked_func_call = state
@@ -2149,7 +2149,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
                 analysis.add_reference(
                     NodePreGypConfigReference::new(
-                        origin.origin_path().parent(),
+                        origin.origin_path().await?.parent(),
                         Pattern::new(pat),
                         compile_time_info.environment().compile_target(),
                     )
@@ -2182,8 +2182,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     // TODO this resolving should happen within Vc<NodeGypBuildReference>
                     let current_context = origin
                         .origin_path()
+                        .await?
                         .root()
-                        .join(s.trim_start_matches("/ROOT/").into());
+                        .await?
+                        .join(s.trim_start_matches("/ROOT/"))?;
                     analysis.add_reference(
                         NodeGypBuildReference::new(
                             current_context,
@@ -2216,9 +2218,12 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     .await?;
                 if let Some(s) = first_arg.as_str() {
                     analysis.add_reference(
-                        NodeBindingsReference::new(origin.origin_path(), s.into())
-                            .to_resolved()
-                            .await?,
+                        NodeBindingsReference::new(
+                            origin.origin_path().await?.clone_value(),
+                            s.into(),
+                        )
+                        .to_resolved()
+                        .await?,
                     );
                     return Ok(());
                 }
@@ -2596,7 +2601,7 @@ async fn handle_free_var_reference(
                             ResolvedVc::upcast(
                                 PlainResolveOrigin::new(
                                     state.origin.asset_context(),
-                                    **lookup_path,
+                                    lookup_path.clone(),
                                 )
                                 .to_resolved()
                                 .await?,
@@ -2630,7 +2635,7 @@ async fn handle_free_var_reference(
             ));
         }
         FreeVarReference::InputRelative(kind) => {
-            let source_path = (*state.source).ident().path();
+            let source_path = (*state.source).ident().path().await?.clone_value();
             let source_path = match kind {
                 InputRelativeConstant::DirName => source_path.parent(),
                 InputRelativeConstant::FileName => source_path,
@@ -2848,7 +2853,7 @@ pub async fn as_abs_path(path: FileSystemPath) -> Result<String> {
 
 /// Generates an absolute path usable for `require.resolve()` calls.
 async fn require_resolve(path: FileSystemPath) -> Result<String> {
-    Ok(format!("/ROOT/{}", path.await?.path.as_str()))
+    Ok(format!("/ROOT/{}", path.path.as_str()))
 }
 
 async fn early_value_visitor(mut v: JsValue) -> Result<(JsValue, bool)> {
@@ -2975,8 +2980,12 @@ async fn value_visitor_inner(
             }
         }
         JsValue::FreeVar(ref kind) => match &**kind {
-            "__dirname" => as_abs_path(origin.origin_path().parent()).await?.into(),
-            "__filename" => as_abs_path(origin.origin_path()).await?.into(),
+            "__dirname" => as_abs_path(origin.origin_path().await?.clone_value().parent())
+                .await?
+                .into(),
+            "__filename" => as_abs_path(origin.origin_path().await?.clone_value())
+                .await?
+                .into(),
 
             "require" => JsValue::unknown_if(
                 ignore,
@@ -3039,7 +3048,7 @@ async fn require_resolve_visitor(
             .await?
             .iter()
             .map(|&source| async move {
-                require_resolve(source.ident().path())
+                require_resolve(source.ident().path().await?.clone_value())
                     .await
                     .map(JsValue::from)
             })
@@ -3094,7 +3103,12 @@ async fn require_context_visitor(
         }
     };
 
-    let dir = origin.origin_path().parent().join(options.dir.clone());
+    let dir = origin
+        .origin_path()
+        .await?
+        .clone_value()
+        .parent()
+        .join(options.dir.as_str())?;
 
     let map = RequireContextMap::generate(
         origin,
@@ -3512,12 +3526,12 @@ async fn resolve_as_webpack_runtime(
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<WebpackRuntime>> {
     let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-    let options = origin.resolve_options(ty.clone());
+    let options = origin.resolve_options(ty.clone()).await?;
 
     let options = apply_cjs_specific_options(options);
 
     let resolved = resolve(
-        origin.origin_path().parent().resolve().await?,
+        origin.origin_path().await?.parent(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         request,
         options,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2838,7 +2838,7 @@ async fn analyze_amd_define_with_deps(
 
 /// Used to generate the "root" path to a __filename/__dirname/import.meta.url
 /// reference.
-pub async fn as_abs_path(path: Vc<FileSystemPath>) -> Result<String> {
+pub async fn as_abs_path(path: FileSystemPath) -> Result<String> {
     // TODO: This should be updated to generate a real system path on the fly
     // during runtime, so that the generated code is constant between systems
     // but the runtime evaluation can take into account the project's
@@ -2847,7 +2847,7 @@ pub async fn as_abs_path(path: Vc<FileSystemPath>) -> Result<String> {
 }
 
 /// Generates an absolute path usable for `require.resolve()` calls.
-async fn require_resolve(path: Vc<FileSystemPath>) -> Result<String> {
+async fn require_resolve(path: FileSystemPath) -> Result<String> {
     Ok(format!("/ROOT/{}", path.await?.path.as_str()))
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -18,13 +18,13 @@ use turbopack_core::{
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct PackageJsonReference {
-    pub package_json: ResolvedVc<FileSystemPath>,
+    pub package_json: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl PackageJsonReference {
     #[turbo_tasks::function]
-    pub fn new(package_json: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(package_json: FileSystemPath) -> Vc<Self> {
         Self::cell(PackageJsonReference { package_json })
     }
 }
@@ -68,7 +68,7 @@ impl DirAssetReference {
 
 #[turbo_tasks::function]
 async fn resolve_reference_from_dir(
-    parent_path: Vc<FileSystemPath>,
+    parent_path: FileSystemPath,
     path: Vc<Pattern>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let path_ref = path.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -34,7 +34,7 @@ impl ModuleReference for PackageJsonReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
-            RawModule::new(Vc::upcast(FileSource::new(*self.package_json)))
+            RawModule::new(Vc::upcast(FileSource::new(self.package_json.clone())))
                 .to_resolved()
                 .await?,
         )))
@@ -46,7 +46,11 @@ impl ValueToString for PackageJsonReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(
-            format!("package.json {}", self.package_json.to_string().await?,).into(),
+            format!(
+                "package.json {}",
+                self.package_json.value_to_string().await?
+            )
+            .into(),
         ))
     }
 }
@@ -76,7 +80,7 @@ async fn resolve_reference_from_dir(
     let matches = match (abs_path, rel_path) {
         (Some(abs_path), Some(rel_path)) => Either::Right(
             read_matches(
-                parent_path.root().resolve().await?,
+                parent_path.root().await?.clone_value(),
                 rcstr!("/ROOT/"),
                 true,
                 Pattern::new(abs_path.or_any_nested_file()),
@@ -97,7 +101,7 @@ async fn resolve_reference_from_dir(
         (Some(abs_path), None) => Either::Left(
             // absolute path only
             read_matches(
-                parent_path.root().resolve().await?,
+                parent_path.root().await?.clone_value(),
                 rcstr!("/ROOT/"),
                 true,
                 Pattern::new(abs_path.or_any_nested_file()),
@@ -124,15 +128,15 @@ async fn resolve_reference_from_dir(
         match pat_match {
             PatternMatch::File(matched_path, file) => {
                 let realpath = file.realpath_with_links().await?;
-                for &symlink in &realpath.symlinks {
+                for symlink in &realpath.symlinks {
                     affecting_sources.push(ResolvedVc::upcast(
-                        FileSource::new(*symlink).to_resolved().await?,
+                        FileSource::new(symlink.clone()).to_resolved().await?,
                     ));
                 }
                 results.push((
                     RequestKey::new(matched_path.clone()),
                     ResolvedVc::upcast(
-                        RawModule::new(Vc::upcast(FileSource::new(*realpath.path)))
+                        RawModule::new(Vc::upcast(FileSource::new(realpath.path.clone())))
                             .to_resolved()
                             .await?,
                     ),
@@ -151,11 +155,8 @@ async fn resolve_reference_from_dir(
 impl ModuleReference for DirAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let parent_path = self.source.ident().path().parent();
-        Ok(resolve_reference_from_dir(
-            parent_path.resolve().await?,
-            *self.path,
-        ))
+        let parent_path = self.source.ident().path().await?.parent();
+        Ok(resolve_reference_from_dir(parent_path, *self.path))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -354,7 +354,7 @@ async fn to_single_pattern_mapping(
                     .into(),
                 )
                 .resolved_cell(),
-                path: origin.origin_path().to_resolved().await?,
+                path: origin.origin_path().await?.clone_value(),
             }
             .resolved_cell()
             .emit();
@@ -380,7 +380,7 @@ async fn to_single_pattern_mapping(
             "asset is not placeable in ESM chunks, so it doesn't have a module id".into(),
         )
         .resolved_cell(),
-        path: origin.origin_path().to_resolved().await?,
+        path: origin.origin_path().await?.clone_value(),
     }
     .resolved_cell()
     .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -25,10 +25,10 @@ impl FileSourceReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for FileSourceReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        let context_dir = self.source.ident().path().parent();
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        let context_dir = self.source.ident().path().await?.parent();
 
-        resolve_raw(context_dir, *self.path, false).as_raw_module_result()
+        Ok(resolve_raw(context_dir, *self.path, false).as_raw_module_result())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -54,7 +54,7 @@ use crate::{
 #[turbo_tasks::value]
 #[derive(Debug)]
 pub(crate) enum DirListEntry {
-    File(ResolvedVc<FileSystemPath>),
+    File(FileSystemPath),
     Dir(ResolvedVc<DirList>),
 }
 
@@ -64,14 +64,14 @@ pub(crate) struct DirList(FxIndexMap<RcStr, DirListEntry>);
 #[turbo_tasks::value_impl]
 impl DirList {
     #[turbo_tasks::function]
-    pub(crate) fn read(dir: Vc<FileSystemPath>, recursive: bool, filter: Vc<EsRegex>) -> Vc<Self> {
+    pub(crate) fn read(dir: FileSystemPath, recursive: bool, filter: Vc<EsRegex>) -> Vc<Self> {
         Self::read_internal(dir, dir, recursive, filter)
     }
 
     #[turbo_tasks::function]
     pub(crate) async fn read_internal(
-        root: Vc<FileSystemPath>,
-        dir: Vc<FileSystemPath>,
+        root: FileSystemPath,
+        dir: FileSystemPath,
         recursive: bool,
         filter: Vc<EsRegex>,
     ) -> Result<Vc<Self>> {
@@ -144,12 +144,12 @@ impl DirList {
 }
 
 #[turbo_tasks::value(transparent)]
-pub(crate) struct FlatDirList(FxIndexMap<RcStr, ResolvedVc<FileSystemPath>>);
+pub(crate) struct FlatDirList(FxIndexMap<RcStr, FileSystemPath>);
 
 #[turbo_tasks::value_impl]
 impl FlatDirList {
     #[turbo_tasks::function]
-    pub(crate) fn read(dir: Vc<FileSystemPath>, recursive: bool, filter: Vc<EsRegex>) -> Vc<Self> {
+    pub(crate) fn read(dir: FileSystemPath, recursive: bool, filter: Vc<EsRegex>) -> Vc<Self> {
         DirList::read(dir, recursive, filter).flatten()
     }
 }
@@ -171,7 +171,7 @@ impl RequireContextMap {
     #[turbo_tasks::function]
     pub(crate) async fn generate(
         origin: Vc<Box<dyn ResolveOrigin>>,
-        dir: Vc<FileSystemPath>,
+        dir: FileSystemPath,
         recursive: bool,
         filter: Vc<EsRegex>,
         issue_source: Option<IssueSource>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -65,7 +65,7 @@ pub(crate) struct DirList(FxIndexMap<RcStr, DirListEntry>);
 impl DirList {
     #[turbo_tasks::function]
     pub(crate) fn read(dir: FileSystemPath, recursive: bool, filter: Vc<EsRegex>) -> Vc<Self> {
-        Self::read_internal(dir, dir, recursive, filter)
+        Self::read_internal(dir.clone(), dir, recursive, filter)
     }
 
     #[turbo_tasks::function]
@@ -75,8 +75,8 @@ impl DirList {
         recursive: bool,
         filter: Vc<EsRegex>,
     ) -> Result<Vc<Self>> {
-        let root_val = &root.await?;
-        let dir_val = &dir.await?;
+        let root_val = root.clone();
+        let dir_val = dir.clone();
         let regex = &filter.await?;
 
         let mut list = FxIndexMap::default();
@@ -90,20 +90,25 @@ impl DirList {
         for (_, entry) in entries.iter().flat_map(|m| m.iter()) {
             match entry {
                 DirectoryEntry::File(path) => {
-                    if let Some(relative_path) = root_val.get_relative_path_to(&*path.await?)
+                    if let Some(relative_path) = root_val.get_relative_path_to(path)
                         && regex.is_match(&relative_path)
                     {
-                        list.insert(relative_path, DirListEntry::File(*path));
+                        list.insert(relative_path, DirListEntry::File(path.clone()));
                     }
                 }
                 DirectoryEntry::Directory(path) if recursive => {
-                    if let Some(relative_path) = dir_val.get_relative_path_to(&*path.await?) {
+                    if let Some(relative_path) = dir_val.get_relative_path_to(path) {
                         list.insert(
                             relative_path,
                             DirListEntry::Dir(
-                                DirList::read_internal(root, **path, recursive, filter)
-                                    .to_resolved()
-                                    .await?,
+                                DirList::read_internal(
+                                    root.clone(),
+                                    path.clone(),
+                                    recursive,
+                                    filter,
+                                )
+                                .to_resolved()
+                                .await?,
                             ),
                         );
                     }
@@ -130,7 +135,7 @@ impl DirList {
             for (k, entry) in &*dir {
                 match entry {
                     DirListEntry::File(path) => {
-                        list.insert(k.clone(), *path);
+                        list.insert(k.clone(), path.clone());
                     }
                     DirListEntry::Dir(d) => {
                         queue.push_back(d.await?);
@@ -177,14 +182,14 @@ impl RequireContextMap {
         issue_source: Option<IssueSource>,
         is_optional: bool,
     ) -> Result<Vc<Self>> {
-        let origin_path = &*origin.origin_path().parent().await?;
+        let origin_path = origin.origin_path().await?.parent();
 
         let list = &*FlatDirList::read(dir, recursive, filter).await?;
 
         let mut map = FxIndexMap::default();
 
         for (context_relative, path) in list {
-            let Some(origin_relative) = origin_path.get_relative_path_to(&*path.await?) else {
+            let Some(origin_relative) = origin_path.get_relative_path_to(path) else {
                 bail!("invariant error: this was already checked in `list_dir`");
             };
 
@@ -234,7 +239,7 @@ impl RequireContextAssetReference {
     ) -> Result<Self> {
         let map = RequireContextMap::generate(
             *origin,
-            origin.origin_path().parent().join(dir.clone()),
+            origin.origin_path().await?.parent().join(&dir)?,
             include_subdirs,
             filter,
             issue_source.clone(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -6,7 +6,7 @@ use crate::SpecifiedModuleType;
 
 #[turbo_tasks::value(shared)]
 pub struct SpecifiedModuleTypeIssue {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub specified_type: SpecifiedModuleType,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 
@@ -14,7 +14,7 @@ pub struct SpecifiedModuleTypeIssue {
 impl Issue for SpecifiedModuleTypeIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -16,17 +16,14 @@ use crate::typescript::TsConfigModuleAsset;
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct TsConfigReference {
-    pub tsconfig: ResolvedVc<FileSystemPath>,
+    pub tsconfig: FileSystemPath,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
 }
 
 #[turbo_tasks::value_impl]
 impl TsConfigReference {
     #[turbo_tasks::function]
-    pub fn new(
-        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-        tsconfig: ResolvedVc<FileSystemPath>,
-    ) -> Vc<Self> {
+    pub fn new(origin: ResolvedVc<Box<dyn ResolveOrigin>>, tsconfig: FileSystemPath) -> Vc<Self> {
         Self::cell(TsConfigReference { tsconfig, origin })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -33,9 +33,12 @@ impl ModuleReference for TsConfigReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
-            TsConfigModuleAsset::new(*self.origin, Vc::upcast(FileSource::new(*self.tsconfig)))
-                .to_resolved()
-                .await?,
+            TsConfigModuleAsset::new(
+                *self.origin,
+                Vc::upcast(FileSource::new(self.tsconfig.clone())),
+            )
+            .to_resolved()
+            .await?,
         )))
     }
 }
@@ -45,7 +48,7 @@ impl ValueToString for TsConfigReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(
-            format!("tsconfig {}", self.tsconfig.to_string().await?,).into(),
+            format!("tsconfig {}", self.tsconfig.value_to_string().await?).into(),
         ))
     }
 }
@@ -70,18 +73,18 @@ impl ModuleReference for TsReferencePathAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(
-            if let Some(path) = &*self
+            if let Some(path) = self
                 .origin
                 .origin_path()
-                .parent()
-                .try_join(self.path.clone())
                 .await?
+                .parent()
+                .try_join(&self.path)?
             {
                 let module = self
                     .origin
                     .asset_context()
                     .process(
-                        Vc::upcast(FileSource::new(**path)),
+                        Vc::upcast(FileSource::new(path.clone())),
                         ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
                     )
                     .module()

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -47,7 +47,7 @@ pub async fn request_to_string(request: Vc<Request>) -> Result<Vc<RcStr>> {
 #[derive(Debug, Clone)]
 pub struct InlineSourceMap {
     /// The file path of the module containing the sourcemap data URL
-    pub origin_path: ResolvedVc<FileSystemPath>,
+    pub origin_path: FileSystemPath,
     /// The Base64 encoded JSON sourcemap string
     pub source_map: RcStr,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use swc_core::{ecma::ast::Expr, quote};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
     resolve::parse::Request,
@@ -57,7 +57,8 @@ impl GenerateSourceMap for InlineSourceMap {
     #[turbo_tasks::function]
     pub async fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {
         let source_map = maybe_decode_data_url(&self.source_map);
-        let source_map = resolve_source_map_sources(source_map.as_ref(), *self.origin_path).await?;
+        let source_map =
+            resolve_source_map_sources(source_map.as_ref(), self.origin_path.clone()).await?;
         Ok(Vc::cell(source_map))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -74,7 +74,7 @@ impl WorkerAssetReference {
                 title: StyledString::Text(rcstr!("non-ecmascript placeable asset")).resolved_cell(),
                 message: StyledString::Text(rcstr!("asset is not placeable in ESM chunks"))
                     .resolved_cell(),
-                path: self.origin.origin_path().to_resolved().await?,
+                path: self.origin.origin_path().await?.clone_value(),
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -104,7 +104,7 @@ impl EcmascriptAnalyzable for EcmascriptModuleLocalsModule {
         let analyze = original_module.analyze();
         let analyze_result = analyze.await?;
 
-        let module_type_result = *original_module.determine_module_type().await?;
+        let module_type_result = original_module.determine_module_type().await?;
         let generate_source_map = *chunking_context
             .reference_module_source_maps(Vc::upcast(self))
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -27,7 +27,7 @@ impl StaticEcmascriptCode {
     #[turbo_tasks::function]
     pub async fn new(
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
-        asset_path: ResolvedVc<FileSystemPath>,
+        asset_path: FileSystemPath,
         generate_source_map: bool,
     ) -> Result<Vc<Self>> {
         let module = asset_context

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -32,7 +32,7 @@ impl StaticEcmascriptCode {
     ) -> Result<Vc<Self>> {
         let module = asset_context
             .process(
-                Vc::upcast(FileSource::new(*asset_path)),
+                Vc::upcast(FileSource::new(asset_path.clone())),
                 ReferenceType::Runtime,
             )
             .module()

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -120,7 +120,7 @@ pub struct TransformContext<'a> {
     pub file_name_str: &'a str,
     pub file_name_hash: u128,
     pub query_str: RcStr,
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
 }
 
 impl EcmascriptInputTransform {
@@ -355,7 +355,7 @@ pub fn remove_directives(program: &mut Program) {
 
 #[turbo_tasks::value(shared)]
 pub struct UnsupportedServerActionIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -374,7 +374,7 @@ impl Issue for UnsupportedServerActionIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -92,7 +92,7 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
         let analyze = self.analyze();
         let analyze_ref = analyze.await?;
 
-        let module_type_result = *module.full_module.determine_module_type().await?;
+        let module_type_result = module.full_module.determine_module_type().await?;
         let generate_source_map = *chunking_context
             .reference_module_source_maps(Vc::upcast(self))
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -56,7 +56,8 @@ impl Module for TsConfigModuleAsset {
             self.source,
             apply_cjs_specific_options(
                 self.origin
-                    .resolve_options(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
+                    .resolve_options(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined))
+                    .await?,
             ),
         )
         .await?;
@@ -133,12 +134,10 @@ impl Module for TsConfigModuleAsset {
                 types
             } else {
                 let mut all_types = Vec::new();
-                let mut current = self.source.ident().path().parent().resolve().await?;
+                let mut current = self.source.ident().path().await?.parent();
                 loop {
-                    if let DirectoryContent::Entries(entries) = &*current
-                        .join(rcstr!("node_modules/@types"))
-                        .read_dir()
-                        .await?
+                    if let DirectoryContent::Entries(entries) =
+                        &*current.join("node_modules/@types")?.read_dir().await?
                     {
                         all_types.extend(entries.iter().filter_map(|(name, _)| {
                             if name.starts_with('.') {
@@ -148,7 +147,7 @@ impl Module for TsConfigModuleAsset {
                             }
                         }));
                     }
-                    let parent = current.parent().resolve().await?;
+                    let parent = current.parent();
                     if parent == current {
                         break;
                     }

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -93,8 +93,8 @@ impl ModuleReference for WebpackChunkAssetReference {
                     Lit::Num(num) => format!("{num}"),
                     _ => todo!(),
                 };
-                let filename = format!("./chunks/{chunk_id}.js").into();
-                let source = Vc::upcast(FileSource::new(context_path.join(filename)));
+                let filename = format!("./chunks/{chunk_id}.js");
+                let source = Vc::upcast(FileSource::new(context_path.join(&filename)?));
 
                 *ModuleResolveResult::module(ResolvedVc::upcast(
                     WebpackModuleAsset::new(source, *self.runtime, *self.transforms)
@@ -160,12 +160,12 @@ impl ModuleReference for WebpackRuntimeAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-        let options = self.origin.resolve_options(ty.clone());
+        let options = self.origin.resolve_options(ty.clone()).await?;
 
         let options = apply_cjs_specific_options(options);
 
         let resolved = resolve(
-            self.origin.origin_path().parent().resolve().await?,
+            self.origin.origin_path().await?.parent(),
             ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
             *self.request,
             options,

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -31,7 +31,7 @@ pub enum WebpackRuntime {
         /// before converting to string
         #[turbo_tasks(trace_ignore)]
         chunk_request_expr: JsValue,
-        context_path: ResolvedVc<FileSystemPath>,
+        context_path: FileSystemPath,
     },
     None,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -12,7 +12,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::source::Source;
 
@@ -216,7 +216,7 @@ pub async fn webpack_runtime(
 
                     return Ok(WebpackRuntime::Webpack5 {
                         chunk_request_expr: value,
-                        context_path: source.ident().path().parent().to_resolved().await?,
+                        context_path: source.ident().path().await?.parent(),
                     }
                     .into());
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -48,7 +48,7 @@ impl WorkerLoaderChunkItem {
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root(),
+            this.chunking_context.output_root().await?.clone_value(),
             self.chunks(),
         ))
     }

--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -17,7 +17,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 #[turbo_tasks::value]
 pub struct ProcessEnvAsset {
     /// The root path which we can construct our env asset path.
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 
     /// A HashMap filled with the env key/values.
     env: ResolvedVc<Box<dyn ProcessEnv>>,
@@ -26,10 +26,7 @@ pub struct ProcessEnvAsset {
 #[turbo_tasks::value_impl]
 impl ProcessEnvAsset {
     #[turbo_tasks::function]
-    pub fn new(
-        root: ResolvedVc<FileSystemPath>,
-        env: ResolvedVc<Box<dyn ProcessEnv>>,
-    ) -> Result<Vc<Self>> {
+    pub fn new(root: FileSystemPath, env: ResolvedVc<Box<dyn ProcessEnv>>) -> Result<Vc<Self>> {
         Ok(ProcessEnvAsset { root, env }.cell())
     }
 }

--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
 use anyhow::Result;
-use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
@@ -34,8 +33,8 @@ impl ProcessEnvAsset {
 #[turbo_tasks::value_impl]
 impl Source for ProcessEnvAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        AssetIdent::from_path(self.root.join(rcstr!(".env.js")))
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(AssetIdent::from_path(self.root.join(".env.js")?))
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/dotenv.rs
+++ b/turbopack/crates/turbopack-env/src/dotenv.rs
@@ -9,7 +9,7 @@ use crate::TryDotenvProcessEnv;
 /// Loads a series of dotenv files according to the precedence rules set by
 /// https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order
 #[turbo_tasks::function]
-pub async fn load_env(project_path: Vc<FileSystemPath>) -> Result<Vc<Box<dyn ProcessEnv>>> {
+pub async fn load_env(project_path: FileSystemPath) -> Result<Vc<Box<dyn ProcessEnv>>> {
     let env: Vc<Box<dyn ProcessEnv>> = Vc::upcast(CommandLineProcessEnv::new());
 
     let node_env = env.read(rcstr!("NODE_ENV")).await?;

--- a/turbopack/crates/turbopack-env/src/dotenv.rs
+++ b/turbopack/crates/turbopack-env/src/dotenv.rs
@@ -22,7 +22,7 @@ pub async fn load_env(project_path: FileSystemPath) -> Result<Vc<Box<dyn Process
         }),
     ));
 
-    let files = [
+    let mut files = [
         Some(format!(".env.{node_env}.local")),
         if node_env == "test" {
             None
@@ -35,10 +35,10 @@ pub async fn load_env(project_path: FileSystemPath) -> Result<Vc<Box<dyn Process
     .into_iter()
     .flatten();
 
-    let env = files.fold(env, |prior, f| {
-        let path = project_path.join(f.into());
-        Vc::upcast(TryDotenvProcessEnv::new(prior, path))
-    });
+    let env = files.try_fold(env, |prior, f| {
+        let path = project_path.join(&f)?;
+        anyhow::Ok(Vc::upcast(TryDotenvProcessEnv::new(prior, path)))
+    })?;
 
     Ok(env)
 }

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -6,7 +6,7 @@ use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString}
 /// An issue that occurred while resolving the parsing or evaluating the .env.
 #[turbo_tasks::value(shared)]
 pub struct ProcessEnvIssue {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub description: ResolvedVc<StyledString>,
 }
 

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -24,7 +24,7 @@ impl Issue for ProcessEnvIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-env/src/try_env.rs
+++ b/turbopack/crates/turbopack-env/src/try_env.rs
@@ -10,7 +10,7 @@ use crate::ProcessEnvIssue;
 pub struct TryDotenvProcessEnv {
     dotenv: ResolvedVc<DotenvProcessEnv>,
     prior: ResolvedVc<Box<dyn ProcessEnv>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -18,7 +18,7 @@ impl TryDotenvProcessEnv {
     #[turbo_tasks::function]
     pub async fn new(
         prior: ResolvedVc<Box<dyn ProcessEnv>>,
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
     ) -> Result<Vc<Self>> {
         let dotenv = DotenvProcessEnv::new(Some(*prior), *path)
             .to_resolved()

--- a/turbopack/crates/turbopack-env/src/try_env.rs
+++ b/turbopack/crates/turbopack-env/src/try_env.rs
@@ -20,7 +20,7 @@ impl TryDotenvProcessEnv {
         prior: ResolvedVc<Box<dyn ProcessEnv>>,
         path: FileSystemPath,
     ) -> Result<Vc<Self>> {
-        let dotenv = DotenvProcessEnv::new(Some(*prior), *path)
+        let dotenv = DotenvProcessEnv::new(Some(*prior), path.clone())
             .to_resolved()
             .await?;
         Ok(TryDotenvProcessEnv {
@@ -51,7 +51,7 @@ impl ProcessEnv for TryDotenvProcessEnv {
                 // If parsing the dotenv file fails (but getting the prior value didn't), then
                 // we want to emit an Issue and fall back to the prior's read.
                 ProcessEnvIssue {
-                    path: self.path,
+                    path: self.path.clone(),
                     // read_all_with_prior will wrap a current error with a context containing the
                     // failing file, which we don't really care about (we report the filepath as the
                     // Issue context, not the description). So extract the real error.

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -102,7 +102,7 @@ fn extension_to_image_format(extension: &str) -> Option<ImageFormat> {
     })
 }
 
-fn result_to_issue<T>(path: ResolvedVc<FileSystemPath>, result: Result<T>) -> Option<T> {
+fn result_to_issue<T>(path: FileSystemPath, result: Result<T>) -> Option<T> {
     match result {
         Ok(r) => Some(r),
         Err(err) => {
@@ -121,7 +121,7 @@ fn result_to_issue<T>(path: ResolvedVc<FileSystemPath>, result: Result<T>) -> Op
 }
 
 fn load_image(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     bytes: &[u8],
     extension: Option<&str>,
 ) -> Option<(ImageBuffer, Option<ImageFormat>)> {
@@ -136,7 +136,7 @@ enum ImageBuffer {
 }
 
 fn load_image_internal(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     bytes: &[u8],
     extension: Option<&str>,
 ) -> Result<(ImageBuffer, Option<ImageFormat>)> {
@@ -202,7 +202,7 @@ fn load_image_internal(
 }
 
 fn compute_blur_data(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     image: image::DynamicImage,
     format: ImageFormat,
     options: &BlurPlaceholderOptions,
@@ -486,7 +486,7 @@ pub async fn optimize(
 
 #[turbo_tasks::value]
 struct ImageProcessingIssue {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     message: ResolvedVc<StyledString>,
     title: Option<ResolvedVc<StyledString>>,
     issue_severity: Option<IssueSeverity>,

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -125,7 +125,7 @@ fn load_image(
     bytes: &[u8],
     extension: Option<&str>,
 ) -> Option<(ImageBuffer, Option<ImageFormat>)> {
-    result_to_issue(path, load_image_internal(path, bytes, extension))
+    result_to_issue(path.clone(), load_image_internal(path, bytes, extension))
 }
 
 /// Type of raw image buffer read by reader from `load_image`.
@@ -348,19 +348,19 @@ pub async fn get_meta_data(
         bail!("Input image not found");
     };
     let bytes = content.content().to_bytes();
-    let path_resolved = ident.path().to_resolved().await?;
-    let path = path_resolved.await?;
+    let path_resolved = ident.path().await?.clone_value();
+    let path = path_resolved.clone();
     let extension = path.extension_ref();
     if extension == Some("svg") {
         let content = result_to_issue(
-            path_resolved,
+            path_resolved.clone(),
             std::str::from_utf8(&bytes).context("Input image is not valid utf-8"),
         );
         let Some(content) = content else {
             return Ok(ImageMetaData::fallback_value(Some(mime::IMAGE_SVG)).cell());
         };
         let info = result_to_issue(
-            path_resolved,
+            path_resolved.clone(),
             calculate(content).context("Failed to parse svg source code for image dimensions"),
         );
         let Some((width, height)) = info else {
@@ -374,7 +374,7 @@ pub async fn get_meta_data(
         }
         .cell());
     }
-    let Some((image, format)) = load_image(path_resolved, &bytes, extension) else {
+    let Some((image, format)) = load_image(path_resolved.clone(), &bytes, extension) else {
         return Ok(ImageMetaData::fallback_value(None).cell());
     };
 
@@ -392,7 +392,7 @@ pub async fn get_meta_data(
                         | Some(ImageFormat::Avif)
                 ) {
                     compute_blur_data(
-                        path_resolved,
+                        path_resolved.clone(),
                         image,
                         format.unwrap(),
                         &*blur_placeholder.await?,
@@ -431,7 +431,7 @@ pub async fn optimize(
         return Ok(FileContent::NotFound.cell());
     };
     let bytes = content.content().to_bytes();
-    let path = ident.path().to_resolved().await?;
+    let path = ident.path().await?.clone_value();
 
     let Some((image, format)) = load_image(path, &bytes, ident.path().await?.extension_ref())
     else {
@@ -500,7 +500,7 @@ impl Issue for ImageProcessingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -247,7 +247,7 @@ struct MdxTransformResult {
 #[turbo_tasks::value]
 struct MdxIssue {
     /// Place of message.
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     loc: Option<IssueSource>,
     /// Reason for message (should use markdown).
     reason: String,

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -120,7 +120,10 @@ impl Asset for MdxTransformedAsset {
     async fn content(self: ResolvedVc<Self>) -> Result<Vc<AssetContent>> {
         let this = self.await?;
         Ok(*transform_process_operation(self)
-            .issue_file_path(this.source.ident().path(), "MDX processing")
+            .issue_file_path(
+                this.source.ident().path().await?.clone_value(),
+                "MDX processing",
+            )
             .await?
             .connect()
             .await?
@@ -220,7 +223,7 @@ impl MdxTransformedAsset {
                 };
 
                 MdxIssue {
-                    path: self.source.ident().path().to_resolved().await?,
+                    path: self.source.ident().path().await?.clone_value(),
                     loc,
                     reason: err.reason,
                     mdx_rule_id: *err.rule_id,
@@ -261,7 +264,7 @@ struct MdxIssue {
 impl Issue for MdxIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/embed_js.rs
+++ b/turbopack/crates/turbopack-node/src/embed_js.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileContent, FileSystem, FileSystemPath, embed_directory};
@@ -8,11 +9,11 @@ pub fn embed_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file(path: RcStr) -> Vc<FileContent> {
-    embed_fs().root().join(path).read()
+pub(crate) async fn embed_file(path: RcStr) -> Result<Vc<FileContent>> {
+    Ok(embed_fs().root().await?.join(&path)?.read())
 }
 
 #[turbo_tasks::function]
-pub(crate) fn embed_file_path(path: RcStr) -> Vc<FileSystemPath> {
-    embed_fs().root().join(path)
+pub(crate) async fn embed_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(embed_fs().root().await?.join(&path)?.cell())
 }

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -84,8 +84,8 @@ pub struct JavaScriptEvaluation(#[turbo_tasks(trace_ignore)] JavaScriptStream);
 #[turbo_tasks::value]
 struct EmittedEvaluatePoolAssets {
     bootstrap: ResolvedVc<Box<dyn OutputAsset>>,
-    output_root: ResolvedVc<FileSystemPath>,
-    entrypoint: ResolvedVc<FileSystemPath>,
+    output_root: FileSystemPath,
+    entrypoint: FileSystemPath,
 }
 
 #[turbo_tasks::function(operation)]
@@ -224,7 +224,7 @@ pub enum EnvVarTracking {
 /// evaluated result automatically.
 pub async fn get_evaluate_pool(
     module_asset: ResolvedVc<Box<dyn Module>>,
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
@@ -400,7 +400,7 @@ pub fn custom_evaluate(evaluate_context: impl EvaluateContext) -> Vc<JavaScriptE
 #[turbo_tasks::function]
 pub fn evaluate(
     module_asset: ResolvedVc<Box<dyn Module>>,
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     context_ident_for_issue: ResolvedVc<AssetIdent>,
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
@@ -581,7 +581,7 @@ async fn basic_compute(
 #[derive(Clone, PartialEq, Eq, Hash, TaskInput, Debug, Serialize, Deserialize, TraceRawVcs)]
 struct BasicEvaluateContext {
     module_asset: ResolvedVc<Box<dyn Module>>,
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     context_ident_for_issue: ResolvedVc<AssetIdent>,
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
@@ -693,8 +693,8 @@ pub struct EvaluationIssue {
     pub context_ident: ResolvedVc<AssetIdent>,
     pub error: StructuredError,
     pub assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-    pub assets_root: ResolvedVc<FileSystemPath>,
-    pub root_path: ResolvedVc<FileSystemPath>,
+    pub assets_root: FileSystemPath,
+    pub root_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -97,7 +97,11 @@ async fn emit_evaluate_pool_assets_operation(
 ) -> Result<Vc<EmittedEvaluatePoolAssets>> {
     let runtime_asset = asset_context
         .process(
-            Vc::upcast(FileSource::new(embed_file_path(rcstr!("ipc/evaluate.ts")))),
+            Vc::upcast(FileSource::new(
+                embed_file_path(rcstr!("ipc/evaluate.ts"))
+                    .await?
+                    .clone_value(),
+            )),
             ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
         .module()
@@ -113,11 +117,11 @@ async fn emit_evaluate_pool_assets_operation(
     } else {
         Cow::Owned(format!("{file_name}.js"))
     };
-    let entrypoint = chunking_context.output_root().join(file_name.into());
+    let entrypoint = chunking_context.output_root().await?.join(&file_name)?;
     let entry_module = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                runtime_asset.ident().path().join(rcstr!("evaluate.js")),
+                runtime_asset.ident().path().await?.join("evaluate.js")?,
                 AssetContent::file(
                     File::from("import { run } from 'RUNTIME'; run(() => import('INNER'))").into(),
                 ),
@@ -134,7 +138,9 @@ async fn emit_evaluate_pool_assets_operation(
     let runtime_entries = {
         let globals_module = asset_context
             .process(
-                Vc::upcast(FileSource::new(embed_file_path(rcstr!("globals.ts")))),
+                Vc::upcast(FileSource::new(
+                    embed_file_path(rcstr!("globals.ts")).await?.clone_value(),
+                )),
                 ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
             )
             .module();
@@ -164,21 +170,21 @@ async fn emit_evaluate_pool_assets_operation(
     );
 
     let bootstrap = chunking_context.root_entry_chunk_group_asset(
-        entrypoint,
+        entrypoint.clone(),
         Vc::<EvaluatableAssets>::cell(runtime_entries)
             .with_entry(*ResolvedVc::try_downcast(entry_module).unwrap()),
         module_graph,
         OutputAssets::empty(),
     );
 
-    let output_root = chunking_context.output_root().to_resolved().await?;
-    let _ = emit_package_json(*output_root).resolve().await?;
-    let _ = emit(bootstrap, *output_root).resolve().await?;
+    let output_root = chunking_context.output_root().await?.clone_value();
+    let _ = emit_package_json(output_root.clone())?.resolve().await?;
+    let _ = emit(bootstrap, output_root.clone()).resolve().await?;
 
     Ok(EmittedEvaluatePoolAssets {
         bootstrap: bootstrap.to_resolved().await?,
         output_root,
-        entrypoint: entrypoint.to_resolved().await?,
+        entrypoint: entrypoint.clone(),
     }
     .cell())
 }
@@ -237,7 +243,7 @@ pub async fn get_evaluate_pool(
         bootstrap,
         output_root,
         entrypoint,
-    } = *emit_evaluate_pool_assets_with_effects_operation(
+    } = &*emit_evaluate_pool_assets_with_effects_operation(
         module_asset,
         asset_context,
         chunking_context,
@@ -246,16 +252,19 @@ pub async fn get_evaluate_pool(
     .read_strongly_consistent()
     .await?;
 
-    let (Some(cwd), Some(entrypoint)) = (to_sys_path(*cwd).await?, to_sys_path(*entrypoint).await?)
-    else {
+    let (Some(cwd), Some(entrypoint)) = (
+        to_sys_path(cwd.clone()).await?,
+        to_sys_path(entrypoint.clone()).await?,
+    ) else {
         panic!("can only evaluate from a disk filesystem");
     };
 
     // Invalidate pool when code content changes
-    content_changed(Vc::upcast(*bootstrap)).await?;
-    let assets_for_source_mapping = internal_assets_for_source_mapping(*bootstrap, *output_root)
-        .to_resolved()
-        .await?;
+    content_changed(Vc::upcast(**bootstrap)).await?;
+    let assets_for_source_mapping =
+        internal_assets_for_source_mapping(**bootstrap, output_root.clone())
+            .to_resolved()
+            .await?;
     let env = match env_var_tracking {
         EnvVarTracking::WholeEnvTracked => env.read_all().await?,
         EnvVarTracking::Untracked => {
@@ -273,8 +282,8 @@ pub async fn get_evaluate_pool(
         entrypoint,
         env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
         assets_for_source_mapping,
-        output_root,
-        chunking_context.root_path().to_resolved().await?,
+        output_root.clone(),
+        chunking_context.root_path().await?.clone_value(),
         available_parallelism().map_or(1, |v| v.get()),
         debug,
     );
@@ -606,7 +615,7 @@ impl EvaluateContext for BasicEvaluateContext {
     fn pool(&self) -> OperationVc<crate::pool::NodeJsPool> {
         get_evaluate_pool(
             self.module_asset,
-            self.cwd,
+            self.cwd.clone(),
             self.env,
             self.asset_context,
             self.chunking_context,
@@ -622,7 +631,7 @@ impl EvaluateContext for BasicEvaluateContext {
     }
 
     fn cwd(&self) -> Vc<turbo_tasks_fs::FileSystemPath> {
-        *self.cwd
+        self.cwd.clone().cell()
     }
 
     fn keep_alive(&self) -> bool {
@@ -634,8 +643,8 @@ impl EvaluateContext for BasicEvaluateContext {
             error,
             context_ident: self.context_ident_for_issue,
             assets_for_source_mapping: pool.assets_for_source_mapping,
-            assets_root: pool.assets_root,
-            root_path: self.chunking_context.root_path().to_resolved().await?,
+            assets_root: pool.assets_root.clone(),
+            root_path: self.chunking_context.root_path().await?.clone_value(),
         }
         .resolved_cell()
         .emit();
@@ -681,8 +690,8 @@ async fn print_error(
     error
         .print(
             *pool.assets_for_source_mapping,
-            *pool.assets_root,
-            evaluate_context.cwd(),
+            pool.assets_root.clone(),
+            evaluate_context.cwd().await?.clone_value(),
             FormattingMode::Plain,
         )
         .await
@@ -721,8 +730,8 @@ impl Issue for EvaluationIssue {
                 self.error
                     .print(
                         *self.assets_for_source_mapping,
-                        *self.assets_root,
-                        *self.root_path,
+                        self.assets_root.clone(),
+                        self.root_path.clone(),
                         FormattingMode::Plain,
                     )
                     .await?

--- a/turbopack/crates/turbopack-node/src/execution_context.rs
+++ b/turbopack/crates/turbopack-node/src/execution_context.rs
@@ -5,7 +5,7 @@ use turbopack_core::chunk::ChunkingContext;
 
 #[turbo_tasks::value]
 pub struct ExecutionContext {
-    pub project_path: ResolvedVc<FileSystemPath>,
+    pub project_path: FileSystemPath,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     pub env: ResolvedVc<Box<dyn ProcessEnv>>,
 }
@@ -14,7 +14,7 @@ pub struct ExecutionContext {
 impl ExecutionContext {
     #[turbo_tasks::function]
     pub fn new(
-        project_path: ResolvedVc<FileSystemPath>,
+        project_path: FileSystemPath,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
         env: ResolvedVc<Box<dyn ProcessEnv>>,
     ) -> Vc<Self> {

--- a/turbopack/crates/turbopack-node/src/execution_context.rs
+++ b/turbopack/crates/turbopack-node/src/execution_context.rs
@@ -28,7 +28,7 @@ impl ExecutionContext {
 
     #[turbo_tasks::function]
     pub fn project_path(&self) -> Vc<FileSystemPath> {
-        *self.project_path
+        self.project_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -41,7 +41,7 @@ pub mod transforms;
 #[turbo_tasks::function]
 async fn emit(
     intermediate_asset: Vc<Box<dyn OutputAsset>>,
-    intermediate_output_path: Vc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
 ) -> Result<()> {
     for asset in internal_assets(intermediate_asset, intermediate_output_path).await? {
         let _ = asset.content().write(asset.path()).resolve().await?;
@@ -64,7 +64,7 @@ struct SeparatedAssets {
 #[turbo_tasks::function]
 async fn internal_assets(
     intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
 ) -> Result<Vc<OutputAssetsSet>> {
     Ok(
         *separate_assets_operation(intermediate_asset, intermediate_output_path)
@@ -82,7 +82,7 @@ pub struct AssetsForSourceMapping(FxHashMap<String, ResolvedVc<Box<dyn GenerateS
 #[turbo_tasks::function]
 async fn internal_assets_for_source_mapping(
     intermediate_asset: Vc<Box<dyn OutputAsset>>,
-    intermediate_output_path: Vc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
 ) -> Result<Vc<AssetsForSourceMapping>> {
     let internal_assets = internal_assets(intermediate_asset, intermediate_output_path).await?;
     let intermediate_output_path = &*intermediate_output_path.await?;
@@ -105,7 +105,7 @@ pub async fn external_asset_entrypoints(
     module: Vc<Box<dyn EvaluatableAsset>>,
     runtime_entries: Vc<EvaluatableAssets>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
 ) -> Result<Vc<OutputAssetsSet>> {
     Ok(*separate_assets_operation(
         get_intermediate_asset(chunking_context, module, runtime_entries)
@@ -123,7 +123,7 @@ pub async fn external_asset_entrypoints(
 #[turbo_tasks::function(operation)]
 async fn separate_assets_operation(
     intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
 ) -> Result<Vc<SeparatedAssets>> {
     let intermediate_output_path = &*intermediate_output_path.await?;
     #[derive(PartialEq, Eq, Hash, Clone, Copy)]
@@ -185,7 +185,7 @@ async fn separate_assets_operation(
 /// Emit a basic package.json that sets the type of the package to commonjs.
 /// Currently code generated for Node is CommonJS, while authored code may be
 /// ESM, for example.
-fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<()> {
+fn emit_package_json(dir: FileSystemPath) -> Vc<()> {
     emit(
         Vc::upcast(VirtualOutputAsset::new(
             dir.join(rcstr!("package.json")),
@@ -198,12 +198,12 @@ fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<()> {
 /// Creates a node.js renderer pool for an entrypoint.
 #[turbo_tasks::function(operation)]
 pub async fn get_renderer_pool_operation(
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
-    output_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
+    output_root: FileSystemPath,
+    project_dir: FileSystemPath,
     debug: bool,
 ) -> Result<Vc<NodeJsPool>> {
     emit_package_json(*intermediate_output_path).await?;

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -9,7 +9,7 @@ pub use node_entry::{NodeEntry, NodeRenderingEntries, NodeRenderingEntry};
 use rustc_hash::FxHashMap;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, ResolvedVc, TryJoinIterExt, Vc,
     graph::{AdjacencyMap, GraphTraversal},
 };
 use turbo_tasks_env::ProcessEnv;
@@ -44,7 +44,11 @@ async fn emit(
     intermediate_output_path: FileSystemPath,
 ) -> Result<()> {
     for asset in internal_assets(intermediate_asset, intermediate_output_path).await? {
-        let _ = asset.content().write(asset.path()).resolve().await?;
+        let _ = asset
+            .content()
+            .write(asset.path().await?.clone_value())
+            .resolve()
+            .await?;
     }
     Ok(())
 }
@@ -84,8 +88,9 @@ async fn internal_assets_for_source_mapping(
     intermediate_asset: Vc<Box<dyn OutputAsset>>,
     intermediate_output_path: FileSystemPath,
 ) -> Result<Vc<AssetsForSourceMapping>> {
-    let internal_assets = internal_assets(intermediate_asset, intermediate_output_path).await?;
-    let intermediate_output_path = &*intermediate_output_path.await?;
+    let internal_assets =
+        internal_assets(intermediate_asset, intermediate_output_path.clone()).await?;
+    let intermediate_output_path = intermediate_output_path.clone();
     let mut internal_assets_for_source_mapping = FxHashMap::default();
     for asset in internal_assets.iter() {
         if let Some(generate_source_map) =
@@ -125,33 +130,36 @@ async fn separate_assets_operation(
     intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
     intermediate_output_path: FileSystemPath,
 ) -> Result<Vc<SeparatedAssets>> {
-    let intermediate_output_path = &*intermediate_output_path.await?;
+    let intermediate_output_path = intermediate_output_path.clone();
     #[derive(PartialEq, Eq, Hash, Clone, Copy)]
     enum Type {
         Internal(ResolvedVc<Box<dyn OutputAsset>>),
         External(ResolvedVc<Box<dyn OutputAsset>>),
     }
-    let get_asset_children = |asset| async move {
-        let Type::Internal(asset) = asset else {
-            return Ok(Vec::new());
-        };
-        asset
-            .references()
-            .await?
-            .iter()
-            .map(|asset| async {
-                // Assets within the output directory are considered as "internal" and all
-                // others as "external". We follow references on "internal" assets, but do not
-                // look into references of "external" assets, since there are no "internal"
-                // assets behind "externals"
-                if asset.path().await?.is_inside_ref(intermediate_output_path) {
-                    Ok(Type::Internal(*asset))
-                } else {
-                    Ok(Type::External(*asset))
-                }
-            })
-            .try_join()
-            .await
+    let get_asset_children = |asset| {
+        let intermediate_output_path = intermediate_output_path.clone();
+        async move {
+            let Type::Internal(asset) = asset else {
+                return Ok(Vec::new());
+            };
+            asset
+                .references()
+                .await?
+                .iter()
+                .map(|asset| async {
+                    // Assets within the output directory are considered as "internal" and all
+                    // others as "external". We follow references on "internal" assets, but do not
+                    // look into references of "external" assets, since there are no "internal"
+                    // assets behind "externals"
+                    if asset.path().await?.is_inside_ref(&intermediate_output_path) {
+                        Ok(Type::Internal(*asset))
+                    } else {
+                        Ok(Type::External(*asset))
+                    }
+                })
+                .try_join()
+                .await
+        }
     };
 
     let graph = AdjacencyMap::new()
@@ -185,14 +193,14 @@ async fn separate_assets_operation(
 /// Emit a basic package.json that sets the type of the package to commonjs.
 /// Currently code generated for Node is CommonJS, while authored code may be
 /// ESM, for example.
-fn emit_package_json(dir: FileSystemPath) -> Vc<()> {
-    emit(
+fn emit_package_json(dir: FileSystemPath) -> Result<Vc<()>> {
+    Ok(emit(
         Vc::upcast(VirtualOutputAsset::new(
-            dir.join(rcstr!("package.json")),
+            dir.join("package.json")?,
             AssetContent::file(File::from("{\"type\": \"commonjs\"}").into()),
         )),
         dir,
-    )
+    ))
 }
 
 /// Creates a node.js renderer pool for an entrypoint.
@@ -206,24 +214,26 @@ pub async fn get_renderer_pool_operation(
     project_dir: FileSystemPath,
     debug: bool,
 ) -> Result<Vc<NodeJsPool>> {
-    emit_package_json(*intermediate_output_path).await?;
+    emit_package_json(intermediate_output_path.clone())?.await?;
 
-    let _ = emit(*intermediate_asset, *output_root).resolve().await?;
+    let _ = emit(*intermediate_asset, output_root.clone())
+        .resolve()
+        .await?;
     let assets_for_source_mapping =
-        internal_assets_for_source_mapping(*intermediate_asset, *output_root);
+        internal_assets_for_source_mapping(*intermediate_asset, output_root.clone());
 
-    let entrypoint = intermediate_asset.path();
+    let entrypoint = intermediate_asset.path().await?.clone_value();
 
-    let Some(cwd) = to_sys_path(*cwd).await? else {
+    let Some(cwd) = to_sys_path(cwd.clone()).await? else {
         bail!(
             "can only render from a disk filesystem, but `cwd = {}`",
-            cwd.to_string().await?
+            cwd.value_to_string().await?
         );
     };
-    let Some(entrypoint) = to_sys_path(entrypoint).await? else {
+    let Some(entrypoint) = to_sys_path(entrypoint.clone()).await? else {
         bail!(
             "can only render from a disk filesystem, but `entrypoint = {}`",
-            entrypoint.to_string().await?
+            entrypoint.value_to_string().await?
         );
     };
     // Invalidate pool when code content changes
@@ -253,23 +263,28 @@ pub async fn get_intermediate_asset(
     main_entry: ResolvedVc<Box<dyn EvaluatableAsset>>,
     other_entries: Vc<EvaluatableAssets>,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
-    Ok(Vc::upcast(chunking_context.root_entry_chunk_group_asset(
-        chunking_context.chunk_path(None, main_entry.ident(), rcstr!(".js")),
-        other_entries.with_entry(*main_entry),
-        ModuleGraph::from_modules(
-            Vc::cell(vec![ChunkGroupEntry::Entry(
-                other_entries
-                    .await?
-                    .into_iter()
-                    .copied()
-                    .chain(std::iter::once(main_entry))
-                    .map(ResolvedVc::upcast)
-                    .collect(),
-            )]),
-            false,
+    Ok(Vc::upcast(
+        chunking_context.root_entry_chunk_group_asset(
+            chunking_context
+                .chunk_path(None, main_entry.ident(), rcstr!(".js"))
+                .await?
+                .clone_value(),
+            other_entries.with_entry(*main_entry),
+            ModuleGraph::from_modules(
+                Vc::cell(vec![ChunkGroupEntry::Entry(
+                    other_entries
+                        .await?
+                        .into_iter()
+                        .copied()
+                        .chain(std::iter::once(main_entry))
+                        .map(ResolvedVc::upcast)
+                        .collect(),
+                )]),
+                false,
+            ),
+            OutputAssets::empty(),
         ),
-        OutputAssets::empty(),
-    )))
+    ))
 }
 
 #[derive(Clone, Debug)]

--- a/turbopack/crates/turbopack-node/src/node_entry.rs
+++ b/turbopack/crates/turbopack-node/src/node_entry.rs
@@ -9,9 +9,9 @@ pub struct NodeRenderingEntry {
     pub runtime_entries: ResolvedVc<EvaluatableAssets>,
     pub module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    pub intermediate_output_path: ResolvedVc<FileSystemPath>,
-    pub output_root: ResolvedVc<FileSystemPath>,
-    pub project_dir: ResolvedVc<FileSystemPath>,
+    pub intermediate_output_path: FileSystemPath,
+    pub output_root: FileSystemPath,
+    pub project_dir: FileSystemPath,
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -73,8 +73,8 @@ struct NodeJsPoolProcess {
     child: Option<Child>,
     connection: TcpStream,
     assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-    assets_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    assets_root: FileSystemPath,
+    project_dir: FileSystemPath,
     stdout_handler: OutputStreamHandler<ChildStdout, Stdout>,
     stderr_handler: OutputStreamHandler<ChildStderr, Stderr>,
     debug: bool,
@@ -159,8 +159,8 @@ struct OutputStreamHandler<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> {
     stream: BufReader<R>,
     shared: SharedOutputSet,
     assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-    root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
+    project_dir: FileSystemPath,
     final_stream: W,
 }
 
@@ -197,8 +197,8 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> OutputStreamHandler<R, W> {
         async fn write_source_mapped_final<W: AsyncWrite + Unpin>(
             bytes: &[u8],
             assets_for_source_mapping: Vc<AssetsForSourceMapping>,
-            root: Vc<FileSystemPath>,
-            project_dir: Vc<FileSystemPath>,
+            root: FileSystemPath,
+            project_dir: FileSystemPath,
             final_stream: &mut W,
         ) -> Result<()> {
             if let Ok(text) = std::str::from_utf8(bytes) {
@@ -342,8 +342,8 @@ impl NodeJsPoolProcess {
         env: &FxHashMap<RcStr, RcStr>,
         entrypoint: &Path,
         assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-        assets_root: ResolvedVc<FileSystemPath>,
-        project_dir: ResolvedVc<FileSystemPath>,
+        assets_root: FileSystemPath,
+        project_dir: FileSystemPath,
         shared_stdout: SharedOutputSet,
         shared_stderr: SharedOutputSet,
         debug: bool,
@@ -727,8 +727,8 @@ pub struct NodeJsPool {
     entrypoint: PathBuf,
     env: FxHashMap<RcStr, RcStr>,
     pub assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-    pub assets_root: ResolvedVc<FileSystemPath>,
-    pub project_dir: ResolvedVc<FileSystemPath>,
+    pub assets_root: FileSystemPath,
+    pub project_dir: FileSystemPath,
     #[turbo_tasks(trace_ignore, debug_ignore)]
     processes: Arc<Mutex<BinaryHeap<NodeJsPoolProcess>>>,
     /// Semaphore to limit the number of concurrent operations in general
@@ -758,8 +758,8 @@ impl NodeJsPool {
         entrypoint: PathBuf,
         env: FxHashMap<RcStr, RcStr>,
         assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-        assets_root: ResolvedVc<FileSystemPath>,
-        project_dir: ResolvedVc<FileSystemPath>,
+        assets_root: FileSystemPath,
+        project_dir: FileSystemPath,
         concurrency: usize,
         debug: bool,
     ) -> Self {

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -120,8 +120,8 @@ impl NodeJsPoolProcess {
                 apply_source_mapping(
                     text,
                     *self.assets_for_source_mapping,
-                    *self.assets_root,
-                    *self.project_dir,
+                    self.assets_root.clone(),
+                    self.project_dir.clone(),
                     formatting_mode,
                 )
                 .await
@@ -130,8 +130,8 @@ impl NodeJsPoolProcess {
                 let cow = apply_source_mapping(
                     text,
                     *self.assets_for_source_mapping,
-                    *self.assets_root,
-                    *self.project_dir,
+                    self.assets_root.clone(),
+                    self.project_dir.clone(),
                     formatting_mode,
                 )
                 .await?;
@@ -298,8 +298,8 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> OutputStreamHandler<R, W> {
                             write_source_mapped_final(
                                 &entry.data,
                                 **assets_for_source_mapping,
-                                **root,
-                                **project_dir,
+                                root.clone(),
+                                project_dir.clone(),
                                 final_stream,
                             )
                             .await?;
@@ -325,8 +325,8 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> OutputStreamHandler<R, W> {
             write_source_mapped_final(
                 &buffer,
                 **assets_for_source_mapping,
-                **root,
-                **project_dir,
+                root.clone(),
+                project_dir.clone(),
                 final_stream,
             )
             .await?;
@@ -440,16 +440,16 @@ impl NodeJsPoolProcess {
             stream: child_stdout,
             shared: shared_stdout,
             assets_for_source_mapping,
-            root: assets_root,
-            project_dir,
+            root: assets_root.clone(),
+            project_dir: project_dir.clone(),
             final_stream: stdout(),
         };
         let stderr_handler = OutputStreamHandler {
             stream: child_stderr,
             shared: shared_stderr,
             assets_for_source_mapping,
-            root: assets_root,
-            project_dir,
+            root: assets_root.clone(),
+            project_dir: project_dir.clone(),
             final_stream: stderr(),
         };
 
@@ -457,8 +457,8 @@ impl NodeJsPoolProcess {
             child: Some(child),
             connection,
             assets_for_source_mapping,
-            assets_root,
-            project_dir,
+            assets_root: assets_root.clone(),
+            project_dir: project_dir.clone(),
             stdout_handler,
             stderr_handler,
             debug,
@@ -838,8 +838,8 @@ impl NodeJsPool {
             &self.env,
             self.entrypoint.as_path(),
             self.assets_for_source_mapping,
-            self.assets_root,
-            self.project_dir,
+            self.assets_root.clone(),
+            self.project_dir.clone(),
             self.shared_stdout.clone(),
             self.shared_stderr.clone(),
             self.debug,

--- a/turbopack/crates/turbopack-node/src/render/issue.rs
+++ b/turbopack/crates/turbopack-node/src/render/issue.rs
@@ -5,7 +5,7 @@ use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString}
 #[turbo_tasks::value(shared)]
 #[derive(Copy, Clone)]
 pub struct RenderingIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub message: ResolvedVc<StyledString>,
     pub status: Option<i32>,
 }

--- a/turbopack/crates/turbopack-node/src/render/issue.rs
+++ b/turbopack/crates/turbopack-node/src/render/issue.rs
@@ -3,7 +3,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString};
 #[turbo_tasks::value(shared)]
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct RenderingIssue {
     pub file_path: FileSystemPath,
     pub message: ResolvedVc<StyledString>,
@@ -24,7 +24,7 @@ impl Issue for RenderingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -20,11 +20,11 @@ use crate::{get_intermediate_asset, node_entry::NodeEntry, route_matcher::RouteM
 /// Creates a [NodeApiContentSource].
 #[turbo_tasks::function]
 pub fn create_node_api_source(
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     base_segments: Vec<BaseSegment>,
     route_type: RouteType,
-    server_root: ResolvedVc<FileSystemPath>,
+    server_root: FileSystemPath,
     route_match: ResolvedVc<Box<dyn RouteMatcher>>,
     pathname: ResolvedVc<RcStr>,
     entry: ResolvedVc<Box<dyn NodeEntry>>,
@@ -56,11 +56,11 @@ pub fn create_node_api_source(
 /// to this directory.
 #[turbo_tasks::value]
 pub struct NodeApiContentSource {
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     base_segments: Vec<BaseSegment>,
     route_type: RouteType,
-    server_root: ResolvedVc<FileSystemPath>,
+    server_root: FileSystemPath,
     pathname: ResolvedVc<RcStr>,
     route_match: ResolvedVc<Box<dyn RouteMatcher>>,
     entry: ResolvedVc<Box<dyn NodeEntry>>,

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -125,15 +125,15 @@ impl GetContentSourceContent for NodeApiContentSource {
         };
         let entry = (*self.entry).entry(data.clone()).await?;
         Ok(ContentSourceContent::HttpProxy(render_proxy_operation(
-            self.cwd,
+            self.cwd.clone(),
             self.env,
-            self.server_root.join(path.clone()).to_resolved().await?,
+            self.server_root.join(&path.clone())?,
             ResolvedVc::upcast(entry.module),
             entry.runtime_entries,
             entry.chunking_context,
-            entry.intermediate_output_path,
-            entry.output_root,
-            entry.project_dir,
+            entry.intermediate_output_path.clone(),
+            entry.output_root.clone(),
+            entry.project_dir.clone(),
             RenderData {
                 params: params.clone(),
                 method: method.clone(),

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -35,15 +35,15 @@ use crate::{
 /// Renders a module as static HTML in a node.js process.
 #[turbo_tasks::function(operation)]
 pub async fn render_proxy_operation(
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     runtime_entries: ResolvedVc<EvaluatableAssets>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
-    output_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
+    output_root: FileSystemPath,
+    project_dir: FileSystemPath,
     data: ResolvedVc<RenderData>,
     body: ResolvedVc<Body>,
     debug: bool,
@@ -96,7 +96,7 @@ pub async fn render_proxy_operation(
 }
 
 async fn proxy_error(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     error: anyhow::Error,
     operation: Option<NodeJsOperation>,
 ) -> Result<(u16, RcStr)> {
@@ -152,15 +152,15 @@ struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
 
 #[derive(Clone, Debug, TaskInput, PartialEq, Eq, Hash, Serialize, Deserialize, TraceRawVcs)]
 struct RenderStreamOptions {
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     runtime_entries: ResolvedVc<EvaluatableAssets>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
-    output_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
+    output_root: FileSystemPath,
+    project_dir: FileSystemPath,
     data: ResolvedVc<RenderData>,
     body: ResolvedVc<Body>,
     debug: bool,

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -244,9 +244,9 @@ async fn render_stream_internal(
             cwd,
             env,
             intermediate_asset,
-            intermediate_output_path,
+            intermediate_output_path.clone(),
             output_root,
-            project_dir,
+            project_dir.clone(),
             debug,
         );
 
@@ -281,8 +281,8 @@ async fn render_stream_internal(
                 let trace = trace_stack(
                     error,
                     *intermediate_asset,
-                    *intermediate_output_path,
-                    *project_dir
+                    intermediate_output_path.clone(),
+                    project_dir.clone()
                 )
                 .await?;
                 let (status, body) =  proxy_error(path, anyhow!("error rendering: {}", trace), Some(operation)).await?;
@@ -315,7 +315,7 @@ async fn render_stream_internal(
                     // headers/body to a proxy error.
                     operation.disallow_reuse();
                     let trace =
-                        trace_stack(error, *intermediate_asset, *intermediate_output_path, *project_dir).await?;
+                        trace_stack(error, *intermediate_asset, intermediate_output_path.clone(), project_dir.clone()).await?;
                     Err(anyhow!("error during streaming render: {}", trace))?;
                     return;
                 }

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -76,16 +76,16 @@ impl StaticResult {
 /// Renders a module as static HTML in a node.js process.
 #[turbo_tasks::function(operation)]
 pub async fn render_static_operation(
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     runtime_entries: ResolvedVc<EvaluatableAssets>,
     fallback_page: ResolvedVc<DevHtmlAsset>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
-    output_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
+    output_root: FileSystemPath,
+    project_dir: FileSystemPath,
     data: ResolvedVc<RenderData>,
     debug: bool,
 ) -> Result<Vc<StaticResult>> {
@@ -138,7 +138,7 @@ pub async fn render_static_operation(
 }
 
 async fn static_error(
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     error: anyhow::Error,
     operation: Option<NodeJsOperation>,
     fallback_page: Vc<DevHtmlAsset>,
@@ -203,16 +203,16 @@ struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
 
 #[derive(Clone, Debug, TaskInput, PartialEq, Eq, Hash, Deserialize, Serialize, TraceRawVcs)]
 struct RenderStreamOptions {
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     module: ResolvedVc<Box<dyn EvaluatableAsset>>,
     runtime_entries: ResolvedVc<EvaluatableAssets>,
     fallback_page: ResolvedVc<DevHtmlAsset>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-    intermediate_output_path: ResolvedVc<FileSystemPath>,
-    output_root: ResolvedVc<FileSystemPath>,
-    project_dir: ResolvedVc<FileSystemPath>,
+    intermediate_output_path: FileSystemPath,
+    output_root: FileSystemPath,
+    project_dir: FileSystemPath,
     data: ResolvedVc<RenderData>,
     debug: bool,
 }

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -295,9 +295,9 @@ async fn render_stream_internal(
             cwd,
             env,
             intermediate_asset,
-            intermediate_output_path,
+            intermediate_output_path.clone(),
             output_root,
-            project_dir,
+            project_dir.clone(),
             debug,
         );
 
@@ -346,8 +346,8 @@ async fn render_stream_internal(
                 let trace = trace_stack(
                     error,
                     *intermediate_asset,
-                    *intermediate_output_path,
-                    *project_dir,
+                    intermediate_output_path.clone(),
+                    project_dir.clone(),
                 )
                 .await?;
                 yield RenderItem::Response(
@@ -379,7 +379,7 @@ async fn render_stream_internal(
                     // headers/body to a proxy error.
                     operation.disallow_reuse();
                     let trace =
-                        trace_stack(error, *intermediate_asset, *intermediate_output_path, *project_dir).await?;
+                        trace_stack(error, *intermediate_asset, intermediate_output_path.clone(), project_dir.clone()).await?;
                         drop(guard);
                     Err(anyhow!("error during streaming render: {}", trace))?;
                     return;

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -43,11 +43,11 @@ use crate::{
 /// to this directory.
 #[turbo_tasks::function]
 pub fn create_node_rendered_source(
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     base_segments: Vec<BaseSegment>,
     route_type: RouteType,
-    server_root: ResolvedVc<FileSystemPath>,
+    server_root: FileSystemPath,
     route_match: ResolvedVc<Box<dyn RouteMatcher>>,
     pathname: ResolvedVc<RcStr>,
     entry: ResolvedVc<Box<dyn NodeEntry>>,
@@ -83,11 +83,11 @@ pub fn create_node_rendered_source(
 /// see [create_node_rendered_source]
 #[turbo_tasks::value]
 pub struct NodeRenderContentSource {
-    cwd: ResolvedVc<FileSystemPath>,
+    cwd: FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     base_segments: Vec<BaseSegment>,
     route_type: RouteType,
-    server_root: ResolvedVc<FileSystemPath>,
+    server_root: FileSystemPath,
     route_match: ResolvedVc<Box<dyn RouteMatcher>>,
     pathname: ResolvedVc<RcStr>,
     entry: ResolvedVc<Box<dyn NodeEntry>>,

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -122,7 +122,7 @@ impl GetContentSource for NodeRenderContentSource {
                     *entry.module,
                     *entry.runtime_entries,
                     *entry.chunking_context,
-                    *entry.intermediate_output_path,
+                    entry.intermediate_output_path.clone(),
                 )
                 .await?
                 .iter()
@@ -130,7 +130,7 @@ impl GetContentSource for NodeRenderContentSource {
             )
         }
         Ok(Vc::upcast(AssetGraphContentSource::new_lazy_multiple(
-            *self.server_root,
+            self.server_root.clone(),
             Vc::cell(set),
         )))
     }
@@ -183,16 +183,16 @@ impl GetContentSourceContent for NodeRenderContentSource {
         };
         let entry = (*self.entry).entry(data.clone()).await?;
         let result_op = render_static_operation(
-            self.cwd,
+            self.cwd.clone(),
             self.env,
-            self.server_root.join(path.clone()).to_resolved().await?,
+            self.server_root.join(&path)?,
             ResolvedVc::upcast(entry.module),
             entry.runtime_entries,
             self.fallback_page,
             entry.chunking_context,
-            entry.intermediate_output_path,
-            entry.output_root,
-            entry.project_dir,
+            entry.intermediate_output_path.clone(),
+            entry.output_root.clone(),
+            entry.project_dir.clone(),
             RenderData {
                 params: params.clone(),
                 method: method.clone(),
@@ -207,7 +207,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
             self.debug,
         )
         .issue_file_path(
-            entry.module.ident().path(),
+            entry.module.ident().path().await?.clone_value(),
             format!("server-side rendering {pathname}"),
         )
         .await?;

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -31,8 +31,8 @@ const MAX_CODE_FRAMES: usize = 3;
 pub async fn apply_source_mapping(
     text: &'_ str,
     assets_for_source_mapping: Vc<AssetsForSourceMapping>,
-    root: Vc<FileSystemPath>,
-    project_dir: Vc<FileSystemPath>,
+    root: FileSystemPath,
+    project_dir: FileSystemPath,
     formatting_mode: FormattingMode,
 ) -> Result<Cow<'_, str>> {
     static STACK_TRACE_LINE: Lazy<Regex> =
@@ -188,19 +188,19 @@ enum ResolvedSourceMapping {
     },
     MappedProject {
         frame: StackFrame<'static>,
-        project_path: ReadRef<FileSystemPath>,
+        project_path: FileSystemPath,
         lines: ReadRef<FileLinesContent>,
     },
     MappedLibrary {
         frame: StackFrame<'static>,
-        project_path: ReadRef<FileSystemPath>,
+        project_path: FileSystemPath,
     },
 }
 
 async fn resolve_source_mapping(
     assets_for_source_mapping: Vc<AssetsForSourceMapping>,
-    root: Vc<FileSystemPath>,
-    project_dir: Vc<FileSystemPath>,
+    root: FileSystemPath,
+    project_dir: FileSystemPath,
     frame: &StackFrame<'_>,
 ) -> Result<ResolvedSourceMapping> {
     let Some((line, column)) = frame.get_pos() else {
@@ -275,8 +275,8 @@ impl StructuredError {
     pub async fn print(
         &self,
         assets_for_source_mapping: Vc<AssetsForSourceMapping>,
-        root: Vc<FileSystemPath>,
-        root_path: Vc<FileSystemPath>,
+        root: FileSystemPath,
+        root_path: FileSystemPath,
         formatting_mode: FormattingMode,
     ) -> Result<String> {
         let mut message = String::new();
@@ -322,8 +322,8 @@ impl StructuredError {
 pub async fn trace_stack(
     error: StructuredError,
     root_asset: Vc<Box<dyn OutputAsset>>,
-    output_path: Vc<FileSystemPath>,
-    project_dir: Vc<FileSystemPath>,
+    output_path: FileSystemPath,
+    project_dir: FileSystemPath,
 ) -> Result<String> {
     let assets_for_source_mapping = internal_assets_for_source_mapping(root_asset, output_path);
 
@@ -340,8 +340,8 @@ pub async fn trace_stack(
 pub async fn trace_stack_with_source_mapping_assets(
     error: StructuredError,
     assets_for_source_mapping: Vc<AssetsForSourceMapping>,
-    output_path: Vc<FileSystemPath>,
-    project_dir: Vc<FileSystemPath>,
+    output_path: FileSystemPath,
+    project_dir: FileSystemPath,
 ) -> Result<String> {
     error
         .print(

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -62,9 +62,13 @@ pub async fn apply_source_mapping(
             line: Some(line),
             column: Some(column),
         };
-        let resolved =
-            resolve_source_mapping(assets_for_source_mapping, root, project_dir.root(), &frame)
-                .await;
+        let resolved = resolve_source_mapping(
+            assets_for_source_mapping,
+            root.clone(),
+            project_dir.root().await?.clone_value(),
+            &frame,
+        )
+        .await;
         write_resolved(
             &mut new,
             resolved,
@@ -238,17 +242,17 @@ async fn resolve_source_mapping(
                 PROJECT_FILESYSTEM_NAME,
                 "]/"
             )) {
-                let fs_path = project_dir.join(project_path.into());
+                let fs_path = project_dir.join(project_path)?;
                 if lib_code {
                     return Ok(ResolvedSourceMapping::MappedLibrary {
                         frame: frame.clone(),
-                        project_path: fs_path.await?,
+                        project_path: fs_path.clone(),
                     });
                 } else {
                     let lines = fs_path.read().lines().await?;
                     return Ok(ResolvedSourceMapping::MappedProject {
                         frame: frame.clone(),
-                        project_path: fs_path.await?,
+                        project_path: fs_path.clone(),
                         lines,
                     });
                 }
@@ -295,8 +299,13 @@ impl StructuredError {
 
         for frame in &self.stack {
             let frame = frame.unmangle_identifiers(magic);
-            let resolved =
-                resolve_source_mapping(assets_for_source_mapping, root, root_path, &frame).await;
+            let resolved = resolve_source_mapping(
+                assets_for_source_mapping,
+                root.clone(),
+                root_path.clone(),
+                &frame,
+            )
+            .await;
             write_resolved(
                 &mut message,
                 resolved,
@@ -310,8 +319,13 @@ impl StructuredError {
         if let Some(cause) = &self.cause {
             message.write_str("\nCaused by: ")?;
             message.write_str(
-                &Box::pin(cause.print(assets_for_source_mapping, root, root_path, formatting_mode))
-                    .await?,
+                &Box::pin(cause.print(
+                    assets_for_source_mapping,
+                    root.clone(),
+                    root_path.clone(),
+                    formatting_mode,
+                ))
+                .await?,
             )?;
         }
 
@@ -325,7 +339,8 @@ pub async fn trace_stack(
     output_path: FileSystemPath,
     project_dir: FileSystemPath,
 ) -> Result<String> {
-    let assets_for_source_mapping = internal_assets_for_source_mapping(root_asset, output_path);
+    let assets_for_source_mapping =
+        internal_assets_for_source_mapping(root_asset, output_path.clone());
 
     trace_stack_with_source_mapping_assets(
         error,

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -194,7 +194,7 @@ struct ProcessPostCssResult {
 #[turbo_tasks::function]
 async fn config_changed(
     asset_context: Vc<Box<dyn AssetContext>>,
-    postcss_config_path: Vc<FileSystemPath>,
+    postcss_config_path: FileSystemPath,
 ) -> Result<Vc<Completion>> {
     let config_asset = asset_context
         .process(
@@ -217,7 +217,7 @@ async fn config_changed(
 #[turbo_tasks::function]
 async fn extra_configs_changed(
     asset_context: Vc<Box<dyn AssetContext>>,
-    postcss_config_path: Vc<FileSystemPath>,
+    postcss_config_path: FileSystemPath,
 ) -> Result<Vc<Completion>> {
     let parent_path = postcss_config_path.parent();
 
@@ -258,7 +258,7 @@ async fn extra_configs_changed(
 
 #[turbo_tasks::value]
 pub struct JsonSource {
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
     pub key: ResolvedVc<Option<RcStr>>,
     pub allow_json5: bool,
 }
@@ -267,7 +267,7 @@ pub struct JsonSource {
 impl JsonSource {
     #[turbo_tasks::function]
     pub fn new(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         key: ResolvedVc<Option<RcStr>>,
         allow_json5: bool,
     ) -> Vc<Self> {
@@ -329,8 +329,8 @@ impl Asset for JsonSource {
 
 #[turbo_tasks::function]
 pub(crate) async fn config_loader_source(
-    project_path: Vc<FileSystemPath>,
-    postcss_config_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
+    postcss_config_path: FileSystemPath,
 ) -> Result<Vc<Box<dyn Source>>> {
     let postcss_config_path_value = &*postcss_config_path.await?;
     let postcss_config_path_filename = postcss_config_path_value.file_name();
@@ -393,8 +393,8 @@ pub(crate) async fn config_loader_source(
 #[turbo_tasks::function]
 async fn postcss_executor(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_path: Vc<FileSystemPath>,
-    postcss_config_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
+    postcss_config_path: FileSystemPath,
 ) -> Result<Vc<ProcessResult>> {
     let config_asset = asset_context
         .process(
@@ -416,10 +416,10 @@ async fn postcss_executor(
 }
 
 async fn find_config_in_location(
-    project_path: Vc<FileSystemPath>,
+    project_path: FileSystemPath,
     location: PostCssConfigLocation,
     source: Vc<Box<dyn Source>>,
-) -> Result<Option<Vc<FileSystemPath>>> {
+) -> Result<Option<FileSystemPath>> {
     if let FindContextFileResult::Found(config_path, _) =
         *find_context_file_or_package_key(project_path, postcss_configs(), rcstr!("postcss"))
             .await?
@@ -561,7 +561,7 @@ impl PostCssTransformedAsset {
 
 #[turbo_tasks::value]
 struct PostCssTransformIssue {
-    source: ResolvedVc<FileSystemPath>,
+    source: FileSystemPath,
     description: RcStr,
     severity: IssueSeverity,
     title: RcStr,

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -170,7 +170,10 @@ impl Asset for PostCssTransformedAsset {
     async fn content(self: ResolvedVc<Self>) -> Result<Vc<AssetContent>> {
         let this = self.await?;
         Ok(*transform_process_operation(self)
-            .issue_file_path(this.source.ident().path(), "PostCSS processing")
+            .issue_file_path(
+                this.source.ident().path().await?.clone_value(),
+                "PostCSS processing",
+            )
             .await?
             .connect()
             .await?
@@ -198,7 +201,7 @@ async fn config_changed(
 ) -> Result<Vc<Completion>> {
     let config_asset = asset_context
         .process(
-            Vc::upcast(FileSource::new(postcss_config_path)),
+            Vc::upcast(FileSource::new(postcss_config_path.clone())),
             ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
         .module();
@@ -222,9 +225,9 @@ async fn extra_configs_changed(
     let parent_path = postcss_config_path.parent();
 
     let config_paths = [
-        parent_path.join(rcstr!("tailwind.config.js")),
-        parent_path.join(rcstr!("tailwind.config.mjs")),
-        parent_path.join(rcstr!("tailwind.config.ts")),
+        parent_path.join("tailwind.config.js")?,
+        parent_path.join("tailwind.config.mjs")?,
+        parent_path.join("tailwind.config.ts")?,
     ];
 
     let configs = config_paths
@@ -286,12 +289,9 @@ impl Source for JsonSource {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         match &*self.key.await? {
             Some(key) => Ok(AssetIdent::from_path(
-                self.path
-                    .append(rcstr!("."))
-                    .append(key.clone())
-                    .append(rcstr!(".json")),
+                self.path.append(".")?.append(key)?.append(".json")?,
             )),
-            None => Ok(AssetIdent::from_path(self.path.append(rcstr!(".json")))),
+            None => Ok(AssetIdent::from_path(self.path.append(".json")?)),
         }
     }
 }
@@ -332,7 +332,7 @@ pub(crate) async fn config_loader_source(
     project_path: FileSystemPath,
     postcss_config_path: FileSystemPath,
 ) -> Result<Vc<Box<dyn Source>>> {
-    let postcss_config_path_value = &*postcss_config_path.await?;
+    let postcss_config_path_value = postcss_config_path.clone();
     let postcss_config_path_filename = postcss_config_path_value.file_name();
 
     if postcss_config_path_filename == "package.json" {
@@ -358,10 +358,7 @@ pub(crate) async fn config_loader_source(
         return Ok(Vc::upcast(FileSource::new(postcss_config_path)));
     }
 
-    let Some(config_path) = project_path
-        .await?
-        .get_relative_path_to(postcss_config_path_value)
-    else {
+    let Some(config_path) = project_path.get_relative_path_to(&postcss_config_path_value) else {
         bail!("Unable to get relative path to postcss config");
     };
 
@@ -385,7 +382,7 @@ pub(crate) async fn config_loader_source(
     };
 
     Ok(Vc::upcast(VirtualSource::new(
-        postcss_config_path.append(rcstr!("_.loader.mjs")),
+        postcss_config_path.append("_.loader.mjs")?,
         AssetContent::file(File::from(code).into()),
     )))
 }
@@ -406,9 +403,11 @@ async fn postcss_executor(
         .await?;
 
     Ok(asset_context.process(
-        Vc::upcast(FileSource::new(embed_file_path(rcstr!(
-            "transforms/postcss.ts"
-        )))),
+        Vc::upcast(FileSource::new(
+            embed_file_path(rcstr!("transforms/postcss.ts"))
+                .await?
+                .clone_value(),
+        )),
         ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
             rcstr!("CONFIG") => config_asset
         })),
@@ -421,21 +420,21 @@ async fn find_config_in_location(
     source: Vc<Box<dyn Source>>,
 ) -> Result<Option<FileSystemPath>> {
     if let FindContextFileResult::Found(config_path, _) =
-        *find_context_file_or_package_key(project_path, postcss_configs(), rcstr!("postcss"))
+        &*find_context_file_or_package_key(project_path, postcss_configs(), rcstr!("postcss"))
             .await?
     {
-        return Ok(Some(*config_path));
+        return Ok(Some(config_path.clone()));
     }
 
     if matches!(location, PostCssConfigLocation::ProjectPathOrLocalPath)
-        && let FindContextFileResult::Found(config_path, _) = *find_context_file_or_package_key(
-            source.ident().path().parent(),
+        && let FindContextFileResult::Found(config_path, _) = &*find_context_file_or_package_key(
+            source.ident().path().await?.parent(),
             postcss_configs(),
             rcstr!("postcss"),
         )
         .await?
     {
-        return Ok(Some(*config_path));
+        return Ok(Some(config_path.clone()));
     }
 
     Ok(None)
@@ -475,7 +474,8 @@ impl PostCssTransformedAsset {
         //
         // We look for the config in the project path first, then the source path
         let Some(config_path) =
-            find_config_in_location(**project_path, self.config_location, *self.source).await?
+            find_config_in_location(project_path.clone(), self.config_location, *self.source)
+                .await?
         else {
             return Ok(ProcessPostCssResult {
                 content: self.source.content().to_resolved().await?,
@@ -500,31 +500,30 @@ impl PostCssTransformedAsset {
         let source_map = self.source_map;
 
         // This invalidates the transform when the config changes.
-        let config_changed = config_changed(*evaluate_context, config_path)
+        let config_changed = config_changed(*evaluate_context, config_path.clone())
             .to_resolved()
             .await?;
 
-        let postcss_executor = postcss_executor(*evaluate_context, **project_path, config_path)
-            .module()
-            .to_resolved()
-            .await?;
+        let postcss_executor =
+            postcss_executor(*evaluate_context, project_path.clone(), config_path)
+                .module()
+                .to_resolved()
+                .await?;
         let css_fs_path = self.source.ident().path();
 
         // We need to get a path relative to the project because the postcss loader
         // runs with the project as the current working directory.
-        let css_path = if let Some(css_path) = project_path
-            .await?
-            .get_relative_path_to(&*css_fs_path.await?)
-        {
-            css_path.into_owned()
-        } else {
-            // This shouldn't be an error since it can happen on virtual assets
-            "".into()
-        };
+        let css_path =
+            if let Some(css_path) = project_path.get_relative_path_to(&*css_fs_path.await?) {
+                css_path.into_owned()
+            } else {
+                // This shouldn't be an error since it can happen on virtual assets
+                "".into()
+            };
 
         let config_value = evaluate_webpack_loader(WebpackLoaderContext {
             module_asset: postcss_executor,
-            cwd: *project_path,
+            cwd: project_path.clone(),
             env: *env,
             context_ident_for_issue: self.source.ident().to_resolved().await?,
             asset_context: evaluate_context,
@@ -571,7 +570,7 @@ struct PostCssTransformIssue {
 impl Issue for PostCssTransformIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.source
+        self.source.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/transforms/util.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/util.rs
@@ -35,13 +35,16 @@ pub async fn emitted_assets_to_virtual_sources(
         .collect::<BTreeMap<_, _>>()
         .into_iter()
         .map(|(file, (content, _source_map))| {
-            // TODO handle SourceMap
-            VirtualSource::new(
-                ServerFileSystem::new().root().join(file),
-                AssetContent::File(FileContent::Content(File::from(content)).resolved_cell())
-                    .cell(),
-            )
-            .to_resolved()
+            async move {
+                // TODO handle SourceMap
+                VirtualSource::new(
+                    ServerFileSystem::new().root().await?.join(&file)?,
+                    AssetContent::File(FileContent::Content(File::from(content)).resolved_cell())
+                        .cell(),
+                )
+                .to_resolved()
+                .await
+            }
         })
         .try_join()
         .await

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -415,7 +415,7 @@ pub enum ResponseMessage {
 #[derive(Clone, PartialEq, Eq, Hash, TaskInput, Serialize, Deserialize, Debug, TraceRawVcs)]
 pub struct WebpackLoaderContext {
     pub module_asset: ResolvedVc<Box<dyn Module>>,
-    pub cwd: ResolvedVc<FileSystemPath>,
+    pub cwd: FileSystemPath,
     pub env: ResolvedVc<Box<dyn ProcessEnv>>,
     pub context_ident_for_issue: ResolvedVc<AssetIdent>,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
@@ -723,7 +723,7 @@ async fn apply_webpack_resolve_options(
 #[turbo_tasks::value(shared)]
 pub struct BuildDependencyIssue {
     pub context_ident: ResolvedVc<AssetIdent>,
-    pub path: ResolvedVc<FileSystemPath>,
+    pub path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -767,12 +767,12 @@ impl Issue for BuildDependencyIssue {
 
 #[turbo_tasks::value(shared)]
 pub struct EvaluateEmittedErrorIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub severity: IssueSeverity,
     pub error: StructuredError,
     pub assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-    pub assets_root: ResolvedVc<FileSystemPath>,
-    pub project_dir: ResolvedVc<FileSystemPath>,
+    pub assets_root: FileSystemPath,
+    pub project_dir: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -817,13 +817,13 @@ impl Issue for EvaluateEmittedErrorIssue {
 
 #[turbo_tasks::value(shared)]
 pub struct EvaluateErrorLoggingIssue {
-    pub file_path: ResolvedVc<FileSystemPath>,
+    pub file_path: FileSystemPath,
     pub severity: IssueSeverity,
     #[turbo_tasks(trace_ignore)]
     pub logging: Vec<LogInfo>,
     pub assets_for_source_mapping: ResolvedVc<AssetsForSourceMapping>,
-    pub assets_root: ResolvedVc<FileSystemPath>,
-    pub project_dir: ResolvedVc<FileSystemPath>,
+    pub assets_root: FileSystemPath,
+    pub project_dir: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -188,9 +188,11 @@ async fn webpack_loaders_executor(
     evaluate_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<ProcessResult>> {
     Ok(evaluate_context.process(
-        Vc::upcast(FileSource::new(embed_file_path(rcstr!(
-            "transforms/webpack-loaders.ts"
-        )))),
+        Vc::upcast(FileSource::new(
+            embed_file_path(rcstr!("transforms/webpack-loaders.ts"))
+                .await?
+                .clone_value(),
+        )),
         ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
     ))
 }
@@ -206,7 +208,7 @@ impl WebpackLoadersProcessedAsset {
             project_path,
             chunking_context,
             env,
-        } = *transform.execution_context.await?;
+        } = &*transform.execution_context.await?;
         let source_content = this.source.content();
         let AssetContent::File(file) = *source_content.await? else {
             bail!("Webpack Loaders transform only support transforming files");
@@ -239,26 +241,22 @@ impl WebpackLoadersProcessedAsset {
             .to_resolved()
             .await?;
 
-        let resource_fs_path = this.source.ident().path();
-        let resource_fs_path_ref = resource_fs_path.await?;
-        let Some(resource_path) = project_path
-            .await?
-            .get_relative_path_to(&resource_fs_path_ref)
-        else {
+        let resource_fs_path = this.source.ident().path().await?.clone_value();
+        let resource_fs_path_ref = resource_fs_path.clone();
+        let Some(resource_path) = project_path.get_relative_path_to(&resource_fs_path_ref) else {
             bail!(format!(
                 "Resource path \"{}\" need to be on project filesystem \"{}\"",
-                resource_fs_path_ref,
-                project_path.await?
+                resource_fs_path_ref, project_path
             ));
         };
         let loaders = transform.loaders.await?;
         let config_value = evaluate_webpack_loader(WebpackLoaderContext {
             module_asset: webpack_loaders_executor,
-            cwd: project_path,
-            env,
+            cwd: project_path.clone(),
+            env: *env,
             context_ident_for_issue: this.source.ident().to_resolved().await?,
             asset_context: evaluate_context,
-            chunking_context,
+            chunking_context: *chunking_context,
             resolve_options_context: Some(transform.resolve_options_context),
             args: vec![
                 ResolvedVc::cell(content),
@@ -439,7 +437,7 @@ impl EvaluateContext for WebpackLoaderContext {
     fn pool(&self) -> OperationVc<crate::pool::NodeJsPool> {
         get_evaluate_pool(
             self.module_asset,
-            self.cwd,
+            self.cwd.clone(),
             self.env,
             self.asset_context,
             self.chunking_context,
@@ -458,7 +456,7 @@ impl EvaluateContext for WebpackLoaderContext {
     }
 
     fn cwd(&self) -> Vc<turbo_tasks_fs::FileSystemPath> {
-        *self.cwd
+        self.cwd.clone().cell()
     }
 
     fn keep_alive(&self) -> bool {
@@ -470,8 +468,8 @@ impl EvaluateContext for WebpackLoaderContext {
             error,
             context_ident: self.context_ident_for_issue,
             assets_for_source_mapping: pool.assets_for_source_mapping,
-            assets_root: pool.assets_root,
-            root_path: self.chunking_context.root_path().to_resolved().await?,
+            assets_root: pool.assets_root.clone(),
+            root_path: self.chunking_context.root_path().await?.clone_value(),
         }
         .resolved_cell()
         .emit();
@@ -504,19 +502,20 @@ impl EvaluateContext for WebpackLoaderContext {
                     .try_join();
                 let file_subscriptions = file_paths
                     .iter()
-                    .map(|p| self.cwd.join(p.clone()).read())
+                    .map(|p| async move { self.cwd.join(p)?.read().await })
                     .try_join();
                 let directory_subscriptions = directories
                     .iter()
-                    .map(|(dir, glob)| {
+                    .map(|(dir, glob)| async move {
                         self.cwd
-                            .join(dir.clone())
+                            .join(dir)?
                             .track_glob(Glob::new(glob.clone()), false)
+                            .await
                     })
                     .try_join();
                 let build_paths = build_file_paths
                     .iter()
-                    .map(|path| self.cwd.join(path.clone()).to_resolved())
+                    .map(|path| async move { self.cwd.join(path) })
                     .try_join();
                 let (resolved_build_paths, ..) = try_join!(
                     build_paths,
@@ -536,12 +535,12 @@ impl EvaluateContext for WebpackLoaderContext {
             }
             InfoMessage::EmittedError { error, severity } => {
                 EvaluateEmittedErrorIssue {
-                    file_path: self.context_ident_for_issue.path().to_resolved().await?,
+                    file_path: self.context_ident_for_issue.path().await?.clone_value(),
                     error,
                     severity,
                     assets_for_source_mapping: pool.assets_for_source_mapping,
-                    assets_root: pool.assets_root,
-                    project_dir: self.chunking_context.root_path().to_resolved().await?,
+                    assets_root: pool.assets_root.clone(),
+                    project_dir: self.chunking_context.root_path().await?.clone_value(),
                 }
                 .resolved_cell()
                 .emit();
@@ -568,20 +567,24 @@ impl EvaluateContext for WebpackLoaderContext {
                 let Some(resolve_options_context) = self.resolve_options_context else {
                     bail!("Resolve options are not available in this context");
                 };
-                let lookup_path = self.cwd.join(lookup_path);
+                let lookup_path = self.cwd.join(&lookup_path)?;
                 let request = Request::parse(Pattern::Constant(request));
-                let options = resolve_options(lookup_path, *resolve_options_context);
+                let options = resolve_options(lookup_path.clone(), *resolve_options_context);
 
                 let options = apply_webpack_resolve_options(options, webpack_options);
 
-                let resolved = resolve(lookup_path, ReferenceType::Undefined, request, options);
+                let resolved = resolve(
+                    lookup_path.clone(),
+                    ReferenceType::Undefined,
+                    request,
+                    options,
+                );
 
                 let request_str = request.to_string().await?;
-                let lookup_path_str = lookup_path.to_string().await?;
+                let lookup_path_str = lookup_path.value_to_string().await?;
                 if let Some(source) = *resolved.first_source().await? {
                     if let Some(path) = self
                         .cwd
-                        .await?
                         .get_relative_path_to(&*source.ident().path().await?)
                     {
                         Ok(ResponseMessage::Resolve { path })
@@ -618,7 +621,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 .collect();
 
             EvaluateErrorLoggingIssue {
-                file_path: self.context_ident_for_issue.path().to_resolved().await?,
+                file_path: self.context_ident_for_issue.path().await?.clone_value(),
                 logging: logs,
                 severity: if has_errors {
                     IssueSeverity::Error
@@ -626,8 +629,8 @@ impl EvaluateContext for WebpackLoaderContext {
                     IssueSeverity::Warning
                 },
                 assets_for_source_mapping: pool.assets_for_source_mapping,
-                assets_root: pool.assets_root,
-                project_dir: self.chunking_context.root_path().to_resolved().await?,
+                assets_root: pool.assets_root.clone(),
+                project_dir: self.chunking_context.root_path().await?.clone_value(),
             }
             .resolved_cell()
             .emit();
@@ -752,7 +755,7 @@ impl Issue for BuildDependencyIssue {
         Ok(Vc::cell(Some(
             StyledString::Line(vec![
                 StyledString::Text(rcstr!("The file at ")),
-                StyledString::Code(self.path.await?.to_string().into()),
+                StyledString::Code(self.path.to_string().into()),
                 StyledString::Text(
                     " is a build dependency, which is not yet implemented.
     Changing this file or any dependency will not be recognized and might require restarting the \
@@ -779,7 +782,7 @@ pub struct EvaluateEmittedErrorIssue {
 impl Issue for EvaluateEmittedErrorIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -803,8 +806,8 @@ impl Issue for EvaluateEmittedErrorIssue {
                 self.error
                     .print(
                         *self.assets_for_source_mapping,
-                        *self.assets_root,
-                        *self.project_dir,
+                        self.assets_root.clone(),
+                        self.project_dir.clone(),
                         FormattingMode::Plain,
                     )
                     .await?
@@ -830,7 +833,7 @@ pub struct EvaluateErrorLoggingIssue {
 impl Issue for EvaluateErrorLoggingIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -105,17 +105,17 @@ impl NodeJsChunkingContextBuilder {
 #[derive(Debug, Clone, Hash, TaskInput)]
 pub struct NodeJsChunkingContext {
     /// The root path of the project
-    root_path: ResolvedVc<FileSystemPath>,
+    root_path: FileSystemPath,
     /// This path is used to compute the url to request chunks or assets from
-    output_root: ResolvedVc<FileSystemPath>,
+    output_root: FileSystemPath,
     /// The relative path from the output_root to the root_path.
     output_root_to_root_path: RcStr,
     /// This path is used to compute the url to request chunks or assets from
-    client_root: ResolvedVc<FileSystemPath>,
+    client_root: FileSystemPath,
     /// Chunks are placed at this path
-    chunk_root_path: ResolvedVc<FileSystemPath>,
+    chunk_root_path: FileSystemPath,
     /// Static assets are placed at this path
-    asset_root_path: ResolvedVc<FileSystemPath>,
+    asset_root_path: FileSystemPath,
     /// Static assets requested from this url base
     asset_prefix: Option<RcStr>,
     /// The environment chunks will be evaluated in.
@@ -143,12 +143,12 @@ pub struct NodeJsChunkingContext {
 impl NodeJsChunkingContext {
     /// Creates a new chunking context builder.
     pub fn builder(
-        root_path: ResolvedVc<FileSystemPath>,
-        output_root: ResolvedVc<FileSystemPath>,
+        root_path: FileSystemPath,
+        output_root: FileSystemPath,
         output_root_to_root_path: RcStr,
-        client_root: ResolvedVc<FileSystemPath>,
-        chunk_root_path: ResolvedVc<FileSystemPath>,
-        asset_root_path: ResolvedVc<FileSystemPath>,
+        client_root: FileSystemPath,
+        chunk_root_path: FileSystemPath,
+        asset_root_path: FileSystemPath,
         environment: ResolvedVc<Environment>,
         runtime_type: RuntimeType,
     ) -> NodeJsChunkingContextBuilder {
@@ -263,7 +263,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn asset_url(&self, ident: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
+    async fn asset_url(&self, ident: FileSystemPath) -> Result<Vc<RcStr>> {
         let asset_path = ident.await?.to_string();
         let asset_path = asset_path
             .strip_prefix(&format!("{}/", self.client_root.await?.path))
@@ -388,7 +388,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     pub async fn entry_chunk_group(
         self: ResolvedVc<Self>,
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         evaluatable_assets: Vc<EvaluatableAssets>,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -229,12 +229,12 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     fn root_path(&self) -> Vc<FileSystemPath> {
-        *self.root_path
+        self.root_path.clone().cell()
     }
 
     #[turbo_tasks::function]
     fn output_root(&self) -> Vc<FileSystemPath> {
-        *self.output_root
+        self.output_root.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -264,9 +264,9 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     async fn asset_url(&self, ident: FileSystemPath) -> Result<Vc<RcStr>> {
-        let asset_path = ident.await?.to_string();
+        let asset_path = ident.to_string();
         let asset_path = asset_path
-            .strip_prefix(&format!("{}/", self.client_root.await?.path))
+            .strip_prefix(&format!("{}/", self.client_root.path))
             .context("expected client root to contain asset path")?;
 
         Ok(Vc::cell(
@@ -281,7 +281,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     fn chunk_root_path(&self) -> Vc<FileSystemPath> {
-        *self.chunk_root_path
+        self.chunk_root_path.clone().cell()
     }
 
     #[turbo_tasks::function]
@@ -291,12 +291,12 @@ impl ChunkingContext for NodeJsChunkingContext {
         ident: Vc<AssetIdent>,
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
-        let root_path = *self.chunk_root_path;
+        let root_path = self.chunk_root_path.clone();
         let name = ident
-            .output_name(*self.root_path, extension)
+            .output_name(self.root_path.clone(), extension)
             .owned()
             .await?;
-        Ok(root_path.join(name))
+        Ok(root_path.join(&name)?.cell())
     }
 
     #[turbo_tasks::function]
@@ -344,7 +344,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 content_hash = &content_hash[..8]
             ),
         };
-        Ok(self.asset_root_path.join(asset_path.into()))
+        Ok(self.asset_root_path.join(&asset_path)?.cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -87,8 +87,8 @@ impl EcmascriptBuildNodeChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
         Ok(EcmascriptBuildNodeChunkVersion::new(
-            self.chunking_context.output_root(),
-            self.chunk.path(),
+            self.chunking_context.output_root().await?.clone_value(),
+            self.chunk.path().await?.clone_value(),
             *self.content,
             self.chunking_context.await?.minify_type(),
         ))

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -22,7 +22,7 @@ use crate::NodeJsChunkingContext;
 /// runtime entries.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptBuildNodeEntryChunk {
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
     other_chunks: ResolvedVc<OutputAssets>,
     evaluatable_assets: ResolvedVc<EvaluatableAssets>,
     exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
@@ -35,7 +35,7 @@ impl EcmascriptBuildNodeEntryChunk {
     /// Creates a new [`Vc<EcmascriptBuildNodeEntryChunk>`].
     #[turbo_tasks::function]
     pub fn new(
-        path: ResolvedVc<FileSystemPath>,
+        path: FileSystemPath,
         other_chunks: ResolvedVc<OutputAssets>,
         evaluatable_assets: ResolvedVc<EvaluatableAssets>,
         exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -57,10 +57,10 @@ impl EcmascriptBuildNodeEntryChunk {
     async fn code(self: Vc<Self>) -> Result<Vc<Code>> {
         let this = self.await?;
 
-        let output_root = this.chunking_context.output_root().await?;
-        let chunk_path = self.path().await?;
-        let chunk_directory = self.path().parent().await?;
-        let runtime_path = self.runtime_chunk().path().await?;
+        let output_root = this.chunking_context.output_root().await?.clone_value();
+        let chunk_path = self.path().await?.clone_value();
+        let chunk_directory = self.path().await?.parent();
+        let runtime_path = self.runtime_chunk().path().await?.clone_value();
         let runtime_relative_path =
             if let Some(path) = chunk_directory.get_relative_path_to(&runtime_path) {
                 path
@@ -152,7 +152,10 @@ impl EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     async fn source_map(self: Vc<Self>) -> Result<Vc<SourceMapAsset>> {
         let this = self.await?;
-        Ok(SourceMapAsset::new_fixed(*this.path, Vc::upcast(self)))
+        Ok(SourceMapAsset::new_fixed(
+            this.path.clone(),
+            Vc::upcast(self),
+        ))
     }
 }
 
@@ -168,7 +171,7 @@ impl ValueToString for EcmascriptBuildNodeEntryChunk {
 impl OutputAsset for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.path
+        self.path.clone().cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -95,12 +95,13 @@ impl EcmascriptBuildNodeRuntimeChunk {
     }
 
     #[turbo_tasks::function]
-    fn ident_for_path(self: Vc<Self>) -> Vc<AssetIdent> {
-        AssetIdent::from_path(
+    async fn ident_for_path(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
+        Ok(AssetIdent::from_path(
             turbopack_ecmascript_runtime::embed_fs()
                 .root()
-                .join(rcstr!("runtime.js")),
-        )
+                .await?
+                .join("runtime.js")?,
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -17,8 +17,8 @@ pub(super) struct EcmascriptBuildNodeChunkVersion {
 impl EcmascriptBuildNodeChunkVersion {
     #[turbo_tasks::function]
     pub async fn new(
-        output_root: Vc<FileSystemPath>,
-        chunk_path: Vc<FileSystemPath>,
+        output_root: FileSystemPath,
+        chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
         minify_type: MinifyType,
     ) -> Result<Vc<Self>> {

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -22,8 +22,8 @@ impl EcmascriptBuildNodeChunkVersion {
         content: Vc<EcmascriptChunkContent>,
         minify_type: MinifyType,
     ) -> Result<Vc<Self>> {
-        let output_root = output_root.await?;
-        let chunk_path = chunk_path.await?;
+        let output_root = output_root.clone();
+        let chunk_path = chunk_path.clone();
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -94,7 +94,7 @@ pub async fn esm_resolve(
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::EcmaScriptModules(ty);
-    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), ty.clone())
+    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()).await?, ty.clone())
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -109,7 +109,7 @@ pub async fn cjs_resolve(
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO pass CommonJsReferenceSubType
     let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
+    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()).await?)
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -124,11 +124,11 @@ pub async fn cjs_resolve_source(
 ) -> Result<Vc<ResolveResult>> {
     // TODO pass CommonJsReferenceSubType
     let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
+    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()).await?)
         .resolve()
         .await?;
     let result = resolve(
-        origin.origin_path().parent().resolve().await?,
+        origin.origin_path().await?.parent(),
         ty.clone(),
         *request,
         options,
@@ -137,7 +137,7 @@ pub async fn cjs_resolve_source(
     handle_resolve_source_error(
         result,
         ty,
-        origin.origin_path(),
+        origin.origin_path().await?.clone_value(),
         *request,
         options,
         is_optional,
@@ -161,7 +161,7 @@ async fn specific_resolve(
     handle_resolve_error(
         result,
         reference_type,
-        origin.origin_path(),
+        origin.origin_path().await?.clone_value(),
         request,
         options,
         is_optional,

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -34,7 +34,7 @@ struct NodePreGypConfig {
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct NodePreGypConfigReference {
-    pub context_dir: ResolvedVc<FileSystemPath>,
+    pub context_dir: FileSystemPath,
     pub config_file_pattern: ResolvedVc<Pattern>,
     pub compile_target: ResolvedVc<CompileTarget>,
 }
@@ -43,7 +43,7 @@ pub struct NodePreGypConfigReference {
 impl NodePreGypConfigReference {
     #[turbo_tasks::function]
     pub fn new(
-        context_dir: ResolvedVc<FileSystemPath>,
+        context_dir: FileSystemPath,
         config_file_pattern: ResolvedVc<Pattern>,
         compile_target: ResolvedVc<CompileTarget>,
     ) -> Vc<Self> {
@@ -83,7 +83,7 @@ impl ValueToString for NodePreGypConfigReference {
 
 #[turbo_tasks::function]
 pub async fn resolve_node_pre_gyp_files(
-    context_dir: Vc<FileSystemPath>,
+    context_dir: FileSystemPath,
     config_file_pattern: Vc<Pattern>,
     compile_target: Vc<CompileTarget>,
 ) -> Result<Vc<ModuleResolveResult>> {
@@ -218,17 +218,14 @@ pub async fn resolve_node_pre_gyp_files(
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct NodeGypBuildReference {
-    pub context_dir: ResolvedVc<FileSystemPath>,
+    pub context_dir: FileSystemPath,
     pub compile_target: ResolvedVc<CompileTarget>,
 }
 
 #[turbo_tasks::value_impl]
 impl NodeGypBuildReference {
     #[turbo_tasks::function]
-    pub fn new(
-        context_dir: ResolvedVc<FileSystemPath>,
-        compile_target: ResolvedVc<CompileTarget>,
-    ) -> Vc<Self> {
+    pub fn new(context_dir: FileSystemPath, compile_target: ResolvedVc<CompileTarget>) -> Vc<Self> {
         Self::cell(NodeGypBuildReference {
             context_dir,
             compile_target,
@@ -258,7 +255,7 @@ impl ValueToString for NodeGypBuildReference {
 
 #[turbo_tasks::function]
 pub async fn resolve_node_gyp_build_files(
-    context_dir: Vc<FileSystemPath>,
+    context_dir: FileSystemPath,
     compile_target: Vc<CompileTarget>,
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO Proper parser
@@ -331,14 +328,14 @@ pub async fn resolve_node_gyp_build_files(
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
 pub struct NodeBindingsReference {
-    pub context_dir: ResolvedVc<FileSystemPath>,
+    pub context_dir: FileSystemPath,
     pub file_name: RcStr,
 }
 
 #[turbo_tasks::value_impl]
 impl NodeBindingsReference {
     #[turbo_tasks::function]
-    pub fn new(context_dir: ResolvedVc<FileSystemPath>, file_name: RcStr) -> Vc<Self> {
+    pub fn new(context_dir: FileSystemPath, file_name: RcStr) -> Vc<Self> {
         Self::cell(NodeBindingsReference {
             context_dir,
             file_name,
@@ -366,7 +363,7 @@ impl ValueToString for NodeBindingsReference {
 
 #[turbo_tasks::function]
 pub async fn resolve_node_bindings_files(
-    context_dir: Vc<FileSystemPath>,
+    context_dir: FileSystemPath,
     file_name: RcStr,
 ) -> Result<Vc<ModuleResolveResult>> {
     static BINDINGS_TRY: LazyLock<[&'static str; 5]> = LazyLock::new(|| {

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -60,7 +60,7 @@ impl ModuleReference for NodePreGypConfigReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         resolve_node_pre_gyp_files(
-            *self.context_dir,
+            self.context_dir.clone(),
             *self.config_file_pattern,
             *self.compile_target,
         )
@@ -71,7 +71,7 @@ impl ModuleReference for NodePreGypConfigReference {
 impl ValueToString for NodePreGypConfigReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let context_dir = self.context_dir.to_string().await?;
+        let context_dir = self.context_dir.value_to_string().await?;
         let config_file_pattern = self.config_file_pattern.to_string().await?;
         let compile_target = self.compile_target.await?;
         Ok(Vc::cell(
@@ -105,8 +105,8 @@ pub async fn resolve_node_pre_gyp_files(
         && let AssetContent::File(file) = &*config_asset.content().await?
         && let FileContent::Content(config_file) = &*file.await?
     {
-        let config_file_path = config_asset.ident().path();
-        let mut affecting_paths = vec![config_file_path];
+        let config_file_path = config_asset.ident().path().await?.clone_value();
+        let mut affecting_paths = vec![config_file_path.clone()];
         let config_file_dir = config_file_path.parent();
         let node_pre_gyp_config: NodePreGypConfigJson =
             parse_json_rope_with_source_context(config_file.content())?;
@@ -135,16 +135,16 @@ pub async fn resolve_node_pre_gyp_files(
 
             // Find all dynamic libraries in the given directory.
             if let DirectoryContent::Entries(entries) = &*config_file_dir
-                .join(native_binding_path.clone())
+                .join(&native_binding_path)?
                 .read_dir()
                 .await?
             {
                 let extension = compile_target.dylib_ext();
                 for (key, entry) in entries.iter().filter(|(k, _)| k.ends_with(extension)) {
-                    if let &DirectoryEntry::File(dylib) | &DirectoryEntry::Symlink(dylib) = entry {
+                    if let DirectoryEntry::File(dylib) | DirectoryEntry::Symlink(dylib) = entry {
                         sources.insert(
                             format!("{native_binding_path}/{key}").into(),
-                            Vc::upcast(FileSource::new(*dylib)),
+                            Vc::upcast(FileSource::new(dylib.clone())),
                         );
                     }
                 }
@@ -155,7 +155,7 @@ pub async fn resolve_node_pre_gyp_files(
                 native_binding_path, node_pre_gyp_config.binary.module_name
             )
             .into();
-            let resolved_file_vc = config_file_dir.join(node_file_path.clone());
+            let resolved_file_vc = config_file_dir.join(&node_file_path)?;
             if *resolved_file_vc.get_type().await? == FileSystemEntryType::File {
                 sources.insert(
                     node_file_path,
@@ -166,26 +166,26 @@ pub async fn resolve_node_pre_gyp_files(
         if let DirectoryContent::Entries(entries) = &*config_file_dir
             // TODO
             // read the dependencies path from `bindings.gyp`
-            .join(rcstr!("deps/lib"))
+            .join("deps/lib")?
             .read_dir()
             .await?
         {
             for (key, entry) in entries.iter() {
-                match *entry {
+                match entry {
                     DirectoryEntry::File(dylib) => {
                         sources.insert(
                             format!("deps/lib/{key}").into(),
-                            Vc::upcast(FileSource::new(*dylib)),
+                            Vc::upcast(FileSource::new(dylib.clone())),
                         );
                     }
                     DirectoryEntry::Symlink(dylib) => {
                         let realpath_with_links = dylib.realpath_with_links().await?;
-                        for &symlink in realpath_with_links.symlinks.iter() {
-                            affecting_paths.push(*symlink);
+                        for symlink in realpath_with_links.symlinks.iter() {
+                            affecting_paths.push(symlink.clone());
                         }
                         sources.insert(
                             format!("deps/lib/{key}").into(),
-                            Vc::upcast(FileSource::new(*realpath_with_links.path)),
+                            Vc::upcast(FileSource::new(realpath_with_links.path.clone())),
                         );
                     }
                     _ => {}
@@ -237,7 +237,7 @@ impl NodeGypBuildReference {
 impl ModuleReference for NodeGypBuildReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        resolve_node_gyp_build_files(*self.context_dir, *self.compile_target)
+        resolve_node_gyp_build_files(self.context_dir.clone(), *self.compile_target)
     }
 }
 
@@ -245,7 +245,7 @@ impl ModuleReference for NodeGypBuildReference {
 impl ValueToString for NodeGypBuildReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let context_dir = self.context_dir.to_string().await?;
+        let context_dir = self.context_dir.value_to_string().await?;
         let compile_target = self.compile_target.await?;
         Ok(Vc::cell(
             format!("node-gyp in {context_dir} for {compile_target}").into(),
@@ -264,7 +264,7 @@ pub async fn resolve_node_gyp_build_files(
             .expect("create napi_build_version regex failed")
     });
     let binding_gyp_pat = Pattern::new(Pattern::Constant(rcstr!("binding.gyp")));
-    let gyp_file = resolve_raw(context_dir, binding_gyp_pat, true);
+    let gyp_file = resolve_raw(context_dir.clone(), binding_gyp_pat, true);
     if let [binding_gyp] = &gyp_file.primary_sources().await?[..] {
         let mut merged_affecting_sources =
             gyp_file.await?.get_affecting_sources().collect::<Vec<_>>();
@@ -276,7 +276,7 @@ pub async fn resolve_node_gyp_build_files(
                 FxIndexMap::with_capacity_and_hasher(captured.len(), Default::default());
             for found in captured.iter().skip(1).flatten() {
                 let name = found.as_str();
-                let target_path = context_dir.join(rcstr!("build/Release"));
+                let target_path = context_dir.join("build/Release")?;
                 let resolved_prebuilt_file = resolve_raw(
                     target_path,
                     Pattern::new(Pattern::Constant(format!("{name}.node").into())),
@@ -347,7 +347,7 @@ impl NodeBindingsReference {
 impl ModuleReference for NodeBindingsReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        resolve_node_bindings_files(*self.context_dir, self.file_name.clone())
+        resolve_node_bindings_files(self.context_dir.clone(), self.file_name.clone())
     }
 }
 
@@ -356,7 +356,7 @@ impl ValueToString for NodeBindingsReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(
-            format!("bindings in {}", self.context_dir.to_string().await?,).into(),
+            format!("bindings in {}", self.context_dir.value_to_string().await?,).into(),
         ))
     }
 }
@@ -378,7 +378,7 @@ pub async fn resolve_node_bindings_files(
     let mut root_context_dir = context_dir;
     loop {
         let resolved = resolve_raw(
-            root_context_dir,
+            root_context_dir.clone(),
             Pattern::new(Pattern::Constant(rcstr!("package.json"))),
             true,
         )
@@ -390,23 +390,22 @@ pub async fn resolve_node_bindings_files(
         {
             break;
         };
-        let current_context = root_context_dir.await?;
+        let current_context = root_context_dir.clone();
         let parent = root_context_dir.parent();
-        let parent_context = parent.await?;
-        if parent_context.path == current_context.path {
+        if parent.path == current_context.path {
             break;
         }
         root_context_dir = parent;
     }
 
     let try_path = |sub_path: RcStr| async move {
-        let path = root_context_dir.join(sub_path.clone());
+        let path = root_context_dir.join(&sub_path)?;
         Ok(
             if matches!(*path.get_type().await?, FileSystemEntryType::File) {
                 Some((
                     RequestKey::new(sub_path),
                     ResolvedVc::upcast(
-                        RawModule::new(Vc::upcast(FileSource::new(path)))
+                        RawModule::new(Vc::upcast(FileSource::new(path.clone())))
                             .to_resolved()
                             .await?,
                     ),
@@ -419,7 +418,7 @@ pub async fn resolve_node_bindings_files(
 
     let modules = BINDINGS_TRY
         .iter()
-        .map(|try_dir| try_path(format!("{}/{}", try_dir, &file_name).into()))
+        .map(|try_dir| try_path.clone()(format!("{}/{}", try_dir, &file_name).into()))
         .try_flat_join()
         .await?;
     Ok(*ModuleResolveResult::modules(modules))

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -86,7 +86,7 @@ const EDGE_NODE_EXTERNALS: [&str; 5] = ["buffer", "events", "assert", "util", "a
 
 #[turbo_tasks::function]
 async fn base_resolve_options(
-    resolve_path: Vc<FileSystemPath>,
+    resolve_path: FileSystemPath,
     options_context: Vc<ResolveOptionsContext>,
 ) -> Result<Vc<ResolveOptions>> {
     let parent = resolve_path.parent().resolve().await?;
@@ -276,7 +276,7 @@ async fn base_resolve_options(
 
 #[turbo_tasks::function]
 pub async fn resolve_options(
-    resolve_path: Vc<FileSystemPath>,
+    resolve_path: FileSystemPath,
     options_context: Vc<ResolveOptionsContext>,
 ) -> Result<Vc<ResolveOptions>> {
     let options_context_value = options_context.await?;

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -89,14 +89,14 @@ async fn base_resolve_options(
     resolve_path: FileSystemPath,
     options_context: Vc<ResolveOptionsContext>,
 ) -> Result<Vc<ResolveOptions>> {
-    let parent = resolve_path.parent().resolve().await?;
+    let parent = resolve_path.parent();
     if parent != resolve_path {
         return Ok(base_resolve_options(parent, options_context));
     }
-    let resolve_path_value = resolve_path.await?;
+    let resolve_path_value = resolve_path.clone();
     let opt = options_context.await?;
     let emulating = opt.emulate_environment;
-    let root = resolve_path_value.fs.root();
+    let root = resolve_path_value.fs.root().await?.clone_value();
     let mut direct_mappings = AliasMap::new();
     let node_externals = if let Some(environment) = emulating {
         environment.node_externals().owned().await?
@@ -220,7 +220,7 @@ async fn base_resolve_options(
         modules: if let Some(environment) = emulating {
             if *environment.resolve_node_modules().await? {
                 vec![ResolveModules::Nested(
-                    root.to_resolved().await?,
+                    root.clone(),
                     vec![rcstr!("node_modules")],
                 )]
             } else {
@@ -228,8 +228,11 @@ async fn base_resolve_options(
             }
         } else {
             let mut mods = Vec::new();
-            if let Some(dir) = opt.enable_node_modules {
-                mods.push(ResolveModules::Nested(dir, vec![rcstr!("node_modules")]));
+            if let Some(dir) = &opt.enable_node_modules {
+                mods.push(ResolveModules::Nested(
+                    dir.clone(),
+                    vec![rcstr!("node_modules")],
+                ));
             }
             mods
         },
@@ -281,37 +284,38 @@ pub async fn resolve_options(
 ) -> Result<Vc<ResolveOptions>> {
     let options_context_value = options_context.await?;
     if !options_context_value.rules.is_empty() {
-        let context_value = &*resolve_path.await?;
+        let context_value = resolve_path.clone();
         for (condition, new_options_context) in options_context_value.rules.iter() {
-            if condition.matches(context_value).await? {
-                return Ok(resolve_options(resolve_path, **new_options_context));
+            if condition.matches(&context_value).await? {
+                return Ok(resolve_options(resolve_path.clone(), **new_options_context));
             }
         }
     }
 
-    let resolve_options = base_resolve_options(resolve_path, options_context);
+    let resolve_options = base_resolve_options(resolve_path.clone(), options_context);
 
     let resolve_options = if options_context_value.enable_typescript {
         let find_tsconfig = async || {
             // Otherwise, attempt to find a tsconfig up the file tree
-            let tsconfig = find_context_file(resolve_path, tsconfig()).await?;
-            anyhow::Ok::<Vc<ResolveOptions>>(match *tsconfig {
-                FindContextFileResult::Found(path, _) => {
-                    apply_tsconfig_resolve_options(resolve_options, tsconfig_resolve_options(*path))
-                }
+            let tsconfig = find_context_file(resolve_path.clone(), tsconfig()).await?;
+            anyhow::Ok::<Vc<ResolveOptions>>(match &*tsconfig {
+                FindContextFileResult::Found(path, _) => apply_tsconfig_resolve_options(
+                    resolve_options,
+                    tsconfig_resolve_options(path.clone()),
+                ),
                 FindContextFileResult::NotFound(_) => resolve_options,
             })
         };
 
         // Use a specified tsconfig path if provided. In Next.js, this is always provided by the
         // default config, at the very least.
-        if let Some(tsconfig_path) = options_context_value.tsconfig_path {
+        if let Some(tsconfig_path) = &options_context_value.tsconfig_path {
             let meta = tsconfig_path.metadata().await;
             if meta.is_ok() {
                 // If the file exists, use it.
                 apply_tsconfig_resolve_options(
                     resolve_options,
-                    tsconfig_resolve_options(*tsconfig_path),
+                    tsconfig_resolve_options(tsconfig_path.clone()),
                 )
             } else {
                 // Otherwise, try and find one.

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -30,11 +30,11 @@ pub struct ResolveOptionsContext {
     #[serde(default)]
     /// Enable resolving of the node_modules folder when within the provided
     /// directory
-    pub enable_node_modules: Option<ResolvedVc<FileSystemPath>>,
+    pub enable_node_modules: Option<FileSystemPath>,
     #[serde(default)]
     /// A specific path to a tsconfig.json file to use for resolving modules. If `None`, one will
     /// be looked up through the filesystem
-    pub tsconfig_path: Option<ResolvedVc<FileSystemPath>>,
+    pub tsconfig_path: Option<FileSystemPath>,
     #[serde(default)]
     /// Mark well-known Node.js modules as external imports and load them using
     /// native `require`. e.g. url, querystring, os

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -168,7 +168,7 @@ async fn resolve_extends(
 }
 
 async fn resolve_extends_rooted_or_relative(
-    lookup_path: Vc<FileSystemPath>,
+    lookup_path: FileSystemPath,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     path: &str,
@@ -215,7 +215,7 @@ pub async fn read_from_tsconfigs<T>(
 #[turbo_tasks::value]
 #[derive(Default)]
 pub struct TsConfigResolveOptions {
-    base_url: Option<ResolvedVc<FileSystemPath>>,
+    base_url: Option<FileSystemPath>,
     import_map: Option<ResolvedVc<ImportMap>>,
     is_module_resolution_nodenext: bool,
 }
@@ -231,7 +231,7 @@ impl ValueDefault for TsConfigResolveOptions {
 /// Returns the resolve options
 #[turbo_tasks::function]
 pub async fn tsconfig_resolve_options(
-    tsconfig: Vc<FileSystemPath>,
+    tsconfig: FileSystemPath,
 ) -> Result<Vc<TsConfigResolveOptions>> {
     let configs = read_tsconfigs(
         tsconfig.read(),

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueDefault, Vc, fxindexset};
-use turbo_tasks_fs::{FileContent, FileJsonContent, FileSystemPath};
+use turbo_tasks_fs::{FileContent, FileJsonContent, FileSystemPath, FileSystemPathOption};
 use turbopack_core::{
     asset::Asset,
     context::AssetContext,
@@ -122,7 +122,7 @@ async fn resolve_extends(
     extends: &str,
     resolve_options: Vc<ResolveOptions>,
 ) -> Result<Vc<OptionSource>> {
-    let parent_dir = tsconfig.ident().path().parent();
+    let parent_dir = tsconfig.ident().path().await?.parent();
     let request = Request::parse_string(extends.into());
 
     // TS's resolution is weird, and has special behavior for different import
@@ -157,7 +157,7 @@ async fn resolve_extends(
         // All other types are treated as module imports, and potentially joined with
         // "tsconfig.json". This includes "relative" imports like '.' and '..'.
         _ => {
-            let mut result = resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
+            let mut result = resolve(parent_dir.clone(), ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
             if result.await?.is_none() {
                 let request = Request::parse_string(format!("{extends}/tsconfig").into());
                 result = resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
@@ -174,7 +174,7 @@ async fn resolve_extends_rooted_or_relative(
     path: &str,
 ) -> Result<Vc<OptionSource>> {
     let mut result = resolve(
-        lookup_path,
+        lookup_path.clone(),
         ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
         request,
         resolve_options,
@@ -187,7 +187,7 @@ async fn resolve_extends_rooted_or_relative(
     if !path.ends_with(".json") && result.await?.is_none() {
         let request = Request::parse_string(format!("{path}.json").into());
         result = resolve(
-            lookup_path,
+            lookup_path.clone(),
             ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
             request,
             resolve_options,
@@ -228,6 +228,16 @@ impl ValueDefault for TsConfigResolveOptions {
     }
 }
 
+#[turbo_tasks::function]
+async fn try_join_base_url(
+    source: ResolvedVc<Box<dyn Source>>,
+    base_url: RcStr,
+) -> Result<Vc<FileSystemPathOption>> {
+    Ok(Vc::cell(
+        source.ident().path().await?.parent().try_join(&base_url)?,
+    ))
+}
+
 /// Returns the resolve options
 #[turbo_tasks::function]
 pub async fn tsconfig_resolve_options(
@@ -235,8 +245,8 @@ pub async fn tsconfig_resolve_options(
 ) -> Result<Vc<TsConfigResolveOptions>> {
     let configs = read_tsconfigs(
         tsconfig.read(),
-        ResolvedVc::upcast(FileSource::new(tsconfig).to_resolved().await?),
-        node_cjs_resolve_options(tsconfig.root()),
+        ResolvedVc::upcast(FileSource::new(tsconfig.clone()).to_resolved().await?),
+        node_cjs_resolve_options(tsconfig.root().await?.clone_value()),
     )
     .await?;
 
@@ -247,11 +257,11 @@ pub async fn tsconfig_resolve_options(
     let base_url = if let Some(base_url) = read_from_tsconfigs(&configs, |json, source| {
         json["compilerOptions"]["baseUrl"]
             .as_str()
-            .map(|base_url| source.ident().path().parent().try_join(base_url.into()))
+            .map(|base_url| try_join_base_url(*source, base_url.into()))
     })
     .await?
     {
-        *base_url.await?
+        (*base_url.await?).clone()
     } else {
         None
     };
@@ -261,13 +271,13 @@ pub async fn tsconfig_resolve_options(
         if let FileJsonContent::Content(json) = &*content.await?
             && let JsonValue::Object(paths) = &json["compilerOptions"]["paths"]
         {
-            let mut context_dir = source.ident().path().parent();
+            let mut context_dir = source.ident().path().await?.parent();
             if let Some(base_url) = json["compilerOptions"]["baseUrl"].as_str()
-                && let Some(new_context) = *context_dir.try_join(base_url.into()).await?
+                && let Some(new_context) = context_dir.try_join(base_url)?
             {
-                context_dir = *new_context;
+                context_dir = new_context;
             };
-            let context_dir = context_dir.to_resolved().await?;
+            let context_dir = context_dir.clone();
             for (key, value) in paths.iter() {
                 if let JsonValue::Array(vec) = value {
                     let entries = vec
@@ -291,7 +301,7 @@ pub async fn tsconfig_resolve_options(
                         .collect();
                     all_paths.insert(
                         key.to_string(),
-                        ImportMapping::primary_alternatives(entries, Some(context_dir)),
+                        ImportMapping::primary_alternatives(entries, Some(context_dir.clone())),
                     );
                 } else {
                     TsConfigIssue {
@@ -350,13 +360,13 @@ pub async fn apply_tsconfig_resolve_options(
 ) -> Result<Vc<ResolveOptions>> {
     let tsconfig_resolve_options = tsconfig_resolve_options.await?;
     let mut resolve_options = resolve_options.owned().await?;
-    if let Some(base_url) = tsconfig_resolve_options.base_url {
+    if let Some(base_url) = &tsconfig_resolve_options.base_url {
         // We want to resolve in `compilerOptions.baseUrl` first, then in other
         // locations as a fallback.
         resolve_options.modules.insert(
             0,
             ResolveModules::Path {
-                dir: base_url,
+                dir: base_url.clone(),
                 // tsconfig basepath doesn't apply to json requests
                 excluded_extensions: ResolvedVc::cell(fxindexset![rcstr!(".json")]),
             },
@@ -384,8 +394,8 @@ pub async fn type_resolve(
     request: Vc<Request>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined);
-    let context_path = origin.origin_path().parent();
-    let options = origin.resolve_options(ty.clone());
+    let context_path = origin.origin_path().await?.parent();
+    let options = origin.resolve_options(ty.clone()).await?;
     let options = apply_typescript_types_options(options);
     let types_request = if let Request::Module {
         module: m,
@@ -408,10 +418,9 @@ pub async fn type_resolve(
     } else {
         None
     };
-    let context_path = context_path.resolve().await?;
     let result = if let Some(types_request) = types_request {
         let result1 = resolve(
-            context_path,
+            context_path.clone(),
             ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
             request,
             options,
@@ -442,7 +451,7 @@ pub async fn type_resolve(
     handle_resolve_error(
         result,
         ty,
-        origin.origin_path(),
+        origin.origin_path().await?.clone_value(),
         request,
         options,
         false,

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -137,7 +137,7 @@ impl EcmascriptChunkItem for StaticUrlJsChunkItem {
                 path = StringifyJs(
                     &self
                         .chunking_context
-                        .asset_url(self.static_asset.path())
+                        .asset_url(self.static_asset.path().await?.clone_value())
                         .await?
                 )
             )

--- a/turbopack/crates/turbopack-static/src/fixed.rs
+++ b/turbopack/crates/turbopack-static/src/fixed.rs
@@ -10,17 +10,14 @@ use turbopack_core::{
 /// content hashing to generate a long term cacheable URL.
 #[turbo_tasks::value]
 pub struct FixedStaticAsset {
-    output_path: ResolvedVc<FileSystemPath>,
+    output_path: FileSystemPath,
     source: ResolvedVc<Box<dyn Source>>,
 }
 
 #[turbo_tasks::value_impl]
 impl FixedStaticAsset {
     #[turbo_tasks::function]
-    pub fn new(
-        output_path: ResolvedVc<FileSystemPath>,
-        source: ResolvedVc<Box<dyn Source>>,
-    ) -> Vc<Self> {
+    pub fn new(output_path: FileSystemPath, source: ResolvedVc<Box<dyn Source>>) -> Vc<Self> {
         FixedStaticAsset {
             output_path,
             source,

--- a/turbopack/crates/turbopack-static/src/fixed.rs
+++ b/turbopack/crates/turbopack-static/src/fixed.rs
@@ -30,7 +30,7 @@ impl FixedStaticAsset {
 impl OutputAsset for FixedStaticAsset {
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath> {
-        *self.output_path
+        self.output_path.clone().cell()
     }
 }
 

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -25,7 +25,7 @@ static ANSI_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\x1b\[\d+m").unwrap()
 
 pub async fn snapshot_issues<I: IntoIterator<Item = ReadRef<PlainIssue>>>(
     captured_issues: I,
-    issues_path: Vc<FileSystemPath>,
+    issues_path: FileSystemPath,
     workspace_root: &str,
 ) -> Result<()> {
     let expected_issues = expected(issues_path).await?;
@@ -63,7 +63,7 @@ pub async fn snapshot_issues<I: IntoIterator<Item = ReadRef<PlainIssue>>>(
         );
 
         // Annoyingly, the PlainIssue.source -> PlainIssueSource.asset ->
-        // PlainSource.path -> FileSystemPath.fs -> DiskFileSystem.root changes
+        // PlainSource.path -> Vc<FileSystemPath>.fs -> DiskFileSystem.root changes
         // for everyone.
         let content: RcStr = formatted
             .as_str()
@@ -81,7 +81,7 @@ pub async fn snapshot_issues<I: IntoIterator<Item = ReadRef<PlainIssue>>>(
     matches_expected(expected_issues, seen).await
 }
 
-pub async fn expected(dir: Vc<FileSystemPath>) -> Result<FxHashSet<Vc<FileSystemPath>>> {
+pub async fn expected(dir: FileSystemPath) -> Result<FxHashSet<FileSystemPath>> {
     let mut expected = FxHashSet::default();
     let entries = dir.read_dir().await?;
     if let DirectoryContent::Entries(entries) = &*entries {
@@ -102,8 +102,8 @@ pub async fn expected(dir: Vc<FileSystemPath>) -> Result<FxHashSet<Vc<FileSystem
 }
 
 pub async fn matches_expected(
-    expected: FxHashSet<Vc<FileSystemPath>>,
-    seen: FxHashSet<Vc<FileSystemPath>>,
+    expected: FxHashSet<FileSystemPath>,
+    seen: FxHashSet<FileSystemPath>,
 ) -> Result<()> {
     for path in diff_paths(&expected, &seen).await? {
         let p = &path.await?.path;
@@ -117,7 +117,7 @@ pub async fn matches_expected(
     Ok(())
 }
 
-pub async fn diff(path: Vc<FileSystemPath>, actual: Vc<AssetContent>) -> Result<()> {
+pub async fn diff(path: FileSystemPath, actual: Vc<AssetContent>) -> Result<()> {
     let path_str = &path.await?.path;
     let expected = AssetContent::file(path.read());
 
@@ -154,7 +154,7 @@ pub async fn diff(path: Vc<FileSystemPath>, actual: Vc<AssetContent>) -> Result<
     Ok(())
 }
 
-async fn get_contents(file: Vc<AssetContent>, path: Vc<FileSystemPath>) -> Result<Option<String>> {
+async fn get_contents(file: Vc<AssetContent>, path: FileSystemPath) -> Result<Option<String>> {
     Ok(
         match &*file.await.context(format!(
             "Unable to read AssetContent of {}",
@@ -184,18 +184,18 @@ async fn get_contents(file: Vc<AssetContent>, path: Vc<FileSystemPath>) -> Resul
     )
 }
 
-async fn remove_file(path: Vc<FileSystemPath>) -> Result<()> {
+async fn remove_file(path: FileSystemPath) -> Result<()> {
     path.write(FileContent::NotFound.cell()).await?;
     Ok(())
 }
 
 /// Values in left that are not in right.
-/// Vc<FileSystemPath> hashes as a Vc, not as the file path, so we need to get
+/// FileSystemPath hashes as a Vc, not as the file path, so we need to get
 /// the path to properly diff.
 async fn diff_paths(
-    left: &FxHashSet<Vc<FileSystemPath>>,
-    right: &FxHashSet<Vc<FileSystemPath>>,
-) -> Result<FxHashSet<Vc<FileSystemPath>>> {
+    left: &FxHashSet<FileSystemPath>,
+    right: &FxHashSet<FileSystemPath>,
+) -> Result<FxHashSet<FileSystemPath>> {
     let mut map = left
         .iter()
         .map(|p| async move { Ok((p.await?.path.clone(), *p)) })

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use similar::TextDiff;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ReadRef, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{
     DirectoryContent, DirectoryEntry, File, FileContent, FileSystemEntryType, FileSystemPath,
 };
@@ -28,7 +28,7 @@ pub async fn snapshot_issues<I: IntoIterator<Item = ReadRef<PlainIssue>>>(
     issues_path: FileSystemPath,
     workspace_root: &str,
 ) -> Result<()> {
-    let expected_issues = expected(issues_path).await?;
+    let expected_issues = expected(issues_path.clone()).await?;
     let mut seen = FxHashSet::default();
     for plain_issue in captured_issues.into_iter() {
         let title = styled_string_to_file_safe_string(&plain_issue.title)
@@ -45,8 +45,8 @@ pub async fn snapshot_issues<I: IntoIterator<Item = ReadRef<PlainIssue>>>(
         };
         let hash = encode_hex(plain_issue.internal_hash_ref(true));
 
-        let path = issues_path.join(format!("{title}-{}.txt", &hash[0..6]).into());
-        if !seen.insert(path) {
+        let path = issues_path.join(&format!("{title}-{}.txt", &hash[0..6]))?;
+        if !seen.insert(path.clone()) {
             continue;
         }
 
@@ -88,7 +88,7 @@ pub async fn expected(dir: FileSystemPath) -> Result<FxHashSet<FileSystemPath>> 
         for (file, entry) in entries {
             match entry {
                 DirectoryEntry::File(file) => {
-                    expected.insert(**file);
+                    expected.insert(file.clone());
                 }
                 _ => bail!(
                     "expected file at {}, found {:?}",
@@ -106,9 +106,9 @@ pub async fn matches_expected(
     seen: FxHashSet<FileSystemPath>,
 ) -> Result<()> {
     for path in diff_paths(&expected, &seen).await? {
-        let p = &path.await?.path;
+        let p = &path.path;
         if *UPDATE {
-            remove_file(path).await?;
+            remove_file(path.clone()).await?;
             println!("removed file {p}");
         } else {
             bail!("expected file {}, but it was not emitted", p);
@@ -118,11 +118,11 @@ pub async fn matches_expected(
 }
 
 pub async fn diff(path: FileSystemPath, actual: Vc<AssetContent>) -> Result<()> {
-    let path_str = &path.await?.path;
+    let path_str = &path.path;
     let expected = AssetContent::file(path.read());
 
-    let actual = get_contents(actual, path).await?;
-    let expected = get_contents(expected, path).await?;
+    let actual = get_contents(actual, path.clone()).await?;
+    let expected = get_contents(expected, path.clone()).await?;
 
     if actual != expected {
         if let Some(actual) = actual {
@@ -158,11 +158,11 @@ async fn get_contents(file: Vc<AssetContent>, path: FileSystemPath) -> Result<Op
     Ok(
         match &*file.await.context(format!(
             "Unable to read AssetContent of {}",
-            path.to_string().await?
+            path.value_to_string().await?
         ))? {
             AssetContent::File(file) => match &*file.await.context(format!(
                 "Unable to read FileContent of {}",
-                path.to_string().await?
+                path.value_to_string().await?
             ))? {
                 FileContent::NotFound => None,
                 FileContent::Content(expected) => {
@@ -198,16 +198,16 @@ async fn diff_paths(
 ) -> Result<FxHashSet<FileSystemPath>> {
     let mut map = left
         .iter()
-        .map(|p| async move { Ok((p.await?.path.clone(), *p)) })
+        .map(|p| async move { Ok((p.path.clone(), p.clone())) })
         .try_join()
         .await?
         .iter()
         .cloned()
         .collect::<FxHashMap<_, _>>();
     for p in right {
-        map.remove(&p.await?.path);
+        map.remove(&p.path);
     }
-    Ok(map.values().copied().collect())
+    Ok(map.values().cloned().collect())
 }
 
 fn styled_string_to_file_safe_string(styled_string: &StyledString) -> String {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -61,7 +61,7 @@ use crate::util::REPO_ROOT;
 #[turbo_tasks::value]
 struct RunTestResult {
     js_result: ResolvedVc<JsResult>,
-    path: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
 }
 
 #[turbo_tasks::value]
@@ -250,10 +250,10 @@ struct TestOptions {
 
 #[turbo_tasks::value]
 struct PreparedTest {
-    path: ResolvedVc<FileSystemPath>,
-    project_path: ResolvedVc<FileSystemPath>,
-    tests_path: ResolvedVc<FileSystemPath>,
-    project_root: ResolvedVc<FileSystemPath>,
+    path: FileSystemPath,
+    project_path: FileSystemPath,
+    tests_path: FileSystemPath,
+    project_root: FileSystemPath,
     options: TestOptions,
 }
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -269,7 +269,7 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
 
     let root_fs = DiskFileSystem::new(rcstr!("workspace"), REPO_ROOT.clone(), vec![]);
     let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone(), vec![]);
-    let project_root = project_fs.root().to_resolved().await?;
+    let project_root = project_fs.root().await?.clone_value();
 
     let relative_path = resource_path.strip_prefix(&*REPO_ROOT).context(format!(
         "stripping repo root {:?} from resource path {:?}",
@@ -277,13 +277,14 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
         resource_path.display()
     ))?;
     let relative_path: RcStr = sys_to_unix(relative_path.to_str().unwrap()).into();
-    let path = root_fs.root().join(relative_path.clone());
-    let project_path = project_root.join(relative_path.clone());
+    let path = root_fs.root().await?.join(&relative_path.clone())?;
+    let project_path = project_root.join(&relative_path.clone())?;
     let tests_path = project_fs
         .root()
-        .join(rcstr!("turbopack/crates/turbopack-tests"));
+        .await?
+        .join("turbopack/crates/turbopack-tests")?;
 
-    let options_file = path.join(rcstr!("options.json"));
+    let options_file = path.join("options.json")?;
 
     let mut options = TestOptions::default();
     if matches!(*options_file.get_type().await?, FileSystemEntryType::File)
@@ -294,9 +295,9 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
     }
 
     Ok(PreparedTest {
-        path: path.to_resolved().await?,
-        project_path: project_path.to_resolved().await?,
-        tests_path: tests_path.to_resolved().await?,
+        path: path.clone(),
+        project_path: project_path.clone(),
+        tests_path: tests_path.clone(),
         project_root,
         options,
     }
@@ -310,19 +311,18 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         project_path,
         tests_path,
         project_root,
-        ref options,
-    } = *prepared_test.await?;
+        options,
+    } = &*prepared_test.await?;
 
-    let jest_entry_path = tests_path.join(rcstr!("js/jest-entry.ts"));
-    let test_path = project_path.join(rcstr!("input/index.js"));
+    let jest_entry_path = tests_path.join("js/jest-entry.ts")?;
+    let test_path = project_path.join("input/index.js")?;
 
-    let chunk_root_path = path.join(rcstr!("output")).to_resolved().await?;
-    let static_root_path = path.join(rcstr!("static")).to_resolved().await?;
+    let chunk_root_path = path.join("output")?;
+    let static_root_path = path.join("static")?;
 
     let chunk_root_path_in_root_path_offset = project_path
-        .join(rcstr!("output"))
-        .await?
-        .get_relative_path_to(&*project_root.await?)
+        .join("output")?
+        .get_relative_path_to(project_root)
         .context("Project path is in root path")?;
 
     let env = Environment::new(ExecutionEnvironment::NodeJsBuildTime(
@@ -394,12 +394,12 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         .into(),
         ResolveOptionsContext {
             enable_typescript: true,
-            enable_node_modules: Some(project_root),
+            enable_node_modules: Some(project_root.clone()),
             custom_conditions: vec![rcstr!("development")],
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),
                 ResolveOptionsContext {
-                    enable_node_modules: Some(project_root),
+                    enable_node_modules: Some(project_root.clone()),
                     custom_conditions: vec![rcstr!("development")],
                     browser: true,
                     ..Default::default()
@@ -416,10 +416,10 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     ));
 
     let chunking_context = NodeJsChunkingContext::builder(
-        project_root,
-        chunk_root_path,
+        project_root.clone(),
+        chunk_root_path.clone(),
         chunk_root_path_in_root_path_offset,
-        static_root_path,
+        static_root_path.clone(),
         chunk_root_path,
         static_root_path,
         env,
@@ -472,7 +472,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
 
     let res = evaluate(
         jest_entry_asset,
-        *path,
+        path.clone(),
         Vc::upcast(CommandLineProcessEnv::new()),
         test_source.ident(),
         asset_context,
@@ -499,14 +499,14 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
                 },
             }
             .resolved_cell(),
-            path,
+            path: path.clone(),
         }
         .cell());
     };
 
     Ok(RunTestResult {
         js_result: JsResult::resolved_cell(parse_json_with_source_context(bytes.to_str()?)?),
-        path,
+        path: path.clone(),
     }
     .cell())
 }
@@ -516,20 +516,16 @@ async fn snapshot_issues(
     prepared_test: Vc<PreparedTest>,
     run_result_op: OperationVc<RunTestResult>,
 ) -> Result<Vc<()>> {
-    let PreparedTest { path, .. } = *prepared_test.await?;
+    let PreparedTest { path, .. } = &*prepared_test.await?;
     let _ = run_result_op.resolve_strongly_consistent().await;
 
     let captured_issues = run_result_op.peek_issues_with_path().await?;
 
     let plain_issues = captured_issues.get_plain_issues().await?;
 
-    turbopack_test_utils::snapshot::snapshot_issues(
-        plain_issues,
-        path.join(rcstr!("issues")),
-        &REPO_ROOT,
-    )
-    .await
-    .context("Unable to handle issues")?;
+    turbopack_test_utils::snapshot::snapshot_issues(plain_issues, path.join("issues")?, &REPO_ROOT)
+        .await
+        .context("Unable to handle issues")?;
 
     Ok(Default::default())
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -506,8 +506,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
 
 async fn walk_asset(
     asset: ResolvedVc<Box<dyn OutputAsset>>,
-    output_path: &ReadRef<FileSystemPath>,
-    seen: &mut FxHashSet<Vc<FileSystemPath>>,
+    output_path: &FileSystemPath,
+    seen: &mut FxHashSet<FileSystemPath>,
     queue: &mut VecDeque<ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<()> {
     let path = asset.path().resolve().await?;
@@ -535,7 +535,7 @@ async fn walk_asset(
 
 async fn maybe_load_env(
     _context: Vc<Box<dyn AssetContext>>,
-    path: Vc<FileSystemPath>,
+    path: FileSystemPath,
 ) -> Result<Option<Vc<Box<dyn Source>>>> {
     let dotenv_path = path.join(rcstr!("input/.env"));
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -11,9 +11,7 @@ use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde_json::json;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{
-    ReadConsistency, ReadRef, ResolvedVc, TurboTasks, ValueToString, Vc, apply_effects,
-};
+use turbo_tasks::{ReadConsistency, ResolvedVc, TurboTasks, ValueToString, Vc, apply_effects};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
@@ -191,12 +189,16 @@ async fn run(resource: PathBuf) -> Result<()> {
 #[turbo_tasks::function(operation)]
 async fn run_inner_operation(resource: RcStr) -> Result<()> {
     let out_op = run_test_operation(resource);
-    let out_vc = out_op.resolve_strongly_consistent().await?;
+    let out_vc = out_op
+        .resolve_strongly_consistent()
+        .await?
+        .await?
+        .clone_value();
     let captured_issues = out_op.peek_issues_with_path().await?;
 
     let plain_issues = captured_issues.get_plain_issues().await?;
 
-    snapshot_issues(plain_issues, out_vc.join(rcstr!("issues")), &REPO_ROOT)
+    snapshot_issues(plain_issues, out_vc.join("issues")?, &REPO_ROOT)
         .await
         .context("Unable to handle issues")?;
 
@@ -219,21 +221,17 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Ok(options_str) => parse_json_with_source_context(&options_str).unwrap(),
     };
     let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone(), vec![]);
-    let project_root = project_fs.root().to_resolved().await?;
+    let project_root = project_fs.root().await?.clone_value();
 
     let relative_path = test_path.strip_prefix(&*REPO_ROOT)?;
     let relative_path: RcStr = sys_to_unix(relative_path.to_str().unwrap()).into();
-    let project_path = project_root
-        .join(relative_path.clone())
-        .to_resolved()
-        .await?;
+    let project_path = project_root.join(&relative_path)?;
 
     let project_path_to_project_root = project_path
-        .await?
-        .get_relative_path_to(&*project_root.await?)
+        .get_relative_path_to(&project_root)
         .context("Project path is in root path")?;
 
-    let entry_asset = project_path.join(options.entry.into());
+    let entry_asset = project_path.join(&options.entry)?;
 
     let env = Environment::new(match options.environment {
         SnapshotEnvironment::Browser => {
@@ -333,12 +331,12 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         ResolveOptionsContext {
             enable_typescript: true,
             enable_react: true,
-            enable_node_modules: Some(project_root),
+            enable_node_modules: Some(project_root.clone()),
             custom_conditions: vec![rcstr!("development")],
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),
                 ResolveOptionsContext {
-                    enable_node_modules: Some(project_root),
+                    enable_node_modules: Some(project_root.clone()),
                     custom_conditions: vec![rcstr!("development")],
                     ..Default::default()
                 }
@@ -350,22 +348,22 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Layer::new(rcstr!("test")),
     ));
 
-    let runtime_entries = maybe_load_env(asset_context, *project_path)
+    let runtime_entries = maybe_load_env(asset_context, project_path.clone())
         .await?
         .map(|asset| EvaluatableAssets::one(asset.to_evaluatable(asset_context)));
 
-    let chunk_root_path = project_path.join(rcstr!("output")).to_resolved().await?;
-    let static_root_path = project_path.join(rcstr!("static")).to_resolved().await?;
+    let chunk_root_path = project_path.join("output")?;
+    let static_root_path = project_path.join("static")?;
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match options.runtime {
         Runtime::Browser => {
             let mut builder = BrowserChunkingContext::builder(
                 project_root,
-                project_path,
+                project_path.clone(),
                 project_path_to_project_root,
-                project_path,
-                chunk_root_path,
-                static_root_path,
+                project_path.clone(),
+                chunk_root_path.clone(),
+                static_root_path.clone(),
                 env,
                 options.runtime_type,
             )
@@ -387,11 +385,11 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Runtime::NodeJs => {
             let mut builder = NodeJsChunkingContext::builder(
                 project_root,
-                project_path,
+                project_path.clone(),
                 project_path_to_project_root,
-                project_path,
-                chunk_root_path,
-                static_root_path,
+                project_path.clone(),
+                chunk_root_path.clone(),
+                static_root_path.clone(),
                 env,
                 options.runtime_type,
             )
@@ -413,10 +411,10 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         }
     };
 
-    let expected_paths = expected(*chunk_root_path)
+    let expected_paths = expected(chunk_root_path.clone())
         .await?
-        .union(&expected(*static_root_path).await?)
-        .copied()
+        .union(&expected(static_root_path.clone()).await?)
+        .cloned()
         .collect();
 
     let entry_module = asset_context
@@ -458,17 +456,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                         .entry_chunk_group(
                             // `expected` expects a completely flat output directory.
                             chunk_root_path
-                                .join(
-                                    entry_module
-                                        .ident()
-                                        .path()
-                                        .file_stem()
-                                        .await?
-                                        .as_deref()
-                                        .unwrap()
-                                        .into(),
-                                )
-                                .with_extension(rcstr!("entry.js")),
+                                .join(entry_module.ident().path().await?.file_stem().unwrap())?
+                                .with_extension("entry.js"),
                             evaluatable_assets,
                             module_graph,
                             OutputAssets::empty(),
@@ -487,7 +476,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let mut seen = FxHashSet::default();
     let mut queue: VecDeque<_> = chunks.await?.iter().copied().collect();
 
-    let output_path = project_path.await?;
+    let output_path = project_path.clone();
     while let Some(asset) = queue.pop_front() {
         walk_asset(asset, &output_path, &mut seen, &mut queue)
             .await
@@ -501,7 +490,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .await
         .context("Actual assets doesn't match with expected assets")?;
 
-    Ok(*project_path)
+    Ok(project_path.cell())
 }
 
 async fn walk_asset(
@@ -510,15 +499,15 @@ async fn walk_asset(
     seen: &mut FxHashSet<FileSystemPath>,
     queue: &mut VecDeque<ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<()> {
-    let path = asset.path().resolve().await?;
+    let path = asset.path().await?.clone_value();
 
-    if !seen.insert(path) {
+    if !seen.insert(path.clone()) {
         return Ok(());
     }
 
-    if path.await?.is_inside_ref(output_path) {
+    if path.is_inside_ref(output_path) {
         // Only consider assets that should be written to disk.
-        diff(path, asset.content()).await?;
+        diff(path.clone(), asset.content()).await?;
     }
 
     queue.extend(
@@ -537,13 +526,13 @@ async fn maybe_load_env(
     _context: Vc<Box<dyn AssetContext>>,
     path: FileSystemPath,
 ) -> Result<Option<Vc<Box<dyn Source>>>> {
-    let dotenv_path = path.join(rcstr!("input/.env"));
+    let dotenv_path = path.join("input/.env")?;
 
     if !dotenv_path.read().await?.is_content() {
         return Ok(None);
     }
 
-    let env = DotenvProcessEnv::new(None, dotenv_path);
+    let env = DotenvProcessEnv::new(None, dotenv_path.clone());
     let asset = ProcessEnvAsset::new(dotenv_path, Vc::upcast(env));
     Ok(Some(Vc::upcast(asset)))
 }

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use anyhow::Result;
 use indoc::{formatdoc, writedoc};
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::File;
 use turbopack_core::{asset::AssetContent, source::Source, virtual_source::VirtualSource};
@@ -56,7 +56,7 @@ pub(crate) async fn instantiating_loader_source(
     let code: RcStr = code.into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().append(rcstr!("_.loader.mjs")),
+        source.ident().path().await?.append("_.loader.mjs")?,
         AssetContent::file(File::from(code).into()),
     )))
 }
@@ -80,7 +80,7 @@ pub(crate) async fn compiling_loader_source(
     .into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().append(rcstr!("_.loader.mjs")),
+        source.ident().path().await?.append("_.loader.mjs")?,
         AssetContent::file(File::from(code).into()),
     )))
 }

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
@@ -51,14 +50,14 @@ impl WebAssemblySource {
 #[turbo_tasks::value_impl]
 impl Source for WebAssemblySource {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        match self.source_ty {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(match self.source_ty {
             WebAssemblySourceType::Binary => self.source.ident(),
             WebAssemblySourceType::Text => self
                 .source
                 .ident()
-                .with_path(self.source.ident().path().append(rcstr!("_.wasm"))),
-        }
+                .with_path(self.source.ident().path().await?.append("_.wasm")?),
+        })
     }
 }
 

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -80,11 +80,11 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
         async move {
             let task = tt.spawn_once_task(async move {
                 let input_fs = DiskFileSystem::new("tests".into(), tests_root.clone(), vec![]);
-                let input = input_fs.root().join(input.clone());
+                let input = input_fs.root().await?.join(&input)?;
 
                 let input_dir = input.parent().parent();
                 let output_fs: Vc<NullFileSystem> = NullFileSystem.into();
-                let output_dir = output_fs.root().to_resolved().await?;
+                let output_dir = output_fs.root().await?.clone_value();
 
                 let source = FileSource::new(input);
                 let compile_time_info = CompileTimeInfo::builder(
@@ -119,7 +119,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let module = module_asset_context
                     .process(Vc::upcast(source), ReferenceType::Undefined)
                     .module();
-                let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, *output_dir)
+                let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, output_dir.clone())
                     .to_resolved()
                     .await?;
 

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -42,9 +42,9 @@ async fn main() -> Result<()> {
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);
-            let input = fs.root().join(rcstr!("demo"));
-            let output = fs.root().join(rcstr!("out"));
-            let entry = fs.root().join(rcstr!("demo/index.js"));
+            let input = fs.root().await?.join("demo")?;
+            let output = fs.root().await?.join("out")?;
+            let entry = fs.root().await?.join("demo/index.js")?;
 
             let source = FileSource::new(entry);
             let module_asset_context = turbopack::ModuleAssetContext::new(
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
                 ResolveOptionsContext {
                     enable_typescript: true,
                     enable_react: true,
-                    enable_node_modules: Some(fs.root().to_resolved().await?),
+                    enable_node_modules: Some(fs.root().await?.clone_value()),
                     custom_conditions: vec![rcstr!("development")],
                     ..Default::default()
                 }
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
                     turbopack_core::reference_type::ReferenceType::Undefined,
                 )
                 .module();
-            let rebased = RebasedAsset::new(module, input, output);
+            let rebased = RebasedAsset::new(module, input, output.clone());
             emit_with_completion(Vc::upcast(rebased), output).await?;
 
             anyhow::Ok::<Vc<()>>(Default::default())

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -49,8 +49,8 @@ pub async fn node_evaluate_asset_context(
             Some(
                 turbopack_node::embed_js::embed_fs()
                     .root()
-                    .to_resolved()
-                    .await?,
+                    .await?
+                    .clone_value(),
             ),
         )
         .resolved_cell(),
@@ -69,9 +69,10 @@ pub async fn node_evaluate_asset_context(
         enable_node_modules: Some(
             execution_context
                 .project_path()
+                .await?
                 .root()
-                .to_resolved()
-                .await?,
+                .await?
+                .clone_value(),
         ),
         enable_node_externals: true,
         enable_node_native_modules: true,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -492,7 +492,7 @@ async fn process_default_internal(
     let ident = source.ident().resolve().await?;
     let path_ref = ident.path().await?;
     let options = ModuleOptions::new(
-        ident.path().parent(),
+        ident.path().await?.parent(),
         module_asset_context.module_options_context(),
         module_asset_context.resolve_options_context(),
     );
@@ -724,7 +724,7 @@ impl AssetContext for ModuleAssetContext {
         };
         // TODO move `apply_commonjs/esm_resolve_options` etc. to here
         Ok(resolve_options(
-            origin_path.parent().resolve().await?,
+            origin_path.parent(),
             *module_asset_context.await?.resolve_options_context,
         ))
     }
@@ -737,7 +737,7 @@ impl AssetContext for ModuleAssetContext {
         resolve_options: Vc<ResolveOptions>,
         reference_type: ReferenceType,
     ) -> Result<Vc<ModuleResolveResult>> {
-        let context_path = origin_path.parent().resolve().await?;
+        let context_path = origin_path.parent();
 
         let result = resolve(
             context_path,
@@ -804,10 +804,11 @@ impl AssetContext for ModuleAssetContext {
                                     traced,
                                     self.module_options_context()
                                         .await?
-                                        .enable_externals_tracing,
+                                        .enable_externals_tracing
+                                        .clone(),
                                 ) {
                                     let externals_context = externals_tracing_module_context(ty);
-                                    let root_origin = tracing_root.join("_".into());
+                                    let root_origin = tracing_root.join("_")?;
 
                                     // Normalize reference type, there is no such thing as a
                                     // `ReferenceType::EcmaScriptModules(ImportPart(Evaluation))`
@@ -832,7 +833,7 @@ impl AssetContext for ModuleAssetContext {
 
                                     let external_result = externals_context
                                         .resolve_asset(
-                                            root_origin,
+                                            root_origin.clone(),
                                             Request::parse_string(name.clone()),
                                             externals_context.resolve_options(
                                                 root_origin,
@@ -957,7 +958,7 @@ pub fn emit_with_completion_operation(
     asset: ResolvedVc<Box<dyn OutputAsset>>,
     output_dir: FileSystemPath,
 ) -> Vc<()> {
-    emit_with_completion(*asset, *output_dir)
+    emit_with_completion(*asset, output_dir)
 }
 
 #[turbo_tasks::function]
@@ -977,7 +978,7 @@ async fn emit_aggregated_assets(
         }
         AggregatedGraphNodeContent::Children(children) => {
             for aggregated in children {
-                let _ = emit_aggregated_assets(**aggregated, output_dir);
+                let _ = emit_aggregated_assets(**aggregated, output_dir.clone());
             }
         }
     }
@@ -985,8 +986,10 @@ async fn emit_aggregated_assets(
 }
 
 #[turbo_tasks::function]
-pub fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) {
-    let _ = asset.content().write(asset.path());
+pub async fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
+    let _ = asset.content().write(asset.path().await?.clone_value());
+
+    Ok(())
 }
 
 #[turbo_tasks::function]
@@ -994,8 +997,8 @@ pub async fn emit_asset_into_dir(
     asset: Vc<Box<dyn OutputAsset>>,
     output_dir: FileSystemPath,
 ) -> Result<()> {
-    let dir = &*output_dir.await?;
-    if asset.path().await?.is_inside_ref(dir) {
+    let dir = output_dir.clone();
+    if asset.path().await?.is_inside_ref(&dir) {
         let _ = emit_asset(asset);
     }
     Ok(())

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -713,7 +713,7 @@ impl AssetContext for ModuleAssetContext {
     #[turbo_tasks::function]
     async fn resolve_options(
         self: Vc<Self>,
-        origin_path: Vc<FileSystemPath>,
+        origin_path: FileSystemPath,
         _reference_type: ReferenceType,
     ) -> Result<Vc<ResolveOptions>> {
         let this = self.await?;
@@ -732,7 +732,7 @@ impl AssetContext for ModuleAssetContext {
     #[turbo_tasks::function]
     async fn resolve_asset(
         self: Vc<Self>,
-        origin_path: Vc<FileSystemPath>,
+        origin_path: FileSystemPath,
         request: Vc<Request>,
         resolve_options: Vc<ResolveOptions>,
         reference_type: ReferenceType,
@@ -948,20 +948,20 @@ impl AssetContext for ModuleAssetContext {
 }
 
 #[turbo_tasks::function]
-pub fn emit_with_completion(asset: Vc<Box<dyn OutputAsset>>, output_dir: Vc<FileSystemPath>) {
+pub fn emit_with_completion(asset: Vc<Box<dyn OutputAsset>>, output_dir: FileSystemPath) {
     let _ = emit_assets_aggregated(asset, output_dir);
 }
 
 #[turbo_tasks::function(operation)]
 pub fn emit_with_completion_operation(
     asset: ResolvedVc<Box<dyn OutputAsset>>,
-    output_dir: ResolvedVc<FileSystemPath>,
+    output_dir: FileSystemPath,
 ) -> Vc<()> {
     emit_with_completion(*asset, *output_dir)
 }
 
 #[turbo_tasks::function]
-fn emit_assets_aggregated(asset: Vc<Box<dyn OutputAsset>>, output_dir: Vc<FileSystemPath>) {
+fn emit_assets_aggregated(asset: Vc<Box<dyn OutputAsset>>, output_dir: FileSystemPath) {
     let aggregated = aggregate(asset);
     let _ = emit_aggregated_assets(aggregated, output_dir);
 }
@@ -969,7 +969,7 @@ fn emit_assets_aggregated(asset: Vc<Box<dyn OutputAsset>>, output_dir: Vc<FileSy
 #[turbo_tasks::function]
 async fn emit_aggregated_assets(
     aggregated: Vc<AggregatedGraph>,
-    output_dir: Vc<FileSystemPath>,
+    output_dir: FileSystemPath,
 ) -> Result<()> {
     match &*aggregated.content().await? {
         AggregatedGraphNodeContent::Asset(asset) => {
@@ -992,7 +992,7 @@ pub fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) {
 #[turbo_tasks::function]
 pub async fn emit_asset_into_dir(
     asset: Vc<Box<dyn OutputAsset>>,
-    output_dir: Vc<FileSystemPath>,
+    output_dir: FileSystemPath,
 ) -> Result<()> {
     let dir = &*output_dir.await?;
     if asset.path().await?.is_inside_ref(dir) {

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -44,7 +44,7 @@ fn package_import_map_from_import_mapping(
 #[turbo_tasks::function]
 fn package_import_map_from_context(
     package_name: RcStr,
-    context_path: ResolvedVc<FileSystemPath>,
+    context_path: FileSystemPath,
 ) -> Vc<ImportMap> {
     let mut import_map = ImportMap::default();
     import_map.insert_exact_alias(
@@ -63,7 +63,7 @@ pub struct ModuleOptions {
 impl ModuleOptions {
     #[turbo_tasks::function]
     pub async fn new(
-        path: Vc<FileSystemPath>,
+        path: FileSystemPath,
         module_options_context: Vc<ModuleOptionsContext>,
         resolve_options_context: Vc<ResolveOptionsContext>,
     ) -> Result<Vc<ModuleOptions>> {
@@ -112,7 +112,7 @@ impl ModuleOptions {
 
     #[turbo_tasks::function]
     async fn new_internal(
-        path: Option<Vc<FileSystemPath>>,
+        path: Option<FileSystemPath>,
         module_options_context: Vc<ModuleOptionsContext>,
         resolve_options_context: Vc<ResolveOptionsContext>,
     ) -> Result<Vc<ModuleOptions>> {

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -76,7 +76,7 @@ impl ModuleOptions {
         } = *module_options_context.await?;
 
         if !rules.is_empty() {
-            let path_value = path.await?;
+            let path_value = path.clone();
 
             for (condition, new_context) in rules.iter() {
                 if condition.matches(&path_value).await? {
@@ -472,7 +472,8 @@ impl ModuleOptions {
                 } else {
                     package_import_map_from_context(
                         rcstr!("postcss"),
-                        path.context("need_path in ModuleOptions::new is incorrect")?,
+                        path.clone()
+                            .context("need_path in ModuleOptions::new is incorrect")?,
                     )
                 };
 
@@ -653,7 +654,7 @@ impl ModuleOptions {
 
                             match &condition.path {
                                 ConditionPath::Glob(glob) => RuleCondition::ResourcePathGlob {
-                                    base: execution_context.project_path().await?,
+                                    base: execution_context.project_path().await?.clone_value(),
                                     glob: Glob::new(glob.clone()).await?,
                                 },
                                 ConditionPath::Regex(regex) => {
@@ -662,7 +663,7 @@ impl ModuleOptions {
                             }
                         } else if key.contains('/') {
                             RuleCondition::ResourcePathGlob {
-                                base: execution_context.project_path().await?,
+                                base: execution_context.project_path().await?.clone_value(),
                                 glob: Glob::new(key.clone()).await?,
                             }
                         } else {

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -157,7 +157,7 @@ pub struct ModuleOptionsContext {
     ///
     /// The filepath is the directory from which the bundled files will require the externals at
     /// runtime.
-    pub enable_externals_tracing: Option<ResolvedVc<FileSystemPath>>,
+    pub enable_externals_tracing: Option<FileSystemPath>,
 
     /// If true, it stores the last successful parse result in state and keeps using it when
     /// parsing fails. This is useful to keep the module graph structure intact when syntax errors

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -15,11 +15,11 @@ pub enum RuleCondition {
     Not(Box<RuleCondition>),
     ReferenceType(ReferenceType),
     ResourceIsVirtualSource,
-    ResourcePathEquals(ReadRef<FileSystemPath>),
+    ResourcePathEquals(FileSystemPath),
     ResourcePathHasNoExtension,
     ResourcePathEndsWith(String),
     ResourcePathInDirectory(String),
-    ResourcePathInExactDirectory(ReadRef<FileSystemPath>),
+    ResourcePathInExactDirectory(FileSystemPath),
     ContentTypeStartsWith(String),
     ContentTypeEmpty,
     ResourcePathRegex(#[turbo_tasks(trace_ignore)] Regex),
@@ -31,7 +31,7 @@ pub enum RuleCondition {
     /// any glob starting with `./` or `../` will only match paths in the
     /// project. Globs starting with `**` can match any path.
     ResourcePathGlob {
-        base: ReadRef<FileSystemPath>,
+        base: FileSystemPath,
         #[turbo_tasks(trace_ignore)]
         glob: ReadRef<Glob>,
     },

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -114,7 +114,7 @@ impl RuleCondition {
                         return Ok(ResolvedVc::try_downcast_type::<VirtualSource>(source).is_some());
                     }
                     RuleCondition::ResourcePathEquals(other) => {
-                        return Ok(path == &**other);
+                        return Ok(path == other);
                     }
                     RuleCondition::ResourcePathEndsWith(end) => {
                         return Ok(path.path.ends_with(end));
@@ -223,7 +223,6 @@ impl RuleCondition {
 
 #[cfg(test)]
 pub mod tests {
-    use turbo_rcstr::rcstr;
     use turbo_tasks::Vc;
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
     use turbo_tasks_fs::{FileContent, FileSystem, VirtualFileSystem};
@@ -246,28 +245,25 @@ pub mod tests {
     #[turbo_tasks::function]
     pub async fn run_leaves_test() -> Result<()> {
         let fs = VirtualFileSystem::new();
-        let virtual_path = fs.root().join(rcstr!("foo.js"));
+        let virtual_path = fs.root().await?.join("foo.js")?;
         let virtual_source = Vc::upcast::<Box<dyn Source>>(VirtualSource::new(
-            virtual_path,
+            virtual_path.clone(),
             AssetContent::File(FileContent::NotFound.cell().to_resolved().await?).cell(),
         ))
         .to_resolved()
         .await?;
 
-        let non_virtual_path = fs.root().join(rcstr!("bar.js"));
-        let non_virtual_source = Vc::upcast::<Box<dyn Source>>(FileSource::new(non_virtual_path))
-            .to_resolved()
-            .await?;
+        let non_virtual_path = fs.root().await?.join("bar.js")?;
+        let non_virtual_source =
+            Vc::upcast::<Box<dyn Source>>(FileSource::new(non_virtual_path.clone()))
+                .to_resolved()
+                .await?;
 
         {
             let condition = RuleCondition::ReferenceType(ReferenceType::Runtime);
             assert!(
                 condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Runtime
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Runtime)
                     .await
                     .unwrap()
             );
@@ -275,7 +271,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Css(
                             turbopack_core::reference_type::CssReferenceSubType::Compose
                         )
@@ -289,11 +285,7 @@ pub mod tests {
             let condition = RuleCondition::ResourceIsVirtualSource;
             assert!(
                 condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Undefined
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Undefined)
                     .await
                     .unwrap()
             );
@@ -301,7 +293,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -309,14 +301,10 @@ pub mod tests {
             );
         }
         {
-            let condition = RuleCondition::ResourcePathEquals(virtual_path.await?);
+            let condition = RuleCondition::ResourcePathEquals(virtual_path.clone());
             assert!(
                 condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Undefined
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Undefined)
                     .await
                     .unwrap()
             );
@@ -324,7 +312,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -337,7 +325,7 @@ pub mod tests {
                 condition
                     .matches(
                         virtual_source,
-                        &*fs.root().join(rcstr!("foo")).await?,
+                        &fs.root().await?.join("foo")?,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -347,7 +335,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -358,11 +346,7 @@ pub mod tests {
             let condition = RuleCondition::ResourcePathEndsWith("foo.js".to_string());
             assert!(
                 condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Undefined
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Undefined)
                     .await
                     .unwrap()
             );
@@ -370,7 +354,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -395,29 +379,26 @@ pub mod tests {
     #[turbo_tasks::function]
     pub async fn run_rule_condition_tree_test() -> Result<()> {
         let fs = VirtualFileSystem::new();
-        let virtual_path = fs.root().join(rcstr!("foo.js"));
+        let virtual_path = fs.root().await?.join("foo.js")?;
         let virtual_source = Vc::upcast::<Box<dyn Source>>(VirtualSource::new(
-            virtual_path,
+            virtual_path.clone(),
             AssetContent::File(FileContent::NotFound.cell().to_resolved().await?).cell(),
         ))
         .to_resolved()
         .await?;
 
-        let non_virtual_path = fs.root().join(rcstr!("bar.js"));
-        let non_virtual_source = Vc::upcast::<Box<dyn Source>>(FileSource::new(non_virtual_path))
-            .to_resolved()
-            .await?;
+        let non_virtual_path = fs.root().await?.join("bar.js")?;
+        let non_virtual_source =
+            Vc::upcast::<Box<dyn Source>>(FileSource::new(non_virtual_path.clone()))
+                .to_resolved()
+                .await?;
 
         {
             // not
             let condition = RuleCondition::not(RuleCondition::ResourceIsVirtualSource);
             assert!(
                 !condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Undefined
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Undefined)
                     .await
                     .unwrap()
             );
@@ -425,7 +406,7 @@ pub mod tests {
                 condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -442,11 +423,7 @@ pub mod tests {
             ]);
             assert!(
                 condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Undefined
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Undefined)
                     .await
                     .unwrap()
             );
@@ -454,7 +431,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -467,15 +444,11 @@ pub mod tests {
             let condition = RuleCondition::all(vec![
                 RuleCondition::ResourcePathEndsWith("foo.js".to_string()),
                 RuleCondition::ResourceIsVirtualSource,
-                RuleCondition::ResourcePathEquals(virtual_path.await?),
+                RuleCondition::ResourcePathEquals(virtual_path.clone()),
             ]);
             assert!(
                 condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Undefined
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Undefined)
                     .await
                     .unwrap()
             );
@@ -483,7 +456,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await
@@ -496,7 +469,7 @@ pub mod tests {
             // Build a simple tree to cover our various composite conditions
             let condition = RuleCondition::all(vec![
                 RuleCondition::ResourceIsVirtualSource,
-                RuleCondition::ResourcePathEquals(virtual_path.await?),
+                RuleCondition::ResourcePathEquals(virtual_path.clone()),
                 RuleCondition::Not(Box::new(RuleCondition::ResourcePathHasNoExtension)),
                 RuleCondition::Any(vec![
                     RuleCondition::ResourcePathEndsWith("foo.js".to_string()),
@@ -505,11 +478,7 @@ pub mod tests {
             ]);
             assert!(
                 condition
-                    .matches(
-                        virtual_source,
-                        &*virtual_path.await?,
-                        &ReferenceType::Undefined
-                    )
+                    .matches(virtual_source, &virtual_path, &ReferenceType::Undefined)
                     .await
                     .unwrap()
             );
@@ -517,7 +486,7 @@ pub mod tests {
                 !condition
                     .matches(
                         non_virtual_source,
-                        &*non_virtual_path.await?,
+                        &non_virtual_path,
                         &ReferenceType::Undefined
                     )
                     .await

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -17,13 +17,13 @@ use turbopack_core::{
 /// Resolve plugins that warns when importing a sass file.
 #[turbo_tasks::value]
 pub(crate) struct UnsupportedSassResolvePlugin {
-    root: ResolvedVc<FileSystemPath>,
+    root: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
 impl UnsupportedSassResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: ResolvedVc<FileSystemPath>) -> Vc<Self> {
+    pub fn new(root: FileSystemPath) -> Vc<Self> {
         UnsupportedSassResolvePlugin { root }.cell()
     }
 }
@@ -38,8 +38,8 @@ impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: ResolvedVc<FileSystemPath>,
-        lookup_path: ResolvedVc<FileSystemPath>,
+        fs_path: FileSystemPath,
+        lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         request: ResolvedVc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
@@ -59,7 +59,7 @@ impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
 
 #[turbo_tasks::value(shared)]
 struct UnsupportedSassModuleIssue {
-    file_path: ResolvedVc<FileSystemPath>,
+    file_path: FileSystemPath,
     request: ResolvedVc<Request>,
 }
 

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -31,8 +31,11 @@ impl UnsupportedSassResolvePlugin {
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
     #[turbo_tasks::function]
-    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        AfterResolvePluginCondition::new(self.root.root(), Glob::new("**/*.{sass,scss}".into()))
+    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
+        Ok(AfterResolvePluginCondition::new(
+            self.root.root().await?.clone_value(),
+            Glob::new("**/*.{sass,scss}".into()),
+        ))
     }
 
     #[turbo_tasks::function]
@@ -43,8 +46,8 @@ impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
         _reference_type: ReferenceType,
         request: ResolvedVc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
-        let extension = fs_path.extension().await?;
-        if ["sass", "scss"].iter().any(|ext| *ext == &**extension) {
+        let extension = fs_path.extension();
+        if ["sass", "scss"].contains(&extension) {
             UnsupportedSassModuleIssue {
                 file_path: lookup_path,
                 request,
@@ -83,7 +86,7 @@ impl Issue for UnsupportedSassModuleIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+        self.file_path.clone().cell()
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
### What?

Make `FileSystemPath` usable without `Vc<T>`.

### Why?

String concatenation does not require caching.

### How?
Closes PACK-4468
