### PR TITLE
fix: Replace shouldHydrate with reactRoot check

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -466,7 +466,6 @@ const performanceMeasures = {
 
 let reactRoot: any = null
 // On initial render a hydrate should always happen
-let shouldHydrate: boolean = true
 
 function clearMarks(): void {
   ;[
@@ -582,14 +581,12 @@ function renderReactElement(
     performance.mark(performanceMarks.beforeRender)
   }
 
-  const reactEl = fn(shouldHydrate ? markHydrateComplete : markRenderComplete)
+  const reactEl = fn(!reactRoot ? markHydrateComplete : markRenderComplete)
   if (!reactRoot) {
     // Unlike with createRoot, you don't need a separate root.render() call here
     reactRoot = ReactDOM.hydrateRoot(domEl, reactEl, {
       onRecoverableError,
     })
-    // TODO: Remove shouldHydrate variable when React 18 is stable as it can depend on `reactRoot` existing
-    shouldHydrate = false
   } else {
     const startTransition = (React as any).startTransition
     startTransition(() => {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


React 18 has been stable for a while now, and we can rely on reactRoot to determine whether we're in the hydration or render phase, making the `shouldHydrate` variable unnecessary.

 So I replaced the `shouldHydrate` variable with a reactRoot check.