### PR TITLE
Turbopack: respect PURE comments for minification

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -43,6 +43,7 @@ pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Resu
     let (src, mut src_map_buf) = {
         let fm = cm.new_source_file(FileName::Anon.into(), source_code);
 
+        // Collect all comments and pass to the minifier so that `PURE` comments are respected.
         let comments = SingleThreadedComments::default();
 
         let lexer = Lexer::new(

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -43,11 +43,13 @@ pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Resu
     let (src, mut src_map_buf) = {
         let fm = cm.new_source_file(FileName::Anon.into(), source_code);
 
+        let comments = SingleThreadedComments::default();
+
         let lexer = Lexer::new(
             Syntax::default(),
             EsVersion::latest(),
             StringInput::from(&*fm),
-            None,
+            Some(&comments),
         );
         let mut parser = Parser::new_from(lexer);
 
@@ -60,7 +62,6 @@ pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Resu
                         bail!("failed to parse source code\n{}", fm.src)
                     }
                 };
-                let comments = SingleThreadedComments::default();
                 let unresolved_mark = Mark::new();
                 let top_level_mark = Mark::new();
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -30,7 +30,7 @@ use turbopack::{
     module_options::{EcmascriptOptionsContext, ModuleOptionsContext, TypescriptTransformOptions},
 };
 use turbopack_core::{
-    chunk::ChunkingConfig,
+    chunk::{ChunkingConfig, MangleType, MinifyType},
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
     condition::ContextCondition,
@@ -243,6 +243,8 @@ struct TestOptions {
     tree_shaking_mode: Option<TreeShakingMode>,
     remove_unused_exports: Option<bool>,
     scope_hoisting: Option<bool>,
+    #[serde(default)]
+    minify: bool,
 }
 
 #[turbo_tasks::value]
@@ -437,6 +439,13 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         },
     )
     .module_merging(options.scope_hoisting.unwrap_or(true))
+    .minify_type(if options.minify {
+        MinifyType::Minify {
+            mangle: Some(MangleType::OptimalSize),
+        }
+    } else {
+        MinifyType::NoMinify
+    })
     .build();
 
     let jest_entry_source = FileSource::new(jest_entry_path);

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/minification/pure/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/minification/pure/input/index.js
@@ -1,0 +1,9 @@
+let state = 0
+
+const unused = /*@__PURE__*/ (() => {
+  state++
+})()
+
+it('should remove unused PURE statements', () => {
+  expect(state).toBe(0)
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/minification/pure/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/minification/pure/options.json
@@ -1,0 +1,3 @@
+{
+  "minify": true
+}


### PR DESCRIPTION
Previously, when Turbopack invoked the swc minifier, comments were ignored, so code explicitly marked as side-effect free was still not removed

```js
const unused = /*@__PURE__*/ (() => {
  state++
})()
```
(same for unused JSX as well)

This makes the output smaller

Closes PACK-4910