### PR TITLE
Add htmlrewriter to default server externals

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
@@ -50,6 +50,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `eslint`
 - `express`
 - `firebase-admin`
+- `htmlrewriter`
 - `import-in-the-middle`
 - `isolated-vm`
 - `jest`

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
@@ -50,6 +50,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `eslint`
 - `express`
 - `firebase-admin`
+- `htmlrewriter`
 - `import-in-the-middle`
 - `isolated-vm`
 - `jest`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -31,6 +31,7 @@
   "eslint",
   "express",
   "firebase-admin",
+  "htmlrewriter",
   "import-in-the-middle",
   "isolated-vm",
   "jest",


### PR DESCRIPTION
This package needs to be externalized to have it's wasm dependencies traced properly for node runtime so this adds it to our default list. 

x-ref: [slack thread](https://vercel.slack.com/archives/C07LQPFERGF/p1750713377659779?thread_ts=1750693981.162239&cid=C07LQPFERGF)