### PR TITLE
GDPR and CCPA compliance

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -42,7 +42,12 @@ export function GoogleAnalytics(props: GAParams) {
           window['${dataLayerName}'] = window['${dataLayerName}'] || [];
           function gtag(){window['${dataLayerName}'].push(arguments);}
           gtag('js', new Date());
-
+          gtag('consent', 'default', {
+            ad_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+            analytics_storage: 'denied',
+          });
           gtag('config', '${gaId}' ${debugMode ? ",{ 'debug_mode': true }" : ''});`,
         }}
         nonce={nonce}


### PR DESCRIPTION
Add GDPR and CCPA default compliance

According to google best practices: [link](https://developers.google.com/tag-platform/security/guides/consent?sjid=4699436591195666657-SA&consentmode=advanced#default-consent) for full GDPR compliance this code needs to be called before anything else like "config" 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Adds GDPR and CCPA

### Why?

Yes, in many regions, particularly in the European Economic Area (EEA) and the UK due to regulations like GDPR and the ePrivacy Directive, it is legally required to obtain user consent before setting cookies or collecting personal data for purposes like analytics and advertising.

The `gtag('consent', 'default', { ... });` command is a crucial part of Google Consent Mode v2, which helps websites communicate user consent choices to Google's various tags (like Google Analytics and Google Ads).

Here's why its placement and use are important for legal compliance:

* **Prior Consent (Opt-in):** In regions with strict privacy laws (like the GDPR), you generally need *explicit prior consent* from users before you can store any information on their device (like cookies) or collect their personal data. This means that if a user hasn't given consent, you cannot fire tags that set cookies or track personal data.
* **Default Denied State:** The `gtag('consent', 'default', { 'ad_storage': 'denied', ... });` command sets the initial, default consent state. To comply with "privacy by default" principles, it's generally recommended that these be set to `'denied'` unless the user has explicitly granted consent. This ensures that no data is collected before a user makes a choice.
* **Order of Execution is Vital:** Google explicitly states that the `gtag('consent', 'default', ...)` command **must be called on every page of your site before any commands that send measurement data (such as `config` or `event`)**. If you call `config` (which often initializes Google Analytics tracking) before setting the default consent to `denied`, you risk collecting data before you have the user's consent, which could be a legal violation.

**Can't I set it after calling 'config' and still be legal?**

**No, generally not, if you want to be legally compliant in privacy-focused regions.**

Setting the consent after calling `config` means that for the initial page load, your Google tags might fire and attempt to set cookies or collect data *before* the user's consent preferences are known or applied. This is precisely what regulations like GDPR aim to prevent.

**Basic vs. Advanced Consent Mode:**

Google Consent Mode v2 offers two main implementation types:

1.  **Basic Consent Mode:** This mode blocks Google tags from loading *until* a user interacts with a consent banner and grants consent. No data is sent to Google before consent is given. This is generally the most compliant approach for strict privacy regulations.
2.  **Advanced Consent Mode:** In this mode, Google Tags load immediately with default consent settings (which should ideally be `'denied'`). If consent is denied, cookieless pings are sent, allowing for some limited, aggregated data for modeling. If consent is granted, full measurement data is sent. While this offers more data, the initial "cookieless pings" even without explicit consent can be a point of contention in some legal interpretations, especially regarding the ePrivacy Directive.

**Recommendation for Compliance:**

To ensure legal compliance, especially for users in the EEA and UK:

* **Implement a robust Consent Management Platform (CMP):** A good CMP will handle the consent banner display, user choice storage, and integrate seamlessly with Google Consent Mode.
* **Prioritize `gtag('consent', 'default', ...)`:** Ensure this command is executed as early as possible in your page's `<head>` section, *before* any other Google tag scripts (including `gtag('config', 'GA_MEASUREMENT_ID');`).
* **Set defaults to 'denied':** For all consent types (`ad_storage`, `ad_user_data`, `ad_personalization`, `analytics_storage`), set their default state to `'denied'`.
* **Update consent based on user interaction:** Once a user interacts with your consent banner, use `gtag('consent', 'update', ...)` to reflect their choices. Your CMP should handle this automatically.

**Disclaimer:** I am an AI and cannot provide legal advice. Data privacy laws are complex and vary by jurisdiction. You should always consult with a legal professional specializing in data privacy to ensure your website's compliance with all applicable regulations.

### How?
Calls 'consent' with default legally valid values

Closes NEXT-
Fixes #

-->
