### PR TITLE
[devtools] issues-tab-sidebar: move suspense down to the stack frame

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-sidebar-frame-skeleton.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-sidebar-frame-skeleton.tsx
@@ -19,6 +19,7 @@ export const DEVTOOLS_PANEL_TAB_ISSUES_SIDEBAR_FRAME_SKELETON_STYLES = css`
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s ease-in-out infinite;
 
+    /* Equal to the line-height of the sidebar-frame-source. */
     height: var(--size-18);
   }
 

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-sidebar-frame-skeleton.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-sidebar-frame-skeleton.tsx
@@ -2,10 +2,7 @@ import { css } from '../../../../utils/css'
 
 export function IssuesTabSidebarFrameSkeleton() {
   return (
-    <>
-      <div data-nextjs-devtools-panel-tab-issues-sidebar-frame-skeleton-bar="1" />
-      <div data-nextjs-devtools-panel-tab-issues-sidebar-frame-skeleton-bar="2" />
-    </>
+    <div data-nextjs-devtools-panel-tab-issues-sidebar-frame-skeleton-bar />
   )
 }
 
@@ -21,15 +18,8 @@ export const DEVTOOLS_PANEL_TAB_ISSUES_SIDEBAR_FRAME_SKELETON_STYLES = css`
     );
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.5s ease-in-out infinite;
-  }
 
-  [data-nextjs-devtools-panel-tab-issues-sidebar-frame-skeleton-bar='1'] {
-    width: 75%;
-    margin-bottom: 8px;
-  }
-
-  [data-nextjs-devtools-panel-tab-issues-sidebar-frame-skeleton-bar='2'] {
-    width: 36.5%;
+    height: var(--size-18);
   }
 
   @keyframes skeleton-shimmer {

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-sidebar.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/issues-tab/issues-tab-sidebar.tsx
@@ -58,18 +58,12 @@ const IssuesTabSidebarFrameItem = memo(function IssuesTabSidebarFrameItem({
     return null
   }
 
-  const errorType = getErrorTypeLabel(runtimeError.error, runtimeError.type)
   const frameSource = getFrameSource(firstFrame.originalStackFrame)
 
   return (
-    <>
-      <span data-nextjs-devtools-panel-tab-issues-sidebar-frame-error-type>
-        {errorType}
-      </span>
-      <span data-nextjs-devtools-panel-tab-issues-sidebar-frame-source>
-        {frameSource}
-      </span>
-    </>
+    <span data-nextjs-devtools-panel-tab-issues-sidebar-frame-source>
+      {frameSource}
+    </span>
   )
 })
 
@@ -84,12 +78,16 @@ const IssuesTabSidebarFrame = memo(function IssuesTabSidebarFrame({
   isActive: boolean
   setActiveIndex: (idx: number) => void
 }) {
+  const errorType = getErrorTypeLabel(runtimeError.error, runtimeError.type)
   return (
     <button
       data-nextjs-devtools-panel-tab-issues-sidebar-frame
       data-nextjs-devtools-panel-tab-issues-sidebar-frame-active={isActive}
       onClick={() => setActiveIndex(idx)}
     >
+      <span data-nextjs-devtools-panel-tab-issues-sidebar-frame-error-type>
+        {errorType}
+      </span>
       <Suspense fallback={<IssuesTabSidebarFrameSkeleton />}>
         <IssuesTabSidebarFrameItem runtimeError={runtimeError} />
       </Suspense>


### PR DESCRIPTION
The Suspense boundary can move further down to what needs to be suspended, which is the frame source.

https://github.com/user-attachments/assets/5c554204-abeb-4d97-bc1a-051d6ab539f4

