### PR TITLE
Add `--debug-prerender` option for `next build`

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -126,7 +126,7 @@ program
   .option('-d, --debug', 'Enables a more verbose build output.')
   .option(
     '--debug-prerender',
-    'Show usable stack traces during pre-rendering. Not for production use!'
+    'Enables debug mode for prerendering. Not for production use!'
   )
   .option('--no-lint', 'Disables linting.')
   .option('--no-mangling', 'Disables mangling.')

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -124,7 +124,10 @@ program
     )}`
   )
   .option('-d, --debug', 'Enables a more verbose build output.')
-
+  .option(
+    '--debug-prerender',
+    'Show usable stack traces during pre-rendering. Not for production use!'
+  )
   .option('--no-lint', 'Disables linting.')
   .option('--no-mangling', 'Disables mangling.')
   .option('--profile', 'Enables production profiling for React.')

--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -94,4 +94,5 @@ export const NextBuildContext: Partial<{
   fetchCacheKeyPrefix?: string
   allowedRevalidateHeaderKeys?: string[]
   isCompileMode?: boolean
+  debugPrerender: boolean
 }> = {}

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -827,11 +827,15 @@ export default async function build(
       version: process.env.__NEXT_VERSION as string,
     })
 
+    // TODO: Use dedicated `debugPrerender` CLI flag.
+    const debugPrerender = debugOutput
+
     NextBuildContext.nextBuildSpan = nextBuildSpan
     NextBuildContext.dir = dir
     NextBuildContext.appDirOnly = appDirOnly
     NextBuildContext.reactProductionProfiling = reactProductionProfiling
     NextBuildContext.noMangling = noMangling
+    NextBuildContext.debugPrerender = debugPrerender
 
     await nextBuildSpan.traceAsyncFn(async () => {
       // attempt to load global env values so they are available in next.config.js
@@ -850,6 +854,7 @@ export default async function build(
                 // Log for next.config loading process
                 silent: false,
                 reactProductionProfiling,
+                debugPrerender,
               }),
             turborepoAccessTraceResult
           )
@@ -970,10 +975,12 @@ export default async function build(
       )
 
       // Always log next version first then start rest jobs
-      const { envInfo, experimentalFeatures } = await getStartServerInfo(
+      const { envInfo, experimentalFeatures } = await getStartServerInfo({
         dir,
-        false
-      )
+        dev: false,
+        debugPrerender,
+      })
+
       logStartInfo({
         networkUrl: null,
         appUrl: null,
@@ -2738,6 +2745,7 @@ export default async function build(
               silent: true,
               buildExport: true,
               debugOutput,
+              debugPrerender,
               pages: combinedPages,
               outdir,
               statusMessage: 'Generating static pages',

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -807,6 +807,7 @@ export default async function build(
   dir: string,
   reactProductionProfiling = false,
   debugOutput = false,
+  debugPrerender = false,
   runLint = true,
   noMangling = false,
   appDirOnly = false,
@@ -826,9 +827,6 @@ export default async function build(
       isTurboBuild: String(isTurbopack),
       version: process.env.__NEXT_VERSION as string,
     })
-
-    // TODO: Use dedicated `debugPrerender` CLI flag.
-    const debugPrerender = debugOutput
 
     NextBuildContext.nextBuildSpan = nextBuildSpan
     NextBuildContext.dir = dir

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -249,7 +249,8 @@ export async function workerMain(workerData: {
   /// load the config because it's not serializable
   NextBuildContext.config = await loadConfig(
     PHASE_PRODUCTION_BUILD,
-    NextBuildContext.dir!
+    NextBuildContext.dir!,
+    { debugPrerender: NextBuildContext.debugPrerender }
   )
 
   // Matches handling in build/index.ts

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -385,7 +385,8 @@ export async function workerMain(workerData: {
   /// load the config because it's not serializable
   NextBuildContext.config = await loadConfig(
     PHASE_PRODUCTION_BUILD,
-    NextBuildContext.dir!
+    NextBuildContext.dir!,
+    { debugPrerender: NextBuildContext.debugPrerender }
   )
   NextBuildContext.nextBuildSpan = trace(
     `worker-main-${workerData.compilerName}`

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -65,8 +65,8 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
 
   if (debugPrerender) {
     warn(
-      `Debug prerendering is enabled. ${italic(
-        'Note: This may affect performance, should only be used for debugging purposes, and must not be deployed to production.'
+      `Prerendering is running in debug mode. ${italic(
+        'Note: This may affect performance and should not be used for production.'
       )}`
     )
   }

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -13,6 +13,7 @@ import { disableMemoryDebuggingMode } from '../lib/memory/shutdown'
 
 export type NextBuildOptions = {
   debug?: boolean
+  debugPrerender?: boolean
   profile?: boolean
   lint: boolean
   mangling: boolean
@@ -31,6 +32,7 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
 
   const {
     debug,
+    debugPrerender,
     experimentalDebugMemoryUsage,
     profile,
     lint,
@@ -51,13 +53,19 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
 
   if (!mangling) {
     warn(
-      'Mangling is disabled. Note: This may affect performance and should only be used for debugging purposes.'
+      `Mangling is disabled. ${italic('Note: This may affect performance and should only be used for debugging purposes.')}`
     )
   }
 
   if (profile) {
     warn(
       `Profiling is enabled. ${italic('Note: This may affect performance.')}`
+    )
+  }
+
+  if (debugPrerender) {
+    warn(
+      `Debug prerendering is enabled. ${italic('Note: This may affect performance and should only be used for debugging purposes.')}`
     )
   }
 
@@ -83,6 +91,7 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
     dir,
     profile,
     debug || Boolean(process.env.NEXT_DEBUG_BUILD),
+    debugPrerender,
     lint,
     !mangling,
     experimentalAppOnly,

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -65,7 +65,9 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
 
   if (debugPrerender) {
     warn(
-      `Debug prerendering is enabled. ${italic('Note: This may affect performance and should only be used for debugging purposes.')}`
+      `Debug prerendering is enabled. ${italic(
+        'Note: This may affect performance, should only be used for debugging purposes, and must not be deployed to production.'
+      )}`
     )
   }
 

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -89,9 +89,11 @@ async function exportAppImpl(
 
   const nextConfig =
     options.nextConfig ||
-    (await span
-      .traceChild('load-next-config')
-      .traceAsyncFn(() => loadConfig(PHASE_EXPORT, dir)))
+    (await span.traceChild('load-next-config').traceAsyncFn(() =>
+      loadConfig(PHASE_EXPORT, dir, {
+        debugPrerender: options.debugPrerender,
+      })
+    ))
 
   const distDir = join(dir, nextConfig.distDir)
   const telemetry = options.buildExport ? null : new Telemetry({ distDir })

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -105,6 +105,7 @@ export interface ExportAppOptions {
   enabledDirectories: NextEnabledDirectories
   silent?: boolean
   debugOutput?: boolean
+  debugPrerender?: boolean
   pages?: string[]
   buildExport: boolean
   statusMessage?: string

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -7,6 +7,7 @@ import * as ciEnvironment from '../server/ci-info'
 import {
   CONFIG_FILES,
   PHASE_DEVELOPMENT_SERVER,
+  PHASE_EXPORT,
   PHASE_PRODUCTION_BUILD,
   PHASE_PRODUCTION_SERVER,
 } from '../shared/lib/constants'
@@ -1158,12 +1159,14 @@ export default async function loadConfig(
     silent = true,
     onLoadUserConfig,
     reactProductionProfiling,
+    debugPrerender,
   }: {
     customConfig?: object | null
     rawConfig?: boolean
     silent?: boolean
     onLoadUserConfig?: (conf: NextConfig) => void
     reactProductionProfiling?: boolean
+    debugPrerender?: boolean
   } = {}
 ): Promise<NextConfigComplete> {
   if (!process.env.__NEXT_PRIVATE_RENDER_WORKER) {
@@ -1259,11 +1262,14 @@ export default async function loadConfig(
       throw err
     }
 
+    const loadedConfig = Object.freeze(
+      (await normalizeConfig(
+        phase,
+        interopDefault(userConfigModule)
+      )) as NextConfig
+    )
+
     // Clone a new userConfig each time to avoid mutating the original
-    const loadedConfig = (await normalizeConfig(
-      phase,
-      interopDefault(userConfigModule)
-    )) as NextConfig
     const userConfig = cloneObject(loadedConfig) as NextConfig
 
     if (!process.env.NEXT_MINIMAL) {
@@ -1382,7 +1388,42 @@ export default async function loadConfig(
       userConfig.htmlLimitedBots = userConfig.htmlLimitedBots.source
     }
 
-    onLoadUserConfig?.(Object.freeze(loadedConfig))
+    if (
+      debugPrerender &&
+      (phase === PHASE_PRODUCTION_BUILD || phase === PHASE_EXPORT)
+    ) {
+      userConfig.experimental ??= {}
+
+      userConfig.experimental.serverSourceMaps = true
+      if (!silent) {
+        Log.warn(
+          `\`experimental.serverSourceMaps\` has been set to \`true\` because \`next build\` was run with \`--debug-prerender\`.`
+        )
+      }
+
+      userConfig.experimental.serverMinification = false
+      if (!silent) {
+        Log.warn(
+          `\`experimental.serverMinification\` has been set to \`false\` because \`next build\` was run with \`--debug-prerender\`.`
+        )
+      }
+
+      userConfig.experimental.enablePrerenderSourceMaps = true
+      if (!silent) {
+        Log.warn(
+          `\`experimental.enablePrerenderSourceMaps\` has been set to \`true\` because \`next build\` was run with \`--debug-prerender\`.`
+        )
+      }
+
+      userConfig.experimental.prerenderEarlyExit = false
+      if (!silent) {
+        Log.warn(
+          `\`experimental.prerenderEarlyExit\` has been set to \`false\` because \`next build\` was run with \`--debug-prerender\`.`
+        )
+      }
+    }
+
+    onLoadUserConfig?.(userConfig)
     const completeConfig = assignDefaults(
       dir,
       {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1493,24 +1493,11 @@ export default async function loadConfig(
   return await applyModifyConfig(completeConfig, phase, silent)
 }
 
-export type ConfiguredExperimentalFeature =
-  | {
-      name: keyof ExperimentalConfig
-      type: 'boolean'
-      value: boolean
-      reason?: string
-    }
-  | {
-      name: keyof ExperimentalConfig
-      type: 'number'
-      value: number
-      reason?: string
-    }
-  | {
-      name: keyof ExperimentalConfig
-      type: 'other'
-      reason?: string
-    }
+export type ConfiguredExperimentalFeature = {
+  key: keyof ExperimentalConfig
+  value: ExperimentalConfig[keyof ExperimentalConfig]
+  reason?: string
+}
 
 export function addConfiguredExperimentalFeature<
   KeyType extends keyof ExperimentalConfig,
@@ -1524,13 +1511,7 @@ export function addConfiguredExperimentalFeature<
     key in defaultConfig.experimental &&
     value !== (defaultConfig.experimental as Record<string, unknown>)[key]
   ) {
-    configuredExperimentalFeatures.push(
-      typeof value === 'boolean'
-        ? { name: key, type: 'boolean', value, reason }
-        : typeof value === 'number'
-          ? { name: key, type: 'number', value, reason }
-          : { name: key, type: 'other', reason }
-    )
+    configuredExperimentalFeatures.push({ key, value, reason })
   }
 }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1430,6 +1430,14 @@ export default async function loadConfig(
         false,
         reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
       )
+
+      setExperimentalFeatureForDebugPrerender(
+        userConfig.experimental,
+        'turbopackMinify',
+        false,
+        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
+      )
+
       setExperimentalFeatureForDebugPrerender(
         userConfig.experimental,
         'enablePrerenderSourceMaps',
@@ -1507,10 +1515,7 @@ export function addConfiguredExperimentalFeature<
   value: ExperimentalConfig[KeyType],
   reason?: string
 ) {
-  if (
-    key in defaultConfig.experimental &&
-    value !== (defaultConfig.experimental as Record<string, unknown>)[key]
-  ) {
+  if (value !== (defaultConfig.experimental as Record<string, unknown>)[key]) {
     configuredExperimentalFeatures.push({ key, value, reason })
   }
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1424,19 +1424,25 @@ export default async function loadConfig(
         reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
       )
 
-      setExperimentalFeatureForDebugPrerender(
-        userConfig.experimental,
-        'serverMinification',
-        false,
-        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
-      )
-
-      setExperimentalFeatureForDebugPrerender(
-        userConfig.experimental,
-        'turbopackMinify',
-        false,
-        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
-      )
+      if (process.env.TURBOPACK) {
+        setExperimentalFeatureForDebugPrerender(
+          userConfig.experimental,
+          'turbopackMinify',
+          false,
+          reportExperimentalFeatures
+            ? configuredExperimentalFeatures
+            : undefined
+        )
+      } else {
+        setExperimentalFeatureForDebugPrerender(
+          userConfig.experimental,
+          'serverMinification',
+          false,
+          reportExperimentalFeatures
+            ? configuredExperimentalFeatures
+            : undefined
+        )
+      }
 
       setExperimentalFeatureForDebugPrerender(
         userConfig.experimental,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1157,14 +1157,16 @@ export default async function loadConfig(
     customConfig,
     rawConfig,
     silent = true,
-    onLoadUserConfig,
+    reportExperimentalFeatures,
     reactProductionProfiling,
     debugPrerender,
   }: {
     customConfig?: object | null
     rawConfig?: boolean
     silent?: boolean
-    onLoadUserConfig?: (conf: NextConfig) => void
+    reportExperimentalFeatures?: (
+      configuredExperimentalFeatures: ConfiguredExperimentalFeature[]
+    ) => void
     reactProductionProfiling?: boolean
     debugPrerender?: boolean
   } = {}
@@ -1271,6 +1273,8 @@ export default async function loadConfig(
 
     // Clone a new userConfig each time to avoid mutating the original
     const userConfig = cloneObject(loadedConfig) as NextConfig
+
+    const configuredExperimentalFeatures: ConfiguredExperimentalFeature[] = []
 
     if (!process.env.NEXT_MINIMAL) {
       // We only validate the config against schema in non minimal mode
@@ -1388,42 +1392,63 @@ export default async function loadConfig(
       userConfig.htmlLimitedBots = userConfig.htmlLimitedBots.source
     }
 
+    if (reportExperimentalFeatures && userConfig.experimental) {
+      for (const name of Object.keys(
+        userConfig.experimental
+      ) as (keyof ExperimentalConfig)[]) {
+        const value = userConfig.experimental[name]
+
+        if (name === 'turbo' && !process.env.TURBOPACK) {
+          // Ignore any Turbopack config if Turbopack is not enabled
+          continue
+        }
+
+        addConfiguredExperimentalFeature(
+          configuredExperimentalFeatures,
+          name,
+          value
+        )
+      }
+    }
+
     if (
       debugPrerender &&
       (phase === PHASE_PRODUCTION_BUILD || phase === PHASE_EXPORT)
     ) {
       userConfig.experimental ??= {}
 
-      userConfig.experimental.serverSourceMaps = true
-      if (!silent) {
-        Log.warn(
-          `\`experimental.serverSourceMaps\` has been set to \`true\` because \`next build\` was run with \`--debug-prerender\`.`
-        )
-      }
+      setExperimentalFeatureForDebugPrerender(
+        userConfig.experimental,
+        'serverSourceMaps',
+        true,
+        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
+      )
 
-      userConfig.experimental.serverMinification = false
-      if (!silent) {
-        Log.warn(
-          `\`experimental.serverMinification\` has been set to \`false\` because \`next build\` was run with \`--debug-prerender\`.`
-        )
-      }
+      setExperimentalFeatureForDebugPrerender(
+        userConfig.experimental,
+        'serverMinification',
+        false,
+        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
+      )
+      setExperimentalFeatureForDebugPrerender(
+        userConfig.experimental,
+        'enablePrerenderSourceMaps',
+        true,
+        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
+      )
 
-      userConfig.experimental.enablePrerenderSourceMaps = true
-      if (!silent) {
-        Log.warn(
-          `\`experimental.enablePrerenderSourceMaps\` has been set to \`true\` because \`next build\` was run with \`--debug-prerender\`.`
-        )
-      }
-
-      userConfig.experimental.prerenderEarlyExit = false
-      if (!silent) {
-        Log.warn(
-          `\`experimental.prerenderEarlyExit\` has been set to \`false\` because \`next build\` was run with \`--debug-prerender\`.`
-        )
-      }
+      setExperimentalFeatureForDebugPrerender(
+        userConfig.experimental,
+        'prerenderEarlyExit',
+        false,
+        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
+      )
     }
 
-    onLoadUserConfig?.(userConfig)
+    if (reportExperimentalFeatures) {
+      reportExperimentalFeatures(configuredExperimentalFeatures)
+    }
+
     const completeConfig = assignDefaults(
       dir,
       {
@@ -1469,47 +1494,71 @@ export default async function loadConfig(
 }
 
 export type ConfiguredExperimentalFeature =
-  | { name: keyof ExperimentalConfig; type: 'boolean'; value: boolean }
-  | { name: keyof ExperimentalConfig; type: 'number'; value: number }
-  | { name: keyof ExperimentalConfig; type: 'other' }
+  | {
+      name: keyof ExperimentalConfig
+      type: 'boolean'
+      value: boolean
+      reason?: string
+    }
+  | {
+      name: keyof ExperimentalConfig
+      type: 'number'
+      value: number
+      reason?: string
+    }
+  | {
+      name: keyof ExperimentalConfig
+      type: 'other'
+      reason?: string
+    }
 
-export function getConfiguredExperimentalFeatures(
-  userNextConfigExperimental: NextConfig['experimental']
+export function addConfiguredExperimentalFeature<
+  KeyType extends keyof ExperimentalConfig,
+>(
+  configuredExperimentalFeatures: ConfiguredExperimentalFeature[],
+  key: KeyType,
+  value: ExperimentalConfig[KeyType],
+  reason?: string
 ) {
-  const configuredExperimentalFeatures: ConfiguredExperimentalFeature[] = []
-
-  if (!userNextConfigExperimental) {
-    return configuredExperimentalFeatures
+  if (
+    key in defaultConfig.experimental &&
+    value !== (defaultConfig.experimental as Record<string, unknown>)[key]
+  ) {
+    configuredExperimentalFeatures.push(
+      typeof value === 'boolean'
+        ? { name: key, type: 'boolean', value, reason }
+        : typeof value === 'number'
+          ? { name: key, type: 'number', value, reason }
+          : { name: key, type: 'other', reason }
+    )
   }
+}
 
-  // defaultConfig.experimental is predefined and will never be undefined
-  // This is only a type guard for the typescript
-  if (defaultConfig.experimental) {
-    for (const name of Object.keys(
-      userNextConfigExperimental
-    ) as (keyof ExperimentalConfig)[]) {
-      const value = userNextConfigExperimental[name]
+function setExperimentalFeatureForDebugPrerender<
+  KeyType extends keyof ExperimentalConfig,
+>(
+  experimentalConfig: ExperimentalConfig,
+  key: KeyType,
+  value: ExperimentalConfig[KeyType],
+  configuredExperimentalFeatures: ConfiguredExperimentalFeature[] | undefined
+) {
+  if (experimentalConfig[key] !== value) {
+    experimentalConfig[key] = value
 
-      if (name === 'turbo' && !process.env.TURBOPACK) {
-        // Ignore any Turbopack config if Turbopack is not enabled
-        continue
-      }
+    if (configuredExperimentalFeatures) {
+      const action =
+        value === true ? 'enabled' : value === false ? 'disabled' : 'set'
 
-      if (
-        name in defaultConfig.experimental &&
-        value !== (defaultConfig.experimental as Record<string, unknown>)[name]
-      ) {
-        configuredExperimentalFeatures.push(
-          typeof value === 'boolean'
-            ? { name, type: 'boolean', value }
-            : typeof value === 'number'
-              ? { name, type: 'number', value }
-              : { name, type: 'other' }
-        )
-      }
+      const reason = `${action} by \`--debug-prerender\``
+
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        key,
+        value,
+        reason
+      )
     }
   }
-  return configuredExperimentalFeatures
 }
 
 function cloneObject(obj: any): any {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1424,25 +1424,12 @@ export default async function loadConfig(
         reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
       )
 
-      if (process.env.TURBOPACK) {
-        setExperimentalFeatureForDebugPrerender(
-          userConfig.experimental,
-          'turbopackMinify',
-          false,
-          reportExperimentalFeatures
-            ? configuredExperimentalFeatures
-            : undefined
-        )
-      } else {
-        setExperimentalFeatureForDebugPrerender(
-          userConfig.experimental,
-          'serverMinification',
-          false,
-          reportExperimentalFeatures
-            ? configuredExperimentalFeatures
-            : undefined
-        )
-      }
+      setExperimentalFeatureForDebugPrerender(
+        userConfig.experimental,
+        process.env.TURBOPACK ? 'turbopackMinify' : 'serverMinification',
+        false,
+        reportExperimentalFeatures ? configuredExperimentalFeatures : undefined
+      )
 
       setExperimentalFeatureForDebugPrerender(
         userConfig.experimental,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1271,10 +1271,29 @@ export default async function loadConfig(
       )) as NextConfig
     )
 
+    const configuredExperimentalFeatures: ConfiguredExperimentalFeature[] = []
+
+    if (reportExperimentalFeatures && loadedConfig.experimental) {
+      for (const name of Object.keys(
+        loadedConfig.experimental
+      ) as (keyof ExperimentalConfig)[]) {
+        const value = loadedConfig.experimental[name]
+
+        if (name === 'turbo' && !process.env.TURBOPACK) {
+          // Ignore any Turbopack config if Turbopack is not enabled
+          continue
+        }
+
+        addConfiguredExperimentalFeature(
+          configuredExperimentalFeatures,
+          name,
+          value
+        )
+      }
+    }
+
     // Clone a new userConfig each time to avoid mutating the original
     const userConfig = cloneObject(loadedConfig) as NextConfig
-
-    const configuredExperimentalFeatures: ConfiguredExperimentalFeature[] = []
 
     if (!process.env.NEXT_MINIMAL) {
       // We only validate the config against schema in non minimal mode
@@ -1390,25 +1409,6 @@ export default async function loadConfig(
     if (userConfig?.htmlLimitedBots instanceof RegExp) {
       // @ts-expect-error: override the htmlLimitedBots with default string, type covert: RegExp -> string
       userConfig.htmlLimitedBots = userConfig.htmlLimitedBots.source
-    }
-
-    if (reportExperimentalFeatures && userConfig.experimental) {
-      for (const name of Object.keys(
-        userConfig.experimental
-      ) as (keyof ExperimentalConfig)[]) {
-        const value = userConfig.experimental[name]
-
-        if (name === 'turbo' && !process.env.TURBOPACK) {
-          // Ignore any Turbopack config if Turbopack is not enabled
-          continue
-        }
-
-        addConfiguredExperimentalFeature(
-          configuredExperimentalFeatures,
-          name,
-          value
-        )
-      }
     }
 
     if (

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -5,10 +5,7 @@ import {
   PHASE_DEVELOPMENT_SERVER,
   PHASE_PRODUCTION_BUILD,
 } from '../../shared/lib/constants'
-import loadConfig, {
-  getConfiguredExperimentalFeatures,
-  type ConfiguredExperimentalFeature,
-} from '../config'
+import loadConfig, { type ConfiguredExperimentalFeature } from '../config'
 
 export function logStartInfo({
   networkUrl,
@@ -57,8 +54,9 @@ export function logStartInfo({
           : '·'
 
       const suffix = exp.type === 'number' ? `: ${exp.value}` : ''
+      const reason = exp.reason ? ` (${exp.reason})` : ''
 
-      Log.bootstrap(`  ${symbol} ${exp.name}${suffix}`)
+      Log.bootstrap(`  ${symbol} ${exp.name}${suffix}${reason}`)
     }
     /* indicate if there are more than the maximum shown no. flags */
     if (experimentalFeatures.length > maxExperimentalFeatures) {
@@ -87,11 +85,8 @@ export async function getStartServerInfo({
     dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_BUILD,
     dir,
     {
-      onLoadUserConfig(userConfig) {
-        const configuredExperimentalFeatures =
-          getConfiguredExperimentalFeatures(userConfig.experimental)
-
-        experimentalFeatures = configuredExperimentalFeatures.sort(
+      reportExperimentalFeatures(features) {
+        experimentalFeatures = features.sort(
           ({ name: a }, { name: b }) => a.length - b.length
         )
       },

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -70,10 +70,15 @@ export function logStartInfo({
   Log.info('')
 }
 
-export async function getStartServerInfo(
-  dir: string,
+export async function getStartServerInfo({
+  dir,
+  dev,
+  debugPrerender,
+}: {
+  dir: string
   dev: boolean
-): Promise<{
+  debugPrerender?: boolean
+}): Promise<{
   envInfo?: string[]
   experimentalFeatures?: ConfiguredExperimentalFeature[]
 }> {
@@ -90,6 +95,7 @@ export async function getStartServerInfo(
           ({ name: a }, { name: b }) => a.length - b.length
         )
       },
+      debugPrerender,
     }
   )
 

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -47,16 +47,20 @@ export function logStartInfo({
     // only show a maximum number of flags
     for (const exp of experimentalFeatures.slice(0, maxExperimentalFeatures)) {
       const symbol =
-        exp.type === 'boolean'
+        typeof exp.value === 'boolean'
           ? exp.value === true
             ? bold('✓')
             : bold('⨯')
           : '·'
 
-      const suffix = exp.type === 'number' ? `: ${exp.value}` : ''
+      const suffix =
+        typeof exp.value === 'number' || typeof exp.value === 'string'
+          ? `: ${JSON.stringify(exp.value)}`
+          : ''
+
       const reason = exp.reason ? ` (${exp.reason})` : ''
 
-      Log.bootstrap(`  ${symbol} ${exp.name}${suffix}${reason}`)
+      Log.bootstrap(`  ${symbol} ${exp.key}${suffix}${reason}`)
     }
     /* indicate if there are more than the maximum shown no. flags */
     if (experimentalFeatures.length > maxExperimentalFeatures) {
@@ -87,7 +91,7 @@ export async function getStartServerInfo({
     {
       reportExperimentalFeatures(features) {
         experimentalFeatures = features.sort(
-          ({ name: a }, { name: b }) => a.length - b.length
+          ({ key: a }, { key: b }) => a.length - b.length
         )
       },
       debugPrerender,

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -53,11 +53,7 @@ export function logStartInfo({
             : bold('⨯')
           : '·'
 
-      const suffix =
-        typeof exp.value === 'number' || typeof exp.value === 'string'
-          ? `: ${JSON.stringify(exp.value)}`
-          : ''
-
+      const suffix = typeof exp.value === 'number' ? `: ${exp.value}` : ''
       const reason = exp.reason ? ` (${exp.reason})` : ''
 
       Log.bootstrap(`  ${symbol} ${exp.key}${suffix}${reason}`)

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -278,7 +278,7 @@ export async function startServer(
       let envInfo: string[] | undefined
       let experimentalFeatures: ConfiguredExperimentalFeature[] | undefined
       if (isDev) {
-        const startServerInfo = await getStartServerInfo(dir, isDev)
+        const startServerInfo = await getStartServerInfo({ dir, dev: isDev })
         envInfo = startServerInfo.envInfo
         experimentalFeatures = startServerInfo.experimentalFeatures
       }

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -143,6 +143,20 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toMatch(' · cpus: 2')
   })
 
+  it('should show the configured value for string features', async () => {
+    configFile.write(`
+      module.exports = {
+        experimental: {
+          ppr: 'incremental'
+        }
+      }
+    `)
+
+    const stdout = await collectStdoutFromDev(appDir)
+    expect(stdout).toMatch(experimentalHeader)
+    expect(stdout).toMatch(' · ppr: "incremental"')
+  })
+
   it('should show warning with config from object with experimental and multiple keys', async () => {
     configFile.write(`
       module.exports = {

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -143,20 +143,6 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toMatch(' · cpus: 2')
   })
 
-  it('should show the configured value for string features', async () => {
-    configFile.write(`
-      module.exports = {
-        experimental: {
-          ppr: 'incremental'
-        }
-      }
-    `)
-
-    const stdout = await collectStdoutFromDev(appDir)
-    expect(stdout).toMatch(experimentalHeader)
-    expect(stdout).toMatch(' · ppr: "incremental"')
-  })
-
   it('should show warning with config from object with experimental and multiple keys', async () => {
     configFile.write(`
       module.exports = {

--- a/test/production/app-dir/build-output-prerender/app/client/page.tsx
+++ b/test/production/app-dir/build-output-prerender/app/client/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  return <p>Current time: {new Date().toISOString()}</p>
+}

--- a/test/production/app-dir/build-output-prerender/app/layout.tsx
+++ b/test/production/app-dir/build-output-prerender/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/build-output-prerender/app/server/page.tsx
+++ b/test/production/app-dir/build-output-prerender/app/server/page.tsx
@@ -1,0 +1,14 @@
+import { setTimeout } from 'timers/promises'
+
+async function cachedDelay() {
+  'use cache'
+  await setTimeout(3000)
+}
+
+export default async function Page() {
+  // Defer rendering to ensure the prerender order is deterministic, i.e. the
+  // client page will be finished prerendering first.
+  await cachedDelay()
+
+  return <p>Random: {Math.random()}</p>
+}

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -1,0 +1,179 @@
+import { nextTestSetup } from 'e2e-utils'
+const { version: nextVersion } = require('next/package.json')
+
+describe('build-output-prerender', () => {
+  describe('without --debug-prerender', () => {
+    const { next, isTurbopack } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+    })
+
+    beforeAll(() => next.build())
+
+    it('prints only the user-selected experimental flags', async () => {
+      if (isTurbopack) {
+        expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "▲ Next.js x.y.x (Turbopack)
+            - Experiments (use with caution):
+              ✓ dynamicIO"
+        `)
+      } else {
+        expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "▲ Next.js x.y.x
+            - Experiments (use with caution):
+              ✓ dynamicIO"
+        `)
+      }
+    })
+
+    it('shows only a single prerender error with a mangled stack', async () => {
+      if (isTurbopack) {
+        expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+             at x (<next-dist-dir>)
+         Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
+         Export encountered an error on /client/page: /client, exiting the build."
+        `)
+      } else {
+        expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+             at x (<next-dist-dir>)
+         Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
+         Export encountered an error on /client/page: /client, exiting the build."
+        `)
+      }
+    })
+  })
+
+  describe('with --debug-prerender', () => {
+    const { next, isTurbopack } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+      buildOptions: ['--debug-prerender'],
+    })
+
+    beforeAll(() => next.build())
+
+    it('prints a warning and the customized experimental flags', async () => {
+      if (isTurbopack) {
+        expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+            ▲ Next.js x.y.x (Turbopack)
+            - Experiments (use with caution):
+              ✓ dynamicIO
+              ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+              ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+              ⨯ serverMinification (disabled by \`--debug-prerender\`)
+              ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+              ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+        `)
+      } else {
+        expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+            ▲ Next.js x.y.x
+            - Experiments (use with caution):
+              ✓ dynamicIO
+              ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+              ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+              ⨯ serverMinification (disabled by \`--debug-prerender\`)
+              ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+              ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+        `)
+      }
+    })
+
+    it('shows all prerender errors with readable stacks and code frames', async () => {
+      if (isTurbopack) {
+        expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+             at Page (turbopack:///[project]/app/client/page.tsx:4:27)
+           2 |
+           3 | export default function Page() {
+         > 4 |   return <p>Current time: {new Date().toISOString()}</p>
+             |                           ^
+           5 | }
+           6 |
+         Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
+         Error: Route "/server" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
+             at Page (turbopack:///[project]/app/server/page.tsx:13:26)
+           11 |   await cachedDelay()
+           12 |
+         > 13 |   return <p>Random: {Math.random()}</p>
+              |                          ^
+           14 | }
+           15 |
+         Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
+
+         > Export encountered errors on following paths:
+         	/client/page: /client
+         	/server/page: /server"
+        `)
+      } else {
+        expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
+         "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+             at Page (webpack:///app/client/page.tsx:4:27)
+           2 |
+           3 | export default function Page() {
+         > 4 |   return <p>Current time: {new Date().toISOString()}</p>
+             |                           ^
+           5 | }
+           6 |
+         Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
+         Error: Route "/server" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
+             at Page (webpack:///app/server/page.tsx:13:26)
+           11 |   await cachedDelay()
+           12 |
+         > 13 |   return <p>Random: {Math.random()}</p>
+              |                          ^
+           14 | }
+           15 |
+         Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
+
+         > Export encountered errors on following paths:
+         	/client/page: /client
+         	/server/page: /server"
+        `)
+      }
+    })
+  })
+})
+
+function getPreambleOutput(cliOutput: string): string {
+  const lines: string[] = []
+
+  for (const line of cliOutput.split('\n')) {
+    if (line.includes('Creating an optimized production build')) {
+      break
+    }
+
+    if (!line.includes('Loading config from')) {
+      lines.push(line.replace(nextVersion, 'x.y.x'))
+    }
+  }
+
+  return lines.join('\n').trim()
+}
+
+function getPrerenderOutput(cliOutput: string): string {
+  let foundPrerenderingLine = false
+  const lines: string[] = []
+
+  for (const line of cliOutput.split('\n')) {
+    if (line.includes('Collecting page data')) {
+      foundPrerenderingLine = true
+      continue
+    }
+
+    if (line.includes('Next.js build worker exited')) {
+      break
+    }
+
+    if (foundPrerenderingLine && !line.includes('Generating static pages')) {
+      lines.push(
+        line.replace(/at \w+ \(.next[^)]+\)/, 'at x (<next-dist-dir>)')
+      )
+    }
+  }
+
+  return lines.join('\n').trim()
+}

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -13,13 +13,13 @@ describe('build-output-prerender', () => {
     it('prints only the user-selected experimental flags', async () => {
       if (isTurbopack) {
         expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-         "▲ Next.js x.y.x (Turbopack)
+         "▲ Next.js x.y.z (Turbopack)
             - Experiments (use with caution):
               ✓ dynamicIO"
         `)
       } else {
         expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-         "▲ Next.js x.y.x
+         "▲ Next.js x.y.z
             - Experiments (use with caution):
               ✓ dynamicIO"
         `)
@@ -58,7 +58,7 @@ describe('build-output-prerender', () => {
       if (isTurbopack) {
         expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
          "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-            ▲ Next.js x.y.x (Turbopack)
+            ▲ Next.js x.y.z (Turbopack)
             - Experiments (use with caution):
               ✓ dynamicIO
               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
@@ -69,7 +69,7 @@ describe('build-output-prerender', () => {
       } else {
         expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
          "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-            ▲ Next.js x.y.x
+            ▲ Next.js x.y.z
             - Experiments (use with caution):
               ✓ dynamicIO
               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
@@ -150,7 +150,7 @@ function getPreambleOutput(cliOutput: string): string {
       continue
     }
 
-    lines.push(line.replace(nextVersion, 'x.y.x'))
+    lines.push(line.replace(nextVersion, 'x.y.z'))
   }
 
   return lines.join('\n').trim()

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -63,7 +63,6 @@ describe('build-output-prerender', () => {
               ✓ dynamicIO
               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-              ⨯ serverMinification (disabled by \`--debug-prerender\`)
               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
               ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
         `)
@@ -73,7 +72,6 @@ describe('build-output-prerender', () => {
             ▲ Next.js x.y.x
             - Experiments (use with caution):
               ✓ dynamicIO
-              ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
               ⨯ serverMinification (disabled by \`--debug-prerender\`)
               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -150,11 +150,6 @@ function getPreambleOutput(cliOutput: string): string {
       continue
     }
 
-    // Ignore the test-only config log. Can be removed when #80666 is merged.
-    if (line.includes('Loading config from')) {
-      continue
-    }
-
     lines.push(line.replace(nextVersion, 'x.y.x'))
   }
 

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -144,9 +144,18 @@ function getPreambleOutput(cliOutput: string): string {
       break
     }
 
-    if (!line.includes('Loading config from')) {
-      lines.push(line.replace(nextVersion, 'x.y.x'))
+    // Ignore the test-only warning that `experimental.ppr` has been defaulted
+    // to `true` when `__NEXT_EXPERIMENTAL_PPR` is set to `true`.
+    if (line.includes('__NEXT_EXPERIMENTAL_PPR')) {
+      continue
     }
+
+    // Ignore the test-only config log. Can be removed when #80666 is merged.
+    if (line.includes('Loading config from')) {
+      continue
+    }
+
+    lines.push(line.replace(nextVersion, 'x.y.x'))
   }
 
   return lines.join('\n').trim()

--- a/test/production/app-dir/build-output-prerender/next.config.js
+++ b/test/production/app-dir/build-output-prerender/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
When running `next build --debug-prerender`, we will set a few experimental flags that ensure the following:

- No minification is applied to server code.
    - `experimental.serverMinification = false`, or
    - `experimental.turbopackMinify = false`
- Source maps for server bundles are generated.
    - `experimental.serverSourceMaps = true`
- Source maps are consumed by Node.js in the spawned child processes that prerender the routes.
    - `experimental.enablePrerenderSourceMaps = true`
- The build is not exited after the first error to show a complete list of prerender errors.
    - `experimental.prerenderEarlyExit = false`

While `next dev` remains the primary recommended way to debug prerender errors when `dynamicIO` is enabled, this build option does offer an alternative to get a more usable build output, with readable stacks and code frames.

**Note:** For performance reasons, artifacts generated with `next build --debug-prerender` should not be deployed to production. This mode is only intended for debugging purposes.

Closes NAR-142