### PR TITLE
refactor(turbopack/napi): Add a NextTurbopackContext type, rename VcArc to DetachedVc

### DIFF
--- a/crates/napi/src/next_api/mod.rs
+++ b/crates/napi/src/next_api/mod.rs
@@ -1,3 +1,4 @@
 pub mod endpoint;
 pub mod project;
+pub mod turbopack_ctx;
 pub mod utils;

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -59,14 +59,17 @@ use turbopack_trace_utils::{
 };
 use url::Url;
 
-use super::{
-    endpoint::ExternalEndpoint,
-    utils::{
-        NapiDiagnostic, NapiIssue, NextTurboTasks, RootTask, TurbopackResult, VcArc,
-        create_turbo_tasks, get_diagnostics, get_issues, subscribe,
+use crate::{
+    next_api::{
+        endpoint::ExternalEndpoint,
+        utils::{
+            DetachedVc, NapiDiagnostic, NapiIssue, NextTurboTasks, NextTurbopackContext, RootTask,
+            TurbopackResult, create_turbo_tasks, get_diagnostics, get_issues, subscribe,
+        },
     },
+    register,
+    util::DhatProfilerGuard,
 };
-use crate::{register, util::DhatProfilerGuard};
 
 /// Used by [`benchmark_file_io`]. This is a noisy benchmark, so set the
 /// threshold high.
@@ -320,7 +323,7 @@ impl From<NapiDefineEnv> for DefineEnv {
 }
 
 pub struct ProjectInstance {
-    turbo_tasks: NextTurboTasks,
+    turbopack_ctx: NextTurbopackContext,
     container: ResolvedVc<ProjectContainer>,
     exit_receiver: tokio::sync::Mutex<Option<ExitReceiver>>,
 }
@@ -447,18 +450,17 @@ pub async fn project_new(
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
 
-    let tasks_ref = turbo_tasks.clone();
-    turbo_tasks.spawn_once_task(async move {
-        benchmark_file_io(
-            tasks_ref,
-            container.project().node_root().await?.clone_value(),
-        )
-        .await
-        .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
+    turbo_tasks.spawn_once_task({
+        let tt = turbo_tasks.clone();
+        async move {
+            benchmark_file_io(tt, container.project().node_root().await?.clone_value())
+                .await
+                .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
+        }
     });
     Ok(External::new_with_size_hint(
         ProjectInstance {
-            turbo_tasks,
+            turbopack_ctx: NextTurbopackContext::new(turbo_tasks),
             container,
             exit_receiver: tokio::sync::Mutex::new(Some(exit_receiver)),
         },
@@ -568,10 +570,11 @@ pub async fn project_update(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
     options: NapiPartialProjectOptions,
 ) -> napi::Result<()> {
-    let turbo_tasks = project.turbo_tasks.clone();
     let options = options.into();
     let container = project.container;
-    turbo_tasks
+    project
+        .turbopack_ctx
+        .turbo_tasks()
         .run_once(async move {
             container.update(options).await?;
             Ok(())
@@ -591,7 +594,8 @@ pub async fn project_invalidate_persistent_cache(
         // TODO: Let the JS caller specify a reason? We need to limit the reasons to ones we know
         // how to generate a message for on the Rust side of the FFI.
         project
-            .turbo_tasks
+            .turbopack_ctx
+            .turbo_tasks()
             .backend()
             .backing_storage()
             .invalidate(invalidation_reasons::USER_REQUEST)
@@ -629,7 +633,7 @@ async fn project_on_exit_internal(project: &ProjectInstance) {
 pub async fn project_shutdown(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
 ) {
-    project.turbo_tasks.stop_and_wait().await;
+    project.turbopack_ctx.turbo_tasks().stop_and_wait().await;
     project_on_exit_internal(&project).await;
 }
 
@@ -664,10 +668,14 @@ pub struct NapiRoute {
 }
 
 impl NapiRoute {
-    fn from_route(pathname: String, value: RouteOperation, turbo_tasks: &NextTurboTasks) -> Self {
+    fn from_route(
+        pathname: String,
+        value: RouteOperation,
+        turbopack_ctx: &NextTurbopackContext,
+    ) -> Self {
         let convert_endpoint = |endpoint: OperationVc<OptionEndpoint>| {
-            Some(External::new(ExternalEndpoint(VcArc::new(
-                turbo_tasks.clone(),
+            Some(External::new(ExternalEndpoint(DetachedVc::new(
+                turbopack_ctx.clone(),
                 endpoint,
             ))))
         };
@@ -728,10 +736,13 @@ pub struct NapiMiddleware {
 }
 
 impl NapiMiddleware {
-    fn from_middleware(value: &MiddlewareOperation, turbo_tasks: &NextTurboTasks) -> Result<Self> {
+    fn from_middleware(
+        value: &MiddlewareOperation,
+        turbopack_ctx: &NextTurbopackContext,
+    ) -> Result<Self> {
         Ok(NapiMiddleware {
-            endpoint: External::new(ExternalEndpoint(VcArc::new(
-                turbo_tasks.clone(),
+            endpoint: External::new(ExternalEndpoint(DetachedVc::new(
+                turbopack_ctx.clone(),
                 value.endpoint,
             ))),
         })
@@ -747,15 +758,15 @@ pub struct NapiInstrumentation {
 impl NapiInstrumentation {
     fn from_instrumentation(
         value: &InstrumentationOperation,
-        turbo_tasks: &NextTurboTasks,
+        turbopack_ctx: &NextTurbopackContext,
     ) -> Result<Self> {
         Ok(NapiInstrumentation {
-            node_js: External::new(ExternalEndpoint(VcArc::new(
-                turbo_tasks.clone(),
+            node_js: External::new(ExternalEndpoint(DetachedVc::new(
+                turbopack_ctx.clone(),
                 value.node_js,
             ))),
-            edge: External::new(ExternalEndpoint(VcArc::new(
-                turbo_tasks.clone(),
+            edge: External::new(ExternalEndpoint(DetachedVc::new(
+                turbopack_ctx.clone(),
                 value.edge,
             ))),
         })
@@ -775,33 +786,33 @@ pub struct NapiEntrypoints {
 impl NapiEntrypoints {
     fn from_entrypoints_op(
         entrypoints: &EntrypointsOperation,
-        turbo_tasks: &NextTurboTasks,
+        turbopack_ctx: &NextTurbopackContext,
     ) -> Result<Self> {
         let routes = entrypoints
             .routes
             .iter()
-            .map(|(k, v)| NapiRoute::from_route(k.to_string(), v.clone(), turbo_tasks))
+            .map(|(k, v)| NapiRoute::from_route(k.to_string(), v.clone(), turbopack_ctx))
             .collect();
         let middleware = entrypoints
             .middleware
             .as_ref()
-            .map(|m| NapiMiddleware::from_middleware(m, turbo_tasks))
+            .map(|m| NapiMiddleware::from_middleware(m, turbopack_ctx))
             .transpose()?;
         let instrumentation = entrypoints
             .instrumentation
             .as_ref()
-            .map(|i| NapiInstrumentation::from_instrumentation(i, turbo_tasks))
+            .map(|i| NapiInstrumentation::from_instrumentation(i, turbopack_ctx))
             .transpose()?;
-        let pages_document_endpoint = External::new(ExternalEndpoint(VcArc::new(
-            turbo_tasks.clone(),
+        let pages_document_endpoint = External::new(ExternalEndpoint(DetachedVc::new(
+            turbopack_ctx.clone(),
             entrypoints.pages_document_endpoint,
         )));
-        let pages_app_endpoint = External::new(ExternalEndpoint(VcArc::new(
-            turbo_tasks.clone(),
+        let pages_app_endpoint = External::new(ExternalEndpoint(DetachedVc::new(
+            turbopack_ctx.clone(),
             entrypoints.pages_app_endpoint,
         )));
-        let pages_error_endpoint = External::new(ExternalEndpoint(VcArc::new(
-            turbo_tasks.clone(),
+        let pages_error_endpoint = External::new(ExternalEndpoint(DetachedVc::new(
+            turbopack_ctx.clone(),
             entrypoints.pages_error_endpoint,
         )));
         Ok(NapiEntrypoints {
@@ -864,13 +875,15 @@ pub async fn project_write_all_entrypoints_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
     app_dir_only: bool,
 ) -> napi::Result<TurbopackResult<NapiEntrypoints>> {
-    let turbo_tasks = project.turbo_tasks.clone();
-    let compilation_event_sender = turbo_tasks.clone();
+    let container = project.container;
+    let tt = project.turbopack_ctx.turbo_tasks().clone();
 
-    let (entrypoints, issues, diags) = turbo_tasks
+    let (entrypoints, issues, diags) = project
+        .turbopack_ctx
+        .turbo_tasks()
         .run_once(async move {
             let entrypoints_with_issues_op =
-                get_all_written_entrypoints_with_issues_operation(project.container, app_dir_only);
+                get_all_written_entrypoints_with_issues_operation(container, app_dir_only);
 
             // Read and compile the files
             let EntrypointsWithIssues {
@@ -889,7 +902,7 @@ pub async fn project_write_all_entrypoints_to_disk(
             effects.apply().await?;
 
             // Send a compilation event to indicate that the files have been written to disk
-            compilation_event_sender.send_compilation_event(Arc::new(TimingEvent::new(
+            tt.send_compilation_event(Arc::new(TimingEvent::new(
                 "Finished writing to disk".to_owned(),
                 now.elapsed(),
             )));
@@ -900,7 +913,7 @@ pub async fn project_write_all_entrypoints_to_disk(
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
 
     Ok(TurbopackResult {
-        result: NapiEntrypoints::from_entrypoints_op(&entrypoints, &turbo_tasks)?,
+        result: NapiEntrypoints::from_entrypoints_op(&entrypoints, &project.turbopack_ctx)?,
         issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
         diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
     })
@@ -969,10 +982,10 @@ pub fn project_entrypoints_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
     func: JsFunction,
 ) -> napi::Result<External<RootTask>> {
-    let turbo_tasks = project.turbo_tasks.clone();
+    let turbopack_ctx = project.turbopack_ctx.clone();
     let container = project.container;
     subscribe(
-        turbo_tasks.clone(),
+        turbopack_ctx.clone(),
         func,
         move || {
             async move {
@@ -994,7 +1007,7 @@ pub fn project_entrypoints_subscribe(
             let (entrypoints, issues, diags) = ctx.value;
 
             Ok(vec![TurbopackResult {
-                result: NapiEntrypoints::from_entrypoints_op(&entrypoints, &turbo_tasks)?,
+                result: NapiEntrypoints::from_entrypoints_op(&entrypoints, &turbopack_ctx)?,
                 issues: issues
                     .iter()
                     .map(|issue| NapiIssue::from(&**issue))
@@ -1048,11 +1061,10 @@ pub fn project_hmr_events(
     identifier: RcStr,
     func: JsFunction,
 ) -> napi::Result<External<RootTask>> {
-    let turbo_tasks = project.turbo_tasks.clone();
-    let project = project.container;
+    let container = project.container;
     let session = TransientInstance::new(());
     subscribe(
-        turbo_tasks.clone(),
+        project.turbopack_ctx.clone(),
         func,
         {
             let outer_identifier = identifier.clone();
@@ -1061,7 +1073,7 @@ pub fn project_hmr_events(
                 let identifier: RcStr = outer_identifier.clone();
                 let session = session.clone();
                 async move {
-                    let project = project.project().to_resolved().await?;
+                    let project = container.project().to_resolved().await?;
                     let state = project
                         .hmr_version_state(identifier.clone(), session)
                         .to_resolved()
@@ -1174,10 +1186,9 @@ pub fn project_hmr_identifiers_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
     func: JsFunction,
 ) -> napi::Result<External<RootTask>> {
-    let turbo_tasks = project.turbo_tasks.clone();
     let container = project.container;
     subscribe(
-        turbo_tasks.clone(),
+        project.turbopack_ctx.clone(),
         func,
         move || async move {
             let hmr_identifiers_with_issues_op =
@@ -1276,10 +1287,10 @@ pub fn project_update_info_subscribe(
         let message = ctx.value;
         Ok(vec![NapiUpdateMessage::from(message)])
     })?;
-    let turbo_tasks = project.turbo_tasks.clone();
     tokio::spawn(async move {
+        let tt = project.turbopack_ctx.turbo_tasks();
         loop {
-            let update_info = turbo_tasks
+            let update_info = tt
                 .aggregated_update_info(Duration::ZERO, Duration::ZERO)
                 .await;
 
@@ -1291,11 +1302,10 @@ pub fn project_update_info_subscribe(
             let update_info = match update_info {
                 Some(update_info) => update_info,
                 None => {
-                    turbo_tasks
-                        .get_or_wait_aggregated_update_info(Duration::from_millis(
-                            aggregation_ms.into(),
-                        ))
-                        .await
+                    tt.get_or_wait_aggregated_update_info(Duration::from_millis(
+                        aggregation_ms.into(),
+                    ))
+                    .await
                 }
             };
 
@@ -1321,7 +1331,6 @@ pub fn project_compilation_events_subscribe(
     func: JsFunction,
     event_types: Option<Vec<String>>,
 ) -> napi::Result<()> {
-    let turbo_tasks = project.turbo_tasks.clone();
     let tsfn: ThreadsafeFunction<Arc<dyn CompilationEvent>> =
         func.create_threadsafe_function(0, |ctx| {
             let event: Arc<dyn CompilationEvent> = ctx.value;
@@ -1339,7 +1348,8 @@ pub fn project_compilation_events_subscribe(
         })?;
 
     tokio::spawn(async move {
-        let mut receiver = turbo_tasks.subscribe_to_compilation_events(event_types);
+        let tt = project.turbopack_ctx.turbo_tasks();
+        let mut receiver = tt.subscribe_to_compilation_events(event_types);
         while let Some(msg) = receiver.recv().await {
             let status = tsfn.call(Ok(msg), ThreadsafeFunctionCallMode::Blocking);
 
@@ -1552,9 +1562,10 @@ pub async fn project_trace_source(
     frame: StackFrame,
     current_directory_file_url: String,
 ) -> napi::Result<Option<StackFrame>> {
-    let turbo_tasks = project.turbo_tasks.clone();
     let container = project.container;
-    let traced_frame = turbo_tasks
+    let traced_frame = project
+        .turbopack_ctx
+        .turbo_tasks()
         .run_once(async move {
             project_trace_source_operation(
                 container,
@@ -1574,11 +1585,12 @@ pub async fn project_get_source_for_asset(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
     file_path: RcStr,
 ) -> napi::Result<Option<String>> {
-    let turbo_tasks = project.turbo_tasks.clone();
-    let source = turbo_tasks
+    let container = project.container;
+    let source = project
+        .turbopack_ctx
+        .turbo_tasks()
         .run_once(async move {
-            let source_content = &*project
-                .container
+            let source_content = &*container
                 .project()
                 .project_path()
                 .await?
@@ -1606,10 +1618,10 @@ pub async fn project_get_source_map(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
     file_path: RcStr,
 ) -> napi::Result<Option<String>> {
-    let turbo_tasks = project.turbo_tasks.clone();
     let container = project.container;
-
-    let source_map = turbo_tasks
+    let source_map = project
+        .turbopack_ctx
+        .turbo_tasks()
         .run_once(async move {
             let Some(map) = &*get_source_map_rope_operation(container, file_path)
                 .read_strongly_consistent()

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -62,9 +62,10 @@ use url::Url;
 use crate::{
     next_api::{
         endpoint::ExternalEndpoint,
+        turbopack_ctx::{NextTurboTasks, NextTurbopackContext, create_turbo_tasks},
         utils::{
-            DetachedVc, NapiDiagnostic, NapiIssue, NextTurboTasks, NextTurbopackContext, RootTask,
-            TurbopackResult, create_turbo_tasks, get_diagnostics, get_issues, subscribe,
+            DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult, get_diagnostics,
+            get_issues, subscribe,
         },
     },
     register,

--- a/crates/napi/src/next_api/turbopack_ctx.rs
+++ b/crates/napi/src/next_api/turbopack_ctx.rs
@@ -1,0 +1,122 @@
+//! Utilities for constructing and using the [`NextTurbopackContext`] type.
+
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::Result;
+use either::Either;
+use serde::Serialize;
+use turbo_tasks::{
+    TurboTasks, TurboTasksApi,
+    message_queue::{CompilationEvent, Severity},
+};
+use turbo_tasks_backend::{
+    BackendOptions, DefaultBackingStorage, GitVersionInfo, NoopBackingStorage, StartupCacheState,
+    TurboTasksBackend, db_invalidation::invalidation_reasons, default_backing_storage,
+    noop_backing_storage,
+};
+
+pub type NextTurboTasks =
+    Arc<TurboTasks<TurboTasksBackend<Either<DefaultBackingStorage, NoopBackingStorage>>>>;
+
+/// A value often wrapped in [`napi::bindgen_prelude::External`] that retains the Turbopack instance
+/// used by Next.js, and various napi helpers that may have been passed to us from JS.
+///
+/// This is not a [`turbo_tasks::value`], and should only be used within the top-level napi layer.
+/// It should not be passed to a [`turbo_tasks::function`]. For serializable information about the
+/// project, use the [`next_api::project::Project`] type.
+#[derive(Clone)]
+pub struct NextTurbopackContext {
+    inner: Arc<NextTurboContextInner>,
+}
+
+struct NextTurboContextInner {
+    turbo_tasks: NextTurboTasks,
+}
+
+impl NextTurbopackContext {
+    pub fn new(turbo_tasks: NextTurboTasks) -> Self {
+        NextTurbopackContext {
+            inner: Arc::new(NextTurboContextInner { turbo_tasks }),
+        }
+    }
+
+    pub fn turbo_tasks(&self) -> &NextTurboTasks {
+        &self.inner.turbo_tasks
+    }
+}
+
+pub fn create_turbo_tasks(
+    output_path: PathBuf,
+    persistent_caching: bool,
+    _memory_limit: usize,
+    dependency_tracking: bool,
+    is_ci: bool,
+) -> Result<NextTurboTasks> {
+    Ok(if persistent_caching {
+        let version_info = GitVersionInfo {
+            describe: env!("VERGEN_GIT_DESCRIBE"),
+            dirty: option_env!("CI").is_none_or(|value| value.is_empty())
+                && env!("VERGEN_GIT_DIRTY") == "true",
+        };
+        let (backing_storage, cache_state) =
+            default_backing_storage(&output_path.join("cache/turbopack"), &version_info, is_ci)?;
+        let tt = TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions {
+                storage_mode: Some(if std::env::var("TURBO_ENGINE_READ_ONLY").is_ok() {
+                    turbo_tasks_backend::StorageMode::ReadOnly
+                } else {
+                    turbo_tasks_backend::StorageMode::ReadWrite
+                }),
+                dependency_tracking,
+                ..Default::default()
+            },
+            Either::Left(backing_storage),
+        ));
+        if let StartupCacheState::Invalidated { reason_code } = cache_state {
+            tt.send_compilation_event(Arc::new(StartupCacheInvalidationEvent { reason_code }));
+        }
+        tt
+    } else {
+        TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions {
+                storage_mode: None,
+                dependency_tracking,
+                ..Default::default()
+            },
+            Either::Right(noop_backing_storage()),
+        ))
+    })
+}
+
+#[derive(Serialize)]
+struct StartupCacheInvalidationEvent {
+    reason_code: Option<String>,
+}
+
+impl CompilationEvent for StartupCacheInvalidationEvent {
+    fn type_name(&self) -> &'static str {
+        "StartupCacheInvalidationEvent"
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn message(&self) -> String {
+        let reason_msg = match self.reason_code.as_deref() {
+            Some(invalidation_reasons::PANIC) => {
+                " because we previously detected an internal error in Turbopack"
+            }
+            Some(invalidation_reasons::USER_REQUEST) => " as the result of a user request",
+            _ => "", // ignore unknown reasons
+        };
+        format!(
+            "Turbopack's persistent cache has been deleted{reason_msg}. Builds or page loads may \
+             be slower as a result."
+        )
+    }
+
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -34,6 +34,33 @@ use crate::util::log_internal_error_and_inform;
 pub type NextTurboTasks =
     Arc<TurboTasks<TurboTasksBackend<Either<DefaultBackingStorage, NoopBackingStorage>>>>;
 
+/// A value often wrapped in [`External`] that retains the Turbopack instance used by Next.js, and
+/// various napi helpers that may have been passed to us from JS.
+///
+/// This is not a [`turbo_tasks::value`], and should only be used within the top-level napi layer.
+/// It should not be passed to a [`turbo_tasks::function`]. For serializable information about the
+/// project, use the [`next_api::project::Project`] type.
+#[derive(Clone)]
+pub struct NextTurbopackContext {
+    inner: Arc<NextTurboContextInner>,
+}
+
+impl NextTurbopackContext {
+    pub fn new(turbo_tasks: NextTurboTasks) -> Self {
+        NextTurbopackContext {
+            inner: Arc::new(NextTurboContextInner { turbo_tasks }),
+        }
+    }
+
+    pub fn turbo_tasks(&self) -> &NextTurboTasks {
+        &self.inner.turbo_tasks
+    }
+}
+
+struct NextTurboContextInner {
+    turbo_tasks: NextTurboTasks,
+}
+
 #[derive(Serialize)]
 struct StartupCacheInvalidationEvent {
     reason_code: Option<String>,
@@ -110,26 +137,35 @@ pub fn create_turbo_tasks(
     })
 }
 
-/// A helper type to hold both a Vc operation and the TurboTasks root process.
-/// Without this, we'd need to pass both individually all over the place
+/// An [`OperationVc`] that can be passed back and forth to JS across the [`napi`][mod@napi]
+/// boundary via [`External`].
+///
+/// It is a helper type to hold both a [`OperationVc`] and the [`NextTurbopackContext`]. Without
+/// this, we'd need to pass both individually all over the place.
+///
+/// This napi-specific abstraction does not implement [`turbo_tasks::NonLocalValue`] or
+/// [`turbo_tasks::OperationValue`] and should be dereferenced to an [`OperationVc`] before being
+/// passed to a [`turbo_tasks::function`].
+//
+// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
 #[derive(Clone)]
-pub struct VcArc<T> {
-    turbo_tasks: NextTurboTasks,
+pub struct DetachedVc<T> {
+    turbopack_ctx: NextTurbopackContext,
     /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.
     vc: OperationVc<T>,
 }
 
-impl<T> VcArc<T> {
-    pub fn new(turbo_tasks: NextTurboTasks, vc: OperationVc<T>) -> Self {
-        Self { turbo_tasks, vc }
+impl<T> DetachedVc<T> {
+    pub fn new(turbopack_ctx: NextTurbopackContext, vc: OperationVc<T>) -> Self {
+        Self { turbopack_ctx, vc }
     }
 
-    pub fn turbo_tasks(&self) -> &NextTurboTasks {
-        &self.turbo_tasks
+    pub fn turbopack_ctx(&self) -> &NextTurbopackContext {
+        &self.turbopack_ctx
     }
 }
 
-impl<T> Deref for VcArc<T> {
+impl<T> Deref for DetachedVc<T> {
     type Target = OperationVc<T>;
 
     fn deref(&self) -> &Self::Target {
@@ -144,11 +180,18 @@ pub fn serde_enum_to_string<T: Serialize>(value: &T) -> Result<String> {
         .to_string())
 }
 
-/// The root of our turbopack computation.
+/// An opaque handle to the root of a turbo-tasks computation created by
+/// [`turbo_tasks::TurboTasks::spawn_root_task`] that can be passed back and forth to JS across the
+/// [`napi`][mod@napi] boundary via [`External`].
+///
+/// JavaScript code receiving this value **must** call [`root_task_dispose`] in a `try...finally`
+/// block to avoid leaking root tasks.
+///
+/// This is used by [`subscribe`] to create a computation that re-executes when dependencies change.
+//
+// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
 pub struct RootTask {
-    #[allow(dead_code)]
-    turbo_tasks: NextTurboTasks,
-    #[allow(dead_code)]
+    turbopack_ctx: NextTurbopackContext,
     task_id: Option<TaskId>,
 }
 
@@ -163,7 +206,10 @@ pub fn root_task_dispose(
     #[napi(ts_arg_type = "{ __napiType: \"RootTask\" }")] mut root_task: External<RootTask>,
 ) -> napi::Result<()> {
     if let Some(task) = root_task.task_id.take() {
-        root_task.turbo_tasks.dispose_root_task(task);
+        root_task
+            .turbopack_ctx
+            .turbo_tasks()
+            .dispose_root_task(task);
     }
     Ok(())
 }
@@ -392,13 +438,13 @@ impl<T: ToNapiValue> ToNapiValue for TurbopackResult<T> {
 }
 
 pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send, V: ToNapiValue>(
-    turbo_tasks: NextTurboTasks,
+    turbopack_ctx: NextTurbopackContext,
     func: JsFunction,
     handler: impl 'static + Sync + Send + Clone + Fn() -> F,
     mapper: impl 'static + Sync + Send + FnMut(ThreadSafeCallContext<T>) -> napi::Result<Vec<V>>,
 ) -> napi::Result<External<RootTask>> {
     let func: ThreadsafeFunction<T> = func.create_threadsafe_function(0, mapper)?;
-    let task_id = turbo_tasks.spawn_root_task(move || {
+    let task_id = turbopack_ctx.turbo_tasks().spawn_root_task(move || {
         let handler = handler.clone();
         let func = func.clone();
         Box::pin(async move {
@@ -420,7 +466,7 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
         })
     });
     Ok(External::new(RootTask {
-        turbo_tasks,
+        turbopack_ctx,
         task_id: Some(task_id),
     }))
 }

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -1,7 +1,6 @@
-use std::{future::Future, ops::Deref, path::PathBuf, sync::Arc};
+use std::{future::Future, ops::Deref, sync::Arc};
 
 use anyhow::{Context, Result, anyhow};
-use either::Either;
 use napi::{
     JsFunction, JsObject, JsUnknown, NapiRaw, NapiValue, Status,
     bindgen_prelude::{External, ToNapiValue},
@@ -10,14 +9,7 @@ use napi::{
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use turbo_tasks::{
-    Effects, OperationVc, ReadRef, TaskId, TryJoinIterExt, TurboTasks, TurboTasksApi, Vc,
-    VcValueType, get_effects,
-    message_queue::{CompilationEvent, Severity},
-};
-use turbo_tasks_backend::{
-    DefaultBackingStorage, GitVersionInfo, NoopBackingStorage, StartupCacheState,
-    TurboTasksBackend, db_invalidation::invalidation_reasons, default_backing_storage,
-    noop_backing_storage,
+    Effects, OperationVc, ReadRef, TaskId, TryJoinIterExt, Vc, VcValueType, get_effects,
 };
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{
@@ -29,113 +21,7 @@ use turbopack_core::{
     source_pos::SourcePos,
 };
 
-use crate::util::log_internal_error_and_inform;
-
-pub type NextTurboTasks =
-    Arc<TurboTasks<TurboTasksBackend<Either<DefaultBackingStorage, NoopBackingStorage>>>>;
-
-/// A value often wrapped in [`External`] that retains the Turbopack instance used by Next.js, and
-/// various napi helpers that may have been passed to us from JS.
-///
-/// This is not a [`turbo_tasks::value`], and should only be used within the top-level napi layer.
-/// It should not be passed to a [`turbo_tasks::function`]. For serializable information about the
-/// project, use the [`next_api::project::Project`] type.
-#[derive(Clone)]
-pub struct NextTurbopackContext {
-    inner: Arc<NextTurboContextInner>,
-}
-
-impl NextTurbopackContext {
-    pub fn new(turbo_tasks: NextTurboTasks) -> Self {
-        NextTurbopackContext {
-            inner: Arc::new(NextTurboContextInner { turbo_tasks }),
-        }
-    }
-
-    pub fn turbo_tasks(&self) -> &NextTurboTasks {
-        &self.inner.turbo_tasks
-    }
-}
-
-struct NextTurboContextInner {
-    turbo_tasks: NextTurboTasks,
-}
-
-#[derive(Serialize)]
-struct StartupCacheInvalidationEvent {
-    reason_code: Option<String>,
-}
-
-impl CompilationEvent for StartupCacheInvalidationEvent {
-    fn type_name(&self) -> &'static str {
-        "StartupCacheInvalidationEvent"
-    }
-
-    fn severity(&self) -> Severity {
-        Severity::Warning
-    }
-
-    fn message(&self) -> String {
-        let reason_msg = match self.reason_code.as_deref() {
-            Some(invalidation_reasons::PANIC) => {
-                " because we previously detected an internal error in Turbopack"
-            }
-            Some(invalidation_reasons::USER_REQUEST) => " as the result of a user request",
-            _ => "", // ignore unknown reasons
-        };
-        format!(
-            "Turbopack's persistent cache has been deleted{reason_msg}. Builds or page loads may \
-             be slower as a result."
-        )
-    }
-
-    fn to_json(&self) -> String {
-        serde_json::to_string(self).unwrap()
-    }
-}
-
-pub fn create_turbo_tasks(
-    output_path: PathBuf,
-    persistent_caching: bool,
-    _memory_limit: usize,
-    dependency_tracking: bool,
-    is_ci: bool,
-) -> Result<NextTurboTasks> {
-    Ok(if persistent_caching {
-        let version_info = GitVersionInfo {
-            describe: env!("VERGEN_GIT_DESCRIBE"),
-            dirty: option_env!("CI").is_none_or(|value| value.is_empty())
-                && env!("VERGEN_GIT_DIRTY") == "true",
-        };
-        let (backing_storage, cache_state) =
-            default_backing_storage(&output_path.join("cache/turbopack"), &version_info, is_ci)?;
-        let tt = TurboTasks::new(TurboTasksBackend::new(
-            turbo_tasks_backend::BackendOptions {
-                storage_mode: Some(if std::env::var("TURBO_ENGINE_READ_ONLY").is_ok() {
-                    turbo_tasks_backend::StorageMode::ReadOnly
-                } else {
-                    turbo_tasks_backend::StorageMode::ReadWrite
-                }),
-                dependency_tracking,
-                ..Default::default()
-            },
-            Either::Left(backing_storage),
-        ));
-        if let StartupCacheState::Invalidated { reason_code } = cache_state {
-            tt.send_compilation_event(Arc::new(StartupCacheInvalidationEvent { reason_code }));
-        }
-        tt
-    } else {
-        TurboTasks::new(TurboTasksBackend::new(
-            turbo_tasks_backend::BackendOptions {
-                storage_mode: None,
-                dependency_tracking,
-                ..Default::default()
-            },
-            Either::Right(noop_backing_storage()),
-        ))
-    })
-}
+use crate::{next_api::turbopack_ctx::NextTurbopackContext, util::log_internal_error_and_inform};
 
 /// An [`OperationVc`] that can be passed back and forth to JS across the [`napi`][mod@napi]
 /// boundary via [`External`].


### PR DESCRIPTION
- Introduce `NextTurbopackContext` for use later in https://github.com/vercel/next.js/pull/81272 . In this PR, it's just a thin single-field wrapper, but we add callbacks to it in the next PR.
- Wrap all the places we pass around `NextTurboTasks` in this new `NextTurbopackContext` type.
- `VcArc` was a bit vague of a name, the important thing its that the `Vc` is detached from the turbo-tasks graph. `DetachedVc` matches the prefixed naming of `ResolvedVc` and `OperationVc`.

Closes PACK-5029