### PR TITLE
Turbopack: Improve compaction in Persistent Caching

### DIFF
--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -22,8 +22,10 @@ fn main() -> Result<()> {
         .context("Failed to retrieve meta information")?;
     for meta_file in meta_info {
         println!(
-            "META {:08}.meta: family = {}, ",
-            meta_file.sequence_number, meta_file.family
+            "META {:08}.meta: family = {}, sst_size = {} MiB",
+            meta_file.sequence_number,
+            meta_file.family,
+            meta_file.entries.iter().map(|e| e.sst_size).sum::<u64>() / 1024 / 1024,
         );
         for MetaFileEntryInfo {
             sequence_number,

--- a/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
@@ -1,0 +1,166 @@
+struct IntervalPoint<T> {
+    start: u64,
+    value: Option<T>,
+}
+
+pub struct IntervalMap<T> {
+    intervals: Vec<IntervalPoint<T>>,
+}
+
+impl<T> Default for IntervalMap<T> {
+    fn default() -> Self {
+        Self {
+            intervals: Vec::new(),
+        }
+    }
+}
+
+impl<T> IntervalMap<T> {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Ensures that there is an interval point at the specified location.
+    fn ensure_point(&mut self, location: u64) -> usize
+    where
+        T: Clone,
+    {
+        match self
+            .intervals
+            .binary_search_by_key(&location, |point| point.start)
+        {
+            Ok(index) => index,
+            Err(index) => {
+                // If the location does not exist, we need to insert a new interval
+                let value = if index > 0 {
+                    self.intervals[index - 1].value.clone()
+                } else {
+                    None
+                };
+                self.intervals.insert(
+                    index,
+                    IntervalPoint {
+                        start: location,
+                        value,
+                    },
+                );
+                index
+            }
+        }
+    }
+
+    /// Applies the update function to all values in the specified range.
+    pub fn update(&mut self, range: &(u64, u64), mut update: impl FnMut(&mut T))
+    where
+        T: Default + Clone,
+    {
+        let start = range.0;
+        let end = range.1;
+        if start > end {
+            return;
+        }
+
+        let start = self.ensure_point(start);
+        if end == u64::MAX {
+            for i in start..self.intervals.len() {
+                update(self.intervals[i].value.get_or_insert_default());
+            }
+        } else {
+            let end = self.ensure_point(end + 1);
+
+            for i in start..end {
+                update(self.intervals[i].value.get_or_insert_default());
+            }
+        }
+    }
+
+    /// Tests if any values in the specified range satisfy the predicate.
+    pub fn test(&self, range: &(u64, u64), mut predicate: impl FnMut(&T) -> bool) -> bool {
+        let start = range.0;
+        let end = range.1;
+        if start > end {
+            return false;
+        }
+
+        let start_index = self
+            .intervals
+            .binary_search_by_key(&start, |point| point.start)
+            .unwrap_or_else(|x| x);
+
+        let end_index = match self
+            .intervals
+            .binary_search_by_key(&end, |point| point.start)
+        {
+            Ok(index) => index + 1,
+            Err(index) => index,
+        };
+
+        for i in start_index..end_index {
+            if let Some(value) = &self.intervals[i].value {
+                if predicate(value) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Returns an iterator over the ranges and their associated values.
+    pub fn ranges(&self) -> impl Iterator<Item = ((u64, u64), &T)> {
+        (0..self.intervals.len()).filter_map(move |i| {
+            let start = self.intervals[i].start;
+            let end = if i + 1 < self.intervals.len() {
+                self.intervals[i + 1].start - 1
+            } else {
+                u64::MAX
+            };
+            self.intervals[i]
+                .value
+                .as_ref()
+                .map(|value| ((start, end), value))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interval_map() {
+        let mut map = IntervalMap::new();
+        map.update(&(5, 15), |v| *v += 1);
+        map.update(&(10, 15), |v| *v += 2);
+        map.update(&(10, 20), |v| *v += 4);
+        map.update(&(0, u64::MAX), |v| *v += 8);
+        map.update(&(15, 20), |v| *v += 16);
+
+        let expected = vec![
+            ((0, 4), &8),
+            ((5, 9), &(1 | 8)),
+            ((10, 14), &(1 | 2 | 4 | 8)),
+            ((15, 15), &(1 | 2 | 4 | 8 | 16)),
+            ((16, 20), &(4 | 8 | 16)),
+            ((21, u64::MAX), &8),
+        ];
+        let result: Vec<_> = map.ranges().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_interval_map_empty() {
+        let map: IntervalMap<u32> = IntervalMap::new();
+        let result: Vec<_> = map.ranges().collect();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_interval_map_single_point() {
+        let mut map: IntervalMap<u32> = IntervalMap::new();
+        map.update(&(10, 10), |v| *v += 1);
+
+        let result: Vec<_> = map.ranges().collect();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], ((10, 10), &1));
+    }
+}

--- a/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
@@ -87,7 +87,7 @@ impl<T> IntervalMap<T> {
             .binary_search_by_key(&start, |point| point.start)
         {
             Ok(index) => index,
-            Err(index) if index == 0 => 0,
+            Err(0) => 0,
             Err(index) => index - 1,
         };
 

--- a/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
@@ -96,10 +96,10 @@ impl<T> IntervalMap<T> {
         };
 
         for i in start_index..end_index {
-            if let Some(value) = &self.intervals[i].value {
-                if predicate(value) {
-                    return true;
-                }
+            if let Some(value) = &self.intervals[i].value
+                && predicate(value)
+            {
+                return true;
             }
         }
         false

--- a/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/interval_map.rs
@@ -82,10 +82,14 @@ impl<T> IntervalMap<T> {
             return false;
         }
 
-        let start_index = self
+        let start_index = match self
             .intervals
             .binary_search_by_key(&start, |point| point.start)
-            .unwrap_or_else(|x| x);
+        {
+            Ok(index) => index,
+            Err(index) if index == 0 => 0,
+            Err(index) => index - 1,
+        };
 
         let end_index = match self
             .intervals
@@ -129,11 +133,11 @@ mod tests {
     #[test]
     fn test_interval_map() {
         let mut map = IntervalMap::new();
-        map.update(&(5, 15), |v| *v += 1);
-        map.update(&(10, 15), |v| *v += 2);
-        map.update(&(10, 20), |v| *v += 4);
-        map.update(&(0, u64::MAX), |v| *v += 8);
-        map.update(&(15, 20), |v| *v += 16);
+        map.update(&(5, 15), |v| *v |= 1);
+        map.update(&(10, 15), |v| *v |= 2);
+        map.update(&(10, 20), |v| *v |= 4);
+        map.update(&(0, u64::MAX), |v| *v |= 8);
+        map.update(&(15, 20), |v| *v |= 16);
 
         let expected = vec![
             ((0, 4), &8),
@@ -145,6 +149,19 @@ mod tests {
         ];
         let result: Vec<_> = map.ranges().collect();
         assert_eq!(result, expected);
+
+        // test the `test` method
+        assert!(map.test(&(0, 10), |v| *v & 1 != 0));
+        assert!(map.test(&(0, 10), |v| *v & 2 != 0));
+        assert!(map.test(&(0, 50), |v| *v & 4 != 0));
+        assert!(map.test(&(15, 15), |v| *v & 16 != 0));
+        assert!(map.test(&(0, 15), |v| *v & 16 != 0));
+        assert!(map.test(&(20, 20), |v| *v & 16 != 0));
+        assert!(map.test(&(20, u64::MAX), |v| *v & 16 != 0));
+        assert!(map.test(&(0, u64::MAX), |v| *v & 8 != 0));
+        assert!(map.test(&(0, 0), |v| *v & 8 != 0));
+        assert!(map.test(&(u64::MAX, u64::MAX), |v| *v & 8 != 0));
+        assert!(map.test(&(123, 1234), |v| *v & 8 != 0));
     }
 
     #[test]

--- a/turbopack/crates/turbo-persistence/src/compaction/mod.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/mod.rs
@@ -1,1 +1,2 @@
+pub(self) mod interval_map;
 pub mod selector;

--- a/turbopack/crates/turbo-persistence/src/compaction/mod.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/mod.rs
@@ -1,2 +1,2 @@
-pub(self) mod interval_map;
+mod interval_map;
 pub mod selector;

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -1,17 +1,8 @@
-/// The merge and move jobs that the compaction algorithm has computed. It's expected that all move
-/// jobs are executed in parallel and when that has finished the move jobs are executed in parallel.
-#[derive(Debug)]
-pub struct CompactionJobs {
-    pub merge_jobs: Vec<Vec<usize>>,
-    pub move_jobs: Vec<usize>,
-}
+use std::u64;
 
-impl CompactionJobs {
-    #[cfg(test)]
-    pub(self) fn is_empty(&self) -> bool {
-        self.merge_jobs.is_empty() && self.move_jobs.is_empty()
-    }
-}
+use smallvec::{SmallVec, smallvec};
+
+use crate::compaction::interval_map::IntervalMap;
 
 type Range = (u64, u64);
 
@@ -29,7 +20,7 @@ fn is_overlapping(a: &Range, b: &Range) -> bool {
 }
 
 fn spread(range: &Range) -> u64 {
-    range.1 - range.0
+    (range.1 - range.0).saturating_add(1)
 }
 
 /// Extends the range `a` to include the range `b`, returns `true` if the range was extended.
@@ -46,14 +37,68 @@ fn extend_range(a: &mut Range, b: &Range) -> bool {
     extended
 }
 
-/// Computes the total coverage of the compactables.
-pub fn total_coverage<T: Compactable>(compactables: &[T], full_range: Range) -> f32 {
+#[derive(Debug)]
+pub struct CompactableMetrics {
+    /// The total coverage of the compactables.
+    pub coverage: f32,
+
+    /// The maximum overlap of the compactables.
+    pub overlap: f32,
+
+    /// The possible duplication of the compactables.
+    pub duplicated_size: u64,
+
+    /// The possible duplication of the compactables as factor to total size.
+    pub duplication: f32,
+}
+
+/// Computes metrics about the compactables.
+pub fn compute_metrics<T: Compactable>(
+    compactables: &[T],
+    full_range: Range,
+) -> CompactableMetrics {
+    let mut interval_map: IntervalMap<(DuplicationInfo, usize)> = IntervalMap::new();
     let mut coverage = 0.0f32;
     for c in compactables {
         let range = c.range();
         coverage += spread(&range) as f32;
+        interval_map.update(&range, |(dup_info, count)| {
+            dup_info.add(c.size(), &range);
+            *count += 1;
+        });
     }
-    coverage / spread(&full_range) as f32
+    let full_spread = spread(&full_range) as f32;
+
+    let (duplicated_size, duplication, overlap) = interval_map
+        .ranges()
+        .map(|(range, (dup_info, count))| {
+            let duplicated_size = dup_info.duplication(&range);
+            let total_size = dup_info.size(&range);
+            let overlap = spread(&range) as f32 * count.saturating_sub(1) as f32;
+            (duplicated_size, total_size, overlap)
+        })
+        .reduce(|(dup1, total1, overlap1), (dup2, total2, overlap2)| {
+            (dup1 + dup2, total1 + total2, overlap1 + overlap2)
+        })
+        .map(|(duplicated_size, total_size, overlap)| {
+            (
+                duplicated_size,
+                if total_size > 0 {
+                    duplicated_size as f32 / total_size as f32
+                } else {
+                    0.0
+                },
+                overlap,
+            )
+        })
+        .unwrap_or((0, 0.0, 0.0));
+
+    CompactableMetrics {
+        coverage: coverage / full_spread,
+        overlap: overlap / full_spread,
+        duplicated_size,
+        duplication,
+    }
 }
 
 /// Configuration for the compaction algorithm.
@@ -61,168 +106,259 @@ pub struct CompactConfig {
     /// The minimum number of files to merge at once.
     pub min_merge: usize,
 
+    /// The optimal number of files to merge at once.
+    pub optimal_merge_count: usize,
+
     /// The maximum number of files to merge at once.
     pub max_merge: usize,
 
     /// The maximum size of all files to merge at once.
     pub max_merge_size: u64,
+
+    /// The amount of duplication that need to be in a merge job to be considered for merging.
+    pub min_merge_duplication_size: u64,
+
+    /// The optimal duplication size for merging.
+    pub optimal_merge_duplication_size: u64,
+
+    /// The maximum number of merge segments to determine.
+    pub max_merge_segments: usize,
 }
 
-/// For a list of compactables, computes merge and move jobs that are expected to perform best.
-pub fn get_compaction_jobs<T: Compactable>(
-    compactables: &[T],
-    config: &CompactConfig,
-) -> CompactionJobs {
-    let (jobs, _) = get_compaction_jobs_internal(compactables, config, 0);
-    jobs
+impl Default for CompactConfig {
+    fn default() -> Self {
+        const MB: u64 = 1024 * 1024;
+        Self {
+            min_merge: 2,
+            optimal_merge_count: 8,
+            max_merge: 32,
+            max_merge_size: 500 * MB,
+            min_merge_duplication_size: 1 * MB,
+            optimal_merge_duplication_size: 10 * MB,
+            max_merge_segments: 8,
+        }
+    }
 }
 
-fn get_compaction_jobs_internal<T: Compactable>(
+#[derive(Clone, Default)]
+struct DuplicationInfo {
+    total_size: u64,
+    max_size: u64,
+}
+
+impl DuplicationInfo {
+    fn duplication(&self, range: &Range) -> u64 {
+        if self.total_size == 0 {
+            return 0;
+        }
+        // This is equal to (self.total_size - self.max_size) * spread(range) / u64::MAX
+        // but we use widening_mul to avoid overflow.
+        (self.total_size - self.max_size)
+            .widening_mul(spread(range))
+            .1
+    }
+
+    fn size(&self, range: &Range) -> u64 {
+        if self.total_size == 0 {
+            return 0;
+        }
+        // This is equal to self.total_size * spread(range) / u64::MAX
+        // but we use widening_mul to avoid overflow.
+        self.total_size.widening_mul(spread(range)).1
+    }
+
+    fn add(&mut self, size: u64, range: &Range) {
+        // Scale size to full range:
+        let scaled_size = (size as u128 * u64::MAX as u128 / spread(range) as u128) as u64;
+        self.total_size = self.total_size.saturating_add(scaled_size);
+        self.max_size = self.max_size.max(scaled_size);
+    }
+}
+
+fn total_duplication_size(duplication: &IntervalMap<DuplicationInfo>) -> u64 {
+    duplication
+        .ranges()
+        .map(|(range, info)| info.duplication(&range))
+        .sum()
+}
+
+type MergeSegments = Vec<SmallVec<[usize; 1]>>;
+
+pub fn get_merge_segments<T: Compactable>(
     compactables: &[T],
     config: &CompactConfig,
-    start_index: usize,
-) -> (CompactionJobs, f32) {
-    let len = compactables.len();
-    let mut used_compactables = vec![false; len];
-    let mut need_move = vec![false; len];
-    let mut merge_jobs = Vec::new();
-    let mut merge_jobs_reducation = 0.0f32;
-    let mut move_jobs = Vec::new();
+) -> MergeSegments {
+    // Process all compactables in reverse order.
+    // For each compactable, find the smallest set of compactables that overlaps with it and matches
+    // the conditions.
+    // To find the set:
+    // - Set the current range to the range of the first unused compactable.
+    // - When the set matches the conditions, add the set as merge job, mark all used compactables
+    //   and continue.
+    // - Find the next unused compactable that overlaps with the current range.
+    // - If the range need to be extended, restart the search with the new range.
+    // - If the compactable is within the range, add it to the current set.
+    // - If the set is too large, mark the starting compactable as used and continue with the next
 
-    let age = |i| (len - 1 - i) as f32;
+    let mut unused_compactables = compactables.iter().collect::<Vec<_>>();
+    let mut used_compactables = vec![false; compactables.len()];
 
-    loop {
-        // Find the first unused compactable.
-        let Some(start) = used_compactables
-            .iter()
-            .skip(start_index)
-            .position(|&used| !used)
-            .map(|i| i + start_index)
-        else {
-            break;
-        };
-        if start >= len - 1 {
+    let mut merge_segments: MergeSegments = Vec::new();
+    let mut real_merge_segments = 0;
+
+    // Iterate in reverse order to process the compactables from the end.
+    // That's the order in which compactables are read, so we need to keep that order.
+    'outer: while let Some(start_compactable) = unused_compactables.pop() {
+        let start_index = unused_compactables.len();
+        if used_compactables[start_index] {
+            continue;
+        }
+        if real_merge_segments >= config.max_merge_segments {
+            // We have reached the maximum number of merge jobs, so we stop here.
             break;
         }
-        used_compactables[start] = true;
-        let start_range = compactables[start].range();
-        let mut range = start_range;
+        let mut current_range = start_compactable.range();
 
-        let mut merge_job_size = compactables[start].size();
-        let mut merge_job = Vec::new();
-        merge_job.push(start);
-        let mut merge_job_input_spread = spread(&start_range) as f32;
+        // We might need to restart the search if we need to extend the range.
+        'search: loop {
+            let mut current_set = smallvec![start_index];
+            let mut current_size = start_compactable.size();
+            let mut duplication: IntervalMap<DuplicationInfo> = IntervalMap::new();
+            let mut current_skip = 0;
 
-        'outer: loop {
-            // Find the next overlapping unused compactable and extend the range to cover it.
-            // If it already covers it, add this to the current set.
-            let mut i = start + 1;
+            // We will capture compactables in the current_range until we find a optimal merge
+            // segment or are limited by size or count.
             loop {
-                if !used_compactables[i] {
-                    let range_for_i = compactables[i].range();
-                    if is_overlapping(&range, &range_for_i) {
-                        let mut extended_range = range;
-                        if !extend_range(&mut extended_range, &range_for_i) {
-                            let size = compactables[i].size();
-                            if merge_job_size + size > config.max_merge_size {
-                                break 'outer;
-                            }
-                            used_compactables[i] = true;
-                            merge_job.push(i);
-                            merge_job_size += compactables[i].size();
-                            merge_job_input_spread += spread(&range_for_i) as f32;
-                        } else {
-                            let s = spread(&range);
-                            // Disallow doubling the range spread
-                            if merge_job.len() >= config.min_merge
-                                && spread(&extended_range) - s > s
-                            {
-                                break 'outer;
-                            }
-                            range = extended_range;
-                            // Need to restart the search from the beginning as the extended range
-                            // may overlap with compactables that were
-                            // already processed.
-                            break;
-                        }
+                // Early exit if we have found an optimal merge segment.
+                let duplication_size = total_duplication_size(&duplication);
+                let optimal_merge_job = current_set.len() >= config.optimal_merge_count
+                    && duplication_size >= config.optimal_merge_duplication_size;
+                if optimal_merge_job {
+                    for &i in current_set.iter() {
+                        used_compactables[i] = true;
                     }
+                    current_set.reverse();
+                    merge_segments.push(current_set);
+                    real_merge_segments += 1;
+                    continue 'outer;
                 }
-                i += 1;
-                if i >= compactables.len() {
-                    break 'outer;
+
+                // If we are limited by size or count, we might also crate a merge segment if it's
+                // within the limits.
+                let valid_merge_job = current_set.len() >= config.min_merge
+                    && duplication_size >= config.min_merge_duplication_size;
+                let mut end_job =
+                    |mut current_set: SmallVec<[usize; 1]>, used_compactables: &mut Vec<bool>| {
+                        if valid_merge_job {
+                            for &i in current_set.iter() {
+                                used_compactables[i] = true;
+                            }
+                            current_set.reverse();
+                            merge_segments.push(current_set);
+                            real_merge_segments += 1;
+                        } else {
+                            merge_segments.push(smallvec![start_index]);
+                        }
+                    };
+
+                // Check if we run into the count or size limit.
+                if current_set.len() >= config.max_merge || current_size >= config.max_merge_size {
+                    // The set is so large so we can't add more compactables to it.
+                    end_job(current_set, &mut used_compactables);
+                    continue 'outer;
                 }
-                if merge_job.len() >= config.max_merge {
-                    break 'outer;
+
+                // Find the next compactable that overlaps with the current range.
+                let Some((next_index, compactable)) = unused_compactables
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .skip(current_skip)
+                    .find(|(i, compactable)| {
+                        if used_compactables[*i] {
+                            return false;
+                        }
+                        let range = compactable.range();
+                        is_overlapping(&current_range, &range)
+                    })
+                else {
+                    // There are no more compactables that overlap with the current range.
+                    end_job(current_set, &mut used_compactables);
+                    continue 'outer;
+                };
+                current_skip = unused_compactables.len() - next_index;
+
+                // Check if we run into the size limit.
+                let size = compactable.size();
+                if current_size + size > config.max_merge_size {
+                    // The next compactable is too large to be added to the current set.
+                    end_job(current_set, &mut used_compactables);
+                    continue 'outer;
                 }
+
+                // Check if the next compactable is larger than the current range. We need to
+                // restart from beginning here as there could be previously skipped compactables
+                // that are within the larger range.
+                let range = compactable.range();
+                if extend_range(&mut current_range, &range) {
+                    // The range was extended, so we need to restart the search.
+                    continue 'search;
+                }
+
+                // The next compactable is within the current range, so we can add it to the current
+                // set.
+                current_set.push(next_index);
+                current_size += size;
+                duplication.update(&range, |dup_info| {
+                    dup_info.add(size, &range);
+                });
             }
         }
-
-        if merge_job.len() < config.min_merge {
-            continue;
-        }
-        let mut merge_range = compactables[start].range();
-        if !merge_job
-            .iter()
-            .skip(1)
-            .any(|&i| is_overlapping(&merge_range, &compactables[i].range()))
-        {
-            // No overlapping ranges, skip that merge job.
-            continue;
-        }
-
-        for &i in merge_job.iter().skip(1) {
-            extend_range(&mut merge_range, &compactables[i].range());
-        }
-        merge_jobs_reducation = (merge_job_input_spread - spread(&merge_range) as f32) * age(start);
-
-        for (i, compactable) in compactables
-            .iter()
-            .enumerate()
-            .skip(merge_job.last().unwrap() + 1)
-        {
-            if used_compactables[i] {
-                continue;
-            }
-            let range = compactable.range();
-            if is_overlapping(&merge_range, &range) && !need_move[i] {
-                need_move[i] = true;
-                used_compactables[i] = true;
-                move_jobs.push(i);
-            }
-        }
-
-        merge_jobs.push(merge_job);
     }
 
-    // Check if there is an alternative with better reduction.
-    if !move_jobs.is_empty() {
-        let offset = move_jobs[0];
-        let (result, estimated_reduction) =
-            get_compaction_jobs_internal(compactables, config, offset);
-        if estimated_reduction > merge_jobs_reducation {
-            return (result, estimated_reduction);
-        }
+    while merge_segments.last().is_some_and(|s| s.len() == 1) {
+        // Remove segments that only contain a single compactable.
+        merge_segments.pop();
     }
 
-    move_jobs.sort_unstable();
+    // Reverse it since we processed in reverse order.
+    merge_segments.reverse();
 
-    (
-        CompactionJobs {
-            merge_jobs,
-            move_jobs,
-        },
-        merge_jobs_reducation,
-    )
+    // Remove single compectable segments that don't overlap with previous segments. We don't need
+    // to touch them.
+    // TODO: Technically it's a bit inefficient to use an IntervalMap here, but
+    // it's not very hot code anyway.
+    let mut used_ranges: IntervalMap<bool> = IntervalMap::new();
+    merge_segments.retain(|segment| {
+        // Remove a single element segments which doesn't overlap with previous used ranges.
+        if segment.len() == 1 {
+            let range = compactables[segment[0]].range();
+            if !used_ranges.test(&range, |in_use| *in_use) {
+                return false;
+            }
+        }
+        // Mark the ranges of the segment as used.
+        for i in segment {
+            let range = compactables[*i].range();
+            used_ranges.update(&range, |in_use| {
+                *in_use = true;
+            });
+        }
+        true
+    });
+
+    merge_segments
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
         fmt::Debug,
-        mem::{swap, take},
+        mem::{replace, swap},
+        usize,
     };
 
-    use rand::{Rng, SeedableRng};
+    use rand::{Rng, SeedableRng, seq::SliceRandom};
 
     use super::*;
 
@@ -241,30 +377,20 @@ mod tests {
         }
     }
 
-    fn compact<const N: usize>(
-        ranges: [(u64, u64); N],
-        max_merge: usize,
-        max_merge_size: u64,
-    ) -> CompactionJobs {
+    fn compact<const N: usize>(ranges: [(u64, u64); N], config: &CompactConfig) -> Vec<Vec<usize>> {
         let compactables = ranges
             .iter()
             .map(|&range| TestCompactable { range, size: 100 })
             .collect::<Vec<_>>();
-        let config = CompactConfig {
-            max_merge,
-            min_merge: 2,
-            max_merge_size,
-        };
-        get_compaction_jobs(&compactables, &config)
+        let jobs = get_merge_segments(&compactables, config);
+        jobs.into_iter()
+            .map(|job| job.into_iter().collect())
+            .collect()
     }
 
     #[test]
-    fn test_compaction_jobs() {
-        let CompactionJobs {
-            merge_jobs,
-            move_jobs,
-            ..
-        } = compact(
+    fn test_compaction_jobs_by_count() {
+        let merge_jobs = compact(
             [
                 (0, 10),
                 (10, 30),
@@ -276,20 +402,22 @@ mod tests {
                 (90, 100),
                 (30, 40),
             ],
-            3,
-            u64::MAX,
+            &CompactConfig {
+                min_merge: 2,
+                optimal_merge_count: 3,
+                max_merge: 4,
+                max_merge_size: u64::MAX,
+                min_merge_duplication_size: 0,
+                optimal_merge_duplication_size: 0,
+                max_merge_segments: usize::MAX,
+            },
         );
-        assert_eq!(merge_jobs, vec![vec![0, 1, 2], vec![4, 5, 6]]);
-        assert_eq!(move_jobs, vec![3, 8]);
+        assert_eq!(merge_jobs, vec![vec![1, 2, 3], vec![5, 6, 8]]);
     }
 
     #[test]
     fn test_compaction_jobs_by_size() {
-        let CompactionJobs {
-            merge_jobs,
-            move_jobs,
-            ..
-        } = compact(
+        let merge_jobs = compact(
             [
                 (0, 10),
                 (10, 30),
@@ -301,26 +429,141 @@ mod tests {
                 (90, 100),
                 (30, 40),
             ],
-            usize::MAX,
-            300,
+            &CompactConfig {
+                min_merge: 2,
+                optimal_merge_count: 2,
+                max_merge: usize::MAX,
+                max_merge_size: 300,
+                min_merge_duplication_size: 0,
+                optimal_merge_duplication_size: u64::MAX,
+                max_merge_segments: usize::MAX,
+            },
         );
-        assert_eq!(merge_jobs, vec![vec![0, 1, 2], vec![4, 5, 6]]);
-        assert_eq!(move_jobs, vec![3, 8]);
+        assert_eq!(merge_jobs, vec![vec![1, 2, 3], vec![5, 6, 8]]);
+    }
+
+    #[test]
+    fn test_compaction_jobs_full() {
+        let merge_jobs = compact(
+            [
+                (0, 10),
+                (10, 30),
+                (9, 13),
+                (0, 30),
+                (40, 44),
+                (41, 42),
+                (41, 47),
+                (90, 100),
+                (30, 40),
+            ],
+            &CompactConfig {
+                min_merge: 2,
+                optimal_merge_count: usize::MAX,
+                max_merge: usize::MAX,
+                max_merge_size: u64::MAX,
+                min_merge_duplication_size: 0,
+                optimal_merge_duplication_size: u64::MAX,
+                max_merge_segments: usize::MAX,
+            },
+        );
+        assert_eq!(merge_jobs, vec![vec![0, 1, 2, 3, 4, 5, 6, 8]]);
+    }
+
+    #[test]
+    fn test_compaction_jobs_big() {
+        let merge_jobs = compact(
+            [
+                (0, 10),
+                (10, 30),
+                (9, 13),
+                (0, 30),
+                (40, 44),
+                (41, 42),
+                (41, 47),
+                (90, 100),
+                (30, 40),
+            ],
+            &CompactConfig {
+                min_merge: 2,
+                optimal_merge_count: 7,
+                max_merge: usize::MAX,
+                max_merge_size: u64::MAX,
+                min_merge_duplication_size: 0,
+                optimal_merge_duplication_size: 0,
+                max_merge_segments: usize::MAX,
+            },
+        );
+        assert_eq!(merge_jobs, vec![vec![1, 2, 3, 4, 5, 6, 8]]);
+    }
+
+    #[test]
+    fn test_compaction_jobs_small() {
+        let merge_jobs = compact(
+            [
+                (0, 10),
+                (10, 30),
+                (9, 13),
+                (0, 30),
+                (40, 44),
+                (41, 42),
+                (41, 47),
+                (90, 100),
+                (30, 40),
+            ],
+            &CompactConfig {
+                min_merge: 2,
+                optimal_merge_count: 2,
+                max_merge: usize::MAX,
+                max_merge_size: u64::MAX,
+                min_merge_duplication_size: 0,
+                optimal_merge_duplication_size: 0,
+                max_merge_segments: usize::MAX,
+            },
+        );
+        assert_eq!(
+            merge_jobs,
+            vec![vec![0, 1], vec![2, 3], vec![4, 5], vec![6, 8]]
+        );
+    }
+
+    pub fn debug_print_compactables<T: Compactable>(compactables: &[T], max_key: u64) {
+        const WIDTH: usize = 128;
+        let char_width: u64 = max_key / WIDTH as u64;
+        for (i, c) in compactables.iter().enumerate() {
+            let range = c.range();
+            let size = c.size();
+            let start = (range.0 / char_width) as usize;
+            let end = (range.1 / char_width) as usize;
+            let mut line = format!("{i:>3} | ");
+            for j in 0..WIDTH {
+                if j >= start && j <= end {
+                    line.push('█');
+                } else {
+                    line.push(' ');
+                }
+            }
+            println!("{line} | {size:>6}");
+        }
     }
 
     #[test]
     fn simulate_compactions() {
+        const KEY_RANGE: u64 = 10000;
+        const WARM_KEY_COUNT: usize = 100;
+        const INITIAL_CHUNK_SIZE: usize = 100;
+        const ITERATIONS: usize = 100;
+
         let mut rnd = rand::rngs::SmallRng::from_seed([0; 32]);
-        let mut keys = (0..1000)
-            .map(|_| rnd.random_range(0..10000))
-            .collect::<Vec<_>>();
+        let mut keys = (0..KEY_RANGE).collect::<Vec<_>>();
+        keys.shuffle(&mut rnd);
 
+        let mut batch_index = 0;
         let mut containers = keys
-            .chunks(100)
-            .map(|keys| Container::new(keys.to_vec()))
+            .chunks(INITIAL_CHUNK_SIZE)
+            .map(|keys| Container::new(batch_index, keys.to_vec()))
             .collect::<Vec<_>>();
 
-        let mut warm_keys = (0..100)
+        let mut warm_keys = (0..WARM_KEY_COUNT)
             .map(|_| {
                 let i = rnd.random_range(0..keys.len());
                 keys.swap_remove(i)
@@ -329,36 +572,63 @@ mod tests {
 
         let mut number_of_compactions = 0;
 
-        for _ in 0..100 {
-            let coverage = total_coverage(&containers, (0, 10000));
+        for _ in 0..ITERATIONS {
+            let total_size = containers.iter().map(|c| c.keys.len()).sum::<usize>();
+            let metrics = compute_metrics(&containers, (0, KEY_RANGE));
+            debug_print_compactables(&containers, KEY_RANGE);
             println!(
-                "{containers:#?} coverage: {}, items: {}",
-                coverage,
+                "size: {}, coverage: {}, overlap: {}, duplication: {}, items: {}",
+                total_size,
+                metrics.coverage,
+                metrics.overlap,
+                metrics.duplication,
                 containers.len()
             );
 
-            if coverage > 10.0 {
-                let config = CompactConfig {
-                    max_merge: 4,
-                    min_merge: 2,
-                    max_merge_size: u64::MAX,
-                };
-                let jobs = get_compaction_jobs(&containers, &config);
-                if !jobs.is_empty() {
-                    println!("{jobs:?}");
+            assert!(containers.len() < 400);
+            // assert!(metrics.duplication < 4.0);
 
-                    do_compact(&mut containers, jobs);
-                    number_of_compactions += 1;
-                }
+            let config = CompactConfig {
+                max_merge: 16,
+                min_merge: 2,
+                optimal_merge_count: 4,
+                max_merge_size: 5000,
+                min_merge_duplication_size: 200,
+                optimal_merge_duplication_size: 500,
+                max_merge_segments: 4,
+            };
+            let jobs = get_merge_segments(&containers, &config);
+            if !jobs.is_empty() {
+                println!("{jobs:?}");
+
+                batch_index += 1;
+                do_compact(&mut containers, jobs, batch_index);
+                number_of_compactions += 1;
+
+                let new_metrics = compute_metrics(&containers, (0, KEY_RANGE));
+                println!(
+                    "Compaction done: coverage: {} ({}), overlap: {} ({}), duplication: {} ({})",
+                    new_metrics.coverage,
+                    new_metrics.coverage - metrics.coverage,
+                    new_metrics.overlap,
+                    new_metrics.overlap - metrics.overlap,
+                    new_metrics.duplication,
+                    new_metrics.duplication - metrics.duplication
+                );
             } else {
                 println!("No compaction needed");
             }
 
             // Modify warm keys
-            containers.push(Container::new(warm_keys.clone()));
+            batch_index += 1;
+            let pieces = rnd.random_range(1..4);
+            for chunk in warm_keys.chunks(warm_keys.len().div_ceil(pieces)) {
+                containers.push(Container::new(batch_index, chunk.to_vec()));
+            }
 
             // Change some warm keys
-            for _ in 0..10 {
+            let changes = rnd.random_range(0..100);
+            for _ in 0..changes {
                 let i = rnd.random_range(0..warm_keys.len());
                 let j = rnd.random_range(0..keys.len());
                 swap(&mut warm_keys[i], &mut keys[j]);
@@ -366,19 +636,21 @@ mod tests {
         }
         println!("Number of compactions: {number_of_compactions}");
 
-        assert!(containers.len() < 40);
-        let coverage = total_coverage(&containers, (0, 10000));
-        assert!(coverage < 12.0);
+        let metrics = compute_metrics(&containers, (0, KEY_RANGE));
+        assert!(number_of_compactions < 40);
+        assert!(containers.len() < 30);
+        assert!(metrics.duplication < 0.5);
     }
 
     struct Container {
+        batch_index: usize,
         keys: Vec<u64>,
     }
 
     impl Container {
-        fn new(mut keys: Vec<u64>) -> Self {
+        fn new(batch_index: usize, mut keys: Vec<u64>) -> Self {
             keys.sort_unstable();
-            Self { keys }
+            Self { batch_index, keys }
         }
     }
 
@@ -395,30 +667,44 @@ mod tests {
     impl Debug for Container {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let (l, r) = self.range();
-            write!(f, "{} {l} - {r} ({})", self.keys.len(), r - l)
+            write!(
+                f,
+                "#{} {}b {l} - {r} ({})",
+                self.batch_index,
+                self.keys.len(),
+                r - l
+            )
         }
     }
 
-    fn do_compact(containers: &mut Vec<Container>, jobs: CompactionJobs) {
-        for merge_job in jobs.merge_jobs {
-            let mut keys = Vec::new();
-            for i in merge_job {
-                keys.append(&mut containers[i].keys);
+    fn do_compact(containers: &mut Vec<Container>, segments: MergeSegments, batch_index: usize) {
+        let total_size = containers.iter().map(|c| c.keys.len()).sum::<usize>();
+        for merge_job in segments {
+            if merge_job.len() < 2 {
+                let container = replace(
+                    &mut containers[merge_job[0]],
+                    Container {
+                        batch_index: 0,
+                        keys: Default::default(),
+                    },
+                );
+                containers.push(container);
+            } else {
+                let mut keys = Vec::new();
+                for i in merge_job {
+                    keys.append(&mut containers[i].keys);
+                }
+                keys.sort_unstable();
+                keys.dedup();
+                containers.extend(keys.chunks(1000).map(|keys| Container {
+                    batch_index,
+                    keys: keys.to_vec(),
+                }));
             }
-            keys.sort_unstable();
-            keys.dedup();
-            containers.extend(keys.chunks(100).map(|keys| Container {
-                keys: keys.to_vec(),
-            }));
-        }
-
-        for i in jobs.move_jobs {
-            let moved_container = Container {
-                keys: take(&mut containers[i].keys),
-            };
-            containers.push(moved_container);
         }
 
         containers.retain(|c| !c.keys.is_empty());
+        let total_size2 = containers.iter().map(|c| c.keys.len()).sum::<usize>();
+        println!("Compaction done: {total_size} -> {total_size2}",);
     }
 }

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -102,38 +102,38 @@ pub fn compute_metrics<T: Compactable>(
 /// Configuration for the compaction algorithm.
 pub struct CompactConfig {
     /// The minimum number of files to merge at once.
-    pub min_merge: usize,
+    pub min_merge_count: usize,
 
     /// The optimal number of files to merge at once.
     pub optimal_merge_count: usize,
 
     /// The maximum number of files to merge at once.
-    pub max_merge: usize,
+    pub max_merge_count: usize,
 
     /// The maximum size of all files to merge at once.
-    pub max_merge_size: u64,
+    pub max_merge_bytes: u64,
 
     /// The amount of duplication that need to be in a merge job to be considered for merging.
-    pub min_merge_duplication_size: u64,
+    pub min_merge_duplication_bytes: u64,
 
     /// The optimal duplication size for merging.
-    pub optimal_merge_duplication_size: u64,
+    pub optimal_merge_duplication_bytes: u64,
 
     /// The maximum number of merge segments to determine.
-    pub max_merge_segments: usize,
+    pub max_merge_segment_count: usize,
 }
 
 impl Default for CompactConfig {
     fn default() -> Self {
         const MB: u64 = 1024 * 1024;
         Self {
-            min_merge: 2,
+            min_merge_count: 2,
             optimal_merge_count: 8,
-            max_merge: 32,
-            max_merge_size: 500 * MB,
-            min_merge_duplication_size: MB,
-            optimal_merge_duplication_size: 10 * MB,
-            max_merge_segments: 8,
+            max_merge_count: 32,
+            max_merge_bytes: 500 * MB,
+            min_merge_duplication_bytes: MB,
+            optimal_merge_duplication_bytes: 10 * MB,
+            max_merge_segment_count: 8,
         }
     }
 }
@@ -211,7 +211,7 @@ pub fn get_merge_segments<T: Compactable>(
         if used_compactables[start_index] {
             continue;
         }
-        if real_merge_segments >= config.max_merge_segments {
+        if real_merge_segments >= config.max_merge_segment_count {
             // We have reached the maximum number of merge jobs, so we stop here.
             break;
         }
@@ -230,7 +230,7 @@ pub fn get_merge_segments<T: Compactable>(
                 // Early exit if we have found an optimal merge segment.
                 let duplication_size = total_duplication_size(&duplication);
                 let optimal_merge_job = current_set.len() >= config.optimal_merge_count
-                    && duplication_size >= config.optimal_merge_duplication_size;
+                    && duplication_size >= config.optimal_merge_duplication_bytes;
                 if optimal_merge_job {
                     for &i in current_set.iter() {
                         used_compactables[i] = true;
@@ -243,8 +243,8 @@ pub fn get_merge_segments<T: Compactable>(
 
                 // If we are limited by size or count, we might also crate a merge segment if it's
                 // within the limits.
-                let valid_merge_job = current_set.len() >= config.min_merge
-                    && duplication_size >= config.min_merge_duplication_size;
+                let valid_merge_job = current_set.len() >= config.min_merge_count
+                    && duplication_size >= config.min_merge_duplication_bytes;
                 let mut end_job =
                     |mut current_set: SmallVec<[usize; 1]>, used_compactables: &mut Vec<bool>| {
                         if valid_merge_job {
@@ -260,7 +260,9 @@ pub fn get_merge_segments<T: Compactable>(
                     };
 
                 // Check if we run into the count or size limit.
-                if current_set.len() >= config.max_merge || current_size >= config.max_merge_size {
+                if current_set.len() >= config.max_merge_count
+                    || current_size >= config.max_merge_bytes
+                {
                     // The set is so large so we can't add more compactables to it.
                     end_job(current_set, &mut used_compactables);
                     continue 'outer;
@@ -288,7 +290,7 @@ pub fn get_merge_segments<T: Compactable>(
 
                 // Check if we run into the size limit.
                 let size = compactable.size();
-                if current_size + size > config.max_merge_size {
+                if current_size + size > config.max_merge_bytes {
                     // The next compactable is too large to be added to the current set.
                     end_job(current_set, &mut used_compactables);
                     continue 'outer;
@@ -400,13 +402,13 @@ mod tests {
                 (30, 40),
             ],
             &CompactConfig {
-                min_merge: 2,
+                min_merge_count: 2,
                 optimal_merge_count: 3,
-                max_merge: 4,
-                max_merge_size: u64::MAX,
-                min_merge_duplication_size: 0,
-                optimal_merge_duplication_size: 0,
-                max_merge_segments: usize::MAX,
+                max_merge_count: 4,
+                max_merge_bytes: u64::MAX,
+                min_merge_duplication_bytes: 0,
+                optimal_merge_duplication_bytes: 0,
+                max_merge_segment_count: usize::MAX,
             },
         );
         assert_eq!(merge_jobs, vec![vec![1, 2, 3], vec![5, 6, 8]]);
@@ -427,13 +429,13 @@ mod tests {
                 (30, 40),
             ],
             &CompactConfig {
-                min_merge: 2,
+                min_merge_count: 2,
                 optimal_merge_count: 2,
-                max_merge: usize::MAX,
-                max_merge_size: 300,
-                min_merge_duplication_size: 0,
-                optimal_merge_duplication_size: u64::MAX,
-                max_merge_segments: usize::MAX,
+                max_merge_count: usize::MAX,
+                max_merge_bytes: 300,
+                min_merge_duplication_bytes: 0,
+                optimal_merge_duplication_bytes: u64::MAX,
+                max_merge_segment_count: usize::MAX,
             },
         );
         assert_eq!(merge_jobs, vec![vec![1, 2, 3], vec![5, 6, 8]]);
@@ -454,13 +456,13 @@ mod tests {
                 (30, 40),
             ],
             &CompactConfig {
-                min_merge: 2,
+                min_merge_count: 2,
                 optimal_merge_count: usize::MAX,
-                max_merge: usize::MAX,
-                max_merge_size: u64::MAX,
-                min_merge_duplication_size: 0,
-                optimal_merge_duplication_size: u64::MAX,
-                max_merge_segments: usize::MAX,
+                max_merge_count: usize::MAX,
+                max_merge_bytes: u64::MAX,
+                min_merge_duplication_bytes: 0,
+                optimal_merge_duplication_bytes: u64::MAX,
+                max_merge_segment_count: usize::MAX,
             },
         );
         assert_eq!(merge_jobs, vec![vec![0, 1, 2, 3, 4, 5, 6, 8]]);
@@ -481,13 +483,13 @@ mod tests {
                 (30, 40),
             ],
             &CompactConfig {
-                min_merge: 2,
+                min_merge_count: 2,
                 optimal_merge_count: 7,
-                max_merge: usize::MAX,
-                max_merge_size: u64::MAX,
-                min_merge_duplication_size: 0,
-                optimal_merge_duplication_size: 0,
-                max_merge_segments: usize::MAX,
+                max_merge_count: usize::MAX,
+                max_merge_bytes: u64::MAX,
+                min_merge_duplication_bytes: 0,
+                optimal_merge_duplication_bytes: 0,
+                max_merge_segment_count: usize::MAX,
             },
         );
         assert_eq!(merge_jobs, vec![vec![1, 2, 3, 4, 5, 6, 8]]);
@@ -508,13 +510,13 @@ mod tests {
                 (30, 40),
             ],
             &CompactConfig {
-                min_merge: 2,
+                min_merge_count: 2,
                 optimal_merge_count: 2,
-                max_merge: usize::MAX,
-                max_merge_size: u64::MAX,
-                min_merge_duplication_size: 0,
-                optimal_merge_duplication_size: 0,
-                max_merge_segments: usize::MAX,
+                max_merge_count: usize::MAX,
+                max_merge_bytes: u64::MAX,
+                min_merge_duplication_bytes: 0,
+                optimal_merge_duplication_bytes: 0,
+                max_merge_segment_count: usize::MAX,
             },
         );
         assert_eq!(
@@ -586,13 +588,13 @@ mod tests {
             // assert!(metrics.duplication < 4.0);
 
             let config = CompactConfig {
-                max_merge: 16,
-                min_merge: 2,
+                max_merge_count: 16,
+                min_merge_count: 2,
                 optimal_merge_count: 4,
-                max_merge_size: 5000,
-                min_merge_duplication_size: 200,
-                optimal_merge_duplication_size: 500,
-                max_merge_segments: 4,
+                max_merge_bytes: 5000,
+                min_merge_duplication_bytes: 200,
+                optimal_merge_duplication_bytes: 500,
+                max_merge_segment_count: 4,
             };
             let jobs = get_merge_segments(&containers, &config);
             if !jobs.is_empty() {

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -1,5 +1,3 @@
-use std::u64;
-
 use smallvec::{SmallVec, smallvec};
 
 use crate::compaction::interval_map::IntervalMap;
@@ -133,7 +131,7 @@ impl Default for CompactConfig {
             optimal_merge_count: 8,
             max_merge: 32,
             max_merge_size: 500 * MB,
-            min_merge_duplication_size: 1 * MB,
+            min_merge_duplication_size: MB,
             optimal_merge_duplication_size: 10 * MB,
             max_merge_segments: 8,
         }
@@ -355,7 +353,6 @@ mod tests {
     use std::{
         fmt::Debug,
         mem::{replace, swap},
-        usize,
     };
 
     use rand::{Rng, SeedableRng, seq::SliceRandom};

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -149,25 +149,20 @@ impl DuplicationInfo {
         if self.total_size == 0 {
             return 0;
         }
-        // This is equal to (self.total_size - self.max_size) * spread(range) / u64::MAX
-        // but we use widening_mul to avoid overflow.
-        (self.total_size - self.max_size)
-            .widening_mul(spread(range))
-            .1
+        ((self.total_size - self.max_size) as u128 * spread(range) as u128 / (u64::MAX as u128 + 1))
+            as u64
     }
 
     fn size(&self, range: &Range) -> u64 {
         if self.total_size == 0 {
             return 0;
         }
-        // This is equal to self.total_size * spread(range) / u64::MAX
-        // but we use widening_mul to avoid overflow.
-        self.total_size.widening_mul(spread(range)).1
+        (self.total_size as u128 * spread(range) as u128 / (u64::MAX as u128 + 1)) as u64
     }
 
     fn add(&mut self, size: u64, range: &Range) {
         // Scale size to full range:
-        let scaled_size = (size as u128 * u64::MAX as u128 / spread(range) as u128) as u64;
+        let scaled_size = (size as u128 * (u64::MAX as u128 + 1) / spread(range) as u128) as u64;
         self.total_size = self.total_size.saturating_add(scaled_size);
         self.max_size = self.max_size.max(scaled_size);
     }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -10,6 +10,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicU32, Ordering},
     },
+    u64,
 };
 
 use anyhow::{Context, Result, bail};
@@ -21,12 +22,11 @@ use parking_lot::{Mutex, RwLock};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use tracing::Span;
 
+pub use crate::compaction::selector::CompactConfig;
 use crate::{
     QueryKey,
     arc_slice::ArcSlice,
-    compaction::selector::{
-        CompactConfig, Compactable, CompactionJobs, get_compaction_jobs, total_coverage,
-    },
+    compaction::selector::{Compactable, compute_metrics, get_merge_segments},
     constants::{
         AQMF_AVG_SIZE, AQMF_CACHE_SIZE, DATA_THRESHOLD_PER_COMPACTED_FILE, KEY_BLOCK_AVG_SIZE,
         KEY_BLOCK_CACHE_SIZE, MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE,
@@ -650,7 +650,15 @@ impl TurboPersistence {
     /// Runs a full compaction on the database. This will rewrite all SST files, removing all
     /// duplicate keys and separating all key ranges into unique files.
     pub fn full_compact(&self) -> Result<()> {
-        self.compact(0.0, usize::MAX, u64::MAX)?;
+        self.compact(&CompactConfig {
+            min_merge: 2,
+            optimal_merge_count: usize::MAX,
+            max_merge: usize::MAX,
+            max_merge_size: u64::MAX,
+            min_merge_duplication_size: 0,
+            optimal_merge_duplication_size: u64::MAX,
+            max_merge_segments: usize::MAX,
+        })?;
         Ok(())
     }
 
@@ -658,12 +666,7 @@ impl TurboPersistence {
     /// files is above the given threshold. The coverage is the average number of SST files that
     /// need to be read to find a key. It also limits the maximum number of SST files that are
     /// merged at once, which is the main factor for the runtime of the compaction.
-    pub fn compact(
-        &self,
-        max_coverage: f32,
-        max_merge_sequence: usize,
-        max_merge_size: u64,
-    ) -> Result<()> {
+    pub fn compact(&self, compact_config: &CompactConfig) -> Result<()> {
         if self.read_only {
             bail!("Compaction is not allowed on a read only database");
         }
@@ -697,9 +700,7 @@ impl TurboPersistence {
                 &mut sst_seq_numbers_to_delete,
                 &mut blob_seq_numbers_to_delete,
                 &mut keys_written,
-                max_coverage,
-                max_merge_sequence,
-                max_merge_size,
+                compact_config,
             )
             .context("Failed to compact database")?;
         }
@@ -732,9 +733,7 @@ impl TurboPersistence {
         sst_seq_numbers_to_delete: &mut Vec<u32>,
         blob_seq_numbers_to_delete: &mut Vec<u32>,
         keys_written: &mut u64,
-        max_coverage: f32,
-        max_merge_sequence: usize,
-        max_merge_size: u64,
+        compact_config: &CompactConfig,
     ) -> Result<()> {
         if meta_files.is_empty() {
             return Ok(());
@@ -811,8 +810,10 @@ impl TurboPersistence {
             .map(|(family, ssts_with_ranges)| {
                 let family = family as u32;
                 let _span = span.clone().entered();
-                let coverage = total_coverage(&ssts_with_ranges, (0, u64::MAX));
-                if coverage <= max_coverage {
+
+                let merge_jobs = get_merge_segments(&ssts_with_ranges, &compact_config);
+
+                if merge_jobs.is_empty() {
                     return Ok(PartialResultPerFamily {
                         new_meta_file: None,
                         new_sst_files: Vec::new(),
@@ -822,24 +823,18 @@ impl TurboPersistence {
                     });
                 }
 
-                let CompactionJobs {
-                    merge_jobs,
-                    move_jobs,
-                } = get_compaction_jobs(
-                    &ssts_with_ranges,
-                    &CompactConfig {
-                        min_merge: 2,
-                        max_merge: max_merge_sequence,
-                        max_merge_size,
-                    },
-                );
-
-                if !merge_jobs.is_empty() {
+                {
+                    let metrics = compute_metrics(&ssts_with_ranges, (0, u64::MAX));
                     let guard = log_mutex.lock();
                     let mut log = self.open_log()?;
                     writeln!(
                         log,
-                        "Compaction for family {family} (coverage: {coverage}):"
+                        "Compaction for family {family} (coverage: {}, overlap: {}, duplication: \
+                         {} / {} MiB):",
+                        metrics.coverage,
+                        metrics.overlap,
+                        metrics.duplication,
+                        metrics.duplicated_size / 1024 / 1024
                     )?;
                     for job in merge_jobs.iter() {
                         writeln!(log, "  merge")?;
@@ -855,32 +850,63 @@ impl TurboPersistence {
                 // Later we will remove the merged files
                 let sst_seq_numbers_to_delete = merge_jobs
                     .iter()
+                    .filter(|l| l.len() > 1)
                     .flat_map(|l| l.iter().copied())
                     .map(|index| ssts_with_ranges[index].seq)
                     .collect::<Vec<_>>();
 
-                let meta_file_builder = Mutex::new(MetaFileBuilder::new(family));
-
                 // Merge SST files
                 let span = tracing::trace_span!("merge files");
-                struct PartialMergeResult {
-                    new_sst_files: Vec<(u32, File)>,
-                    blob_seq_numbers_to_delete: Vec<u32>,
-                    keys_written: u64,
+                enum PartialMergeResult<'l> {
+                    Merged {
+                        new_sst_files: Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
+                        blob_seq_numbers_to_delete: Vec<u32>,
+                        keys_written: u64,
+                    },
+                    Move {
+                        seq: u32,
+                        meta: StaticSortedFileBuilderMeta<'l>,
+                    },
                 }
                 let merge_result = merge_jobs
                     .into_par_iter()
                     .with_min_len(1)
                     .map(|indicies| {
                         let _span = span.clone().entered();
+                        if indicies.len() == 1 {
+                            // If we only have one file, we can just move it
+                            let index = indicies[0];
+                            let meta_index = ssts_with_ranges[index].meta_index;
+                            let index_in_meta = ssts_with_ranges[index].index_in_meta;
+                            let meta_file = &meta_files[meta_index];
+                            let entry = meta_file.entry(index_in_meta);
+                            let aqmf = Cow::Borrowed(entry.raw_aqmf(meta_file.aqmf_data()));
+                            let meta = StaticSortedFileBuilderMeta {
+                                min_hash: entry.min_hash(),
+                                max_hash: entry.max_hash(),
+                                aqmf,
+                                key_compression_dictionary_length: entry
+                                    .key_compression_dictionary_length(),
+                                value_compression_dictionary_length: entry
+                                    .value_compression_dictionary_length(),
+                                block_count: entry.block_count(),
+                                size: entry.size(),
+                                entries: 0,
+                            };
+                            return Ok(PartialMergeResult::Move {
+                                seq: entry.sequence_number(),
+                                meta,
+                            });
+                        }
+
                         fn create_sst_file(
                             entries: &[LookupEntry],
                             total_key_size: usize,
                             total_value_size: usize,
                             path: &Path,
                             seq: u32,
-                            meta_file_builder: &Mutex<MetaFileBuilder>,
-                        ) -> Result<(u32, File)> {
+                        ) -> Result<(u32, File, StaticSortedFileBuilderMeta<'static>)>
+                        {
                             let _span = tracing::trace_span!("write merged sst file").entered();
                             let builder = StaticSortedFileBuilder::new(
                                 entries,
@@ -889,8 +915,7 @@ impl TurboPersistence {
                             )?;
                             let (meta, file) =
                                 builder.write(&path.join(format!("{seq:08}.sst")))?;
-                            meta_file_builder.lock().add(seq, meta);
-                            Ok((seq, file))
+                            Ok((seq, file, meta))
                         }
 
                         let mut new_sst_files = Vec::new();
@@ -958,7 +983,6 @@ impl TurboPersistence {
                                                 selected_total_value_size,
                                                 path,
                                                 seq,
-                                                &meta_file_builder,
                                             )?);
 
                                             entries.clear();
@@ -989,7 +1013,6 @@ impl TurboPersistence {
                                 total_value_size,
                                 path,
                                 seq,
-                                &meta_file_builder,
                             )?);
                         } else
                         // If we have two sets of entries left, merge them and
@@ -1014,7 +1037,6 @@ impl TurboPersistence {
                                 last_entries_total_sizes.1 / 2,
                                 path,
                                 seq1,
-                                &meta_file_builder,
                             )?);
 
                             keys_written += part2.len() as u64;
@@ -1024,10 +1046,9 @@ impl TurboPersistence {
                                 last_entries_total_sizes.1 / 2,
                                 path,
                                 seq2,
-                                &meta_file_builder,
                             )?);
                         }
-                        Ok(PartialMergeResult {
+                        Ok(PartialMergeResult::Merged {
                             new_sst_files,
                             blob_seq_numbers_to_delete,
                             keys_written,
@@ -1038,76 +1059,61 @@ impl TurboPersistence {
                         format!("Failed to merge database files for family {family}")
                     })?;
 
-                let mut meta_file_builder = meta_file_builder.into_inner();
+                let Some((sst_files_len, blob_delete_len)) = merge_result
+                    .iter()
+                    .map(|r| {
+                        if let PartialMergeResult::Merged {
+                            new_sst_files,
+                            blob_seq_numbers_to_delete,
+                            keys_written: _,
+                        } = r
+                        {
+                            (new_sst_files.len(), blob_seq_numbers_to_delete.len())
+                        } else {
+                            (0, 0)
+                        }
+                    })
+                    .reduce(|(a1, a2), (b1, b2)| (a1 + b1, a2 + b2))
+                else {
+                    unreachable!()
+                };
+
+                let mut new_sst_files = Vec::with_capacity(sst_files_len);
+                let mut blob_seq_numbers_to_delete = Vec::with_capacity(blob_delete_len);
+
+                let mut meta_file_builder = MetaFileBuilder::new(family);
+
+                let mut keys_written = 0;
+                for result in merge_result {
+                    match result {
+                        PartialMergeResult::Merged {
+                            new_sst_files: merged_new_sst_files,
+                            blob_seq_numbers_to_delete: merged_blob_seq_numbers_to_delete,
+                            keys_written: merged_keys_written,
+                        } => {
+                            for (seq, file, meta) in merged_new_sst_files {
+                                meta_file_builder.add(seq, meta);
+                                new_sst_files.push((seq, file));
+                            }
+                            blob_seq_numbers_to_delete.extend(merged_blob_seq_numbers_to_delete);
+                            keys_written += merged_keys_written;
+                        }
+                        PartialMergeResult::Move { seq, meta } => {
+                            meta_file_builder.add(seq, meta);
+                        }
+                    }
+                }
 
                 for &seq in sst_seq_numbers_to_delete.iter() {
                     meta_file_builder.add_obsolete_sst_file(seq);
                 }
 
-                // Move SST files
-                let span = tracing::trace_span!("query moved sst files").entered();
-                for index in move_jobs {
-                    let meta_index = ssts_with_ranges[index].meta_index;
-                    let index_in_meta = ssts_with_ranges[index].index_in_meta;
-                    let meta_file = &meta_files[meta_index];
-                    let entry = meta_file.entry(index_in_meta);
-                    let aqmf = Cow::Borrowed(entry.raw_aqmf(meta_file.aqmf_data()));
-                    let meta = StaticSortedFileBuilderMeta {
-                        min_hash: entry.min_hash(),
-                        max_hash: entry.max_hash(),
-                        aqmf,
-                        key_compression_dictionary_length: entry
-                            .key_compression_dictionary_length(),
-                        value_compression_dictionary_length: entry
-                            .value_compression_dictionary_length(),
-                        block_count: entry.block_count(),
-                        size: entry.size(),
-                        entries: 0,
-                    };
-                    meta_file_builder.add(entry.sequence_number(), meta);
-                }
-                drop(span);
-
-                let span = tracing::trace_span!("write meta file").entered();
                 let seq = sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
-                let meta_file = meta_file_builder.write(&self.path, seq)?;
-                drop(span);
+                let meta_file = {
+                    let _span = tracing::trace_span!("write meta file").entered();
+                    meta_file_builder.write(&self.path, seq)?
+                };
 
-                let mut new_sst_files = Vec::with_capacity(
-                    merge_result
-                        .iter()
-                        .map(
-                            |PartialMergeResult {
-                                 new_sst_files: v,
-                                 blob_seq_numbers_to_delete: _,
-                                 keys_written: _,
-                             }| v.len(),
-                        )
-                        .sum(),
-                );
-                let mut blob_seq_numbers_to_delete = Vec::with_capacity(
-                    merge_result
-                        .iter()
-                        .map(
-                            |PartialMergeResult {
-                                 new_sst_files: _,
-                                 blob_seq_numbers_to_delete: v,
-                                 keys_written: _,
-                             }| v.len(),
-                        )
-                        .sum(),
-                );
-                let mut keys_written = 0;
-                for PartialMergeResult {
-                    new_sst_files: merged_new_sst_files,
-                    blob_seq_numbers_to_delete: merged_blob_seq_numbers_to_delete,
-                    keys_written: merged_keys_written,
-                } in merge_result
-                {
-                    new_sst_files.extend(merged_new_sst_files);
-                    blob_seq_numbers_to_delete.extend(merged_blob_seq_numbers_to_delete);
-                    keys_written += merged_keys_written;
-                }
                 Ok(PartialResultPerFamily {
                     new_meta_file: Some((seq, meta_file)),
                     new_sst_files,

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -650,13 +650,13 @@ impl TurboPersistence {
     /// duplicate keys and separating all key ranges into unique files.
     pub fn full_compact(&self) -> Result<()> {
         self.compact(&CompactConfig {
-            min_merge: 2,
+            min_merge_count: 2,
             optimal_merge_count: usize::MAX,
-            max_merge: usize::MAX,
-            max_merge_size: u64::MAX,
-            min_merge_duplication_size: 0,
-            optimal_merge_duplication_size: u64::MAX,
-            max_merge_segments: usize::MAX,
+            max_merge_count: usize::MAX,
+            max_merge_bytes: u64::MAX,
+            min_merge_duplication_bytes: 0,
+            optimal_merge_duplication_bytes: u64::MAX,
+            max_merge_segment_count: usize::MAX,
         })?;
         Ok(())
     }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -10,7 +10,6 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicU32, Ordering},
     },
-    u64,
 };
 
 use anyhow::{Context, Result, bail};
@@ -811,7 +810,7 @@ impl TurboPersistence {
                 let family = family as u32;
                 let _span = span.clone().entered();
 
-                let merge_jobs = get_merge_segments(&ssts_with_ranges, &compact_config);
+                let merge_jobs = get_merge_segments(&ssts_with_ranges, compact_config);
 
                 if merge_jobs.is_empty() {
                     return Ok(PartialResultPerFamily {

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(get_mut_unchecked)]
 #![feature(sync_unsafe_cell)]
 #![feature(iter_collect_into)]
-#![feature(bigint_helper_methods)]
 
 mod arc_slice;
 mod collector;

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(get_mut_unchecked)]
 #![feature(sync_unsafe_cell)]
 #![feature(iter_collect_into)]
+#![feature(bigint_helper_methods)]
 
 mod arc_slice;
 mod collector;
@@ -24,7 +25,7 @@ mod value_buf;
 mod write_batch;
 
 pub use arc_slice::ArcSlice;
-pub use db::{MetaFileEntryInfo, MetaFileInfo, TurboPersistence};
+pub use db::{CompactConfig, MetaFileEntryInfo, MetaFileInfo, TurboPersistence};
 pub use key::{KeyBase, QueryKey, StoreKey};
 pub use value_buf::ValueBuffer;
 pub use write_batch::WriteBatch;

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -3,7 +3,11 @@ use std::{fs, time::Instant};
 use anyhow::Result;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-use crate::{constants::MAX_MEDIUM_VALUE_SIZE, db::TurboPersistence, write_batch::WriteBatch};
+use crate::{
+    constants::MAX_MEDIUM_VALUE_SIZE,
+    db::{CompactConfig, TurboPersistence},
+    write_batch::WriteBatch,
+};
 
 #[test]
 fn full_cycle() -> Result<()> {
@@ -455,7 +459,12 @@ fn persist_changes() -> Result<()> {
     {
         let db = TurboPersistence::open(path.to_path_buf())?;
 
-        db.compact(1.0, 3, u64::MAX)?;
+        db.compact(&CompactConfig {
+            optimal_merge_count: 4,
+            min_merge_duplication_size: 1,
+            optimal_merge_duplication_size: 1,
+            ..Default::default()
+        })?;
 
         check(&db, 1, 13)?;
         check(&db, 2, 22)?;
@@ -528,7 +537,12 @@ fn partial_compaction() -> Result<()> {
         {
             let db = TurboPersistence::open(path.to_path_buf())?;
 
-            db.compact(3.0, 3, u64::MAX)?;
+            db.compact(&CompactConfig {
+                optimal_merge_count: 4,
+                min_merge_duplication_size: 1,
+                optimal_merge_duplication_size: 1,
+                ..Default::default()
+            })?;
 
             for j in 0..i {
                 check(&db, j, j)?;
@@ -630,7 +644,12 @@ fn merge_file_removal() -> Result<()> {
         {
             let db = TurboPersistence::open(path.to_path_buf())?;
 
-            db.compact(3.0, 3, u64::MAX)?;
+            db.compact(&CompactConfig {
+                optimal_merge_count: 4,
+                min_merge_duplication_size: 1,
+                optimal_merge_duplication_size: 1,
+                ..Default::default()
+            })?;
 
             for j in 0..32 {
                 check(&db, j, expected_values[j as usize])?;

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -461,8 +461,8 @@ fn persist_changes() -> Result<()> {
 
         db.compact(&CompactConfig {
             optimal_merge_count: 4,
-            min_merge_duplication_size: 1,
-            optimal_merge_duplication_size: 1,
+            min_merge_duplication_bytes: 1,
+            optimal_merge_duplication_bytes: 1,
             ..Default::default()
         })?;
 
@@ -539,8 +539,8 @@ fn partial_compaction() -> Result<()> {
 
             db.compact(&CompactConfig {
                 optimal_merge_count: 4,
-                min_merge_duplication_size: 1,
-                optimal_merge_duplication_size: 1,
+                min_merge_duplication_bytes: 1,
+                optimal_merge_duplication_bytes: 1,
                 ..Default::default()
             })?;
 
@@ -646,8 +646,8 @@ fn merge_file_removal() -> Result<()> {
 
             db.compact(&CompactConfig {
                 optimal_merge_count: 4,
-                min_merge_duplication_size: 1,
-                optimal_merge_duplication_size: 1,
+                min_merge_duplication_bytes: 1,
+                optimal_merge_duplication_bytes: 1,
                 ..Default::default()
             })?;
 

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -1,21 +1,31 @@
 use std::{
+    cmp::max,
     path::PathBuf,
     sync::Arc,
-    thread::{JoinHandle, spawn},
+    thread::{JoinHandle, available_parallelism, spawn},
 };
 
 use anyhow::Result;
 use parking_lot::Mutex;
-use turbo_persistence::{ArcSlice, KeyBase, StoreKey, TurboPersistence, ValueBuffer};
+use turbo_persistence::{
+    ArcSlice, CompactConfig, KeyBase, StoreKey, TurboPersistence, ValueBuffer,
+};
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},
     write_batch::{BaseWriteBatch, ConcurrentWriteBatch, WriteBatch, WriteBuffer},
 };
 
-const COMPACT_MAX_COVERAGE: f32 = 20.0;
-const COMPACT_MAX_MERGE_SEQUENCE: usize = 64;
-const COMPACT_MAX_MERGE_SIZE: u64 = 512 * 1024 * 1024; // 512 MiB
+const MB: u64 = 1024 * 1024;
+const COMPACT_CONFIG: CompactConfig = CompactConfig {
+    min_merge: 3,
+    optimal_merge_count: 8,
+    max_merge: 64,
+    max_merge_size: 512 * MB,
+    min_merge_duplication_size: 1 * MB,
+    optimal_merge_duplication_size: 100 * MB,
+    max_merge_segments: 16,
+};
 
 pub struct TurboKeyValueDatabase {
     db: Arc<TurboPersistence>,
@@ -32,11 +42,10 @@ impl TurboKeyValueDatabase {
         // start compaction in background if the database is not empty
         if !db.is_empty() {
             let handle = spawn(move || {
-                db.compact(
-                    COMPACT_MAX_COVERAGE,
-                    COMPACT_MAX_MERGE_SEQUENCE,
-                    COMPACT_MAX_MERGE_SIZE,
-                )
+                db.compact(&CompactConfig {
+                    max_merge_segments: available_parallelism().map_or(4, |c| max(4, c.get() / 4)),
+                    ..COMPACT_CONFIG
+                })
             });
             this.compact_join_handle.get_mut().replace(handle);
         }
@@ -140,11 +149,10 @@ impl<'a> BaseWriteBatch<'a> for TurboWriteBatch<'a> {
             // Start a new compaction in the background
             let db = self.db.clone();
             let handle = spawn(move || {
-                db.compact(
-                    COMPACT_MAX_COVERAGE,
-                    COMPACT_MAX_MERGE_SEQUENCE,
-                    COMPACT_MAX_MERGE_SIZE,
-                )
+                db.compact(&CompactConfig {
+                    max_merge_segments: available_parallelism().map_or(4, |c| max(4, c.get() / 2)),
+                    ..COMPACT_CONFIG
+                })
             });
             self.compact_join_handle.lock().replace(handle);
         }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -18,13 +18,13 @@ use crate::database::{
 
 const MB: u64 = 1024 * 1024;
 const COMPACT_CONFIG: CompactConfig = CompactConfig {
-    min_merge: 3,
+    min_merge_count: 3,
     optimal_merge_count: 8,
-    max_merge: 64,
-    max_merge_size: 512 * MB,
-    min_merge_duplication_size: MB,
-    optimal_merge_duplication_size: 100 * MB,
-    max_merge_segments: 16,
+    max_merge_count: 64,
+    max_merge_bytes: 512 * MB,
+    min_merge_duplication_bytes: MB,
+    optimal_merge_duplication_bytes: 100 * MB,
+    max_merge_segment_count: 16,
 };
 
 pub struct TurboKeyValueDatabase {
@@ -43,7 +43,8 @@ impl TurboKeyValueDatabase {
         if !db.is_empty() {
             let handle = spawn(move || {
                 db.compact(&CompactConfig {
-                    max_merge_segments: available_parallelism().map_or(4, |c| max(4, c.get() / 4)),
+                    max_merge_segment_count: available_parallelism()
+                        .map_or(4, |c| max(4, c.get() / 4)),
                     ..COMPACT_CONFIG
                 })
             });
@@ -150,7 +151,8 @@ impl<'a> BaseWriteBatch<'a> for TurboWriteBatch<'a> {
             let db = self.db.clone();
             let handle = spawn(move || {
                 db.compact(&CompactConfig {
-                    max_merge_segments: available_parallelism().map_or(4, |c| max(4, c.get() / 2)),
+                    max_merge_segment_count: available_parallelism()
+                        .map_or(4, |c| max(4, c.get() / 2)),
                     ..COMPACT_CONFIG
                 })
             });

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo.rs
@@ -22,7 +22,7 @@ const COMPACT_CONFIG: CompactConfig = CompactConfig {
     optimal_merge_count: 8,
     max_merge: 64,
     max_merge_size: 512 * MB,
-    min_merge_duplication_size: 1 * MB,
+    min_merge_duplication_size: MB,
     optimal_merge_duplication_size: 100 * MB,
     max_merge_segments: 16,
 };


### PR DESCRIPTION
### What?

Refactors the compaction algorithm with the following improvements.

* Multiple ranges can be compacted in parallel
* Instead of going for the largest merge it looks for an "optimal" size and runs multiple in parallel
* Compaction considers duplicated size and tries to reduce it
* Compaction works on recent SST files first as they tend to be less compacted yet and potentially contains more duplication.
* Limits the parallel compactions to CPUs / 4 during the build and CPUs / 2 after the build

Closes PACK-4950