### PR TITLE
[devtools] fix: build error should share the issue content layout

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout.tsx
@@ -24,7 +24,7 @@ export function IssuesTabContentLayout({
   debugInfo: DebugInfo
   children: React.ReactNode
 
-  errorCode?: string
+  errorCode?: string | null
   environmentName?: string
 }) {
   return (

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout.tsx
@@ -1,0 +1,80 @@
+import type { DebugInfo } from '../../../../../shared/types'
+import type { ReadyRuntimeError } from '../../../../utils/get-error-by-type'
+import type { ErrorType } from '../../../errors/error-type-label/error-type-label'
+
+import {
+  GenericErrorDescription,
+  HydrationErrorDescription,
+} from '../../../../container/errors'
+import { EnvironmentNameLabel } from '../../../errors/environment-name-label/environment-name-label'
+import { ErrorMessage } from '../../../errors/error-message/error-message'
+import { ErrorOverlayToolbar } from '../../../errors/error-overlay-toolbar/error-overlay-toolbar'
+import { ErrorTypeLabel } from '../../../errors/error-type-label/error-type-label'
+import { IssueFeedbackButton } from '../../../errors/error-overlay-toolbar/issue-feedback-button'
+import { css } from '../../../../utils/css'
+
+// This behaves like the ErrorOverlayLayout.
+export function IssuesTabContentLayout({
+  hydrationWarning,
+  activeError,
+  errorCode,
+  errorType,
+  debugInfo,
+  children,
+}: {
+  hydrationWarning: string | null
+  activeError: ReadyRuntimeError
+  errorCode: string | undefined
+  errorType: ErrorType
+  debugInfo: DebugInfo
+  children: React.ReactNode
+}) {
+  const errorMessage = hydrationWarning ? (
+    <HydrationErrorDescription message={hydrationWarning} />
+  ) : (
+    <GenericErrorDescription error={activeError.error} />
+  )
+
+  return (
+    <div data-nextjs-devtools-panel-tab-issues-content-layout>
+      <div className="nextjs-container-errors-header">
+        <div
+          className="nextjs__container_errors__error_title"
+          // allow assertion in tests before error rating is implemented
+          data-nextjs-error-code={errorCode}
+        >
+          <span data-nextjs-error-label-group>
+            <ErrorTypeLabel errorType={errorType} />
+            {activeError.error.environmentName && (
+              <EnvironmentNameLabel
+                environmentName={activeError.error.environmentName}
+              />
+            )}
+          </span>
+          <ErrorOverlayToolbar
+            error={activeError.error}
+            debugInfo={debugInfo}
+            // TODO: Move the button inside and remove the feedback on the footer of the error overlay.
+            feedbackButton={
+              errorCode && <IssueFeedbackButton errorCode={errorCode} />
+            }
+          />
+        </div>
+        <ErrorMessage errorMessage={errorMessage} />
+      </div>
+      {children}
+    </div>
+  )
+}
+
+// The components in this file shares the style with the Error Overlay.
+export const DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_LAYOUT_STYLES = css`
+  [data-nextjs-devtools-panel-tab-issues-content-layout] {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    min-height: 0;
+    padding: 14px;
+  }
+`

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout.tsx
@@ -1,40 +1,32 @@
 import type { DebugInfo } from '../../../../../shared/types'
-import type { ReadyRuntimeError } from '../../../../utils/get-error-by-type'
 import type { ErrorType } from '../../../errors/error-type-label/error-type-label'
 
-import {
-  GenericErrorDescription,
-  HydrationErrorDescription,
-} from '../../../../container/errors'
-import { EnvironmentNameLabel } from '../../../errors/environment-name-label/environment-name-label'
 import { ErrorMessage } from '../../../errors/error-message/error-message'
 import { ErrorOverlayToolbar } from '../../../errors/error-overlay-toolbar/error-overlay-toolbar'
 import { ErrorTypeLabel } from '../../../errors/error-type-label/error-type-label'
+import { EnvironmentNameLabel } from '../../../errors/environment-name-label/environment-name-label'
 import { IssueFeedbackButton } from '../../../errors/error-overlay-toolbar/issue-feedback-button'
 import { css } from '../../../../utils/css'
 
 // This behaves like the ErrorOverlayLayout.
 export function IssuesTabContentLayout({
-  hydrationWarning,
-  activeError,
-  errorCode,
+  error,
   errorType,
+  message,
   debugInfo,
   children,
+  errorCode,
+  environmentName,
 }: {
-  hydrationWarning: string | null
-  activeError: ReadyRuntimeError
-  errorCode: string | undefined
+  error: Error & { environmentName?: string }
   errorType: ErrorType
+  message: string
   debugInfo: DebugInfo
   children: React.ReactNode
-}) {
-  const errorMessage = hydrationWarning ? (
-    <HydrationErrorDescription message={hydrationWarning} />
-  ) : (
-    <GenericErrorDescription error={activeError.error} />
-  )
 
+  errorCode?: string
+  environmentName?: string
+}) {
   return (
     <div data-nextjs-devtools-panel-tab-issues-content-layout>
       <div className="nextjs-container-errors-header">
@@ -45,14 +37,12 @@ export function IssuesTabContentLayout({
         >
           <span data-nextjs-error-label-group>
             <ErrorTypeLabel errorType={errorType} />
-            {activeError.error.environmentName && (
-              <EnvironmentNameLabel
-                environmentName={activeError.error.environmentName}
-              />
+            {environmentName && (
+              <EnvironmentNameLabel environmentName={environmentName} />
             )}
           </span>
           <ErrorOverlayToolbar
-            error={activeError.error}
+            error={error}
             debugInfo={debugInfo}
             // TODO: Move the button inside and remove the feedback on the footer of the error overlay.
             feedbackButton={
@@ -60,7 +50,7 @@ export function IssuesTabContentLayout({
             }
           />
         </div>
-        <ErrorMessage errorMessage={errorMessage} />
+        <ErrorMessage errorMessage={message} />
       </div>
       {children}
     </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content.tsx
@@ -11,6 +11,11 @@ import { CallStack } from '../../../call-stack/call-stack'
 import { NEXTJS_HYDRATION_ERROR_LINK } from '../../../../../shared/react-19-hydration-error'
 import { ErrorContentSkeleton } from '../../../../container/runtime-error/error-content-skeleton'
 import { css } from '../../../../utils/css'
+import { getErrorTextFromBuildErrorMessage } from '../../../../container/build-error'
+import { IssuesTabContentLayout } from './issues-tab-content-layout'
+import type { DebugInfo } from '../../../../../shared/types'
+import type { ErrorType } from '../../../errors/error-type-label/error-type-label'
+import { IssuesTabEmptyContent } from './issues-tab-empty-content'
 
 // This consists of the Build Error, Runtime Error, etc.
 export function IssuesTabContent({
@@ -19,6 +24,9 @@ export function IssuesTabContent({
   hydrationWarning,
   errorDetails,
   activeError,
+  errorType,
+  debugInfo,
+  errorCode,
 }: {
   notes: string | null
   buildError: OverlayState['buildError']
@@ -27,50 +35,100 @@ export function IssuesTabContent({
     hydrationWarning: string | null
     notes: string | null
     reactOutputComponentDiff: string | null
-  }
-  activeError: ReadyRuntimeError
+  } | null
+  activeError: ReadyRuntimeError | null
+  errorType: ErrorType | null
+  debugInfo: DebugInfo
+  errorCode: string | null | undefined
 }) {
+  if (buildError) {
+    return <BuildError message={buildError} debugInfo={debugInfo} />
+  }
+
   return (
-    <>
-      {buildError ? (
-        <Terminal content={buildError} />
-      ) : (
-        <>
-          <div className="error-overlay-notes-container">
-            {notes ? (
-              <>
-                <p
-                  id="nextjs__container_errors__notes"
-                  className="nextjs__container_errors__notes"
-                >
-                  {notes}
-                </p>
-              </>
-            ) : null}
-            {hydrationWarning ? (
-              <p
-                id="nextjs__container_errors__link"
-                className="nextjs__container_errors__link"
-              >
-                <HotlinkedText
-                  text={`See more info here: ${NEXTJS_HYDRATION_ERROR_LINK}`}
-                />
-              </p>
-            ) : null}
-          </div>
-          {errorDetails.reactOutputComponentDiff ? (
-            <PseudoHtmlDiff
-              reactOutputComponentDiff={
-                errorDetails.reactOutputComponentDiff || ''
-              }
+    <ErrorContent
+      notes={notes}
+      hydrationWarning={hydrationWarning}
+      errorDetails={errorDetails}
+      activeError={activeError}
+      errorType={errorType}
+      debugInfo={debugInfo}
+      errorCode={errorCode}
+    />
+  )
+}
+
+function ErrorContent({
+  notes,
+  hydrationWarning,
+  errorDetails,
+  activeError,
+  errorType,
+  debugInfo,
+  errorCode,
+}: {
+  notes: string | null
+  hydrationWarning: string | null
+  errorDetails: {
+    hydrationWarning: string | null
+    notes: string | null
+    reactOutputComponentDiff: string | null
+  } | null
+  activeError: ReadyRuntimeError | null
+  errorType: ErrorType | null
+  debugInfo: DebugInfo
+  errorCode: string | null | undefined
+}) {
+  // If there's an activeError, the rest should have a value.
+  if (
+    !activeError ||
+    errorType === null ||
+    errorCode === null ||
+    errorDetails === null
+  ) {
+    return <IssuesTabEmptyContent />
+  }
+
+  return (
+    <IssuesTabContentLayout
+      error={activeError.error}
+      errorType={errorType}
+      message={activeError.error.message}
+      debugInfo={debugInfo}
+      errorCode={errorCode}
+      environmentName={activeError.error.environmentName}
+    >
+      <div className="error-overlay-notes-container">
+        {notes ? (
+          <>
+            <p
+              id="nextjs__container_errors__notes"
+              className="nextjs__container_errors__notes"
+            >
+              {notes}
+            </p>
+          </>
+        ) : null}
+        {hydrationWarning ? (
+          <p
+            id="nextjs__container_errors__link"
+            className="nextjs__container_errors__link"
+          >
+            <HotlinkedText
+              text={`See more info here: ${NEXTJS_HYDRATION_ERROR_LINK}`}
             />
-          ) : null}
-          <Suspense fallback={<ErrorContentSkeleton />}>
-            <RuntimeError key={activeError.id.toString()} error={activeError} />
-          </Suspense>
-        </>
-      )}
-    </>
+          </p>
+        ) : null}
+      </div>
+      {errorDetails.reactOutputComponentDiff ? (
+        <PseudoHtmlDiff
+          reactOutputComponentDiff={errorDetails.reactOutputComponentDiff || ''}
+        />
+      ) : null}
+      <Suspense fallback={<ErrorContentSkeleton />}>
+        <RuntimeError key={activeError.id.toString()} error={activeError} />
+      </Suspense>
+    </IssuesTabContentLayout>
   )
 }
 
@@ -114,6 +172,30 @@ function RuntimeError({ error }: { error: ReadyRuntimeError }) {
         />
       )}
     </>
+  )
+}
+
+function BuildError({
+  message,
+  debugInfo,
+}: {
+  message: string
+  debugInfo: DebugInfo
+}) {
+  const error = new Error(message)
+  const formattedMessage = useMemo(
+    () => getErrorTextFromBuildErrorMessage(message) || 'Failed to compile',
+    [message]
+  )
+  return (
+    <IssuesTabContentLayout
+      errorType={'Build Error'}
+      error={error}
+      message={formattedMessage}
+      debugInfo={debugInfo}
+    >
+      <Terminal content={message} />
+    </IssuesTabContentLayout>
   )
 }
 

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content.tsx
@@ -79,13 +79,7 @@ function ErrorContent({
   debugInfo: DebugInfo
   errorCode: string | null | undefined
 }) {
-  // If there's an activeError, the rest should have a value.
-  if (
-    !activeError ||
-    errorType === null ||
-    errorCode === null ||
-    errorDetails === null
-  ) {
+  if (!activeError || !errorType) {
     return <IssuesTabEmptyContent />
   }
 
@@ -120,7 +114,7 @@ function ErrorContent({
           </p>
         ) : null}
       </div>
-      {errorDetails.reactOutputComponentDiff ? (
+      {errorDetails?.reactOutputComponentDiff ? (
         <PseudoHtmlDiff
           reactOutputComponentDiff={errorDetails.reactOutputComponentDiff || ''}
         />

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content.tsx
@@ -1,19 +1,7 @@
 import type { OverlayState } from '../../../../shared'
-import type { DebugInfo } from '../../../../../shared/types'
 import type { ReadyRuntimeError } from '../../../../utils/get-error-by-type'
-import type { ErrorType } from '../../../errors/error-type-label/error-type-label'
 
 import { Suspense, useMemo, useState } from 'react'
-
-import {
-  GenericErrorDescription,
-  HydrationErrorDescription,
-} from '../../../../container/errors'
-import { EnvironmentNameLabel } from '../../../errors/environment-name-label/environment-name-label'
-import { ErrorMessage } from '../../../errors/error-message/error-message'
-import { ErrorOverlayToolbar } from '../../../errors/error-overlay-toolbar/error-overlay-toolbar'
-import { ErrorTypeLabel } from '../../../errors/error-type-label/error-type-label'
-import { IssueFeedbackButton } from '../../../errors/error-overlay-toolbar/issue-feedback-button'
 import { Terminal } from '../../../terminal'
 import { HotlinkedText } from '../../../hot-linked-text'
 import { PseudoHtmlDiff } from '../../../../container/runtime-error/component-stack-pseudo-html'
@@ -24,15 +12,13 @@ import { NEXTJS_HYDRATION_ERROR_LINK } from '../../../../../shared/react-19-hydr
 import { ErrorContentSkeleton } from '../../../../container/runtime-error/error-content-skeleton'
 import { css } from '../../../../utils/css'
 
+// This consists of the Build Error, Runtime Error, etc.
 export function IssuesTabContent({
   notes,
   buildError,
   hydrationWarning,
   errorDetails,
   activeError,
-  errorCode,
-  errorType,
-  debugInfo,
 }: {
   notes: string | null
   buildError: OverlayState['buildError']
@@ -43,78 +29,48 @@ export function IssuesTabContent({
     reactOutputComponentDiff: string | null
   }
   activeError: ReadyRuntimeError
-  errorCode: string | undefined
-  errorType: ErrorType
-  debugInfo: DebugInfo
 }) {
-  if (buildError) {
-    return <Terminal content={buildError} />
-  }
-
-  const errorMessage = hydrationWarning ? (
-    <HydrationErrorDescription message={hydrationWarning} />
-  ) : (
-    <GenericErrorDescription error={activeError.error} />
-  )
-
   return (
-    <div data-nextjs-devtools-panel-tab-issues-content-container>
-      <div className="nextjs-container-errors-header">
-        <div
-          className="nextjs__container_errors__error_title"
-          // allow assertion in tests before error rating is implemented
-          data-nextjs-error-code={errorCode}
-        >
-          <span data-nextjs-error-label-group>
-            <ErrorTypeLabel errorType={errorType} />
-            {activeError.error.environmentName && (
-              <EnvironmentNameLabel
-                environmentName={activeError.error.environmentName}
-              />
-            )}
-          </span>
-          <ErrorOverlayToolbar
-            error={activeError.error}
-            debugInfo={debugInfo}
-            // TODO: Move the button inside and remove the feedback on the footer of the error overlay.
-            feedbackButton={
-              errorCode && <IssueFeedbackButton errorCode={errorCode} />
-            }
-          />
-        </div>
-        <ErrorMessage errorMessage={errorMessage} />
-      </div>
-      <div className="error-overlay-notes-container">
-        {notes ? (
-          <>
-            <p
-              id="nextjs__container_errors__notes"
-              className="nextjs__container_errors__notes"
-            >
-              {notes}
-            </p>
-          </>
-        ) : null}
-        {hydrationWarning ? (
-          <p
-            id="nextjs__container_errors__link"
-            className="nextjs__container_errors__link"
-          >
-            <HotlinkedText
-              text={`See more info here: ${NEXTJS_HYDRATION_ERROR_LINK}`}
+    <>
+      {buildError ? (
+        <Terminal content={buildError} />
+      ) : (
+        <>
+          <div className="error-overlay-notes-container">
+            {notes ? (
+              <>
+                <p
+                  id="nextjs__container_errors__notes"
+                  className="nextjs__container_errors__notes"
+                >
+                  {notes}
+                </p>
+              </>
+            ) : null}
+            {hydrationWarning ? (
+              <p
+                id="nextjs__container_errors__link"
+                className="nextjs__container_errors__link"
+              >
+                <HotlinkedText
+                  text={`See more info here: ${NEXTJS_HYDRATION_ERROR_LINK}`}
+                />
+              </p>
+            ) : null}
+          </div>
+          {errorDetails.reactOutputComponentDiff ? (
+            <PseudoHtmlDiff
+              reactOutputComponentDiff={
+                errorDetails.reactOutputComponentDiff || ''
+              }
             />
-          </p>
-        ) : null}
-      </div>
-      {errorDetails.reactOutputComponentDiff ? (
-        <PseudoHtmlDiff
-          reactOutputComponentDiff={errorDetails.reactOutputComponentDiff || ''}
-        />
-      ) : null}
-      <Suspense fallback={<ErrorContentSkeleton />}>
-        <RuntimeError key={activeError.id.toString()} error={activeError} />
-      </Suspense>
-    </div>
+          ) : null}
+          <Suspense fallback={<ErrorContentSkeleton />}>
+            <RuntimeError key={activeError.id.toString()} error={activeError} />
+          </Suspense>
+        </>
+      )}
+    </>
   )
 }
 
@@ -162,13 +118,4 @@ function RuntimeError({ error }: { error: ReadyRuntimeError }) {
 }
 
 // The components in this file shares the style with the Error Overlay.
-export const DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_STYLES = css`
-  [data-nextjs-devtools-panel-tab-issues-content-container] {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    min-height: 0;
-    padding: 14px;
-  }
-`
+export const DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_STYLES = css``

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-empty-content.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-empty-content.tsx
@@ -1,0 +1,64 @@
+import { Warning } from '../../../../icons/warning'
+import { css } from '../../../../utils/css'
+
+export function IssuesTabEmptyContent() {
+  return (
+    <div data-nextjs-devtools-panel-tab-issues-empty>
+      <div data-nextjs-devtools-panel-tab-issues-empty-content>
+        <div data-nextjs-devtools-panel-tab-issues-empty-icon>
+          <Warning width={16} height={16} />
+        </div>
+        <h3 data-nextjs-devtools-panel-tab-issues-empty-title>
+          No Issues Found
+        </h3>
+        <p data-nextjs-devtools-panel-tab-issues-empty-subtitle>
+          Issues will appear here when they occur.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export const DEVTOOLS_PANEL_TAB_ISSUES_EMPTY_CONTENT_STYLES = css`
+  [data-nextjs-devtools-panel-tab-issues-empty] {
+    display: flex;
+    flex: 1;
+    padding: 12px;
+    min-height: 0;
+  }
+
+  [data-nextjs-devtools-panel-tab-issues-empty-content] {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    border: 1px dashed var(--color-gray-alpha-500);
+    border-radius: 4px;
+  }
+
+  [data-nextjs-devtools-panel-tab-issues-empty-icon] {
+    margin-bottom: 16px;
+    padding: 8px;
+    border: 1px solid var(--color-gray-alpha-400);
+    border-radius: 6px;
+
+    background-color: var(--color-background-100);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  [data-nextjs-devtools-panel-tab-issues-empty-title] {
+    color: var(--color-gray-1000);
+    font-size: 16px;
+    font-weight: 500;
+    line-height: var(--line-height-20);
+  }
+
+  [data-nextjs-devtools-panel-tab-issues-empty-subtitle] {
+    color: var(--color-gray-900);
+    font-size: 14px;
+    line-height: var(--line-height-21);
+  }
+`

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab.tsx
@@ -8,6 +8,7 @@ import { IssuesTabContent } from './issues-tab-content'
 import { css } from '../../../../utils/css'
 import { useActiveRuntimeError } from '../../../../hooks/use-active-runtime-error'
 import { Warning } from '../../../../icons/warning'
+import { IssuesTabContentLayout } from './issues-tab-content-layout'
 
 export function IssuesTab({
   debugInfo,
@@ -59,16 +60,21 @@ export function IssuesTab({
       />
 
       {/* This is the copy of the Error Overlay content. */}
-      <IssuesTabContent
-        buildError={buildError}
-        notes={notes}
-        hydrationWarning={hydrationWarning}
-        errorDetails={errorDetails}
+      <IssuesTabContentLayout
         activeError={activeError}
-        debugInfo={debugInfo}
+        hydrationWarning={hydrationWarning}
         errorCode={errorCode}
         errorType={errorType}
-      />
+        debugInfo={debugInfo}
+      >
+        <IssuesTabContent
+          buildError={buildError}
+          notes={notes}
+          hydrationWarning={hydrationWarning}
+          errorDetails={errorDetails}
+          activeError={activeError}
+        />
+      </IssuesTabContentLayout>
     </div>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab.tsx
@@ -7,8 +7,6 @@ import { IssuesTabSidebar } from './issues-tab-sidebar'
 import { IssuesTabContent } from './issues-tab-content'
 import { css } from '../../../../utils/css'
 import { useActiveRuntimeError } from '../../../../hooks/use-active-runtime-error'
-import { Warning } from '../../../../icons/warning'
-import { IssuesTabContentLayout } from './issues-tab-content-layout'
 
 export function IssuesTab({
   debugInfo,
@@ -32,49 +30,27 @@ export function IssuesTab({
     errorDetails,
   } = useActiveRuntimeError({ runtimeErrors, getSquashedHydrationErrorDetails })
 
-  if (!activeError) {
-    return (
-      <div data-nextjs-devtools-panel-tab-issues-empty>
-        <div data-nextjs-devtools-panel-tab-issues-empty-content>
-          <div data-nextjs-devtools-panel-tab-issues-empty-icon>
-            <Warning width={16} height={16} />
-          </div>
-          <h3 data-nextjs-devtools-panel-tab-issues-empty-title>
-            No Issues Found
-          </h3>
-          <p data-nextjs-devtools-panel-tab-issues-empty-subtitle>
-            Issues will appear here when they occur.
-          </p>
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div data-nextjs-devtools-panel-tab-issues>
-      <IssuesTabSidebar
-        runtimeErrors={runtimeErrors}
-        errorType={errorType}
-        activeIdx={activeIdx}
-        setActiveIndex={setActiveIndex}
-      />
+      {buildError ? null : (
+        <IssuesTabSidebar
+          runtimeErrors={runtimeErrors}
+          errorType={errorType}
+          activeIdx={activeIdx}
+          setActiveIndex={setActiveIndex}
+        />
+      )}
 
-      {/* This is the copy of the Error Overlay content. */}
-      <IssuesTabContentLayout
-        activeError={activeError}
+      <IssuesTabContent
+        buildError={buildError}
+        notes={notes}
         hydrationWarning={hydrationWarning}
-        errorCode={errorCode}
+        errorDetails={errorDetails}
+        activeError={activeError}
         errorType={errorType}
         debugInfo={debugInfo}
-      >
-        <IssuesTabContent
-          buildError={buildError}
-          notes={notes}
-          hydrationWarning={hydrationWarning}
-          errorDetails={errorDetails}
-          activeError={activeError}
-        />
-      </IssuesTabContentLayout>
+        errorCode={errorCode}
+      />
     </div>
   )
 }
@@ -84,47 +60,5 @@ export const DEVTOOLS_PANEL_TAB_ISSUES_STYLES = css`
     display: flex;
     flex: 1;
     min-height: 0;
-  }
-
-  [data-nextjs-devtools-panel-tab-issues-empty] {
-    display: flex;
-    flex: 1;
-    padding: 12px;
-    min-height: 0;
-  }
-
-  [data-nextjs-devtools-panel-tab-issues-empty-content] {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    flex: 1;
-    border: 1px dashed var(--color-gray-alpha-500);
-    border-radius: 4px;
-  }
-
-  [data-nextjs-devtools-panel-tab-issues-empty-icon] {
-    margin-bottom: 16px;
-    padding: 8px;
-    border: 1px solid var(--color-gray-alpha-400);
-    border-radius: 6px;
-
-    background-color: var(--color-background-100);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  [data-nextjs-devtools-panel-tab-issues-empty-title] {
-    color: var(--color-gray-1000);
-    font-size: 16px;
-    font-weight: 500;
-    line-height: var(--line-height-20);
-  }
-
-  [data-nextjs-devtools-panel-tab-issues-empty-subtitle] {
-    color: var(--color-gray-900);
-    font-size: 14px;
-    line-height: var(--line-height-21);
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/container/build-error.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/build-error.tsx
@@ -8,7 +8,7 @@ export interface BuildErrorProps extends ErrorBaseProps {
   message: string
 }
 
-const getErrorTextFromBuildErrorMessage = (multiLineMessage: string) => {
+export const getErrorTextFromBuildErrorMessage = (multiLineMessage: string) => {
   const lines = multiLineMessage.split('\n')
   // The multi-line build error message looks like:
   // <file path>:<line number>:<column number>

--- a/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
@@ -37,6 +37,7 @@ import { ISSUE_FEEDBACK_BUTTON_STYLES } from '../components/errors/error-overlay
 import { ERROR_CONTENT_SKELETON_STYLES } from '../container/runtime-error/error-content-skeleton'
 import { SEGMENTS_EXPLORER_TAB_STYLES } from '../components/devtools-panel/devtools-panel-tab/segments-explorer-tab'
 import { SEGMENTS_EXPLORER_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/segments-explorer'
+import { DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_LAYOUT_STYLES } from '../components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout'
 
 export function ComponentStyles() {
   return (
@@ -77,6 +78,7 @@ export function ComponentStyles() {
         ${DEVTOOLS_PANEL_TAB_ISSUES_SIDEBAR_STYLES}
         ${DEVTOOLS_PANEL_TAB_ISSUES_SIDEBAR_FRAME_SKELETON_STYLES}
         ${DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_STYLES}
+        ${DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_LAYOUT_STYLES}
         ${ISSUE_FEEDBACK_BUTTON_STYLES}
         ${ERROR_CONTENT_SKELETON_STYLES}
         ${SEGMENTS_EXPLORER_TAB_STYLES}

--- a/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
@@ -38,6 +38,7 @@ import { ERROR_CONTENT_SKELETON_STYLES } from '../container/runtime-error/error-
 import { SEGMENTS_EXPLORER_TAB_STYLES } from '../components/devtools-panel/devtools-panel-tab/segments-explorer-tab'
 import { SEGMENTS_EXPLORER_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/segments-explorer'
 import { DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_LAYOUT_STYLES } from '../components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-content-layout'
+import { DEVTOOLS_PANEL_TAB_ISSUES_EMPTY_CONTENT_STYLES } from '../components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-empty-content'
 
 export function ComponentStyles() {
   return (
@@ -75,6 +76,7 @@ export function ComponentStyles() {
         ${DEVTOOLS_PANEL_VERSION_INFO_STYLES}
         ${DEVTOOLS_PANEL_TAB_SETTINGS_STYLES}
         ${DEVTOOLS_PANEL_TAB_ISSUES_STYLES}
+        ${DEVTOOLS_PANEL_TAB_ISSUES_EMPTY_CONTENT_STYLES}
         ${DEVTOOLS_PANEL_TAB_ISSUES_SIDEBAR_STYLES}
         ${DEVTOOLS_PANEL_TAB_ISSUES_SIDEBAR_FRAME_SKELETON_STYLES}
         ${DEVTOOLS_PANEL_TAB_ISSUES_CONTENT_STYLES}


### PR DESCRIPTION
Previously, the no issue page was displayed when there was no runtime error. Also, if there was a build error, it would've returned the Terminal only. Therefore, created a layout that behaves similarly to ErrorOverlayLayout and shares across the build error and the runtime error.

### Before

https://github.com/user-attachments/assets/542b46ee-b0e5-4dbf-b443-f67245acf6dd

### After

https://github.com/user-attachments/assets/20a3539a-720b-422e-9fa0-ea1c4023857d