### PR TITLE
feat: handle rootParams in routes (finish changes)

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -4,8 +4,8 @@ use next_core::{
     app_segment_config::NextSegmentConfig,
     app_structure::{
         AppPageLoaderTree, CollectedRootParams, Entrypoint as AppEntrypoint,
-        Entrypoints as AppEntrypoints, FileSystemPathVec, MetadataItem, collect_root_params,
-        get_entrypoints,
+        Entrypoints as AppEntrypoints, FileSystemPathVec, MetadataItem, RootParamVecOption,
+        collect_root_params, get_entrypoints,
     },
     get_edge_resolve_options_context, get_next_package,
     next_app::{
@@ -991,7 +991,10 @@ pub fn app_entry_point_to_route(
 ) -> Vc<Route> {
     match entrypoint {
         AppEntrypoint::AppPage {
-            pages, loader_tree, ..
+            pages,
+            loader_tree,
+            root_params,
+            ..
         } => Route::AppPage(
             pages
                 .into_iter()
@@ -1005,6 +1008,7 @@ pub fn app_entry_point_to_route(
                             },
                             app_project,
                             page: page.clone(),
+                            root_params,
                         }
                         .resolved_cell(),
                     ),
@@ -1016,6 +1020,7 @@ pub fn app_entry_point_to_route(
                             },
                             app_project,
                             page,
+                            root_params,
                         }
                         .resolved_cell(),
                     ),
@@ -1026,6 +1031,7 @@ pub fn app_entry_point_to_route(
             page,
             path,
             root_layouts,
+            root_params,
             ..
         } => Route::AppRoute {
             original_name: page.to_string().into(),
@@ -1034,17 +1040,24 @@ pub fn app_entry_point_to_route(
                     ty: AppEndpointType::Route { path, root_layouts },
                     app_project,
                     page,
+                    root_params,
                 }
                 .resolved_cell(),
             ),
         },
-        AppEntrypoint::AppMetadata { page, metadata, .. } => Route::AppRoute {
+        AppEntrypoint::AppMetadata {
+            page,
+            metadata,
+            root_params,
+            ..
+        } => Route::AppRoute {
             original_name: page.to_string().into(),
             endpoint: ResolvedVc::upcast(
                 AppEndpoint {
                     ty: AppEndpointType::Metadata { metadata },
                     app_project,
                     page,
+                    root_params,
                 }
                 .resolved_cell(),
             ),
@@ -1082,6 +1095,7 @@ struct AppEndpoint {
     ty: AppEndpointType,
     app_project: ResolvedVc<AppProject>,
     page: AppPage,
+    root_params: ResolvedVc<RootParamVecOption>,
 }
 
 #[turbo_tasks::value_impl]
@@ -1136,6 +1150,7 @@ impl AppEndpoint {
                 .clone_value(),
             config,
             next_config,
+            *self.root_params,
         ))
     }
 

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -103,6 +103,7 @@ pub async fn get_app_metadata_route_entry(
         project_root,
         Some(segment_config),
         next_config,
+        Vc::cell(None), // Metadata routes don't have root params
     ))
 }
 

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -71,7 +71,6 @@ import {
 } from '../lib/is-internal-component'
 import { isMetadataRouteFile } from '../lib/metadata/is-metadata-route'
 import { RouteKind } from '../server/route-kind'
-import { encodeToBase64 } from './webpack/loaders/utils'
 import { normalizeCatchAllRoutes } from './normalize-catchall-routes'
 import type { PageExtensions } from './page-extensions-type'
 import type { MappedPages } from './build-context'
@@ -718,7 +717,10 @@ export async function createEntrypoints(
               page,
               name: serverBundlePath,
               pagePath: absolutePagePath,
-              rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+              rootParams:
+                (staticInfo as AppPageStaticInfo).rootParams?.map(
+                  (p) => p.param
+                ) || [],
               appDir,
               appPaths: matchedAppPaths,
               pageExtensions,
@@ -726,7 +728,9 @@ export async function createEntrypoints(
               assetPrefix: config.assetPrefix,
               nextConfigOutput: config.output,
               preferredRegion: staticInfo.preferredRegion,
-              middlewareConfig: encodeToBase64(staticInfo.middleware || {}),
+              middlewareConfig: Buffer.from(
+                JSON.stringify(staticInfo.middleware || {})
+              ).toString('base64'),
               isGlobalNotFoundEnabled: config.experimental.globalNotFound
                 ? true
                 : undefined,
@@ -797,7 +801,10 @@ export async function createEntrypoints(
                 name: serverBundlePath,
                 page,
                 pagePath: absolutePagePath,
-                rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+                rootParams:
+                  (staticInfo as AppPageStaticInfo).rootParams?.map(
+                    (p) => p.param
+                  ) || [],
                 appDir: appDir!,
                 appPaths: matchedAppPaths,
                 pageExtensions,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
@@ -11,7 +11,6 @@ import { AppPathnameNormalizer } from '../../../../server/normalizers/built/app/
 import { loadEntrypoint } from '../../../load-entrypoint'
 import type { PageExtensions } from '../../../page-extensions-type'
 import { getFilenameAndExtension } from '../next-metadata-route-loader'
-import type { ParamInfo } from '../next-root-params-loader'
 
 export async function createAppRouteCode({
   appDir,
@@ -27,7 +26,7 @@ export async function createAppRouteCode({
   name: string
   page: string
   pagePath: string
-  rootParams: ParamInfo[]
+  rootParams: string[]
   resolveAppRoute: (
     pathname: string
   ) => Promise<string | undefined> | string | undefined
@@ -81,7 +80,7 @@ export async function createAppRouteCode({
     },
     {
       nextConfigOutput: JSON.stringify(nextConfigOutput),
-      rootParamNames: JSON.stringify(rootParams.map((p) => p.param)),
+      rootParamNames: JSON.stringify(rootParams),
     }
   )
 }

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -33,13 +33,12 @@ import type { PageExtensions } from '../../../page-extensions-type'
 import { PARALLEL_ROUTE_DEFAULT_PATH } from '../../../../client/components/builtin/default'
 import type { Compilation } from 'webpack'
 import { createAppRouteCode } from './create-app-route-code'
-import type { ParamInfo } from '../next-root-params-loader'
 
 export type AppLoaderOptions = {
   name: string
   page: string
   pagePath: string
-  rootParams: ParamInfo[]
+  rootParams: string[]
   appDir: string
   appPaths: readonly string[] | null
   preferredRegion: string | string[] | undefined

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -975,7 +975,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                           entryData.absolutePagePath
                         ).replace(/\\/g, '/')
                       ),
-                      rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+                      rootParams:
+                        (staticInfo as AppPageStaticInfo).rootParams?.map(
+                          (p) => p.param
+                        ) || [],
                       appDir: this.appDir!,
                       pageExtensions: this.config.pageExtensions,
                       rootDir: this.dir,
@@ -1099,7 +1102,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                     page,
                     appPaths: entryData.appPaths,
                     pagePath,
-                    rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+                    rootParams:
+                      (staticInfo as AppPageStaticInfo).rootParams?.map(
+                        (p) => p.param
+                      ) || [],
                     appDir: this.appDir!,
                     pageExtensions: this.config.pageExtensions,
                     rootDir: this.dir,

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -211,12 +211,6 @@ export async function getRootParam(paramName: string): Promise<ParamValue> {
 
   const actionStore = actionAsyncStorage.getStore()
   if (actionStore) {
-    if (actionStore.isAppRoute) {
-      // TODO(root-params): add support for route handlers
-      throw new Error(
-        `Route ${workStore.route} used ${apiName} inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.`
-      )
-    }
     if (actionStore.isAction) {
       // Actions are not fundamentally tied to a route (even if they're always submitted from some page),
       // so root params would be inconsistent if an action is called from multiple roots.

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -386,9 +386,8 @@ export class AppRouteRouteModule extends RouteModule<
             (prerenderStore = {
               type: 'prerender',
               phase: 'action',
-              // This replicates prior behavior where rootParams is empty in routes
-              // TODO we need to make this have the proper rootParams for this route
-              rootParams: {},
+              // Use the root params from the request store
+              rootParams: requestStore.rootParams,
               implicitTags,
               renderSignal: prospectiveController.signal,
               controller: prospectiveController,
@@ -482,7 +481,7 @@ export class AppRouteRouteModule extends RouteModule<
           const finalRoutePrerenderStore: PrerenderStore = (prerenderStore = {
             type: 'prerender',
             phase: 'action',
-            rootParams: {},
+            rootParams: requestStore.rootParams,
             implicitTags,
             renderSignal: finalController.signal,
             controller: finalController,
@@ -567,7 +566,7 @@ export class AppRouteRouteModule extends RouteModule<
           prerenderStore = {
             type: 'prerender-legacy',
             phase: 'action',
-            rootParams: {},
+            rootParams: requestStore.rootParams,
             implicitTags,
             revalidate: defaultRevalidate,
             expire: INFINITE_CACHE,
@@ -697,10 +696,20 @@ export class AppRouteRouteModule extends RouteModule<
       null
     )
 
+    // Extract root params from context.params based on rootParamNames
+    const rootParams: Record<string, string | string[] | undefined> = {}
+    if (context.params && this.rootParamNames.length > 0) {
+      for (const paramName of this.rootParamNames) {
+        if (paramName in context.params) {
+          rootParams[paramName] = context.params[paramName]
+        }
+      }
+    }
+
     const requestStore = createRequestStoreForAPI(
       req,
       req.nextUrl,
-      {}, // TODO: real rootParams
+      rootParams,
       implicitTags,
       undefined,
       context.prerenderManifest.preview

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/simple/app/[lang]/[locale]/route-handler/route.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/simple/app/[lang]/[locale]/route-handler/route.tsx
@@ -1,6 +1,8 @@
 import { lang, locale } from 'next/root-params'
 
 export async function GET() {
+  console.log('lang', await lang())
+  console.log('locale', await locale())
   return Response.json(
     // TODO(root-params): We're missing some wiring to set `requestStore.rootParams`,
     // so both of these will currently return undefined


### PR DESCRIPTION
## Enable root params in route handlers

This PR enables the use of root params in route handlers by:

1. Modifying the app route module to extract root params from context.params based on rootParamNames
2. Passing these root params to the request store in route handlers
3. Removing the error that previously prevented using root params in route handlers
4. Simplifying the rootParams handling by directly using string arrays instead of ParamInfo objects
5. Replacing the custom encodeToBase64 utility with standard Buffer.from().toString('base64')

The changes ensure that route handlers can properly access root params like `lang()` and `locale()` from the next/root-params API.

Fixes #[issue-number]