### PR TITLE
[devtools] segment explorer tab

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -107,6 +107,10 @@ export function getDefineEnv({
   const isDynamicIOEnabled = !!config.experimental.dynamicIO
   const isUseCacheEnabled = !!config.experimental.useCache
 
+  const isDevToolPanelUIEnabled =
+    !!process.env.__NEXT_DEVTOOL_NEW_PANEL_UI ||
+    !!config.experimental.devtoolNewPanelUI
+
   const defineEnv: DefineEnv = {
     // internal field to identify the plugin config
     __NEXT_DEFINE_ENV: true,
@@ -297,9 +301,9 @@ export function getDefineEnv({
         }
       : {}),
     'process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER':
-      config.experimental.devtoolSegmentExplorer ?? false,
-    'process.env.__NEXT_DEVTOOL_NEW_PANEL_UI':
-      config.experimental.devtoolNewPanelUI ?? false,
+      // Enable segment explorer in devtools
+      isDevToolPanelUIEnabled || !!config.experimental.devtoolSegmentExplorer,
+    'process.env.__NEXT_DEVTOOL_NEW_PANEL_UI': isDevToolPanelUIEnabled,
 
     // The devtools need to know whether or not to show an option to clear the
     // bundler cache. This option may be removed later once Turbopack's

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx
@@ -6,11 +6,13 @@ import type { HydrationErrorState } from '../../../../shared/hydration-error'
 
 import { SettingsTab } from './settings-tab'
 import { IssuesTab } from './issues-tab/issues-tab'
+import { SegmentsExplorerTab } from './segments-explorer-tab'
 
 export function DevToolsPanelTab({
   activeTab,
   devToolsPosition,
   scale,
+  routerType,
   handlePositionChange,
   handleScaleChange,
   debugInfo,
@@ -20,6 +22,7 @@ export function DevToolsPanelTab({
 }: {
   activeTab: DevToolsPanelTabType
   devToolsPosition: Corners
+  routerType: 'app' | 'pages'
   scale: number
   handlePositionChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
   handleScaleChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
@@ -39,7 +42,7 @@ export function DevToolsPanelTab({
         />
       )
     case 'route':
-      return <div>Route</div>
+      return <SegmentsExplorerTab routerType={routerType} />
     case 'issues':
       return (
         <IssuesTab

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
@@ -1,0 +1,30 @@
+import { useSegmentTree } from '../../../segment-explorer'
+import { PageSegmentTree } from '../../overview/segment-explorer'
+
+function SegmentsExplorer({
+  routerType,
+}: React.HTMLProps<HTMLDivElement> & {
+  routerType: 'app' | 'pages'
+}) {
+  const tree = useSegmentTree()
+  const isAppRouter = routerType === 'app'
+  return <PageSegmentTree tree={tree} isAppRouter={isAppRouter} />
+}
+
+export function SegmentsExplorerTab({
+  routerType,
+}: {
+  routerType: 'app' | 'pages'
+}) {
+  return (
+    <div data-nextjs-devtools-panel-segments-explorer>
+      <SegmentsExplorer routerType={routerType} />
+    </div>
+  )
+}
+
+export const SEGMENTS_EXPLORER_TAB_STYLES = `
+  [data-nextjs-devtools-panel-segments-explorer] {
+    padding: 0 8px;
+  }
+`

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -163,6 +163,7 @@ export function DevToolsPanel({
                   activeTab={activeTab}
                   devToolsPosition={state.devToolsPosition}
                   scale={state.scale}
+                  routerType={state.routerType}
                   handlePositionChange={handlePositionChange}
                   handleScaleChange={handleScaleChange}
                   debugInfo={state.debugInfo}

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -9,7 +9,7 @@ const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
 }
 
-function PageSegmentTree({
+export function PageSegmentTree({
   tree,
   isAppRouter,
 }: {

--- a/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
@@ -35,6 +35,7 @@ import { DEVTOOLS_PANEL_TAB_ISSUES_SIDEBAR_FRAME_SKELETON_STYLES } from '../comp
 import { DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_STYLES } from '../components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content'
 import { ISSUE_FEEDBACK_BUTTON_STYLES } from '../components/errors/error-overlay-toolbar/issue-feedback-button'
 import { ERROR_CONTENT_SKELETON_STYLES } from '../container/runtime-error/error-content-skeleton'
+import { SEGMENTS_EXPLORER_TAB_STYLES } from '../components/devtools-panel/devtools-panel-tab/segments-explorer-tab'
 
 export function ComponentStyles() {
   return (
@@ -76,6 +77,7 @@ export function ComponentStyles() {
         ${DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_STYLES}
         ${ISSUE_FEEDBACK_BUTTON_STYLES}
         ${ERROR_CONTENT_SKELETON_STYLES}
+        ${SEGMENTS_EXPLORER_TAB_STYLES}
       `}
     </style>
   )


### PR DESCRIPTION
### What

- Integrate segment explorer into route info panel of dev tool
- Always enable segment explorer flag when new panel flag is enabled
- Introduce a env flag that we can use it for local development `process.env.__NEXT_DEVTOOL_NEW_PANEL_UI` which will enable the devtool panel UI

### Screenshot

<img width="600" alt="image" src="https://github.com/user-attachments/assets/086eb54a-3b25-4191-b9a0-9dae5bb4f7fd" />
