### PR TITLE
Create no-insecure-comparison.js

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-insecure-comparison.js
+++ b/packages/eslint-plugin-next/lib/rules/no-insecure-comparison.js
@@ -1,0 +1,45 @@
+const cryptoIdentifiers = new Set(['Buffer', 'Uint8Array', 'Uint32Array', 'crypto', 'secret', 'token', 'signature']);
+const sensitiveProperties = new Set(['secret', 'key', 'token', 'password', 'signature']);
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent insecure comparisons of cryptographic values",
+      category: "Security",
+      recommended: "error",
+    },
+    fixable: "code",
+    schema: [],
+  },
+  create(context) {
+    return {
+      BinaryExpression(node) {
+        if (node.operator !== "===" && node.operator !== "==") return;
+        
+        const isSensitive = (identifier) => 
+          cryptoIdentifiers.has(identifier.name) ||
+          sensitiveProperties.has(identifier.name) ||
+          (identifier.name && identifier.name.toLowerCase().includes('secret'));
+          
+        const leftIsSensitive = node.left.type === "Identifier" && isSensitive(node.left);
+        const rightIsSensitive = node.right.type === "Identifier" && isSensitive(node.right);
+        
+        if (leftIsSensitive || rightIsSensitive) {
+          context.report({
+            node,
+            message: "Use crypto.timingSafeEqual for cryptographic comparisons to prevent timing attacks",
+            fix(fixer) {
+              const [a, b] = [node.left, node.right];
+              return fixer.replaceText(
+                node,
+                `!crypto.timingSafeEqual(Buffer.from(${context.getSourceCode().getText(a)}, ` +
+                `Buffer.from(${context.getSourceCode().getText(b)}))`
+              );
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/packages/eslint-plugin-next/lib/rules/no-insecure-comparison.js
+++ b/packages/eslint-plugin-next/lib/rules/no-insecure-comparison.js
@@ -33,7 +33,7 @@ module.exports = {
               const [a, b] = [node.left, node.right];
               return fixer.replaceText(
                 node,
-                `!crypto.timingSafeEqual(Buffer.from(${context.getSourceCode().getText(a)}, ` +
+                `crypto.timingSafeEqual(Buffer.from(${context.getSourceCode().getText(a)}), ` +
                 `Buffer.from(${context.getSourceCode().getText(b)}))`
               );
             }


### PR DESCRIPTION
This is an excellent action plan. Let's tackle these in priority order for maximum security impact and maintainability:

### 1. Implement the ESLint "no-insecure-comparison" rule (Immediate Security Gate) I'll draft a robust implementation:

**File: `packages/eslint-plugin-next/lib/rules/no-insecure-comparison.js`**
```javascript
const cryptoIdentifiers = new Set(['Buffer', 'Uint8Array', 'Uint32Array', 'crypto', 'secret', 'token', 'signature']);
const sensitiveProperties = new Set(['secret', 'key', 'token', 'password', 'signature']);

module.exports = {
  meta: {
    type: "problem",
    docs: {
      description: "Prevent insecure comparisons of cryptographic values",
      category: "Security",
      recommended: "error",
    },
    fixable: "code",
    schema: [],
  },
  create(context) {
    return {
      BinaryExpression(node) {
        if (node.operator !== "===" && node.operator !== "==") return;
        
        const isSensitive = (identifier) => 
          cryptoIdentifiers.has(identifier.name) ||
          sensitiveProperties.has(identifier.name) ||
          (identifier.name && identifier.name.toLowerCase().includes('secret'));
          
        const leftIsSensitive = node.left.type === "Identifier" && isSensitive(node.left);
        const rightIsSensitive = node.right.type === "Identifier" && isSensitive(node.right);
        
        if (leftIsSensitive || rightIsSensitive) {
          context.report({
            node,
            message: "Use crypto.timingSafeEqual for cryptographic comparisons to prevent timing attacks",
            fix(fixer) {
              const [a, b] = [node.left, node.right];
              return fixer.replaceText(
                node,
                `!crypto.timingSafeEqual(Buffer.from(${context.getSourceCode().getText(a)}, ` +
                `Buffer.from(${context.getSourceCode().getText(b)}))`
              );
            }
          });
        }
      }
    };
  }
};
```

**Test Case: `packages/eslint-plugin-next/tests/rules/no-insecure-comparison.test.js`**
```javascript
const RuleTester = require("eslint").RuleTester;
const rule = require("../../lib/rules/no-insecure-comparison");

const tester = new RuleTester({
  parserOptions: { ecmaVersion: 2020 },
});

tester.run("no-insecure-comparison", rule, {
  valid: [
    "if (crypto.timingSafeEqual(a, b)) {}",
    "if (a === b) {} // non-crypto comparison"
  ],
  invalid: [
    {
      code: "if (userToken === expectedToken) {}",
      errors: [{ message: "Use crypto.timingSafeEqual" }],
      output: 
        "if (!crypto.timingSafeEqual(Buffer.from(userToken), Buffer.from(expectedToken)) {}"
    },
    {
      code: "if (Buffer.from(sig) === expectedSignature) {}",
      errors: [{ message: "Use crypto.timingSafeEqual" }],
      output: 
        "if (!crypto.timingSafeEqual(Buffer.from(Buffer.from(sig)), Buffer.from(expectedSignature)) {}"
    }
  ]
});
```

### 2. Bake Timing-Safe Checks into CI (Security Benchmarking) Create a performance test harness:

**File: `test/bench/crypto-timing.js`**
```javascript
const crypto = require('crypto');
const { performance } = require('perf_hooks');
const assert = require('assert');

// Test vectors
const SHORT_A = Buffer.from('a');
const SHORT_B = Buffer.from('b');
const LONG_A = crypto.randomBytes(1024);
const LONG_B = crypto.randomBytes(1024);

function measure(fn) {
  const runs = 10000;
  const times = [];
  
  for (let i = 0; i < runs; i++) {
    const start = performance.now();
    fn();
    times.push(performance.now() - start);
  }
  
  return {
    avg: times.reduce((sum, t) => sum + t, 0) / runs,
    min: Math.min(...times),
    max: Math.max(...times)
  };
}

// Test constant-time equality
const equalTime = measure(() => crypto.timingSafeEqual(SHORT_A, SHORT_A));
const notEqualTime = measure(() => crypto.timingSafeEqual(SHORT_A, SHORT_B));
const longEqualTime = measure(() => crypto.timingSafeEqual(LONG_A, LONG_A));
const longNotEqualTime = measure(() => crypto.timingSafeEqual(LONG_A, LONG_B));

// Assert timing consistency
const MAX_VARIANCE = 0.1; // 10%
assert(
  Math.abs(equalTime.avg - notEqualTime.avg) / equalTime.avg < MAX_VARIANCE,
  `Timing variance exceeds threshold: ${equalTime.avg} vs ${notEqualTime.avg}`
);

console.log('TimingSafeEqual consistency verified:');
console.table({ equalTime, notEqualTime, longEqualTime, longNotEqualTime });
```

**CI Integration (`.github/workflows/ci.yml`):**
```yaml
- name: Crypto Timing Safety
  run: |
    node test/bench/crypto-timing.js
    echo "Timing consistency verified"
```

### 3. Migrate Off crypto-js (Dependency Hardening) Migration plan:
```mermaid
graph TD
    A[Identify crypto-js usage] --> B{Web Crypto API available?}
    B -->|Yes| C[Replace with Web Crypto]
    B -->|No| D[Use Node crypto module]
    C --> E[Update tests]
    D --> E
    E --> F[Remove crypto-js dependency]
```

### 4. Shore Up Buffer Limits & Errors (Defense in Depth) Add these security enhancements:

**File: `packages/next/server/crypto-utils.js`**
```javascript
const MAX_BUFFER_SIZE = 1024; // 1KB

function safeBufferConversion(input, encoding = 'hex') {
  if (input.length > MAX_BUFFER_SIZE * 2 && encoding === 'hex') {
    throw new SecurityError('Input exceeds maximum allowed size');
  }
  return Buffer.from(input, encoding);
}

class SecurityError extends Error {
  constructor(message) {
    super(message);
    this.name = 'SecurityError';
    // Remove stack trace for production
    if (process.env.NODE_ENV === 'production') {
      this.stack = undefined;
    }
  }
}
```

### 5. Key Rotation & Vault Integration (Future-Proofing) Architecture sketch:
```javascript
// packages/next/server/crypto/key-manager.js
class KeyManager {
  constructor() {
    this.strategies = {
      local: new LocalKeyStrategy(),
      aws: new AWSKMSStrategy(),
      vault: new VaultStrategy()
    };
  }

  async sign(data) {
    return this.currentStrategy.sign(data);
  }

  rotate() {
    // Implementation varies by strategy
  }
}
```

### Execution Plan:
1. **Immediately**:
   - Merge ESLint rule (security gate)
   - Add CI timing checks (prevent regression)

2. **Next Sprint**:
   - Complete crypto-js migration
   - Implement buffer size limits
   - Enhance error sanitization

3. **Q3 Roadmap**:
   - Key rotation architecture
   - Vault integration spike
   - HSM support exploration

Let's start with the ESLint rule and CI benchmark - I'll open a PR for these today. For the crypto-js migration, I'll audit all usage patterns and prepare a migration guide.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
