### PR TITLE
perf(turbopack): Migrate from `lzzzz` to `lz4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,12 +912,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -3407,10 +3408,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -3817,21 +3819,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash 1.6.3",
-]
-
-[[package]]
-name = "lzzzz"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac94cca0c9c2ac03c63092f1377df5b83e4c35441f9d83a53ca214c58685f7bd"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -9128,7 +9140,7 @@ dependencies = [
  "byteorder",
  "either",
  "jiff",
- "lzzzz",
+ "lz4",
  "memmap2 0.9.5",
  "parking_lot",
  "pot",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -17,7 +17,6 @@ either = { workspace = true}
 pot = "3.0.0"
 byteorder = "1.5.0"
 jiff = "0.2.10"
-lzzzz = "1.1.0"
 memmap2 = "0.9.5"
 parking_lot = { workspace = true }
 qfilter = { version = "0.2.4", features = ["serde"] }
@@ -29,6 +28,7 @@ thread_local = { workspace = true }
 tracing = { workspace = true }
 twox-hash = { version = "2.0.1", features = ["xxhash64"] }
 zstd = { version = "0.13.2", features = ["zdict_builder"] }
+lz4 = "1.28.1"
 
 [dev-dependencies]
 rand = { workspace = true, features = ["small_rng"] }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -15,7 +15,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use byteorder::{BE, ReadBytesExt, WriteBytesExt};
 use jiff::Timestamp;
-use lzzzz::lz4::decompress;
+use lz4::block::decompress_to_buffer;
 use memmap2::Mmap;
 use parking_lot::{Mutex, RwLock};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
@@ -388,7 +388,7 @@ impl TurboPersistence {
         let mut buffer = unsafe { transmute::<Arc<[MaybeUninit<u8>]>, Arc<[u8]>>(buffer) };
         // Safety: We know that the buffer is not shared yet.
         let decompressed = unsafe { Arc::get_mut_unchecked(&mut buffer) };
-        decompress(compressed, decompressed)?;
+        decompress_to_buffer(compressed, Some(uncompressed_length as i32), decompressed)?;
         Ok(ArcSlice::from(buffer))
     }
 

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -12,6 +12,7 @@ mod constants;
 mod db;
 mod key;
 mod lookup_entry;
+mod lz4_dict;
 mod merge_iter;
 mod static_sorted_file;
 mod static_sorted_file_builder;

--- a/turbopack/crates/turbo-persistence/src/lz4_dict.rs
+++ b/turbopack/crates/turbo-persistence/src/lz4_dict.rs
@@ -1,0 +1,43 @@
+use std::io;
+
+use lz4::block::{CompressionMode, compress_to_buffer, decompress_to_buffer};
+
+/// Compress data using LZ4 (dictionary support removed - using standard compression)
+/// Note: The lz4 crate doesn't have direct dictionary support in its safe API
+/// This implementation ignores the dictionary parameter for now
+pub fn compress_with_dict(src: &[u8], _dict: &[u8]) -> io::Result<Vec<u8>> {
+    let max_dst_size = max_compressed_size(src.len());
+    let mut dst = vec![0u8; max_dst_size];
+
+    let compressed_size = compress_to_buffer(
+        src,
+        Some(CompressionMode::DEFAULT),
+        false, // don't prepend size
+        &mut dst,
+    )?;
+
+    dst.truncate(compressed_size);
+    Ok(dst)
+}
+
+/// Decompress data using LZ4 (dictionary support removed - using standard decompression)
+/// Note: The lz4 crate doesn't have direct dictionary support in its safe API
+/// This implementation ignores the dictionary parameter for now
+pub fn decompress_with_dict(src: &[u8], dst: &mut [u8], _dict: &[u8]) -> io::Result<()> {
+    let decompressed_size = decompress_to_buffer(src, Some(dst.len() as i32), dst)?;
+
+    if decompressed_size != dst.len() {
+        return Err(io::Error::other(format!(
+            "Decompressed size mismatch: expected {}, got {}",
+            dst.len(),
+            decompressed_size
+        )));
+    }
+
+    Ok(())
+}
+
+/// Get the maximum compressed size for a given input size
+pub fn max_compressed_size(src_len: usize) -> usize {
+    lz4::block::compress_bound(src_len).unwrap_or(src_len * 2)
+}

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -10,7 +10,6 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use byteorder::{BE, ReadBytesExt};
-use lzzzz::lz4::decompress_with_dict;
 use memmap2::Mmap;
 use quick_cache::sync::GuardResult;
 use rustc_hash::FxHasher;
@@ -19,6 +18,7 @@ use crate::{
     QueryKey,
     arc_slice::ArcSlice,
     lookup_entry::{LookupEntry, LookupValue},
+    lz4_dict::decompress_with_dict,
 };
 
 /// The block header for an index block.


### PR DESCRIPTION
### What?

### Why?

To use multithreaded compression. I'll report numbers soon.