### PR TITLE
[build] remove the default imports for error boundary

### DIFF
--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -29,11 +29,6 @@ export {
 export * as serverHooks from '../../client/components/hooks-server-context'
 export { HTTPAccessFallbackBoundary } from '../../client/components/http-access-fallback/error-boundary'
 export { createMetadataComponents } from '../../lib/metadata/metadata'
-// Not being directly used but should be included in the client manifest for /_not-found
-// * ErrorBoundary -> client/components/error-boundary
-// * GlobalError -> client/components/global-error
-import '../../client/components/error-boundary'
-import '../../client/components/builtin/global-error'
 export {
   MetadataBoundary,
   ViewportBoundary,


### PR DESCRIPTION
After we have all the conventions properly defined in the loader tree including the built-in ones since #80957 , the fix in  #59085 is not required anymore.

If you have custom conventions, they'll be bundled.
If you don't have the custom conventions, the default one will be bundled.