### PR TITLE
test(turbopack): Use `mimalloc` for codspeed to make it realistic

### DIFF
--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -41,7 +41,7 @@ turbopack-nodejs = { workspace = true }
 turbopack-wasm = { workspace = true }
 
 [dev-dependencies]
-turbo-tasks-malloc = { workspace = true }
+turbo-tasks-malloc = { workspace = true, features = ["custom_allocator"] }
 divan = { workspace = true }
 tokio = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -41,7 +41,7 @@ turbopack-nodejs = { workspace = true }
 turbopack-wasm = { workspace = true }
 
 [dev-dependencies]
-turbo-tasks-malloc = { workspace = true, features = ["custom_allocator"] }
+turbo-tasks-malloc = { workspace = true }
 divan = { workspace = true }
 tokio = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/next-api/benches/hmr.rs
+++ b/crates/next-api/benches/hmr.rs
@@ -1,4 +1,5 @@
-extern crate turbo_tasks_malloc;
+#[global_allocator]
+static ALLOC: turbo_tasks_malloc::TurboMalloc = turbo_tasks_malloc::TurboMalloc;
 
 use std::{
     env,

--- a/crates/next-api/benches/hmr.rs
+++ b/crates/next-api/benches/hmr.rs
@@ -1,6 +1,3 @@
-#[global_allocator]
-static ALLOC: turbo_tasks_malloc::TurboMalloc = turbo_tasks_malloc::TurboMalloc;
-
 use std::{
     env,
     fs::{create_dir_all, write},

--- a/turbopack/crates/turbopack-cli/Cargo.toml
+++ b/turbopack/crates/turbopack-cli/Cargo.toml
@@ -74,6 +74,7 @@ webbrowser = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 regex = { workspace = true }
 turbopack-bench = { workspace = true }
+turbo-tasks-malloc = { workspace = true, features = ["custom_allocator"] }
 
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -84,9 +84,7 @@ fn bench_small_apps(c: &mut Criterion) {
                             no_minify: false,
                             force_memory_cleanup: true,
                         })
-                        .await?;
-
-                        anyhow::Ok(())
+                        .await
                     })
                     .unwrap();
                 });

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -69,7 +69,6 @@ fn bench_small_apps(c: &mut Criterion) {
                     let app_name = app.file_name().unwrap().to_string_lossy().to_string();
 
                     rt.block_on(async move {
-                        let start_allocations = TurboMalloc::allocation_counters();
                         turbopack_cli::build::build(&BuildArguments {
                             common: CommonArguments {
                                 entries: Some(vec![format!("{app_name}/index.tsx")]),
@@ -86,9 +85,6 @@ fn bench_small_apps(c: &mut Criterion) {
                             force_memory_cleanup: true,
                         })
                         .await?;
-
-                        let alloc_info = start_allocations.until_now();
-                        println!("alloc_info: {alloc_info:?}");
 
                         anyhow::Ok(())
                     })

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(codspeed), allow(unused))]
 
-extern crate turbo_tasks_malloc;
+#[global_allocator]
+static ALLOC: turbo_tasks_malloc::TurboMalloc = turbo_tasks_malloc::TurboMalloc;
 
 use std::{
     path::{Path, PathBuf},
@@ -68,6 +69,7 @@ fn bench_small_apps(c: &mut Criterion) {
                     let app_name = app.file_name().unwrap().to_string_lossy().to_string();
 
                     rt.block_on(async move {
+                        let start_allocations = TurboMalloc::allocation_counters();
                         turbopack_cli::build::build(&BuildArguments {
                             common: CommonArguments {
                                 entries: Some(vec![format!("{app_name}/index.tsx")]),
@@ -83,7 +85,12 @@ fn bench_small_apps(c: &mut Criterion) {
                             no_minify: false,
                             force_memory_cleanup: true,
                         })
-                        .await
+                        .await?;
+
+                        let alloc_info = start_allocations.until_now();
+                        println!("alloc_info: {alloc_info:?}");
+
+                        anyhow::Ok(())
                     })
                     .unwrap();
                 });


### PR DESCRIPTION
### What?

Use `mimalloc` for the codspeed benchmark to make it more realistic.


### Why?

I made a mistake while creating https://github.com/vercel/next.js/pull/79980. I'm retrying this to make the benchmark more realistic.

Note: I didn't apply it to HMR benchmarks because it makes them more flaky.

Closes PACK-4904