### PR TITLE
[turbopack] Defend against json cyles in our execution tests

### DIFF
--- a/turbopack/crates/turbopack-tests/js/jest-entry.ts
+++ b/turbopack/crates/turbopack-tests/js/jest-entry.ts
@@ -36,7 +36,7 @@ export default async function run() {
   await import('TESTS')
 
   let jestResult = await jest.run()
-  // Jest test results can contain references to arbirtrary objects.
+  // Jest test results can contain references to arbitrary objects.
   // Defensively remove circular references to avoid breaking our serialization protocol.
   const seen = new Set()
   jestResult = JSON.parse(

--- a/turbopack/crates/turbopack-tests/js/jest-entry.ts
+++ b/turbopack/crates/turbopack-tests/js/jest-entry.ts
@@ -35,7 +35,23 @@ export default async function run() {
 
   await import('TESTS')
 
-  const jestResult = await jest.run()
+  let jestResult = await jest.run()
+  // Jest test results can contain references to arbirtrary objects.
+  // Defensively remove circular references to avoid breaking our serialization protocol.
+  const seen = new Set()
+  jestResult = JSON.parse(
+    JSON.stringify(jestResult, (k, v) => {
+      if (v != null && typeof v === 'object') {
+        if (!seen.has(v)) {
+          seen.add(v)
+          return v
+        } else {
+          return 'CIRCULAR_REFERENCE_REMOVED'
+        }
+      }
+      return v
+    })
+  )
 
   // Wait a full tick for unhandledRejection handlers to run -- a microtask is not sufficient.
   await new Promise((resolve) => setTimeout(resolve, 0))

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
@@ -8,7 +8,7 @@ it('`this` in esm should be undefined', () => {
     },
   }
   // Regression test for a bug where we didn't identify the `this` ref in `foo` as being bound.
-  expect(o.foo).toBe(o)
+  expect(o.foo).toBe(undefined)
 })
 
 // Use a dummy export to ensure this is parsed as an esm module

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js
@@ -8,7 +8,7 @@ it('`this` in esm should be undefined', () => {
     },
   }
   // Regression test for a bug where we didn't identify the `this` ref in `foo` as being bound.
-  expect(o.foo).toBe(undefined)
+  expect(o.foo).toBe(o)
 })
 
 // Use a dummy export to ensure this is parsed as an esm module


### PR DESCRIPTION
Handle circular references in Jest test results 

Otherwise failing tests may crash the IPC mechanism. e.g. a test failure induced this

```
──── STDERR:             turbopack-tests::execution test_tests__execution__turbopack__basic__esm_this
Input: /Users/lukesandberg/projects/next.js/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this
new file turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/issues/Error evaluating Node.js code-4c12f2.txt detected:
--- expected
+++ actual
@@ -0,0 +1,6 @@
+error - [transform] [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js  Error evaluating Node.js code
+  TypeError: Converting circular structure to JSON
+      --> starting at object with constructor 'Object'
+      --- property 'foo' closes the circle
+      [at <anonymous>]
+      at run (turbopack:///[turbopack-node]/ipc/evaluate.ts:96:52) [WORKSPACE_ROOT/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/output/[turbopack-node]__b000890d._.js:414:66]
\ No newline at end of file
```

With this change we can see the actual test failure

```
thread 'test_tests__execution__turbopack__basic__esm_this' panicked at turbopack/crates/turbopack-tests/tests/execution.rs:106:9:
Failed with error(s) in the following test(s):

"`this` in esm should be undefined":
Error: expect(received).toBe(expected) // Object.is equality

Expected: undefined
Received: {"foo": [Circular]}
    at Object.eval (file:///Users/lukesandberg/projects/next.js/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/output/b1abf_turbopack-tests_tests_execution_turbopack_basic_esm-this_input_index_021e2195.js:18:19)
    at Promise.then.completed (/Users/lukesandberg/projects/next.js/node_modules/.pnpm/jest-circus@29.5.0/node_modules/jest-circus/build/utils.js:293:28)

```

Closes PACK-4964