### PR TITLE
[segment explorer] hover state for open-in-editor color

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -220,6 +220,11 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     user-select: none;
     cursor: pointer;
   }
+
+  .segment-explorer-file-label:hover {
+    filter: brightness(1.05);
+  }
+
   .segment-explorer-file-label--layout,
   .segment-explorer-file-label--template,
   .segment-explorer-file-label--default {


### PR DESCRIPTION
Add a simple hover state for the open in editor button

https://github.com/user-attachments/assets/fcca7f7e-3a73-41e0-a24f-47a86313a969

Closes NEXT-4582
