### PR TITLE
Turbopack: Don't convert script to module when using preset-env

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -217,14 +217,12 @@ impl EcmascriptInputTransform {
 
                 // Explicit type annotation to ensure that we don't duplicate transforms in the
                 // final binary
-                program.mutate(
-                    (preset_env::transform_from_env::<&'_ dyn Comments>(
-                        top_level_mark,
-                        Some(&comments),
-                        config,
-                        Assumptions::default(),
-                    )),
-                );
+                program.mutate(preset_env::transform_from_env::<&'_ dyn Comments>(
+                    top_level_mark,
+                    Some(&comments),
+                    config,
+                    Assumptions::default(),
+                ));
             }
             EcmascriptInputTransform::TypeScript {
                 // TODO(WEB-1213)

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -215,32 +215,16 @@ impl EcmascriptInputTransform {
                     },
                 );
 
-                let module_program = std::mem::replace(program, Program::Module(Module::dummy()));
-
-                let module_program = if let Program::Script(Script {
-                    span,
-                    mut body,
-                    shebang,
-                }) = module_program
-                {
-                    Program::Module(Module {
-                        span,
-                        body: body.drain(..).map(ModuleItem::Stmt).collect(),
-                        shebang,
-                    })
-                } else {
-                    module_program
-                };
-
                 // Explicit type annotation to ensure that we don't duplicate transforms in the
                 // final binary
-                *program =
-                    module_program.apply(preset_env::transform_from_env::<&'_ dyn Comments>(
+                program.mutate(
+                    (preset_env::transform_from_env::<&'_ dyn Comments>(
                         top_level_mark,
                         Some(&comments),
                         config,
                         Assumptions::default(),
-                    ));
+                    )),
+                );
             }
             EcmascriptInputTransform::TypeScript {
                 // TODO(WEB-1213)

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -6,9 +6,9 @@ use rustc_hash::FxHashMap;
 use swc_core::{
     atoms::{Atom, atom},
     base::SwcComments,
-    common::{Mark, SourceMap, comments::Comments, util::take::Take},
+    common::{Mark, SourceMap, comments::Comments},
     ecma::{
-        ast::{Module, ModuleItem, Program, Script},
+        ast::{ModuleItem, Program},
         preset_env::{self, Targets},
         transforms::{base::assumptions::Assumptions, optimization::inline_globals, react::react},
     },

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
@@ -1,16 +1,16 @@
 (globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js", {
 
-"[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {
-"use strict";
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js [test] (ecmascript)": (function(__turbopack_context__) {
 
-var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
-;
+var { m: module, e: exports } = __turbopack_context__;
+{
+var _class_call_check = __turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
 var Foo = function Foo() {
     "use strict";
-    (0, __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__["_"])(this, Foo);
+    _class_call_check._(this, Foo);
 };
 console.log(Foo, [].includes('foo'));
-}),
+}}),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)": (function(__turbopack_context__) {
 
 var { m: module, e: exports } = __turbopack_context__;

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
@@ -1,7 +1,9 @@
 (globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js", {
 
-"[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js [test] (ecmascript)": (function(__turbopack_context__) {
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {
+"use strict";
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
 ;
@@ -11,12 +13,17 @@ var { m: module, e: exports } = __turbopack_context__;
 var _class_call_check = __turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
 var _class_call_check = __turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
 >>>>>>> 7d1bb8c74f (Revert mark switching)
+=======
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
+;
+;
+>>>>>>> 0e36667c89 (Revert "Revert mark switching")
 var Foo = function Foo() {
     "use strict";
-    _class_call_check._._(this, Foo);
+    (0, __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__["_"])(this, Foo);
 };
 console.log(Foo, [].includes('foo'));
-}}),
+}),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)": (function(__turbopack_context__) {
 
 var { m: module, e: exports } = __turbopack_context__;

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
@@ -3,21 +3,8 @@
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {
 "use strict";
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
 ;
-=======
-var { m: module, e: exports } = __turbopack_context__;
-{
-var _class_call_check = __turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
-var _class_call_check = __turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
->>>>>>> 7d1bb8c74f (Revert mark switching)
-=======
-var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
-;
-;
->>>>>>> 0e36667c89 (Revert "Revert mark switching")
 var Foo = function Foo() {
     "use strict";
     (0, __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__["_"])(this, Foo);

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
@@ -1,16 +1,22 @@
 (globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js", {
 
-"[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {
-"use strict";
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js [test] (ecmascript)": (function(__turbopack_context__) {
 
+<<<<<<< HEAD
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
 ;
+=======
+var { m: module, e: exports } = __turbopack_context__;
+{
+var _class_call_check = __turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
+var _class_call_check = __turbopack_context__.r("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
+>>>>>>> 7d1bb8c74f (Revert mark switching)
 var Foo = function Foo() {
     "use strict";
-    (0, __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__["_"])(this, Foo);
+    _class_call_check._._(this, Foo);
 };
 console.log(Foo, [].includes('foo'));
-}),
+}}),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)": (function(__turbopack_context__) {
 
 var { m: module, e: exports } = __turbopack_context__;

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
@@ -2,6 +2,6 @@
   "version": 3,
   "sources": [],
   "sections": [
-    {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
+    {"offset": {"line": 6, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";AAAA,IAAA,AAAM,MAAN,SAAM;;8BAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
     {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
@@ -2,6 +2,11 @@
   "version": 3,
   "sources": [],
   "sections": [
+<<<<<<< HEAD
     {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
     {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
+=======
+    {"offset": {"line": 6, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;gCAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
+    {"offset": {"line": 18, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
+>>>>>>> 7d1bb8c74f (Revert mark switching)
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
@@ -2,15 +2,6 @@
   "version": 3,
   "sources": [],
   "sections": [
-<<<<<<< HEAD
-<<<<<<< HEAD
     {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
     {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
-=======
-    {"offset": {"line": 6, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;gCAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
-=======
-    {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
->>>>>>> 0e36667c89 (Revert "Revert mark switching")
-    {"offset": {"line": 18, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
->>>>>>> 7d1bb8c74f (Revert mark switching)
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
@@ -3,10 +3,14 @@
   "sources": [],
   "sections": [
 <<<<<<< HEAD
+<<<<<<< HEAD
     {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
     {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
 =======
     {"offset": {"line": 6, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;gCAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
+=======
+    {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
+>>>>>>> 0e36667c89 (Revert "Revert mark switching")
     {"offset": {"line": 18, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
 >>>>>>> 7d1bb8c74f (Revert mark switching)
 }


### PR DESCRIPTION
Both swc's `preset_env` and the `crates/next-core/src/next_shared/transforms/next_track_dynamic_imports.rs` were using the `Program::{Module, Script}` type to determine whether to insert CJS requires or ESM imports.

Remove the normaliziation of modules to scripts to allow these transforms to insert the right type of import.

Closes PACK-4873