### PR TITLE
[turbopack[ Fix a bug in top level `this` analysis

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -797,11 +797,13 @@ pub fn is_in_try(ast_path: &AstNodePath<AstParentNodeRef<'_>>) -> bool {
         .iter()
         .rev()
         .find_map(|ast_ref| match ast_ref.kind() {
-            AstParentKind::ArrowExpr(ArrowExprField::Body) => Some(false),
-            AstParentKind::Function(FunctionField::Body) => Some(false),
-            AstParentKind::Constructor(ConstructorField::Body) => Some(false),
-            AstParentKind::ClassMethod(ClassMethodField::Function) => Some(false),
-            AstParentKind::MethodProp(MethodPropField::Function) => Some(false),
+            AstParentKind::ArrowExpr(ArrowExprField::Body)
+            | AstParentKind::Function(FunctionField::Body)
+            | AstParentKind::Constructor(ConstructorField::Body)
+            | AstParentKind::ClassMethod(ClassMethodField::Function)
+            | AstParentKind::GetterProp(GetterPropField::Body)
+            | AstParentKind::SetterProp(SetterPropField::Body)
+            | AstParentKind::MethodProp(MethodPropField::Function) => Some(false),
             AstParentKind::TryStmt(TryStmtField::Block) => Some(true),
             _ => None,
         })
@@ -1928,6 +1930,8 @@ impl VisitAstPath for Analyzer<'_> {
             matches!(
                 node.kind(),
                 AstParentKind::MethodProp(MethodPropField::Function)
+                    | AstParentKind::GetterProp(GetterPropField::Body)
+                    | AstParentKind::SetterProp(SetterPropField::Body)
                     | AstParentKind::Constructor(ConstructorField::Body)
                     | AstParentKind::ClassMethod(ClassMethodField::Function)
                     | AstParentKind::ClassDecl(ClassDeclField::Class)

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
@@ -7,7 +7,8 @@ it('`this` in cjs should be exports', () => {
       return this
     },
   }
-  expect(o.foo).toBe(exports)
+  // Regression test for a bug where we didn't identify the `this` ref in `foo` as being bound.
+  expect(o.foo).toBe(o)
 })
 
 // Use a dummy assignment to ensure we are parsed as a cjs module

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/cjs-this/input/index.js
@@ -2,6 +2,12 @@ const t = this
 
 it('`this` in cjs should be exports', () => {
   expect(t).toBe(exports)
+  let o = {
+    get foo() {
+      return this
+    },
+  }
+  expect(o.foo).toBe(exports)
 })
 
 // Use a dummy assignment to ensure we are parsed as a cjs module

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
@@ -7,7 +7,8 @@ it('`this` in esm should be undefined', () => {
       return this
     },
   }
-  expect(o.foo).toBeUndefined()
+  // Regression test for a bug where we didn't identify the `this` ref in `foo` as being bound.
+  expect(o.foo).toBe(o)
 })
 
 // Use a dummy export to ensure this is parsed as an esm module

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
@@ -2,6 +2,12 @@ const t = this
 
 it('`this` in esm should be undefined', () => {
   expect(t).toBeUndefined()
+  let o = {
+    get foo() {
+      return this
+    },
+  }
+  expect(o.foo).toBeUndefined()
 })
 
 // Use a dummy export to ensure this is parsed as an esm module


### PR DESCRIPTION
### What

Fix a bug where we incorrectly identified a `this` reference in a getter prop of an object literal as being 'top level'.

Reported here: https://github.com/vercel/next.js/pull/80925#issuecomment-3018327194

Closes PACK-4945