### PR TITLE
Add more test cases to the `dynamicIO` sync IO access test suite

### DIFF
--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -1,5 +1,5 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
-import { getPrerenderOutput } from './utils'
+import { assertLog, getPrerenderOutput } from './utils'
 
 describe.each(
   isNextDev
@@ -90,11 +90,11 @@ describe.each(
              "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
              "environmentLabel": "Server",
              "label": "Console Error",
-             "source": "app/page.tsx (52:8) @ LongRunningComponent
-         > 52 |     use(
+             "source": "app/page.tsx (48:8) @ LongRunningComponent
+         > 48 |     use(
               |        ^",
              "stack": [
-               "LongRunningComponent app/page.tsx (52:8)",
+               "LongRunningComponent app/page.tsx (48:8)",
                "IndirectionTwo app/indirection.tsx (7:34)",
                "Page app/page.tsx (19:61)",
                "main <anonymous> (1:13)",
@@ -276,8 +276,19 @@ describe.each(
          }
         `)
       })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
+      })
     } else {
-      it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
+      it('should not error the build when synchronously reading search params in a server component if all dynamic access is inside a Suspense boundary', async () => {
         try {
           await next.start()
         } catch {
@@ -314,28 +325,39 @@ describe.each(
              "description": "Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
              "environmentLabel": "Prerender",
              "label": "Console Error",
-             "source": "app/page.tsx (40:5) @ SearchParamsReadingComponent
-         > 40 |   ).foo
+             "source": "app/page.tsx (41:5) @ SearchParamsReadingComponent
+         > 41 |   ).foo
               |     ^",
              "stack": [
-               "SearchParamsReadingComponent app/page.tsx (40:5)",
-               "Page app/page.tsx (19:11)",
+               "SearchParamsReadingComponent app/page.tsx (41:5)",
+               "Page app/page.tsx (20:11)",
              ],
            },
            {
              "description": "Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
              "environmentLabel": "Server",
              "label": "Console Error",
-             "source": "app/page.tsx (40:5) @ SearchParamsReadingComponent
-         > 40 |   ).foo
+             "source": "app/page.tsx (41:5) @ SearchParamsReadingComponent
+         > 41 |   ).foo
               |     ^",
              "stack": [
-               "SearchParamsReadingComponent app/page.tsx (40:5)",
+               "SearchParamsReadingComponent app/page.tsx (41:5)",
                "LogSafely <anonymous> (0:0)",
              ],
            },
          ]
         `)
+      })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
       })
     } else {
       it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
@@ -353,14 +375,14 @@ describe.each(
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
-                 at SearchParamsReadingComponent (turbopack:///[project]/app/page.tsx:40:4)
-               38 |   const fooParams = (
-               39 |     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
-             > 40 |   ).foo
+                 at SearchParamsReadingComponent (turbopack:///[project]/app/page.tsx:41:4)
+               39 |   const fooParams = (
+               40 |     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
+             > 41 |   ).foo
                   |    ^
-               41 |   return (
-               42 |     <div>
-               43 |       this component read the accessed the \`foo\` search param: {fooParams}
+               42 |
+               43 |   console.log(
+               44 |     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -380,14 +402,14 @@ describe.each(
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`searchParams.foo\`. \`searchParams\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
-                 at SearchParamsReadingComponent (webpack:///app/page.tsx:40:4)
-               38 |   const fooParams = (
-               39 |     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
-             > 40 |   ).foo
+                 at SearchParamsReadingComponent (webpack:///app/page.tsx:41:4)
+               39 |   const fooParams = (
+               40 |     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
+             > 41 |   ).foo
                   |    ^
-               41 |   return (
-               42 |     <div>
-               43 |       this component read the accessed the \`foo\` search param: {fooParams}
+               42 |
+               43 |   console.log(
+               44 |     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -431,18 +453,29 @@ describe.each(
            "description": "Route "/" used \`cookies().get('token')\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/page.tsx (34:67) @ CookiesReadingComponent
-         > 34 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-              |                                                                   ^",
+           "source": "app/page.tsx (33:66) @ CookiesReadingComponent
+         > 33 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+              |                                                                  ^",
            "stack": [
-             "CookiesReadingComponent app/page.tsx (34:67)",
-             "Page app/page.tsx (17:11)",
+             "CookiesReadingComponent app/page.tsx (33:66)",
+             "Page app/page.tsx (16:11)",
            ],
          }
         `)
       })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
+      })
     } else {
-      it('should not error the build when synchronously reading search params in a client component if all dynamic access is inside a Suspense boundary', async () => {
+      it('should not error the build when synchronously reading cookies if all dynamic access is inside a Suspense boundary', async () => {
         try {
           await next.start()
         } catch {
@@ -502,6 +535,17 @@ describe.each(
          ]
         `)
       })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
+      })
     } else {
       it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
         try {
@@ -523,9 +567,9 @@ describe.each(
                31 |   await new Promise((r) => process.nextTick(r))
              > 32 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
                   |                                                                  ^
-               33 |   return <div>this component read the \`token\` cookie synchronously</div>
-               34 | }
-               35 |
+               33 |
+               34 |   console.log(
+               35 |     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -568,6 +612,485 @@ describe.each(
                  at c (<next-dist-dir>)
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
+            `)
+          }
+        }
+      })
+    }
+  })
+
+  describe('Sync Dynamic - draftMode', () => {
+    const { next, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-draft-mode',
+      skipStart: !isNextDev,
+      skipDeployment: true,
+      buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      // We don't error the build, but we do show a dev-only error so that users
+      // migrate to the async usage.
+      it('should show a collapsed redbox error', async () => {
+        const browser = await next.browser('/')
+
+        if (isTurbopack) {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/" used \`draftMode().isEnabled\`. \`draftMode()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/page.tsx (25:31) @ DraftModeReadingComponent
+           > 25 |   const isEnabled = (draftMode() as unknown as UnsafeUnwrappedDraftMode)
+                |                               ^",
+             "stack": [
+               "DraftModeReadingComponent app/page.tsx (25:31)",
+               "Page app/page.tsx (16:11)",
+             ],
+           }
+          `)
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/" used \`draftMode().isEnabled\`. \`draftMode()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/page.tsx (25:21) @ DraftModeReadingComponent
+           > 25 |   const isEnabled = (draftMode() as unknown as UnsafeUnwrappedDraftMode)
+                |                     ^",
+             "stack": [
+               "DraftModeReadingComponent app/page.tsx (25:21)",
+               "Page app/page.tsx (16:11)",
+             ],
+           }
+          `)
+        }
+      })
+
+      // TODO: We should not change the `prerenderPhase` flag in this case.
+      it.failing(
+        'should prefix a log after sync `draftMode().isEnabled` access with "Prerender"',
+        async () => {
+          const browser = await next.browser('/')
+          const logs = await browser.log()
+
+          assertLog(
+            logs,
+            'Prerender',
+            'This log should be prefixed with the "Prerender" environment, because the sync access above does not lead to an abort.'
+          )
+        }
+      )
+    } else {
+      it('should not error the build when synchronously reading draftMode ', async () => {
+        try {
+          await next.start()
+        } catch {
+          throw new Error('expected build not to fail for fully static project')
+        }
+
+        expect(next.cliOutput).toContain('○ / ')
+        const $ = await next.render$('/')
+        expect($('#draft-mode').text()).toBe('false')
+      })
+    }
+  })
+
+  describe('Sync Dynamic - With Fallback - headers', () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-headers-with-fallback',
+      skipStart: !isNextDev,
+      skipDeployment: true,
+      buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      // We don't error the build, but we do show a dev-only error so that users
+      // migrate to the async usage.
+      it('should show a collapsed redbox error', async () => {
+        const browser = await next.browser('/')
+
+        await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "description": "Route "/" used \`headers().get('user-agent')\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/page.tsx (33:70) @ HeadersReadingComponent
+             > 33 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                  |                                                                      ^",
+               "stack": [
+                 "HeadersReadingComponent app/page.tsx (33:70)",
+                 "Page app/page.tsx (16:11)",
+               ],
+             }
+            `)
+      })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
+      })
+    } else {
+      it('should not error the build when synchronously reading headers if all dynamic access is inside a Suspense boundary', async () => {
+        try {
+          await next.start()
+        } catch {
+          throw new Error('expected build not to fail for fully static project')
+        }
+
+        expect(next.cliOutput).toContain('◐ / ')
+        const $ = await next.render$('/')
+        expect($('[data-fallback]').length).toBe(2)
+      })
+    }
+  })
+
+  describe('Sync Dynamic - Without Fallback - headers', () => {
+    const { next, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-headers-without-fallback',
+      skipStart: !isNextDev,
+      skipDeployment: true,
+      buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      // TODO: Ideally we'd only show the error once.
+      it('should show a collapsed redbox error', async () => {
+        const browser = await next.browser('/')
+
+        await expect(browser).toDisplayCollapsedRedbox(`
+             [
+               {
+                 "description": "Route "/" used \`headers().get('user-agent')\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                 "environmentLabel": "Server",
+                 "label": "Console Error",
+                 "source": "app/page.tsx (32:70) @ HeadersReadingComponent
+             > 32 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                  |                                                                      ^",
+                 "stack": [
+                   "HeadersReadingComponent app/page.tsx (32:70)",
+                   "Page app/page.tsx (17:11)",
+                 ],
+               },
+               {
+                 "description": "Route "/" used \`headers().get('user-agent')\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                 "environmentLabel": "Server",
+                 "label": "Console Error",
+                 "source": "app/page.tsx (32:70) @ HeadersReadingComponent
+             > 32 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                  |                                                                      ^",
+                 "stack": [
+                   "HeadersReadingComponent app/page.tsx (32:70)",
+                   "LogSafely <anonymous> (0:0)",
+                 ],
+               },
+             ]
+            `)
+      })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
+      })
+    } else {
+      it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
+        try {
+          await next.build()
+        } catch {
+          // we expect the build to fail
+        }
+
+        const output = getPrerenderOutput(next.cliOutput, {
+          isMinified: !inPrerenderDebugMode,
+        })
+
+        if (isTurbopack) {
+          if (inPrerenderDebugMode) {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/" used \`headers().get('user-agent')\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at HeadersReadingComponent (turbopack:///[project]/app/page.tsx:32:69)
+               30 | async function HeadersReadingComponent() {
+               31 |   await new Promise((r) => process.nextTick(r))
+             > 32 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                  |                                                                     ^
+               33 |     'user-agent'
+               34 |   )
+               35 |
+             Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+             > Export encountered errors on following paths:
+             	/page: /"
+            `)
+          } else {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/" used \`headers().get('user-agent')\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at a (<next-dist-dir>)
+                 at b (<next-dist-dir>)
+                 at c (<next-dist-dir>)
+             Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+             Export encountered an error on /page: /, exiting the build."
+            `)
+          }
+        } else {
+          if (inPrerenderDebugMode) {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/" used \`headers().get('user-agent')\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at createHeadersAccessError (webpack://<next-src>)
+                 at Promise.get (webpack://<next-src>)
+                 at HeadersReadingComponent (webpack:///app/page.tsx:32:69)
+               501 | ) {
+               502 |   const prefix = route ? \`Route "\${route}" \` : 'This route '
+             > 503 |   return new Error(
+                   |         ^
+               504 |     \`\${prefix}used \${expression}. \` +
+               505 |       \`\\\`headers()\\\` should be awaited before using its value. \` +
+               506 |       \`Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis\`
+             Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+
+             > Export encountered errors on following paths:
+             	/page: /"
+            `)
+          } else {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/" used \`headers().get('user-agent')\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at a (<next-dist-dir>)
+                 at b (<next-dist-dir>)
+                 at c (<next-dist-dir>)
+             Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+             Export encountered an error on /page: /, exiting the build."
+            `)
+          }
+        }
+      })
+    }
+  })
+
+  describe('Sync Dynamic - With Fallback - params', () => {
+    const { next, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-params-with-fallback',
+      skipStart: !isNextDev,
+      skipDeployment: true,
+      buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      // We don't error the build, but we do show a dev-only error so that users
+      // migrate to the async usage.
+      it('should show a collapsed redbox error', async () => {
+        const browser = await next.browser('/test')
+
+        if (isTurbopack) {
+          await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "description": "Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/[slug]/page.tsx (32:23) @ ParamsReadingComponent
+             > 32 |   const slug = params.slug
+                  |                       ^",
+               "stack": [
+                 "ParamsReadingComponent app/[slug]/page.tsx (32:23)",
+                 "Page app/[slug]/page.tsx (15:11)",
+               ],
+             }
+            `)
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": null,
+             "stack": [
+               "ParamsReadingComponent rsc:/Server/webpack-internal:///(rsc)/app/%5Bslug%5D/page.tsx (85:25)",
+               "Page rsc:/Prerender/webpack-internal:///(rsc)/app/%5Bslug%5D/page.tsx (30:106)",
+             ],
+           }
+          `)
+        }
+      })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/test')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
+      })
+    } else {
+      it('should not error the build when synchronously reading params if all dynamic access is inside a Suspense boundary', async () => {
+        try {
+          await next.start()
+        } catch {
+          throw new Error('expected build not to fail for fully static project')
+        }
+
+        expect(next.cliOutput).toContain('◐ /[slug] ')
+        const $ = await next.render$('/test')
+        expect($('[data-fallback]').length).toBe(2)
+      })
+    }
+  })
+
+  describe('Sync Dynamic - Without Fallback - params', () => {
+    const { next, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-params-without-fallback',
+      skipStart: !isNextDev,
+      skipDeployment: true,
+      buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('should show a collapsed redbox error', async () => {
+        const browser = await next.browser('/test')
+
+        if (isTurbopack) {
+          await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "description": "Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/[slug]/page.tsx (31:23) @ ParamsReadingComponent
+             > 31 |   const slug = params.slug
+                  |                       ^",
+               "stack": [
+                 "ParamsReadingComponent app/[slug]/page.tsx (31:23)",
+                 "Page app/[slug]/page.tsx (16:11)",
+               ],
+             }
+            `)
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": null,
+             "stack": [
+               "ParamsReadingComponent rsc:/Server/webpack-internal:///(rsc)/app/%5Bslug%5D/page.tsx (74:25)",
+               "Page rsc:/Prerender/webpack-internal:///(rsc)/app/%5Bslug%5D/page.tsx (30:106)",
+             ],
+           }
+          `)
+        }
+      })
+
+      it('should prefix a log after sync dynamic IO with "Server"', async () => {
+        const browser = await next.browser('/test')
+        const logs = await browser.log()
+
+        assertLog(
+          logs,
+          'Server',
+          'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+        )
+      })
+    } else {
+      it('should error the build if dynamic IO happens in the root (outside a Suspense)', async () => {
+        try {
+          await next.build()
+        } catch {
+          // we expect the build to fail
+        }
+
+        const output = getPrerenderOutput(next.cliOutput, {
+          isMinified: !inPrerenderDebugMode,
+        })
+
+        if (isTurbopack) {
+          if (inPrerenderDebugMode) {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at Reflect.get (<anonymous>)
+                 at ParamsReadingComponent (turbopack:///[project]/app/[slug]/page.tsx:31:22)
+               29 | async function ParamsReadingComponent({ params }) {
+               30 |   await new Promise((r) => process.nextTick(r))
+             > 31 |   const slug = params.slug
+                  |                      ^
+               32 |
+               33 |   console.log(
+               34 |     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+             Error occurred prerendering page "/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+
+             > Export encountered errors on following paths:
+             	/[slug]/page: /[slug]"
+            `)
+          } else {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at a (<next-dist-dir>)
+                 at b (<next-dist-dir>)
+                 at c (<anonymous>)
+                 at d (<next-dist-dir>)
+                 at e (<next-dist-dir>)
+                 at f (<next-dist-dir>)
+             Error occurred prerendering page "/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+             Export encountered an error on /[slug]/page: /[slug], exiting the build."
+            `)
+          }
+        } else {
+          if (inPrerenderDebugMode) {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at Reflect.get (<anonymous>)
+                 at ParamsReadingComponent (webpack:///app/[slug]/page.tsx:31:22)
+               29 | async function ParamsReadingComponent({ params }) {
+               30 |   await new Promise((r) => process.nextTick(r))
+             > 31 |   const slug = params.slug
+                  |                      ^
+               32 |
+               33 |   console.log(
+               34 |     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+             Error occurred prerendering page "/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+
+             > Export encountered errors on following paths:
+             	/[slug]/page: /[slug]"
+            `)
+          } else {
+            expect(output).toMatchInlineSnapshot(`
+             "Error: Route "/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
+                 at a (<next-dist-dir>)
+                 at b (<next-dist-dir>)
+                 at c (<anonymous>)
+                 at d (<next-dist-dir>)
+                 at e (<next-dist-dir>)
+                 at f (<next-dist-dir>)
+             Error occurred prerendering page "/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+             Export encountered an error on /[slug]/page: /[slug], exiting the build."
             `)
           }
         }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-with-fallback/app/page.tsx
@@ -42,11 +42,7 @@ function SearchParamsReadingComponent({
   const fooParams = (
     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
   ).foo
-  return (
-    <div>
-      this component read the accessed the `foo` search param: {fooParams}
-    </div>
-  )
+  return <div>this component read the `foo` search param: {fooParams}</div>
 }
 
 function LongRunningComponent() {

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/app/page.tsx
@@ -40,11 +40,7 @@ function SearchParamsReadingComponent({
   const fooParams = (
     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
   ).foo
-  return (
-    <div>
-      this component read the accessed the `foo` search param: {fooParams}
-    </div>
-  )
+  return <div>this component read the `foo` search param: {fooParams}</div>
 }
 
 function LongRunningComponent() {

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-with-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-cookies-with-fallback/app/page.tsx
@@ -7,10 +7,9 @@ export default async function Page() {
   return (
     <>
       <p>
-        This page access cookies synchronously and it triggers dynamic before
-        another component is finished which doesn't define a fallback UI with
-        Suspense. This is considered a build error and the message should
-        clearly indicate that it was caused by a synchronous dynamic API usage.
+        This page accesses cookies synchronously but it does so late enough in
+        the render that all unfinished sub-trees have a defined Suspense
+        boundary. This is fine and doesn't need to error the build.
       </p>
       <Suspense fallback={<Fallback />}>
         <IndirectionOne>
@@ -31,8 +30,17 @@ export default async function Page() {
 
 async function CookiesReadingComponent() {
   await new Promise((r) => process.nextTick(r))
-  const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-  return <div>this component read the `token` cookie synchronously</div>
+  const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+
+  console.log(
+    'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+  )
+
+  return (
+    <div>
+      this component read the `token` cookie synchronously: {token?.value}
+    </div>
+  )
 }
 
 async function LongRunningComponent() {

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/app/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/app/indirection.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function IndirectionOne({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/app/page.tsx
@@ -1,0 +1,42 @@
+import { Suspense } from 'react'
+import { draftMode, UnsafeUnwrappedDraftMode } from 'next/headers'
+
+import { IndirectionOne } from './indirection'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page accesses draftMode.isEnabled synchronously. This does not
+        trigger dynamic, and the build should succeed. In dev mode, we do log an
+        error for the sync access though.
+      </p>
+      <Suspense fallback={<Fallback />}>
+        <IndirectionOne>
+          <DraftModeReadingComponent />
+        </IndirectionOne>
+      </Suspense>
+    </>
+  )
+}
+
+async function DraftModeReadingComponent() {
+  await new Promise((r) => process.nextTick(r))
+  const isEnabled = (draftMode() as unknown as UnsafeUnwrappedDraftMode)
+    .isEnabled
+
+  console.log(
+    'This log should be prefixed with the "Prerender" environment, because the sync access above does not lead to an abort.'
+  )
+
+  return (
+    <div>
+      this component read the draftMode isEnabled status synchronously:{' '}
+      <span id="draft-mode">{isEnabled.toString()}</span>
+    </div>
+  )
+}
+
+function Fallback() {
+  return <div data-fallback="">loading...</div>
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-draft-mode/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/app/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/app/indirection.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function IndirectionOne({ children }) {
+  return children
+}
+
+export function IndirectionTwo({ children }) {
+  return children
+}
+
+export function IndirectionThree({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/app/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
-import { cookies, type UnsafeUnwrappedCookies } from 'next/headers'
+import { headers, UnsafeUnwrappedHeaders } from 'next/headers'
 
 import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
 
@@ -7,19 +7,20 @@ export default async function Page() {
   return (
     <>
       <p>
-        This page accesses cookies synchronously and it triggers dynamic before
-        another component is finished which doesn't define a fallback UI with
-        Suspense. This is considered a build error and the message should
-        clearly indicate that it was caused by a synchronous dynamic API usage.
+        This page accesses headers synchronously but it does so late enough in
+        the render that all unfinished sub-trees have a defined Suspense
+        boundary. This is fine and doesn't need to error the build.
       </p>
       <Suspense fallback={<Fallback />}>
         <IndirectionOne>
-          <CookiesReadingComponent />
+          <HeadersReadingComponent />
         </IndirectionOne>
       </Suspense>
-      <IndirectionTwo>
-        <LongRunningComponent />
-      </IndirectionTwo>
+      <Suspense fallback={<Fallback />}>
+        <IndirectionTwo>
+          <LongRunningComponent />
+        </IndirectionTwo>
+      </Suspense>
       <IndirectionThree>
         <ShortRunningComponent />
       </IndirectionThree>
@@ -27,15 +28,21 @@ export default async function Page() {
   )
 }
 
-async function CookiesReadingComponent() {
+async function HeadersReadingComponent() {
   await new Promise((r) => process.nextTick(r))
-  const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+  const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+    'user-agent'
+  )
 
   console.log(
     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
   )
 
-  return <div>this component read the `token` cookie synchronously</div>
+  return (
+    <div>
+      this component read the `user-agent` header synchronously: {userAgent}
+    </div>
+  )
 }
 
 async function LongRunningComponent() {
@@ -48,7 +55,7 @@ async function LongRunningComponent() {
   return (
     <div>
       this component took a long time to resolve (but still before the dynamicIO
-      cutoff). It might not be done before the sync cookies call happens.
+      cutoff). It might not be done before the sync headers call happens.
     </div>
   )
 }
@@ -57,7 +64,7 @@ async function ShortRunningComponent() {
   return (
     <div>
       This component runs quickly (in a microtask). It should be finished before
-      the sync cookies call is triggered.
+      the sync headers call is triggered.
     </div>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-with-fallback/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/app/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/app/indirection.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function IndirectionOne({ children }) {
+  return children
+}
+
+export function IndirectionTwo({ children }) {
+  return children
+}
+
+export function IndirectionThree({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/app/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
-import { cookies, type UnsafeUnwrappedCookies } from 'next/headers'
+import { headers, type UnsafeUnwrappedHeaders } from 'next/headers'
 
 import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
 
@@ -7,14 +7,14 @@ export default async function Page() {
   return (
     <>
       <p>
-        This page accesses cookies synchronously and it triggers dynamic before
+        This page accesses headers synchronously and it triggers dynamic before
         another component is finished which doesn't define a fallback UI with
         Suspense. This is considered a build error and the message should
         clearly indicate that it was caused by a synchronous dynamic API usage.
       </p>
       <Suspense fallback={<Fallback />}>
         <IndirectionOne>
-          <CookiesReadingComponent />
+          <HeadersReadingComponent />
         </IndirectionOne>
       </Suspense>
       <IndirectionTwo>
@@ -27,15 +27,21 @@ export default async function Page() {
   )
 }
 
-async function CookiesReadingComponent() {
+async function HeadersReadingComponent() {
   await new Promise((r) => process.nextTick(r))
-  const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+  const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+    'user-agent'
+  )
 
   console.log(
     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
   )
 
-  return <div>this component read the `token` cookie synchronously</div>
+  return (
+    <div>
+      this component read the `user-agent` header synchronously: {userAgent}
+    </div>
+  )
 }
 
 async function LongRunningComponent() {
@@ -48,7 +54,7 @@ async function LongRunningComponent() {
   return (
     <div>
       this component took a long time to resolve (but still before the dynamicIO
-      cutoff). It might not be done before the sync cookies call happens.
+      cutoff). It might not be done before the sync headers call happens.
     </div>
   )
 }
@@ -57,7 +63,7 @@ async function ShortRunningComponent() {
   return (
     <div>
       This component runs quickly (in a microtask). It should be finished before
-      the sync cookies call is triggered.
+      the sync headers call is triggered.
     </div>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-headers-without-fallback/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/app/[slug]/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/app/[slug]/indirection.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function IndirectionOne({ children }) {
+  return children
+}
+
+export function IndirectionTwo({ children }) {
+  return children
+}
+
+export function IndirectionThree({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/app/[slug]/page.tsx
@@ -1,25 +1,25 @@
 import { Suspense } from 'react'
-import { cookies, type UnsafeUnwrappedCookies } from 'next/headers'
 
 import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
 
-export default async function Page() {
+export default async function Page({ params }) {
   return (
     <>
       <p>
-        This page accesses cookies synchronously and it triggers dynamic before
-        another component is finished which doesn't define a fallback UI with
-        Suspense. This is considered a build error and the message should
-        clearly indicate that it was caused by a synchronous dynamic API usage.
+        This page accesses params synchronously but it does so late enough in
+        the render that all unfinished sub-trees have a defined Suspense
+        boundary. This is fine and doesn't need to error the build.
       </p>
       <Suspense fallback={<Fallback />}>
         <IndirectionOne>
-          <CookiesReadingComponent />
+          <ParamsReadingComponent params={params} />
         </IndirectionOne>
       </Suspense>
-      <IndirectionTwo>
-        <LongRunningComponent />
-      </IndirectionTwo>
+      <Suspense fallback={<Fallback />}>
+        <IndirectionTwo>
+          <LongRunningComponent />
+        </IndirectionTwo>
+      </Suspense>
       <IndirectionThree>
         <ShortRunningComponent />
       </IndirectionThree>
@@ -27,15 +27,15 @@ export default async function Page() {
   )
 }
 
-async function CookiesReadingComponent() {
+async function ParamsReadingComponent({ params }) {
   await new Promise((r) => process.nextTick(r))
-  const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+  const slug = params.slug
 
   console.log(
     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
   )
 
-  return <div>this component read the `token` cookie synchronously</div>
+  return <div>this component read the `slug` param synchronously: {slug}</div>
 }
 
 async function LongRunningComponent() {
@@ -48,7 +48,7 @@ async function LongRunningComponent() {
   return (
     <div>
       this component took a long time to resolve (but still before the dynamicIO
-      cutoff). It might not be done before the sync cookies call happens.
+      cutoff). It might not be done before the sync params call happens.
     </div>
   )
 }
@@ -57,7 +57,7 @@ async function ShortRunningComponent() {
   return (
     <div>
       This component runs quickly (in a microtask). It should be finished before
-      the sync cookies call is triggered.
+      the sync params call is triggered.
     </div>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-with-fallback/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/app/[slug]/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/app/[slug]/indirection.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export function IndirectionOne({ children }) {
+  return children
+}
+
+export function IndirectionTwo({ children }) {
+  return children
+}
+
+export function IndirectionThree({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/app/[slug]/page.tsx
@@ -1,20 +1,19 @@
 import { Suspense } from 'react'
-import { cookies, type UnsafeUnwrappedCookies } from 'next/headers'
 
 import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
 
-export default async function Page() {
+export default async function Page({ params }) {
   return (
     <>
       <p>
-        This page accesses cookies synchronously and it triggers dynamic before
+        This page accesses params synchronously and it triggers dynamic before
         another component is finished which doesn't define a fallback UI with
         Suspense. This is considered a build error and the message should
         clearly indicate that it was caused by a synchronous dynamic API usage.
       </p>
       <Suspense fallback={<Fallback />}>
         <IndirectionOne>
-          <CookiesReadingComponent />
+          <ParamsReadingComponent params={params} />
         </IndirectionOne>
       </Suspense>
       <IndirectionTwo>
@@ -27,15 +26,15 @@ export default async function Page() {
   )
 }
 
-async function CookiesReadingComponent() {
+async function ParamsReadingComponent({ params }) {
   await new Promise((r) => process.nextTick(r))
-  const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+  const slug = params.slug
 
   console.log(
     'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
   )
 
-  return <div>this component read the `token` cookie synchronously</div>
+  return <div>this component read the `slug` param synchronously: {slug}</div>
 }
 
 async function LongRunningComponent() {
@@ -48,7 +47,7 @@ async function LongRunningComponent() {
   return (
     <div>
       this component took a long time to resolve (but still before the dynamicIO
-      cutoff). It might not be done before the sync cookies call happens.
+      cutoff). It might not be done before the sync params call happens.
     </div>
   )
 }
@@ -57,7 +56,7 @@ async function ShortRunningComponent() {
   return (
     <div>
       This component runs quickly (in a microtask). It should be finished before
-      the sync cookies call is triggered.
+      the sync params call is triggered.
     </div>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-params-without-fallback/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-with-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-with-fallback/app/page.tsx
@@ -40,6 +40,11 @@ async function SearchParamsReadingComponent({
   const fooParams = (
     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
   ).foo
+
+  console.log(
+    'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+  )
+
   return (
     <div>
       this component read the accessed the `foo` search param: {fooParams}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-without-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-server-search-without-fallback/app/page.tsx
@@ -10,9 +10,10 @@ export default async function Page(props: {
   return (
     <>
       <p>
-        This page accesses searchParams synchronously but it does so late enough
-        in the render that all unfinished sub-trees have a defined Suspense
-        boundary. This is fine and doesn't need to error the build.
+        This page accesses searchParams synchronously and it triggers dynamic
+        before another component is finished which doesn't define a fallback UI
+        with Suspense. This is considered a build error and the message should
+        clearly indicate that it was caused by a synchronous dynamic API usage.
       </p>
       <Suspense fallback={<Fallback />}>
         <IndirectionOne>
@@ -38,6 +39,11 @@ async function SearchParamsReadingComponent({
   const fooParams = (
     searchParams as unknown as UnsafeUnwrappedSearchParams<typeof searchParams>
   ).foo
+
+  console.log(
+    'This log should be prefixed with the "Server" environment, because the sync IO access above advanced the rendering out of the "Prerender" environment.'
+  )
+
   return (
     <div>
       this component read the accessed the `foo` search param: {fooParams}

--- a/test/e2e/app-dir/dynamic-io-errors/utils.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/utils.ts
@@ -1,6 +1,7 @@
 // Used to deterministically stub out minified local names in stack traces.
 const abc = 'abcdefghijklmnopqrstuvwxyz'
 const hostElementsUsedInFixtures = ['html', 'body', 'main', 'div']
+import escapeStringRegexp from 'escape-string-regexp'
 
 export function getPrerenderOutput(
   cliOutput: string,
@@ -49,4 +50,20 @@ export function getPrerenderOutput(
   }
 
   return lines.join('\n').trim()
+}
+
+export function assertLog(
+  logs: Array<{ source: string; message: string }>,
+  environment: 'Server' | 'Prerender' | 'Cache',
+  message: string
+) {
+  expect(logs.map((l) => l.message)).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(
+        new RegExp(
+          `^.*${escapeStringRegexp(message)}.*  \\b${environment}\\b  $`
+        )
+      ),
+    ])
+  )
 }


### PR DESCRIPTION
With this PR, we're adding test fixtures for `headers()`, `draftMode()`, and (fallback) `params`, by more or less copy&pasting the fixture for `cookies()`.

We're also adding assertions for environment prefixes of `console.log()` calls that happen after the sync IO access.