### PR TITLE
[devtools] proper draggable for header and footer only

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
@@ -55,11 +55,9 @@ export const DEVTOOLS_PANEL_FOOTER_STYLES = css`
     /* For draggable */
     cursor: move;
     user-select: none;
-
-    /* Reset for children */
-    & * {
+    & > * {
       cursor: auto;
-      /* user-select: auto; seems to not restore properly */
+      /* user-select: auto; follows the parent (parent none -> child none), so reset the direct child to text */
       user-select: text;
     }
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
@@ -51,6 +51,17 @@ export const DEVTOOLS_PANEL_FOOTER_STYLES = css`
     align-items: center;
     border-top: 1px solid var(--color-gray-400);
     border-radius: 0 0 var(--rounded-xl) var(--rounded-xl);
+
+    /* For draggable */
+    cursor: move;
+    user-select: none;
+
+    /* Reset for children */
+    & * {
+      cursor: auto;
+      /* user-select: auto; seems to not restore properly */
+      user-select: text;
+    }
   }
 
   [data-nextjs-devtools-panel-footer-tab-group] {

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -324,7 +324,7 @@ export const DEVTOOLS_PANEL_STYLES = css`
   [data-nextjs-devtools-panel-header-action-button] {
     background: transparent;
     border: none;
-    cursor: pointer !important;
+    cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -97,6 +97,7 @@ export function DevToolsPanel({
             devToolsPosition: p,
           })
         }}
+        dragHandleSelector="[data-nextjs-devtools-panel-header], [data-nextjs-devtools-panel-footer]"
       >
         <>
           <Dialog
@@ -257,6 +258,16 @@ export const DEVTOOLS_PANEL_STYLES = css`
     justify-content: space-between;
     align-items: center;
     border-bottom: 1px solid var(--color-gray-400);
+
+    /* For draggable */
+    cursor: move;
+    user-select: none;
+    /* Reset for children */
+    & * {
+      cursor: auto;
+      /* user-select: auto; seems to not restore properly */
+      user-select: text;
+    }
   }
 
   [data-nextjs-devtools-panel-header-tab-group] {
@@ -314,7 +325,7 @@ export const DEVTOOLS_PANEL_STYLES = css`
   [data-nextjs-devtools-panel-header-action-button] {
     background: transparent;
     border: none;
-    cursor: pointer;
+    cursor: pointer !important;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -262,10 +262,9 @@ export const DEVTOOLS_PANEL_STYLES = css`
     /* For draggable */
     cursor: move;
     user-select: none;
-    /* Reset for children */
-    & * {
+    & > * {
       cursor: auto;
-      /* user-select: auto; seems to not restore properly */
+      /* user-select: auto; follows the parent (parent none -> child none), so reset the direct child to text */
       user-select: text;
     }
   }


### PR DESCRIPTION
Previously, the entire dialog was draggable, which conflicted with the default user select. Therefore, only the header and the footer were specified to be draggable, which does not include the children, e.g., a button inside the header.

### Before

https://github.com/user-attachments/assets/c5867462-5cdd-486e-b84c-e6bbd47a4c34

### After

https://github.com/user-attachments/assets/4906898a-5442-4526-b0ce-e31ac86c1322

Closes NEXT-4547