### PR TITLE
Turbopack Build: Fix edge-config-validation test

### DIFF
--- a/test/production/edge-config-validations/index.test.ts
+++ b/test/production/edge-config-validations/index.test.ts
@@ -25,7 +25,7 @@ describe('Edge config validations', () => {
     const res = await next.build()
     expect(res.exitCode).toBe(1)
     expect(res.cliOutput).toContain(
-      '/middleware contains invalid middleware config: Expected string, received boolean at "unstable_allowDynamic", or Expected array, received boolean at "unstable_allowDynamic"'
+      'middleware contains invalid middleware config: Expected string, received boolean at "unstable_allowDynamic", or Expected array, received boolean at "unstable_allowDynamic"'
     )
   })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -19041,10 +19041,10 @@
     "runtimeError": false
   },
   "test/production/edge-config-validations/index.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "Edge config validations fails to build when unstable_allowDynamic is not a string"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

This test is correct but in Turbopack we correctly leave out `/` since middleware is not a route by itself.

Closes PACK-4883