### PR TITLE
[turbopack] Delete `FunctionId`

### DIFF
--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -213,9 +213,7 @@ mod ser {
                 unreachable!();
             };
             let mut state = serializer.serialize_seq(Some(2))?;
-            // It would be a little tricky but we _could_ store the function id on the native_fn so
-            // that instead of a hashmap lookup this would be a memory access on the NativeFn
-            state.serialize_element(&registry::get_function_id(native_fn))?;
+            state.serialize_element(&registry::get_function_global_name(native_fn))?;
             let arg = *arg;
             let arg = native_fn.arg_meta.as_serialize(arg);
             state.serialize_element(arg)?;
@@ -237,10 +235,10 @@ mod ser {
                 where
                     A: serde::de::SeqAccess<'de>,
                 {
-                    let fn_id = seq
+                    let fn_name = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
-                    let native_fn = registry::get_function(fn_id);
+                    let native_fn = registry::get_function_by_global_name(fn_name);
                     let seed = native_fn.arg_meta.deserialization_seed();
                     let arg = seq
                         .next_element_seed(seed)?

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -113,7 +113,6 @@ macro_rules! define_id {
 }
 
 define_id!(TaskId: u32, derive(Serialize, Deserialize), serde(transparent));
-define_id!(FunctionId: u32);
 define_id!(ValueTypeId: u32);
 define_id!(TraitTypeId: u32);
 define_id!(BackendJobId: u32);
@@ -202,12 +201,6 @@ macro_rules! make_serializable {
     };
 }
 
-make_serializable!(
-    FunctionId,
-    registry::get_function_global_name,
-    registry::get_function_id_by_global_name,
-    FunctionIdVisitor
-);
 make_serializable!(
     ValueTypeId,
     registry::get_value_type_global_name,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -94,8 +94,7 @@ pub use completion::{Completion, Completions};
 pub use display::ValueToString;
 pub use effect::{ApplyEffectsContext, Effects, apply_effects, effect, get_effects};
 pub use id::{
-    ExecutionId, FunctionId, LocalTaskId, SessionId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId,
-    ValueTypeId,
+    ExecutionId, LocalTaskId, SessionId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId,
 };
 pub use invalidation::{
     DynamicEqHash, InvalidationReason, InvalidationReasonKind, InvalidationReasonSet, Invalidator,

--- a/turbopack/crates/turbo-tasks/src/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks/src/task_statistics.rs
@@ -73,7 +73,7 @@ impl Serialize for TaskStatistics {
     {
         let mut map = serializer.serialize_map(Some(self.inner.len()))?;
         for entry in &self.inner {
-            let key = registry::get_function_global_name(registry::get_function_id(entry.key()));
+            let key = registry::get_function_global_name(entry.key());
             map.serialize_entry(key, entry.value())?;
         }
         map.end()


### PR DESCRIPTION
## Delete the `FunctionId` type

This is only used to map to/from global names,  we can just do that directly and remove some indirection.

This is a tiny cleanup following https://github.com/vercel/next.js/pull/80695 which made functionids irrelevant to most  of the runtime.

Closes PACK-4886