### PR TITLE
[devtools] restart server pending state

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -17,6 +17,7 @@ import {
   type DevToolsScale,
 } from './preferences'
 import { ShortcutRecorder } from './shortcut-recorder'
+import { useRestartServer } from '../../error-overlay-toolbar/use-restart-server'
 
 export function UserPreferences({
   hide,
@@ -69,6 +70,7 @@ export function UserPreferencesBody({
   scale: DevToolsScale
   setScale: (value: DevToolsScale) => void
 }) {
+  const { restartServer, isPending } = useRestartServer()
   const [theme, setTheme] = useState(getInitialTheme())
 
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -103,21 +105,6 @@ export function UserPreferencesBody({
   function handleSizeChange({ target }: React.ChangeEvent<HTMLSelectElement>) {
     const value = Number(target.value) as DevToolsScale
     setScale(value)
-  }
-
-  function handleRestartDevServer(invalidatePersistentCache: boolean) {
-    let endpoint = '/__nextjs_restart_dev'
-
-    if (invalidatePersistentCache) {
-      endpoint = '/__nextjs_restart_dev?invalidatePersistentCache'
-    }
-
-    fetch(endpoint, {
-      method: 'POST',
-    }).then(() => {
-      // TODO: poll server status and reload when the server is back up.
-      // https://github.com/vercel/next.js/pull/80005
-    })
   }
 
   return (
@@ -253,10 +240,10 @@ export function UserPreferencesBody({
               data-restart-dev-server
               className="action-button"
               onClick={() =>
-                handleRestartDevServer(/*invalidatePersistentCache*/ false)
+                restartServer({ invalidatePersistentCache: false })
               }
             >
-              <span>Restart</span>
+              <span>{isPending ? 'Restarting...' : 'Restart'}</span>
             </button>
           </div>
         </div>
@@ -279,10 +266,10 @@ export function UserPreferencesBody({
                 data-reset-bundler-cache
                 className="action-button"
                 onClick={() =>
-                  handleRestartDevServer(/*invalidatePersistentCache*/ true)
+                  restartServer({ invalidatePersistentCache: true })
                 }
               >
-                <span>Reset Cache</span>
+                <span>{isPending ? 'Resetting...' : 'Reset Cache'}</span>
               </button>
             </div>
           </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -242,6 +242,7 @@ export function UserPreferencesBody({
               onClick={() =>
                 restartServer({ invalidatePersistentCache: false })
               }
+              disabled={isPending}
             >
               <span>{isPending ? 'Restarting...' : 'Restart'}</span>
             </button>
@@ -268,6 +269,7 @@ export function UserPreferencesBody({
                 onClick={() =>
                   restartServer({ invalidatePersistentCache: true })
                 }
+                disabled={isPending}
               >
                 <span>{isPending ? 'Resetting...' : 'Reset Cache'}</span>
               </button>
@@ -393,6 +395,11 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
       color: var(--color-gray-1000);
       background: var(--color-background-100);
     }
+  }
+
+  .preference-section button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   :global(.icon) {

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -244,7 +244,7 @@ export function UserPreferencesBody({
               }
               disabled={isPending}
             >
-              <span>{isPending ? 'Restarting...' : 'Restart'}</span>
+              <span>Restart</span>
             </button>
           </div>
         </div>
@@ -271,7 +271,7 @@ export function UserPreferencesBody({
                 }
                 disabled={isPending}
               >
-                <span>{isPending ? 'Resetting...' : 'Reset Cache'}</span>
+                <span>Reset Cache</span>
               </button>
             </div>
           </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { RefreshClockWise } from '../../../icons/refresh-clock-wise'
 import {
   ACTION_RESTART_SERVER_BUTTON,
@@ -16,30 +16,17 @@ import { css } from '../../../utils/css'
  * telemetry on how often this is used.
  */
 export function RestartServerButton({ showButton }: { showButton: boolean }) {
-  const [disabled, setDisabled] = useState(false)
-  const { restartServerAction, isPending } = useRestartServer()
+  const { restartServer, isPending } = useRestartServer()
 
   if (!showButton) {
     return null
   }
 
-  async function handleClick() {
-    const hasServerRestarted = await restartServerAction({
-      invalidatePersistentCache: true,
-    })
-
-    if (hasServerRestarted) {
-      // Disable the button after a successful restart to prevent multiple server restart.
-      setDisabled(true)
-      window.location.reload()
-    }
-  }
-
   return (
     <button
       className="restart-dev-server-button"
-      onClick={handleClick}
-      disabled={isPending || disabled}
+      onClick={() => restartServer({ invalidatePersistentCache: true })}
+      disabled={isPending}
       title="Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing."
     >
       <RefreshClockWise width={14} height={14} spinning={isPending} />

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -32,6 +32,7 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
       disabled={isPending}
       title="Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing."
     >
+      {/* TODO: Add loading spinner. */}
       <RefreshClockWise width={14} height={14} />
       {isPending ? 'Restarting...' : 'Clear Bundler Cache &amp; Restart'}
     </button>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { RefreshClockWise } from '../../../icons/refresh-clock-wise'
 import {
   ACTION_RESTART_SERVER_BUTTON,
@@ -16,6 +16,7 @@ import { css } from '../../../utils/css'
  * telemetry on how often this is used.
  */
 export function RestartServerButton({ showButton }: { showButton: boolean }) {
+  const [disabled, setDisabled] = useState(false)
   const { restartServerAction, isPending } = useRestartServer()
 
   if (!showButton) {
@@ -28,6 +29,8 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
     })
 
     if (hasServerRestarted) {
+      // Disable the button after a successful restart to prevent multiple server restart.
+      setDisabled(true)
       window.location.reload()
     }
   }
@@ -36,7 +39,7 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
     <button
       className="restart-dev-server-button"
       onClick={handleClick}
-      disabled={isPending}
+      disabled={isPending || disabled}
       title="Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing."
     >
       <RefreshClockWise width={14} height={14} spinning={isPending} />

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -15,16 +15,14 @@ import { useRestartServer } from './use-restart-server'
  * telemetry on how often this is used.
  */
 export function RestartServerButton({ showButton }: { showButton: boolean }) {
-  const { restartServerAction, isPending } = useRestartServer({
-    invalidatePersistentCache: true,
-  })
+  const { restartServerAction, isPending } = useRestartServer()
 
   if (!showButton) {
     return null
   }
 
   function handleClick() {
-    restartServerAction()
+    restartServerAction({ invalidatePersistentCache: true })
   }
 
   return (

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -33,7 +33,7 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
       title="Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing."
     >
       <RefreshClockWise width={14} height={14} />
-      {isPending ? 'Restarting...' : 'Clear Bundler Cache & Restart'}
+      {isPending ? 'Restarting...' : 'Clear Bundler Cache &amp; Restart'}
     </button>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -38,7 +38,7 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
             : undefined,
         }}
       />
-      {isPending ? 'Restarting...' : 'Reset Bundler Cache'}
+      Reset Bundler Cache
     </button>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../../shared'
 import type { SupportedErrorEvent } from '../../../container/runtime-error/render-error'
 import { useRestartServer } from './use-restart-server'
+import { css } from '../../../utils/css'
 
 /**
  * When the Turbopack persistent cache is enabled, and the user reloads on a
@@ -21,8 +22,14 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
     return null
   }
 
-  function handleClick() {
-    restartServerAction({ invalidatePersistentCache: true })
+  async function handleClick() {
+    const hasServerRestarted = await restartServerAction({
+      invalidatePersistentCache: true,
+    })
+
+    if (hasServerRestarted) {
+      window.location.reload()
+    }
   }
 
   return (
@@ -32,9 +39,8 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
       disabled={isPending}
       title="Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing."
     >
-      {/* TODO: Add loading spinner. */}
-      <RefreshClockWise width={14} height={14} />
-      {isPending ? 'Restarting...' : 'Clear Bundler Cache &amp; Restart'}
+      <RefreshClockWise width={14} height={14} spinning={isPending} />
+      {isPending ? 'Restarting...' : 'Reset Bundler Cache'}
     </button>
   )
 }
@@ -83,7 +89,7 @@ export function usePersistentCacheErrorDetection({
   }, [errors, dispatch])
 }
 
-export const RESTART_SERVER_BUTTON_STYLES = `
+export const RESTART_SERVER_BUTTON_STYLES = css`
   .restart-dev-server-button {
     display: flex;
     justify-content: center;

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -29,7 +29,15 @@ export function RestartServerButton({ showButton }: { showButton: boolean }) {
       disabled={isPending}
       title="Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing."
     >
-      <RefreshClockWise width={14} height={14} spinning={isPending} />
+      <RefreshClockWise
+        width={14}
+        height={14}
+        style={{
+          animation: isPending
+            ? 'refresh-clock-wise-spin 1s linear infinite'
+            : undefined,
+        }}
+      />
       {isPending ? 'Restarting...' : 'Reset Bundler Cache'}
     </button>
   )
@@ -104,5 +112,14 @@ export const RESTART_SERVER_BUTTON_STYLES = css`
   .restart-dev-server-button:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+
+  @keyframes refresh-clock-wise-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -5,6 +5,7 @@ import {
   type OverlayDispatch,
 } from '../../../shared'
 import type { SupportedErrorEvent } from '../../../container/runtime-error/render-error'
+import { useRestartServer } from './use-restart-server'
 
 /**
  * When the Turbopack persistent cache is enabled, and the user reloads on a
@@ -14,28 +15,27 @@ import type { SupportedErrorEvent } from '../../../container/runtime-error/rende
  * telemetry on how often this is used.
  */
 export function RestartServerButton({ showButton }: { showButton: boolean }) {
+  const { restartServerAction, isPending } = useRestartServer({
+    invalidatePersistentCache: true,
+  })
+
   if (!showButton) {
     return null
   }
 
   function handleClick() {
-    // TODO: Use Client Action for transition indicator when DevTools is isolated.
-    fetch('/__nextjs_restart_dev?invalidatePersistentCache', {
-      method: 'POST',
-    }).then(() => {
-      // TODO: poll server status and reload when the server is back up.
-      // https://github.com/vercel/next.js/pull/80005
-    })
+    restartServerAction()
   }
 
   return (
     <button
       className="restart-dev-server-button"
       onClick={handleClick}
+      disabled={isPending}
       title="Clears the bundler cache and restarts the dev server. Helpful if you are seeing stale errors or changes are not appearing."
     >
       <RefreshClockWise width={14} height={14} />
-      Clear Bundler Cache &amp; Restart
+      {isPending ? 'Restarting...' : 'Clear Bundler Cache & Restart'}
     </button>
   )
 }
@@ -104,5 +104,10 @@ export const RESTART_SERVER_BUTTON_STYLES = `
     font-size: var(--size-12);
     font-weight: 500;
     line-height: var(--size-16);
+  }
+
+  .restart-dev-server-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
@@ -27,10 +27,9 @@ export function useRestartServer() {
         return
       }
 
-      // Poll for server restart confirmation
+      // Poll for server restart confirmation.
       let restartConfirmed = false
-      for (let i = 0; i < 30; i++) {
-        // Wait a bit before checking
+      for (let i = 0; i < 10; i++) {
         await new Promise((resolve) => setTimeout(resolve, 200))
 
         try {

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
@@ -1,18 +1,18 @@
 import { useTransition } from 'react'
 
-export function useRestartServer({
-  invalidatePersistentCache,
-}: {
-  invalidatePersistentCache: boolean
-}) {
+export function useRestartServer() {
   const [isPending, startTransition] = useTransition()
-  const url = invalidatePersistentCache
-    ? '/__nextjs_restart_dev?invalidatePersistentCache=1'
-    : '/__nextjs_restart_dev'
-
   let hasError = false
 
-  const restartServerAction = () => {
+  const restartServerAction = ({
+    invalidatePersistentCache,
+  }: {
+    invalidatePersistentCache: boolean
+  }) => {
+    const url = invalidatePersistentCache
+      ? '/__nextjs_restart_dev?invalidatePersistentCache=1'
+      : '/__nextjs_restart_dev'
+
     startTransition(async () => {
       const prevId = await fetch('/__nextjs_server_status')
         .then((res) => res.json())

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
@@ -1,64 +1,75 @@
-import { useTransition } from 'react'
+import { useState } from 'react'
 
 export function useRestartServer() {
-  const [isPending, startTransition] = useTransition()
+  const [isPending, setIsPending] = useState(false)
 
   /**
    * @returns A Promise that resolves to a boolean value of server restart status.
    */
-  const restartServerAction = ({
+  const restartServerAction = async ({
     invalidatePersistentCache,
   }: {
     invalidatePersistentCache: boolean
   }): Promise<boolean> => {
+    setIsPending(true)
+
     const url = invalidatePersistentCache
       ? '/__nextjs_restart_dev?invalidatePersistentCache=1'
       : '/__nextjs_restart_dev'
 
-    return new Promise((resolve) => {
-      startTransition(async () => {
+    try {
+      const curId = await fetch('/__nextjs_server_status')
+        .then((res) => res.json())
+        .then((data) => data.executionId as number)
+        .catch((error) => {
+          console.log(
+            '[Next.js DevTools] Failed to fetch server status while restarting dev server.',
+            error
+          )
+          return null
+        })
+
+      const restartRes = await fetch(url, {
+        method: 'POST',
+      })
+
+      if (!restartRes.ok) {
+        // Use console log to avoid spamming the error overlay which users can't control.
+        console.log(
+          '[Next.js DevTools] Failed to fetch restart server endpoint. Status:',
+          restartRes.status
+        )
+        return false
+      }
+
+      // Poll for server restart confirmation.
+      for (let i = 0; i < 10; i++) {
+        await new Promise((resolveTimeout) => setTimeout(resolveTimeout, 200))
+
         try {
-          const curId = await fetch('/__nextjs_server_status')
+          const nextId = await fetch('/__nextjs_server_status')
             .then((res) => res.json())
             .then((data) => data.executionId as number)
 
-          const restartRes = await fetch(url, {
-            method: 'POST',
-          })
-
-          if (!restartRes.ok) {
-            resolve(false)
-            return
+          // If the execution ID has changed, the server has restarted successfully.
+          if (curId !== nextId) {
+            return true
           }
-
-          // Poll for server restart confirmation.
-          for (let i = 0; i < 10; i++) {
-            await new Promise((resolveTimeout) =>
-              setTimeout(resolveTimeout, 200)
-            )
-
-            try {
-              const nextId = await fetch('/__nextjs_server_status')
-                .then((res) => res.json())
-                .then((data) => data.executionId as number)
-
-              // If the execution ID has changed, the server has restarted successfully.
-              if (curId !== nextId) {
-                resolve(true)
-                return
-              }
-            } catch (e) {
-              continue
-            }
-          }
-
-          // If we've exhausted all polling attempts, consider it failed
-          resolve(false)
-        } catch (error) {
-          resolve(false)
+        } catch (e) {
+          continue
         }
-      })
-    })
+      }
+
+      console.log(
+        '[Next.js DevTools] Failed to restart server. Exhausted all polling attempts.'
+      )
+      return false
+    } catch (error) {
+      console.log('[Next.js DevTools] Failed to restart server.', error)
+      return false
+    } finally {
+      setIsPending(false)
+    }
   }
 
   return {

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
@@ -78,7 +78,7 @@ export function useRestartServer() {
       console.log('[Next.js DevTools] Failed to restart server.', error)
       return
     } finally {
-      // If server restarted, don't reset isPending.
+      // If server restarted, don't reset isPending since the page will reload.
       if (!serverRestarted) {
         setIsPending(false)
       }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
@@ -2,61 +2,67 @@ import { useTransition } from 'react'
 
 export function useRestartServer() {
   const [isPending, startTransition] = useTransition()
-  let hasError = false
 
+  /**
+   * @returns A Promise that resolves to a boolean value of server restart status.
+   */
   const restartServerAction = ({
     invalidatePersistentCache,
   }: {
     invalidatePersistentCache: boolean
-  }) => {
+  }): Promise<boolean> => {
     const url = invalidatePersistentCache
       ? '/__nextjs_restart_dev?invalidatePersistentCache=1'
       : '/__nextjs_restart_dev'
 
-    startTransition(async () => {
-      const curId = await fetch('/__nextjs_server_status')
-        .then((res) => res.json())
-        .then((data) => data.executionId as number)
-
-      const restartRes = await fetch(url, {
-        method: 'POST',
-      })
-
-      if (!restartRes.ok) {
-        hasError = true
-        return
-      }
-
-      // Poll for server restart confirmation.
-      let restartConfirmed = false
-      for (let i = 0; i < 10; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 200))
-
+    return new Promise((resolve) => {
+      startTransition(async () => {
         try {
-          const nextId = await fetch('/__nextjs_server_status')
+          const curId = await fetch('/__nextjs_server_status')
             .then((res) => res.json())
             .then((data) => data.executionId as number)
 
-          // If the execution ID has changed, the server has restarted successfully.
-          if (curId !== nextId) {
-            restartConfirmed = true
-            break
-          }
-        } catch (error) {
-          continue
-        }
-      }
+          const restartRes = await fetch(url, {
+            method: 'POST',
+          })
 
-      if (!restartConfirmed) {
-        hasError = true
-        return
-      }
+          if (!restartRes.ok) {
+            resolve(false)
+            return
+          }
+
+          // Poll for server restart confirmation.
+          for (let i = 0; i < 10; i++) {
+            await new Promise((resolveTimeout) =>
+              setTimeout(resolveTimeout, 200)
+            )
+
+            try {
+              const nextId = await fetch('/__nextjs_server_status')
+                .then((res) => res.json())
+                .then((data) => data.executionId as number)
+
+              // If the execution ID has changed, the server has restarted successfully.
+              if (curId !== nextId) {
+                resolve(true)
+                return
+              }
+            } catch (e) {
+              continue
+            }
+          }
+
+          // If we've exhausted all polling attempts, consider it failed
+          resolve(false)
+        } catch (error) {
+          resolve(false)
+        }
+      })
     })
   }
 
   return {
     restartServerAction,
     isPending,
-    hasError,
   }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
@@ -1,0 +1,63 @@
+import { useTransition } from 'react'
+
+export function useRestartServer({
+  invalidatePersistentCache,
+}: {
+  invalidatePersistentCache: boolean
+}) {
+  const [isPending, startTransition] = useTransition()
+  const url = invalidatePersistentCache
+    ? '/__nextjs_restart_dev?invalidatePersistentCache=1'
+    : '/__nextjs_restart_dev'
+
+  let hasError = false
+
+  const restartServerAction = () => {
+    startTransition(async () => {
+      const prevId = await fetch('/__nextjs_server_status')
+        .then((res) => res.json())
+        .then((data) => data.executionId as number)
+
+      const restartRes = await fetch(url, {
+        method: 'POST',
+      })
+
+      if (!restartRes.ok) {
+        hasError = true
+        return
+      }
+
+      // Poll for server restart confirmation
+      let restartConfirmed = false
+      for (let i = 0; i < 30; i++) {
+        // Wait a bit before checking
+        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        try {
+          const curId = await fetch('/__nextjs_server_status')
+            .then((res) => res.json())
+            .then((data) => data.executionId as number)
+
+          // If the execution ID has changed, the server has restarted successfully.
+          if (curId !== prevId) {
+            restartConfirmed = true
+            break
+          }
+        } catch (error) {
+          continue
+        }
+      }
+
+      if (!restartConfirmed) {
+        hasError = true
+        return
+      }
+    })
+  }
+
+  return {
+    restartServerAction,
+    isPending,
+    hasError,
+  }
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/use-restart-server.ts
@@ -14,7 +14,7 @@ export function useRestartServer() {
       : '/__nextjs_restart_dev'
 
     startTransition(async () => {
-      const prevId = await fetch('/__nextjs_server_status')
+      const curId = await fetch('/__nextjs_server_status')
         .then((res) => res.json())
         .then((data) => data.executionId as number)
 
@@ -33,12 +33,12 @@ export function useRestartServer() {
         await new Promise((resolve) => setTimeout(resolve, 200))
 
         try {
-          const curId = await fetch('/__nextjs_server_status')
+          const nextId = await fetch('/__nextjs_server_status')
             .then((res) => res.json())
             .then((data) => data.executionId as number)
 
           // If the execution ID has changed, the server has restarted successfully.
-          if (curId !== prevId) {
+          if (curId !== nextId) {
             restartConfirmed = true
             break
           }

--- a/packages/next/src/next-devtools/dev-overlay/icons/refresh-clock-wise.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/icons/refresh-clock-wise.tsx
@@ -1,6 +1,21 @@
-export function RefreshClockWise(props: React.SVGProps<SVGSVGElement>) {
+import { css } from '../utils/css'
+
+export function RefreshClockWise({
+  spinning,
+  ...props
+}: React.SVGProps<SVGSVGElement> & { spinning: boolean }) {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" {...props}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      {...props}
+      style={{
+        animation: spinning
+          ? 'refresh-clock-wise-spin 1s linear infinite'
+          : undefined,
+        ...props.style,
+      }}
+    >
       <path
         d="M4.30969 8.37891H2.38782C2.9805 10.3647 4.82188 11.8124 7.00012 11.8125C8.81977 11.8124 10.4043 10.8024 11.2228 9.30957L11.5382 8.73438L12.6896 9.36523L12.3741 9.94043L12.1681 10.2891C11.0815 11.993 9.17324 13.1249 7.00012 13.125C4.42207 13.1249 2.21747 11.5322 1.3136 9.27734V11.375H0.00109863V7.72266L0.0147705 7.58984C0.0760304 7.29089 0.340278 7.06641 0.657349 7.06641H4.30969V8.37891ZM7.00012 0.875C9.57685 0.875118 11.7819 2.46569 12.6866 4.71875V2.625H13.9991V6.27734C13.9991 6.63974 13.7053 6.93354 13.3429 6.93359H9.68958V5.62109H11.6115C11.0186 3.6356 9.17813 2.18763 7.00012 2.1875C5.17131 2.18757 3.57959 3.20771 2.76477 4.71289L2.45227 5.29004L1.29797 4.66504L1.61047 4.08789C2.64547 2.17605 4.67052 0.875068 7.00012 0.875Z"
         fill="#A35200"
@@ -8,3 +23,14 @@ export function RefreshClockWise(props: React.SVGProps<SVGSVGElement>) {
     </svg>
   )
 }
+
+export const REFRESH_CLOCK_WISE_STYLES = css`
+  @keyframes refresh-clock-wise-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`

--- a/packages/next/src/next-devtools/dev-overlay/icons/refresh-clock-wise.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/icons/refresh-clock-wise.tsx
@@ -1,21 +1,6 @@
-import { css } from '../utils/css'
-
-export function RefreshClockWise({
-  spinning,
-  ...props
-}: React.SVGProps<SVGSVGElement> & { spinning: boolean }) {
+export function RefreshClockWise(props: React.SVGProps<SVGSVGElement>) {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-      {...props}
-      style={{
-        animation: spinning
-          ? 'refresh-clock-wise-spin 1s linear infinite'
-          : undefined,
-        ...props.style,
-      }}
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" {...props}>
       <path
         d="M4.30969 8.37891H2.38782C2.9805 10.3647 4.82188 11.8124 7.00012 11.8125C8.81977 11.8124 10.4043 10.8024 11.2228 9.30957L11.5382 8.73438L12.6896 9.36523L12.3741 9.94043L12.1681 10.2891C11.0815 11.993 9.17324 13.1249 7.00012 13.125C4.42207 13.1249 2.21747 11.5322 1.3136 9.27734V11.375H0.00109863V7.72266L0.0147705 7.58984C0.0760304 7.29089 0.340278 7.06641 0.657349 7.06641H4.30969V8.37891ZM7.00012 0.875C9.57685 0.875118 11.7819 2.46569 12.6866 4.71875V2.625H13.9991V6.27734C13.9991 6.63974 13.7053 6.93354 13.3429 6.93359H9.68958V5.62109H11.6115C11.0186 3.6356 9.17813 2.18763 7.00012 2.1875C5.17131 2.18757 3.57959 3.20771 2.76477 4.71289L2.45227 5.29004L1.29797 4.66504L1.61047 4.08789C2.64547 2.17605 4.67052 0.875068 7.00012 0.875Z"
         fill="#A35200"
@@ -23,14 +8,3 @@ export function RefreshClockWise({
     </svg>
   )
 }
-
-export const REFRESH_CLOCK_WISE_STYLES = css`
-  @keyframes refresh-clock-wise-spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-`

--- a/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/styles/component-styles.tsx
@@ -25,6 +25,7 @@ import { CALL_STACK_STYLES } from '../components/call-stack/call-stack'
 import { ISSUE_FEEDBACK_BUTTON_STYLES } from '../components/errors/error-overlay-toolbar/issue-feedback-button'
 import { ERROR_CONTENT_SKELETON_STYLES } from '../container/runtime-error/error-content-skeleton'
 import { SHORTCUT_RECORDER_STYLES } from '../components/errors/dev-tools-indicator/dev-tools-info/shortcut-recorder'
+
 export function ComponentStyles() {
   return (
     <style>


### PR DESCRIPTION
This PR adds a pending state to the clear bundler cache & server restart.

When the user clicks the restart server button, Next.js fetches `/__nextjs_server_status` for the current server's execution ID. Then it queries `/__nextjs_restart_dev` middleware to trigger the server restart, then polls the `/__nextjs_server_status` path to confirm the server execution ID differs, which means the new server is online.

When the server has restarted, reload the window.

Closes NEXT-4562
Closes NEXT-4501