### PR TITLE
[turbopack] Add execution tests to demonstrate a bug

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
@@ -1,7 +1,6 @@
 const t = this
 
 it('`this` in cjs should be exports', () => {
-  // TODO: This is WRONG, it should be undefined
   expect(t).toBe(exports)
 })
 

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
@@ -1,0 +1,9 @@
+const t = this
+
+it('`this` in cjs should be exports', () => {
+  // TODO: This is WRONG, it should be undefined
+  expect(t).toBe(exports)
+})
+
+// Use a dummy assignment to ensure we are parsed as a cjs module
+exports.something = 'something'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
@@ -1,0 +1,9 @@
+const t = this
+
+it('`this` in esm should be undefined', () => {
+  // TODO: This is WRONG, it should be undefined
+  expect(t).toBe(globalThis)
+})
+
+// Use a dummy export to ensure this is parsed as an esm module
+export const foo = t


### PR DESCRIPTION
 ## Add tests for top level `this` behavior in CJS and ESM modules

### What?
Added two test cases to verify the behavior of `this` in CommonJS and ESM modules:
- CJS test verifies that `this` should be equal to `exports`
- ESM test verifies that `this` should be equal to `globalThis` WHICH IS A BUG, it should be `undefined`



Closes PACK-4906