### PR TITLE
Turbopack: Allow distdir in project directory, outside of the application

### DIFF
--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -47,13 +47,6 @@ impl NftJsonAsset {
         }
         .cell()
     }
-
-    #[turbo_tasks::function]
-    async fn dist_dir(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("/{}/", self.project.dist_dir().await?).into(),
-        ))
-    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -107,11 +107,13 @@ impl Asset for NftJsonAsset {
         let client_root = this.project.client_fs().root();
         let client_root_ref = client_root.await?;
 
+        // Example: [output]/apps/my-website/.next/server/app -- without the `.nft.json`
         let ident_folder = self.path().parent().await?;
+        // Example: [project]/apps/my-website/.next/server/app -- without the `.nft.json`
         let ident_folder_in_project_fs = this
             .project
-            .project_path()
-            .join(ident_folder.path.clone())
+            .project_root_path() // Example: [project]
+            .join(ident_folder.path.clone()) // apps/my-website/.next/server/app
             .await?;
 
         let chunk = this.chunk;

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -33,7 +33,10 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
-use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath, VirtualFileSystem, invalidation};
+use turbo_tasks_fs::{
+    DiskFileSystem, FileSystem, FileSystemPath, VirtualFileSystem, get_relative_path_to,
+    invalidation,
+};
 use turbopack::{
     ModuleAssetContext, evaluate_context::node_build_environment,
     global_module_ids::get_global_module_id_strategy, transition::TransitionOptions,
@@ -662,7 +665,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub fn output_fs(&self) -> Vc<DiskFileSystem> {
-        DiskFileSystem::new(rcstr!("output"), self.project_path.clone(), vec![])
+        DiskFileSystem::new(rcstr!("output"), self.root_path.clone(), vec![])
     }
 
     #[turbo_tasks::function]
@@ -673,7 +676,13 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn node_root(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        Ok(self.output_fs().root().join(this.dist_dir.clone()))
+        let relative_from_root_to_project_path =
+            get_relative_path_to(&*this.root_path, &*this.project_path);
+        Ok(self
+            .output_fs()
+            .root()
+            .join(relative_from_root_to_project_path.into())
+            .join(this.dist_dir.clone()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -677,7 +677,7 @@ impl Project {
     pub async fn node_root(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
         let relative_from_root_to_project_path =
-            get_relative_path_to(&*this.root_path, &*this.project_path);
+            get_relative_path_to(&this.root_path, &this.project_path);
         Ok(self
             .output_fs()
             .root()

--- a/test/e2e/app-dir/upward-distdir/apps/next-nx-test/app/layout.tsx
+++ b/test/e2e/app-dir/upward-distdir/apps/next-nx-test/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/upward-distdir/apps/next-nx-test/app/page.tsx
+++ b/test/e2e/app-dir/upward-distdir/apps/next-nx-test/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/upward-distdir/apps/next-nx-test/next.config.js
+++ b/test/e2e/app-dir/upward-distdir/apps/next-nx-test/next.config.js
@@ -1,0 +1,8 @@
+const path = require('path')
+
+module.exports = {
+  distDir: '../.next',
+  turbopack: {
+    root: path.join(__dirname, '../..'),
+  },
+}

--- a/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
+++ b/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
@@ -1,0 +1,18 @@
+import { nextTestSetup, isNextDev } from 'e2e-utils'
+
+describe('upward-distdir', () => {
+  const { next } = nextTestSetup({
+    skipDeployment: true,
+    files: __dirname,
+    installCommand: 'pnpm install',
+    buildCommand: 'pnpm next build apps/next-nx-test',
+    startCommand: isNextDev
+      ? 'pnpm next dev apps/next-nx-test'
+      : 'pnpm next start apps/next-nx-test',
+  })
+
+  it('should work', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -3909,13 +3909,13 @@
     "runtimeError": false
   },
   "test/e2e/app-dir/nx-handling/nx-handling.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "nx-handling should work for pages API",
       "nx-handling should work for pages page",
       "nx-handling should work with app page",
       "nx-handling should work with app route"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Allow putting `distDir` anywhere in the monorepo (inside the project root), not just inside the app's directory.

Closes PACK-4865