### PR TITLE
[devtools] overlay backdrop visibility hidden when not fullscreen

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -228,10 +228,12 @@ export const DEVTOOLS_PANEL_STYLES = css`
 
   [data-nextjs-devtools-panel-overlay-backdrop] {
     opacity: 0;
+    visibility: hidden;
   }
 
   [data-nextjs-devtools-panel-overlay-backdrop='true'] {
     opacity: 1;
+    visibility: visible;
   }
 
   [data-nextjs-devtools-panel-draggable] {


### PR DESCRIPTION
### Why?

The overlay backdrop covers the browser inspector in minimized mode.

Closes NEXT-4567