### PR TITLE
Use snapshots to verify error stack traces for dynamic validation errors

### DIFF
--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -1,94 +1,119 @@
 import { nextTestSetup } from 'e2e-utils'
+import { getPrerenderOutput } from './utils'
 
-import { createExpectError } from './utils'
-
-function runTests(options: { withMinification: boolean }) {
-  const { withMinification } = options
-  describe(`Dynamic IO Errors - ${withMinification ? 'With Minification' : 'Without Minification'}`, () => {
-    describe('Sync Dynamic - With Fallback - Math.random()', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-random-with-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should not error the build when calling Math.random() if all dynamic access is inside a Suspense boundary', async () => {
-        try {
-          await next.start()
-        } catch {
-          throw new Error('expected build not to fail for fully static project')
-        }
-
-        expect(next.cliOutput).toContain('◐ / ')
-        const $ = await next.render$('/')
-        expect($('[data-fallback]').length).toBe(2)
-      })
+describe.each([
+  { inDebugMode: true, name: 'With --prerender-debug' },
+  { inDebugMode: false, name: 'Without --prerender-debug' },
+])('Dynamic IO Errors - $name', ({ inDebugMode }) => {
+  describe('Sync Dynamic - With Fallback - Math.random()', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-random-with-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
     })
 
-    describe('Sync Dynamic - Without Fallback - Math.random()', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-random-without-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
+    if (skipped) {
+      return
+    }
 
-      if (skipped) {
-        return
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should not error the build when calling Math.random() if all dynamic access is inside a Suspense boundary', async () => {
+      try {
+        await next.start()
+      } catch {
+        throw new Error('expected build not to fail for fully static project')
       }
 
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build if Math.random() happens before some component outside a Suspense boundary is complete', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Error: Route "/" used `Math.random()` outside of `"use cache"` and without explicitly calling `await connection()` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random'
-        )
-        expectError('Error occurred prerendering page "/"')
-        expectError('exiting the build.')
-      })
+      expect(next.cliOutput).toContain('◐ / ')
+      const $ = await next.render$('/')
+      expect($('[data-fallback]').length).toBe(2)
     })
   })
-}
 
-runTests({ withMinification: true })
-runTests({ withMinification: false })
+  describe('Sync Dynamic - Without Fallback - Math.random()', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-random-without-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if Math.random() happens before some component outside a Suspense boundary is complete', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
+               at RandomReadingComponent (turbopack:///[project]/app/page.tsx:35:22)
+             33 |     use(new Promise((r) => process.nextTick(r)))
+             34 |   }
+           > 35 |   const random = Math.random()
+                |                      ^
+             36 |   return (
+             37 |     <div>
+             38 |       <span id="rand">{random}</span>
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
+               at a (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
+               at RandomReadingComponent (webpack:///app/page.tsx:35:22)
+             33 |     use(new Promise((r) => process.nextTick(r)))
+             34 |   }
+           > 35 |   const random = Math.random()
+                |                      ^
+             36 |   return (
+             37 |     <div>
+             38 |       <span id="rand">{random}</span>
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
+               at a (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+})

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -171,7 +171,8 @@ describe.each([
           expect(output).toMatchInlineSnapshot(`
            "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                at a (<anonymous>)
-               at b (<anonymous>)
+               at main (<anonymous>)
+               at b (<next-dist-dir>)
                at c (<next-dist-dir>)
                at d (<next-dist-dir>)
                at e (<next-dist-dir>)
@@ -180,12 +181,11 @@ describe.each([
                at h (<next-dist-dir>)
                at i (<next-dist-dir>)
                at j (<next-dist-dir>)
-               at k (<next-dist-dir>)
-               at l (<anonymous>)
-               at m (<next-dist-dir>)
-               at n (<anonymous>)
-               at o (<anonymous>)
-               at p (<anonymous>)
+               at k (<anonymous>)
+               at l (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
            Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
            Export encountered an error on /page: /, exiting the build."
           `)
@@ -226,7 +226,8 @@ describe.each([
           expect(output).toMatchInlineSnapshot(`
            "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                at a (<anonymous>)
-               at b (<anonymous>)
+               at main (<anonymous>)
+               at b (<next-dist-dir>)
                at c (<next-dist-dir>)
                at d (<next-dist-dir>)
                at e (<next-dist-dir>)
@@ -235,12 +236,11 @@ describe.each([
                at h (<next-dist-dir>)
                at i (<next-dist-dir>)
                at j (<next-dist-dir>)
-               at k (<next-dist-dir>)
-               at l (<anonymous>)
-               at m (<next-dist-dir>)
-               at n (<anonymous>)
-               at o (<anonymous>)
-               at p (<anonymous>)
+               at k (<anonymous>)
+               at l (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
            Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
            Export encountered an error on /page: /, exiting the build."
           `)

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -1,183 +1,335 @@
 import { nextTestSetup } from 'e2e-utils'
 import { assertNoErrorToast } from 'next-test-utils'
+import { getPrerenderOutput } from './utils'
 
-import { createExpectError } from './utils'
+describe.each([
+  { inDebugMode: true, name: 'With --prerender-debug' },
+  { inDebugMode: false, name: 'Without --prerender-debug' },
+])('Dynamic IO Errors - $name', ({ inDebugMode }) => {
+  describe('Error Attribution with Sync IO - Guarded RSC with guarded Client sync IO', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files:
+        __dirname +
+        '/fixtures/sync-attribution/guarded-async-guarded-clientsync',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
 
-function runTests(options: { withMinification: boolean }) {
-  const { withMinification } = options
-  describe(`Dynamic IO Errors - ${withMinification ? 'With Minification' : 'Without Minification'}`, () => {
-    describe('Error Attribution with Sync IO - Guarded RSC with guarded Client sync IO', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files:
-          __dirname +
-          '/fixtures/sync-attribution/guarded-async-guarded-clientsync',
-        skipStart: true,
-        skipDeployment: true,
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not show a validation error in the dev overlay', async () => {
+        await next.start()
+        const browser = await next.browser('/')
+        await assertNoErrorToast(browser)
       })
+    } else {
+      it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
+        try {
+          await next.start()
+        } catch {
+          throw new Error('expected build not to fail')
+        }
+        expect(next.cliOutput).toContain('◐ / ')
+      })
+    }
+  })
 
-      if (skipped) {
-        return
+  describe('Error Attribution with Sync IO - Guarded RSC with unguarded Client sync IO', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files:
+        __dirname +
+        '/fixtures/sync-attribution/guarded-async-unguarded-clientsync',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build with a reason related to sync IO access', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
       }
 
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
       })
 
-      if (isNextDev) {
-        it('does not show a validation error in the dev overlay', async () => {
-          await next.start()
-          const browser = await next.browser('/')
-          await assertNoErrorToast(browser)
-        })
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at SyncIO (turbopack:///[project]/app/client.tsx:5:15)
+             3 | export function SyncIO() {
+             4 |   // This is a sync IO access that should not cause an error
+           > 5 |   const data = new Date().toISOString()
+               |               ^
+             6 |
+             7 |   return (
+             8 |     <main>
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at a (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
       } else {
-        it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
-          try {
-            await next.start()
-          } catch {
-            throw new Error('expected build not to fail')
-          }
-          expect(next.cliOutput).toContain('◐ / ')
-        })
-      }
-    })
-    describe('Error Attribution with Sync IO - Guarded RSC with unguarded Client sync IO', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files:
-          __dirname +
-          '/fixtures/sync-attribution/guarded-async-unguarded-clientsync',
-        skipStart: true,
-        skipDeployment: true,
-      })
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at SyncIO (webpack:///app/client.tsx:5:15)
+             3 | export function SyncIO() {
+             4 |   // This is a sync IO access that should not cause an error
+           > 5 |   const data = new Date().toISOString()
+               |               ^
+             6 |
+             7 |   return (
+             8 |     <main>
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at a (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
         }
-      })
-
-      it('should error the build with a reason related to sync IO access', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Error: Route "/" used `new Date()` inside a Client Component without a Suspense boundary above it.'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
-    })
-    describe('Error Attribution with Sync IO - Unguarded RSC with guarded Client sync IO', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files:
-          __dirname +
-          '/fixtures/sync-attribution/unguarded-async-guarded-clientsync',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
       }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build with a reason related dynamic data', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it.'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
-    })
-    describe('Error Attribution with Sync IO - unguarded RSC with unguarded Client sync IO', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files:
-          __dirname +
-          '/fixtures/sync-attribution/unguarded-async-unguarded-clientsync',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build with a reason related to sync IO access', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Error: Route "/" used `new Date()` inside a Client Component without a Suspense boundary above it.'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
     })
   })
-}
 
-runTests({ withMinification: true })
-runTests({ withMinification: false })
+  describe('Error Attribution with Sync IO - Unguarded RSC with guarded Client sync IO', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files:
+        __dirname +
+        '/fixtures/sync-attribution/unguarded-async-guarded-clientsync',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build with a reason related dynamic data', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at section (<anonymous>)
+               at main (<anonymous>)
+               at RenderFromTemplateContext (<anonymous>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<anonymous>)
+               at b (<anonymous>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at l (<anonymous>)
+               at m (<next-dist-dir>)
+               at n (<anonymous>)
+               at o (<anonymous>)
+               at p (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at section (<anonymous>)
+               at main (<anonymous>)
+               at InnerLayoutRouter (webpack://<next-src>)
+               at RedirectErrorBoundary (webpack://<next-src>)
+               at RedirectBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackErrorBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackBoundary (webpack://<next-src>)
+               at LoadingBoundary (webpack://<next-src>)
+               at ErrorBoundary (webpack://<next-src>)
+               at InnerScrollAndFocusHandler (webpack://<next-src>)
+               at ScrollAndFocusHandler (webpack://<next-src>)
+               at RenderFromTemplateContext (<anonymous>)
+               at OuterLayoutRouter (webpack://<next-src>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+             332 |  */
+             333 | function InnerLayoutRouter({
+           > 334 |   tree,
+                 |  ^
+             335 |   segmentPath,
+             336 |   cacheNode,
+             337 |   url,
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<anonymous>)
+               at b (<anonymous>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at l (<anonymous>)
+               at m (<next-dist-dir>)
+               at n (<anonymous>)
+               at o (<anonymous>)
+               at p (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Error Attribution with Sync IO - unguarded RSC with unguarded Client sync IO', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files:
+        __dirname +
+        '/fixtures/sync-attribution/unguarded-async-unguarded-clientsync',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build with a reason related to sync IO access', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at SyncIO (turbopack:///[project]/app/client.tsx:5:15)
+             3 | export function SyncIO() {
+             4 |   // This is a sync IO access that should not cause an error
+           > 5 |   const data = new Date().toISOString()
+               |               ^
+             6 |
+             7 |   return (
+             8 |     <main>
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at a (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at SyncIO (webpack:///app/client.tsx:5:15)
+             3 | export function SyncIO() {
+             4 |   // This is a sync IO access that should not cause an error
+           > 5 |   const data = new Date().toISOString()
+               |               ^
+             6 |
+             7 |   return (
+             8 |     <main>
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
+               at a (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+})

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -104,9 +104,9 @@ describe.each([
                at m (<next-dist-dir>)
                at n (<anonymous>)
                at o (<next-dist-dir>)
-               at p (<anonymous>)
-               at q (<anonymous>)
-               at r (<anonymous>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
            Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
            Export encountered an error on /page: /, exiting the build."
           `)
@@ -163,9 +163,9 @@ describe.each([
                at m (<next-dist-dir>)
                at n (<anonymous>)
                at o (<next-dist-dir>)
-               at p (<anonymous>)
-               at q (<anonymous>)
-               at r (<anonymous>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
            Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
            Export encountered an error on /page: /, exiting the build."
           `)

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -1,258 +1,410 @@
 import { nextTestSetup } from 'e2e-utils'
+import { getPrerenderOutput } from './utils'
 
-import { createExpectError } from './utils'
-
-function runTests(options: { withMinification: boolean }) {
-  const { withMinification } = options
-  describe(`Dynamic IO Errors - ${withMinification ? 'With Minification' : 'Without Minification'}`, () => {
-    describe('Sync Dynamic - With Fallback - client searchParams', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-client-search-with-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
-        try {
-          await next.start()
-        } catch {
-          throw new Error('expected build not to fail for fully static project')
-        }
-
-        expect(next.cliOutput).toContain('◐ / ')
-        const $ = await next.render$('/')
-        expect($('[data-fallback]').length).toBe(2)
-      })
+describe.each([
+  { inDebugMode: true, name: 'With --prerender-debug' },
+  { inDebugMode: false, name: 'Without --prerender-debug' },
+])('Dynamic IO Errors - $name', ({ inDebugMode }) => {
+  describe('Sync Dynamic - With Fallback - client searchParams', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-client-search-with-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
     })
 
-    describe('Sync Dynamic - Without Fallback - client searchParams', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-client-search-without-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
+    if (skipped) {
+      return
+    }
 
-      if (skipped) {
-        return
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
+      try {
+        await next.start()
+      } catch {
+        throw new Error('expected build not to fail for fully static project')
       }
 
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        // TODO we need to figure out a way to improve this error message. This is the rare case where the sync IO is escaping out of it's parent Suspense because something is rendering too slowly in the root. At the moment we don't have a way of discriminating between this and something like Request data access in the server.
-        // expectError('Route "/" used `searchParams.foo`')
-        expectError(
-          'Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it.'
-        )
-        expectError('Error occurred prerendering page "/"')
-        expectError('exiting the build.')
-      })
-    })
-
-    describe('Sync Dynamic - With Fallback - server searchParams', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-server-search-with-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
-        try {
-          await next.start()
-        } catch {
-          throw new Error('expected build not to fail for fully static project')
-        }
-
-        expect(next.cliOutput).toContain('◐ / ')
-        const $ = await next.render$('/')
-        expect($('[data-fallback]').length).toBe(2)
-      })
-    })
-
-    describe('Sync Dynamic - Without Fallback - server searchParams', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-server-search-without-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError('Route "/" used `searchParams.foo`')
-        expectError('Error occurred prerendering page "/"')
-        expectError('exiting the build.')
-      })
-    })
-
-    describe('Sync Dynamic - With Fallback - cookies', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-cookies-with-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
-        try {
-          await next.start()
-        } catch {
-          throw new Error('expected build not to fail for fully static project')
-        }
-
-        expect(next.cliOutput).toContain('◐ / ')
-        const $ = await next.render$('/')
-        expect($('[data-fallback]').length).toBe(2)
-      })
-    })
-
-    describe('Sync Dynamic - Without Fallback - cookies', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/sync-cookies-without-fallback',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError('Route "/" used `cookies().get(\'token\')`')
-        expectError('Error occurred prerendering page "/"')
-        expectError('exiting the build.')
-      })
+      expect(next.cliOutput).toContain('◐ / ')
+      const $ = await next.render$('/')
+      expect($('[data-fallback]').length).toBe(2)
     })
   })
-}
 
-runTests({ withMinification: true })
-runTests({ withMinification: false })
+  describe('Sync Dynamic - Without Fallback - client searchParams', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-client-search-without-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at LongRunningComponent (<anonymous>)
+               at IndirectionTwo (turbopack:///[project]/app/indirection.tsx:7:33)
+               at Page (turbopack:///[project]/app/page.tsx:19:60)
+               at RenderFromTemplateContext (<anonymous>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+              5 | }
+              6 |
+           >  7 | export function IndirectionTwo({ children }) {
+                |                                 ^
+              8 |   return children
+              9 | }
+             10 |
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<anonymous>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at l (<next-dist-dir>)
+               at m (<next-dist-dir>)
+               at n (<anonymous>)
+               at o (<next-dist-dir>)
+               at p (<anonymous>)
+               at q (<anonymous>)
+               at r (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at LongRunningComponent (<anonymous>)
+               at IndirectionTwo (webpack:///app/indirection.tsx:7:33)
+               at Page (webpack:///app/page.tsx:19:60)
+               at ClientPageRoot (webpack://<next-src>)
+               at InnerLayoutRouter (webpack://<next-src>)
+               at RedirectErrorBoundary (webpack://<next-src>)
+               at RedirectBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackErrorBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackBoundary (webpack://<next-src>)
+               at LoadingBoundary (webpack://<next-src>)
+               at ErrorBoundary (webpack://<next-src>)
+               at InnerScrollAndFocusHandler (webpack://<next-src>)
+               at ScrollAndFocusHandler (webpack://<next-src>)
+               at RenderFromTemplateContext (<anonymous>)
+               at OuterLayoutRouter (webpack://<next-src>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+              5 | }
+              6 |
+           >  7 | export function IndirectionTwo({ children }) {
+                |                                 ^
+              8 |   return children
+              9 | }
+             10 |
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<anonymous>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at l (<next-dist-dir>)
+               at m (<next-dist-dir>)
+               at n (<anonymous>)
+               at o (<next-dist-dir>)
+               at p (<anonymous>)
+               at q (<anonymous>)
+               at r (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Sync Dynamic - With Fallback - server searchParams', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-server-search-with-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
+      try {
+        await next.start()
+      } catch {
+        throw new Error('expected build not to fail for fully static project')
+      }
+
+      expect(next.cliOutput).toContain('◐ / ')
+      const $ = await next.render$('/')
+      expect($('[data-fallback]').length).toBe(2)
+    })
+  })
+
+  describe('Sync Dynamic - Without Fallback - server searchParams', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-server-search-without-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at SearchParamsReadingComponent (turbopack:///[project]/app/page.tsx:40:4)
+             38 |   const fooParams = (
+             39 |     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
+           > 40 |   ).foo
+                |    ^
+             41 |   return (
+             42 |     <div>
+             43 |       this component read the accessed the \`foo\` search param: {fooParams}
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at SearchParamsReadingComponent (webpack:///app/page.tsx:40:4)
+             38 |   const fooParams = (
+             39 |     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
+           > 40 |   ).foo
+                |    ^
+             41 |   return (
+             42 |     <div>
+             43 |       this component read the accessed the \`foo\` search param: {fooParams}
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Sync Dynamic - With Fallback - cookies', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-cookies-with-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
+      try {
+        await next.start()
+      } catch {
+        throw new Error('expected build not to fail for fully static project')
+      }
+
+      expect(next.cliOutput).toContain('◐ / ')
+      const $ = await next.render$('/')
+      expect($('[data-fallback]').length).toBe(2)
+    })
+  })
+
+  describe('Sync Dynamic - Without Fallback - cookies', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-cookies-without-fallback',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`cookies().get('token')\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at CookiesReadingComponent (turbopack:///[project]/app/page.tsx:32:66)
+             30 | async function CookiesReadingComponent() {
+             31 |   await new Promise((r) => process.nextTick(r))
+           > 32 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                |                                                                  ^
+             33 |   return <div>this component read the \`token\` cookie synchronously</div>
+             34 | }
+             35 |
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`cookies().get('token')\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`cookies().get('token')\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at createCookiesAccessError (webpack://<next-src>)
+               at Promise.get (webpack://<next-src>)
+               at CookiesReadingComponent (webpack:///app/page.tsx:32:66)
+             579 | ) {
+             580 |   const prefix = route ? \`Route "\${route}" \` : 'This route '
+           > 581 |   return new Error(
+                 |         ^
+             582 |     \`\${prefix}used \${expression}. \` +
+             583 |       \`\\\`cookies()\\\` should be awaited before using its value. \` +
+             584 |       \`Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis\`
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/" used \`cookies().get('token')\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+})

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -1,394 +1,654 @@
 import { nextTestSetup } from 'e2e-utils'
+import { getPrerenderOutput } from './utils'
 
-import { createExpectError } from './utils'
-
-function runTests(options: { withMinification: boolean }) {
-  const isTurbopack = !!process.env.IS_TURBOPACK_TEST
-  const { withMinification } = options
-  describe(`Dynamic IO Errors - ${withMinification ? 'With Minification' : 'Without Minification'}`, () => {
-    describe('Dynamic Metadata - Static Route', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-metadata-static-route',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      // This test used to assert the opposite but now that metadata is streaming during prerenders
-      // we don't have to error the build when it is dynamic
-      it('should error the build if generateMetadata is dynamic when the rest of the route is prerenderable', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Route "/" has a `generateMetadata` that depends on Request data (`cookies()`, etc...) or uncached external data (`fetch(...)`, etc...) when the rest of the route does not'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
-    })
-    describe('Dynamic Metadata - Error Route', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-metadata-error-route',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      // This test is just here because there was a bug when dynamic metadata was used alongside another dynamic IO violation which caused the validation to be skipped.
-      it('should error the build for the correct reason when there is a dynamic IO violation alongside dynamic metadata', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
-    })
-    describe('Dynamic Metadata - Static Route With Suspense', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-metadata-static-with-suspense',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      // This test used to assert the opposite but now that metadata is streaming during prerenders
-      // we don't have to error the build when it is dynamic
-      it('should not error the build if generateMetadata is dynamic', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Route "/" has a `generateMetadata` that depends on Request data (`cookies()`, etc...) or uncached external data (`fetch(...)`, etc...) when the rest of the route does not'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
+describe.each([
+  { inDebugMode: true, name: 'With --prerender-debug' },
+  { inDebugMode: false, name: 'Without --prerender-debug' },
+])('Dynamic IO Errors - $name', ({ inDebugMode }) => {
+  describe('Dynamic Metadata - Static Route', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-metadata-static-route',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
     })
 
-    describe('Dynamic Metadata - Dynamic Route', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-metadata-dynamic-route',
-        skipStart: true,
-        skipDeployment: true,
-      })
+    if (skipped) {
+      return
+    }
 
-      if (skipped) {
-        return
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if generateMetadata is dynamic when the rest of the route is prerenderable', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
       }
 
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(
+            getPrerenderOutput(next.cliOutput, { isMinified: !inDebugMode })
+          ).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
       }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
-        try {
-          await next.start()
-        } catch {
-          throw new Error('expected build not to fail for fully static project')
-        }
-
-        expect(next.cliOutput).toContain('◐ / ')
-        const $ = await next.render$('/')
-        expect($('#dynamic').text()).toBe('Dynamic')
-        expect($('[data-fallback]').length).toBe(1)
-      })
-    })
-
-    describe('Dynamic Viewport - Static Route', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-viewport-static-route',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build if generateViewport is dynamic', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or uncached external data (`fetch(...)`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
-    })
-
-    describe('Dynamic Viewport - Dynamic Route', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-viewport-dynamic-route',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build if generateViewport is dynamic even if there are other uses of dynamic on the page', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or uncached external data (`fetch(...)`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport'
-        )
-        expectError('Error occurred prerendering page "/"')
-      })
-    })
-
-    describe('Static Route', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/static',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should not error the build when all routes are static', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-          throw new Error('expected build not to fail for fully static project')
-        }
-      })
-    })
-
-    describe('Dynamic Root', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-root',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
-        try {
-          await next.start()
-        } catch {
-          // we expect the build to fail
-        }
-        const expectError = createExpectError(next.cliOutput)
-
-        expectError(
-          'Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it.',
-          // Turbopack doesn't support disabling minification yet
-          withMinification || isTurbopack ? undefined : 'IndirectionTwo'
-        )
-        expectError(
-          'Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it.',
-          // Turbopack doesn't support disabling minification yet
-          withMinification || isTurbopack ? undefined : 'IndirectionThree'
-        )
-        expectError('Error occurred prerendering page "/"')
-        expectError('exiting the build.')
-      })
-    })
-
-    describe('Dynamic Boundary', () => {
-      const { next, isNextDev, skipped } = nextTestSetup({
-        files: __dirname + '/fixtures/dynamic-boundary',
-        skipStart: true,
-        skipDeployment: true,
-      })
-
-      if (skipped) {
-        return
-      }
-
-      if (isNextDev) {
-        it('does not run in dev', () => {})
-        return
-      }
-
-      beforeEach(async () => {
-        if (!withMinification) {
-          await next.patchFile('next.config.js', (content) =>
-            content.replace(
-              'serverMinification: true,',
-              'serverMinification: false,'
-            )
-          )
-        }
-      })
-
-      it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
-        try {
-          await next.start()
-        } catch {
-          throw new Error('expected build not to fail for fully static project')
-          // we expect the build to fail
-        }
-
-        expect(next.cliOutput).toContain('◐ / ')
-        const $ = await next.render$('/')
-        expect($('[data-fallback]').length).toBe(2)
-      })
     })
   })
-}
 
-runTests({ withMinification: true })
-runTests({ withMinification: false })
+  describe('Dynamic Metadata - Error Route', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-metadata-error-route',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    // This test is just here because there was a bug when dynamic metadata was used alongside another dynamic IO violation which caused the validation to be skipped.
+    it('should error the build for the correct reason when there is a dynamic IO violation alongside dynamic metadata', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at InnerLayoutRouter (webpack://<next-src>)
+               at RedirectErrorBoundary (webpack://<next-src>)
+               at RedirectBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackErrorBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackBoundary (webpack://<next-src>)
+               at LoadingBoundary (webpack://<next-src>)
+               at ErrorBoundary (webpack://<next-src>)
+               at InnerScrollAndFocusHandler (webpack://<next-src>)
+               at ScrollAndFocusHandler (webpack://<next-src>)
+               at RenderFromTemplateContext (webpack://<next-src>)
+               at OuterLayoutRouter (webpack://<next-src>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+             332 |  */
+             333 | function InnerLayoutRouter({
+           > 334 |   tree,
+                 |  ^
+             335 |   segmentPath,
+             336 |   cacheNode,
+             337 |   url,
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Dynamic Metadata - Static Route With Suspense', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-metadata-static-with-suspense',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if generateMetadata is dynamic when the rest of the route is prerenderable', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Dynamic Metadata - Dynamic Route', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-metadata-dynamic-route',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
+      try {
+        await next.start()
+      } catch {
+        throw new Error('expected build not to fail for fully static project')
+      }
+
+      expect(next.cliOutput).toContain('◐ / ')
+      const $ = await next.render$('/')
+      expect($('#dynamic').text()).toBe('Dynamic')
+      expect($('[data-fallback]').length).toBe(1)
+    })
+  })
+
+  describe('Dynamic Viewport - Static Route', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-viewport-static-route',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if generateViewport is dynamic', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Dynamic Viewport - Dynamic Route', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-viewport-dynamic-route',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if generateViewport is dynamic even if there are other uses of dynamic on the page', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Route "/" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Static Route', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/static',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should not error the build when all routes are static', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+        throw new Error('expected build not to fail for fully static project')
+      }
+    })
+  })
+
+  describe('Dynamic Root', () => {
+    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-root',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
+      try {
+        await next.start()
+      } catch {
+        // we expect the build to fail
+      }
+
+      const output = getPrerenderOutput(next.cliOutput, {
+        isMinified: !inDebugMode,
+      })
+
+      if (isTurbopack) {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at IndirectionTwo (turbopack:///[project]/app/indirection.tsx:7:33)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+              5 | }
+              6 |
+           >  7 | export function IndirectionTwo({ children }) {
+                |                                 ^
+              8 |   return children
+              9 | }
+             10 |
+           Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at l (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at m (<next-dist-dir>)
+               at n (<next-dist-dir>)
+               at o (<next-dist-dir>)
+               at p (<next-dist-dir>)
+               at q (<next-dist-dir>)
+               at r (<next-dist-dir>)
+               at s (<next-dist-dir>)
+               at t (<next-dist-dir>)
+               at u (<next-dist-dir>)
+               at v (<next-dist-dir>)
+               at w (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      } else {
+        if (inDebugMode) {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at IndirectionTwo (webpack:///app/indirection.tsx:7:33)
+               at InnerLayoutRouter (webpack://<next-src>)
+               at RedirectErrorBoundary (webpack://<next-src>)
+               at RedirectBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackErrorBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackBoundary (webpack://<next-src>)
+               at LoadingBoundary (webpack://<next-src>)
+               at ErrorBoundary (webpack://<next-src>)
+               at InnerScrollAndFocusHandler (webpack://<next-src>)
+               at ScrollAndFocusHandler (webpack://<next-src>)
+               at RenderFromTemplateContext (webpack://<next-src>)
+               at OuterLayoutRouter (webpack://<next-src>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+              5 | }
+              6 |
+           >  7 | export function IndirectionTwo({ children }) {
+                |                                 ^
+              8 |   return children
+              9 | }
+             10 |
+           Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at InnerLayoutRouter (webpack://<next-src>)
+               at RedirectErrorBoundary (webpack://<next-src>)
+               at RedirectBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackErrorBoundary (webpack://<next-src>)
+               at HTTPAccessFallbackBoundary (webpack://<next-src>)
+               at LoadingBoundary (webpack://<next-src>)
+               at ErrorBoundary (webpack://<next-src>)
+               at InnerScrollAndFocusHandler (webpack://<next-src>)
+               at ScrollAndFocusHandler (webpack://<next-src>)
+               at RenderFromTemplateContext (webpack://<next-src>)
+               at OuterLayoutRouter (webpack://<next-src>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+             332 |  */
+             333 | function InnerLayoutRouter({
+           > 334 |   tree,
+                 |  ^
+             335 |   segmentPath,
+             336 |   cacheNode,
+             337 |   url,
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+           > Export encountered errors on following paths:
+           	/page: /"
+          `)
+        } else {
+          expect(output).toMatchInlineSnapshot(`
+           "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at a (<next-dist-dir>)
+               at b (<next-dist-dir>)
+               at c (<next-dist-dir>)
+               at d (<next-dist-dir>)
+               at e (<next-dist-dir>)
+               at f (<next-dist-dir>)
+               at g (<next-dist-dir>)
+               at h (<next-dist-dir>)
+               at i (<next-dist-dir>)
+               at j (<next-dist-dir>)
+               at k (<next-dist-dir>)
+               at l (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               at m (<next-dist-dir>)
+               at n (<next-dist-dir>)
+               at o (<next-dist-dir>)
+               at p (<next-dist-dir>)
+               at q (<next-dist-dir>)
+               at r (<next-dist-dir>)
+               at s (<next-dist-dir>)
+               at t (<next-dist-dir>)
+               at u (<next-dist-dir>)
+               at v (<next-dist-dir>)
+               at w (<next-dist-dir>)
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /page: /, exiting the build."
+          `)
+        }
+      }
+    })
+  })
+
+  describe('Dynamic Boundary', () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/dynamic-boundary',
+      skipStart: true,
+      skipDeployment: true,
+      buildOptions: inDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('does not run in dev', () => {})
+      return
+    }
+
+    it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
+      try {
+        await next.start()
+      } catch {
+        throw new Error('expected build not to fail for fully static project')
+        // we expect the build to fail
+      }
+
+      expect(next.cliOutput).toContain('◐ / ')
+      const $ = await next.render$('/')
+      expect($('[data-fallback]').length).toBe(2)
+    })
+  })
+})

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-boundary/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-boundary/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-dynamic-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-dynamic-route/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-error-route/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-route/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/app/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/app/indirection.tsx
@@ -7,7 +7,3 @@ export function IndirectionOne({ children }) {
 export function IndirectionTwo({ children }) {
   return children
 }
-
-export function IndirectionThree({ children }) {
-  return children
-}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/app/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 
-import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
+import { IndirectionOne, IndirectionTwo } from './indirection'
 
 export default async function Page() {
   return (
@@ -24,12 +24,10 @@ export default async function Page() {
           <FetchingComponent nonce="d" />
         </Suspense>
       </IndirectionTwo>
-      <IndirectionThree>
-        <FetchingComponent nonce="e" />
-        <Suspense fallback="loading...">
-          <FetchingComponent nonce="f" />
-        </Suspense>
-      </IndirectionThree>
+      <FetchingComponent nonce="e" />
+      <Suspense fallback="loading...">
+        <FetchingComponent nonce="f" />
+      </Suspense>
     </>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-root/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: false,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-dynamic-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-dynamic-route/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-static-route/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-viewport-static-route/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: false,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/static/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/static/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-guarded-clientsync/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/guarded-async-unguarded-clientsync/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-guarded-clientsync/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/unguarded-async-unguarded-clientsync/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-with-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-without-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-with-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-with-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-without-fallback/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
-    serverMinification: true,
   },
 }
 

--- a/test/e2e/app-dir/dynamic-io-errors/utils.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/utils.ts
@@ -1,5 +1,6 @@
 // Used to deterministically stub out minified local names in stack traces.
 const abc = 'abcdefghijklmnopqrstuvwxyz'
+const hostElementsUsedInFixtures = ['html', 'body', 'main', 'div']
 
 export function getPrerenderOutput(
   cliOutput: string,
@@ -12,8 +13,13 @@ export function getPrerenderOutput(
   const replaceNextDistStackFrame = () =>
     `at ${abc[i++ % abc.length]} (<next-dist-dir>)`
 
-  const replaceAnonymousStackFrame = () =>
-    `at ${abc[i++ % abc.length]} (<anonymous>)`
+  const replaceAnonymousStackFrame = (_m, name) => {
+    const deterministicName = hostElementsUsedInFixtures.includes(name)
+      ? name
+      : abc[i++ % abc.length]
+
+    return `at ${deterministicName} (<anonymous>)`
+  }
 
   for (const line of cliOutput.split('\n')) {
     if (line.includes('Collecting page data')) {
@@ -30,7 +36,10 @@ export function getPrerenderOutput(
         isMinified
           ? line
               .replace(/at [\w.]+ \(.next[^)]+\)/, replaceNextDistStackFrame)
-              .replace(/at [\w.]+ \(<anonymous>\)/, replaceAnonymousStackFrame)
+              .replace(
+                /at ([\w.]+) \(<anonymous>\)/,
+                replaceAnonymousStackFrame
+              )
           : line.replace(
               /at ([\w.]+) \((webpack:\/\/)\/src[^)]+\)/,
               `at $1 ($2<next-src>)`

--- a/test/e2e/app-dir/dynamic-io-errors/utils.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/utils.ts
@@ -1,35 +1,43 @@
-const stackStart = /\s+at /
+// Used to deterministically stub out minified local names in stack traces.
+const abc = 'abcdefghijklmnopqrstuvwxyz'
 
-export function createExpectError(cliOutput: string) {
-  let cliIndex = 0
-  return function expectError(
-    containing: string,
-    withStackContaining?: string
-  ): void {
-    const initialCliIndex = cliIndex
-    let lines = cliOutput.slice(cliIndex).split('\n')
+export function getPrerenderOutput(
+  cliOutput: string,
+  { isMinified }: { isMinified: boolean }
+): string {
+  const lines: string[] = []
+  let foundPrerenderingLine = false
+  let i = 0
 
-    let i = 0
-    while (i < lines.length) {
-      let line = lines[i++] + '\n'
-      cliIndex += line.length
-      if (line.includes(containing)) {
-        if (typeof withStackContaining !== 'string') {
-          return
-        } else {
-          while (i < lines.length) {
-            let stackLine = lines[i++] + '\n'
-            if (!stackStart.test(stackLine)) {
-              expect(stackLine).toContain(withStackContaining)
-            }
-            if (stackLine.includes(withStackContaining)) {
-              return
-            }
-          }
-        }
-      }
+  const replaceNextDistStackFrame = () =>
+    `at ${abc[i++ % abc.length]} (<next-dist-dir>)`
+
+  const replaceAnonymousStackFrame = () =>
+    `at ${abc[i++ % abc.length]} (<anonymous>)`
+
+  for (const line of cliOutput.split('\n')) {
+    if (line.includes('Collecting page data')) {
+      foundPrerenderingLine = true
+      continue
     }
 
-    expect(cliOutput.slice(initialCliIndex)).toContain(containing)
+    if (line.includes('Next.js build worker exited')) {
+      break
+    }
+
+    if (foundPrerenderingLine && !line.includes('Generating static pages')) {
+      lines.push(
+        isMinified
+          ? line
+              .replace(/at [\w.]+ \(.next[^)]+\)/, replaceNextDistStackFrame)
+              .replace(/at [\w.]+ \(<anonymous>\)/, replaceAnonymousStackFrame)
+          : line.replace(
+              /at ([\w.]+) \((webpack:\/\/)\/src[^)]+\)/,
+              `at $1 ($2<next-src>)`
+            )
+      )
+    }
   }
+
+  return lines.join('\n').trim()
 }


### PR DESCRIPTION
For now, this is just documenting the current state of affairs with regards to how we print dynamic validation errors during prerendering.

Previously, the tests were run with and without `experimental.serverMinification`. Now, we're running them with and without the `--debug-prerender` CLI flag instead.

In follow-ups, we will add assertions for `next dev`, and also improve the errors for `next build`.

> [!NOTE]  
> This PR is best reviewed with hidden whitespace changes.