### PR TITLE
Fix PPR no fallback case

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -186,12 +186,6 @@ export async function handler(
       prerenderManifest.routes[normalizedSrcPage]
   )
 
-  // if the page is dynamicParams: false and this pathname wasn't prerender
-  // trigger the no fallback handling
-  if (isSSG && prerenderInfo?.fallback === false && !isPrerendered) {
-    throw new NoFallbackError()
-  }
-
   const userAgent = req.headers['user-agent'] || ''
   const botType = getBotType(userAgent)
   const isHtmlBot = isHtmlBotRequest(req)
@@ -315,6 +309,12 @@ export async function handler(
     !isDynamicRSCRequest
   ) {
     ssgCacheKey = resolvedPathname
+  }
+
+  // if the page is dynamicParams: false and this pathname wasn't prerender
+  // trigger the no fallback handling
+  if (ssgCacheKey && prerenderInfo?.fallback === false && !isPrerendered) {
+    throw new NoFallbackError()
   }
 
   const ComponentMod = {

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -655,8 +655,8 @@ export async function handler(
         pageIsDynamic &&
         (isProduction || !isPrerendered)
       ) {
-        // if the page is dynamicParams: false and this pathname wasn't prerender
-        // trigger the no fallback handling
+        // if the page has dynamicParams: false and this pathname wasn't
+        // prerendered trigger the no fallback handling
         if (
           // In development, fall through to render to handle missing
           // getStaticPaths.

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -311,10 +311,9 @@ export async function handler(
     ssgCacheKey = resolvedPathname
   }
 
-  // if the page is dynamicParams: false and this pathname wasn't prerender
-  // trigger the no fallback handling
-  if (ssgCacheKey && prerenderInfo?.fallback === false && !isPrerendered) {
-    throw new NoFallbackError()
+  let staticPathKey = ssgCacheKey
+  if (!staticPathKey && routeModule.isDev) {
+    staticPathKey = resolvedPathname
   }
 
   const ComponentMod = {
@@ -650,12 +649,24 @@ export async function handler(
       if (
         !minimalMode &&
         fallbackMode !== FallbackMode.BLOCKING_STATIC_RENDER &&
-        ssgCacheKey &&
+        staticPathKey &&
         !didRespond &&
         !isDraftMode &&
         pageIsDynamic &&
         (isProduction || !isPrerendered)
       ) {
+        // if the page is dynamicParams: false and this pathname wasn't prerender
+        // trigger the no fallback handling
+        if (
+          // In development, fall through to render to handle missing
+          // getStaticPaths.
+          (isProduction || prerenderInfo) &&
+          // When fallback isn't present, abort this render so we 404
+          fallbackMode === FallbackMode.NOT_FOUND
+        ) {
+          throw new NoFallbackError()
+        }
+
         let fallbackResponse: ResponseCacheEntry | null | undefined
 
         if (isRoutePPREnabled && !isRSCRequest) {


### PR DESCRIPTION
When we are resuming with postponed state we don't handle SSG behavior so this ensures we only trigger the `NoFallback` case if we have created a cache key. 