### PR TITLE
Turbopack: inline `typeof window` in node_modules for server

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -359,6 +359,7 @@ pub async fn get_client_module_options_context(
     // node_modules context
     let foreign_codes_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
+            enable_typeof_window_inlining: None,
             // Ignore e.g. import(`${url}`) requests in node_modules.
             ignore_dynamic_requests: true,
             ..module_options_context.ecmascript

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -359,7 +359,6 @@ pub async fn get_client_module_options_context(
     // node_modules context
     let foreign_codes_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
-            enable_typeof_window_inlining: None,
             // Ignore e.g. import(`${url}`) requests in node_modules.
             ignore_dynamic_requests: true,
             ..module_options_context.ecmascript

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -613,10 +613,6 @@ pub async fn get_server_module_options_context(
             };
 
             let foreign_code_module_options_context = ModuleOptionsContext {
-                ecmascript: EcmascriptOptionsContext {
-                    enable_typeof_window_inlining: None,
-                    ..module_options_context.ecmascript
-                },
                 module_rules: foreign_next_server_rules.clone(),
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
@@ -680,10 +676,6 @@ pub async fn get_server_module_options_context(
             next_server_rules.extend(source_transform_rules);
 
             let foreign_code_module_options_context = ModuleOptionsContext {
-                ecmascript: EcmascriptOptionsContext {
-                    enable_typeof_window_inlining: None,
-                    ..module_options_context.ecmascript
-                },
                 module_rules: foreign_next_server_rules.clone(),
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -71,7 +71,7 @@ pub enum DecoratorsKind {
 }
 
 /// The types when replacing `typeof window` with a constant.
-#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
 pub enum TypeofWindow {
     Object,
     Undefined,


### PR DESCRIPTION
We can't inline it in the browser because window is indeed undefined in web workers. But in the server context, it is indeed always undefined
related: 
- https://github.com/vercel/next.js/pull/8361
- https://github.com/vercel/next.js/pull/8355
- https://github.com/vercel/next.js/issues/7873

Closes PACK-4944