### PR TITLE
Revert "(E2E) Log which config file is used for `next start`"

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1214,14 +1214,6 @@ export default async function loadConfig(
 
   const path = await findUp(CONFIG_FILES, { cwd: dir })
 
-  if (process.env.__NEXT_TEST_MODE) {
-    if (path) {
-      Log.info(`Loading config from ${path}`)
-    } else {
-      Log.info('No config file found')
-    }
-  }
-
   // If config file was found
   if (path?.length) {
     configFileName = basename(path)

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -659,6 +659,7 @@ describe('CLI Usage', () => {
       expect(stdout).not.toMatch(/ready/i)
       expect(stdout).not.toMatch('started')
       expect(stdout).not.toMatch(`${port}`)
+      expect(stripAnsi(stdout).trim()).toBeFalsy()
     })
 
     test('Allow retry if default port is already in use', async () => {

--- a/test/integration/edge-runtime-configurable-guards/next.config.js
+++ b/test/integration/edge-runtime-configurable-guards/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {}


### PR DESCRIPTION
Reverts vercel/next.js#73105