### PR TITLE
Turbopack: fix codegen of directives 

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -51,6 +51,7 @@ impl EcmascriptChunkItemContent {
 
         let content = content.await?;
         let async_module = async_module_options.owned().await?;
+        let strict = content.strict;
 
         Ok(EcmascriptChunkItemContent {
             rewrite_source_path: if *chunking_context.should_use_file_source_map_uris().await? {
@@ -76,6 +77,7 @@ impl EcmascriptChunkItemContent {
                 }
 
                 EcmascriptChunkItemOptions {
+                    strict,
                     refresh,
                     externals,
                     // These things are not available in ESM

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -125,6 +125,7 @@ impl CachedExternalModule {
             inner_code: code.build(),
             source_map: None,
             is_esm: self.external_type != CachedExternalType::CommonJs,
+            strict: false,
             additional_ids: Default::default(),
         }
         .cell())

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+console.log('this is CJS')
+module.exports = 1234

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_b7c39fa7.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_b7c39fa7.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_b7c39fa7.js",
+    {},
+    {"otherChunks":["output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_b7c39fa7.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_b7c39fa7.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js
@@ -1,0 +1,13 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js", {
+
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {
+"use strict";
+
+var { m: module, e: exports } = __turbopack_context__;
+{
+console.log('this is CJS');
+module.exports = 1234;
+}}),
+}]);
+
+//# sourceMappingURL=4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 7, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js"],"sourcesContent":["'use strict'\n\nconsole.log('this is CJS')\nmodule.exports = 1234\n"],"names":[],"mappings":"AAEA,QAAQ,GAAG,CAAC;AACZ,OAAO,OAAO,GAAG"}}]
+}


### PR DESCRIPTION
Closes PACK-4894

Previously, directives in the input weren't handled correctly, this was the output:
The `use strict` doesn't do anything here because directives only have an effect at the top of modules and at the top of functions.
```js
"[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js [test] (ecmascript)": ((__turbopack_context__) => {

var { m: module, e: exports } = __turbopack_context__;
{
'use strict';
console.log('this is CJS');
module.exports = 1234;
}}),
}]);
```

Instead:
1. detect if `use strict` is in the input file
2. strip all directives
3. prepend `"use strict"`  at the top of the chunk item, if it was strict strict