### PR TITLE
fix(turbopack): Do not run `inject_helpers` pass multiple times

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -10,11 +10,7 @@ use swc_core::{
     ecma::{
         ast::{Module, ModuleItem, Program, Script},
         preset_env::{self, Targets},
-        transforms::{
-            base::{assumptions::Assumptions, helpers::inject_helpers},
-            optimization::inline_globals,
-            react::react,
-        },
+        transforms::{base::assumptions::Assumptions, optimization::inline_globals, react::react},
     },
     quote,
 };
@@ -238,15 +234,13 @@ impl EcmascriptInputTransform {
 
                 // Explicit type annotation to ensure that we don't duplicate transforms in the
                 // final binary
-                *program = module_program.apply((
-                    preset_env::transform_from_env::<&'_ dyn Comments>(
+                *program =
+                    module_program.apply(preset_env::transform_from_env::<&'_ dyn Comments>(
                         top_level_mark,
                         Some(&comments),
                         config,
                         Assumptions::default(),
-                    ),
-                    inject_helpers(unresolved_mark),
-                ));
+                    ));
             }
             EcmascriptInputTransform::TypeScript {
                 // TODO(WEB-1213)
@@ -270,7 +264,7 @@ impl EcmascriptInputTransform {
                     ..Default::default()
                 };
 
-                program.mutate((decorators(config), inject_helpers(unresolved_mark)));
+                program.mutate(decorators(config));
             }
             EcmascriptInputTransform::Plugin(transform) => {
                 transform.await?.transform(program, ctx).await?

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js
@@ -5,7 +5,6 @@
 
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js [test] (ecmascript)");
 ;
-;
 var Foo = function Foo() {
     "use strict";
     (0, __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$swc$2f$helpers$2f$_$2f$_class_call_check$2e$js__$5b$test$5d$__$28$ecmascript$29$__["_"])(this, Foo);

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map
@@ -2,6 +2,6 @@
   "version": 3,
   "sources": [],
   "sections": [
-    {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
-    {"offset": {"line": 18, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
+    {"offset": {"line": 5, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js"],"sourcesContent":["class Foo {}\n\nconsole.log(Foo, [].includes('foo'))\n"],"names":[],"mappings":";;AAAA,IAAA,AAAM,MAAN,SAAM;;2OAAA;;AAEN,QAAQ,GAAG,CAAC,KAAK,EAAE,CAAC,QAAQ,CAAC"}},
+    {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js"],"sourcesContent":["\"purposefully empty stub\";\n\"@swc/helpers/_/_class_call_check.js\";\n"],"names":[],"mappings":"AAAA;AACA","ignoreList":[0]}}]
 }


### PR DESCRIPTION
### What?

Remove `inject_helpers` passes from `apply_transforms`

### Why?

We run `inject_helpers` from `fn parse` anyway, so we don't need to run it from `apply_transforms`.


Closes PACK-4871