### PR TITLE
[turbopack] Simplify the implementations of TaskOutput::try_from_raw_vc

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -144,10 +144,6 @@ impl TurboTasksCallApi for VcStorage {
 }
 
 impl TurboTasksApi for VcStorage {
-    fn pin(&self) -> Arc<dyn TurboTasksApi> {
-        self.this.upgrade().unwrap()
-    }
-
     fn invalidate(&self, _task: TaskId) {
         unreachable!()
     }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -100,8 +100,6 @@ pub trait TurboTasksCallApi: Sync + Send {
 /// This trait is needed because thread locals cannot contain an unresolved [`Backend`] type
 /// parameter.
 pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
-    fn pin(&self) -> Arc<dyn TurboTasksApi>;
-
     fn invalidate(&self, task: TaskId);
     fn invalidate_with_reason(&self, task: TaskId, reason: StaticOrArc<dyn InvalidationReason>);
 
@@ -1243,10 +1241,6 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
 }
 
 impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
-    fn pin(&self) -> Arc<dyn TurboTasksApi> {
-        self.pin()
-    }
-
     #[instrument(level = Level::INFO, skip_all, name = "invalidate")]
     fn invalidate(&self, task: TaskId) {
         self.backend.invalidate_task(task, self);


### PR DESCRIPTION
Because RawVc is just a type erased version of Vc<T> we can have a single implementation.

Closes PACK-4863