### PR TITLE
fix(turbo-tasks): Temporarily disable immutable task optimizations

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -87,6 +87,10 @@ impl ConnectChildOperation {
             });
         }
 
+        // https://vercel.slack.com/archives/C03EWR7LGEN/p1750889741099559
+        // HACK: immutable tracking is broken, disable it for now
+        is_child_immutable = false;
+
         // Immutable tasks cannot be invalidated, meaning that we never reschedule them.
         if !is_child_immutable && ctx.should_track_activeness() {
             queue.push(AggregationUpdateJob::IncreaseActiveCount {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -597,7 +597,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
     }
 
     fn is_immutable(&self) -> bool {
-        self.task.state().is_immutable()
+        // https://vercel.slack.com/archives/C03EWR7LGEN/p1750889741099559
+        // HACK: immutable tracking is broken, disable it for now
+        false
+        // self.task.state().is_immutable()
     }
     fn mark_as_immutable(&mut self) {
         self.task.state_mut().set_is_immutable(true);


### PR DESCRIPTION
https://vercel.slack.com/archives/C03EWR7LGEN/p1750889741099559

Looks like this is broken, this seems like the easiest way to disable the feature for the moment.

Closes PACK-4902