### PR TITLE
[devtools] Allow opting out of environment feature flags

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -107,9 +107,7 @@ export function getDefineEnv({
   const isDynamicIOEnabled = !!config.experimental.dynamicIO
   const isUseCacheEnabled = !!config.experimental.useCache
 
-  const isDevToolPanelUIEnabled =
-    !!process.env.__NEXT_DEVTOOL_NEW_PANEL_UI ||
-    !!config.experimental.devtoolNewPanelUI
+  const isDevToolPanelUIEnabled = Boolean(config.experimental.devtoolNewPanelUI)
 
   const defineEnv: DefineEnv = {
     // internal field to identify the plugin config

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1355,6 +1355,7 @@ export const defaultConfig = {
       static: process.env.NEXT_STATIC_CACHE_HANDLER_PATH,
     },
     cssChunking: true,
+    devtoolNewPanelUI: process.env.__NEXT_DEVTOOL_NEW_PANEL_UI === 'true',
     multiZoneDraftMode: false,
     appNavFailHandling: false,
     prerenderEarlyExit: true,


### PR DESCRIPTION
Once you set the environment variable via `export` (e.g. in your bash profile), you'd have to manually unset it to disable the flag since we favored the environment flag over the config flag.

Instead, I'm following the same pattern as for PPR using the environment variable as a default for the config. That way you can globally enable the flag e.g. in your Bash profile, but still opt-out on a per-app basis if needed.