### PR TITLE
refactor(turbopack): Implement `BackingStorage` for `Either`, replace `NextTurboTasks` with a type alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,6 +4406,7 @@ dependencies = [
  "anyhow",
  "console-subscriber",
  "dhat",
+ "either",
  "getrandom 0.2.15",
  "iana-time-zone",
  "lightningcss-napi",

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -57,6 +57,7 @@ ignored = [
 anyhow = "1.0.66"
 console-subscriber = { workspace = true, optional = true }
 dhat = { workspace = true, optional = true }
+either = { workspace = true }
 owo-colors = { workspace = true }
 napi = { workspace = true }
 napi-derive = "2"

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -894,8 +894,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let process = |task_id: TaskId, (meta, data): (Option<Vec<_>>, Option<Vec<_>>)| {
             (
                 task_id,
-                meta.map(|d| B::serialize(task_id, &d)),
-                data.map(|d| B::serialize(task_id, &d)),
+                meta.map(|d| self.backing_storage.serialize(task_id, &d)),
+                data.map(|d| self.backing_storage.serialize(task_id, &d)),
             )
         };
         let process_snapshot = |task_id: TaskId, inner: Box<InnerStorageSnapshot>| {
@@ -924,8 +924,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             }
             (
                 task_id,
-                meta.map(|meta| B::serialize(task_id, &meta)),
-                data.map(|data| B::serialize(task_id, &data)),
+                meta.map(|meta| self.backing_storage.serialize(task_id, &meta)),
+                data.map(|data| self.backing_storage.serialize(task_id, &data)),
             )
         };
 

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
+use std::{any::type_name, sync::Arc};
 
 use anyhow::Result;
+use either::Either;
 use smallvec::SmallVec;
 use turbo_tasks::{SessionId, TaskId, backend::CachedTaskType};
 
@@ -45,7 +46,7 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
     fn next_session_id(&self) -> Result<SessionId>;
     fn uncompleted_operations(&self) -> Result<Vec<AnyOperation>>;
     #[allow(clippy::ptr_arg)]
-    fn serialize(task: TaskId, data: &Vec<CachedDataItem>) -> Result<SmallVec<[u8; 16]>>;
+    fn serialize(&self, task: TaskId, data: &Vec<CachedDataItem>) -> Result<SmallVec<[u8; 16]>>;
     fn save_snapshot<I>(
         &self,
         session_id: SessionId,
@@ -91,5 +92,149 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
 
     fn shutdown(&self) -> Result<()> {
         Ok(())
+    }
+}
+
+impl<L, R> BackingStorage for Either<L, R>
+where
+    L: BackingStorage,
+    R: BackingStorage,
+{
+    fn invalidate(&self, reason_code: &str) -> Result<()> {
+        either::for_both!(self, this => this.invalidate(reason_code))
+    }
+}
+
+impl<L, R> BackingStorageSealed for Either<L, R>
+where
+    L: BackingStorageSealed,
+    R: BackingStorageSealed,
+{
+    type ReadTransaction<'l> = Either<L::ReadTransaction<'l>, R::ReadTransaction<'l>>;
+
+    fn next_free_task_id(&self) -> Result<TaskId> {
+        either::for_both!(self, this => this.next_free_task_id())
+    }
+
+    fn next_session_id(&self) -> Result<SessionId> {
+        either::for_both!(self, this => this.next_session_id())
+    }
+
+    fn uncompleted_operations(&self) -> Result<Vec<AnyOperation>> {
+        either::for_both!(self, this => this.uncompleted_operations())
+    }
+
+    fn serialize(&self, task: TaskId, data: &Vec<CachedDataItem>) -> Result<SmallVec<[u8; 16]>> {
+        either::for_both!(self, this => this.serialize(task, data))
+    }
+
+    fn save_snapshot<I>(
+        &self,
+        session_id: SessionId,
+        operations: Vec<Arc<AnyOperation>>,
+        task_cache_updates: Vec<ChunkedVec<(Arc<CachedTaskType>, TaskId)>>,
+        snapshots: Vec<I>,
+    ) -> Result<()>
+    where
+        I: Iterator<
+                Item = (
+                    TaskId,
+                    Option<SmallVec<[u8; 16]>>,
+                    Option<SmallVec<[u8; 16]>>,
+                ),
+            > + Send
+            + Sync,
+    {
+        either::for_both!(self, this => this.save_snapshot(
+            session_id,
+            operations,
+            task_cache_updates,
+            snapshots,
+        ))
+    }
+
+    fn start_read_transaction(&self) -> Option<Self::ReadTransaction<'_>> {
+        Some(match self {
+            Either::Left(this) => Either::Left(this.start_read_transaction()?),
+            Either::Right(this) => Either::Right(this.start_read_transaction()?),
+        })
+    }
+
+    unsafe fn forward_lookup_task_cache(
+        &self,
+        tx: Option<&Self::ReadTransaction<'_>>,
+        key: &CachedTaskType,
+    ) -> Result<Option<TaskId>> {
+        match self {
+            Either::Left(this) => {
+                let tx = tx.map(|tx| read_transaction_left_or_panic(tx.as_ref()));
+                unsafe { this.forward_lookup_task_cache(tx, key) }
+            }
+            Either::Right(this) => {
+                let tx = tx.map(|tx| read_transaction_right_or_panic(tx.as_ref()));
+                unsafe { this.forward_lookup_task_cache(tx, key) }
+            }
+        }
+    }
+
+    unsafe fn reverse_lookup_task_cache(
+        &self,
+        tx: Option<&Self::ReadTransaction<'_>>,
+        task_id: TaskId,
+    ) -> Result<Option<Arc<CachedTaskType>>> {
+        match self {
+            Either::Left(this) => {
+                let tx = tx.map(|tx| read_transaction_left_or_panic(tx.as_ref()));
+                unsafe { this.reverse_lookup_task_cache(tx, task_id) }
+            }
+            Either::Right(this) => {
+                let tx = tx.map(|tx| read_transaction_right_or_panic(tx.as_ref()));
+                unsafe { this.reverse_lookup_task_cache(tx, task_id) }
+            }
+        }
+    }
+
+    unsafe fn lookup_data(
+        &self,
+        tx: Option<&Self::ReadTransaction<'_>>,
+        task_id: TaskId,
+        category: TaskDataCategory,
+    ) -> Result<Vec<CachedDataItem>> {
+        match self {
+            Either::Left(this) => {
+                let tx = tx.map(|tx| read_transaction_left_or_panic(tx.as_ref()));
+                unsafe { this.lookup_data(tx, task_id, category) }
+            }
+            Either::Right(this) => {
+                let tx = tx.map(|tx| read_transaction_right_or_panic(tx.as_ref()));
+                unsafe { this.lookup_data(tx, task_id, category) }
+            }
+        }
+    }
+}
+
+// similar to `Either::unwrap_left`, but does not require `R: Debug`.
+fn read_transaction_left_or_panic<L, R>(either: Either<L, R>) -> L {
+    match either {
+        Either::Left(l) => l,
+        Either::Right(_) => panic!(
+            "expected ReadTransaction of Either::Left containing {}, received Either::Right type \
+             of {}",
+            type_name::<L>(),
+            type_name::<R>(),
+        ),
+    }
+}
+
+// similar to `Either::unwrap_right`, but does not require `R: Debug`.
+fn read_transaction_right_or_panic<L, R>(either: Either<L, R>) -> R {
+    match either {
+        Either::Left(_) => panic!(
+            "expected ReadTransaction of Either::Right containing {}, received Either::Left type \
+             of {}",
+            type_name::<R>(),
+            type_name::<L>(),
+        ),
+        Either::Right(r) => r,
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -298,7 +298,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
         get(&self.inner.database).context("Unable to read uncompleted operations from database")
     }
 
-    fn serialize(task: TaskId, data: &Vec<CachedDataItem>) -> Result<SmallVec<[u8; 16]>> {
+    fn serialize(&self, task: TaskId, data: &Vec<CachedDataItem>) -> Result<SmallVec<[u8; 16]>> {
         serialize(task, data)
     }
 


### PR DESCRIPTION
The `NextTurboTasks` enum existed to allow us to enable or disable persistent caching at runtime.

This PR implements `BackingStorage` for `Either`, so that the complexity of this branching is moved into `turbo-tasks-backend`.

This eliminates the need for the next.js and eventually other consumers (`turbopack-cli`, Utoo) to handle this branching if they want to support multiple backing storage layers.

The tradeoff is that moving these branches further down in the callstack might lead to more (easily predicted) branches in the code. We can see if codspeed notices anything. **Update:** Codspeed is performance-neutral.

Closes PACK-4975