### PR TITLE
[test] Add case for import conditions in Pages Router API routes

### DIFF
--- a/test/e2e/import-conditions/.gitignore
+++ b/test/e2e/import-conditions/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/test/e2e/import-conditions/import-conditions.test.ts
+++ b/test/e2e/import-conditions/import-conditions.test.ts
@@ -89,6 +89,58 @@ describe('react version', () => {
     })
   })
 
+  it('Pages Router API route with nodejs runtime', async () => {
+    const response = await next.fetch('/api/node-route')
+    const middlewareHeaders = {
+      react: response.headers.get('x-react-condition'),
+      serverFavoringBrowser: response.headers.get(
+        'x-server-favoring-browser-condition'
+      ),
+      serverFavoringEdge: response.headers.get(
+        'x-server-favoring-edge-condition'
+      ),
+    }
+    const apiConditions = await response.json()
+    expect({ apiConditions, middlewareHeaders }).toEqual({
+      apiConditions: {
+        react: 'default',
+        serverFavoringBrowser: 'node',
+        serverFavoringEdge: 'node',
+      },
+      middlewareHeaders: {
+        react: 'react-server',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
+      },
+    })
+  })
+
+  it('Pages Router API route with edge runtime', async () => {
+    const response = await next.fetch('/api/edge-route')
+    const middlewareHeaders = {
+      react: response.headers.get('x-react-condition'),
+      serverFavoringBrowser: response.headers.get(
+        'x-server-favoring-browser-condition'
+      ),
+      serverFavoringEdge: response.headers.get(
+        'x-server-favoring-edge-condition'
+      ),
+    }
+    const apiConditions = await response.json()
+    expect({ apiConditions, middlewareHeaders }).toEqual({
+      apiConditions: {
+        react: 'default',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
+      },
+      middlewareHeaders: {
+        react: 'react-server',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
+      },
+    })
+  })
+
   it('App Router page headers with edge runtime', async () => {
     const response = await next.fetch('/app/edge-page')
 

--- a/test/e2e/import-conditions/pages/api/edge-route.ts
+++ b/test/e2e/import-conditions/pages/api/edge-route.ts
@@ -1,0 +1,15 @@
+import * as react from 'library-with-exports/react'
+import * as serverFavoringBrowser from 'library-with-exports/server-favoring-browser'
+import * as serverFavoringEdge from 'library-with-exports/server-favoring-edge'
+
+export const config = {
+  runtime: 'experimental-edge',
+}
+
+export default function handler() {
+  return Response.json({
+    react: react.condition,
+    serverFavoringBrowser: serverFavoringBrowser.condition,
+    serverFavoringEdge: serverFavoringEdge.condition,
+  })
+}

--- a/test/e2e/import-conditions/pages/api/node-route.ts
+++ b/test/e2e/import-conditions/pages/api/node-route.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import * as react from 'library-with-exports/react'
+import * as serverFavoringBrowser from 'library-with-exports/server-favoring-browser'
+import * as serverFavoringEdge from 'library-with-exports/server-favoring-edge'
+
+export const config = {
+  runtime: 'nodejs',
+}
+
+export default function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  return response.status(200).json({
+    react: react.condition,
+    serverFavoringBrowser: serverFavoringBrowser.condition,
+    serverFavoringEdge: serverFavoringEdge.condition,
+  })
+}


### PR DESCRIPTION
Case was absent from the react-server condition test suite but relevant to double check for an upcoming refactor