### PR TITLE
Show string values for configured experimental features

### DIFF
--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -53,7 +53,11 @@ export function logStartInfo({
             : bold('⨯')
           : '·'
 
-      const suffix = typeof exp.value === 'number' ? `: ${exp.value}` : ''
+      const suffix =
+        typeof exp.value === 'number' || typeof exp.value === 'string'
+          ? `: ${JSON.stringify(exp.value)}`
+          : ''
+
       const reason = exp.reason ? ` (${exp.reason})` : ''
 
       Log.bootstrap(`  ${symbol} ${exp.key}${suffix}${reason}`)

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -143,6 +143,20 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toMatch(' · cpus: 2')
   })
 
+  it('should show the configured value for string features', async () => {
+    configFile.write(`
+      module.exports = {
+        experimental: {
+          ppr: 'incremental'
+        }
+      }
+    `)
+
+    const stdout = await collectStdoutFromDev(appDir)
+    expect(stdout).toMatch(experimentalHeader)
+    expect(stdout).toMatch(' · ppr: "incremental"')
+  })
+
   it('should show warning with config from object with experimental and multiple keys', async () => {
     configFile.write(`
       module.exports = {


### PR DESCRIPTION
Follow-up to #74692. We can not only show numbers, but also strings when printing the configured experimental features in the CLI.