### PR TITLE
Remove all references to @mdx-js/react

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1010,7 +1010,6 @@ async fn insert_next_shared_aliases(
         vec![
             request_to_import_mapping(project_path.clone(), "./mdx-components"),
             request_to_import_mapping(project_path.clone(), "./src/mdx-components"),
-            request_to_import_mapping(project_path.clone(), "@mdx-js/react"),
             request_to_import_mapping(project_path.clone(), "@next/mdx/mdx-components.js"),
         ],
     );

--- a/docs/01-app/02-guides/mdx.mdx
+++ b/docs/01-app/02-guides/mdx.mdx
@@ -33,7 +33,7 @@ The `@next/mdx` package, and related packages, are used to configure Next.js so 
 Install these packages to render MDX with Next.js:
 
 ```bash filename="Terminal"
-npm install @next/mdx @mdx-js/loader @mdx-js/react @types/mdx
+npm install @next/mdx @mdx-js/loader @types/mdx
 ```
 
 ## Configure `next.config.mjs`

--- a/examples/mdx-pages/package.json
+++ b/examples/mdx-pages/package.json
@@ -6,8 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@mdx-js/loader": "^1.5.1",
-    "@mdx-js/react": "^1.6.18",
+    "@mdx-js/loader": "^3.1.0",
     "@next/mdx": "^9.1.1",
     "next": "latest",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@fullhuman/postcss-purgecss": "1.3.0",
     "@jest/expect-utils": "29.7.0",
     "@mdx-js/loader": "2.2.1",
-    "@mdx-js/react": "2.2.1",
     "@next/bundle-analyzer": "workspace:*",
     "@next/env": "workspace:*",
     "@next/eslint-plugin-next": "workspace:*",

--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -31,7 +31,6 @@ module.exports =
         config.resolve.alias['next-mdx-import-source-file'] = [
           'private-next-root-dir/src/mdx-components',
           'private-next-root-dir/mdx-components',
-          '@mdx-js/react',
           require.resolve('./mdx-components.js'),
         ]
         config.module.rules.push({

--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -8,14 +8,10 @@
     "directory": "packages/next-mdx"
   },
   "peerDependencies": {
-    "@mdx-js/loader": ">=0.15.0",
-    "@mdx-js/react": ">=0.15.0"
+    "@mdx-js/loader": ">=0.15.0"
   },
   "peerDependenciesMeta": {
     "@mdx-js/loader": {
-      "optional": true
-    },
-    "@mdx-js/react": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ importers:
       '@mdx-js/loader':
         specifier: 2.2.1
         version: 2.2.1(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15)))
-      '@mdx-js/react':
-        specifier: 2.2.1
-        version: 2.2.1(react@19.2.0-canary-9be531cd-20250729)
       '@next/bundle-analyzer':
         specifier: workspace:*
         version: link:packages/next-bundle-analyzer
@@ -1694,9 +1691,6 @@ importers:
       '@mdx-js/loader':
         specifier: '>=0.15.0'
         version: 2.2.1(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15)))
-      '@mdx-js/react':
-        specifier: '>=0.15.0'
-        version: 2.2.1(react@19.2.0-canary-eaee5308-20250728)
       source-map:
         specifier: ^0.7.0
         version: 0.7.3
@@ -4421,11 +4415,6 @@ packages:
 
   '@mdx-js/mdx@2.2.1':
     resolution: {integrity: sha512-hZ3ex7exYLJn6FfReq8yTvA6TE53uW9UHJQM9IlSauOuS55J9y8RtA7W+dzp6Yrzr00/U1sd7q+Wf61q6SfiTQ==}
-
-  '@mdx-js/react@2.2.1':
-    resolution: {integrity: sha512-YdXcMcEnqZhzql98RNrqYo9cEhTTesBiCclEtoiQUbJwx87q9453GTapYU6kJ8ZZ2ek1Vp25SiAXEFy5O/eAPw==}
-    peerDependencies:
-      react: 19.2.0-canary-9be531cd-20250729
 
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
@@ -14128,7 +14117,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.11.0:
@@ -20294,18 +20282,6 @@ snapshots:
       vfile: 5.3.6
     transitivePeerDependencies:
       - supports-color
-
-  '@mdx-js/react@2.2.1(react@19.2.0-canary-9be531cd-20250729)':
-    dependencies:
-      '@types/mdx': 2.0.3
-      '@types/react': 19.1.8
-      react: 19.2.0-canary-9be531cd-20250729
-
-  '@mdx-js/react@2.2.1(react@19.2.0-canary-eaee5308-20250728)':
-    dependencies:
-      '@types/mdx': 2.0.3
-      '@types/react': 19.1.8
-      react: 19.2.0-canary-eaee5308-20250728
 
   '@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.2.0-canary-9be531cd-20250729)':
     dependencies:

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -12,7 +12,6 @@ describe('ReactRefreshRegression app', () => {
       'styled-components': '6.1.16',
       '@next/mdx': 'canary',
       '@mdx-js/loader': '2.2.1',
-      '@mdx-js/react': '2.2.1',
     },
     skipStart: true,
   })

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -11,7 +11,6 @@ describe('Error overlay - RSC build errors', () => {
       '@next/mdx': 'canary',
       'react-wrap-balancer': '^0.2.4',
       'react-tweet': '^3.2.0',
-      '@mdx-js/react': '^2.3.0',
       tailwindcss: '^3.2.6',
       typescript: 'latest',
       '@types/react': '^18.0.28',

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -13,7 +13,6 @@ describe('ReactRefreshRegression', () => {
       'styled-components': '6.1.16',
       '@next/mdx': 'canary',
       '@mdx-js/loader': '2.2.1',
-      '@mdx-js/react': '2.2.1',
     },
   })
 

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -7,7 +7,6 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
       dependencies: {
         '@next/mdx': 'canary',
         '@mdx-js/loader': '^2.2.1',
-        '@mdx-js/react': '^2.2.1',
         'rehype-katex': '7.0.1',
         'rehype-slug': '6.0.0',
         'remark-gfm': '4.0.1',

--- a/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
+++ b/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
@@ -6,7 +6,6 @@ describe('modularizeImports', () => {
     dependencies: {
       '@next/mdx': 'canary',
       '@mdx-js/loader': '^2.2.1',
-      '@mdx-js/react': '^2.2.1',
     },
   })
 


### PR DESCRIPTION
### What?

Remove all references to `@mdx-js/react`. One occurrence remains in the lockfile due to an indirect dependency.

### Why?

`@mdx-js/react` is actively harmful for Next.js users. `@mdx-js/react` uses React context. React context can’t be used in server components. As a result, users who have `@mdx-js/react` inside their `node_modules` get confusing errors.

Removing `@mdx-js/react` from all documentation, tests, and optional peer dependencies, has no drawbacks. Removing `@mdx-js/react` as a `next-mdx-import-source` alias, fixes the confusing errors.

Users who insist on using `@mdx-js/react`, can still do this by explicitly specifying the `providerImportSource` option.

### How?

Search for `@mdx-js/react`, and remove all occurences it.