### PR TITLE
[node-webstreams] Exhaustive React aliases in App Router

### DIFF
--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -174,7 +174,7 @@ pub async fn get_edge_resolve_options_context(
             .map(RcStr::from),
     );
 
-    if ty.supports_react_server() {
+    if ty.should_use_react_server_condition() {
         custom_conditions.push(rcstr!("react-server"));
     };
 

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -723,7 +723,9 @@ async fn get_react_client_package(next_config: Vc<NextConfig>) -> Result<&'stati
     Ok(react_client_package)
 }
 
-async fn rsc_aliases(
+// Use createVendoredReactAliases in file:///./../../../packages/next/src/build/create-compiler-aliases.ts
+// as the source of truth.
+async fn apply_vendored_react_aliases_server(
     import_map: &mut ImportMap,
     project_path: FileSystemPath,
     ty: ServerContextType,
@@ -739,93 +741,194 @@ async fn rsc_aliases(
     } else {
         ""
     };
-    let react_client_package = get_react_client_package(next_config).await?;
+    let react_condition = if ty.should_use_react_server_condition() {
+        "server"
+    } else {
+        "client"
+    };
 
-    let mut alias = FxIndexMap::default();
-    if matches!(
-        ty,
-        ServerContextType::AppSSR { .. }
-            | ServerContextType::AppRSC { .. }
-            | ServerContextType::AppRoute { .. }
-    ) {
-        alias.extend(fxindexmap! {
-            "react" => format!("next/dist/compiled/react{react_channel}"),
-            "react-dom" => format!("next/dist/compiled/react-dom{react_channel}"),
-            "react/jsx-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
-            "react/jsx-dev-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
-            "react/compiler-runtime" => format!("next/dist/compiled/react{react_channel}/compiler-runtime"),
-            "react-dom/client" => format!("next/dist/compiled/react-dom{react_channel}/{react_client_package}"),
-            "react-dom/static" => format!("next/dist/compiled/react-dom{react_channel}/static"),
-            "react-dom/static.edge" => format!("next/dist/compiled/react-dom{react_channel}/static.edge"),
-            "react-dom/static.browser" => format!("next/dist/compiled/react-dom{react_channel}/static.browser"),
-            "react-dom/server" => format!("next/dist/compiled/react-dom{react_channel}/server"),
-            "react-dom/server.edge" => format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
-            "react-dom/server.browser" => format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+    // ✅ Correct alias
+    // ❌ Incorrect alias i.e. importing this entrypoint should throw an error.
+    // ❔ Alias that may produce correct code in certain conditions.Keep until react-markup is
+    // available.
+
+    let mut react_alias = FxIndexMap::default();
+    if runtime == NextRuntime::NodeJs && react_condition == "client" {
+        react_alias.extend(fxindexmap! {
+            // file:///./../../../packages/next/src/compiled/react/package.json
+            "react" =>                                  /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/ssr/react"),
+            "react/compiler-runtime" =>                 /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/ssr/react-compiler-runtime"),
+            "react/jsx-dev-runtime" =>                  /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime"),
+            "react/jsx-runtime" =>                      /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-runtime"),
+            // file:///./../../../packages/next/src/compiled/react-dom/package.json
+            "react-dom" =>                              /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/ssr/react-dom"),
+            "react-dom/client" =>                       /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/client"),
+            "react-dom/server" =>                       /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/server.node"),
+            "react-dom/server.browser" =>               /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+            // TODO: Use build without legacy APIs
+            "react-dom/server.edge" =>                  /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+            "react-dom/static" =>                       /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/static.node"),
+            "react-dom/static.browser" =>               /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/static.browser"),
+            "react-dom/static.edge" =>                  /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/static.edge"),
+            // file:///./../../../packages/next/src/compiled/react-server-dom-webpack/package.json
+            "react-server-dom-webpack/client" =>        /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-webpack/client.edge" =>   /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
+            "react-server-dom-webpack/server.edge" =>   /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+            "react-server-dom-webpack/server.node" =>   /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+            "react-server-dom-webpack/static.edge" =>   /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
+            "react-server-dom-turbopack/client" =>      /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-turbopack/client.edge" => /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
+            "react-server-dom-turbopack/server.edge" => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+            "react-server-dom-turbopack/server.node" => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+            "react-server-dom-turbopack/static.edge" => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
+        })
+    } else if runtime == NextRuntime::NodeJs && react_condition == "server" {
+        react_alias.extend(fxindexmap! {
+            // file:///./../../../packages/next/src/compiled/react/package.json
+            "react" =>                                  /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react"),
+            "react/compiler-runtime" =>                 /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime"),
+            "react/jsx-dev-runtime" =>                  /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime"),
+            "react/jsx-runtime" =>                      /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime"),
+            // file:///./../../../packages/next/src/compiled/react-dom/package.json
+            "react-dom" =>                              /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-dom"),
+            "react-dom/client" =>                       /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/client"),
+            "react-dom/server" =>                       /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/server.node"),
+            "react-dom/server.browser" =>               /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+            // TODO: Use build without legacy APIs
+            "react-dom/server.edge" =>                  /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+            "react-dom/static" =>                       /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/static.node"),
+            "react-dom/static.browser" =>               /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/static.browser"),
+            "react-dom/static.edge" =>                  /* ❔ */ format!("next/dist/compiled/react-dom{react_channel}/static.edge"),
+            // file:///./../../../packages/next/src/compiled/react-server-dom-webpack/package.json
+            "react-server-dom-webpack/client" =>        /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-webpack/client.edge" =>   /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-webpack/server.edge" =>   /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
+            "react-server-dom-webpack/server.node" =>   /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
+            "react-server-dom-webpack/static.edge" =>   /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
+            "react-server-dom-turbopack/client" =>      /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-turbopack/client.edge" => /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-turbopack/server.edge" => /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
+            "react-server-dom-turbopack/server.node" => /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
+            "react-server-dom-turbopack/static.edge" => /* ✅ */ format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
+
+            // Needed to make `react-dom/server` work.
+            // TODO: really?
+                "next/dist/compiled/react" => format!("next/dist/compiled/react/index.js"),
+        })
+    } else if runtime == NextRuntime::Edge && react_condition == "client" {
+        react_alias.extend(fxindexmap! {
+            // file:///./../../../packages/next/src/compiled/react/package.json
+            "react" =>                                  /* ✅ */ format!("next/dist/compiled/react{react_channel}"),
+            "react/compiler-runtime" =>                 /* ✅ */ format!("next/dist/compiled/react{react_channel}/compiler-runtime"),
+            "react/jsx-dev-runtime" =>                  /* ✅ */ format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime"),
+            "react/jsx-runtime" =>                      /* ✅ */ format!("next/dist/compiled/react{react_channel}/jsx-runtime"),
+            // file:///./../../../packages/next/src/compiled/react-dom/package.json
+            "react-dom" =>                              /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}"),
+            "react-dom/client" =>                       /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/client"),
+            "react-dom/server" =>                       /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+            "react-dom/server.browser" =>               /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+            // TODO: Use build without legacy APIs
+            "react-dom/server.edge" =>                  /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+            "react-dom/static" =>                       /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/static.edge"),
+            "react-dom/static.browser" =>               /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/static.browser"),
+            "react-dom/static.edge" =>                  /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/static.edge"),
+            // file:///./../../../packages/next/src/compiled/react-server-dom-webpack/package.json
+            "react-server-dom-webpack/client" =>        /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-webpack/client.edge" =>   /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-webpack/server.edge" =>   /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+            "react-server-dom-webpack/server.node" =>   /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+            "react-server-dom-webpack/static.edge" =>   /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
+            "react-server-dom-turbopack/client" =>      /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-turbopack/client.edge" => /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-turbopack/server.edge" => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+            "react-server-dom-turbopack/server.node" => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+            "react-server-dom-turbopack/static.edge" => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
+        })
+    } else if runtime == NextRuntime::Edge && react_condition == "server" {
+        react_alias.extend(fxindexmap! {
+            // file:///./../../../packages/next/src/compiled/react/package.json
+            "react" =>                                  /* ✅ */ format!("next/dist/compiled/react{react_channel}/react.react-server"),
+            "react/compiler-runtime" =>                 /* ❌ */ format!("next/dist/compiled/react{react_channel}/compiler-runtime"),
+            "react/jsx-dev-runtime" =>                  /* ✅ */ format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime.react-server"),
+            "react/jsx-runtime" =>                      /* ✅ */ format!("next/dist/compiled/react{react_channel}/jsx-runtime.react-server"),
+            // file:///./../../../packages/next/src/compiled/react-dom/package.json
+            "react-dom" =>                              /* ✅ */ format!("next/dist/compiled/react-dom{react_channel}/react-dom.react-server"),
+            "react-dom/client" =>                       /* ❌ */ format!("next/dist/compiled/react-dom{react_channel}/client"),
+            "react-dom/server" =>                       /* ❌ */ format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+            "react-dom/server.browser" =>               /* ❌ */ format!("next/dist/compiled/react-dom{react_channel}/server.browser"),
+            // TODO: Use build without legacy APIs
+            "react-dom/server.edge" =>                  /* ❌ */ format!("next/dist/compiled/react-dom{react_channel}/server.edge"),
+            "react-dom/static" =>                       /* ❌ */ format!("next/dist/compiled/react-dom{react_channel}/static.edge"),
+            "react-dom/static.browser" =>               /* ❌ */ format!("next/dist/compiled/react-dom{react_channel}/static.browser"),
+            "react-dom/static.edge" =>                  /* ❌ */ format!("next/dist/compiled/react-dom{react_channel}/static.edge"),
+            // file:///./../../../packages/next/src/compiled/react-server-dom-webpack/package.json
+            "react-server-dom-webpack/client" =>        /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-webpack/client.edge" =>   /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-webpack/server.edge" =>   /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+            "react-server-dom-webpack/server.node" =>   /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+            "react-server-dom-webpack/static.edge" =>   /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
+            "react-server-dom-turbopack/client" =>      /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-turbopack/client.edge" => /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
+            "react-server-dom-turbopack/server.edge" => /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
+            "react-server-dom-turbopack/server.node" => /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
+            "react-server-dom-turbopack/static.edge" => /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
+        });
+
+        react_alias.extend(fxindexmap! {
+            // This should just be `next/dist/compiled/react${react_channel}` but how to Rust.
+            "next/dist/compiled/react"                               => react_alias["react"].clone(),
+            "next/dist/compiled/react-experimental"                  => react_alias["react"].clone(),
+            "next/dist/compiled/react/compiler-runtime"              => react_alias["react/compiler-runtime"].clone(),
+            "next/dist/compiled/react-experimental/compiler-runtime" => react_alias["react/compiler-runtime"].clone(),
+            "next/dist/compiled/react/jsx-dev-runtime"               => react_alias["react/jsx-dev-runtime"].clone(),
+            "next/dist/compiled/react-experimental/jsx-dev-runtime"  => react_alias["react/jsx-dev-runtime"].clone(),
+            "next/dist/compiled/react/jsx-runtime"                   => react_alias["react/jsx-runtime"].clone(),
+            "next/dist/compiled/react-experimental/jsx-runtime"      => react_alias["react/jsx-runtime"].clone(),
+            "next/dist/compiled/react-dom"                           => react_alias["react-dom"].clone(),
+            "next/dist/compiled/react-dom-experimental"              => react_alias["react-dom"].clone(),
         });
     }
-    alias.extend(fxindexmap! {
-        "react-server-dom-webpack/client" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client"),
-        "react-server-dom-webpack/client.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
-        "react-server-dom-webpack/server.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
-        "react-server-dom-webpack/server.node" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
-        "react-server-dom-webpack/static.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
-        "react-server-dom-turbopack/client" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client"),
-        "react-server-dom-turbopack/client.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge"),
-        "react-server-dom-turbopack/server.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge"),
-        "react-server-dom-turbopack/server.node" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node"),
-        "react-server-dom-turbopack/static.edge" => format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge"),
+
+    let react_client_package = get_react_client_package(next_config).await?;
+    react_alias.extend(fxindexmap! {
+        "react-dom/client" => format!("next/dist/compiled/react-dom{react_channel}/{react_client_package}"),
     });
 
-    if runtime == NextRuntime::NodeJs {
-        if matches!(ty, ServerContextType::AppSSR { .. }) {
-            alias.extend(fxindexmap! {
-                    "react/jsx-runtime" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-runtime"),
-                    "react/jsx-dev-runtime" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime"),
-                    "react/compiler-runtime" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-compiler-runtime"),
-                    "react" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react"),
-                    "react-dom" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-dom"),
-                    "react-server-dom-webpack/client.edge" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
-                    "react-server-dom-turbopack/client.edge" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
-                });
-        } else if ty.should_use_react_server_condition() {
-            alias.extend(fxindexmap! {
-                "react/jsx-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime"),
-                "react/jsx-dev-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime"),
-                "react/compiler-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime"),
-                "react" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react"),
-                "react-dom" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-dom"),
-                "react-server-dom-webpack/server.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
-                "react-server-dom-webpack/server.node" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
-                "react-server-dom-webpack/static.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
-                "react-server-dom-turbopack/server.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-edge"),
-                "react-server-dom-turbopack/server.node" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-server-node"),
-                "react-server-dom-turbopack/static.edge" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-turbopack-static-edge"),
-                "next/navigation" => format!("next/dist/api/navigation.react-server"),
-
-                // Needed to make `react-dom/server` work.
-                "next/dist/compiled/react" => format!("next/dist/compiled/react/index.js"),
-            });
-        }
+    let mut alias = react_alias;
+    if react_condition == "server" {
+        // This is used in the server runtime to import React Server Components.
+        alias.extend(fxindexmap! {
+            "next/navigation" => format!("next/dist/api/navigation.react-server"),
+        });
     }
 
-    if runtime == NextRuntime::Edge && ty.should_use_react_server_condition() {
+    insert_exact_alias_map(import_map, project_path, alias);
+
+    Ok(())
+}
+
+async fn rsc_aliases(
+    import_map: &mut ImportMap,
+    project_path: FileSystemPath,
+    ty: ServerContextType,
+    runtime: NextRuntime,
+    next_config: Vc<NextConfig>,
+) -> Result<()> {
+    apply_vendored_react_aliases_server(
+        import_map,
+        project_path.clone(),
+        ty.clone(),
+        runtime,
+        next_config,
+    )
+    .await?;
+
+    let mut alias = FxIndexMap::default();
+    if ty.should_use_react_server_condition() {
+        // This is used in the server runtime to import React Server Components.
         alias.extend(fxindexmap! {
-            "react" => format!("next/dist/compiled/react{react_channel}/react.react-server"),
-            "next/dist/compiled/react" => format!("next/dist/compiled/react{react_channel}/react.react-server"),
-            "next/dist/compiled/react-experimental" =>  format!("next/dist/compiled/react-experimental/react.react-server"),
-            "react/jsx-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-runtime.react-server"),
-            "react/compiler-runtime" => format!("next/dist/compiled/react{react_channel}/compiler-runtime"),
-            "next/dist/compiled/react/jsx-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-runtime.react-server"),
-            "next/dist/compiled/react-experimental/jsx-runtime" => format!("next/dist/compiled/react-experimental/jsx-runtime.react-server"),
-            "next/dist/compiled/react/compiler-runtime" => format!("next/dist/compiled/react{react_channel}/compiler-runtime"),
-            "react/jsx-dev-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime.react-server"),
-            "next/dist/compiled/react/jsx-dev-runtime" => format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime.react-server"),
-            "next/dist/compiled/react-experimental/jsx-dev-runtime" => format!("next/dist/compiled/react-experimental/jsx-dev-runtime.react-server"),
-            "react-dom" => format!("next/dist/compiled/react-dom{react_channel}/react-dom.react-server"),
-            "next/dist/compiled/react-dom" => format!("next/dist/compiled/react-dom{react_channel}/react-dom.react-server"),
-            "next/dist/compiled/react-dom-experimental" => format!("next/dist/compiled/react-dom-experimental/react-dom.react-server"),
             "next/navigation" => format!("next/dist/api/navigation.react-server"),
-        })
+        });
     }
 
     insert_exact_alias_map(import_map, project_path.clone(), alias);

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -787,7 +787,7 @@ async fn rsc_aliases(
                     "react-server-dom-webpack/client.edge" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
                     "react-server-dom-turbopack/client.edge" => format!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client-edge"),
                 });
-        } else if ty.supports_react_server() {
+        } else if ty.should_use_react_server_condition() {
             alias.extend(fxindexmap! {
                 "react/jsx-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime"),
                 "react/jsx-dev-runtime" => format!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime"),
@@ -808,7 +808,7 @@ async fn rsc_aliases(
         }
     }
 
-    if runtime == NextRuntime::Edge && ty.supports_react_server() {
+    if runtime == NextRuntime::Edge && ty.should_use_react_server_condition() {
         alias.extend(fxindexmap! {
             "react" => format!("next/dist/compiled/react{react_channel}/react.react-server"),
             "next/dist/compiled/react" => format!("next/dist/compiled/react{react_channel}/react.react-server"),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -113,7 +113,7 @@ pub enum ServerContextType {
 }
 
 impl ServerContextType {
-    pub fn supports_react_server(&self) -> bool {
+    pub fn should_use_react_server_condition(&self) -> bool {
         matches!(
             self,
             ServerContextType::AppRSC { .. }
@@ -212,7 +212,7 @@ pub async fn get_server_resolve_options_context(
             .map(RcStr::from),
     );
 
-    if ty.supports_react_server() {
+    if ty.should_use_react_server_condition() {
         custom_conditions.push(rcstr!("react-server"));
     };
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -714,5 +714,7 @@
   "713": "Unexpected error during process lookup",
   "714": "cannot run loadNative when `NEXT_TEST_WASM` is set",
   "715": "Server Action \"%s\" was not found on the server. \\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
-  "716": "NEXT_DEVTOOLS_SIMULATED_ERROR"
+  "716": "NEXT_DEVTOOLS_SIMULATED_ERROR",
+  "717": "Unsupported environment condition \"%s\" and react condition \"%s\". This is a bug in Next.js.",
+  "718": "React Server is not supported in browser builds. This is a bug in Next.js."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -715,5 +715,5 @@
   "714": "cannot run loadNative when `NEXT_TEST_WASM` is set",
   "715": "Server Action \"%s\" was not found on the server. \\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "716": "NEXT_DEVTOOLS_SIMULATED_ERROR",
-  "717": "React Server is not supported in browser builds. This is a bug in Next.js."
+  "717": "Unsupported environment condition \"%s\" and react condition \"%s\". This is a bug in Next.js."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -715,6 +715,5 @@
   "714": "cannot run loadNative when `NEXT_TEST_WASM` is set",
   "715": "Server Action \"%s\" was not found on the server. \\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "716": "NEXT_DEVTOOLS_SIMULATED_ERROR",
-  "717": "Unsupported environment condition \"%s\" and react condition \"%s\". This is a bug in Next.js.",
-  "718": "React Server is not supported in browser builds. This is a bug in Next.js."
+  "717": "React Server is not supported in browser builds. This is a bug in Next.js."
 }

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -18,7 +18,7 @@ import { defaultOverrides } from '../server/require-hook'
 import { hasExternalOtelApiPackage } from './webpack-config'
 import { NEXT_PROJECT_ROOT } from './next-dir-paths'
 import { WEBPACK_LAYERS } from '../lib/constants'
-import { isWebpackServerOnlyLayer } from './utils'
+import { shouldUseReactServerCondition } from './utils'
 
 interface CompilerAliases {
   [alias: string]: string | string[]
@@ -271,14 +271,6 @@ export function createRSCAliases(
     reactProductionProfiling: boolean
   }
 ): CompilerAliases {
-  const isServerOnlyLayer = isWebpackServerOnlyLayer(layer)
-  // For middleware, instrumentation layers, treat them as rsc layer.
-  // Since we only built the runtime package for rsc, convert everything to rsc
-  // to ensure the runtime modules path existed.
-  if (isServerOnlyLayer) {
-    layer = WEBPACK_LAYERS.reactServerComponents
-  }
-
   let alias: Record<string, string> = {
     react$: `next/dist/compiled/react${bundledReactChannel}`,
     'react-dom$': `next/dist/compiled/react-dom${bundledReactChannel}`,
@@ -304,29 +296,29 @@ export function createRSCAliases(
   if (!isEdgeServer) {
     if (layer === WEBPACK_LAYERS.serverSideRendering) {
       alias = Object.assign(alias, {
-        'react/jsx-runtime$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-jsx-runtime`,
-        'react/jsx-dev-runtime$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-jsx-dev-runtime`,
-        'react/compiler-runtime$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-compiler-runtime`,
-        react$: `next/dist/server/route-modules/app-page/vendored/${layer}/react`,
-        'react-dom$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-dom`,
-        'react-server-dom-webpack/client.edge$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-server-dom-webpack-client-edge`,
+        'react/jsx-runtime$': `next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-runtime`,
+        'react/jsx-dev-runtime$': `next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime`,
+        'react/compiler-runtime$': `next/dist/server/route-modules/app-page/vendored/ssr/react-compiler-runtime`,
+        react$: `next/dist/server/route-modules/app-page/vendored/ssr/react`,
+        'react-dom$': `next/dist/server/route-modules/app-page/vendored/ssr/react-dom`,
+        'react-server-dom-webpack/client.edge$': `next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge`,
       })
-    } else if (layer === WEBPACK_LAYERS.reactServerComponents) {
+    } else if (shouldUseReactServerCondition(layer)) {
       alias = Object.assign(alias, {
-        'react/jsx-runtime$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-jsx-runtime`,
-        'react/jsx-dev-runtime$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-jsx-dev-runtime`,
-        'react/compiler-runtime$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-compiler-runtime`,
-        react$: `next/dist/server/route-modules/app-page/vendored/${layer}/react`,
-        'react-dom$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-dom`,
-        'react-server-dom-webpack/server.edge$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-server-dom-webpack-server-edge`,
-        'react-server-dom-webpack/server.node$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-server-dom-webpack-server-node`,
-        'react-server-dom-webpack/static.edge$': `next/dist/server/route-modules/app-page/vendored/${layer}/react-server-dom-webpack-static-edge`,
+        'react/jsx-runtime$': `next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime`,
+        'react/jsx-dev-runtime$': `next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime`,
+        'react/compiler-runtime$': `next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime`,
+        react$: `next/dist/server/route-modules/app-page/vendored/rsc/react`,
+        'react-dom$': `next/dist/server/route-modules/app-page/vendored/rsc/react-dom`,
+        'react-server-dom-webpack/server.edge$': `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge`,
+        'react-server-dom-webpack/server.node$': `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node`,
+        'react-server-dom-webpack/static.edge$': `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge`,
       })
     }
   }
 
   if (isEdgeServer) {
-    if (layer === WEBPACK_LAYERS.reactServerComponents) {
+    if (shouldUseReactServerCondition(layer)) {
       alias = Object.assign(alias, {
         react$: `next/dist/compiled/react${bundledReactChannel}/react.react-server`,
         'next/dist/compiled/react$': `next/dist/compiled/react${bundledReactChannel}/react.react-server`,

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -347,15 +347,15 @@ export function createVendoredReactAliases(
       // file:///./../compiled/react-dom/package.json
       'react-dom$':                            /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}`,
       'react-dom/client$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
-      'react-dom/server$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       'react-dom/server.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
       'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-      'react-dom/static$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
       'react-dom/static.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
       'react-dom/static.edge$':                /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       // file:///./../compiled/react-server-dom-webpack/package.json
-      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.browser`,
       'react-server-dom-webpack/client.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
       'react-server-dom-webpack/server.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
       'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
@@ -372,15 +372,15 @@ export function createVendoredReactAliases(
       // file:///./../compiled/react-dom/package.json
       'react-dom$':                            /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}`,
       'react-dom/client$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
-      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       'react-dom/server.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
       'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
       'react-dom/static.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
       'react-dom/static.edge$':                /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       // file:///./../compiled/react-server-dom-webpack/package.json
-      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.browser`,
       'react-server-dom-webpack/client.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
       'react-server-dom-webpack/server.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
       'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
@@ -397,15 +397,15 @@ export function createVendoredReactAliases(
       // file:///./../compiled/react-dom/package.json
       'react-dom$':                           /* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react-dom`,
       'react-dom/client$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
-      'react-dom/server$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.node`,
       'react-dom/server.browser$':            /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
       'react-dom/server.edge$':               /* ✅ */`next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-      'react-dom/static$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`, 
-      'react-dom/static.edge$':               /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      'react-dom/static$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.node`, 
       'react-dom/static.browser$':            /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      'react-dom/static.edge$':               /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       // file:///./../compiled/react-server-dom-webpack/package.json
-      'react-server-dom-webpack/client$':     /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client$':     /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.node`,
       'react-server-dom-webpack/client.edge$':/* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge`,
       'react-server-dom-webpack/server.edge$':/* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
       'react-server-dom-webpack/server.node$':/* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
@@ -422,15 +422,15 @@ export function createVendoredReactAliases(
       // file:///./../compiled/react-dom/package.json
       'react-dom$':                            /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-dom`,
       'react-dom/client$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
-      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.node`,
       'react-dom/server.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
       'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
-      'react-dom/static.edge$':                /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.node`,
       'react-dom/static.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      'react-dom/static.edge$':                /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       // file:///./../compiled/react-server-dom-webpack/package.json
-      'react-server-dom-webpack/client$':      /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client$':      /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.node`,
       'react-server-dom-webpack/client.edge$': /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
       'react-server-dom-webpack/server.edge$': /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge`,
       'react-server-dom-webpack/server.node$': /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node`,
@@ -447,15 +447,15 @@ export function createVendoredReactAliases(
       // file:///./../compiled/react-dom/package.json
       'react-dom$':                            /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}`,
       'react-dom/client$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
-      'react-dom/server$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.edge`,
       'react-dom/server.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
       'react-dom/server.edge$':                /* ✅ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-      'react-dom/static$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
-      'react-dom/static.edge$':                /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      'react-dom/static$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       'react-dom/static.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      'react-dom/static.edge$':                /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       // file:///./../compiled/react-server-dom-webpack/package.json
-      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
       'react-server-dom-webpack/client.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
       'react-server-dom-webpack/server.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
       'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
@@ -472,15 +472,15 @@ export function createVendoredReactAliases(
       // file:///./../compiled/react-dom/package.json
       'react-dom$':                            /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/react-dom.react-server`,
       'react-dom/client$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
-      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.edge`,
       'react-dom/server.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
       'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       'react-dom/static.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
       'react-dom/static.edge$':                /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       // file:///./../compiled/react-server-dom-webpack/package.json
-      'react-server-dom-webpack/client$':      /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client$':      /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
       'react-server-dom-webpack/client.edge$': /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
       'react-server-dom-webpack/server.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
       'react-server-dom-webpack/server.node$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -17,7 +17,6 @@ import type { NextConfigComplete } from '../server/config-shared'
 import { defaultOverrides } from '../server/require-hook'
 import { hasExternalOtelApiPackage } from './webpack-config'
 import { NEXT_PROJECT_ROOT } from './next-dir-paths'
-import { WEBPACK_LAYERS } from '../lib/constants'
 import { shouldUseReactServerCondition } from './utils'
 
 interface CompilerAliases {
@@ -259,88 +258,257 @@ export function createAppRouterApiAliases(isServerOnlyLayer: boolean) {
   return aliasMap
 }
 
-export function createRSCAliases(
-  bundledReactChannel: string,
+// file:///./../compiled/react/package.json
+type ReactEntrypoint = 'jsx-runtime' | 'jsx-dev-runtime' | 'compiler-runtime'
+// file:///./../compiled/react-dom/package.json
+type ReactDOMEntrypoint =
+  | 'client'
+  | 'server'
+  | 'server.edge'
+  | 'server.browser'
+  // TOOD: server.node
+  | 'static'
+  | 'static.browser'
+  | 'static.edge'
+// TODO: static.node
+
+// file:///./../compiled/react-server-dom-webpack/package.json
+type ReactServerDOMWebpackEntrypoint =
+  | 'client'
+  // TODO: client.browser
+  | 'client.edge'
+  // TODO: client.node
+  // TODO: server
+  // TODO: server.browser
+  | 'server.edge'
+  | 'server.node'
+  // TODO: static
+  // TODO: static.browser
+  | 'static.edge'
+// TODO: static.node
+
+type ReactPackagesEntryPoint =
+  | 'react'
+  | `react/${ReactEntrypoint}`
+  | 'react-dom'
+  | `react-dom/${ReactDOMEntrypoint}`
+  | `react-server-dom-webpack/${ReactServerDOMWebpackEntrypoint}`
+
+type BundledReactChannel = '' | '-experimental'
+
+type ReactAliases = {
+  [K in `${ReactPackagesEntryPoint}$`]: string
+} & {
+  // Edge Runtime does not use next-server runtime.
+  // This means we rely on rewritten import sources in compiled React.
+  // We need to alias those rewritten import sources.
+  [K in
+    | `next/dist/compiled/react${BundledReactChannel}$`
+    | `next/dist/compiled/react${BundledReactChannel}/${ReactEntrypoint}$`
+    | `next/dist/compiled/react-dom${BundledReactChannel}$`]?: string
+}
+
+export function createVendoredReactAliases(
+  bundledReactChannel: BundledReactChannel,
   {
     layer,
+    isBrowser,
     isEdgeServer,
     reactProductionProfiling,
   }: {
     layer: WebpackLayerName
+    isBrowser: boolean
     isEdgeServer: boolean
     reactProductionProfiling: boolean
   }
 ): CompilerAliases {
-  let alias: Record<string, string> = {
-    react$: `next/dist/compiled/react${bundledReactChannel}`,
-    'react-dom$': `next/dist/compiled/react-dom${bundledReactChannel}`,
-    'react/jsx-runtime$': `next/dist/compiled/react${bundledReactChannel}/jsx-runtime`,
-    'react/jsx-dev-runtime$': `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime`,
-    'react/compiler-runtime$': `next/dist/compiled/react${bundledReactChannel}/compiler-runtime`,
-    'react-dom/client$': `next/dist/compiled/react-dom${bundledReactChannel}/client`,
-    'react-dom/server$': `next/dist/compiled/react-dom${bundledReactChannel}/server`,
-    'react-dom/server.browser$': `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
-    'react-dom/static$': `next/dist/compiled/react-dom${bundledReactChannel}/static`,
-    'react-dom/static.edge$': `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
-    'react-dom/static.browser$': `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
-    // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
-    'react-dom/server.edge$': `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-    // react-server-dom-webpack alias
-    'react-server-dom-webpack/client$': `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
-    'react-server-dom-webpack/client.edge$': `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
-    'react-server-dom-webpack/server.edge$': `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
-    'react-server-dom-webpack/server.node$': `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
-    'react-server-dom-webpack/static.edge$': `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
-  }
+  const environmentCondition = isBrowser
+    ? 'browser'
+    : isEdgeServer
+      ? 'edge'
+      : 'nodejs'
+  const reactConditon = shouldUseReactServerCondition(layer)
+    ? 'server'
+    : 'client'
 
-  if (!isEdgeServer) {
-    if (layer === WEBPACK_LAYERS.serverSideRendering) {
-      alias = Object.assign(alias, {
-        'react/jsx-runtime$': `next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-runtime`,
-        'react/jsx-dev-runtime$': `next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime`,
-        'react/compiler-runtime$': `next/dist/server/route-modules/app-page/vendored/ssr/react-compiler-runtime`,
-        react$: `next/dist/server/route-modules/app-page/vendored/ssr/react`,
-        'react-dom$': `next/dist/server/route-modules/app-page/vendored/ssr/react-dom`,
-        'react-server-dom-webpack/client.edge$': `next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge`,
-      })
-    } else if (shouldUseReactServerCondition(layer)) {
-      alias = Object.assign(alias, {
-        'react/jsx-runtime$': `next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime`,
-        'react/jsx-dev-runtime$': `next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime`,
-        'react/compiler-runtime$': `next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime`,
-        react$: `next/dist/server/route-modules/app-page/vendored/rsc/react`,
-        'react-dom$': `next/dist/server/route-modules/app-page/vendored/rsc/react-dom`,
-        'react-server-dom-webpack/server.edge$': `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge`,
-        'react-server-dom-webpack/server.node$': `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node`,
-        'react-server-dom-webpack/static.edge$': `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge`,
-      })
-    }
-  }
+  // ✅ Correct alias
+  // ❌ Incorrect alias i.e. importing this entrypoint should throw an error.
+  // ❔ Alias that may produce correct code in certain conditions.Keep until react-markup is available.
 
-  if (isEdgeServer) {
-    if (shouldUseReactServerCondition(layer)) {
-      alias = Object.assign(alias, {
-        react$: `next/dist/compiled/react${bundledReactChannel}/react.react-server`,
-        'next/dist/compiled/react$': `next/dist/compiled/react${bundledReactChannel}/react.react-server`,
-        'next/dist/compiled/react-experimental$': `next/dist/compiled/react-experimental/react.react-server`,
-        'react/jsx-runtime$': `next/dist/compiled/react${bundledReactChannel}/jsx-runtime.react-server`,
-        'react/compiler-runtime$': `next/dist/compiled/react${bundledReactChannel}/compiler-runtime`,
-        'next/dist/compiled/react/jsx-runtime$': `next/dist/compiled/react${bundledReactChannel}/jsx-runtime.react-server`,
-        'next/dist/compiled/react-experimental/jsx-runtime$': `next/dist/compiled/react-experimental/jsx-runtime.react-server`,
-        'react/jsx-dev-runtime$': `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime.react-server`,
-        'next/dist/compiled/react/jsx-dev-runtime$': `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime.react-server`,
-        'next/dist/compiled/react-experimental/jsx-dev-runtime$': `next/dist/compiled/react-experimental/jsx-dev-runtime.react-server`,
-        'react-dom$': `next/dist/compiled/react-dom${bundledReactChannel}/react-dom.react-server`,
-        'next/dist/compiled/react-dom$': `next/dist/compiled/react-dom${bundledReactChannel}/react-dom.react-server`,
-        'next/dist/compiled/react-dom-experimental$': `next/dist/compiled/react-dom-experimental/react-dom.react-server`,
-      })
+  let reactAlias: ReactAliases
+  if (environmentCondition === 'browser' && reactConditon === 'client') {
+    // prettier-ignore
+    reactAlias = {
+      // file:///./../compiled/react/package.json
+      react$:                                  /* ✅ */ `next/dist/compiled/react${bundledReactChannel}`,
+      'react/compiler-runtime$':               /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/compiler-runtime`,
+      'react/jsx-dev-runtime$':                /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime`,
+      'react/jsx-runtime$':                    /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/jsx-runtime`,
+      // file:///./../compiled/react-dom/package.json
+      'react-dom$':                            /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}`,
+      'react-dom/client$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
+      'react-dom/server$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
+      // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
+      'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
+      'react-dom/static$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      'react-dom/static.edge$':                /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      // file:///./../compiled/react-server-dom-webpack/package.json
+      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
+      'react-server-dom-webpack/server.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
+      'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
+      'react-server-dom-webpack/static.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
     }
+  } else if (environmentCondition === 'browser' && reactConditon === 'server') {
+    // prettier-ignore
+    reactAlias = {
+      // file:///./../compiled/react/package.json
+      react$:                                  /* ❌ */ `next/dist/compiled/react${bundledReactChannel}`,
+      'react/compiler-runtime$':               /* ❌ */ `next/dist/compiled/react${bundledReactChannel}/compiler-runtime`,
+      'react/jsx-dev-runtime$':                /* ❌ */ `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime`,
+      'react/jsx-runtime$':                    /* ❌ */ `next/dist/compiled/react${bundledReactChannel}/jsx-runtime`,
+      // file:///./../compiled/react-dom/package.json
+      'react-dom$':                            /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}`,
+      'react-dom/client$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
+      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
+      // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
+      'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
+      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      'react-dom/static.edge$':                /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      // file:///./../compiled/react-server-dom-webpack/package.json
+      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
+      'react-server-dom-webpack/server.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
+      'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
+      'react-server-dom-webpack/static.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
+    }
+  } else if (environmentCondition === 'nodejs' && reactConditon === 'client') {
+    // prettier-ignore
+    reactAlias = {
+      // file:///./../compiled/react/package.json
+      react$:                                 /* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react`,
+      'react/compiler-runtime$':              /* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react-compiler-runtime`,
+      'react/jsx-dev-runtime$':               /* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime`,
+      'react/jsx-runtime$':                   /* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-runtime`,
+      // file:///./../compiled/react-dom/package.json
+      'react-dom$':                           /* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react-dom`,
+      'react-dom/client$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
+      'react-dom/server$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server.browser$':            /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
+      // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
+      'react-dom/server.edge$':               /* ✅ */`next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
+      'react-dom/static$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`, 
+      'react-dom/static.edge$':               /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      'react-dom/static.browser$':            /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      // file:///./../compiled/react-server-dom-webpack/package.json
+      'react-server-dom-webpack/client$':     /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client.edge$':/* ✅ */ `next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-webpack-client-edge`,
+      'react-server-dom-webpack/server.edge$':/* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
+      'react-server-dom-webpack/server.node$':/* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
+      'react-server-dom-webpack/static.edge$':/* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
+    }
+  } else if (environmentCondition === 'nodejs' && reactConditon === 'server') {
+    // prettier-ignore
+    reactAlias = {
+      // file:///./../compiled/react/package.json
+      react$:                                  /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react`,
+      'react/compiler-runtime$':               /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime`,
+      'react/jsx-dev-runtime$':                /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime`,
+      'react/jsx-runtime$':                    /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-runtime`,
+      // file:///./../compiled/react-dom/package.json
+      'react-dom$':                            /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-dom`,
+      'react-dom/client$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
+      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
+      // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
+      'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
+      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static.edge$':                /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      'react-dom/static.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      // file:///./../compiled/react-server-dom-webpack/package.json
+      'react-server-dom-webpack/client$':      /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client.edge$': /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
+      'react-server-dom-webpack/server.edge$': /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-edge`,
+      'react-server-dom-webpack/server.node$': /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node`,
+      'react-server-dom-webpack/static.edge$': /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge`,
+    }
+  } else if (environmentCondition === 'edge' && reactConditon === 'client') {
+    // prettier-ignore
+    reactAlias = {
+      // file:///./../compiled/react/package.json
+      react$:                                  /* ✅ */ `next/dist/compiled/react${bundledReactChannel}`,
+      'react/compiler-runtime$':               /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/compiler-runtime`,
+      'react/jsx-dev-runtime$':                /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime`,
+      'react/jsx-runtime$':                    /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/jsx-runtime`,
+      // file:///./../compiled/react-dom/package.json
+      'react-dom$':                            /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}`,
+      'react-dom/client$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
+      'react-dom/server$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
+      // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
+      'react-dom/server.edge$':                /* ✅ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
+      'react-dom/static$':                     /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static.edge$':                /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      'react-dom/static.browser$':             /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      // file:///./../compiled/react-server-dom-webpack/package.json
+      'react-server-dom-webpack/client$':      /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
+      'react-server-dom-webpack/server.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
+      'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
+      'react-server-dom-webpack/static.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
+    }
+  } else if (environmentCondition === 'edge' && reactConditon === 'server') {
+    // prettier-ignore
+    reactAlias = {
+      // file:///./../compiled/react/package.json
+      react$:                                  /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/react.react-server`,
+      'react/compiler-runtime$':               /* ❌ */ `next/dist/compiled/react${bundledReactChannel}/compiler-runtime`,
+      'react/jsx-dev-runtime$':                /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime.react-server`,
+      'react/jsx-runtime$':                    /* ✅ */ `next/dist/compiled/react${bundledReactChannel}/jsx-runtime.react-server`,
+      // file:///./../compiled/react-dom/package.json
+      'react-dom$':                            /* ✅ */ `next/dist/compiled/react-dom${bundledReactChannel}/react-dom.react-server`,
+      'react-dom/client$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/client`,
+      'react-dom/server$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+      'react-dom/server.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
+      // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
+      'react-dom/server.edge$':                /* ❌ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
+      'react-dom/static$':                     /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static`,
+      'react-dom/static.browser$':             /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
+      'react-dom/static.edge$':                /* ❌ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
+      // file:///./../compiled/react-server-dom-webpack/package.json
+      'react-server-dom-webpack/client$':      /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client`,
+      'react-server-dom-webpack/client.edge$': /* ❔ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/client.edge`,
+      'react-server-dom-webpack/server.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.edge`,
+      'react-server-dom-webpack/server.node$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
+      'react-server-dom-webpack/static.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
+    }
+
+    // prettier-ignore
+    reactAlias[`next/dist/compiled/react${bundledReactChannel}$`                 ] = reactAlias[`react$`]
+    // prettier-ignore
+    reactAlias[`next/dist/compiled/react${bundledReactChannel}/compiler-runtime$`] = reactAlias[`react/compiler-runtime$`]
+    // prettier-ignore
+    reactAlias[`next/dist/compiled/react${bundledReactChannel}/jsx-dev-runtime$` ] = reactAlias[`react/jsx-dev-runtime$`]
+    // prettier-ignore
+    reactAlias[`next/dist/compiled/react${bundledReactChannel}/jsx-runtime$`     ] = reactAlias[`react/jsx-runtime$`]
+    // prettier-ignore
+    reactAlias[`next/dist/compiled/react-dom${bundledReactChannel}$`             ] = reactAlias[`react-dom$`]
+  } else {
+    throw new Error(
+      `Unsupported environment condition "${environmentCondition}" and react condition "${reactConditon}". This is a bug in Next.js.`
+    )
   }
 
   if (reactProductionProfiling) {
-    alias['react-dom/client$'] =
+    reactAlias['react-dom/client$'] =
       `next/dist/compiled/react-dom${bundledReactChannel}/profiling`
   }
+
+  const alias: CompilerAliases = reactAlias
 
   alias[
     '@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client.ts'

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -266,7 +266,7 @@ type ReactDOMEntrypoint =
   | 'server'
   | 'server.edge'
   | 'server.browser'
-  // TOOD: server.node
+  // TODO: server.node
   | 'static'
   | 'static.browser'
   | 'static.edge'
@@ -327,7 +327,7 @@ export function createVendoredReactAliases(
     : isEdgeServer
       ? 'edge'
       : 'nodejs'
-  const reactConditon = shouldUseReactServerCondition(layer)
+  const reactCondition = shouldUseReactServerCondition(layer)
     ? 'server'
     : 'client'
 
@@ -336,7 +336,7 @@ export function createVendoredReactAliases(
   // ❔ Alias that may produce correct code in certain conditions.Keep until react-markup is available.
 
   let reactAlias: ReactAliases
-  if (environmentCondition === 'browser' && reactConditon === 'client') {
+  if (environmentCondition === 'browser' && reactCondition === 'client') {
     // prettier-ignore
     reactAlias = {
       // file:///./../compiled/react/package.json
@@ -361,7 +361,10 @@ export function createVendoredReactAliases(
       'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
       'react-server-dom-webpack/static.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
     }
-  } else if (environmentCondition === 'browser' && reactConditon === 'server') {
+  } else if (
+    environmentCondition === 'browser' &&
+    reactCondition === 'server'
+  ) {
     // prettier-ignore
     reactAlias = {
       // file:///./../compiled/react/package.json
@@ -386,7 +389,7 @@ export function createVendoredReactAliases(
       'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
       'react-server-dom-webpack/static.edge$': /* ✅ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
     }
-  } else if (environmentCondition === 'nodejs' && reactConditon === 'client') {
+  } else if (environmentCondition === 'nodejs' && reactCondition === 'client') {
     // prettier-ignore
     reactAlias = {
       // file:///./../compiled/react/package.json
@@ -400,8 +403,8 @@ export function createVendoredReactAliases(
       'react-dom/server$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.node`,
       'react-dom/server.browser$':            /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
       // optimizations to ignore the legacy build of react-dom/server in `server.edge` build
-      'react-dom/server.edge$':               /* ✅ */`next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
-      'react-dom/static$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.node`, 
+      'react-dom/server.edge$':               /* ✅ */ `next/dist/build/webpack/alias/react-dom-server-edge${bundledReactChannel}.js`,
+      'react-dom/static$':                    /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.node`,
       'react-dom/static.browser$':            /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,
       'react-dom/static.edge$':               /* ❔ */ `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
       // file:///./../compiled/react-server-dom-webpack/package.json
@@ -411,7 +414,7 @@ export function createVendoredReactAliases(
       'react-server-dom-webpack/server.node$':/* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
       'react-server-dom-webpack/static.edge$':/* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
     }
-  } else if (environmentCondition === 'nodejs' && reactConditon === 'server') {
+  } else if (environmentCondition === 'nodejs' && reactCondition === 'server') {
     // prettier-ignore
     reactAlias = {
       // file:///./../compiled/react/package.json
@@ -436,7 +439,7 @@ export function createVendoredReactAliases(
       'react-server-dom-webpack/server.node$': /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-server-node`,
       'react-server-dom-webpack/static.edge$': /* ✅ */ `next/dist/server/route-modules/app-page/vendored/rsc/react-server-dom-webpack-static-edge`,
     }
-  } else if (environmentCondition === 'edge' && reactConditon === 'client') {
+  } else if (environmentCondition === 'edge' && reactCondition === 'client') {
     // prettier-ignore
     reactAlias = {
       // file:///./../compiled/react/package.json
@@ -461,7 +464,7 @@ export function createVendoredReactAliases(
       'react-server-dom-webpack/server.node$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/server.node`,
       'react-server-dom-webpack/static.edge$': /* ❌ */ `next/dist/compiled/react-server-dom-webpack${bundledReactChannel}/static.edge`,
     }
-  } else if (environmentCondition === 'edge' && reactConditon === 'server') {
+  } else if (environmentCondition === 'edge' && reactCondition === 'server') {
     // prettier-ignore
     reactAlias = {
       // file:///./../compiled/react/package.json
@@ -499,7 +502,7 @@ export function createVendoredReactAliases(
     reactAlias[`next/dist/compiled/react-dom${bundledReactChannel}$`             ] = reactAlias[`react-dom$`]
   } else {
     throw new Error(
-      `Unsupported environment condition "${environmentCondition}" and react condition "${reactConditon}". This is a bug in Next.js.`
+      `Unsupported environment condition "${environmentCondition}" and react condition "${reactCondition}". This is a bug in Next.js.`
     )
   }
 

--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -10,7 +10,7 @@ import {
   NODE_ESM_RESOLVE_OPTIONS,
   NODE_RESOLVE_OPTIONS,
 } from './webpack-config'
-import { isWebpackBundledLayer, isWebpackServerOnlyLayer } from './utils'
+import { isWebpackBundledLayer, shouldUseReactServerCondition } from './utils'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
 const reactPackagesRegex = /^(react|react-dom|react-server-dom-webpack)($|\/)/
 
@@ -216,7 +216,7 @@ export function makeExternalHandler({
     // TODO-APP: bundle route.js with different layer that externals common node_module deps.
     // Make sure @vercel/og is loaded as ESM for Node.js runtime
     if (
-      isWebpackServerOnlyLayer(layer) &&
+      shouldUseReactServerCondition(layer) &&
       request === 'next/dist/compiled/@vercel/og/index.node.js'
     ) {
       return `module ${request}`

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -7,7 +7,7 @@ import type {
   StyledComponentsConfig,
 } from '../../server/config-shared'
 import type { ResolvedBaseUrl } from '../load-jsconfig'
-import { isWebpackServerOnlyLayer, isWebpackAppPagesLayer } from '../utils'
+import { shouldUseReactServerCondition, isWebpackAppPagesLayer } from '../utils'
 import { escapeStringRegexp } from '../../shared/lib/escape-regexp'
 
 const nextDirname = path.dirname(require.resolve('next/package.json'))
@@ -96,7 +96,7 @@ function getBaseSWCOptions({
   useCacheEnabled?: boolean
   trackDynamicImports?: boolean
 }) {
-  const isReactServerLayer = isWebpackServerOnlyLayer(bundleLayer)
+  const isReactServerLayer = shouldUseReactServerCondition(bundleLayer)
   const isAppRouterPagesLayer = isWebpackAppPagesLayer(bundleLayer)
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1846,7 +1846,7 @@ export function getSupportedBrowsers(
   return MODERN_BROWSERSLIST_TARGET
 }
 
-export function isWebpackServerOnlyLayer(
+export function shouldUseReactServerCondition(
   layer: WebpackLayerName | null | undefined
 ): boolean {
   return Boolean(

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -12,7 +12,7 @@ import type { WebpackLayerName } from '../lib/constants'
 import {
   isWebpackBundledLayer,
   isWebpackClientOnlyLayer,
-  isWebpackServerOnlyLayer,
+  shouldUseReactServerCondition,
   isWebpackDefaultLayer,
   RSPACK_DEFAULT_LAYERS_REGEX,
 } from './utils'
@@ -1484,7 +1484,7 @@ export default async function getBaseWebpackConfig(
                 },
               },
               {
-                issuerLayer: isWebpackServerOnlyLayer,
+                issuerLayer: shouldUseReactServerCondition,
                 resolve: {
                   alias: createAppRouterApiAliases(true),
                 },
@@ -1500,7 +1500,7 @@ export default async function getBaseWebpackConfig(
         ...(hasAppDir && !isClient
           ? [
               {
-                issuerLayer: isWebpackServerOnlyLayer,
+                issuerLayer: shouldUseReactServerCondition,
                 test: {
                   // Resolve it if it is a source code file, and it has NOT been
                   // opted out of bundling.
@@ -1571,7 +1571,7 @@ export default async function getBaseWebpackConfig(
                 // Alias react for switching between default set and share subset.
                 oneOf: [
                   {
-                    issuerLayer: isWebpackServerOnlyLayer,
+                    issuerLayer: shouldUseReactServerCondition,
                     test: {
                       // Resolve it if it is a source code file, and it has NOT been
                       // opted out of bundling.
@@ -1688,7 +1688,7 @@ export default async function getBaseWebpackConfig(
               ? [
                   {
                     test: codeCondition.test,
-                    issuerLayer: isWebpackServerOnlyLayer,
+                    issuerLayer: shouldUseReactServerCondition,
                     exclude: asyncStoragesRegex,
                     use: appServerLayerLoaders,
                   },

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -80,7 +80,7 @@ import { OptionalPeerDependencyResolverPlugin } from './webpack/plugins/optional
 import {
   createWebpackAliases,
   createServerOnlyClientOnlyAliases,
-  createRSCAliases,
+  createVendoredReactAliases,
   createNextApiEsmAliases,
   createAppRouterApiAliases,
 } from './create-compiler-aliases'
@@ -1528,10 +1528,11 @@ export default async function getBaseWebpackConfig(
                   // If missing the alias override here, the default alias will be used which aliases
                   // react to the direct file path, not the package name. In that case the condition
                   // will be ignored completely.
-                  alias: createRSCAliases(bundledReactChannel, {
+                  alias: createVendoredReactAliases(bundledReactChannel, {
                     // No server components profiling
                     reactProductionProfiling,
                     layer: WEBPACK_LAYERS.reactServerComponents,
+                    isBrowser: isClient,
                     isEdgeServer,
                   }),
                 },
@@ -1585,9 +1586,10 @@ export default async function getBaseWebpackConfig(
                     resolve: {
                       // It needs `conditionNames` here to require the proper asset,
                       // when react is acting as dependency of compiled/react-dom.
-                      alias: createRSCAliases(bundledReactChannel, {
+                      alias: createVendoredReactAliases(bundledReactChannel, {
                         reactProductionProfiling,
                         layer: WEBPACK_LAYERS.reactServerComponents,
+                        isBrowser: isClient,
                         isEdgeServer,
                       }),
                     },
@@ -1596,9 +1598,10 @@ export default async function getBaseWebpackConfig(
                     test: aliasCodeConditionTest,
                     issuerLayer: WEBPACK_LAYERS.serverSideRendering,
                     resolve: {
-                      alias: createRSCAliases(bundledReactChannel, {
+                      alias: createVendoredReactAliases(bundledReactChannel, {
                         reactProductionProfiling,
                         layer: WEBPACK_LAYERS.serverSideRendering,
+                        isBrowser: isClient,
                         isEdgeServer,
                       }),
                     },
@@ -1609,9 +1612,10 @@ export default async function getBaseWebpackConfig(
                 test: aliasCodeConditionTest,
                 issuerLayer: WEBPACK_LAYERS.appPagesBrowser,
                 resolve: {
-                  alias: createRSCAliases(bundledReactChannel, {
+                  alias: createVendoredReactAliases(bundledReactChannel, {
                     reactProductionProfiling,
                     layer: WEBPACK_LAYERS.appPagesBrowser,
+                    isBrowser: isClient,
                     isEdgeServer,
                   }),
                 },
@@ -1663,9 +1667,10 @@ export default async function getBaseWebpackConfig(
               resolve: {
                 mainFields: getMainField(compilerType, true),
                 conditionNames: reactServerCondition,
-                alias: createRSCAliases(bundledReactChannel, {
+                alias: createVendoredReactAliases(bundledReactChannel, {
                   reactProductionProfiling,
                   layer: WEBPACK_LAYERS.middleware,
+                  isBrowser: isClient,
                   isEdgeServer,
                 }),
               },
@@ -1677,9 +1682,10 @@ export default async function getBaseWebpackConfig(
               resolve: {
                 mainFields: getMainField(compilerType, true),
                 conditionNames: reactServerCondition,
-                alias: createRSCAliases(bundledReactChannel, {
+                alias: createVendoredReactAliases(bundledReactChannel, {
                   reactProductionProfiling,
                   layer: WEBPACK_LAYERS.instrument,
+                  isBrowser: isClient,
                   isEdgeServer,
                 }),
               },
@@ -2530,9 +2536,10 @@ export default async function getBaseWebpackConfig(
       ].map((layer) => ({
         issuerLayer: layer,
         resolve: {
-          alias: createRSCAliases(bundledReactChannel, {
+          alias: createVendoredReactAliases(bundledReactChannel, {
             reactProductionProfiling,
             layer,
+            isBrowser: isClient,
             isEdgeServer,
           }),
         },


### PR DESCRIPTION
The previous logic relied heavily on default-fallthroughs which makes it hard to follow what alias we end up using in which bundle.

The new logic has more duplication which is intended so that you think about each entrypoint. With the new factoring, some bad combinations are more obvious (e.g. `react-dom/server` in product code not using the vendored version or `react-server-dom-webpack/server` not throwing in a Client environment). Compare changing aliases to .node in https://github.com/vercel/next.js/pull/81048/ (based on this refactor) vs changing it without the refactor: https://github.com/vercel/next.js/pull/80941

Fixing the bad combinations is not part of this work. We probably need to finish `react-markup` first before we get more strict with `react-dom/server` usage in Server code.