### PR TITLE
[not-for-merge] Enable verbose output for test runs

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -207,7 +207,7 @@ async function main() {
 
   const options = {
     concurrency: argv.concurrency ?? envConcurrency ?? DEFAULT_CONCURRENCY,
-    debug: argv.debug ?? false,
+    debug: argv.debug ?? true,
     timings: argv.timings ?? false,
     writeTimings: argv.writeTimings ?? false,
     group: argv.group ?? false,
@@ -460,7 +460,6 @@ ${ENDGROUP}`)
         '--runInBand',
         '--forceExit',
         '--verbose',
-        '--silent',
         ...(isTestJob
           ? ['--json', `--outputFile=${test.file}${RESULTS_EXT}`]
           : []),


### PR DESCRIPTION
Some tests that are marked as failed in the manifests are still run in CI. Maybe something is wrong with the generated `--testNamePattern` option.