### PR TITLE
Fix Next DevTools Storybook in recent Node.js versions

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -173,7 +173,7 @@
     "@storybook/addon-a11y": "8.6.0",
     "@storybook/addon-essentials": "8.6.0",
     "@storybook/addon-interactions": "8.6.0",
-    "@storybook/addon-webpack5-compiler-swc": "1.0.5",
+    "@storybook/addon-webpack5-compiler-swc": "3.0.0",
     "@storybook/blocks": "8.6.0",
     "@storybook/react": "8.6.0",
     "@storybook/react-webpack5": "8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1055,8 +1055,8 @@ importers:
         specifier: 8.6.0
         version: 8.6.0(storybook@8.6.0(prettier@3.3.3))
       '@storybook/addon-webpack5-compiler-swc':
-        specifier: 1.0.5
-        version: 1.0.5(@swc/helpers@0.5.15)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))
+        specifier: 3.0.0
+        version: 3.0.0(@swc/helpers@0.5.15)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@storybook/blocks':
         specifier: 8.6.0
         version: 8.6.0(react-dom@19.2.0-canary-197d6a04-20250424(react@19.2.0-canary-197d6a04-20250424))(react@19.2.0-canary-197d6a04-20250424)(storybook@8.6.0(prettier@3.3.3))
@@ -5010,8 +5010,8 @@ packages:
     peerDependencies:
       storybook: ^8.6.0
 
-  '@storybook/addon-webpack5-compiler-swc@1.0.5':
-    resolution: {integrity: sha512-1NlM3noit2vA22OyWb8Ma2lhcEKCS1Snv2kr+EkaVABUqNDfVc9AD/GgYQhF7F/2CoF5N2JU7uzXDzFHd5TzZg==}
+  '@storybook/addon-webpack5-compiler-swc@3.0.0':
+    resolution: {integrity: sha512-qkQwQEvHlxwPCHz/xakGfXJusEa1gKMw7enELh6QGopblfN3rMiV084boqiIqBReqWTasSwHOqvuElAu0NQ+8w==}
     engines: {node: '>=18'}
 
   '@storybook/blocks@8.6.0':
@@ -20691,7 +20691,7 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.0(prettier@3.3.3)
 
-  '@storybook/addon-webpack5-compiler-swc@1.0.5(@swc/helpers@0.5.15)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))':
+  '@storybook/addon-webpack5-compiler-swc@3.0.0(@swc/helpers@0.5.15)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
       '@swc/core': 1.11.24(@swc/helpers@0.5.15)
       swc-loader: 0.2.6(@swc/core@1.11.24(@swc/helpers@0.5.15))(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))


### PR DESCRIPTION
Affected all Node.js versions with `require(esm)` support. We needed https://github.com/storybookjs/addon-webpack5-compiler-swc/commit/70a8e63516bd4f664c2751b9094f38697f39f0ff to fix `pnpm storybook`.

Tested with Node.js 20.19.2 which previously failed.