### PR TITLE
unused dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,7 +353,6 @@ erased-serde = "0.4.5"
 futures = "0.3.26"
 futures-retry = "0.6.0"
 hashbrown = "0.14.5"
-httpmock = { version = "0.6.8", default-features = false }
 image = { version = "0.25.0", default-features = false }
 indexmap = "2.7.1"
 indoc = "2.0.0"


### PR DESCRIPTION
It looks like the crate was unintentionally left behind in [#80341](https://github.com/vercel/next.js/pull/80341).
