### PR TITLE
Turbopack: fix `this` when accessing named properties of namespace

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/import-star/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/import-star/input/index.js
@@ -1,7 +1,11 @@
 import * as R from 'ramda'
+import { pipe } from 'ramda'
 
-console.log((0, R.pipe)('a', 'b', 'c'))
-console.log(R.pipe('a', 'b', 'c'))
+it('should have the correct `this` context', () => {
+  expect((0, R.pipe)()).toBe(false)
+  expect(R.pipe()).toBe(true)
+  expect(pipe()).toBe(false)
+})
 
 it('should import only pipe.js', () => {
   const modules = Object.keys(__turbopack_modules__)

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/import-star/input/node_modules/ramda/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/import-star/input/node_modules/ramda/index.js
@@ -1,1 +1,1 @@
-export * from './pipe';
+export * from './pipe'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/import-star/input/node_modules/ramda/pipe.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/import-star/input/node_modules/ramda/pipe.js
@@ -1,5 +1,3 @@
-
-
-export const pipe= (a,b,c)=> {
-  console.log(a,b,c)
+export function pipe() {
+  return this != null
 }


### PR DESCRIPTION
Previously, this namespace-import-to-named-import optimization always caused `this` to be unbound for function calls.
Now, it is preserved (if possible. There's nothing we can do when this is scope hoisted together).
```js
import * as R from "ramda";
import { pipe } from 'ramda'

expect((0, R.pipe)()).toBe(false);
expect(R.pipe()).toBe(true);
expect(pipe()).toBe(false);
```

```js
var __TURBOPACK__imported__module__ramda = __turbopack_context__.i(
  "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/import-star/input/node_modules/ramda/pipe.js [test] (ecmascript)"
);
it("should have the correct `this` context", () => {
  expect((0, __TURBOPACK__imported__module__ramda["pipe"])()).toBe(false);
  // this was previously also `(0, ns.pipe)()`
  expect(__TURBOPACK__imported__module__ramda["pipe"]()).toBe(true);
  expect((0, __TURBOPACK__imported__module__ramda["pipe"])()).toBe(false);
});
```

Also has  a small bundle size benefit

Closes PACK-4898