### PR TITLE
Prevent typescript errors in IDE for newly generated tests (part 2)

### DIFF
--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -94,6 +94,11 @@ export default function generator(plop: NodePlopAPI): void {
           type: 'add',
           templateFile: path.join(cnaTemplatePath, 'tsconfig.json'),
           path: path.join(targetPath, name, 'tsconfig.json'),
+          transform: (template: string) =>
+            template.replace(
+              '"exclude": ["node_modules"]',
+              '"exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]'
+            ),
         },
         {
           type: 'add',


### PR DESCRIPTION
Follow-up to #78247. This prevents the following error when first opening the generated test file in the IDE:

```
Cannot find module 'e2e-utils' or its corresponding type declarations.
```

We're adding the patterns `**/*.test.ts` and `**/*.test.tsx` to the `tsconfig.json` exclude list in the generator. This is the same patch that's applied in `writeConfigurationDefaults` when first starting the app. By generating it upfront, we ensure that the test files compile without errors when first opened in the IDE, before running `next dev`.

Note: Excluding works because TypeScript looks for another matching `tsconfig.json` further up in the file tree. It finds the root config which includes the test files.