### PR TITLE
Etag is always generated even for dynamic path

### DIFF
--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -283,22 +283,14 @@ export default class NextWebServer extends BaseServer<
       )
     }
 
-    let promise: Promise<void> | undefined
-    if (options.result.isDynamic) {
-      promise = options.result.pipeTo(res.transformStream.writable)
-    } else {
-      const payload = options.result.toUnchunkedString()
-      res.setHeader('Content-Length', String(byteLength(payload)))
-      if (options.generateEtags) {
-        res.setHeader('ETag', generateETag(payload))
-      }
-      res.body(payload)
+    const payload = options.result.toUnchunkedString()
+    res.setHeader('Content-Length', String(byteLength(payload)))
+    if (options.generateEtags) {
+      res.setHeader('ETag', generateETag(payload))
     }
+    res.body(payload)
 
     res.send()
-
-    // If we have a promise, wait for it to resolve.
-    if (promise) await promise
   }
 
   protected async findPageComponents({


### PR DESCRIPTION
Etag was not getting generated for the dynamic path. This PR changes that behaviour so that Etag is always generated now.