### PR TITLE
[build] remove obsolete module field alias for barrel optimized pkg

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -771,7 +771,6 @@ export default async function getBaseWebpackConfig(
       distDir,
       isClient,
       isEdgeServer,
-      isNodeServer,
       dev,
       config,
       pagesDir,


### PR DESCRIPTION
### Issue

In the below `uploadthing` package use case with Next.js, it encountered that having two different `effect` packages lead to version mismatch error from `effect` package itself:
```
Cannot execute an Effect versioned 3.16.8 with a Runtime of version 3.14.21
```

x-ref: https://github.com/juliusmarminge/effect-multiversion-cache-issue/pull/2

### Root Cause

In installed version of `uploadthing` package there's a import of `@effect/platform` where it uses the named imports that will be barrel optimized, the 1st line of the below code:
```tsx
import { FetchHttpClient, Headers } from '@effect/platform';
import * as FiberRef from 'effect/FiberRef';
import * as Layer from 'effect/Layer';
import * as ManagedRuntime from 'effect/ManagedRuntime';
```

Which is resulted in imports of different versions in the bundle
```js
/* harmony import */ var _effect_platform__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @effect/platform */ "(rsc)/./node_modules/.pnpm/@effect+platform@0.85.2_effect@3.16.8/node_modules/@effect/platform/dist/esm/Headers.js"); // 3.16

/* harmony import */ var effect_FiberRef__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! effect/FiberRef */ "(rsc)/./node_modules/.pnpm/effect@3.14.21/node_modules/effect/dist/esm/FiberRef.js"); // 3.14
```

Since `@effect/platform` is one of the package that will be barrel optimizated, there's also a package alias that always resolving those optiomizing packages to the installed version [here](https://github.com/vercel/next.js/blob/92561090bae1c8c865053dc9e8d7342a8fb7fc92/packages/next/src/build/create-compiler-aliases.ts#L162-L166). 

* ❌ The alias was the root cause the issue for `@effect/platform` that alias the depdency to the mismatched version since it's always alising to the user-land installed package rather than the actual path of dependency. 
* ✅ The rest imports are module subpath imports, which won't be applied with barrel-optimization nor the alias, so they'll refer to the correct dependency.

The alias was introduced at the very beginning when we're still bundling the CJS for SSR layer in App Router, mapping from `main` to `module` will help `lucide-react` use the ESM version that can be properly tree-shaken with barrel-optmization. But it's not the case anymore since Next.js 14.x as we prefer to bundle the ESM version for SSR. Then this alias became obsolete and also causing the problem of version mismatching.

Glad it's not the case for uploadthing packages anymore, they've addressed that in new versions. We still need to change this behavior to avoid simialr cases happend with Next.js in the future.

Thanks to @fubhy pointed out [here](https://github.com/vercel/next.js/pull/80765#issuecomment-2994156669).

### Fix

Remove the alias for mapping `main` field to `module` field of packages for barrel optimization.