### PR TITLE
[segment explorer] handle edge and pages router

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -799,6 +799,8 @@ pub struct ExperimentalConfig {
     global_not_found: Option<bool>,
     /// Defaults to false in development mode, true in production mode.
     turbopack_remove_unused_exports: Option<bool>,
+    /// Devtool option for the segment explorer.
+    devtool_segment_explorer: Option<bool>,
 }
 
 #[derive(

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -209,6 +209,15 @@ export function getDefineEnv({
           'process.env.__NEXT_DIST_DIR': distDir,
         }
       : {}),
+    // This is used in devtools to strip the project path in edge runtime,
+    // as there's only a dummy `dir` value (`.`) as edge runtime doesn't have concept of file system.
+    ...(dev && isEdgeServer
+      ? {
+          'process.env.__NEXT_EDGE_PROJECT_DIR': isTurbopack
+            ? path.relative(process.cwd(), projectPath)
+            : projectPath,
+        }
+      : {}),
     'process.env.__NEXT_TRAILING_SLASH': config.trailingSlash,
     'process.env.__NEXT_DEV_INDICATOR': config.devIndicators !== false,
     'process.env.__NEXT_DEV_INDICATOR_POSITION':

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -100,6 +100,7 @@ export function getRender({
         serverActionsManifest,
         serverActions,
         nextFontManifest,
+        devtoolSegmentExplorer: config.experimental.devtoolSegmentExplorer,
       },
       renderToHTML,
       incrementalCacheHandler,

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -337,12 +337,13 @@ function DevToolsPopover({
       />
 
       {/* Page Route Info */}
-      {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER && routerType === 'app' ? (
+      {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER ? (
         <SegmentsExplorer
           isOpen={isSegmentExplorerOpen}
           close={closeToRootMenu}
           triggerRef={triggerRef}
           style={popover}
+          routerType={routerType}
         />
       ) : null}
 
@@ -411,8 +412,7 @@ function DevToolsPopover({
                 onClick={() => setOpen(OVERLAYS.Preferences)}
                 index={isTurbopack ? 2 : 3}
               />
-              {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER &&
-              routerType === 'app' ? (
+              {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER && (
                 <MenuItem
                   data-segment-explorer
                   label="Route Info"
@@ -420,7 +420,7 @@ function DevToolsPopover({
                   onClick={() => setOpen(OVERLAYS.SegmentExplorer)}
                   index={isTurbopack ? 3 : 4}
                 />
-              ) : null}
+              )}
             </div>
           </Context.Provider>
         </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -412,7 +412,7 @@ function DevToolsPopover({
                 onClick={() => setOpen(OVERLAYS.Preferences)}
                 index={isTurbopack ? 2 : 3}
               />
-              {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER && (
+              {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER ? (
                 <MenuItem
                   data-segment-explorer
                   label="Route Info"
@@ -420,7 +420,7 @@ function DevToolsPopover({
                   onClick={() => setOpen(OVERLAYS.SegmentExplorer)}
                   index={isTurbopack ? 3 : 4}
                 />
-              )}
+              ) : null}
             </div>
           </Context.Provider>
         </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -337,7 +337,7 @@ function DevToolsPopover({
       />
 
       {/* Page Route Info */}
-      {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER ? (
+      {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER && routerType === 'app' ? (
         <SegmentsExplorer
           isOpen={isSegmentExplorerOpen}
           close={closeToRootMenu}
@@ -411,7 +411,8 @@ function DevToolsPopover({
                 onClick={() => setOpen(OVERLAYS.Preferences)}
                 index={isTurbopack ? 2 : 3}
               />
-              {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER ? (
+              {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER &&
+              routerType === 'app' ? (
                 <MenuItem
                   data-segment-explorer
                   label="Route Info"

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -9,13 +9,23 @@ const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
 }
 
-function PageSegmentTree({ tree }: { tree: SegmentTrieNode }) {
+function PageSegmentTree({
+  tree,
+  isAppRouter,
+}: {
+  tree: SegmentTrieNode
+  isAppRouter: boolean
+}) {
   return (
     <div
       className="segment-explorer-content"
       data-nextjs-devtool-segment-explorer
     >
-      <PageSegmentTreeLayerPresentation node={tree} level={0} segment="" />
+      {isAppRouter ? (
+        <PageSegmentTreeLayerPresentation node={tree} level={0} segment="" />
+      ) : (
+        <p>Route Info currently is only available for the App Router.</p>
+      )}
     </div>
   )
 }
@@ -163,13 +173,16 @@ function PageSegmentTreeLayerPresentation({
 }
 
 export function SegmentsExplorer(
-  props: DevToolsInfoPropsCore & HTMLProps<HTMLDivElement>
+  props: DevToolsInfoPropsCore &
+    HTMLProps<HTMLDivElement> & {
+      routerType: 'app' | 'pages'
+    }
 ) {
   const tree = useSegmentTree()
-
+  const isAppRouter = props.routerType === 'app'
   return (
     <DevToolsInfo title="Route Info" {...props}>
-      <PageSegmentTree tree={tree} />
+      <PageSegmentTree tree={tree} isAppRouter={isAppRouter} />
     </DevToolsInfo>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -172,14 +172,15 @@ function PageSegmentTreeLayerPresentation({
   )
 }
 
-export function SegmentsExplorer(
-  props: DevToolsInfoPropsCore &
-    HTMLProps<HTMLDivElement> & {
-      routerType: 'app' | 'pages'
-    }
-) {
+export function SegmentsExplorer({
+  routerType,
+  ...props
+}: DevToolsInfoPropsCore &
+  HTMLProps<HTMLDivElement> & {
+    routerType: 'app' | 'pages'
+  }) {
   const tree = useSegmentTree()
-  const isAppRouter = props.routerType === 'app'
+  const isAppRouter = routerType === 'app'
   return (
     <DevToolsInfo title="Route Info" {...props}>
       <PageSegmentTree tree={tree} isAppRouter={isAppRouter} />

--- a/packages/next/src/next-devtools/userspace/use-app-dev-rendering-indicator.tsx
+++ b/packages/next/src/next-devtools/userspace/use-app-dev-rendering-indicator.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useTransition } from 'react'
 import { dispatcher } from 'next/dist/compiled/next-devtools'
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -421,7 +421,10 @@ async function createComponentTreeInternal({
     </>
   ) : undefined
 
-  const dir = ctx.renderOpts.dir || ''
+  const dir =
+    process.env.NEXT_RUNTIME === 'edge'
+      ? process.env.__NEXT_EDGE_PROJECT_DIR!
+      : ctx.renderOpts.dir || ''
 
   const isSegmentViewEnabled =
     process.env.NODE_ENV === 'development' &&
@@ -1048,11 +1051,11 @@ function getConventionPathByType(
   conventionType: 'layout' | 'template' | 'page'
 ) {
   const modules = tree[2]
-  const conventionPath_ = modules[conventionType]
+  const conventionPath = modules[conventionType]
     ? modules[conventionType][1]
     : undefined
-  if (conventionPath_) {
-    return normalizeConventionFilePath(dir, conventionPath_)
+  if (conventionPath) {
+    return normalizeConventionFilePath(dir, conventionPath)
   }
   return undefined
 }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -654,17 +654,7 @@ async function createComponentTreeInternal({
   }
 
   if (isPage) {
-    const pageFilePath = getConventionPathByType(tree, dir, 'page')
-    const PageComponent =
-      isSegmentViewEnabled && pageFilePath
-        ? (pageProps: any) => {
-            return (
-              <SegmentViewNode type={nodeName} pagePath={pageFilePath}>
-                <Component {...pageProps} />
-              </SegmentViewNode>
-            )
-          }
-        : Component
+    const PageComponent = Component
 
     // Assign searchParams to props if this is a page
     let pageElement: React.ReactNode
@@ -730,10 +720,21 @@ async function createComponentTreeInternal({
         )
       }
     }
+
+    const pageFilePath = getConventionPathByType(tree, dir, 'page')
+    const wrappedPageElement =
+      isSegmentViewEnabled && pageFilePath ? (
+        <SegmentViewNode type={nodeName} pagePath={pageFilePath}>
+          {pageElement}
+        </SegmentViewNode>
+      ) : (
+        pageElement
+      )
+
     return [
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
-        {pageElement}
+        {wrappedPageElement}
         {layerAssets}
         <OutletBoundary>
           <MetadataOutlet ready={getViewportReady} />
@@ -745,18 +746,7 @@ async function createComponentTreeInternal({
       isPossiblyPartialResponse,
     ]
   } else {
-    const layoutFilePath = getConventionPathByType(tree, dir, 'layout')
-    const SegmentComponent =
-      isSegmentViewEnabled && layoutFilePath
-        ? (segmentProps: any) => {
-            return (
-              <SegmentViewNode type={nodeName} pagePath={layoutFilePath}>
-                <Component {...segmentProps} />
-              </SegmentViewNode>
-            )
-          }
-        : Component
-
+    const SegmentComponent = Component
     const isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot =
       rootLayoutAtThisLevel &&
       'children' in parallelRoutes &&
@@ -915,10 +905,21 @@ async function createComponentTreeInternal({
         )
       }
     }
+
+    const layoutFilePath = getConventionPathByType(tree, dir, 'layout')
+    const wrappedSegmentNode =
+      isSegmentViewEnabled && layoutFilePath ? (
+        <SegmentViewNode type={nodeName} pagePath={layoutFilePath}>
+          {segmentNode}
+        </SegmentViewNode>
+      ) : (
+        segmentNode
+      )
+
     // For layouts we just render the component
     return [
       actualSegment,
-      segmentNode,
+      wrappedSegmentNode,
       parallelRouteCacheNodeSeedData,
       loadingData,
       isPossiblyPartialResponse,

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/default.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/default.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'default @bar'
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h2>@bar Layout</h2>
+      <div id="bar-children">{children}</div>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'page @bar'
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/test-page/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@bar/test-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'test-page @bar'
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/default.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/default.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'default @foo'
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <div>
+      <h2>@foo Layout</h2>
+      <div id="foo-children">{children}</div>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/no-bar/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/no-bar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'no-bar @foo'
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'page @foo'
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/test-page/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/@foo/test-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'test-page @foo'
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/layout.tsx
@@ -1,0 +1,10 @@
+export default function Layout({ children, bar, foo }) {
+  return (
+    <div>
+      <h1>Parallel Routes Layout</h1>
+      <div id="nested-children">{children}</div>
+      <div id="foo-slot">{foo}</div>
+      <div id="bar-slot">{bar}</div>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/no-bar/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/no-bar/page.tsx
@@ -1,10 +1,7 @@
-import Link from 'next/link'
-
 export default function Page() {
   return (
     <div>
       <p>no bar</p>
-      <Link href="/parallel-routes-edge">Back to /parallel-routes-edge</Link>
     </div>
   )
 }

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/no-bar/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/no-bar/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <p>no bar</p>
+      <Link href="/parallel-routes-edge">Back to /parallel-routes-edge</Link>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      Hello from Nested <br />
+      <Link href="/parallel-routes/test-page">
+        To /parallel-routes/test-page
+      </Link>
+      <br />
+      <Link href="/parallel-routes/no-bar">To /parallel-routes/no-bar</Link>
+    </div>
+  )
+}
+
+export const runtime = 'edge'

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/page.tsx
@@ -1,14 +1,8 @@
-import Link from 'next/link'
-
 export default function Page() {
   return (
     <div>
       Hello from Nested <br />
-      <Link href="/parallel-routes/test-page">
-        To /parallel-routes/test-page
-      </Link>
       <br />
-      <Link href="/parallel-routes/no-bar">To /parallel-routes/no-bar</Link>
     </div>
   )
 }

--- a/test/development/app-dir/segment-explorer/app/parallel-routes-edge/test-page/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes-edge/test-page/page.tsx
@@ -1,0 +1,3 @@
+export default function TestPage() {
+  return 'test page'
+}

--- a/test/development/app-dir/segment-explorer/pages/pages-router.tsx
+++ b/test/development/app-dir/segment-explorer/pages/pages-router.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>pages/pages-router.tsx</p>
+}

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -40,6 +40,23 @@ describe('segment-explorer', () => {
     `)
   })
 
+  it('should render the segment explorer for parallel routes in edge runtime', async () => {
+    const browser = await next.browser('/parallel-routes-edge')
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
+     "app/
+     layout.tsx
+     parallel-routes-edge/
+     layout.tsx
+     page.tsx
+     @bar/
+     layout.tsx
+     page.tsx
+     @foo/
+     layout.tsx
+     page.tsx"
+    `)
+  })
+
   it('should render the segment explorer for nested routes', async () => {
     const browser = await next.browser('/blog/~/grid')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
@@ -89,5 +106,17 @@ describe('segment-explorer', () => {
      template.tsx
      page.tsx"
     `)
+  })
+
+  it('should not show segment explorer for pages router', async () => {
+    const browser = await next.browser('/pages-router')
+
+    // open the devtool button
+    await openDevToolsIndicatorPopover(browser)
+
+    // open the segment explorer
+    expect(
+      await browser.hasElementsByCss('[data-segment-explorer]')
+    ).toBeFalse()
   })
 })

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -108,15 +108,10 @@ describe('segment-explorer', () => {
     `)
   })
 
-  it('should not show segment explorer for pages router', async () => {
+  it('should indicate segment explorer is not available pages router', async () => {
     const browser = await next.browser('/pages-router')
-
-    // open the devtool button
-    await openDevToolsIndicatorPopover(browser)
-
-    // open the segment explorer
-    expect(
-      await browser.hasElementsByCss('[data-segment-explorer]')
-    ).toBeFalse()
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(
+      `"Route Info currently is only available for the App Router."`
+    )
   })
 })

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -108,7 +108,7 @@ describe('segment-explorer', () => {
     `)
   })
 
-  it('should indicate segment explorer is not available pages router', async () => {
+  it('should indicate segment explorer is not available for pages router', async () => {
     const browser = await next.browser('/pages-router')
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(
       `"Route Info currently is only available for the App Router."`

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -451,6 +451,10 @@ export class Playwright<TCurrent = undefined> {
     )
   }
 
+  hasElementsByCss(selector: string) {
+    return this.startChain(() => page.$$eval(selector, (els) => els.length > 0))
+  }
+
   waitForElementByCss(selector: string, timeout = 10_000) {
     return this.startChain(async () => {
       const el = await page.waitForSelector(selector, {

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -451,10 +451,6 @@ export class Playwright<TCurrent = undefined> {
     )
   }
 
-  hasElementsByCss(selector: string) {
-    return this.startChain(() => page.$$eval(selector, (els) => els.length > 0))
-  }
-
   waitForElementByCss(selector: string, timeout = 10_000) {
     return this.startChain(async () => {
       const el = await page.waitForSelector(selector, {


### PR DESCRIPTION
Hide segment explorer for Pages Router as there's no complex routes like App Router parallel routes or interception routes.

While testing more scenarios I found that it's not working properly with Edge runtime. When we get the relative page path of the file by stripping the project dir, the `renderOpts.dir` is quite different between Node.js and Edge, also different between Webpack and Turbopack.
In Node.js we can directly access the dir, however in Edge there's no filesystem concept. We leverage a new env variable to represent project directory, which will be replaced later during bundling code for Edge.

Since turbopack is using the `[project]/` prefix rather than the actual cwd, so for turbopack we'll use the relative project path.

Closes NEXT-4539