### PR TITLE
docs: make instruction clearer

### DIFF
--- a/docs/01-app/02-guides/debugging.mdx
+++ b/docs/01-app/02-guides/debugging.mdx
@@ -109,7 +109,7 @@ To debug server-side Next.js code with browser DevTools, you need to pass the [`
 NODE_OPTIONS='--inspect' next dev
 ```
 
-> **Good to know**: Use `NODE_OPTIONS='--inspect=0.0.0.0'` to allow remote debugging access outside localhost, such as when running the app in a Docker container.
+> **Good to know**: Use `NODE_OPTIONS='--inspect=0.0.0.0:9229'` to allow remote debugging access outside localhost, such as when running the app in a Docker container.
 
 If you're using `npm run dev` or `yarn dev` then you should update the `dev` script on your `package.json`:
 


### PR DESCRIPTION
Just a small thing but reading this section:

![CleanShot 2025-06-26 at 19 13 03](https://github.com/user-attachments/assets/a8f157dd-0695-44f0-aafa-1c5de8b5824c)

I'm inclined to try running:

```shell
NODE_OPTIONS='--inspect=0.0.0.0' next dev 
```

But that gives me this error message which can be a bit confusing:

![image](https://github.com/user-attachments/assets/3f86baa0-d926-4593-a42e-602d5cf9b73c)

If I instead run:

```shell
NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev
```

Then things work as expected:

![CleanShot 2025-06-26 at 19 29 38](https://github.com/user-attachments/assets/ebd71158-24a2-4481-b742-80a3b739d497)

`9229` is the default Node.js debugger port so thought it made sense to use that.
