### PR TITLE
[test] separate hmr env test

### DIFF
--- a/test/development/app-hmr/hmr-env.test.ts
+++ b/test/development/app-hmr/hmr-env.test.ts
@@ -1,0 +1,56 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import path from 'path'
+
+const envFile = '.env.development.local'
+
+describe(`app-dir hmr-env`, () => {
+  const { next } = nextTestSetup({
+    files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+    patchFileDelay: 1000,
+  })
+
+  it.each(['node', 'node-module-var', 'edge', 'edge-module-var'])(
+    'should update server components pages when env files is changed (%s)',
+    async (page) => {
+      const browser = await next.browser(`/env/${page}`)
+      expect(await browser.elementByCss('p').text()).toBe('mac')
+
+      await next.patchFile(envFile, 'MY_DEVICE="ipad"', async () => {
+        let logs
+
+        await retry(async () => {
+          logs = await browser.log()
+          expect(logs).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                message: expect.stringContaining('[Fast Refresh] done'),
+                source: 'log',
+              }),
+            ])
+          )
+        })
+
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toBe('ipad')
+        })
+
+        expect(logs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.stringContaining('[Fast Refresh] done in'),
+              source: 'log',
+            }),
+          ])
+        )
+      })
+
+      // ensure it's restored back to "mac" before the next test
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe('mac')
+      })
+
+      expect(next.cliOutput).not.toContain('FATAL')
+    }
+  )
+})

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -107,50 +107,6 @@ describe(`app-dir-hmr`, () => {
       expect(next.cliOutput).not.toContain('FATAL')
     })
 
-    it.each(['node', 'node-module-var', 'edge', 'edge-module-var'])(
-      'should update server components pages when env files is changed (%s)',
-      async (page) => {
-        const browser = await next.browser(`/env/${page}`)
-        expect(await browser.elementByCss('p').text()).toBe('mac')
-
-        await next.patchFile(envFile, 'MY_DEVICE="ipad"', async () => {
-          let logs
-
-          await retry(async () => {
-            logs = await browser.log()
-            expect(logs).toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({
-                  message: expect.stringContaining('[Fast Refresh] done'),
-                  source: 'log',
-                }),
-              ])
-            )
-          })
-
-          await retry(async () => {
-            expect(await browser.elementByCss('p').text()).toBe('ipad')
-          })
-
-          expect(logs).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                message: expect.stringContaining('[Fast Refresh] done in'),
-                source: 'log',
-              }),
-            ])
-          )
-        })
-
-        // ensure it's restored back to "mac" before the next test
-        await retry(async () => {
-          expect(await browser.elementByCss('p').text()).toBe('mac')
-        })
-
-        expect(next.cliOutput).not.toContain('FATAL')
-      }
-    )
-
     it('should have no unexpected action error for hmr', async () => {
       expect(next.cliOutput).not.toContain('Unexpected action')
     })


### PR DESCRIPTION
Separating the flaky test into a new test which avoid conflicting with the other operations. If this fail again then we can investigate this test individually to see where is broken.

```
pnpm test-dev test/development/app-hmr/hmr.test.ts
  app-dir-hmr > filesystem changes > should update server components pages when env files is changed (node)
```

Noticed there's an error occurred during the run, but not sure where the JSON error is from, hence want to separate this case first.

x-ref: https://github.com/vercel/next.js/actions/runs/15851004173/job/44684284583?pr=80848