### PR TITLE
fix: fixed merge driver output, does not expect debugging messages to output on stdout

### DIFF
--- a/scripts/merge-errors-json/merge.mjs
+++ b/scripts/merge-errors-json/merge.mjs
@@ -44,7 +44,7 @@ function main() {
     writeJsonSync(currentPath, merged)
 
     const addedCount = Object.keys(merged).length - Object.keys(current).length
-    console.log(
+    console.error(
       `merge-errors-json: added ${addedCount === 1 ? '1 new message' : `${addedCount} new messages`} to errors.json`
     )
     process.exit(0)


### PR DESCRIPTION
The git merge driver does not expect debugging messages to output on stdout, and instead requires them to output on stderr. This changes the `console.log` to a `console.error` to account for this requirement.