### PR TITLE
[devtools] refactor segment explorer styles

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
@@ -1,4 +1,3 @@
-import { useSegmentTree } from '../../../segment-explorer'
 import { PageSegmentTree } from '../../overview/segment-explorer'
 
 function SegmentsExplorer({
@@ -6,9 +5,8 @@ function SegmentsExplorer({
 }: React.HTMLProps<HTMLDivElement> & {
   routerType: 'app' | 'pages'
 }) {
-  const tree = useSegmentTree()
   const isAppRouter = routerType === 'app'
-  return <PageSegmentTree tree={tree} isAppRouter={isAppRouter} />
+  return <PageSegmentTree isAppRouter={isAppRouter} />
 }
 
 export function SegmentsExplorerTab({

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -15,7 +15,6 @@ import { TurbopackInfo } from './dev-tools-info/turbopack-info'
 import { RouteInfo } from './dev-tools-info/route-info'
 import GearIcon from '../../../icons/gear-icon'
 import { UserPreferences } from './dev-tools-info/user-preferences'
-import { SegmentsExplorer } from '../../overview/segment-explorer'
 import {
   MENU_CURVE,
   MENU_DURATION_MS,
@@ -27,6 +26,7 @@ import {
   type DevToolsScale,
 } from './dev-tools-info/preferences'
 import { Draggable } from './draggable'
+import { SegmentsExplorer } from './dev-tools-info/segments-explorer'
 
 // TODO: add E2E tests to cover different scenarios
 

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
@@ -1,0 +1,25 @@
+import { PageSegmentTree } from '../../../overview/segment-explorer'
+import { DevToolsInfo, type DevToolsInfoPropsCore } from './dev-tools-info'
+
+export function SegmentsExplorer({
+  routerType,
+  ...props
+}: DevToolsInfoPropsCore &
+  React.HTMLProps<HTMLDivElement> & {
+    routerType: 'app' | 'pages'
+  }) {
+  const isAppRouter = routerType === 'app'
+  return (
+    <DevToolsInfo title="Route Info" {...props}>
+      <div data-nextjs-segments-explorer>
+        <PageSegmentTree isAppRouter={isAppRouter} />
+      </div>
+    </DevToolsInfo>
+  )
+}
+
+export const SEGMENTS_EXPLORER_STYLES = `
+  [data-nextjs-segments-explorer] {
+    margin: -12px -8px;
+  }
+`

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -1,21 +1,13 @@
-import type { HTMLProps } from 'react'
-import { css } from '../../utils/css'
-import type { DevToolsInfoPropsCore } from '../errors/dev-tools-indicator/dev-tools-info/dev-tools-info'
-import { DevToolsInfo } from '../errors/dev-tools-indicator/dev-tools-info/dev-tools-info'
 import { useSegmentTree, type SegmentTrieNode } from '../../segment-explorer'
+import { css } from '../../utils/css'
 import { cx } from '../../utils/cx'
 
 const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
 }
 
-export function PageSegmentTree({
-  tree,
-  isAppRouter,
-}: {
-  tree: SegmentTrieNode
-  isAppRouter: boolean
-}) {
+export function PageSegmentTree({ isAppRouter }: { isAppRouter: boolean }) {
+  const tree = useSegmentTree()
   return (
     <div
       className="segment-explorer-content"
@@ -167,26 +159,9 @@ function PageSegmentTreeLayerPresentation({
   )
 }
 
-export function SegmentsExplorer({
-  routerType,
-  ...props
-}: DevToolsInfoPropsCore &
-  HTMLProps<HTMLDivElement> & {
-    routerType: 'app' | 'pages'
-  }) {
-  const tree = useSegmentTree()
-  const isAppRouter = routerType === 'app'
-  return (
-    <DevToolsInfo title="Route Info" {...props}>
-      <PageSegmentTree tree={tree} isAppRouter={isAppRouter} />
-    </DevToolsInfo>
-  )
-}
-
 export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
   .segment-explorer-content {
     font-size: var(--size-14);
-    margin: -12px -8px;
   }
 
   .segment-explorer-item {
@@ -194,7 +169,7 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     border-radius: 6px;
   }
 
-  .segment-explorer-item:nth-child(odd) {
+  .segment-explorer-item:nth-child(even) {
     background-color: var(--color-background-200);
   }
 

--- a/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
@@ -36,6 +36,7 @@ import { DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_STYLES } from '../components/devtools
 import { ISSUE_FEEDBACK_BUTTON_STYLES } from '../components/errors/error-overlay-toolbar/issue-feedback-button'
 import { ERROR_CONTENT_SKELETON_STYLES } from '../container/runtime-error/error-content-skeleton'
 import { SEGMENTS_EXPLORER_TAB_STYLES } from '../components/devtools-panel/devtools-panel-tab/segments-explorer-tab'
+import { SEGMENTS_EXPLORER_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/segments-explorer'
 
 export function ComponentStyles() {
   return (
@@ -65,6 +66,7 @@ export function ComponentStyles() {
         ${DEV_TOOLS_INFO_TURBOPACK_INFO_STYLES}
         ${DEV_TOOLS_INFO_ROUTE_INFO_STYLES}
         ${DEV_TOOLS_INFO_USER_PREFERENCES_STYLES}
+        ${SEGMENTS_EXPLORER_STYLES}
         ${DEV_TOOLS_INFO_RENDER_FILES_STYLES}
         ${FADER_STYLES}
         ${DEVTOOLS_PANEL_STYLES}


### PR DESCRIPTION
* Separate segment explorer instance from the dev overlay and the dev panel
* Polish the padding, the customization padding on two sides are different. Dev overlay pop up requires minus margin to fit the border, dev tool panel requires the extra padding
* Fix the background order, the darker one should appear from the 2nd row

| After | Before |
|:--|:--|
| <img height="150" src="https://github.com/user-attachments/assets/959dd9c7-2880-41a9-a8c8-9b87ea005c4d"> |  <img height="150" src="https://github.com/user-attachments/assets/610591f0-9716-4d66-9a6d-816867ac2264"> |
| <img height="150" src="https://github.com/user-attachments/assets/b1e30ba0-f366-4f13-a016-1baf141a2382"> |  <img height="150" src="https://github.com/user-attachments/assets/83e21318-6392-48b1-8a83-9c45f1fefc1a"> |
