### PR TITLE
test(codspeed): Make codspeed concurrent on `canary` branch

### DIFF
--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -13,7 +13,8 @@ on:
       - '**/Cargo.lock'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha }}
+  # Limit concurrent runs to 1 per PR, but allow concurrent runs on canary branch
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}-{2}', github.workflow, github.ref_name, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
### What?

Apply same changes as https://github.com/swc-project/swc/pull/10711 to next.js/turbopack. We now run benchmark on `canary` branch in parallel.

### Why?

`codspeed` says `New benchmark` quite frequently, but it's not. This PR should fix it

Closes PACK-4909