### PR TITLE
[segment explorer] handle display loading

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -256,4 +256,8 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     background-color: var(--color-amber-300);
     color: var(--color-amber-900);
   }
+  .segment-explorer-file-label--loading {
+    background-color: var(--color-green-300);
+    color: var(--color-green-900);
+  }
 `

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -593,8 +593,20 @@ async function createComponentTreeInternal({
     parallelRouteCacheNodeSeedData[parallelRouteKey] = flightData
   }
 
-  const loadingData: LoadingModuleData = Loading
-    ? [<Loading key="l" />, loadingStyles, loadingScripts]
+  let loadingElement = Loading ? <Loading key="l" /> : null
+  if (isSegmentViewEnabled && loadingElement) {
+    const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
+    if (loadingFilePath) {
+      loadingElement = (
+        <SegmentViewNode type="loading" pagePath={loadingFilePath}>
+          {loadingElement}
+        </SegmentViewNode>
+      )
+    }
+  }
+
+  const loadingData: LoadingModuleData = loadingElement
+    ? [loadingElement, loadingStyles, loadingScripts]
     : null
 
   // When the segment does not have a layout or page we still have to add the layout router to ensure the path holds the loading component

--- a/test/development/app-dir/segment-explorer/app/search/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/search/layout.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { Fragment } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+export default function SearchLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  let searchParams = useSearchParams()
+  return <Fragment key={searchParams?.get('q')}>{children}</Fragment>
+}

--- a/test/development/app-dir/segment-explorer/app/search/loading.tsx
+++ b/test/development/app-dir/segment-explorer/app/search/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading">Loading...</p>
+}

--- a/test/development/app-dir/segment-explorer/app/search/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/search/page.tsx
@@ -1,0 +1,21 @@
+import { Search } from './search'
+
+type AnySearchParams = { [key: string]: string | Array<string> | undefined }
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<AnySearchParams>
+}) {
+  const search = await searchParams
+  if (Object.keys(search).length > 0) {
+    await new Promise((resolve) => setTimeout(resolve, 30 * 1000))
+  }
+
+  return (
+    <main id="page-content">
+      <Search />
+      <p id="search-value">Search Value: {search.q ?? 'None'}</p>
+    </main>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/search/search.tsx
+++ b/test/development/app-dir/segment-explorer/app/search/search.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function Search() {
+  let router = useRouter()
+
+  function search(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    let input = event.currentTarget.q.value
+    let params = new URLSearchParams([['q', input]])
+    router.push(`/search?${params}`)
+  }
+
+  return (
+    <form onSubmit={search}>
+      <input placeholder="Search..." name="q" className="border" />
+      <button>Submit</button>
+    </form>
+  )
+}

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -160,4 +160,23 @@ describe('segment-explorer', () => {
      unauthorized.tsx"
     `)
   })
+
+  it('should show the loading boundary when it is present', async () => {
+    const browser = await next.browser('/search')
+    const input = await browser.elementByCss('input[name="q"]')
+    await input.fill('abc')
+    await browser.elementByCss('button').click() // submit the form
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#loading').text()).toBe('Loading...')
+    })
+
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
+     "app/
+     layout.tsx
+     search/
+     layout.tsx
+     loading.tsx"
+    `)
+  })
 })


### PR DESCRIPTION
Handle displaying the loading boundaries `loading.js` in segment explorer

![image](https://github.com/user-attachments/assets/c6d1c8f8-92ec-4ee2-a9a7-25af1786452f)

Closes NEXT-4520