### PR TITLE
Turbopack: Add PURE comments for FreeVarReference::EcmaScriptModule

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2587,7 +2587,7 @@ async fn handle_free_var_reference(
         } => {
             let esm_reference = analysis
                 .add_esm_reference_free_var(request.clone(), async || {
-                    Ok(EsmAssetReference::new(
+                    Ok(EsmAssetReference::new_pure(
                         if let Some(lookup_path) = lookup_path {
                             ResolvedVc::upcast(
                                 PlainResolveOrigin::new(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2587,6 +2587,10 @@ async fn handle_free_var_reference(
         } => {
             let esm_reference = analysis
                 .add_esm_reference_free_var(request.clone(), async || {
+                    // There would be no import in the first place if you don't reference the given
+                    // free var (e.g. `process`). This means that it's also fine to remove the
+                    // import again if the variable reference turns out be dead code in some later
+                    // stage of the build, thus mark the import call as /*@__PURE__*/.
                     Ok(EsmAssetReference::new_pure(
                         if let Some(lookup_path) = lookup_path {
                             ResolvedVc::upcast(


### PR DESCRIPTION
Ideally, we'd refactor `Effect`s so that overlapping effects (i.e. `process.env.NODE_ENV` inlining and polyfilling the `process` variable in the browser context) don't run twice.

But this lessens the impact by making
```js
console.log(process.env.NODE_ENV);
```
produce
```js
var __TURBOPACK_imported_$process = /*@__PURE__*/ __turbopack_import__("[project]/node_modules/process/index.js");
console.log("production)";
```
so that the minifier can get rid of the import (even though the module will still be bundled).

Closes PACK-4928