### PR TITLE
[devtools]: default to issues tab when error overlay is programmatically toggled

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -15,6 +15,7 @@ import {
   STORAGE_KEY_SCALE,
   STORAGE_KEY_POSITION,
   ACTION_ERROR_OVERLAY_CLOSE,
+  STORAGE_KEY_ACTIVE_TAB,
 } from '../../shared'
 import { css } from '../../utils/css'
 import { OverlayBackdrop } from '../overlay'
@@ -25,8 +26,6 @@ import { Cross } from '../../icons/cross'
 import { MinimizeIcon } from '../../icons/minimize'
 
 export type DevToolsPanelTabType = 'issues' | 'route' | 'settings'
-
-const STORAGE_KEY_ACTIVE_TAB = 'nextjs-devtools-active-tab'
 
 function useSessionState<T extends string>(
   key: string,
@@ -78,6 +77,9 @@ export function DevToolsPanel({
   if (state.isErrorOverlayOpen !== prevIsErrorOverlayOpen) {
     if (state.isErrorOverlayOpen) {
       setIsFullscreen(true)
+      // We should always show the issues tab initially if we're
+      // programmatically opening the panel to highlight errors.
+      setActiveTab('issues')
     }
     setPrevIsErrorOverlayOpen(state.isErrorOverlayOpen)
   }

--- a/packages/next/src/next-devtools/dev-overlay/shared.ts
+++ b/packages/next/src/next-devtools/dev-overlay/shared.ts
@@ -85,6 +85,7 @@ export const ACTION_RESTART_SERVER_BUTTON = 'restart-server-button'
 export const STORAGE_KEY_THEME = '__nextjs-dev-tools-theme'
 export const STORAGE_KEY_POSITION = '__nextjs-dev-tools-position'
 export const STORAGE_KEY_SCALE = '__nextjs-dev-tools-scale'
+export const STORAGE_KEY_ACTIVE_TAB = '__nextjs-devtools-active-tab'
 
 export const ACTION_DEVTOOL_UPDATE_ROUTE_STATE =
   'segment-explorer-update-route-state'


### PR DESCRIPTION
When there's a build error and we toggle the error overlay on page load, we should ensure that the issues tab is used rather than the one stored in session storage, to avoid the case where we bring up the modal intending to show the user an error but instead show the settings page.

Drive-by refactor: lifted storage variable to the other places where they're defined
Closes NEXT-4596