### PR TITLE
Turbopack: less identifier maps in CSS import validation

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -509,9 +509,8 @@ async fn validate_pages_css_imports(
         .node_weights()
         .map(async |n| Ok((n.module(), n.module().ident().to_string().await?)))
         .try_join()
-        .await
+        .await?
         .into_iter()
-        .flatten()
         .collect::<FxIndexMap<_, _>>();
 
     graph.traverse_edges_from_entries(entries, |parent_info, node| {

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -511,7 +511,7 @@ async fn validate_pages_css_imports(
         .try_join()
         .await?
         .into_iter()
-        .collect::<FxIndexMap<_, _>>();
+        .collect::<FxHashMap<_, _>>();
 
     graph.traverse_edges_from_entries(entries, |parent_info, node| {
         let module = node.module;

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -15,7 +15,7 @@ use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     CollectiblesSource, FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueToString, Vc,
+    TryJoinIterExt, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::css::{CssModuleAsset, ModuleCssAsset};


### PR DESCRIPTION
- Compute the identifier map per module graph, for better invalidation behavior
- Don't store the identifiers, for less memory usage.