### PR TITLE
[devtools] Hide issue count on empty state

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -165,9 +165,13 @@ export function DevToolsPanel({
                       onClick={() => setActiveTab('issues')}
                     >
                       Issues
-                      <span data-nextjs-devtools-panel-header-tab-issues-badge>
-                        {issueCount}
-                      </span>
+                      {issueCount > 0 ? (
+                        <span
+                          data-nextjs-devtools-panel-header-tab-issues-badge
+                        >
+                          {issueCount}
+                        </span>
+                      ) : null}
                     </button>
                     <button
                       data-nextjs-devtools-panel-header-tab={


### PR DESCRIPTION
Closes https://linear.app/vercel/issue/NEXT-4554/

Matches design on Figma. Alternative would be a more demure "0". Before we had the same colors as with one or more issues which is distracting.