### PR TITLE
Turbopack Build: Fix metadata-edge test

### DIFF
--- a/test/e2e/app-dir/metadata-edge/index.test.ts
+++ b/test/e2e/app-dir/metadata-edge/index.test.ts
@@ -22,21 +22,26 @@ describe('app dir - Metadata API on the Edge runtime', () => {
           (file) => {
             return next
               .readFileSync(path.join('.next', file))
-              .includes('ImageResponse')
+              .includes('experimental_FigmaImageResponse')
           }
         )
+        expect(pageFilesThatHaveImageResponse).not.toBeEmpty()
 
         const uniqueAnotherFiles = [
           ...new Set<string>(
             middlewareManifest.functions['/another/page'].files
           ),
         ]
+        expect(uniqueAnotherFiles).not.toBeEmpty()
 
         const anotherFilesThatHaveImageResponse = uniqueAnotherFiles.filter(
           (file) => {
-            return next
-              .readFileSync(path.join('.next', file))
-              .includes('ImageResponse')
+            return (
+              next
+                .readFileSync(path.join('.next', file))
+                // This export is not used but it checks if the `@vercel/og` package is shared between the two routes.
+                .includes('experimental_FigmaImageResponse')
+            )
           }
         )
 

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -3033,11 +3033,10 @@
   },
   "test/e2e/app-dir/metadata-edge/index.test.ts": {
     "passed": [
-      "app dir - Metadata API on the Edge runtime should render OpenGraph image meta tag correctly"
-    ],
-    "failed": [
+      "app dir - Metadata API on the Edge runtime should render OpenGraph image meta tag correctly",
       "app dir - Metadata API on the Edge runtime OG image route should not bundle `ImageResponse` into the page worker"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
This test is checking if `@vercel/og` gets shared between two routes, it assumed that `next/og` itself (the wrapper code) would also be chunked, but the size limit for Turbopack is slightly larger so it doesn't end up bundling it into a separate chunk. Changed the test to check that `@vercel/og` is correctly chunked.

Closes PACK-4880