### PR TITLE
[test] Reduce flakiness of instrumentation-order

### DIFF
--- a/test/e2e/app-dir/instrumentation-order/next.config.js
+++ b/test/e2e/app-dir/instrumentation-order/next.config.js
@@ -1,6 +1,10 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    preloadEntriesOnStart: false,
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
The test was implicitly relying on `preloadEntriesOnStart` to load the module in our prod tests.

Fixes https://github.com/vercel/next.js/actions/runs/15774186781/job/44464850249?pr=80710#step:34:282 and [other flakes](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3A%22test%2Fe2e%2Fapp-dir%2Finstrumentation-order%2Finstrumentation-order.test.ts%22%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1749804083936&end=1750408883936&paused=true)

Now we always trigger the page for the first time in the test and wait for the logs to come in instead of hardcoding a timeout.