### PR TITLE
[turbopack] Update Napi CLI to the latest 2x release

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  NAPI_CLI_VERSION: 2.16.2
+  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20
   CARGO_PROFILE_RELEASE_LTO: 'true'

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -71,7 +71,7 @@ on:
         default: 'x86_64-unknown-linux-gnu'
 
 env:
-  NAPI_CLI_VERSION: 2.14.7
+  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20.9.0
   # run-tests.js reads `TEST_CONCURRENCY` if no explicit `--concurrency` or `-c`

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -16,7 +16,7 @@ on:
 name: Code Freeze
 
 env:
-  NAPI_CLI_VERSION: 2.14.7
+  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20
 

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -5,7 +5,7 @@ on:
 name: Generate Pull Request Stats
 
 env:
-  NAPI_CLI_VERSION: 2.14.7
+  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20
   TEST_CONCURRENCY: 6

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -34,7 +34,7 @@ on:
 name: Trigger Release
 
 env:
-  NAPI_CLI_VERSION: 2.14.7
+  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20
 

--- a/.github/workflows/trigger_release_new.yml
+++ b/.github/workflows/trigger_release_new.yml
@@ -28,7 +28,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  NAPI_CLI_VERSION: 2.14.7
+  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.3.3
   NODE_LTS_VERSION: 20
 

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -35,7 +35,7 @@
     }
   },
   "devDependencies": {
-    "@napi-rs/cli": "2.18.0",
+    "@napi-rs/cli": "2.18.4",
     "cross-env": "6.0.3",
     "wasm-pack": "0.13.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1697,8 +1697,8 @@ importers:
   packages/next-swc:
     devDependencies:
       '@napi-rs/cli':
-        specifier: 2.18.0
-        version: 2.18.0
+        specifier: 2.18.4
+        version: 2.18.4
       cross-env:
         specifier: 6.0.3
         version: 6.0.3
@@ -4356,8 +4356,8 @@ packages:
     resolution: {integrity: sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==}
     engines: {node: '>=18'}
 
-  '@napi-rs/cli@2.18.0':
-    resolution: {integrity: sha512-lfSRT7cs3iC4L+kv9suGYQEezn5Nii7Kpu+THsYVI0tA1Vh59LH45p4QADaD7hvIkmOz79eEGtoKQ9nAkAPkzA==}
+  '@napi-rs/cli@2.18.4':
+    resolution: {integrity: sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -19928,7 +19928,7 @@ snapshots:
       outvariant: 1.4.2
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/cli@2.18.0': {}
+  '@napi-rs/cli@2.18.4': {}
 
   '@napi-rs/triples@1.2.0': {}
 


### PR DESCRIPTION
## What
Update the napi cli to the latest 2x build 2.18.4

## Why
This will make it easy to pass custom cargo profiles to napi, which will make it easier to enable debug assertions, which will happen in a followup.   

Part-of PACK-4578

Closes PACK-4872