### PR TITLE
[devtools]: move RestartServerButton to panel footer

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
@@ -2,13 +2,16 @@ import type { OverlayState } from '../../shared'
 
 import { DevToolsPanelVersionInfo } from './devtools-panel-version-info'
 import { css } from '../../utils/css'
+import { RestartServerButton } from '../errors/error-overlay-toolbar/restart-server-button'
 
 export function DevToolsPanelFooter({
   versionInfo,
   isDraggable,
+  showRestartServerButton,
 }: {
   versionInfo: OverlayState['versionInfo']
   isDraggable: boolean
+  showRestartServerButton: boolean
 }) {
   const bundlerName = (
     process.env.__NEXT_BUNDLER || 'WEBPACK'
@@ -32,6 +35,11 @@ export function DevToolsPanelFooter({
           </span>
         </div>
       </div>
+      {showRestartServerButton && (
+        <div data-nextjs-devtools-panel-footer-tab-group>
+          <RestartServerButton showButton={true} />
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -231,6 +231,7 @@ export function DevToolsPanel({
             <DevToolsPanelFooter
               versionInfo={state.versionInfo}
               isDraggable={!isFullscreen}
+              showRestartServerButton={state.showRestartServerButton}
             />
           </Dialog>
         </>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -61,6 +61,7 @@ const state: OverlayState = {
   isErrorOverlayOpen: false,
   // TODO: This will be handled on the next stack——with proper story.
   isDevToolsPanelOpen: false,
+  showRestartServerButton: false,
   devToolsPosition: 'bottom-left',
   scale: 1,
   page: '',

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -2,7 +2,6 @@ import type { DebugInfo } from '../../../../shared/types'
 import { NodejsInspectorButton } from './nodejs-inspector-button'
 import { CopyStackTraceButton } from './copy-stack-trace-button'
 import { DocsLinkButton } from './docs-link-button'
-import { RestartServerButton } from './restart-server-button'
 
 type ErrorOverlayToolbarProps = {
   error: Error
@@ -19,9 +18,6 @@ export function ErrorOverlayToolbar({
     <span className="error-overlay-toolbar">
       {/* TODO: Move the button inside and remove the feedback on the footer of the error overlay.  */}
       {feedbackButton}
-      {process.env.__NEXT_BUNDLER_HAS_PERSISTENT_CACHE && (
-        <RestartServerButton error={error} />
-      )}
       <CopyStackTraceButton error={error} />
       <DocsLinkButton errorMessage={error.message} />
       <NodejsInspectorButton

--- a/packages/next/src/next-devtools/dev-overlay/container/runtime-error/render-error.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/runtime-error/render-error.tsx
@@ -1,4 +1,5 @@
 import type { OverlayState } from '../../shared'
+import type { OverlayDispatch } from '../../shared'
 
 import { useMemo, useState, useEffect } from 'react'
 import {
@@ -7,6 +8,7 @@ import {
 } from '../../utils/get-error-by-type'
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import type { ComponentStackFrame } from '../../utils/parse-component-stack'
+import { usePersistentCacheErrorDetection } from '../../components/errors/error-overlay-toolbar/restart-server-button'
 
 export type SupportedErrorEvent = {
   id: number
@@ -23,6 +25,7 @@ type Props = {
   }) => React.ReactNode
   state: OverlayState
   isAppDir: boolean
+  dispatch: OverlayDispatch
 }
 
 export const RenderError = (props: Props) => {
@@ -36,7 +39,7 @@ export const RenderError = (props: Props) => {
   }
 }
 
-const RenderRuntimeError = ({ children, state, isAppDir }: Props) => {
+const RenderRuntimeError = ({ children, state, isAppDir, dispatch }: Props) => {
   const { errors } = state
 
   const [lookups, setLookups] = useState<{
@@ -64,6 +67,8 @@ const RenderRuntimeError = ({ children, state, isAppDir }: Props) => {
 
     return [ready, next]
   }, [errors, lookups])
+
+  usePersistentCacheErrorDetection({ errors, dispatch })
 
   useEffect(() => {
     if (nextError == null) {

--- a/packages/next/src/next-devtools/dev-overlay/dev-overlay.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/dev-overlay.tsx
@@ -58,7 +58,7 @@ export function DevOverlay({
       <ComponentStyles />
       <DarkTheme />
 
-      <RenderError state={state} isAppDir={true}>
+      <RenderError state={state} dispatch={dispatch} isAppDir={true}>
         {({ runtimeErrors, totalErrorCount }) => {
           return (
             <>

--- a/packages/next/src/next-devtools/dev-overlay/shared.ts
+++ b/packages/next/src/next-devtools/dev-overlay/shared.ts
@@ -36,6 +36,10 @@ export interface OverlayState {
   staticIndicator: boolean
   showIndicator: boolean
   disableDevIndicator: boolean
+  /** Whether to show the restart server button in the panel UI. Currently
+   *  only used when Turbopack + Persistent Cache is enabled.
+   */
+  showRestartServerButton: boolean
   debugInfo: DebugInfo
   routerType: 'pages' | 'app'
   /** This flag is used to handle the Error Overlay state in the "old" overlay.
@@ -76,6 +80,7 @@ export const ACTION_DEVTOOLS_PANEL_TOGGLE = 'devtools-panel-toggle'
 
 export const ACTION_DEVTOOLS_POSITION = 'devtools-position'
 export const ACTION_DEVTOOLS_SCALE = 'devtools-scale'
+export const ACTION_RESTART_SERVER_BUTTON = 'restart-server-button'
 
 export const STORAGE_KEY_THEME = '__nextjs-dev-tools-theme'
 export const STORAGE_KEY_POSITION = '__nextjs-dev-tools-position'
@@ -176,6 +181,11 @@ export interface DevToolUpdateRouteStateAction {
   page: string
 }
 
+export interface RestartServerButtonAction {
+  type: typeof ACTION_RESTART_SERVER_BUTTON
+  showRestartServerButton: boolean
+}
+
 export type DispatcherEvent =
   | BuildOkAction
   | BuildErrorAction
@@ -200,6 +210,8 @@ export type DispatcherEvent =
   | DevToolsIndicatorPositionAction
   | DevToolsScaleAction
   | DevToolUpdateRouteStateAction
+  | RestartServerButtonAction
+
 const REACT_ERROR_STACK_BOTTOM_FRAME_REGEX =
   // 1st group: v8
   // 2nd group: SpiderMonkey, JavaScriptCore
@@ -238,6 +250,7 @@ export const INITIAL_OVERLAY_STATE: Omit<
   versionInfo: { installed: '0.0.0', staleness: 'unknown' },
   debugInfo: { devtoolsFrontendUrl: undefined },
   isDevToolsPanelOpen: false,
+  showRestartServerButton: false,
   devToolsPosition: 'bottom-left',
   scale: NEXT_DEV_TOOLS_SCALE.Medium,
   page: '',
@@ -420,6 +433,12 @@ export function useErrorOverlayReducer(
         }
         case ACTION_DEVTOOL_UPDATE_ROUTE_STATE: {
           return { ...state, page: action.page }
+        }
+        case ACTION_RESTART_SERVER_BUTTON: {
+          return {
+            ...state,
+            showRestartServerButton: action.showRestartServerButton,
+          }
         }
         default: {
           return state


### PR DESCRIPTION
This moves the restart button to the footer in the new panel UI. It also properly gates to only be enabled with Turbopack + Persistent Cache.

Because it's no longer part of the error overlay, I refactored the logic a bit to hoist the flag into overlay state and setup the beforeunload listener from within the error renderer.

This heuristic still feels a bit unreliable and I'm not entirely convinced how useful it is yet, but the goal with this PR is just to get it to render in the right spot for now. 

![CleanShot 2025-06-30 at 10 24 12@2x](https://github.com/user-attachments/assets/7c96b7ad-0b90-4a08-9b9d-5bea02348ab8)

Closes NEXT-4561
