### PR TITLE
build(turbopack): Update `swc_core` to `v29.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7130,9 +7130,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "29.1.4"
+version = "29.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652bfb5da2b20fd9d39b767a34df30ae3d66c0bf8b0014c4d56e87fc8024a178"
+checksum = "0df473ca42b70e49aab2e90d4f76574f0e3eb4a42ddc95a33f8c93d64af67b55"
 dependencies = [
  "binding_macros",
  "par-core",
@@ -7571,9 +7571,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lexer"
-version = "17.0.4"
+version = "17.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a257fda06cb2aa3f6c0d0d13b534e3376d542d1d84b83c7eda95fbc0729844a"
+checksum = "61f2e87edcfeac99e09c8b47b7b4a921fe2fef0a733f330dc4420727e637d774"
 dependencies = [
  "arrayvec 0.7.4",
  "ascii",
@@ -7680,9 +7680,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "17.0.3"
+version = "17.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e746147b3638778a3bc3665f933f62de2d2a5a7fb6b578cc2d6ef72c76bf0191"
+checksum = "8317bbac117ce986efd166b32017f3f5c07def31291e91f709b764501e103890"
 dependencies = [
  "arrayvec 0.7.4",
  "bitflags 2.9.0",
@@ -8039,9 +8039,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6aa9ebca452a7594290928de2a90464b92ae1634d1c22e2593a77b32953016"
+checksum = "938751c806f23256256e6839914ab33e4ac6e79a3fa2e717d004469881d2e3df"
 dependencies = [
  "indexmap 2.7.1",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,7 +300,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "29.1.4", features = [
+swc_core = { version = "29.2.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",


### PR DESCRIPTION
### What?

ChangeLog: https://github.com/swc-project/swc/compare/swc_core%40v29.1.4...swc_core%40v29.2.0

### Why?

To apply


 - https://github.com/swc-project/swc/pull/10702
 - https://github.com/swc-project/swc/pull/10701

Closes PACK-4907