### PR TITLE
Update revalidatePath.mdx

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/revalidatePath.mdx
+++ b/docs/01-app/03-api-reference/04-functions/revalidatePath.mdx
@@ -30,7 +30,7 @@ revalidatePath(path: string, type?: 'page' | 'layout'): void;
 
 ```ts
 import { revalidatePath } from 'next/cache'
-revalidatePath('/blog/post-1')
+revalidatePath('/blog/post-1/')
 ```
 
 This will revalidate one specific URL on the next page visit.


### PR DESCRIPTION
Hello,

After spending quite some time trying to understand why the `revalidatePath` wasn't working, I have noticed that in order for it to work, the path **must** include the trailing slash. For example:
- http://localhost:3000/blog/post-1 -> `revalidatePath('/blog/post-1/')`
- http://localhost:3000 -> `revalidatePath('/')`
