### PR TITLE
[node-webstreams] Remove unused App externals from next-server bundler config

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -29,14 +29,7 @@ const pagesExternals = [
   'react-server-dom-webpack/static.edge',
 ]
 
-const appExternals = [
-  // Externalize the react-dom/server legacy implementation outside of the runtime.
-  // If users are using them and imported from 'react-dom/server' they will get the external asset bundled.
-  'next/dist/compiled/react-dom/cjs/react-dom-server-legacy.browser.development.js',
-  'next/dist/compiled/react-dom/cjs/react-dom-server-legacy.browser.production.js',
-  'next/dist/compiled/react-dom-experimental/cjs/react-dom-server-legacy.browser.development.js',
-  'next/dist/compiled/react-dom-experimental/cjs/react-dom-server-legacy.browser.production.js',
-]
+const appExternals = []
 
 function makeAppAliases({ experimental, bundler }) {
   const reactChannel = experimental ? '-experimental' : ''


### PR DESCRIPTION
These externals have no effect since we don't import the legacy `react-dom/server` APIs in `next-server` anyway.

We only import the modern APIs since we alias `react-dom/server` to `build/webpack/alias/react-dom-server-edge.js` which does not import from the legacy entrypoint.

## Test plan

- [x] `compiled/next-server` remained unchanged