### PR TITLE
[tests]: add failing deploy test to manifest

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -4,6 +4,14 @@
     "test/e2e/app-dir/actions/app-action.test.ts": {
       "failed": [
         "app-dir action handling fetch actions should invalidate client cache when path is revalidated",
+        "app-dir action handling fetch actions should invalidate client cache when tag is revalidated",
+        "app-dir action handling fetch actions should handle unstable_expireTag"
+      ]
+    },
+    "test/e2e/app-dir/actions/app-action-node-middleware.test.ts": {
+      "failed": [
+        "app-dir action handling fetch actions should invalidate client cache when path is revalidated",
+        "app-dir action handling fetch actions should invalidate client cache when tag is revalidated",
         "app-dir action handling fetch actions should handle unstable_expireTag"
       ]
     },

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -10,7 +10,6 @@ import {
 import type { Request, Response } from 'playwright'
 import fs from 'node:fs/promises'
 import { join } from 'node:path'
-import { setTimeout } from 'node:timers/promises'
 
 const GENERIC_RSC_ERROR =
   'Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
@@ -1487,14 +1486,10 @@ describe('app-dir action handling', () => {
           )
         })
 
-        // Should be the same number although in serverless it might be
-        // eventually consistent.
-        if (!isNextDeploy) {
-          await retry(async () => {
-            const another = await browser.elementByCss('#thankyounext').text()
-            expect(another).toEqual(original)
-          })
-        }
+        await retry(async () => {
+          const another = await browser.elementByCss('#thankyounext').text()
+          expect(another).toEqual(original)
+        })
 
         await browser.elementByCss('#back').click()
         await retry(async () => {
@@ -1510,11 +1505,6 @@ describe('app-dir action handling', () => {
             break
           default:
             throw new Error(`Invalid type: ${type}`)
-        }
-
-        // Give some time for it to be revalidated.
-        if (isNextDeploy) {
-          await setTimeout(5000)
         }
 
         // Should be different


### PR DESCRIPTION
For the same reason we have the other `unstable_expire<x>` tests disabled, this adds another one that has been frequently failing for us. ([Linear x-ref](https://linear.app/vercel/issue/ENET-1729))

`app-action-node-middleware` is also a duplicate of `app-action`, but when we created it, we did not copy over the manifest exclude list. 

