### PR TITLE
Don't start next server unnecessarily to assert build output

### DIFF
--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -36,7 +36,7 @@ describe.each([
     } else {
       it('should not error the build when calling Math.random() if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.build()
+          await next.start()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -36,7 +36,7 @@ describe.each([
     } else {
       it('should not error the build when calling Math.random() if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -88,7 +88,7 @@ describe.each([
     } else {
       it('should error the build if Math.random() happens before some component outside a Suspense boundary is complete', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -38,7 +38,7 @@ describe.each([
     } else {
       it('should not error the build sync IO is used inside a Suspense Boundary in a client Component and nothing else is dynamic', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           throw new Error('expected build not to fail')
         }
@@ -90,7 +90,7 @@ describe.each([
     } else {
       it('should error the build with a reason related to sync IO access', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -228,7 +228,7 @@ describe.each([
     } else {
       it('should error the build with a reason related dynamic data', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -378,7 +378,7 @@ describe.each([
     } else {
       it('should error the build with a reason related to sync IO access', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -51,7 +51,7 @@ describe.each([
     } else {
       it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.build()
+          await next.start()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -288,7 +288,7 @@ describe.each([
     } else {
       it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.build()
+          await next.start()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -469,7 +469,7 @@ describe.each([
     } else {
       it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.build()
+          await next.start()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -51,7 +51,7 @@ describe.each([
     } else {
       it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -124,7 +124,7 @@ describe.each([
     } else {
       it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -288,7 +288,7 @@ describe.each([
     } else {
       it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -358,7 +358,7 @@ describe.each([
     } else {
       it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -469,7 +469,7 @@ describe.each([
     } else {
       it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -539,7 +539,7 @@ describe.each([
     } else {
       it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -47,7 +47,7 @@ describe.each([
     } else {
       it('should error the build if generateMetadata is dynamic when the rest of the route is prerenderable', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -166,7 +166,7 @@ describe.each([
       // This test is just here because there was a bug when dynamic metadata was used alongside another dynamic IO violation which caused the validation to be skipped.
       it('should error the build for the correct reason when there is a dynamic IO violation alongside dynamic metadata', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -300,7 +300,7 @@ describe.each([
     } else {
       it('should error the build if generateMetadata is dynamic when the rest of the route is prerenderable', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -371,7 +371,7 @@ describe.each([
     } else {
       it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -420,7 +420,7 @@ describe.each([
     } else {
       it('should error the build if generateViewport is dynamic', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -502,7 +502,7 @@ describe.each([
     } else {
       it('should error the build if generateViewport is dynamic even if there are other uses of dynamic on the page', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -573,7 +573,7 @@ describe.each([
     } else {
       it('should not error the build when all routes are static', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
           throw new Error('expected build not to fail for fully static project')
@@ -694,7 +694,7 @@ describe.each([
     } else {
       it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           // we expect the build to fail
         }
@@ -884,7 +884,7 @@ describe.each([
     } else {
       it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
         try {
-          await next.start()
+          await next.build()
         } catch {
           throw new Error('expected build not to fail for fully static project')
           // we expect the build to fail

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -575,7 +575,6 @@ describe.each([
         try {
           await next.build()
         } catch {
-          // we expect the build to fail
           throw new Error('expected build not to fail for fully static project')
         }
       })

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -371,7 +371,7 @@ describe.each([
     } else {
       it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
         try {
-          await next.build()
+          await next.start()
         } catch {
           throw new Error('expected build not to fail for fully static project')
         }
@@ -884,7 +884,7 @@ describe.each([
     } else {
       it('should partially prerender when all dynamic components are inside a Suspense boundary', async () => {
         try {
-          await next.build()
+          await next.start()
         } catch {
           throw new Error('expected build not to fail for fully static project')
           // we expect the build to fail


### PR DESCRIPTION
In some of these tests we only need to check the CLI output after a build, so we can skip starting the server to save some cycles.