### PR TITLE
cleanup(turbopack) Show users an error message when Webpack loaders have a glob in only the extension

### DIFF
--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -17,7 +17,9 @@ pub async fn webpack_loader_options(
     foreign: bool,
     condition_strs: Vec<RcStr>,
 ) -> Result<Option<ResolvedVc<WebpackLoadersOptions>>> {
-    let rules = *next_config.webpack_rules(condition_strs).await?;
+    let rules = *next_config
+        .webpack_rules(condition_strs, project_path.clone())
+        .await?;
     let rules = *maybe_add_sass_loader(next_config.sass_config(), rules.map(|v| *v)).await?;
     let rules = if foreign {
         rules


### PR DESCRIPTION
This PR adds validation for webpack loader rules in Next.js configuration to prevent a common issue where users define wildcard extensions without corresponding wildcard patterns in the `as` option. This situation causes all modules to be transformed into the same name, resulting in duplicate module errors.

The changes:
- Add a new `InvalidLoaderRuleError` issue type that provides clear error messages when this misconfiguration is detected
- Check if an extension contains a wildcard (`*`) but the `rename_as` option does not
- Display helpful error messages with links to documentation when this issue is found
- Update the `webpack_rules` function to accept the project path for error reporting

This validation helps users avoid confusing duplicate module errors by providing clear guidance on how to properly configure webpack loaders in Next.js.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/IhNrutw2qOTgYcgE6MlR/6bae20b6-34b0-4643-9a5c-f580ba32c550.png)



Closes PACK-4988