### PR TITLE
[Segment Cache] Enable deploy tests

### DIFF
--- a/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+++ b/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
@@ -2,11 +2,10 @@ import { nextTestSetup } from 'e2e-utils'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache (basic tests)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('ppr is disabled', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/client-only-opt-in/client-only-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/client-only-opt-in/client-only-opt-in.test.ts
@@ -3,11 +3,10 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache prefetch scheduling', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('prefetching is disabled', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts
+++ b/test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts
@@ -3,11 +3,10 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from '../router-act'
 
 describe('dynamic on hover', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('prefetching is disabled', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createRouterAct } from '../router-act'
+import { Page } from 'playwright'
 
 describe('segment cache (incremental opt in)', () => {
   const { next, isNextDeploy, isNextDev } = nextTestSetup({
@@ -20,21 +21,22 @@ describe('segment cache (incremental opt in)', () => {
     // that occur. Then at the end we confirm there are no duplicates.
     const prefetches = new Map()
     const duplicatePrefetches = new Map()
+    const unexpectedResponse = []
 
-    let act
+    let currentPage: Page
     const browser = await next.browser('/', {
       async beforePageLoad(page) {
-        act = createRouterAct(page)
+        currentPage = page
         await page.route('**/*', async (route) => {
           const request = route.request()
+          const headers = await request.allHeaders()
           const isPrefetch =
-            request.headerValue('rsc') !== null &&
-            request.headerValue('next-router-prefetch') !== null
+            headers['rsc'] !== undefined &&
+            headers['next-router-prefetch'] !== undefined
           if (isPrefetch) {
-            const request = route.request()
-            const headers = await request.allHeaders()
+            const url = request.url()
             const prefetchInfo = {
-              href: new URL(request.url()).pathname,
+              href: new URL(url).pathname,
               segment: headers['Next-Router-Segment-Prefetch'.toLowerCase()],
               base: headers['Next-Router-State-Tree'.toLowerCase()] ?? null,
             }
@@ -48,20 +50,12 @@ describe('segment cache (incremental opt in)', () => {
               maxRedirects: 0,
             })
             const status = response.status()
-            const responseHeaders = response.headers()
             if (status !== 200) {
-              await page.unrouteAll({ behavior: 'ignoreErrors' })
-              return page.close({
-                reason: `
-Received an unexpected prefetch response.
-
-Status: ${status}
-URL: ${request.url()}
-Headers: ${JSON.stringify(responseHeaders)}
-
-Response:
-${await response.body()}
-`,
+              unexpectedResponse.push({
+                status,
+                url,
+                headers: response.headers(),
+                response: await response.text(),
               })
             }
             return route.fulfill({ response })
@@ -80,10 +74,8 @@ ${await response.body()}
     expect(await checkbox.isChecked()).toBe(false)
 
     // Click the checkbox to reveal the link and trigger a prefetch
-    await act(async () => {
-      await checkbox.click()
-      await browser.elementByCss(`a[href="${linkHref}"]`)
-    })
+    await checkbox.click()
+    await browser.elementByCss(`a[href="${linkHref}"]`)
 
     // Toggle the visibility of the link. Prefetches are initiated on viewport,
     // so if the cache does not dedupe then properly, this test will detect it.
@@ -98,9 +90,14 @@ ${await response.body()}
     await browser.elementById('page-content')
     expect(new URL(await browser.url()).pathname).toBe(linkHref)
 
-    // Finally, assert there were no duplicate prefetches
-    expect(prefetches.size).not.toBe(0)
-    expect(duplicatePrefetches.size).toBe(0)
+    // Wait for all pending requests to complete.
+    await currentPage.unrouteAll({ behavior: 'wait' })
+
+    // Finally, assert there were no duplicate prefetches and no unexpected
+    // responses.
+    expect(prefetches).not.toBeEmpty()
+    expect(duplicatePrefetches).toBeEmpty()
+    expect(unexpectedResponse).toBeEmpty()
   }
 
   describe('multiple prefetches to same link are deduped', () => {

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache (incremental opt in)', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
   })
   if (isNextDev) {
@@ -44,6 +44,27 @@ describe('segment cache (incremental opt in)', () => {
             } else {
               prefetches.set(key, prefetchInfo)
             }
+            const response = await page.request.fetch(request, {
+              maxRedirects: 0,
+            })
+            const status = response.status()
+            const responseHeaders = response.headers()
+            if (status !== 200) {
+              await page.unrouteAll({ behavior: 'ignoreErrors' })
+              return page.close({
+                reason: `
+Received an unexpected prefetch response.
+
+Status: ${status}
+URL: ${request.url()}
+Headers: ${JSON.stringify(responseHeaders)}
+
+Response:
+${await response.body()}
+`,
+              })
+            }
+            return route.fulfill({ response })
           }
           route.continue()
         })
@@ -84,8 +105,11 @@ describe('segment cache (incremental opt in)', () => {
 
   describe('multiple prefetches to same link are deduped', () => {
     it('page with PPR enabled', () => testPrefetchDeduping('/ppr-enabled'))
-    it('page with PPR enabled, and has a dynamic param', () =>
-      testPrefetchDeduping('/ppr-enabled/dynamic-param'))
+    // FIXME: When deployed, the _tree prefetch request returns an empty 204.
+    ;(isNextDeploy ? it.failing : it)(
+      'page with PPR enabled, and has a dynamic param',
+      () => testPrefetchDeduping('/ppr-enabled/dynamic-param')
+    )
     it('page with PPR disabled', () => testPrefetchDeduping('/ppr-disabled'))
     it('page with PPR disabled, and has a loading boundary', () =>
       testPrefetchDeduping('/ppr-disabled-with-loading-boundary'))

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -21,7 +21,7 @@ describe('segment cache (incremental opt in)', () => {
     // that occur. Then at the end we confirm there are no duplicates.
     const prefetches = new Map()
     const duplicatePrefetches = new Map()
-    const unexpectedResponse = []
+    const unexpectedResponses = []
 
     let currentPage: Page
     const browser = await next.browser('/', {
@@ -51,7 +51,7 @@ describe('segment cache (incremental opt in)', () => {
             })
             const status = response.status()
             if (status !== 200) {
-              unexpectedResponse.push({
+              unexpectedResponses.push({
                 status,
                 url,
                 headers: response.headers(),
@@ -97,7 +97,7 @@ describe('segment cache (incremental opt in)', () => {
     // responses.
     expect(prefetches).not.toBeEmpty()
     expect(duplicatePrefetches).toBeEmpty()
-    expect(unexpectedResponse).toBeEmpty()
+    expect(unexpectedResponses).toBeEmpty()
   }
 
   describe('multiple prefetches to same link are deduped', () => {

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -2,11 +2,10 @@ import { nextTestSetup } from 'e2e-utils'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache (incremental opt in)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('ppr is disabled', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
@@ -2,11 +2,10 @@ import { nextTestSetup } from 'e2e-utils'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache memory pressure', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('disabled in development / deployment', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
@@ -1,11 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('segment cache (MPA navigations)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('ppr is disabled', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/mpa-navigations.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('segment cache (MPA navigations)', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -25,10 +26,14 @@ describe('segment cache (MPA navigations)', () => {
     await link.click()
 
     // The expando should not be present because we did a full-page navigation.
-    const htmlAfterNav = await browser.elementByCss('html')
-    expect(
-      await htmlAfterNav.evaluate((el) => (el as ElementWithExpando).__expando)
-    ).toBe(undefined)
+    await retry(async () => {
+      const htmlAfterNav = await browser.elementByCss('html')
+      expect(
+        await htmlAfterNav.evaluate(
+          (el) => (el as ElementWithExpando).__expando
+        )
+      ).toBe(undefined)
+    })
   })
 
   it(
@@ -52,12 +57,14 @@ describe('segment cache (MPA navigations)', () => {
       await link.click()
 
       // The expando should not be present because we did a full-page navigation.
-      const htmlAfterNav = await browser.elementByCss('html')
-      expect(
-        await htmlAfterNav.evaluate(
-          (el) => (el as ElementWithExpando).__expando
-        )
-      ).toBe(undefined)
+      await retry(async () => {
+        const htmlAfterNav = await browser.elementByCss('html')
+        expect(
+          await htmlAfterNav.evaluate(
+            (el) => (el as ElementWithExpando).__expando
+          )
+        ).toBe(undefined)
+      })
     }
   )
 })

--- a/test/e2e/app-dir/segment-cache/prefetch-auto/prefetch-auto.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-auto/prefetch-auto.test.ts
@@ -3,11 +3,10 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from '../router-act'
 
 describe('<Link prefetch="auto">', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     it('disabled in development / deployment', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
@@ -3,11 +3,10 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache prefetch scheduling', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('prefetching is disabled', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
@@ -2,11 +2,10 @@ import { nextTestSetup } from 'e2e-utils'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache (search params)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('ppr is disabled', () => {})
     return
   }

--- a/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+++ b/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
@@ -89,6 +89,8 @@ describe('segment cache (staleness)', () => {
     const act = createRouterAct(page)
 
     await page.clock.install()
+    const startDate = Date.now()
+    await page.clock.setFixedTime(startDate)
 
     // Navigate to the dynamic page
     await act(
@@ -110,10 +112,10 @@ describe('segment cache (staleness)', () => {
 
     await browser.back()
 
-    // Fast forward 28 seconds. staleTimes.dynamic is configured as 30s, so if
-    // we navigate to the same link again, the old data should be reused without
-    // a new network request.
-    await page.clock.fastForward(28 * 1000)
+    // Advance time by 29 seconds. staleTimes.dynamic is configured as 30s, so
+    // if we navigate to the same link again, the old data should be reused
+    // without a new network request.
+    await page.clock.setFixedTime(startDate + 29 * 1000)
 
     await act(async () => {
       const toggle = await browser.elementByCss(
@@ -130,9 +132,9 @@ describe('segment cache (staleness)', () => {
 
     await browser.back()
 
-    // Fast forward an additional 4 seconds. This time, if we navigate to the
-    // link again, the data is stale, so we issue a new request.
-    await page.clock.fastForward(4 * 1000)
+    // Advance an additional second. This time, if we navigate to the link
+    // again, the data is stale, so we issue a new request.
+    await page.clock.setFixedTime(startDate + 30 * 1000)
 
     await act(
       async () => {

--- a/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+++ b/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
@@ -110,10 +110,10 @@ describe('segment cache (staleness)', () => {
 
     await browser.back()
 
-    // Fast forward 29 seconds. staleTimes.dynamic is configured as 30s, so if
+    // Fast forward 28 seconds. staleTimes.dynamic is configured as 30s, so if
     // we navigate to the same link again, the old data should be reused without
     // a new network request.
-    await page.clock.fastForward(29 * 1000)
+    await page.clock.fastForward(28 * 1000)
 
     await act(async () => {
       const toggle = await browser.elementByCss(
@@ -130,9 +130,9 @@ describe('segment cache (staleness)', () => {
 
     await browser.back()
 
-    // Fast forward an additional second. This time, if we navigate to the link
-    // again, the data is stale, so we issue a new request.
-    await page.clock.fastForward(1 * 1000)
+    // Fast forward an additional 4 seconds. This time, if we navigate to the
+    // link again, the data is stale, so we issue a new request.
+    await page.clock.fastForward(4 * 1000)
 
     await act(
       async () => {

--- a/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+++ b/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
@@ -3,11 +3,10 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from '../router-act'
 
 describe('segment cache (staleness)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     test('disabled in development / deployment', () => {})
     return
   }


### PR DESCRIPTION
With this PR, we're enabling deployment testing for the existing Segment Cache test suites (excluding those that need a custom server setup).

Two timing issues were fixed, and one bug was uncovered. For details see the inline comments below.