### PR TITLE
Turbopack: use correct mark for swc

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -244,7 +244,7 @@ impl EcmascriptInputTransform {
                     program,
                     helpers,
                     preset_env::transform_from_env::<&'_ dyn Comments>(
-                        top_level_mark,
+                        unresolved_mark,
                         Some(&comments),
                         config,
                         Assumptions::default(),


### PR DESCRIPTION
Not sure how this happened


<img width="756" alt="Bildschirmfoto 2025-06-23 um 10 50 52" src="https://github.com/user-attachments/assets/63a0f991-f115-43b6-a179-b2a6ef96ba3c" />


Closes PACK-4876