### PR TITLE
Remove clientRouterFilters from defineEnv as it's unused

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -19,10 +19,6 @@ type BloomFilter = ReturnType<
 
 export interface DefineEnvOptions {
   isTurbopack: boolean
-  clientRouterFilters?: {
-    staticFilter: BloomFilter
-    dynamicFilter: BloomFilter
-  }
   config: NextConfigComplete
   dev: boolean
   distDir: string
@@ -98,7 +94,6 @@ function getImageConfig(
 
 export function getDefineEnv({
   isTurbopack,
-  clientRouterFilters,
   config,
   dev,
   distDir,
@@ -207,10 +202,6 @@ export function getDefineEnv({
     ),
     'process.env.__NEXT_CLIENT_ROUTER_FILTER_ENABLED':
       config.experimental.clientRouterFilter ?? true,
-    'process.env.__NEXT_CLIENT_ROUTER_S_FILTER':
-      clientRouterFilters?.staticFilter ?? false,
-    'process.env.__NEXT_CLIENT_ROUTER_D_FILTER':
-      clientRouterFilters?.dynamicFilter ?? false,
     'process.env.__NEXT_CLIENT_VALIDATE_RSC_REQUEST_HEADERS': Boolean(
       config.experimental.validateRSCRequestHeaders
     ),

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -428,7 +428,6 @@ type RustifiedOptionEnv = { name: string; value: string | undefined }[]
 
 export function createDefineEnv({
   isTurbopack,
-  clientRouterFilters,
   config,
   dev,
   distDir,
@@ -451,7 +450,6 @@ export function createDefineEnv({
     defineEnv[variant] = rustifyOptionEnv(
       getDefineEnv({
         isTurbopack,
-        clientRouterFilters,
         config,
         dev,
         distDir,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -65,7 +65,6 @@ export async function turbopackBuild(): Promise<{
       env: process.env as Record<string, string>,
       defineEnv: createDefineEnv({
         isTurbopack: true,
-        clientRouterFilters: NextBuildContext.clientRouterFilters!,
         config,
         dev,
         distDir,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -236,12 +236,6 @@ export async function createHotReloaderTurbopack(
     distDir,
   })
 
-  // TODO: Implement
-  let clientRouterFilters: any
-  if (nextConfig.experimental.clientRouterFilter) {
-    // TODO this need to be set correctly for filesystem cache to work
-  }
-
   const supportedBrowsers = getSupportedBrowsers(projectPath, dev)
   const currentNodeJsVersion = process.versions.node
 
@@ -263,7 +257,6 @@ export async function createHotReloaderTurbopack(
       env: process.env as Record<string, string>,
       defineEnv: createDefineEnv({
         isTurbopack: true,
-        clientRouterFilters,
         config: nextConfig,
         dev,
         distDir,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -826,7 +826,6 @@ async function startWatcher(
           await hotReloader.turbopackProject.update({
             defineEnv: createDefineEnv({
               isTurbopack: true,
-              clientRouterFilters,
               config: nextConfig,
               dev: true,
               distDir,
@@ -921,7 +920,6 @@ async function startWatcher(
                 ) {
                   const newDefine = getDefineEnv({
                     isTurbopack: false,
-                    clientRouterFilters,
                     config: nextConfig,
                     dev: true,
                     distDir,

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -207,7 +207,6 @@ async function main() {
     defineEnv: createDefineEnv({
       projectPath: __dirname,
       isTurbopack: true,
-      clientRouterFilters: undefined,
       config: nextConfig,
       dev: true,
       distDir: path.join(rootPath, distDir),
@@ -365,7 +364,6 @@ describe('next.rs api', () => {
       defineEnv: createDefineEnv({
         projectPath: next.testDir,
         isTurbopack: true,
-        clientRouterFilters: undefined,
         config: nextConfig,
         dev: true,
         distDir: path.join(rootPath, distDir),


### PR DESCRIPTION
## What?

@mischnic was comparing outputs between webpack/Turbopack and noticed that `__NEXT_CLIENT_ROUTER_FILTER_ENABLED` / `__NEXT_CLIENT_ROUTER_S_FILTER` / `__NEXT_CLIENT_ROUTER_D_FILTER` were not being inlined with Turbopack, but that it's also not being passed for webpack.

Checked with @ijjk in this PR and he said we can remove it as it's an unused option.