### PR TITLE
[node-webstreams] Remove unused PagesApi matching condition when setting react-server

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -777,9 +777,8 @@ async fn rsc_aliases(
     });
 
     if runtime == NextRuntime::NodeJs {
-        match ty {
-            ServerContextType::AppSSR { .. } => {
-                alias.extend(fxindexmap! {
+        if matches!(ty, ServerContextType::AppSSR { .. }) {
+            alias.extend(fxindexmap! {
                     "react/jsx-runtime" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-runtime"),
                     "react/jsx-dev-runtime" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime"),
                     "react/compiler-runtime" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-compiler-runtime"),
@@ -788,30 +787,24 @@ async fn rsc_aliases(
                     "react-server-dom-webpack/client.edge" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
                     "react-server-dom-turbopack/client.edge" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
                 });
-            }
-            ServerContextType::AppRSC { .. }
-            | ServerContextType::AppRoute { .. }
-            | ServerContextType::Middleware { .. }
-            | ServerContextType::Instrumentation { .. } => {
-                alias.extend(fxindexmap! {
-                    "react/jsx-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime"),
-                    "react/jsx-dev-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime"),
-                    "react/compiler-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime"),
-                    "react" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react"),
-                    "react-dom" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-dom"),
-                    "react-server-dom-webpack/server.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
-                    "react-server-dom-webpack/server.node" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
-                    "react-server-dom-webpack/static.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
-                    "react-server-dom-turbopack/server.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
-                    "react-server-dom-turbopack/server.node" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
-                    "react-server-dom-turbopack/static.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
-                    "next/navigation" => format!("next/dist/api/navigation.react-server"),
+        } else if ty.supports_react_server() {
+            alias.extend(fxindexmap! {
+                "react/jsx-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime"),
+                "react/jsx-dev-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime"),
+                "react/compiler-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime"),
+                "react" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react"),
+                "react-dom" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-dom"),
+                "react-server-dom-webpack/server.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
+                "react-server-dom-webpack/server.node" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
+                "react-server-dom-webpack/static.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
+                "react-server-dom-turbopack/server.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
+                "react-server-dom-turbopack/server.node" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
+                "react-server-dom-turbopack/static.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
+                "next/navigation" => format!("next/dist/api/navigation.react-server"),
 
-                    // Needed to make `react-dom/server` work.
-                    "next/dist/compiled/react" => format!("next/dist/compiled/react/index.js"),
-                });
-            }
-            _ => {}
+                // Needed to make `react-dom/server` work.
+                "next/dist/compiled/react" => format!("next/dist/compiled/react/index.js"),
+            });
         }
     }
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -118,7 +118,6 @@ impl ServerContextType {
             self,
             ServerContextType::AppRSC { .. }
                 | ServerContextType::AppRoute { .. }
-                | ServerContextType::PagesApi { .. }
                 | ServerContextType::Middleware { .. }
                 | ServerContextType::Instrumentation { .. }
         )


### PR DESCRIPTION
This looked like we were using `react-server` for Pages Router API routes. That wouldn't match Webpack behavior. We have an existing test in `test/e2e/import-conditions/import-conditions.test.ts` that checks the used import conditions in Pages Router API rotues.

Probably just an oversight when Turbopack started using `react-server` for Middleware and Instrumentation: https://github.com/vercel/next.js/pull/62134/files#diff-611c2f629b9a4c9ccb2fa2f6def7b7bbe8cde6fec2b5e085c3132250f7819803R164-R171

The aliasing implementation is now more closer structured to its Webpack counterpart in `packages/next/src/build/create-compiler-aliases.ts`.

I plan to move them closer together in a follow-up so that future alias work is easier to port between Webpack and Turbopack.