### PR TITLE
Add support for SitemapIndex in metadata route resolver

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -149,9 +149,33 @@ export function resolveManifest(data: MetadataRoute.Manifest): string {
   return JSON.stringify(data)
 }
 
+export function resolveSitemapIndex(data: MetadataRoute.SitemapIndex): string {
+  let content = '<?xml version="1.0" encoding="UTF-8"?>\n'
+  content += '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">\n'
+
+  for (const item of data) {
+    content += '  <sitemap>\n'
+    content += `    <loc>${item.url}</loc>\n`
+
+    if (item.lastModified) {
+      const serializedDate =
+        item.lastModified instanceof Date
+          ? item.lastModified.toISOString()
+          : item.lastModified
+      content += `    <lastmod>${serializedDate}</lastmod>\n`
+    }
+
+    content += '  </sitemap>\n'
+  }
+
+  content += '</sitemapindex>\n'
+  return content
+}
+
+
 export function resolveRouteData(
-  data: MetadataRoute.Robots | MetadataRoute.Sitemap | MetadataRoute.Manifest,
-  fileType: 'robots' | 'sitemap' | 'manifest'
+  data: MetadataRoute.Robots | MetadataRoute.Sitemap | MetadataRoute.Manifest | MetadataRoute.SitemapIndex,
+  fileType: 'robots' | 'sitemap' | 'manifest' | 'sitemapIndex'
 ): string {
   if (fileType === 'robots') {
     return resolveRobots(data as MetadataRoute.Robots)
@@ -161,6 +185,9 @@ export function resolveRouteData(
   }
   if (fileType === 'manifest') {
     return resolveManifest(data as MetadataRoute.Manifest)
+  }
+  if (fileType === 'sitemapIndex') {
+    return resolveSitemapIndex(data as MetadataRoute.SitemapIndex)
   }
   return ''
 }


### PR DESCRIPTION
This PR introduces a new **SitemapIndex** type and extends the **resolveRouteData** function to properly generate sitemap index XML files.
With this enhancement, Next.js can natively support sitemap index files, offering improved flexibility and better sitemap management for applications.