### PR TITLE
Use proper reexports in entry-base.ts

### DIFF
--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -10,40 +10,44 @@ export {
 // eslint-disable-next-line import/no-extraneous-dependencies
 export { unstable_prerender as prerender } from 'react-server-dom-webpack/static.edge'
 
-import LayoutRouter from '../../client/components/layout-router'
-import RenderFromTemplateContext from '../../client/components/render-from-template-context'
-import { workAsyncStorage } from '../app-render/work-async-storage.external'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
-import { actionAsyncStorage } from '../app-render/action-async-storage.external'
-import { ClientPageRoot } from '../../client/components/client-page'
-import { ClientSegmentRoot } from '../../client/components/client-segment'
-import {
+export { default as LayoutRouter } from '../../client/components/layout-router'
+export { default as RenderFromTemplateContext } from '../../client/components/render-from-template-context'
+export { workAsyncStorage } from '../app-render/work-async-storage.external'
+export { workUnitAsyncStorage } from './work-unit-async-storage.external'
+export { actionAsyncStorage } from '../app-render/action-async-storage.external'
+
+export { ClientPageRoot } from '../../client/components/client-page'
+export { ClientSegmentRoot } from '../../client/components/client-segment'
+export {
   createServerSearchParamsForServerPage,
   createPrerenderSearchParamsForClientPage,
 } from '../request/search-params'
-import {
+export {
   createServerParamsForServerSegment,
   createPrerenderParamsForClientSegment,
 } from '../request/params'
-import * as serverHooks from '../../client/components/hooks-server-context'
-import { HTTPAccessFallbackBoundary } from '../../client/components/http-access-fallback/error-boundary'
-import { createMetadataComponents } from '../../lib/metadata/metadata'
-import { patchFetch as _patchFetch } from '../lib/patch-fetch'
+export * as serverHooks from '../../client/components/hooks-server-context'
+export { HTTPAccessFallbackBoundary } from '../../client/components/http-access-fallback/error-boundary'
+export { createMetadataComponents } from '../../lib/metadata/metadata'
 // Not being directly used but should be included in the client manifest for /_not-found
 // * ErrorBoundary -> client/components/error-boundary
 // * GlobalError -> client/components/global-error
 import '../../client/components/error-boundary'
 import '../../client/components/builtin/global-error'
-import {
+export {
   MetadataBoundary,
   ViewportBoundary,
   OutletBoundary,
 } from '../../client/components/metadata/metadata-boundary'
 
-import { preloadStyle, preloadFont, preconnect } from './rsc/preloads'
-import { Postpone } from './rsc/postpone'
-import { taintObjectReference } from './rsc/taint'
+export { preloadStyle, preloadFont, preconnect } from './rsc/preloads'
+export { Postpone } from './rsc/postpone'
+export { taintObjectReference } from './rsc/taint'
 export { collectSegmentData } from './collect-segment-data'
+
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+import { patchFetch as _patchFetch } from '../lib/patch-fetch'
 
 let SegmentViewNode: typeof import('../../next-devtools/userspace/app/segment-explorer').SegmentViewNode =
   () => null
@@ -63,29 +67,7 @@ function patchFetch() {
 }
 
 export {
-  LayoutRouter,
-  RenderFromTemplateContext,
-  workAsyncStorage,
-  workUnitAsyncStorage,
-  actionAsyncStorage,
-  createServerSearchParamsForServerPage,
-  createPrerenderSearchParamsForClientPage,
-  createServerParamsForServerSegment,
-  createPrerenderParamsForClientSegment,
-  serverHooks,
-  preloadStyle,
-  preloadFont,
-  preconnect,
-  Postpone,
-  MetadataBoundary,
-  ViewportBoundary,
-  OutletBoundary,
-  taintObjectReference,
-  ClientPageRoot,
-  ClientSegmentRoot,
-  HTTPAccessFallbackBoundary,
   patchFetch,
-  createMetadataComponents,
   // Development only
   SegmentViewNode,
 }


### PR DESCRIPTION
Purely a cosmetic change I noticed while debugging a Turbopack bug (but unrelated to that)

Closes PACK-4931