### PR TITLE
Turbopack: also inline env vars with undefined value

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -82,6 +82,13 @@ pub struct NapiEnvVar {
 }
 
 #[napi(object)]
+#[derive(Clone, Debug)]
+pub struct NapiOptionEnvVar {
+    pub name: RcStr,
+    pub value: Option<RcStr>,
+}
+
+#[napi(object)]
 pub struct NapiDraftModeOptions {
     pub preview_mode_id: RcStr,
     pub preview_mode_encryption_key: RcStr,
@@ -215,9 +222,9 @@ pub struct NapiPartialProjectOptions {
 #[napi(object)]
 #[derive(Clone, Debug)]
 pub struct NapiDefineEnv {
-    pub client: Vec<NapiEnvVar>,
-    pub edge: Vec<NapiEnvVar>,
-    pub nodejs: Vec<NapiEnvVar>,
+    pub client: Vec<NapiOptionEnvVar>,
+    pub edge: Vec<NapiOptionEnvVar>,
+    pub nodejs: Vec<NapiOptionEnvVar>,
 }
 
 #[napi(object)]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -18,7 +18,7 @@ use next_core::{
         get_server_module_options_context, get_server_resolve_options_context,
     },
     next_telemetry::NextFeatureTelemetry,
-    util::{NextRuntime, parse_config_from_source},
+    util::{NextRuntime, OptionEnvMap, parse_config_from_source},
 };
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
@@ -248,9 +248,9 @@ pub struct PartialProjectOptions {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct DefineEnv {
-    pub client: Vec<(RcStr, RcStr)>,
-    pub edge: Vec<(RcStr, RcStr)>,
-    pub nodejs: Vec<(RcStr, RcStr)>,
+    pub client: Vec<(RcStr, Option<RcStr>)>,
+    pub edge: Vec<(RcStr, Option<RcStr>)>,
+    pub nodejs: Vec<(RcStr, Option<RcStr>)>,
 }
 
 #[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, NonLocalValue)]
@@ -583,25 +583,25 @@ pub struct Project {
 
 #[turbo_tasks::value]
 pub struct ProjectDefineEnv {
-    client: ResolvedVc<EnvMap>,
-    edge: ResolvedVc<EnvMap>,
-    nodejs: ResolvedVc<EnvMap>,
+    client: ResolvedVc<OptionEnvMap>,
+    edge: ResolvedVc<OptionEnvMap>,
+    nodejs: ResolvedVc<OptionEnvMap>,
 }
 
 #[turbo_tasks::value_impl]
 impl ProjectDefineEnv {
     #[turbo_tasks::function]
-    pub fn client(&self) -> Vc<EnvMap> {
+    pub fn client(&self) -> Vc<OptionEnvMap> {
         *self.client
     }
 
     #[turbo_tasks::function]
-    pub fn edge(&self) -> Vc<EnvMap> {
+    pub fn edge(&self) -> Vc<OptionEnvMap> {
         *self.edge
     }
 
     #[turbo_tasks::function]
-    pub fn nodejs(&self) -> Vc<EnvMap> {
+    pub fn nodejs(&self) -> Vc<OptionEnvMap> {
         *self.nodejs
     }
 }

--- a/crates/next-build/src/build_options.rs
+++ b/crates/next-build/src/build_options.rs
@@ -47,7 +47,7 @@ pub struct BuildContext {
 
 #[derive(Debug, Clone)]
 pub struct DefineEnv {
-    pub client: Vec<(RcStr, RcStr)>,
-    pub edge: Vec<(RcStr, RcStr)>,
-    pub nodejs: Vec<(RcStr, RcStr)>,
+    pub client: Vec<(RcStr, Option<RcStr>)>,
+    pub edge: Vec<(RcStr, Option<RcStr>)>,
+    pub nodejs: Vec<(RcStr, Option<RcStr>)>,
 }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -2,8 +2,7 @@ use std::iter::once;
 
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, TaskInput, Vc};
-use turbo_tasks_env::EnvMap;
+use turbo_tasks::{ResolvedVc, TaskInput, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
     css::chunk::CssChunkType,
@@ -19,10 +18,7 @@ use turbopack_core::{
         ChunkingConfig, MangleType, MinifyType, SourceMapsType,
         module_id_strategies::ModuleIdStrategy,
     },
-    compile_time_info::{
-        CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, DefineableNameSegment,
-        FreeVarReferences,
-    },
+    compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
     environment::{
         Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion, RuntimeVersions,
     },
@@ -73,8 +69,8 @@ use crate::{
         get_typescript_transform_options,
     },
     util::{
-        NextRuntime, foreign_code_context_condition, get_transpiled_packages,
-        internal_assets_conditions, load_next_js_templateon,
+        NextRuntime, OptionEnvMap, defines, foreign_code_context_condition,
+        get_transpiled_packages, internal_assets_conditions, load_next_js_templateon,
     },
 };
 
@@ -347,43 +343,20 @@ pub async fn get_server_resolve_options_context(
     .cell())
 }
 
-fn defines(define_env: &FxIndexMap<RcStr, RcStr>) -> CompileTimeDefines {
-    let mut defines = FxIndexMap::default();
-
-    for (k, v) in define_env {
-        defines
-            .entry(
-                k.split('.')
-                    .map(|s| DefineableNameSegment::Name(s.into()))
-                    .collect::<Vec<_>>(),
-            )
-            .or_insert_with(|| {
-                let val = serde_json::from_str(v);
-                match val {
-                    Ok(serde_json::Value::Bool(v)) => CompileTimeDefineValue::Bool(v),
-                    Ok(serde_json::Value::String(v)) => CompileTimeDefineValue::String(v.into()),
-                    _ => CompileTimeDefineValue::JSON(v.clone()),
-                }
-            });
-    }
-
-    CompileTimeDefines(defines)
-}
-
 #[turbo_tasks::function]
-async fn next_server_defines(define_env: Vc<EnvMap>) -> Result<Vc<CompileTimeDefines>> {
+async fn next_server_defines(define_env: Vc<OptionEnvMap>) -> Result<Vc<CompileTimeDefines>> {
     Ok(defines(&*define_env.await?).cell())
 }
 
 #[turbo_tasks::function]
-async fn next_server_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarReferences>> {
+async fn next_server_free_vars(define_env: Vc<OptionEnvMap>) -> Result<Vc<FreeVarReferences>> {
     Ok(free_var_references!(..defines(&*define_env.await?).into_iter()).cell())
 }
 
 #[turbo_tasks::function]
 pub async fn get_server_compile_time_info(
     cwd: RcStr,
-    define_env: Vc<EnvMap>,
+    define_env: Vc<OptionEnvMap>,
     node_version: ResolvedVc<NodeJsVersion>,
 ) -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -80,6 +80,10 @@ export interface NapiEnvVar {
   name: RcStr
   value: RcStr
 }
+export interface NapiOptionEnvVar {
+  name: RcStr
+  value?: RcStr
+}
 export interface NapiDraftModeOptions {
   previewModeId: RcStr
   previewModeEncryptionKey: RcStr
@@ -184,9 +188,9 @@ export interface NapiPartialProjectOptions {
   noMangling?: boolean
 }
 export interface NapiDefineEnv {
-  client: Array<NapiEnvVar>
-  edge: Array<NapiEnvVar>
-  nodejs: Array<NapiEnvVar>
+  client: Array<NapiOptionEnvVar>
+  edge: Array<NapiOptionEnvVar>
+  nodejs: Array<NapiOptionEnvVar>
 }
 export interface NapiTurboEngineOptions {
   /** Use the new backend with persistent caching enabled. */

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -399,6 +399,7 @@ function logLoadFailure(attempts: any, triedWasm = false) {
 }
 
 type RustifiedEnv = { name: string; value: string }[]
+type RustifiedOptionEnv = { name: string; value: string | undefined }[]
 
 export function createDefineEnv({
   isTurbopack,
@@ -421,7 +422,7 @@ export function createDefineEnv({
   }
 
   for (const variant of Object.keys(defineEnv) as (keyof typeof defineEnv)[]) {
-    defineEnv[variant] = rustifyEnv(
+    defineEnv[variant] = rustifyOptionEnv(
       getDefineEnv({
         isTurbopack,
         clientRouterFilters,
@@ -449,6 +450,15 @@ function rustifyEnv(env: Record<string, string>): RustifiedEnv {
       name,
       value,
     }))
+}
+
+function rustifyOptionEnv(
+  env: Record<string, string | undefined>
+): RustifiedOptionEnv {
+  return Object.entries(env).map(([name, value]) => ({
+    name,
+    value,
+  }))
 }
 
 // TODO(sokra) Support wasm option.

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -431,12 +431,13 @@ export interface ProjectOptions {
 }
 
 export interface DefineEnv {
-  client: RustifiedEnv
-  edge: RustifiedEnv
-  nodejs: RustifiedEnv
+  client: RustifiedOptionalEnv
+  edge: RustifiedOptionalEnv
+  nodejs: RustifiedOptionalEnv
 }
 
 export type RustifiedEnv = { name: string; value: string }[]
+export type RustifiedOptionalEnv = { name: string; value: string | undefined }[]
 
 export interface GlobalEntrypoints {
   app: Endpoint | undefined


### PR DESCRIPTION
Previously, only env vars with set values were inline.
But some of them, e.g. `process.env.__NEXT_MANUAL_TRAILING_SLASH` and `process.env.__NEXT_CROSS_ORIGIN` are always set, but might be `undefined` in the env mapping.
Don't drop these but replace them with undefined, as Webpack does.

Closes PACK-4956