### PR TITLE
fix: server actions should fetch from the router canonicalUrl

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -87,7 +87,7 @@ async function fetchServerAction(
 
   const body = await encodeReply(usedArgs, { temporaryReferences })
 
-  const res = await fetch('', {
+  const res = await fetch(state.canonicalUrl, {
     method: 'POST',
     headers: {
       Accept: RSC_CONTENT_TYPE_HEADER,

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -898,13 +898,6 @@ describe('app-dir action handling', () => {
         .elementByCss(`[href='/delayed-action/${runtime}/other']`)
         .click()
 
-      // wait for url to change
-      await retry(async () => {
-        expect(await browser.url()).toBe(
-          `${next.url}/delayed-action/${runtime}/other`
-        )
-      })
-
       await browser.waitForElementByCss('#other-page')
 
       await retry(async () => {


### PR DESCRIPTION
A test related to navigation + server action handling was frequently flaking in CI ([x-ref](https://github.com/vercel/next.js/actions/runs/15746992788/job/44386768835#step:34:2634)). When simulating a 20x browser slowdown, it's fairly easy to reproduce the failure case as well.

The failure occurs due to a race where the router will invoke the server action against the page the user was on _before_ the navigation, but _after_ the navigation action has been processed. As a result, the RSC payload associated with the target page gets replaced by the RSC payload returned from the server action. There exists a window of time where `window.location.pathname` is still referring to the previous URL while `routerState.canonicalUrl` would have been updated to the new page.

This revealed two things:
- The behavior being tested here only tests the expected behavior some of the time: when it failed, it meant the action wasn't actually forwarded (not currently addressed by this PR)
- The router state should be the source of truth when determining the URL to fetch from