### PR TITLE
refactor(turbo-tasks-backend): Remove `ExecuteContextImpl::lower_read_transaction`

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -41,9 +41,6 @@ pub trait BackingStorage: BackingStorageSealed {
 /// [`BackingStorage::invalidate`] method.
 pub trait BackingStorageSealed: 'static + Send + Sync {
     type ReadTransaction<'l>;
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i>;
     fn next_free_task_id(&self) -> Result<TaskId>;
     fn next_session_id(&self) -> Result<SessionId>;
     fn uncompleted_operations(&self) -> Result<Vec<AnyOperation>>;

--- a/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/fresh_db_optimization.rs
@@ -37,12 +37,6 @@ impl<T: KeyValueDatabase> KeyValueDatabase for FreshDbOptimization<T> {
     where
         Self: 'l;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i> {
-        T::lower_read_transaction(tx)
-    }
-
     fn is_empty(&self) -> bool {
         self.fresh_db.load(Ordering::Acquire) || self.database.is_empty()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -18,10 +18,6 @@ pub trait KeyValueDatabase {
     where
         Self: 'l;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i>;
-
     fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>>;
 
     fn is_empty(&self) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/lmdb/mod.rs
@@ -75,12 +75,6 @@ impl KeyValueDatabase for LmbdKeyValueDatabase {
     where
         Self: 'l;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i> {
-        tx
-    }
-
     fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>> {
         Ok(self.env.begin_ro_txn()?)
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/noop_kv.rs
@@ -15,12 +15,6 @@ impl KeyValueDatabase for NoopKvDb {
     where
         Self: 'l;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i> {
-        tx
-    }
-
     fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>> {
         Ok(())
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/read_transaction_cache.rs
@@ -53,14 +53,6 @@ impl<T: KeyValueDatabase + 'static> KeyValueDatabase for ReadTransactionCache<T>
     where
         T: 'l;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i> {
-        // Safety: When T compiles fine and lower_read_transaction is implemented correctly this is
-        // safe to do.
-        unsafe { transmute::<&'r Self::ReadTransaction<'l>, &'r Self::ReadTransaction<'i>>(tx) }
-    }
-
     fn is_empty(&self) -> bool {
         self.database.is_empty()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -105,12 +105,6 @@ impl<T: KeyValueDatabase> KeyValueDatabase for StartupCacheLayer<T> {
     where
         Self: 'l;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i> {
-        T::lower_read_transaction(tx)
-    }
-
     fn is_empty(&self) -> bool {
         self.database.is_empty()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -60,12 +60,6 @@ impl KeyValueDatabase for TurboKeyValueDatabase {
     where
         Self: 'l;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i> {
-        tx
-    }
-
     fn is_empty(&self) -> bool {
         self.db.is_empty()
     }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -262,12 +262,6 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
 {
     type ReadTransaction<'l> = T::ReadTransaction<'l>;
 
-    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
-        tx: &'r Self::ReadTransaction<'l>,
-    ) -> &'r Self::ReadTransaction<'i> {
-        T::lower_read_transaction(tx)
-    }
-
     fn next_free_task_id(&self) -> Result<TaskId> {
         Ok(TaskId::try_from(
             self.inner


### PR DESCRIPTION
Following the removal of the other `transaction` and `lower_read_transaction` callsites in #80816...

If `ExecuteContextImpl::transaction` is inlined into `ExecuteContextImpl::restore_task_data` (the only remaining callsite), we no longer need `lower_read_transaction` and its crimes against Rust lifetimes.

Sanity checked with:

```
cargo check --features turbo-tasks-backend/lmdb
```

Closes PACK-4974