### PR TITLE
chore(turbopack): Add `swc_ecma_minifier` to turbopack trace target

### DIFF
--- a/turbopack/crates/turbopack-trace-utils/src/tracing_presets.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/tracing_presets.rs
@@ -53,6 +53,7 @@ pub static TRACING_TURBOPACK_TARGETS: Lazy<Vec<&str>> = Lazy::new(|| {
             "turbopack_static=trace",
             "turbopack_swc_utils=trace",
             "turbopack_wasm=trace",
+            "swc_ecma_minifier=trace",
         ],
     ]
     .concat()


### PR DESCRIPTION
### What?

Make tracing spans in `swc_ecma_minifier` show up in the profiling result.

### Why?

SWC Minifier consumes a noticeable amount of time in turbopack production builds, so I need to break it down.

Closes PACK-4918