### PR TITLE
Fix fallback: true cache-control

### DIFF
--- a/test/e2e/prerender/pages/fallback-true/[slug].js
+++ b/test/e2e/prerender/pages/fallback-true/[slug].js
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export async function getStaticPaths() {
+  return {
+    paths: ['/fallback-true/first'],
+    fallback: true,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      hello: 'world',
+      post: params.slug,
+      random: Math.random(),
+      time: (await import('perf_hooks')).performance.now(),
+    },
+    revalidate: 2,
+  }
+}
+
+export default ({ post, time, params }) => {
+  if (useRouter().isFallback) {
+    return <p>hi fallback</p>
+  }
+
+  return (
+    <>
+      <p>Post: {post}</p>
+      <span>time: {time}</span>
+      <div id="params">{JSON.stringify(params)}</div>
+      <div id="query">{JSON.stringify(useRouter().query)}</div>
+      <Link href="/" id="home">
+        to home
+      </Link>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures we don't treat cache hits for lazily generated `fallback: true` routes as the fallback itself which has a different cache-control header than cache hits should.  

Fixes: https://github.com/vercel/next.js/issues/80838