### PR TITLE
Check cache busting search params on all RSC requests

### DIFF
--- a/packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts
+++ b/packages/next/src/client/components/router-reducer/set-cache-busting-search-param.ts
@@ -36,12 +36,29 @@ export const setCacheBustingSearchParam = (
     headers[NEXT_ROUTER_STATE_TREE_HEADER],
     headers[NEXT_URL]
   )
-  if (uniqueCacheKey === null) {
-    // None of our custom request headers are present. We don't need to set a
-    // cache-busting search param.
-    return
-  }
+  setCacheBustingSearchParamWithHash(url, uniqueCacheKey)
+}
 
+/**
+ * Sets a cache-busting search parameter on a URL using a provided hash value.
+ *
+ * This function performs the same logic as `setCacheBustingSearchParam` but accepts
+ * a pre-computed hash instead of computing it from headers.
+ *
+ * Example:
+ * URL before: https://example.com/path?query=1
+ * hash: "abc123"
+ * URL after: https://example.com/path?query=1&_rsc=abc123
+ *
+ * If the hash is null, we will set `_rsc` search param without a value.
+ * Like this: https://example.com/path?query=1&_rsc
+ *
+ * Note: This function mutates the input URL directly and does not return anything.
+ */
+export const setCacheBustingSearchParamWithHash = (
+  url: URL,
+  hash: string
+): void => {
   /**
    * Note that we intentionally do not use `url.searchParams.set` here:
    *
@@ -64,6 +81,10 @@ export const setCacheBustingSearchParam = (
     .split('&')
     .filter((pair) => pair && !pair.startsWith(`${NEXT_RSC_UNION_QUERY}=`))
 
-  pairs.push(`${NEXT_RSC_UNION_QUERY}=${uniqueCacheKey}`)
+  if (hash.length > 0) {
+    pairs.push(`${NEXT_RSC_UNION_QUERY}=${hash}`)
+  } else {
+    pairs.push(`${NEXT_RSC_UNION_QUERY}`)
+  }
   url.search = pairs.length ? `?${pairs.join('&')}` : ''
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -11,6 +11,9 @@ import {
   NEXT_ROUTER_STATE_TREE_HEADER,
   ACTION_HEADER,
   NEXT_ACTION_NOT_FOUND_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_URL,
 } from '../../client/components/app-router-headers'
 import {
   getAccessFallbackHTTPStatus,
@@ -54,6 +57,7 @@ import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.exte
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { executeRevalidates } from '../revalidation-utils'
 import { getRequestMeta } from '../request-meta'
+import { setCacheBustingSearchParam } from '../../client/components/router-reducer/set-cache-busting-search-param'
 
 function formDataFromSearchQueryString(query: string) {
   const searchParams = new URLSearchParams(query)
@@ -339,6 +343,20 @@ async function createRedirectRenderResult(
     forwardedHeaders.delete(ACTION_HEADER)
 
     try {
+      setCacheBustingSearchParam(fetchUrl, {
+        [NEXT_ROUTER_PREFETCH_HEADER]: forwardedHeaders.get(
+          NEXT_ROUTER_PREFETCH_HEADER
+        )
+          ? ('1' as const)
+          : undefined,
+        [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]:
+          forwardedHeaders.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER) ??
+          undefined,
+        [NEXT_ROUTER_STATE_TREE_HEADER]:
+          forwardedHeaders.get(NEXT_ROUTER_STATE_TREE_HEADER) ?? undefined,
+        [NEXT_URL]: forwardedHeaders.get(NEXT_URL) ?? undefined,
+      })
+
       const response = await fetch(fetchUrl, {
         method: 'GET',
         headers: forwardedHeaders,

--- a/packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts
+++ b/packages/next/src/shared/lib/router/utils/cache-busting-search-param.ts
@@ -5,14 +5,14 @@ export function computeCacheBustingSearchParam(
   segmentPrefetchHeader: string | string[] | undefined,
   stateTreeHeader: string | string[] | undefined,
   nextUrlHeader: string | string[] | undefined
-): string | null {
+): string {
   if (
     prefetchHeader === undefined &&
     segmentPrefetchHeader === undefined &&
     stateTreeHeader === undefined &&
     nextUrlHeader === undefined
   ) {
-    return null
+    return ''
   }
   return hexHash(
     [

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 describe('app dir - css - experimental inline css', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
@@ -17,7 +18,7 @@ describe('app dir - css - experimental inline css', () => {
 
     it('should not return rsc payload with inlined style as a dynamic client nav', async () => {
       const rscPayload = await (
-        await next.fetch('/a', {
+        await next.fetch(`/a?${NEXT_RSC_UNION_QUERY}`, {
           method: 'GET',
           headers: {
             rsc: '1',
@@ -32,7 +33,7 @@ describe('app dir - css - experimental inline css', () => {
 
       expect(
         await (
-          await next.fetch('/a', {
+          await next.fetch(`/a?${NEXT_RSC_UNION_QUERY}`, {
             method: 'GET',
           })
         ).text()

--- a/test/e2e/app-dir/app-validation/validation.test.ts
+++ b/test/e2e/app-dir/app-validation/validation.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 describe('app dir - validation', () => {
   const { next, skipped } = nextTestSetup({
@@ -11,20 +12,47 @@ describe('app dir - validation', () => {
   }
 
   it('should error when passing invalid router state tree', async () => {
-    const res = await next.fetch('/', {
-      headers: {
-        RSC: '1',
-        'Next-Router-State-Tree': JSON.stringify(['', '']),
-      },
-    })
+    const stateTree1 = JSON.stringify(['', ''])
+    const stateTree2 = JSON.stringify(['', {}])
+
+    const headers1 = {
+      RSC: '1',
+      'Next-Router-State-Tree': stateTree1,
+    }
+
+    const headers2 = {
+      RSC: '1',
+      'Next-Router-State-Tree': stateTree2,
+    }
+
+    const url1 = new URL('/', 'http://localhost')
+    const url2 = new URL('/', 'http://localhost')
+
+    // Add cache busting search param for both requests
+    const cacheBustingParam1 = computeCacheBustingSearchParam(
+      undefined,
+      undefined,
+      stateTree1,
+      undefined
+    )
+    const cacheBustingParam2 = computeCacheBustingSearchParam(
+      undefined,
+      undefined,
+      stateTree2,
+      undefined
+    )
+
+    if (cacheBustingParam1) {
+      url1.searchParams.set('_rsc', cacheBustingParam1)
+    }
+    if (cacheBustingParam2) {
+      url2.searchParams.set('_rsc', cacheBustingParam2)
+    }
+
+    const res = await next.fetch(url1.toString(), { headers: headers1 })
     expect(res.status).toBe(500)
 
-    const res2 = await next.fetch('/', {
-      headers: {
-        RSC: '1',
-        'Next-Router-State-Tree': JSON.stringify(['', {}]),
-      },
-    })
+    const res2 = await next.fetch(url2.toString(), { headers: headers2 })
     expect(res2.status).toBe(200)
   })
 })

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -2,6 +2,10 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, retry, waitFor } from 'next-test-utils'
 import cheerio from 'cheerio'
 import stripAnsi from 'strip-ansi'
+import {
+  NEXT_RSC_UNION_QUERY,
+  RSC_HEADER,
+} from 'next/dist/client/components/app-router-headers'
 
 // TODO: We should decide on an established pattern for gating test assertions
 // on experimental flags. For example, as a first step we could all the common
@@ -306,18 +310,21 @@ describe('app dir - basic', () => {
   }
 
   it('should use text/x-component for flight', async () => {
-    const res = await next.fetch('/dashboard/deployments/123', {
-      headers: {
-        ['RSC'.toString()]: '1',
-      },
-    })
+    const res = await next.fetch(
+      `/dashboard/deployments/123?${NEXT_RSC_UNION_QUERY}`,
+      {
+        headers: {
+          [RSC_HEADER]: '1',
+        },
+      }
+    )
     expect(res.headers.get('Content-Type')).toBe('text/x-component')
   })
 
   it('should use text/x-component for flight with edge runtime', async () => {
-    const res = await next.fetch('/dashboard', {
+    const res = await next.fetch(`/dashboard?${NEXT_RSC_UNION_QUERY}`, {
       headers: {
-        ['RSC'.toString()]: '1',
+        [RSC_HEADER]: '1',
       },
     })
     expect(res.headers.get('Content-Type')).toBe('text/x-component')
@@ -332,9 +339,9 @@ describe('app dir - basic', () => {
   })
 
   it('should return the `vary` header from pages for flight requests', async () => {
-    const res = await next.fetch('/', {
+    const res = await next.fetch(`/?${NEXT_RSC_UNION_QUERY}`, {
       headers: {
-        ['RSC'.toString()]: '1',
+        [RSC_HEADER]: '1',
       },
     })
     expect(res.headers.get('vary')).toBe(

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -2,6 +2,10 @@ import path from 'path'
 import { check } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
+import {
+  NEXT_RSC_UNION_QUERY,
+  RSC_HEADER,
+} from 'next/dist/client/components/app-router-headers'
 
 // TODO: We should decide on an established pattern for gating test assertions
 // on experimental flags. For example, as a first step we could all the common
@@ -380,8 +384,10 @@ describe('app dir - rsc basics', () => {
 
   it('should support streaming for flight response', async () => {
     await next
-      .fetch('/', {
-        headers: { RSC: '1' },
+      .fetch(`/?${NEXT_RSC_UNION_QUERY}`, {
+        headers: {
+          [RSC_HEADER]: '1',
+        },
       })
       .then(async (response) => {
         const result = await resolveStreamResponse(response)

--- a/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
+++ b/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
+import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 
 describe('rsc-redirect', () => {
   const { next } = nextTestSetup({
@@ -14,13 +15,17 @@ describe('rsc-redirect', () => {
   })
 
   it('should get 200 status code for rsc request', async () => {
-    // TODO: add RSC cache busting query param
-    const response = await fetchViaHTTP(next.url, '/origin', undefined, {
-      redirect: 'manual',
-      headers: {
-        RSC: '1',
-      },
-    })
+    const response = await fetchViaHTTP(
+      next.url,
+      `/origin?${NEXT_RSC_UNION_QUERY}`,
+      undefined,
+      {
+        redirect: 'manual',
+        headers: {
+          RSC: '1',
+        },
+      }
+    )
     expect(response.status).toBe(200)
   })
 })

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
@@ -1,6 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-
-import { computeCacheBustingSearchParam } from '../../../../../packages/next/src/shared/lib/router/utils/cache-busting-search-param'
+import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 describe('conflicting routes', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
+import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 
 import { SavedSpan } from './constants'
 import { type Collector, connectCollector } from './collector'
@@ -358,7 +359,7 @@ describe('opentelemetry', () => {
           })
 
           it('should handle RSC with fetch in RSC mode', async () => {
-            await next.fetch('/app/param/rsc-fetch', {
+            await next.fetch(`/app/param/rsc-fetch?${NEXT_RSC_UNION_QUERY}`, {
               ...env.fetchInit,
               headers: {
                 ...env.fetchInit?.headers,
@@ -376,7 +377,7 @@ describe('opentelemetry', () => {
                   'http.method': 'GET',
                   'http.route': '/app/[param]/rsc-fetch',
                   'http.status_code': 200,
-                  'http.target': '/app/param/rsc-fetch',
+                  'http.target': `/app/param/rsc-fetch?${NEXT_RSC_UNION_QUERY}`,
                   'next.route': '/app/[param]/rsc-fetch',
                   'next.rsc': true,
                   'next.span_name': 'RSC GET /app/[param]/rsc-fetch',


### PR DESCRIPTION
For all RSC requests, we require the `_rsc` search param to match the hash of its corresponding RSC headers. In the case where the match fails, we respond with a redirect to the correct search param. This hash check only applies to `next start` mode for now.