### PR TITLE
perf(turbopack): Use `rayon` threadpool for `minify()`

### DIFF
--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -128,7 +128,7 @@ impl EcmascriptBrowserChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -187,7 +187,7 @@ impl EcmascriptBrowserEvaluateChunk {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -23,6 +23,7 @@ use swc_core::{
     },
 };
 use tracing::{Level, instrument};
+use turbo_tasks::spawn_blocking_rayon;
 use turbopack_core::{
     chunk::MangleType,
     code_builder::{Code, CodeBuilder},
@@ -31,121 +32,124 @@ use turbopack_core::{
 use crate::parse::generate_js_source_map;
 
 #[instrument(level = Level::INFO, skip_all)]
-pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
-    let source_maps = source_maps
-        .then(|| code.generate_source_map_ref())
-        .transpose()?;
+pub async fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
+    spawn_blocking_rayon(move || {
+        let source_maps = source_maps
+            .then(|| code.generate_source_map_ref())
+            .transpose()?;
 
-    let source_code = code.into_source_code().into_bytes().into();
-    let source_code = String::from_utf8(source_code)?;
+        let source_code = code.into_source_code().into_bytes().into();
+        let source_code = String::from_utf8(source_code)?;
 
-    let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));
-    let (src, mut src_map_buf) = {
-        let fm = cm.new_source_file(FileName::Anon.into(), source_code);
+        let cm = Arc::new(SwcSourceMap::new(FilePathMapping::empty()));
+        let (src, mut src_map_buf) = {
+            let fm = cm.new_source_file(FileName::Anon.into(), source_code);
 
-        let lexer = Lexer::new(
-            Syntax::default(),
-            EsVersion::latest(),
-            StringInput::from(&*fm),
-            None,
-        );
-        let mut parser = Parser::new_from(lexer);
+            let lexer = Lexer::new(
+                Syntax::default(),
+                EsVersion::latest(),
+                StringInput::from(&*fm),
+                None,
+            );
+            let mut parser = Parser::new_from(lexer);
 
-        let program = try_with_handler(cm.clone(), Default::default(), |handler| {
-            GLOBALS.set(&Default::default(), || {
-                let program = match parser.parse_program() {
-                    Ok(program) => program,
-                    Err(err) => {
-                        err.into_diagnostic(handler).emit();
-                        bail!("failed to parse source code\n{}", fm.src)
-                    }
-                };
-                let comments = SingleThreadedComments::default();
-                let unresolved_mark = Mark::new();
-                let top_level_mark = Mark::new();
+            let program = try_with_handler(cm.clone(), Default::default(), |handler| {
+                GLOBALS.set(&Default::default(), || {
+                    let program = match parser.parse_program() {
+                        Ok(program) => program,
+                        Err(err) => {
+                            err.into_diagnostic(handler).emit();
+                            bail!("failed to parse source code\n{}", fm.src)
+                        }
+                    };
+                    let comments = SingleThreadedComments::default();
+                    let unresolved_mark = Mark::new();
+                    let top_level_mark = Mark::new();
 
-                let program = program.apply(paren_remover(Some(&comments)));
+                    let program = program.apply(paren_remover(Some(&comments)));
 
-                let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
-                    unresolved_mark,
-                    top_level_mark,
-                    false,
-                ));
-
-                program = swc_core::ecma::minifier::optimize(
-                    program,
-                    cm.clone(),
-                    Some(&comments),
-                    None,
-                    &MinifyOptions {
-                        compress: Some(CompressOptions {
-                            // Only run 2 passes, this is a tradeoff between performance and
-                            // compression size. Default is 3 passes.
-                            passes: 2,
-                            keep_classnames: mangle.is_none(),
-                            keep_fnames: mangle.is_none(),
-                            ..Default::default()
-                        }),
-                        mangle: mangle.map(|mangle| {
-                            let reserved = vec!["AbortSignal".into()];
-                            match mangle {
-                                MangleType::OptimalSize => MangleOptions {
-                                    reserved,
-                                    ..Default::default()
-                                },
-                                MangleType::Deterministic => MangleOptions {
-                                    reserved,
-                                    disable_char_freq: true,
-                                    ..Default::default()
-                                },
-                            }
-                        }),
-                        ..Default::default()
-                    },
-                    &ExtraOptions {
-                        top_level_mark,
+                    let mut program = program.apply(swc_core::ecma::transforms::base::resolver(
                         unresolved_mark,
-                        mangle_name_cache: None,
-                    },
-                );
-
-                if mangle.is_none() {
-                    program.mutate(hygiene_with_config(hygiene::Config {
                         top_level_mark,
-                        ..Default::default()
-                    }));
-                }
+                        false,
+                    ));
 
-                Ok(program.apply(ecma::transforms::base::fixer::fixer(Some(
-                    &comments as &dyn Comments,
-                ))))
+                    program = swc_core::ecma::minifier::optimize(
+                        program,
+                        cm.clone(),
+                        Some(&comments),
+                        None,
+                        &MinifyOptions {
+                            compress: Some(CompressOptions {
+                                // Only run 2 passes, this is a tradeoff between performance and
+                                // compression size. Default is 3 passes.
+                                passes: 2,
+                                keep_classnames: mangle.is_none(),
+                                keep_fnames: mangle.is_none(),
+                                ..Default::default()
+                            }),
+                            mangle: mangle.map(|mangle| {
+                                let reserved = vec!["AbortSignal".into()];
+                                match mangle {
+                                    MangleType::OptimalSize => MangleOptions {
+                                        reserved,
+                                        ..Default::default()
+                                    },
+                                    MangleType::Deterministic => MangleOptions {
+                                        reserved,
+                                        disable_char_freq: true,
+                                        ..Default::default()
+                                    },
+                                }
+                            }),
+                            ..Default::default()
+                        },
+                        &ExtraOptions {
+                            top_level_mark,
+                            unresolved_mark,
+                            mangle_name_cache: None,
+                        },
+                    );
+
+                    if mangle.is_none() {
+                        program.mutate(hygiene_with_config(hygiene::Config {
+                            top_level_mark,
+                            ..Default::default()
+                        }));
+                    }
+
+                    Ok(program.apply(ecma::transforms::base::fixer::fixer(Some(
+                        &comments as &dyn Comments,
+                    ))))
+                })
             })
-        })
-        .map_err(|e| e.to_pretty_error())?;
+            .map_err(|e| e.to_pretty_error())?;
 
-        print_program(cm.clone(), program, source_maps.is_some())?
-    };
+            print_program(cm.clone(), program, source_maps.is_some())?
+        };
 
-    let mut builder = CodeBuilder::new(source_maps.is_some());
-    if let Some(original_map) = source_maps.as_ref() {
-        src_map_buf.shrink_to_fit();
-        builder.push_source(
-            &src.into(),
-            Some(generate_js_source_map(
-                &*cm,
-                src_map_buf,
-                Some(original_map),
-                true,
-                // We do not inline source contents.
-                // We provide a synthesized value to `cm.new_source_file` above, so it cannot be
-                // the value user expect anyway.
-                false,
-            )?),
-        );
-    } else {
-        builder.push_source(&src.into(), None);
-    }
-    Ok(builder.build())
+        let mut builder = CodeBuilder::new(source_maps.is_some());
+        if let Some(original_map) = source_maps.as_ref() {
+            src_map_buf.shrink_to_fit();
+            builder.push_source(
+                &src.into(),
+                Some(generate_js_source_map(
+                    &*cm,
+                    src_map_buf,
+                    Some(original_map),
+                    true,
+                    // We do not inline source contents.
+                    // We provide a synthesized value to `cm.new_source_file` above, so it cannot
+                    // be the value user expect anyway.
+                    false,
+                )?),
+            );
+        } else {
+            builder.push_source(&src.into(), None);
+        }
+        Ok(builder.build())
+    })
+    .await
 }
 
 // From https://github.com/swc-project/swc/blob/11efd4e7c5e8081f8af141099d3459c3534c1e1d/crates/swc/src/lib.rs#L523-L560

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -78,7 +78,7 @@ impl EcmascriptBuildNodeChunkContent {
         let mut code = code.build();
 
         if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
-            code = minify(code, source_maps, mangle)?;
+            code = minify(code, source_maps, mangle).await?;
         }
 
         Ok(code.cell())


### PR DESCRIPTION
### What?

Use `rayon` threadpool for minification.

### Why?


https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html

> When running many CPU-bound computations, a semaphore or some other synchronization primitive should be used to limit the number of computations executed in parallel. Specialized CPU-bound executors, such as rayon, may also be a good fit.

<img width="776" alt="image" src="https://github.com/user-attachments/assets/27f3d3cb-b28e-4dd9-93f2-263aa6d34bb2" />



Closes PACK-4949