### PR TITLE
Apply normalizers for init URL used for handlers

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2637,7 +2637,18 @@ export default abstract class Server<
             const parsedInitUrl = parseUrl(
               getRequestMeta(req, 'initURL') || req.url
             )
-            request.url = `${parsedInitUrl.pathname?.replace(/(\.prefetch\.rsc|\.rsc)$/, '')}${parsedInitUrl.search || ''}`
+            let initPathname = parsedInitUrl.pathname || '/'
+
+            for (const normalizer of [
+              this.normalizers.segmentPrefetchRSC,
+              this.normalizers.prefetchRSC,
+              this.normalizers.rsc,
+            ]) {
+              if (normalizer?.match(initPathname)) {
+                initPathname = normalizer.normalize(initPathname)
+              }
+            }
+            request.url = `${initPathname}${parsedInitUrl.search || ''}`
 
             // propagate the request context for dev
             setRequestMeta(request, getRequestMeta(req))

--- a/test/production/standalone-mode/required-server-files/app/isr/[slug]/page.js
+++ b/test/production/standalone-mode/required-server-files/app/isr/[slug]/page.js
@@ -5,6 +5,8 @@ export function generateStaticParams() {
 }
 
 export default async function Page({ params }) {
+  console.log('rendering /isr/[slug]')
+
   const data = await fetch(
     'https://next-data-api-endpoint.vercel.app/api/random',
     {


### PR DESCRIPTION
This applies our normalizers to the `initURL` we pass to the handlers interface as currently it is created before our existing normalizing takes place which causes us to fail to generate the correct cache keys for ISR paths. This specifically breaks our de-duping for client segment cache as it relies on the cache key being consistent across all segment paths being requested during a revalidation. 

In the future we will have to hoist the URL normalizing anyways so this leaves it as is until then. 

This also adds a regression test for the cache key not being normalized causing extra render passes for client segment cache entries when it shouldn't have. 