### PR TITLE
docs: Add a link to what opts into dynamic rendering

### DIFF
--- a/docs/01-app/02-guides/content-security-policy.mdx
+++ b/docs/01-app/02-guides/content-security-policy.mdx
@@ -33,7 +33,7 @@ Even though CSPs are designed to block malicious scripts, there are legitimate s
 
 [Middleware](/docs/app/api-reference/file-conventions/middleware) enables you to add headers and generate nonces before the page renders.
 
-Every time a page is viewed, a fresh nonce should be generated. This means that you **must use dynamic rendering to add nonces**.
+Every time a page is viewed, a fresh nonce should be generated. This means that you **must use [dynamic rendering](/docs/app/getting-started/partial-prerendering#dynamic-rendering) to add nonces**.
 
 For example:
 


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/66871#issuecomment-3005875361

Let's add this patch quickly. I take over the Devin PR - and try to get it merged in the coming days.