### PR TITLE
refactor(turbopack): Make `create_visitor` rustfmt-able

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -269,9 +269,9 @@ macro_rules! create_visitor {
     ($ast_path:expr, $name:ident, |$arg:ident: &mut $ty:ident| $b:block) => {
         $crate::create_visitor!(__ $crate::code_gen::path_to(&$ast_path, |n| {
             matches!(n, swc_core::ecma::visit::AstParentKind::$ty(_))
-        }), $name($arg: &mut $ty) $b)
+        }), $name, |$arg: &mut $ty| $b)
     };
-    (__ $ast_path:expr, $name:ident($arg:ident: &mut $ty:ident) $b:block) => {{
+    (__ $ast_path:expr, $name:ident, |$arg:ident: &mut $ty:ident| $b:block) => {{
         struct Visitor<T: Fn(&mut swc_core::ecma::ast::$ty) + Send + Sync> {
             $name: T,
         }

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -263,10 +263,10 @@ pub fn path_to(
 /// possible visit methods.
 #[macro_export]
 macro_rules! create_visitor {
-    (exact $ast_path:expr, $name:ident($arg:ident: &mut $ty:ident) $b:block) => {
-        $crate::create_visitor!(__ $ast_path.to_vec(), $name($arg: &mut $ty) $b)
+    (exact, $ast_path:expr, $name:ident, |$arg:ident: &mut $ty:ident| $b:block) => {
+        $crate::create_visitor!(__ $ast_path.to_vec(), $name, |$arg: &mut $ty| $b)
     };
-    ($ast_path:expr, $name:ident($arg:ident: &mut $ty:ident) $b:block) => {
+    ($ast_path:expr, $name:ident, |$arg:ident: &mut $ty:ident| $b:block) => {
         $crate::create_visitor!(__ $crate::code_gen::path_to(&$ast_path, |n| {
             matches!(n, swc_core::ecma::visit::AstParentKind::$ty(_))
         }), $name($arg: &mut $ty) $b)

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -202,11 +202,14 @@ impl AmdDefineWithDependenciesCodeGen {
 
         let factory_type = self.factory_type;
 
-        visitors.push(
-            create_visitor!(exact self.path, visit_mut_call_expr(call_expr: &mut CallExpr) {
+        visitors.push(create_visitor!(
+            exact,
+            self.path,
+            visit_mut_call_expr,
+            |call_expr: &mut CallExpr| {
                 transform_amd_factory(call_expr, &resolved_elements, factory_type)
-            }),
-        );
+            }
+        ));
 
         Ok(CodeGeneration::visitors(visitors))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
@@ -36,15 +36,24 @@ impl ConstantConditionCodeGen {
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let value = self.value;
-        let visitors = [
-            create_visitor!(exact self.path, visit_mut_expr(expr: &mut Expr) {
+        let visitors = [create_visitor!(
+            exact,
+            self.path,
+            visit_mut_expr,
+            |expr: &mut Expr| {
                 *expr = match value {
-                    ConstantConditionValue::Truthy => quote!("(\"TURBOPACK compile-time truthy\", 1)" as Expr),
-                    ConstantConditionValue::Falsy => quote!("(\"TURBOPACK compile-time falsy\", 0)" as Expr),
-                    ConstantConditionValue::Nullish => quote!("(\"TURBOPACK compile-time nullish\", null)" as Expr),
+                    ConstantConditionValue::Truthy => {
+                        quote!("(\"TURBOPACK compile-time truthy\", 1)" as Expr)
+                    }
+                    ConstantConditionValue::Falsy => {
+                        quote!("(\"TURBOPACK compile-time falsy\", 0)" as Expr)
+                    }
+                    ConstantConditionValue::Nullish => {
+                        quote!("(\"TURBOPACK compile-time nullish\", null)" as Expr)
+                    }
                 };
-            }),
-        ]
+            }
+        )]
         .into();
 
         Ok(CodeGeneration::visitors(visitors))

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -41,14 +41,24 @@ impl ConstantValueCodeGen {
     ) -> Result<CodeGeneration> {
         let value = self.value.clone();
 
-        let visitor = create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
+        let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
             *expr = match value {
-                CompileTimeDefineValue::Bool(true) => quote!("(\"TURBOPACK compile-time value\", true)" as Expr),
-                CompileTimeDefineValue::Bool(false) => quote!("(\"TURBOPACK compile-time value\", false)" as Expr),
-                CompileTimeDefineValue::String(ref s) => quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = s.to_string().into()),
-                CompileTimeDefineValue::JSON(ref s) => quote!("(\"TURBOPACK compile-time value\", JSON.parse($e))" as Expr, e: Expr = s.to_string().into()),
+                CompileTimeDefineValue::Bool(true) => {
+                    quote!("(\"TURBOPACK compile-time value\", true)" as Expr)
+                }
+                CompileTimeDefineValue::Bool(false) => {
+                    quote!("(\"TURBOPACK compile-time value\", false)" as Expr)
+                }
+                CompileTimeDefineValue::String(ref s) => {
+                    quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = s.to_string().into())
+                }
+                CompileTimeDefineValue::JSON(ref s) => {
+                    quote!("(\"TURBOPACK compile-time value\", JSON.parse($e))" as Expr, e: Expr = s.to_string().into())
+                }
                 // undefined can be re-bound, so use `void 0` to avoid any risks
-                CompileTimeDefineValue::Undefined => quote!("(\"TURBOPACK compile-time value\", void 0)" as Expr),
+                CompileTimeDefineValue::Undefined => {
+                    quote!("(\"TURBOPACK compile-time value\", void 0)" as Expr)
+                }
             };
         });
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
@@ -44,13 +44,21 @@ impl DynamicExpression {
     ) -> Result<CodeGeneration> {
         let visitor = match self.ty {
             DynamicExpressionType::Normal => {
-                create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
-                    *expr = quote!("(() => { const e = new Error(\"Cannot find module as expression is too dynamic\"); e.code = 'MODULE_NOT_FOUND'; throw e; })()" as Expr);
+                create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
+                    *expr = quote!(
+                        "(() => { const e = new Error(\"Cannot find module as expression is too \
+                         dynamic\"); e.code = 'MODULE_NOT_FOUND'; throw e; })()"
+                            as Expr
+                    );
                 })
             }
             DynamicExpressionType::Promise => {
-                create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
-                    *expr = quote!("Promise.resolve().then(() => { const e = new Error(\"Cannot find module as expression is too dynamic\"); e.code = 'MODULE_NOT_FOUND'; throw e; })" as Expr);
+                create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
+                    *expr = quote!(
+                        "Promise.resolve().then(() => { const e = new Error(\"Cannot find module \
+                         as expression is too dynamic\"); e.code = 'MODULE_NOT_FOUND'; throw e; })"
+                            as Expr
+                    );
                 })
             }
         };

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -87,22 +87,26 @@ impl EsmBinding {
                 // normal key-value pairs.
                 Some(swc_core::ecma::visit::AstParentKind::Prop(PropField::Shorthand)) => {
                     ast_path.pop();
-                    visitors.push(
-                        create_visitor!(exact ast_path, visit_mut_prop(prop: &mut Prop) {
+                    visitors.push(create_visitor!(
+                        exact,
+                        ast_path,
+                        visit_mut_prop,
+                        |prop: &mut Prop| {
                             if let Prop::Shorthand(ident) = prop {
                                 // TODO: Merge with the above condition when https://rust-lang.github.io/rfcs/2497-if-let-chains.html lands.
                                 match &imported_ident {
                                     ImportedIdent::Module(imported_ident) => {
                                         *prop = Prop::KeyValue(KeyValueProp {
                                             key: PropName::Ident(ident.clone().into()),
-                                            value: Box::new(imported_ident.as_expr(ident.span, false))
+                                            value: Box::new(
+                                                imported_ident.as_expr(ident.span, false),
+                                            ),
                                         });
                                     }
                                     ImportedIdent::None => {
                                         *prop = Prop::KeyValue(KeyValueProp {
                                             key: PropName::Ident(ident.clone().into()),
-                                            value:
-                                            Expr::undefined(ident.span),
+                                            value: Expr::undefined(ident.span),
                                         });
                                     }
                                     ImportedIdent::Unresolvable => {
@@ -110,8 +114,8 @@ impl EsmBinding {
                                     }
                                 }
                             }
-                        }),
-                    );
+                        }
+                    ));
                     break;
                 }
                 // Any other expression can be replaced with the import accessor.
@@ -125,8 +129,11 @@ impl EsmBinding {
                             ))
                         );
 
-                    visitors.push(
-                        create_visitor!(exact ast_path, visit_mut_expr(expr: &mut Expr) {
+                    visitors.push(create_visitor!(
+                        exact,
+                        ast_path,
+                        visit_mut_expr,
+                        |expr: &mut Expr| {
                             use swc_core::common::Spanned;
                             match &imported_ident {
                                 ImportedIdent::Module(imported_ident) => {
@@ -139,8 +146,8 @@ impl EsmBinding {
                                     // Do nothing, the reference will insert a throw
                                 }
                             }
-                        }),
-                    );
+                        }
+                    ));
                     break;
                 }
                 Some(swc_core::ecma::visit::AstParentKind::BindingIdent(
@@ -156,8 +163,11 @@ impl EsmBinding {
                     {
                         ast_path.pop();
 
-                        visitors.push(
-                            create_visitor!(exact ast_path, visit_mut_simple_assign_target(l: &mut SimpleAssignTarget) {
+                        visitors.push(create_visitor!(
+                            exact,
+                            ast_path,
+                            visit_mut_simple_assign_target,
+                            |l: &mut SimpleAssignTarget| {
                                 use swc_core::common::Spanned;
                                 match &imported_ident {
                                     ImportedIdent::Module(imported_ident) => {
@@ -176,8 +186,8 @@ impl EsmBinding {
                                         // Do nothing, the reference will insert a throw
                                     }
                                 }
-                            })
-                        );
+                            }
+                        ));
                         break;
                     }
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -154,21 +154,23 @@ impl EsmAsyncAssetReferenceCodeGen {
 
         let import_externals = reference.import_externals;
 
-        let visitor = create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
+        let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
             let old_expr = expr.take();
-            let message = if let Expr::Call(CallExpr { args, ..}) = old_expr {
+            let message = if let Expr::Call(CallExpr { args, .. }) = old_expr {
                 match args.into_iter().next() {
-                    Some(ExprOrSpread { spread: None, expr: key_expr }) => {
+                    Some(ExprOrSpread {
+                        spread: None,
+                        expr: key_expr,
+                    }) => {
                         *expr = pm.create_import(*key_expr, import_externals);
                         return;
                     }
                     // These are SWC bugs: https://github.com/swc-project/swc/issues/5394
-                    Some(ExprOrSpread { spread: Some(_), expr: _ }) => {
-                        "spread operator is illegal in import() expressions."
-                    }
-                    _ => {
-                        "import() expressions require at least 1 argument"
-                    }
+                    Some(ExprOrSpread {
+                        spread: Some(_),
+                        expr: _,
+                    }) => "spread operator is illegal in import() expressions.",
+                    _ => "import() expressions require at least 1 argument",
                 }
             } else {
                 "visitor must be executed on a CallExpr"
@@ -184,7 +186,7 @@ impl EsmAsyncAssetReferenceCodeGen {
                     expr: error,
                 }],
                 span: DUMMY_SP,
-               ..Default::default()
+                ..Default::default()
             });
         });
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -101,7 +101,7 @@ impl ImportMetaRef {
         _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
-        let visitor = create_visitor!(self.ast_path, visit_mut_expr(expr: &mut Expr) {
+        let visitor = create_visitor!(self.ast_path, visit_mut_expr, |expr: &mut Expr| {
             *expr = Expr::Ident(meta_ident());
         });
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -93,16 +93,24 @@ impl EsmModuleIdAssetReferenceCodeGen {
         {
             let id = asset.chunk_item_id(Vc::upcast(chunking_context)).await?;
             let id = module_id_to_lit(&id);
-            visitors.push(create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
-                *expr = id.clone()
-            }));
+            visitors.push(create_visitor!(
+                self.path,
+                visit_mut_expr,
+                |expr: &mut Expr| {
+                    *expr = id.clone();
+                }
+            ));
         } else {
             // If the referenced asset can't be found, replace the expression with null.
             // This can happen if the referenced asset is an external, or doesn't resolve
             // to anything.
-            visitors.push(create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
-                *expr = quote!("null" as Expr);
-            }));
+            visitors.push(create_visitor!(
+                self.path,
+                visit_mut_expr,
+                |expr: &mut Expr| {
+                    *expr = quote!("null" as Expr);
+                }
+            ));
         }
 
         Ok(CodeGeneration::visitors(visitors))

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -40,7 +40,7 @@ impl EsmModuleItem {
         let mut visitors = Vec::new();
 
         visitors.push(
-            create_visitor!(self.path, visit_mut_module_item(module_item: &mut ModuleItem) {
+            create_visitor!(self.path, visit_mut_module_item, |module_item: &mut ModuleItem| {
                 let item = replace(module_item, ModuleItem::Stmt(quote!(";" as Stmt)));
                 if let ModuleItem::ModuleDecl(module_decl) = item {
                     match module_decl {

--- a/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
@@ -29,7 +29,7 @@ impl IdentReplacement {
     ) -> Result<CodeGeneration> {
         let value = self.value.clone();
 
-        let visitor = create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
+        let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
             let id = Expr::Ident((&*value).into());
             *expr = quote!("(\"TURBOPACK ident replacement\", $e)" as Expr, e: Expr = id);
         });

--- a/turbopack/crates/turbopack-ecmascript/src/references/member.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/member.rs
@@ -35,7 +35,7 @@ impl MemberReplacement {
         let key = self.key.clone();
         let value = self.value.clone();
 
-        let visitor = create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
+        let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
             let member = Expr::Member(MemberExpr {
                 span: DUMMY_SP,
                 obj: Box::new(Expr::Ident((&*key).into())),

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -325,16 +325,20 @@ impl RequireContextAssetReferenceCodeGen {
 
         let mut visitors = Vec::new();
 
-        visitors.push(create_visitor!(self.path, visit_mut_expr(expr: &mut Expr) {
-            if let Expr::Call(_) = expr {
-                *expr = quote!(
-                    "$turbopack_module_context($turbopack_require($id))" as Expr,
-                    turbopack_module_context: Expr = TURBOPACK_MODULE_CONTEXT.into(),
-                    turbopack_require: Expr = TURBOPACK_REQUIRE.into(),
-                    id: Expr = module_id_to_lit(&module_id)
-                );
+        visitors.push(create_visitor!(
+            self.path,
+            visit_mut_expr,
+            |expr: &mut Expr| {
+                if let Expr::Call(_) = expr {
+                    *expr = quote!(
+                        "$turbopack_module_context($turbopack_require($id))" as Expr,
+                        turbopack_module_context: Expr = TURBOPACK_MODULE_CONTEXT.into(),
+                        turbopack_require: Expr = TURBOPACK_REQUIRE.into(),
+                        id: Expr = module_id_to_lit(&module_id)
+                    );
+                }
             }
-        }));
+        ));
 
         Ok(CodeGeneration::visitors(visitors))
     }


### PR DESCRIPTION
### What?

Make `create_visitor!` macro work with rustfmt

### Why?

It's better!

### How?

Closes PACK-4922

