### PR TITLE
Fix preview builds for forks

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - run: echo "${{ toJson(github.event)}}"
+      - run: echo "${{ github.event.after }}"
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -536,7 +536,7 @@ jobs:
           path: crates/wasm
 
       - name: Create tarballs
-        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.event.head_commit.id }}" "${{ runner.temp }}/preview-tarballs"
+        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.event.after }}" "${{ runner.temp }}/preview-tarballs"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -535,7 +535,7 @@ jobs:
           path: crates/wasm
 
       - name: Create tarballs
-        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.workflow_sha }}" "${{ runner.temp }}/preview-tarballs"
+        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.event.head_commit.id }}" "${{ runner.temp }}/preview-tarballs"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -536,7 +536,9 @@ jobs:
           path: crates/wasm
 
       - name: Create tarballs
-        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.event.after }}" "${{ runner.temp }}/preview-tarballs"
+        # github.event.after is available on push and pull_request#synchronize events.
+        # For workflow_dispatch events, github.sha is the head commit.
+        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.event.after || github.sha }}" "${{ runner.temp }}/preview-tarballs"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - run: echo "${{ toJson(github.event)}}"
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/scripts/create-preview-tarballs.js
+++ b/scripts/create-preview-tarballs.js
@@ -7,7 +7,7 @@ const path = require('node:path')
 async function main() {
   const [
     githubSha,
-    githubWorkflowSha,
+    githubHeadSha,
     tarballDirectory = path.join(os.tmpdir(), 'vercel-nextjs-preview-tarballs'),
   ] = process.argv.slice(2)
   const repoRoot = path.resolve(__dirname, '..')
@@ -103,13 +103,13 @@ async function main() {
   for (const packageInfo of packages) {
     packagesByVersion.set(
       packageInfo.name,
-      `https://vercel-packages.vercel.app/next/commits/${githubWorkflowSha}/${packageInfo.name}`
+      `https://vercel-packages.vercel.app/next/commits/${githubHeadSha}/${packageInfo.name}`
     )
   }
   for (const nextSwcPackageName of nextSwcPackageNames) {
     packagesByVersion.set(
       nextSwcPackageName,
-      `https://vercel-packages.vercel.app/next/commits/${githubWorkflowSha}/${nextSwcPackageName}`
+      `https://vercel-packages.vercel.app/next/commits/${githubHeadSha}/${nextSwcPackageName}`
     )
   }
 


### PR DESCRIPTION
I relied on a bug in https://github.com/vercel/next.js/pull/79648 where `github.workflow_sha` pointed to the head commit of the PR branch. But that's not what the workflow actually runs on. It uses the merge commit.

This used to work in https://github.com/vercel/next.js/actions/runs/15271404964/job/42947987352?pr=79648#step:8:1 but now GitHub correctly sets the workflow_sha to the merge commit.

We can use `github.event.after` which explicitly asks for the head commit of the branch. If that breaks, it'd be a GitHub bug.

## Test plan

- [x] [Linked preview builds](https://github.com/vercel/next.js/actions/runs/15844086051/job/44662390359?pr=80833#step:8:39) works for fork PRS: https://vercel-packages.vercel.app/next/commits/f366813b36120663b4ad6effc4723919089201ae/next
- [x] [Linked preview builds](https://github.com/vercel/next.js/actions/runs/15844090609/job/44662469410#step:8:39) works for upstream PRs: https://vercel-packages.vercel.app/next/commits/f366813b36120663b4ad6effc4723919089201ae/next