### PR TITLE
Stop installing test apps that are skipped anyways

### DIFF
--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -1,20 +1,30 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { assertNoErrorToast } from 'next-test-utils'
 import { getPrerenderOutput } from './utils'
 
-describe.each([
-  { inPrerenderDebugMode: true, name: 'With --prerender-debug' },
-  // { inPrerenderDebugMode: false, name: 'Without --prerender-debug' },
-])('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
-  // We want to skip building and starting in start mode, and in dev mode when
-  // prerender debug mode is enabled, which doesn't exist for `next dev`.
-  const skipStart =
-    process.env.NEXT_TEST_MODE === 'start' || inPrerenderDebugMode
-
+describe.each(
+  isNextDev
+    ? [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Dev',
+        },
+      ]
+    : [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Build Without --prerender-debug',
+        },
+        {
+          inPrerenderDebugMode: true,
+          name: 'Build With --prerender-debug',
+        },
+      ]
+)('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
   describe('Sync Dynamic - With Fallback - Math.random()', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-random-with-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -24,11 +34,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should not show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
         await assertNoErrorToast(browser)
@@ -49,9 +54,9 @@ describe.each([
   })
 
   describe('Sync Dynamic - Without Fallback - Math.random()', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-random-without-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -61,11 +66,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -1,22 +1,32 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { assertNoErrorToast } from 'next-test-utils'
 import { getPrerenderOutput } from './utils'
 
-describe.each([
-  { inPrerenderDebugMode: true, name: 'With --prerender-debug' },
-  { inPrerenderDebugMode: false, name: 'Without --prerender-debug' },
-])('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
-  // We want to skip building and starting in start mode, and in dev mode when
-  // prerender debug mode is enabled, which doesn't exist for `next dev`.
-  const skipStart =
-    process.env.NEXT_TEST_MODE === 'start' || inPrerenderDebugMode
-
+describe.each(
+  isNextDev
+    ? [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Dev',
+        },
+      ]
+    : [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Build Without --prerender-debug',
+        },
+        {
+          inPrerenderDebugMode: true,
+          name: 'Build With --prerender-debug',
+        },
+      ]
+)('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
   describe('Error Attribution with Sync IO - Guarded RSC with guarded Client sync IO', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files:
         __dirname +
         '/fixtures/sync-attribution/guarded-async-guarded-clientsync',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -26,11 +36,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('does not show a validation error in the dev overlay', async () => {
         const browser = await next.browser('/')
         await assertNoErrorToast(browser)
@@ -48,11 +53,11 @@ describe.each([
   })
 
   describe('Error Attribution with Sync IO - Guarded RSC with unguarded Client sync IO', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files:
         __dirname +
         '/fixtures/sync-attribution/guarded-async-unguarded-clientsync',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -62,11 +67,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
@@ -153,11 +153,11 @@ describe.each([
   })
 
   describe('Error Attribution with Sync IO - Unguarded RSC with guarded Client sync IO', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files:
         __dirname +
         '/fixtures/sync-attribution/unguarded-async-guarded-clientsync',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -167,11 +167,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
@@ -330,11 +325,11 @@ describe.each([
   })
 
   describe('Error Attribution with Sync IO - unguarded RSC with unguarded Client sync IO', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files:
         __dirname +
         '/fixtures/sync-attribution/unguarded-async-unguarded-clientsync',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -344,11 +339,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -1,19 +1,29 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
-describe.each([
-  { inPrerenderDebugMode: true, name: 'With --prerender-debug' },
-  { inPrerenderDebugMode: false, name: 'Without --prerender-debug' },
-])('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
-  // We want to skip building and starting in start mode, and in dev mode when
-  // prerender debug mode is enabled, which doesn't exist for `next dev`.
-  const skipStart =
-    process.env.NEXT_TEST_MODE === 'start' || inPrerenderDebugMode
-
+describe.each(
+  isNextDev
+    ? [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Dev',
+        },
+      ]
+    : [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Build Without --prerender-debug',
+        },
+        {
+          inPrerenderDebugMode: true,
+          name: 'Build With --prerender-debug',
+        },
+      ]
+)('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
   describe('Sync Dynamic - With Fallback - client searchParams', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-client-search-with-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -23,11 +33,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       // We don't error the build, but we do show a dev-only error so that users
       // migrate to the async usage.
       it('should show a collapsed redbox error', async () => {
@@ -64,9 +69,9 @@ describe.each([
   })
 
   describe('Sync Dynamic - Without Fallback - client searchParams', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-client-search-without-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -76,11 +81,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox with two errors', async () => {
         const browser = await next.browser('/')
 
@@ -244,9 +244,9 @@ describe.each([
   })
 
   describe('Sync Dynamic - With Fallback - server searchParams', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-server-search-with-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -256,11 +256,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       // We don't error the build, but we do show a dev-only error so that users
       // migrate to the async usage.
       it('should show a collapsed redbox error', async () => {
@@ -297,9 +292,9 @@ describe.each([
   })
 
   describe('Sync Dynamic - Without Fallback - server searchParams', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-server-search-without-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -309,11 +304,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       // TODO: Ideally we'd only show the error once.
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
@@ -419,9 +409,9 @@ describe.each([
   })
 
   describe('Sync Dynamic - With Fallback - cookies', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-cookies-with-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -431,11 +421,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       // We don't error the build, but we do show a dev-only error so that users
       // migrate to the async usage.
       it('should show a collapsed redbox error', async () => {
@@ -472,9 +457,9 @@ describe.each([
   })
 
   describe('Sync Dynamic - Without Fallback - cookies', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/sync-cookies-without-fallback',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -484,11 +469,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       // TODO: Ideally we'd only show the error once.
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -1,20 +1,30 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { assertNoErrorToast } from 'next-test-utils'
 import { getPrerenderOutput } from './utils'
 
-describe.each([
-  { inPrerenderDebugMode: true, name: 'With --prerender-debug' },
-  { inPrerenderDebugMode: false, name: 'Without --prerender-debug' },
-])('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
-  // We want to skip building and starting in start mode, and in dev mode when
-  // prerender debug mode is enabled, which doesn't exist for `next dev`.
-  const skipStart =
-    process.env.NEXT_TEST_MODE === 'start' || inPrerenderDebugMode
-
+describe.each(
+  isNextDev
+    ? [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Dev',
+        },
+      ]
+    : [
+        {
+          inPrerenderDebugMode: false,
+          name: 'Build Without --prerender-debug',
+        },
+        {
+          inPrerenderDebugMode: true,
+          name: 'Build With --prerender-debug',
+        },
+      ]
+)('Dynamic IO Errors - $name', ({ inPrerenderDebugMode }) => {
   describe('Dynamic Metadata - Static Route', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-metadata-static-route',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -24,11 +34,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
@@ -98,9 +103,9 @@ describe.each([
   })
 
   describe('Dynamic Metadata - Error Route', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-metadata-error-route',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -110,11 +115,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
@@ -261,9 +261,9 @@ describe.each([
   })
 
   describe('Dynamic Metadata - Static Route With Suspense', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-metadata-static-with-suspense',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -273,11 +273,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
@@ -343,9 +338,9 @@ describe.each([
   })
 
   describe('Dynamic Metadata - Dynamic Route', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-metadata-dynamic-route',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -355,11 +350,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should not show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
         await assertNoErrorToast(browser)
@@ -381,9 +371,9 @@ describe.each([
   })
 
   describe('Dynamic Viewport - Static Route', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-viewport-static-route',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -393,11 +383,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
@@ -463,9 +448,9 @@ describe.each([
   })
 
   describe('Dynamic Viewport - Dynamic Route', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-viewport-dynamic-route',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -475,11 +460,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
@@ -545,9 +525,9 @@ describe.each([
   })
 
   describe('Static Route', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/static',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -557,11 +537,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should not show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
         await assertNoErrorToast(browser)
@@ -578,9 +553,9 @@ describe.each([
   })
 
   describe('Dynamic Root', () => {
-    const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-root',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -590,11 +565,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should show a collapsed redbox with two errors', async () => {
         const browser = await next.browser('/')
 
@@ -847,9 +817,9 @@ describe.each([
   })
 
   describe('Dynamic Boundary', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/dynamic-boundary',
-      skipStart,
+      skipStart: !isNextDev,
       skipDeployment: true,
       buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
     })
@@ -859,11 +829,6 @@ describe.each([
     }
 
     if (isNextDev) {
-      if (inPrerenderDebugMode) {
-        it('prerender debug mode does not exist for `next dev`', () => {})
-        return
-      }
-
       it('should not show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
         await assertNoErrorToast(browser)


### PR DESCRIPTION
In dev test mode, when running with `--prerender-debug`, instead of skipping the test suite, we can split up the test matrix to avoid installing the non-applicable test apps.