### PR TITLE
Turbopack: pass current Node.js version from JS side instead of invoking node

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -156,6 +156,9 @@ pub struct NapiProjectOptions {
     /// local names for variables, functions etc., which can be useful for
     /// debugging/profiling purposes.
     pub no_mangling: bool,
+
+    /// The version of Node.js that is available/currently running.
+    pub current_node_js_version: RcStr,
 }
 
 /// [NapiProjectOptions] with all fields optional.
@@ -261,6 +264,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
             preview_props: val.preview_props.into(),
             browserslist_query: val.browserslist_query,
             no_mangling: val.no_mangling,
+            current_node_js_version: val.current_node_js_version,
         }
     }
 }

--- a/crates/next-api/benches/hmr.rs
+++ b/crates/next-api/benches/hmr.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     fs::{create_dir_all, write},
     mem::forget,
     path::{Path, PathBuf},
@@ -182,10 +181,7 @@ impl HmrBenchmark {
                 project_path: RcStr::from(project_path.clone()),
                 next_config: load_next_config(),
                 js_config: RcStr::from("{}"),
-                env: vec![(
-                    RcStr::from("PATH"),
-                    RcStr::from(env::var("PATH").unwrap_or_default()),
-                )],
+                env: vec![],
                 define_env: DefineEnv {
                     client: vec![],
                     edge: vec![],

--- a/crates/next-api/benches/hmr.rs
+++ b/crates/next-api/benches/hmr.rs
@@ -205,6 +205,7 @@ impl HmrBenchmark {
                 },
                 browserslist_query: RcStr::from("last 2 versions"),
                 no_mangling: false,
+                current_node_js_version: RcStr::from("18.0.0"),
             };
 
             container.initialize(options).await?;

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -166,6 +166,7 @@ fn main() {
                                      Safari versions, last 1 Edge versions"
                     .into(),
                 no_mangling: false,
+                current_node_js_version: "18.0.0".into(),
             };
 
             let json = serde_json::to_string_pretty(&options).unwrap();

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, Vc};
-use turbo_tasks_env::{EnvMap, ProcessEnv};
+use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{css::chunk::CssChunkType, resolve_options_context::ResolveOptionsContext};
 use turbopack_browser::BrowserChunkingContext;
@@ -83,16 +83,11 @@ async fn next_edge_free_vars(
 pub async fn get_edge_compile_time_info(
     project_path: Vc<FileSystemPath>,
     define_env: Vc<EnvMap>,
-    process_env: Vc<Box<dyn ProcessEnv>>,
+    node_version: ResolvedVc<NodeJsVersion>,
 ) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
         Environment::new(ExecutionEnvironment::EdgeWorker(
-            EdgeWorkerEnvironment {
-                node_version: NodeJsVersion::resolved_cell(NodeJsVersion::Current(
-                    process_env.to_resolved().await?,
-                )),
-            }
-            .resolved_cell(),
+            EdgeWorkerEnvironment { node_version }.resolved_cell(),
         ))
         .to_resolved()
         .await?,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, OptionVcExt, ResolvedVc, TaskInput, Vc};
-use turbo_tasks_env::{EnvMap, ProcessEnv};
+use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
     css::chunk::CssChunkType,
@@ -381,17 +381,15 @@ async fn next_server_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarRefer
 
 #[turbo_tasks::function]
 pub async fn get_server_compile_time_info(
-    process_env: Vc<Box<dyn ProcessEnv>>,
-    define_env: Vc<EnvMap>,
     cwd: RcStr,
+    define_env: Vc<EnvMap>,
+    node_version: ResolvedVc<NodeJsVersion>,
 ) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
         Environment::new(ExecutionEnvironment::NodeJsLambda(
             NodeJsEnvironment {
                 compile_target: CompileTarget::current().to_resolved().await?,
-                node_version: NodeJsVersion::resolved_cell(NodeJsVersion::Current(
-                    process_env.to_resolved().await?,
-                )),
+                node_version,
                 cwd: ResolvedVc::cell(Some(cwd)),
             }
             .resolved_cell(),

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -136,6 +136,8 @@ export interface NapiProjectOptions {
    * debugging/profiling purposes.
    */
   noMangling: boolean
+  /** The version of Node.js that is available/currently running. */
+  currentNodeJsVersion: RcStr
 }
 /** [NapiProjectOptions] with all fields optional. */
 export interface NapiPartialProjectOptions {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -423,6 +423,11 @@ export interface ProjectOptions {
    * debugging/profiling purposes.
    */
   noMangling: boolean
+
+  /**
+   * The version of Node.js that is available/currently running.
+   */
+  currentNodeJsVersion: string
 }
 
 export interface DefineEnv {

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -43,6 +43,7 @@ export async function turbopackBuild(): Promise<{
   const rewrites = NextBuildContext.rewrites!
   const appDirOnly = NextBuildContext.appDirOnly!
   const noMangling = NextBuildContext.noMangling!
+  const currentNodeJsVersion = process.versions.node
 
   const startTime = process.hrtime()
   const bindings = await loadBindings(config?.experimental?.useWasmBinary)
@@ -80,6 +81,7 @@ export async function turbopackBuild(): Promise<{
       previewProps,
       browserslistQuery: supportedBrowsers.join(', '),
       noMangling,
+      currentNodeJsVersion,
     },
     {
       persistentCaching,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -210,6 +210,8 @@ export async function createHotReloaderTurbopack(
     'last 1 Chrome versions, last 1 Firefox versions, last 1 Safari versions, last 1 Edge versions',
   ]
 
+  const currentNodeJsVersion = process.versions.node
+
   const project = await bindings.turbo.createProject(
     {
       projectPath: projectPath,
@@ -243,6 +245,7 @@ export async function createHotReloaderTurbopack(
       previewProps: opts.fsChecker.prerenderManifest.preview,
       browserslistQuery: supportedBrowsers.join(', '),
       noMangling: false,
+      currentNodeJsVersion,
     },
     {
       persistentCaching: isPersistentCachingEnabled(opts.nextConfig),

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -233,6 +233,7 @@ describe('next.rs api', () => {
       },
       browserslistQuery: 'last 2 versions',
       noMangling: false,
+      currentNodeJsVersion: '18.0.0',
     })
     projectUpdateSubscription = filterMapAsyncIterator(
       project.updateInfoSubscribe(1000),

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -197,9 +197,7 @@ describe('next.rs api', () => {
       '.next'
     )
     project = await bindings.turbo.createProject({
-      env: {
-        PATH: process.env.PATH,
-      },
+      env: {},
       jsConfig: {
         compilerOptions: {},
       },

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use browserslist::Distrib;
 use swc_core::ecma::preset_env::{Version, Versions};
 use turbo_rcstr::{RcStr, rcstr};
@@ -261,15 +261,15 @@ pub struct NodeJsEnvironment {
     pub cwd: ResolvedVc<Option<RcStr>>,
 }
 
-impl Default for NodeJsEnvironment {
-    fn default() -> Self {
-        NodeJsEnvironment {
-            compile_target: CompileTarget::current_raw().resolved_cell(),
-            node_version: NodeJsVersion::default().resolved_cell(),
-            cwd: ResolvedVc::cell(None),
-        }
-    }
-}
+// impl Default for NodeJsEnvironment {
+//     fn default() -> Self {
+//         NodeJsEnvironment {
+//             compile_target: CompileTarget::current_raw().resolved_cell(),
+//             node_version: NodeJsVersion::default().resolved_cell(),
+//             cwd: ResolvedVc::cell(None),
+//         }
+//     }
+// }
 
 #[turbo_tasks::value_impl]
 impl NodeJsEnvironment {
@@ -283,7 +283,8 @@ impl NodeJsEnvironment {
 
         Ok(Vc::cell(Versions {
             node: Some(
-                Version::from_str(&str).map_err(|_| anyhow!("Node.js version parse error"))?,
+                Version::from_str(&str)
+                    .map_err(|_| anyhow!("Failed to parse Node.js version: '{}'", str))?,
             ),
             ..Default::default()
         }))
@@ -303,7 +304,9 @@ impl NodeJsEnvironment {
 
 #[turbo_tasks::value(shared)]
 pub enum NodeJsVersion {
+    /// Use the version of Node.js that is available from the environment (via `node --version`)
     Current(ResolvedVc<Box<dyn ProcessEnv>>),
+    /// Use the specified version of Node.js.
     Static(ResolvedVc<RcStr>),
 }
 
@@ -360,12 +363,30 @@ pub async fn get_current_nodejs_version(env: Vc<Box<dyn ProcessEnv>>) -> Result<
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
 
-    Ok(Vc::cell(
-        String::from_utf8(cmd.output()?.stdout)?
-            .strip_prefix('v')
-            .context("Version must begin with v")?
-            .strip_suffix('\n')
-            .context("Version must end with \\n")?
-            .into(),
-    ))
+    let output = cmd.output()?;
+
+    if !output.status.success() {
+        bail!(
+            "'node --version' command failed{}{}",
+            output
+                .status
+                .code()
+                .map(|c| format!(" with exit code {c}"))
+                .unwrap_or_default(),
+            String::from_utf8(output.stderr)
+                .map(|stderr| format!(": {stderr}"))
+                .unwrap_or_default()
+        );
+    }
+
+    let version = String::from_utf8(output.stdout)
+        .context("failed to parse 'node --version' output as utf8")?;
+    if let Some(version_number) = version.strip_prefix("v") {
+        Ok(Vc::cell(version_number.trim().into()))
+    } else {
+        bail!(
+            "Expected 'node --version' to return a version starting with 'v', but received: '{}'",
+            version
+        )
+    }
 }

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -12,7 +12,7 @@ use turbo_tasks_env::ProcessEnv;
 
 use crate::target::CompileTarget;
 
-static DEFAULT_NODEJS_VERSION: &str = "16.0.0";
+static DEFAULT_NODEJS_VERSION: &str = "18.0.0";
 
 #[turbo_tasks::value]
 #[derive(Clone, Copy, Default, Hash, TaskInput, Debug)]
@@ -261,15 +261,15 @@ pub struct NodeJsEnvironment {
     pub cwd: ResolvedVc<Option<RcStr>>,
 }
 
-// impl Default for NodeJsEnvironment {
-//     fn default() -> Self {
-//         NodeJsEnvironment {
-//             compile_target: CompileTarget::current_raw().resolved_cell(),
-//             node_version: NodeJsVersion::default().resolved_cell(),
-//             cwd: ResolvedVc::cell(None),
-//         }
-//     }
-// }
+impl Default for NodeJsEnvironment {
+    fn default() -> Self {
+        NodeJsEnvironment {
+            compile_target: CompileTarget::current_raw().resolved_cell(),
+            node_version: NodeJsVersion::default().resolved_cell(),
+            cwd: ResolvedVc::cell(None),
+        }
+    }
+}
 
 #[turbo_tasks::value_impl]
 impl NodeJsEnvironment {
@@ -326,6 +326,9 @@ pub struct BrowserEnvironment {
 
 #[turbo_tasks::value(shared)]
 pub struct EdgeWorkerEnvironment {
+    // This isn't actually the Edge's worker environment, but we have to use some kind of version
+    // for transpiling ECMAScript features. No tool supports Edge Workers as a separate
+    // environment.
     pub node_version: ResolvedVc<NodeJsVersion>,
 }
 


### PR DESCRIPTION
1. Make Node version detection more resilient by passing `process.versions.node` over to Rust, instead of invoking `node --version` inside of Rust.

2. Also improves the error message for the old codepath, though that one is unused now:
```
- failed to analyse ecmascript module '[project]/middleware.ts [middleware-edge] (ecmascript)'
- Execution of parse failed
- failed to parse [project]/middleware.ts
- Transforming and/or parsing of [project]/middleware.ts failed
- Execution of EdgeWorkerEnvironment::runtime_versions failed
- Execution of get_current_nodejs_version failed
- 'node --version' command failed with exit code 1: error: Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.] {
  type: 'TurbopackInternalError'
}
error: "next" exited with code 1
```

Closes PACK-4921
Closes PACK-4882