### PR TITLE
[segment explorer] handle custom error boundary

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -575,6 +575,7 @@ export default function OuterLayoutRouter({
     const tree = bfcacheEntry.tree
     const stateKey = bfcacheEntry.stateKey
     const segment = tree[0]
+
     const cacheKey = createRouterCacheKey(segment)
 
     // Read segment path from the parallel router cache node.

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -575,7 +575,6 @@ export default function OuterLayoutRouter({
     const tree = bfcacheEntry.tree
     const stateKey = bfcacheEntry.stateKey
     const segment = tree[0]
-
     const cacheKey = createRouterCacheKey(segment)
 
     // Read segment path from the parallel router cache node.

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -260,4 +260,9 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     background-color: var(--color-green-300);
     color: var(--color-green-900);
   }
+  .segment-explorer-file-label--error,
+  .segment-explorer-file-label--global-error {
+    background-color: var(--color-red-300);
+    color: var(--color-red-900);
+  }
 `

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -544,13 +544,8 @@ async function createComponentTreeInternal({
           </Template>
         )
 
-        // template boundary is the same level with layout and page
-        const templateFilePath = getConventionPathByType(
-          parallelRoute,
-          dir,
-          'template'
-        )
-        // error boundary is from the parent segment level
+        const templateFilePath = getConventionPathByType(tree, dir, 'template')
+
         const errorFilePath = getConventionPathByType(tree, dir, 'error')
 
         const wrappedErrorStyles =

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -544,18 +544,31 @@ async function createComponentTreeInternal({
           </Template>
         )
 
+        // template boundary is the same level with layout and page
         const templateFilePath = getConventionPathByType(
           parallelRoute,
           dir,
           'template'
         )
+        // error boundary is from the parent segment level
+        const errorFilePath = getConventionPathByType(tree, dir, 'error')
+
+        const wrappedErrorStyles =
+          isSegmentViewEnabled && errorFilePath ? (
+            <SegmentViewNode type="error" pagePath={errorFilePath}>
+              {errorStyles}
+            </SegmentViewNode>
+          ) : (
+            errorStyles
+          )
+
         return [
           parallelRouteKey,
           <LayoutRouter
             parallelRouterKey={parallelRouteKey}
             // TODO-APP: Add test for loading returning `undefined`. This currently can't be tested as the `webdriver()` tab will wait for the full page to load before returning.
             error={ErrorComponent}
-            errorStyles={errorStyles}
+            errorStyles={wrappedErrorStyles}
             errorScripts={errorScripts}
             template={
               // Only render SegmentViewNode when there's an actual template

--- a/test/development/app-dir/segment-explorer/app/runtime-error/boundary/error.css
+++ b/test/development/app-dir/segment-explorer/app/runtime-error/boundary/error.css
@@ -1,0 +1,5 @@
+.error-title {
+  color: red;
+  font-size: 24px;
+  font-weight: bold;
+}

--- a/test/development/app-dir/segment-explorer/app/runtime-error/boundary/error.tsx
+++ b/test/development/app-dir/segment-explorer/app/runtime-error/boundary/error.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import './error.css'
+
+export default function CustomError() {
+  return <h2 className="error-title">Custom Error</h2>
+}

--- a/test/development/app-dir/segment-explorer/app/runtime-error/boundary/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/runtime-error/boundary/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+export default function Page() {
+  if (typeof window !== 'undefined') {
+    throw new Error('Error on client')
+  }
+  return <p>page</p>
+}

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -179,4 +179,14 @@ describe('segment-explorer', () => {
      loading.tsx"
     `)
   })
+
+  it('should show the custom error boundary when present', async () => {
+    const browser = await next.browser('/runtime-error/boundary')
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
+     "app/
+     layout.tsx
+     runtime-error / boundary/
+     error.tsx"
+    `)
+  })
 })


### PR DESCRIPTION
Display custom error boundary `error.js` in segement explorer when it's rendered

![image](https://github.com/user-attachments/assets/4abad442-0703-4609-8202-b4f41f007afe)

Closes NEXT-4331
