### PR TITLE
Turbopack: unneeded locals module

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/input/index.js
@@ -1,0 +1,2 @@
+import * as NS2 from 'mui-utils'
+console.log(Object(NS2).default)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/generateUtilityClass/generateUtilityClass.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/generateUtilityClass/generateUtilityClass.js
@@ -1,0 +1,3 @@
+export default function generateUtilityClass() {
+  return 'ok'
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js
@@ -1,0 +1,2 @@
+export { default } from './generateUtilityClass/generateUtilityClass'
+export * from './generateUtilityClass/generateUtilityClass'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/package.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/options.json
@@ -1,0 +1,3 @@
+{
+  "treeShakingMode": "reexports-only"
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/b1abf_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_input_index_973ae0da.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/b1abf_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_input_index_973ae0da.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/b1abf_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_input_index_973ae0da.js",
+    {},
+    {"otherChunks":["output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_fa7a0299._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/b1abf_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_input_index_973ae0da.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/b1abf_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_input_index_973ae0da.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_fa7a0299._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_fa7a0299._.js
@@ -1,0 +1,54 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_fa7a0299._.js", {
+
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({});
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript)");
+;
+console.log(Object(__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__).default);
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript) <locals>": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({});
+;
+;
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript) <module evaluation>": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({});
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$locals$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript) <locals>");
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/generateUtilityClass/generateUtilityClass.js [test] (ecmascript)": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({
+    "default": (()=>generateUtilityClass)
+});
+function generateUtilityClass() {
+    return 'ok';
+}
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript) <exports>": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({
+    "default": (()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$generateUtilityClass$2f$generateUtilityClass$2e$js__$5b$test$5d$__$28$ecmascript$29$__["default"])
+});
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$generateUtilityClass$2f$generateUtilityClass$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/generateUtilityClass/generateUtilityClass.js [test] (ecmascript)");
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$locals$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript) <locals>");
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript)": ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s({
+    "default": (()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["default"])
+});
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript) <module evaluation>");
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$tree$2d$shaking$2f$mui$2d$utils$2f$node_modules$2f$mui$2d$utils$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/index.js [test] (ecmascript) <exports>");
+}),
+}]);
+
+//# sourceMappingURL=turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_fa7a0299._.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_fa7a0299._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_mui-utils_fa7a0299._.js.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/input/index.js"],"sourcesContent":["import * as NS2 from 'mui-utils'\nconsole.log(Object(NS2).default)\n"],"names":[],"mappings":";AAAA;;AACA,QAAQ,GAAG,CAAC,OAAO,sOAAK,OAAO"}},
+    {"offset": {"line": 13, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
+    {"offset": {"line": 26, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/mui-utils/node_modules/mui-utils/generateUtilityClass/generateUtilityClass.js"],"sourcesContent":["export default function generateUtilityClass() {\n  return 'ok'\n}\n"],"names":[],"mappings":";;;AAAe,SAAS;IACtB,OAAO;AACT","ignoreList":[0]}}]
+}


### PR DESCRIPTION
This case seems to unnecessarily retain a few intermediary tree shaking modules (particularly, `locals`, which is empty)

We should investigate what's going on here. Scope hoisting isn't able to 100% get rid of this either