### PR TITLE
Perf: Use canonicalUrl from prefetch for dynamic RSC requests

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -190,10 +190,13 @@ function navigateUsingPrefetchedRouteTree(
   if (task !== null) {
     const dynamicRequestTree = task.dynamicRequestTree
     if (dynamicRequestTree !== null) {
-      const promiseForDynamicServerResponse = fetchServerResponse(url, {
-        flightRouterState: dynamicRequestTree,
-        nextUrl,
-      })
+      const promiseForDynamicServerResponse = fetchServerResponse(
+        new URL(canonicalUrl, url.origin),
+        {
+          flightRouterState: dynamicRequestTree,
+          nextUrl,
+        }
+      )
       listenForDynamicRequest(task, promiseForDynamicServerResponse)
     } else {
       // The prefetched tree does not contain dynamic holes — it's

--- a/test/e2e/app-dir/rsc-redirect/app/about/page.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/about/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function Page() {
+  return <div id="about-page">About Page</div>
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/rsc-redirect/app/old-about/page.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/old-about/page.tsx
@@ -1,0 +1,8 @@
+export default function OldAbout() {
+  return (
+    <div>
+      Old About - you should not see this page because middleware should
+      redirect you to /about
+    </div>
+  )
+}

--- a/test/e2e/app-dir/rsc-redirect/app/page.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/page.tsx
@@ -5,7 +5,7 @@ export default function Page() {
   return (
     <div>
       <h1>Home</h1>
-      <Link href="/origin">Go to Origin</Link>
+      <Link href="/old-about">Go to (Old) About Page</Link>
     </div>
   )
 }

--- a/test/e2e/app-dir/rsc-redirect/middleware.ts
+++ b/test/e2e/app-dir/rsc-redirect/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  console.log('middleware called')
+  if (request.nextUrl.pathname === '/old-about') {
+    const url = request.nextUrl.clone()
+    url.pathname = '/about'
+    console.log('redirecting to', url.pathname)
+    return NextResponse.redirect(url)
+  }
+  return NextResponse.next()
+}

--- a/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
+++ b/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
@@ -1,6 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
+import fs from 'fs'
+import path from 'path'
+
+const configPath = path.join(__dirname, 'next.config.js')
 
 describe('rsc-redirect', () => {
   const { next } = nextTestSetup({
@@ -29,3 +33,50 @@ describe('rsc-redirect', () => {
     expect(response.status).toBe(200)
   })
 })
+
+if (process.env.NODE_ENV === 'production') {
+  describe.each([
+    { ppr: true, segmentCache: true },
+    { ppr: true, segmentCache: false },
+    { ppr: false, segmentCache: true },
+    { ppr: false, segmentCache: false },
+  ] as const)(
+    'rsc-redirect /old-about -> /about (ppr: $ppr, segmentCache: $segmentCache)',
+    ({ ppr, segmentCache }) => {
+      beforeAll(() => {
+        // Write next.config.js with the current flags
+        fs.writeFileSync(
+          configPath,
+          `module.exports = { experimental: { ppr: ${ppr}, clientSegmentCache: ${segmentCache} } }\n`
+        )
+      })
+
+      afterAll(() => {
+        // Clean up config file
+        if (fs.existsSync(configPath)) fs.unlinkSync(configPath)
+      })
+
+      const { next } = nextTestSetup({
+        files: __dirname,
+      })
+
+      it('uses prefetched, redirected URL in the navigation, as opposed to the href in the link', async () => {
+        const networkStatuses: number[] = []
+        const browser = await next.browser('/', {
+          beforePageLoad: (page) => {
+            page.on('response', (response) => {
+              networkStatuses.push(response.status())
+            })
+          },
+        })
+        await browser.waitForIdleNetwork()
+        // Clear network statuses before clicking to only capture responses from the click
+        networkStatuses.length = 0
+        await browser.elementByCss('a[href="/old-about"]').click()
+        await browser.waitForElementByCss('#about-page')
+        expect(networkStatuses).toContain(200)
+        expect(networkStatuses).not.toContain(307)
+      })
+    }
+  )
+}


### PR DESCRIPTION
If a prefetch request hits a 307, the browser follows the redirect, and you’ll know the final URL after that. Then, during actual navigation, dynamic data should be fetched from the redirected URL rather than the original one specified in the link.