### PR TITLE
[devtools] add correct scrollbar to dialog body

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -143,7 +143,7 @@ export function DevToolsPanel({
                   </div>
                 </div>
               </DialogHeader>
-              <DialogBody>
+              <DialogBody data-nextjs-devtools-panel-dialog-body>
                 <DevToolsPanelTab
                   activeTab={activeTab}
                   devToolsPosition={state.devToolsPosition}
@@ -167,9 +167,49 @@ export function DevToolsPanel({
 }
 
 export const DEVTOOLS_PANEL_STYLES = css`
+  [data-nextjs-devtools-panel-dialog-body] {
+    overflow-y: auto;
+  }
+
+  [data-nextjs-devtools-panel-dialog-body],
+  [data-nextjs-devtools-panel-dialog-body] * {
+    &::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+      border-radius: 0 0 1rem 1rem;
+      margin-bottom: 1rem;
+    }
+
+    &::-webkit-scrollbar-button {
+      display: none;
+    }
+
+    &::-webkit-scrollbar-track {
+      border-radius: 0 0 1rem 1rem;
+      background-color: var(--color-background-100);
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 1rem;
+      background-color: var(--color-gray-500);
+    }
+  }
+
   /* TODO: Better override dialog header style. This conflicts with issues tab content. */
   [data-nextjs-devtools-panel-dialog-header] {
     margin-bottom: 0 !important;
+  }
+
+  /* Make DialogContent expand to push footer to bottom */
+  [data-nextjs-devtools-panel-dialog] [data-nextjs-dialog-content] {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  /* Make DialogBody a flex container so its children can expand */
+  [data-nextjs-devtools-panel-dialog] [data-nextjs-dialog-body] {
+    display: flex;
+    flex-direction: column;
   }
 
   [data-nextjs-devtools-panel-overlay] {
@@ -218,7 +258,6 @@ export const DEVTOOLS_PANEL_STYLES = css`
     border-radius: var(--rounded-xl);
     box-shadow: var(--shadow-lg);
     position: relative;
-    overflow-y: auto;
     width: 100%;
     max-height: 50vh;
     min-height: 450px;

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -167,49 +167,20 @@ export function DevToolsPanel({
 }
 
 export const DEVTOOLS_PANEL_STYLES = css`
-  [data-nextjs-devtools-panel-dialog-body] {
-    overflow-y: auto;
-  }
-
-  [data-nextjs-devtools-panel-dialog-body],
-  [data-nextjs-devtools-panel-dialog-body] * {
-    &::-webkit-scrollbar {
-      width: 6px;
-      height: 6px;
-      border-radius: 0 0 1rem 1rem;
-      margin-bottom: 1rem;
-    }
-
-    &::-webkit-scrollbar-button {
-      display: none;
-    }
-
-    &::-webkit-scrollbar-track {
-      border-radius: 0 0 1rem 1rem;
-      background-color: var(--color-background-100);
-    }
-
-    &::-webkit-scrollbar-thumb {
-      border-radius: 1rem;
-      background-color: var(--color-gray-500);
-    }
-  }
-
   /* TODO: Better override dialog header style. This conflicts with issues tab content. */
   [data-nextjs-devtools-panel-dialog-header] {
     margin-bottom: 0 !important;
   }
 
-  /* Make DialogContent expand to push footer to bottom */
   [data-nextjs-devtools-panel-dialog] [data-nextjs-dialog-content] {
+    /* Make DialogContent expand to push footer to bottom. */
     flex: 1;
+    /* Hide overflow of devtools panel dialog since we want it on the dialog body only. */
     overflow: hidden;
   }
 
-  /* Make DialogBody a flex container so its children can expand */
-  [data-nextjs-devtools-panel-dialog] [data-nextjs-dialog-body] {
-    display: flex;
-    flex-direction: column;
+  [data-nextjs-devtools-panel-dialog-body] {
+    overflow: auto;
   }
 
   [data-nextjs-devtools-panel-overlay] {

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -97,7 +97,7 @@ export function DevToolsPanel({
             aria-describedby="nextjs__container_dev_tools_panel_desc"
             onClose={onCloseDevToolsPanel}
           >
-            <DialogContent>
+            <DialogContent data-nextjs-devtools-panel-dialog-content>
               <DialogHeader data-nextjs-devtools-panel-dialog-header>
                 <div data-nextjs-devtools-panel-header>
                   <div data-nextjs-devtools-panel-header-tab-group>
@@ -172,7 +172,7 @@ export const DEVTOOLS_PANEL_STYLES = css`
     margin-bottom: 0 !important;
   }
 
-  [data-nextjs-devtools-panel-dialog] [data-nextjs-dialog-content] {
+  [data-nextjs-devtools-panel-dialog-content] {
     /* Make DialogContent expand to push footer to bottom. */
     flex: 1;
     /* Hide overflow of devtools panel dialog since we want it on the dialog body only. */
@@ -181,6 +181,9 @@ export const DEVTOOLS_PANEL_STYLES = css`
 
   [data-nextjs-devtools-panel-dialog-body] {
     overflow: auto;
+    /* Make DialogBody a flex container so its children can expand. */
+    display: flex;
+    flex-direction: column;
   }
 
   [data-nextjs-devtools-panel-overlay] {

--- a/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog-body.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog-body.tsx
@@ -3,14 +3,15 @@ import * as React from 'react'
 export type DialogBodyProps = {
   children?: React.ReactNode
   className?: string
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 const DialogBody: React.FC<DialogBodyProps> = function DialogBody({
   children,
   className,
+  ...props
 }) {
   return (
-    <div data-nextjs-dialog-body className={className}>
+    <div data-nextjs-dialog-body className={className} {...props}>
       {children}
     </div>
   )

--- a/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog-content.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog-content.tsx
@@ -3,14 +3,15 @@ import * as React from 'react'
 export type DialogContentProps = {
   children?: React.ReactNode
   className?: string
-}
+} & React.HTMLAttributes<HTMLDivElement>
 
 const DialogContent: React.FC<DialogContentProps> = function DialogContent({
   children,
   className,
+  ...props
 }) {
   return (
-    <div data-nextjs-dialog-content className={className}>
+    <div data-nextjs-dialog-content className={className} {...props}>
       {children}
     </div>
   )


### PR DESCRIPTION
Since the scrollbar is applied to the whole dialog by default, the header and the footer, which are children of the dialog, were also included in the overflow. Therefore, this PR ensures that the DevTools panel's dialog only targets the dialog body to have the overflow.

### Before

https://github.com/user-attachments/assets/82722635-6f8c-4608-9b73-9e60090dbbfe

### After

https://github.com/user-attachments/assets/0fb4e9a2-bac6-493b-96bf-fec796a15455