### PR TITLE
fix: Use standard PostCSS configuration in create-next-app

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/postcss.config.mjs
+++ b/packages/create-next-app/templates/app-tw/js/postcss.config.mjs
@@ -1,5 +1,7 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };
 
 export default config;

--- a/packages/create-next-app/templates/app-tw/ts/postcss.config.mjs
+++ b/packages/create-next-app/templates/app-tw/ts/postcss.config.mjs
@@ -1,5 +1,7 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };
 
 export default config;


### PR DESCRIPTION
> [!NOTE]
> **Why closed?** I got a bit enthusiastic when submitting the PR by [SO question](https://stackoverflow.com/a/79676077/15167500). Later I found out there's a similar open PR from the end of May, but it still hasn't been reviewed. See: https://github.com/vercel/next.js/pull/79949

<br>

Fix remaining PostCSS config issues (follow-up to #77376).

> ### What?
> Changed the PostCSS plugin format in create-next-app templates from string array syntax to object syntax.

> ### Why?
> The array string format for PostCSS plugins is non-standard, and gives errors when loading using [postcss-load-config](https://github.com/postcss/postcss-load-config?rgh-link-date=2025-03-21T12%3A04%3A28Z):
> ```
> TypeError: Invalid PostCSS Plugin found at: plugins[0]
> ```
>
> This change ensures that Next.js applications using Tailwind CSS can seamlessly integrate with these tools without requiring manual configuration fixes. For example, vitest will crash, which uses postcss-load-config under the hood:
> https://github.com/storybookjs/storybook/issues/30878


> ### How?
> Modified the PostCSS configuration in both JavaScript and TypeScript empty app templates with Tailwind to use the object-based plugin format, which is the standard format recognized by PostCSS tools in the ecosystem.
> 
> Array syntax:
> ```js
> const config = {
>   plugins: ["@tailwindcss/postcss"],
> };
> 
> export default config;
> ```
>
> Object syntax
> ```js
>  const config = {
>   plugins: {
>     "@tailwindcss/postcss": {},
>   },
> };
> ```