### PR TITLE
test(turbopack): Visualize turbopack source maps in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9992,6 +9992,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "similar",
+ "swc_sourcemap",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-build",

--- a/turbopack/crates/turbopack-test-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-test-utils/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = { workspace = true }
 regex = { workspace = true, features = ["pattern"] }
 serde = { workspace = true }
 similar = "2.2.0"
+swc_sourcemap = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -361,6 +361,7 @@ async fn visualize_sourcemap_as_markdown(
 
     // Save markdown file
     let markdown_path = output_path.with_extension("map.md");
+    fs::create_dir_all(&markdown_path.parent().path)?;
     if let Err(e) = fs::write(markdown_path.to_string(), markdown_content) {
         eprintln!("Failed to write sourcemap markdown: {e}");
     } else {

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 use anyhow::{Context, Result, bail};
 use once_cell::sync::Lazy;
@@ -130,6 +130,21 @@ pub async fn diff(path: FileSystemPath, actual: Vc<AssetContent>) -> Result<()> 
                 let content = File::from(RcStr::from(actual)).into();
                 path.write(content).await?;
                 println!("updated contents of {path_str}");
+
+                // 소스맵 파일인지 확인하고 시각화
+                if let Some(extension) = path.extension_ref()
+                    && extension == "map"
+                {
+                    // 소스맵 파일 내용 읽기
+                    if let FileContent::Content(file) = &*content.await?
+                        && let Ok(content_str) = std::str::from_utf8(&file.content().to_bytes())
+                    {
+                        // 소스맵 시각화 수행
+                        if let Err(e) = visualize_sourcemap_as_markdown(content_str, &path).await {
+                            eprintln!("Failed to visualize sourcemap {path}: {e}");
+                        }
+                    }
+                }
             } else {
                 if expected.is_none() {
                     eprintln!("new file {path_str} detected:");
@@ -235,4 +250,121 @@ fn styled_string_to_file_safe_string(styled_string: &StyledString) -> String {
         StyledString::Code(string) => format!("__c_{string}__"),
         StyledString::Strong(string) => format!("__{string}__"),
     }
+}
+
+/// 소스맵을 디코딩하고 마크다운으로 시각화하는 함수
+async fn visualize_sourcemap_as_markdown(
+    sourcemap_content: &str,
+    output_path: &FileSystemPath,
+) -> Result<()> {
+    // 소스맵 파싱
+    let sourcemap = match swc_sourcemap::SourceMap::from_slice(sourcemap_content.as_bytes()) {
+        Ok(sm) => sm,
+        Err(e) => {
+            eprintln!("Failed to parse sourcemap: {e}");
+            return Ok(());
+        }
+    };
+
+    let mut markdown_content = String::new();
+    markdown_content.push_str("# Source Map Visualization\n\n");
+
+    // 기본 정보
+    markdown_content.push_str("## Basic Information\n\n");
+
+    if let Some(file) = sourcemap.get_file() {
+        markdown_content.push_str(&format!("- **File**: {file}\n"));
+    }
+
+    if let Some(source_root) = sourcemap.get_source_root() {
+        markdown_content.push_str(&format!("- **Source Root**: {source_root}\n"));
+    }
+
+    // 소스 파일들
+    markdown_content.push_str("\n## Source Files\n\n");
+    for (i, source) in sourcemap.sources().enumerate() {
+        markdown_content.push_str(&format!("{}. `{source}`\n", i + 1));
+    }
+
+    // 매핑 정보
+    markdown_content.push_str("\n## Mappings Overview\n\n");
+
+    let mut total_mappings = 0;
+    let mut line_count = 0;
+
+    // 토큰 순회
+    for token in sourcemap.tokens() {
+        total_mappings += 1;
+        if token.get_dst_line() > line_count {
+            line_count = token.get_dst_line();
+        }
+    }
+
+    markdown_content.push_str(&format!("- **Total Mappings**: {total_mappings}\n"));
+    markdown_content.push_str(&format!("- **Generated Lines**: {}\n", line_count + 1));
+
+    // 매핑 테이블 (처음 50개만 표시)
+    markdown_content.push_str("\n## Mapping Details (First 50 entries)\n");
+    markdown_content.push_str("| Generated | Original | Source File | Name |\n");
+    markdown_content.push_str("|-----------|----------|-------------|------|\n");
+
+    for (count, token) in sourcemap.tokens().enumerate() {
+        if count >= 50 {
+            markdown_content.push_str("| ... | ... | ... | ... |\n");
+            break;
+        }
+
+        let generated_pos = format!("{}:{}", token.get_dst_line() + 1, token.get_dst_col());
+        let original_pos = format!("{}:{}", token.get_src_line() + 1, token.get_src_col());
+
+        let src_id = token.get_src_id();
+        let source_file = sourcemap
+            .get_source(src_id)
+            .map(|v| &**v)
+            .unwrap_or("Unknown");
+
+        let name = sourcemap
+            .get_name(token.get_name_id())
+            .map(|v| &**v)
+            .unwrap_or("N/A");
+
+        markdown_content.push_str(&format!(
+            "| {generated_pos} | {original_pos} | {source_file} | {name} |\n"
+        ));
+    }
+
+    // 소스 내용 (있는 경우)
+    if sourcemap.source_contents().count() != 0 {
+        markdown_content.push_str("\n## Source Contents\n\n");
+        for (i, content) in sourcemap.source_contents().enumerate() {
+            if let Some(content) = content {
+                let source_name = sourcemap.get_source(i as u32).map(|v| &**v).unwrap_or("");
+                markdown_content.push_str(&format!("### {source_name}\n"));
+                markdown_content.push_str("```javascript\n");
+                // 내용이 너무 길면 처음 20줄만 표시
+                let lines: Vec<&str> = content.lines().collect();
+                if lines.len() > 20 {
+                    for line in &lines[..20] {
+                        markdown_content.push_str(line);
+                        markdown_content.push('\n');
+                    }
+                    markdown_content
+                        .push_str(&format!("\n// ... ({} more lines)\n", lines.len() - 20))
+                } else {
+                    markdown_content.push_str(content);
+                }
+                markdown_content.push_str("```\n\n");
+            }
+        }
+    }
+
+    // 마크다운 파일 저장
+    let markdown_path = output_path.with_extension("map.md");
+    if let Err(e) = fs::write(markdown_path.to_string(), markdown_content) {
+        eprintln!("Failed to write sourcemap markdown: {e}");
+    } else {
+        println!("Generated sourcemap visualization: {markdown_path}");
+    }
+
+    Ok(())
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -15,7 +15,7 @@ use turbo_tasks::{ReadConsistency, ResolvedVc, TurboTasks, ValueToString, Vc, ap
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
-    DiskFileSystem, FileContent, FileSystem, FileSystemPath, json::parse_json_with_source_context,
+    DiskFileSystem, FileSystem, FileSystemPath, json::parse_json_with_source_context,
     util::sys_to_unix,
 };
 use turbopack::{
@@ -28,7 +28,7 @@ use turbopack::{
 };
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::Asset,
     chunk::{
         ChunkingConfig, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssetExt,
         EvaluatableAssets, MinifyType, availability_info::AvailabilityInfo,
@@ -508,23 +508,6 @@ async fn walk_asset(
     if path.is_inside_ref(output_path) {
         // Only consider assets that should be written to disk.
         diff(path.clone(), asset.content()).await?;
-
-        // 소스맵 파일인지 확인하고 시각화
-        if let Some(extension) = path.extension_ref()
-            && extension == "map"
-        {
-            // 소스맵 파일 내용 읽기
-            let content = asset.content().await?;
-            if let AssetContent::File(content) = &*content
-                && let FileContent::Content(file) = &*content.await?
-                && let Ok(content_str) = std::str::from_utf8(&file.content().to_bytes())
-            {
-                // 소스맵 시각화 수행
-                if let Err(e) = visualize_sourcemap_as_markdown(content_str, &path).await {
-                    eprintln!("Failed to visualize sourcemap {path}: {e}");
-                }
-            }
-        }
     }
 
     queue.extend(
@@ -552,121 +535,4 @@ async fn maybe_load_env(
     let env = DotenvProcessEnv::new(None, dotenv_path.clone());
     let asset = ProcessEnvAsset::new(dotenv_path, Vc::upcast(env));
     Ok(Some(Vc::upcast(asset)))
-}
-
-/// 소스맵을 디코딩하고 마크다운으로 시각화하는 함수
-async fn visualize_sourcemap_as_markdown(
-    sourcemap_content: &str,
-    output_path: &FileSystemPath,
-) -> Result<()> {
-    // 소스맵 파싱
-    let sourcemap = match swc_sourcemap::SourceMap::from_slice(sourcemap_content.as_bytes()) {
-        Ok(sm) => sm,
-        Err(e) => {
-            eprintln!("Failed to parse sourcemap: {e}");
-            return Ok(());
-        }
-    };
-
-    let mut markdown_content = String::new();
-    markdown_content.push_str("# Source Map Visualization\n\n");
-
-    // 기본 정보
-    markdown_content.push_str("## Basic Information\n\n");
-
-    if let Some(file) = sourcemap.get_file() {
-        markdown_content.push_str(&format!("- **File**: {file}\n"));
-    }
-
-    if let Some(source_root) = sourcemap.get_source_root() {
-        markdown_content.push_str(&format!("- **Source Root**: {source_root}\n"));
-    }
-
-    // 소스 파일들
-    markdown_content.push_str("\n## Source Files\n\n");
-    for (i, source) in sourcemap.sources().enumerate() {
-        markdown_content.push_str(&format!("{}. `{source}`\n", i + 1));
-    }
-
-    // 매핑 정보
-    markdown_content.push_str("\n## Mappings Overview\n\n");
-
-    let mut total_mappings = 0;
-    let mut line_count = 0;
-
-    // 토큰 순회
-    for token in sourcemap.tokens() {
-        total_mappings += 1;
-        if token.get_dst_line() > line_count {
-            line_count = token.get_dst_line();
-        }
-    }
-
-    markdown_content.push_str(&format!("- **Total Mappings**: {total_mappings}\n"));
-    markdown_content.push_str(&format!("- **Generated Lines**: {}\n", line_count + 1));
-
-    // 매핑 테이블 (처음 50개만 표시)
-    markdown_content.push_str("\n## Mapping Details (First 50 entries)\n");
-    markdown_content.push_str("| Generated | Original | Source File | Name |\n");
-    markdown_content.push_str("|-----------|----------|-------------|------|\n");
-
-    for (count, token) in sourcemap.tokens().enumerate() {
-        if count >= 50 {
-            markdown_content.push_str("| ... | ... | ... | ... |\n");
-            break;
-        }
-
-        let generated_pos = format!("{}:{}", token.get_dst_line() + 1, token.get_dst_col());
-        let original_pos = format!("{}:{}", token.get_src_line() + 1, token.get_src_col());
-
-        let src_id = token.get_src_id();
-        let source_file = sourcemap
-            .get_source(src_id)
-            .map(|v| &**v)
-            .unwrap_or("Unknown");
-
-        let name = sourcemap
-            .get_name(token.get_name_id())
-            .map(|v| &**v)
-            .unwrap_or("N/A");
-
-        markdown_content.push_str(&format!(
-            "| {generated_pos} | {original_pos} | {source_file} | {name} |\n"
-        ));
-    }
-
-    // 소스 내용 (있는 경우)
-    if sourcemap.source_contents().count() != 0 {
-        markdown_content.push_str("\n## Source Contents\n\n");
-        for (i, content) in sourcemap.source_contents().enumerate() {
-            if let Some(content) = content {
-                let source_name = sourcemap.get_source(i as u32).map(|v| &**v).unwrap_or("");
-                markdown_content.push_str(&format!("### {source_name}\n"));
-                markdown_content.push_str("```javascript\n");
-                // 내용이 너무 길면 처음 20줄만 표시
-                let lines: Vec<&str> = content.lines().collect();
-                if lines.len() > 20 {
-                    for line in &lines[..20] {
-                        markdown_content.push_str(line);
-                        markdown_content.push('\n');
-                    }
-                    markdown_content
-                        .push_str(&format!("\n// ... ({} more lines)\n", lines.len() - 20))
-                } else {
-                    markdown_content.push_str(content);
-                }
-                markdown_content.push_str("```\n\n");
-            }
-        }
-    }
-
-    // 마크다운 파일 저장
-    let markdown_path = output_path.with_extension("map.md");
-    if let Err(e) = fs::write(markdown_path.to_string(), markdown_content) {
-        eprintln!("Failed to write sourcemap markdown: {e}");
-    } else {
-        println!("Generated sourcemap visualization: {markdown_path}");
-    }
-
-    Ok(())
 }

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_70a5d821.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_70a5d821.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_92a5f455.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_92a5f455.js.map.md
@@ -1,0 +1,43 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 13
+- **Generated Lines**: 11
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                           | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 7:15      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 8:4       | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 8:10      | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 8:16      | 2:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 9:4       | 3:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 9:12      | 3:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 9:15      | 3:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 9:16      | 3:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 9:20      | 3:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 9:23      | 3:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 10:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+| 11:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js
+
+```javascript
+async function main() {
+  const lib = await import('./lib')
+  console.log(lib.cat)
+}
+
+main()
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_b2d8c81e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_b2d8c81e.js.map.md
@@ -1,0 +1,96 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 91
+- **Generated Lines**: 133
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 21:242    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 21:243    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 21:247    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 21:251    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 22:242    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 22:243    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 22:247    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 22:251    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 32:242    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 32:243    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 32:247    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 32:251    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 44:254    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 44:255    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 44:259    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 45:254    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 45:255    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 45:259    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 46:254    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 46:255    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 46:259    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 71:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 71:9      | 7:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 72:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 72:11     | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 72:253    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 72:254    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 72:258    | 8:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 73:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 74:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 74:9      | 15:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| 74:16     | 15:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js | N/A  |
+| ...       | ...      | ...                                                                                                                 | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_f6ff4167.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_f6ff4167.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/4c35f_tests_snapshot_basic-tree-shake_export-named_input_index_8cbd8543.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/4c35f_tests_snapshot_basic-tree-shake_export-named_input_index_8cbd8543.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_058a40bc._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_058a40bc._.js.map.md
@@ -1,0 +1,104 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 50
+- **Generated Lines**: 95
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 21:240    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 21:241    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 21:245    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 21:249    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 22:240    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 22:241    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 22:245    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 22:249    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 32:240    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 32:241    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 32:245    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 32:249    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 44:252    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 44:253    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 44:257    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 45:252    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 45:253    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 45:257    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 46:252    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 46:253    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 46:257    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 58:0      | 29:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 58:4      | 29:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 58:10     | 29:17    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js   | N/A  |
+| 93:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+| 95:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+| 95:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+| 95:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+| 95:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+| 95:255    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+| 95:256    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+| 95:266    | 3:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js
+
+```javascript
+import { fakeCat } from './module'
+
+console.log(fakeCat)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_23eca458.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_23eca458.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_f7fde6f3._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_f7fde6f3._.js.map.md
@@ -1,0 +1,105 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 101
+- **Generated Lines**: 186
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                           | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 21:244    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 21:245    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 21:249    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 21:253    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 22:244    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 22:245    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 22:249    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 22:253    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 32:244    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 32:245    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 32:249    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 32:253    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 44:256    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 44:257    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 44:261    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 45:256    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 45:257    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 45:261    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 46:256    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 46:257    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 46:261    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 71:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 71:9      | 7:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 72:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 72:11     | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 72:255    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 72:256    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 72:260    | 8:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 73:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 74:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 74:9      | 15:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| 74:16     | 15:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js | N/A  |
+| ...       | ...      | ...                                                                                                                   | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js
+
+```javascript
+import { lib } from './module'
+
+console.log(lib.cat)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_1d4e9676.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_1d4e9676.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_00b867a0._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_00b867a0._.js.map.md
@@ -1,0 +1,107 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 53
+- **Generated Lines**: 78
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                             | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 21:247    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 21:248    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 21:252    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 21:256    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 22:247    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 22:248    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 22:252    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 22:256    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 32:247    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 32:248    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 32:252    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 32:256    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 44:259    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 44:260    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 44:264    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 45:259    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 45:260    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 45:264    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 46:259    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 46:260    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 46:264    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 58:0      | 29:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 58:4      | 29:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 58:10     | 29:17    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js   | N/A  |
+| 75:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| 76:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| 78:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| 78:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| 78:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| 78:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| 78:259    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| 78:260    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js | N/A  |
+| ...       | ...      | ...                                                                                                                     | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js
+
+```javascript
+import { cat as c, dogRef, initialCat, getChimera } from './lib'
+
+console.log(c)
+
+// TODO: Execution
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/4c35f_tests_snapshot_basic-tree-shake_import-named_input_index_c211ee0a.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/4c35f_tests_snapshot_basic-tree-shake_import-named_input_index_c211ee0a.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_f64e7412._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_f64e7412._.js.map.md
@@ -1,0 +1,105 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 51
+- **Generated Lines**: 78
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 21:240    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 21:241    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 21:245    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 21:249    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 22:240    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 22:241    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 22:245    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 22:249    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 32:240    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 32:241    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 32:245    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 32:249    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 44:252    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 44:253    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 44:257    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 45:252    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 45:253    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 45:257    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 46:252    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 46:253    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 46:257    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 58:0      | 29:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 58:4      | 29:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 58:10     | 29:17    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js   | N/A  |
+| 75:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| 76:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| 78:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| 78:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| 78:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| 78:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| 78:252    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| 78:253    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js | N/A  |
+| ...       | ...      | ...                                                                                                                 | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js
+
+```javascript
+import { cat as c } from './lib'
+
+console.log(c)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_096e3273.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_096e3273.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_25e69485._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_25e69485._.js.map.md
@@ -1,0 +1,105 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 100
+- **Generated Lines**: 172
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                           | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 21:244    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 21:245    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 21:249    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 21:253    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 22:244    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 22:245    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 22:249    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 22:253    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 32:244    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 32:245    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 32:249    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 32:253    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 44:256    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 44:257    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 44:261    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 45:256    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 45:257    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 45:261    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 46:256    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 46:257    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 46:261    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 71:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 71:9      | 7:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 72:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 72:11     | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 72:255    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 72:256    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 72:260    | 8:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 73:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 74:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 74:9      | 15:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| 74:16     | 15:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js | N/A  |
+| ...       | ...      | ...                                                                                                                   | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/index.js
+
+```javascript
+import * as lib from './lib'
+
+console.log(lib.cat)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_e082b9f6._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_e082b9f6._.js.map.md
@@ -1,0 +1,92 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 40
+- **Generated Lines**: 53
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                               | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 21:249    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 21:250    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 21:254    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 21:258    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 22:249    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 22:250    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 22:254    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 22:258    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 32:249    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 32:250    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 32:254    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 32:258    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 44:261    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 44:262    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 44:266    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 45:261    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 45:262    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 45:266    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 46:261    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 46:262    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 46:266    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js   | N/A  |
+| 53:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/index.js
+
+```javascript
+import './lib'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_e306c4ba.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_e306c4ba.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_f83a22d6._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_f83a22d6._.js.map.md
@@ -1,0 +1,103 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 96
+- **Generated Lines**: 183
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                              | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 21:250    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 21:251    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 21:255    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 21:259    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 22:250    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 22:251    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 22:255    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 22:259    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 32:250    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 32:251    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 32:255    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 32:259    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 44:262    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 44:263    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 44:267    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 45:262    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 45:263    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 45:267    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 46:262    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 46:263    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 46:267    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 71:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 71:9      | 7:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 72:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 72:11     | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 72:261    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 72:262    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 72:266    | 8:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 73:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 74:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 74:9      | 15:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| 74:16     | 15:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js | N/A  |
+| ...       | ...      | ...                                                                                                                      | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/index.js
+
+```javascript
+const { cat } = require('./lib')
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e03cab12.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e03cab12.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_09a16221.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_09a16221.js.map.md
@@ -1,0 +1,96 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 91
+- **Generated Lines**: 133
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                              | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 12:4      | 1:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 12:10     | 1:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 21:253    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 21:254    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 21:258    | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 21:262    | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 22:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 22:253    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 22:254    | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 22:258    | 11:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 22:262    | 11:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 32:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 32:253    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 32:254    | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 32:258    | 19:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 32:262    | 19:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 44:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 44:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 44:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 44:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 44:265    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 44:266    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 44:270    | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 45:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 45:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 45:11     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 45:12     | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 45:265    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 45:266    | 13:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 45:270    | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 46:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 46:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 46:11     | 21:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 46:12     | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 46:265    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 46:266    | 21:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 46:270    | 21:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 71:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 71:9      | 7:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 72:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 72:11     | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 72:264    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 72:265    | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 72:269    | 8:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 73:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 74:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 74:9      | 15:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| 74:16     | 15:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js | N/A  |
+| ...       | ...      | ...                                                                                                                      | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js
+
+```javascript
+let dog = 'dog'
+
+dog += '!'
+
+console.log(dog)
+
+function getDog() {
+  return dog
+}
+
+dog += '!'
+
+console.log(dog)
+
+function setDog(newDog) {
+  dog = newDog
+}
+
+dog += '!'
+
+// ... (15 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_b9be809d.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_b9be809d.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_import_4525a00e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_import_4525a00e.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_688a2476.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_688a2476.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_46366300._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_46366300._.js.map.md
@@ -1,0 +1,80 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/shared.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 32
+- **Generated Lines**: 30
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                              | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/shared.js                 | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/shared.js                 | N/A  |
+| 13:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 14:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:1      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:4      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:221    | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:222    | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:228    | 4:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:228    | 4:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 17:230    | 4:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:178    | 6:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:182    | 6:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:183    | 6:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:184    | 6:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:186    | 6:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:189    | 6:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 18:191    | 6:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 19:4      | 7:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 19:8      | 7:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 20:0      | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js                  | N/A  |
+| 28:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 28:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 28:13     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 28:18     | 1:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 29:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 29:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 29:18     | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 29:19     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+| 30:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/shared.js
+
+```javascript
+// shared package
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/index.js
+
+```javascript
+import { bar } from 'bar'
+import './shared'
+
+bar(true)
+
+import('./import').then(({ foo }) => {
+  foo(true)
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/bar/index.js
+
+```javascript
+export function bar(value) {
+  console.assert(value)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_b274c771._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_b274c771._.js.map.md
@@ -1,0 +1,67 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 28
+- **Generated Lines**: 24
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                              | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 8:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:1      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:4      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:221    | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:222    | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:228    | 5:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:228    | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 13:230    | 5:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:1      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:4      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:221    | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:222    | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:228    | 6:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:228    | 6:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 14:230    | 6:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js                 | N/A  |
+| 22:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 22:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 22:13     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 22:18     | 1:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 23:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 23:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 23:18     | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 23:19     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+| 24:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/import.js
+
+```javascript
+import { foo } from 'foo'
+import { bar } from 'bar'
+import './shared'
+
+foo(true)
+bar(true)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk/input/node_modules/foo/index.js
+
+```javascript
+export function foo(value) {
+  console.assert(value)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_build_input_1e41378a._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_build_input_1e41378a._.js.map.md
@@ -1,0 +1,80 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/shared.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 32
+- **Generated Lines**: 30
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                    | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/shared.js                 | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/shared.js                 | N/A  |
+| 13:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 14:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:1      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:4      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:227    | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:228    | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:234    | 4:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:234    | 4:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 17:236    | 4:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:184    | 6:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:188    | 6:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:189    | 6:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:190    | 6:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:192    | 6:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:195    | 6:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 18:197    | 6:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 19:4      | 7:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 19:8      | 7:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 20:0      | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js                  | N/A  |
+| 28:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 28:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 28:13     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 28:18     | 1:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 29:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 29:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 29:18     | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 29:19     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+| 30:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/shared.js
+
+```javascript
+// shared package
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/index.js
+
+```javascript
+import { bar } from 'bar'
+import './shared'
+
+bar(true)
+
+import('./import').then(({ foo }) => {
+  foo(true)
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/bar/index.js
+
+```javascript
+export function bar(value) {
+  console.assert(value)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_build_input_23e8ba79._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/4e721_crates_turbopack-tests_tests_snapshot_basic_async_chunk_build_input_23e8ba79._.js.map.md
@@ -1,0 +1,67 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 28
+- **Generated Lines**: 24
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                    | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 8:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:1      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:4      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:227    | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:228    | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:234    | 5:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:234    | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 13:236    | 5:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:1      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:4      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:227    | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:228    | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:234    | 6:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:234    | 6:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 14:236    | 6:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js                 | N/A  |
+| 22:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 22:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 22:13     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 22:18     | 1:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 23:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 23:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 23:18     | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 23:19     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+| 24:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/import.js
+
+```javascript
+import { foo } from 'foo'
+import { bar } from 'bar'
+import './shared'
+
+foo(true)
+bar(true)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/input/node_modules/foo/index.js
+
+```javascript
+export function foo(value) {
+  console.assert(value)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/[turbopack]_runtime.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/[turbopack]_runtime.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/b1abf_turbopack-tests_tests_snapshot_basic_async_chunk_build_input_import_2a82c7a5.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/b1abf_turbopack-tests_tests_snapshot_basic_async_chunk_build_input_import_2a82c7a5.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/index.entry.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/index.entry.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/output/4e721_crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_72356a60.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/output/4e721_crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_72356a60.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_chunked_input_1efdaca0._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_chunked_input_1efdaca0._.js.map.md
@@ -1,0 +1,54 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 18
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                          | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:1       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:4       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:217     | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:218     | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:224     | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:224     | 3:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 9:226     | 3:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js                  | N/A  |
+| 17:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 17:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 17:13     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 17:18     | 1:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 18:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 18:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 18:18     | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 18:19     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+| 19:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/index.js
+
+```javascript
+import { foo } from 'foo'
+
+foo(true)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/chunked/input/node_modules/foo/index.js
+
+```javascript
+export function foo(value) {
+  console.assert(value)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/[turbopack]_runtime.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/[turbopack]_runtime.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/b1abf_turbopack-tests_tests_snapshot_basic_ecmascript_minify_input_index_6869f84f.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/b1abf_turbopack-tests_tests_snapshot_basic_ecmascript_minify_input_index_6869f84f.js.map.md
@@ -1,0 +1,49 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 16
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                   | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| 1:155     | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:159     | 2:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:161     | 8:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:169     | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:169     | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:177     | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:180     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:181     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:192     | 4:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:197     | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:199     | 4:43     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:202     | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:203     | 4:34     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:210     | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:213     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+| 1:214     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js
+
+```javascript
+const inlined = 3
+const message = getMessage()
+
+console.log('Hello,' + ' world!', inlined, message)
+console.log(message)
+
+function getMessage() {
+  return 'Hello'
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/index.entry.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/index.entry.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/output/4e721_crates_turbopack-tests_tests_snapshot_basic_shebang_input_index_6c76c382.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/output/4e721_crates_turbopack-tests_tests_snapshot_basic_shebang_input_index_6c76c382.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_shebang_input_d5e8dcd4._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/output/turbopack_crates_turbopack-tests_tests_snapshot_basic_shebang_input_d5e8dcd4._.js.map.md
@@ -1,0 +1,58 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 18
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                          | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:0       | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:1       | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:4       | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:217     | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:218     | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:224     | 5:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:224     | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 9:226     | 5:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js                  | N/A  |
+| 17:0      | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 17:9      | 3:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 17:13     | 3:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 17:18     | 3:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 18:4      | 4:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 18:12     | 4:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 18:18     | 4:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 18:19     | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+| 19:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/index.js
+
+```javascript
+#!/usr/bin/env node
+
+import { foo } from 'foo'
+
+foo(true)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/shebang/input/node_modules/foo/index.js
+
+```javascript
+#!/usr/bin/env node
+
+export function foo(value) {
+  console.assert(value)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/4e721_crates_turbopack-tests_tests_snapshot_basic_top-level-await_input_9acd43f4._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/4e721_crates_turbopack-tests_tests_snapshot_basic_top-level-await_input_9acd43f4._.js.map.md
@@ -1,0 +1,108 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 62
+- **Generated Lines**: 34
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                   | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| 6:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 6:73      | 1:73     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 11:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 11:6      | 2:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 12:0      | 4:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 12:6      | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 12:25     | 4:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 12:32     | 4:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 13:4      | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 13:12     | 5:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 13:15     | 5:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 13:16     | 5:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 13:33     | 5:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 14:4      | 6:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 14:69     | 6:67     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 15:4      | 7:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 15:10     | 7:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 15:12     | 7:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 15:22     | 7:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 15:24     | 7:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 15:27     | 7:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 15:33     | 7:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 16:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 16:10     | 8:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 16:21     | 8:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 17:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 18:0      | 22:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 18:6      | 22:13    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 18:36     | 22:43    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 18:43     | 22:50    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 19:4      | 23:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 19:10     | 23:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 19:12     | 23:10    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 19:22     | 23:20    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 19:24     | 23:22    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 19:27     | 23:25    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 20:4      | 24:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 20:10     | 24:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 20:21     | 24:19    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 21:0      | 25:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 21:2      | 27:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 21:68     | 27:66    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 22:1      | 28:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 22:68     | 28:67    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js | N/A  |
+| 29:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js   | N/A  |
+| 31:0      | 2:1      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js   | N/A  |
+| 31:1      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js   | N/A  |
+| 32:4      | 3:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js   | N/A  |
+| 32:10     | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js   | N/A  |
+| 32:11     | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js   | N/A  |
+| ...       | ...      | ...                                                                                                           | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/Actions.js
+
+```javascript
+// import() doesn't care about whether a module is an async module or not
+const UserApi = import('./UserAPI.js')
+
+export const CreateUserAction = async (name) => {
+  console.log('Creating user', name)
+  // These are normal awaits, because they are in an async function
+  const { createUser } = await UserApi
+  await createUser(name)
+}
+
+// You can place import() where you like
+// Placing it at top-level will start loading and evaluating on
+//   module evaluation.
+//   see CreateUserAction above
+//   Here: Connecting to the DB starts when the application starts
+// Placing it inside of an (async) function will start loading
+//   and evaluating when the function is called for the first time
+//   which basically makes it lazy-loaded.
+//   see AlternativeCreateUserAction below
+//   Here: Connecting to the DB starts when AlternativeCreateUserAction
+
+// ... (8 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/index.js
+
+```javascript
+import { CreateUserAction } from './Actions.js'
+;(async () => {
+  await CreateUserAction('John')
+  console.log('created user John')
+})()
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/4e721_crates_turbopack-tests_tests_snapshot_basic_top-level-await_input_aa0a0c39._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/4e721_crates_turbopack-tests_tests_snapshot_basic_top-level-await_input_aa0a0c39._.js.map.md
@@ -1,0 +1,106 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/UserAPI.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 79
+- **Generated Lines**: 49
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 12:6      | 1:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 12:20     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 12:27     | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 13:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 13:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 13:15     | 2:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 13:16     | 2:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 13:36     | 2:34     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:4      | 3:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:10     | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:14     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:22     | 3:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:23     | 3:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:27     | 3:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:38     | 3:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 14:41     | 3:41     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 15:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 16:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 16:28     | 6:28     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 17:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 17:6      | 7:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 17:18     | 7:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 18:0      | 9:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 18:6      | 9:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 18:15     | 9:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 18:22     | 9:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 19:4      | 10:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 19:12     | 10:10    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 19:15     | 10:13    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 19:16     | 10:14    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 19:26     | 10:24    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 20:4      | 11:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 20:64     | 11:62    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:4      | 12:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:10     | 12:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:14     | 12:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:22     | 12:20    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:23     | 12:21    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:27     | 12:27    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:38     | 12:38    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 21:41     | 12:41    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 22:4      | 13:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 22:11     | 13:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 23:0      | 14:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 24:0      | 16:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 24:6      | 16:13    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 24:14     | 16:21    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 25:4      | 17:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| 25:12     | 17:10    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js | N/A  |
+| ...       | ...      | ...                                                                                                                 | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/db-connection.js
+
+```javascript
+const connectToDB = async (url) => {
+  console.log('connecting to db', url)
+  await new Promise((r) => setTimeout(r, 1000))
+}
+
+// This is a top-level-await
+await connectToDB('my-sql://example.com')
+
+export const dbCall = async (data) => {
+  console.log('dbCall', data)
+  // This is a normal await, because it's in an async function
+  await new Promise((r) => setTimeout(r, 100))
+  return 'fake data'
+}
+
+export const close = () => {
+  console.log('closes the DB connection')
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/input/UserAPI.js
+
+```javascript
+import { dbCall } from './db-connection.js'
+
+export const createUser = async (name) => {
+  const command = `CREATE USER ${name}`
+  // This is a normal await, because it's in an async function
+  await dbCall({ command })
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/b1abf_turbopack-tests_tests_snapshot_basic_top-level-await_input_UserAPI_182540dd.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/b1abf_turbopack-tests_tests_snapshot_basic_top-level-await_input_UserAPI_182540dd.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/b1abf_turbopack-tests_tests_snapshot_basic_top-level-await_input_index_75cb65d4.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/top-level-await/output/b1abf_turbopack-tests_tests_snapshot_basic_top-level-await_input_index_75cb65d4.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_b7c39fa7.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_b7c39fa7.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/output/4e721_crates_turbopack-tests_tests_snapshot_basic_use-strict_input_index_c0953835.js.map.md
@@ -1,0 +1,36 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 8
+- **Generated Lines**: 9
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                            | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------ | ---- |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+| 8:8       | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+| 8:11      | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+| 8:12      | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+| 9:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+| 9:7       | 4:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+| 9:14      | 4:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+| 9:17      | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/use-strict/input/index.js
+
+```javascript
+'use strict'
+
+console.log('this is CJS')
+module.exports = 1234
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_define_input_index_2206053f.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_define_input_index_2206053f.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_define_input_index_4d74c0a3.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_define_input_index_4d74c0a3.js.map.md
@@ -1,0 +1,96 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 65
+- **Generated Lines**: 31
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 7:40      | 1:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 8:4       | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 8:12      | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 8:15      | 2:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 8:16      | 2:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 10:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 10:40     | 5:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 11:4      | 6:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 11:12     | 6:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 11:15     | 6:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 11:16     | 6:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 12:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 13:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 13:65     | 9:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 14:4      | 10:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 14:12     | 10:10    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 14:15     | 10:13    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 14:16     | 10:14    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 15:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 16:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 16:40     | 13:26    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 17:4      | 14:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 17:12     | 14:10    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 17:15     | 14:13    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 17:16     | 14:14    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 18:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 19:0      | 17:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 21:0      | 21:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 21:4      | 21:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 21:8      | 21:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 22:0      | 23:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 22:8      | 23:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 22:11     | 23:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 23:0      | 24:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 23:8      | 24:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 23:11     | 24:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 24:0      | 25:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 24:8      | 25:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 24:11     | 25:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 25:0      | 27:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 27:0      | 31:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 27:38     | 32:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 27:64     | 33:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 27:72     | 33:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 27:75     | 33:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 27:76     | 33:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 28:0      | 35:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| 28:44     | 35:44    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js | N/A  |
+| ...       | ...      | ...                                                                                                   | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/define/input/index.js
+
+```javascript
+if (DEFINED_VALUE) {
+  console.log('DEFINED_VALUE')
+}
+
+if (DEFINED_TRUE) {
+  console.log('DEFINED_VALUE')
+}
+
+if (A.VERY.LONG.DEFINED.VALUE) {
+  console.log('A.VERY.LONG.DEFINED.VALUE')
+}
+
+if (process.env.NODE_ENV) {
+  console.log('something')
+}
+
+if (process.env.NODE_ENV === 'production') {
+  console.log('production')
+}
+
+// ... (19 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_early-return_input_82bbae08._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_early-return_input_82bbae08._.js.map.md
@@ -1,0 +1,105 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 219
+- **Generated Lines**: 199
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                  | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------ | ---- |
+| 18:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 18:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 19:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 19:44     | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 20:8      | 3:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 21:8      | 4:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 22:4      | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 25:4      | 7:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 25:8      | 7:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 26:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 26:13     | 8:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 27:8      | 9:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 27:12     | 9:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 28:4      | 10:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 29:4      | 14:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 29:10     | 14:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 30:4      | 17:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 30:8      | 17:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 31:4      | 18:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 31:8      | 18:6     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 32:4      | 19:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 32:8      | 20:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 32:13     | 22:6     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 32:18     | 23:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 32:23     | 23:20    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 32:28     | 25:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 33:4      | 27:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 33:13     | 27:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 34:8      | 28:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 37:4      | 30:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 38:4      | 44:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 38:8      | 44:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 39:0      | 46:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 40:0      | 48:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 40:9      | 48:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 41:4      | 49:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 41:44     | 49:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 42:8      | 50:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 43:8      | 51:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 44:4      | 52:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 48:0      | 56:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 49:0      | 58:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 49:9      | 58:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 50:4      | 59:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 50:44     | 59:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 51:8      | 60:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 52:4      | 61:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 55:0      | 63:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 56:0      | 65:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| 56:9      | 65:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js | N/A  |
+| ...       | ...      | ...                                                                                                          | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/module.js
+
+```javascript
+export function a() {
+  if (true) {
+    a1()
+    return
+  }
+  a2()
+  var a3 = 3
+  function a4() {
+    var a5
+  }
+  ;(function a6() {
+    var a7
+  })
+  const a8 = () => {
+    var a9
+  }
+  class a10 {}
+  let a11 = 11
+  let {
+    a12 = 12,
+
+// ... (187 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/input/index.js
+
+```javascript
+import * as module from './module'
+console.log(module)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/output/b1abf_turbopack-tests_tests_snapshot_comptime_early-return_input_index_86abe3b0.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/early-return/output/b1abf_turbopack-tests_tests_snapshot_comptime_early-return_input_index_86abe3b0.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_typeof_input_index_66ffe5ba.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_typeof_input_index_66ffe5ba.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/output/turbopack_crates_turbopack-tests_tests_snapshot_comptime_typeof_input_80f5724c._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/output/turbopack_crates_turbopack-tests_tests_snapshot_comptime_typeof_input_80f5724c._.js.map.md
@@ -1,0 +1,122 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 73
+- **Generated Lines**: 67
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                    | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 12:8      | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 12:11     | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 12:12     | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 13:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 13:8      | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 13:11     | 2:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 13:12     | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 14:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 14:26     | 3:26     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 15:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 15:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 15:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 15:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 16:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 16:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 16:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 16:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 17:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 17:30     | 7:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 18:0      | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 18:8      | 8:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 18:11     | 8:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js            | N/A  |
+| 29:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 36:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 36:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 36:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 36:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 37:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 37:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 37:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 37:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 38:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 38:29     | 5:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 39:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 39:8      | 6:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 39:11     | 6:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 39:12     | 6:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 40:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 40:8      | 7:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 40:11     | 7:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 40:12     | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 41:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 41:30     | 9:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 42:0      | 10:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 42:8      | 10:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 42:11     | 10:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js  | N/A  |
+| 53:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs | N/A  |
+| 53:8      | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs | N/A  |
+| 53:11     | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs | N/A  |
+| ...       | ...      | ...                                                                                                            | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/cjs.js
+
+```javascript
+console.log('typeof require', typeof require)
+console.log('typeof import.meta', typeof import.meta)
+// CJS, should be `object`
+console.log('typeof module', typeof module)
+console.log('typeof exports', typeof exports)
+
+// CJS, should be real require
+console.log(require)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-automatic.js
+
+```javascript
+import './dep.js'
+
+console.log('typeof require', typeof require)
+console.log('typeof import.meta', typeof import.meta)
+// ESM, should be `undefined`
+console.log('typeof module', typeof module)
+console.log('typeof exports', typeof exports)
+
+// ESM, should be require stub
+console.log(require)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs
+
+```javascript
+console.log('typeof require', typeof require)
+console.log('typeof import.meta', typeof import.meta)
+// ESM, should be `undefined`
+console.log('typeof module', typeof module)
+console.log('typeof exports', typeof exports)
+
+// ESM, should be require stub
+console.log(require)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/index.js
+
+```javascript
+import './cjs.js'
+import './esm-automatic.js'
+import './esm-specified.mjs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/unreachable/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_unreachable_input_index_6be1ccbb.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/unreachable/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_unreachable_input_index_6be1ccbb.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/unreachable/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_unreachable_input_index_9022a405.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/comptime/unreachable/output/4e721_crates_turbopack-tests_tests_snapshot_comptime_unreachable_input_index_9022a405.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/4c35f_tests_snapshot_css_absolute-uri-import_input_withduplicateurl_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/4c35f_tests_snapshot_css_absolute-uri-import_input_withduplicateurl_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/withduplicateurl.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                               | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/withduplicateurl.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/withduplicateurl.css
+
+```javascript
+/* This should not be duplicated */
+@import 'https://example.com/stylesheet1.css';
+
+.bar {
+  background-color: green;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/4e721_crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_b44448e2._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/4e721_crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_b44448e2._.css.map.md
@@ -1,0 +1,57 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/other.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/withduplicateurl.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/index.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 3
+- **Generated Lines**: 11
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                               | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/other.css            | N/A  |
+| 8:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/withduplicateurl.css | N/A  |
+| 11:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/index.css            | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/other.css
+
+```javascript
+.foo {
+  background-color: red;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/withduplicateurl.css
+
+```javascript
+/* This should not be duplicated */
+@import 'https://example.com/stylesheet1.css';
+
+.bar {
+  background-color: green;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/index.css
+
+```javascript
+@import 'https://example.com/stylesheet1.css';
+@import 'https://example.com/withquote".css';
+@import './other.css';
+@import './withduplicateurl.css';
+@import url('https://example.com/stylesheet2.css');
+
+body {
+  background-color: blue;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_79532ffd.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_79532ffd.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,34 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/index.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                    | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/index.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/index.css
+
+```javascript
+@import 'https://example.com/stylesheet1.css';
+@import 'https://example.com/withquote".css';
+@import './other.css';
+@import './withduplicateurl.css';
+@import url('https://example.com/stylesheet2.css');
+
+body {
+  background-color: blue;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_e42d0fe1.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_e42d0fe1.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_other_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_other_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/other.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                    | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/other.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/input/other.css
+
+```javascript
+.foo {
+  background-color: red;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/4e721_crates_turbopack-tests_tests_snapshot_css_chained-attributes_input_0c8b8533._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/4e721_crates_turbopack-tests_tests_snapshot_css_chained-attributes_input_0c8b8533._.css.map.md
@@ -1,0 +1,66 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/b.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/a.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 5
+- **Generated Lines**: 38
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                   | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css     | N/A  |
+| 14:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css     | N/A  |
+| 23:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/b.css     | N/A  |
+| 32:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/a.css     | N/A  |
+| 38:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css
+
+```javascript
+.imported {
+  color: red;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/b.css
+
+```javascript
+@import url('./c.css') layer(foo) (orientation: landscape);
+@import url('./c.css') layer(bar) (orientation: portrait);
+
+.imported {
+  color: orange;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/a.css
+
+```javascript
+@import url('./b.css') supports(font-format(woff2));
+
+.imported {
+  color: cyan;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css
+
+```javascript
+@import url('./a.css') layer(layer) supports(not(display: inline-grid)) print;
+
+.style {
+  color: yellow;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_a_css_f40a1131._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_a_css_f40a1131._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/a.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/a.css
+
+```javascript
+@import url('./b.css') supports(font-format(woff2));
+
+.imported {
+  color: cyan;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_b_css_92a7695f._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_b_css_92a7695f._.single.css.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/b.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/b.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/b.css
+
+```javascript
+@import url('./c.css') layer(foo) (orientation: landscape);
+@import url('./c.css') layer(bar) (orientation: portrait);
+
+.imported {
+  color: orange;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_c_css_253d00ef._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_c_css_253d00ef._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css
+
+```javascript
+.imported {
+  color: red;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_c_css_b584d5ad._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_c_css_b584d5ad._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/c.css
+
+```javascript
+.imported {
+  color: red;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_index_0d5b04e3.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_index_0d5b04e3.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_index_67920c94.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_index_67920c94.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_style_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/output/b1abf_turbopack-tests_tests_snapshot_css_chained-attributes_input_style_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                   | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/chained-attributes/input/style.css
+
+```javascript
+@import url('./a.css') layer(layer) supports(not(display: inline-grid)) print;
+
+.style {
+  color: yellow;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_index_49d4edb8.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_index_49d4edb8.js.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 8
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                  | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------ | ---- |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js | N/A  |
+| 8:8       | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js | N/A  |
+| 8:11      | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js | N/A  |
+| 8:12      | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js
+
+```javascript
+import './style.css'
+
+console.log('css-legacy-nesting')
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_index_f994aad2.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_index_f994aad2.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/b1abf_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_style_da464693.css.map.md
@@ -1,0 +1,39 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 3
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                   | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css | N/A  |
+| 2:109     | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css | N/A  |
+| 2:201     | 10:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/style.css
+
+```javascript
+.prose :where(table):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
+  tr {
+    td:first-child {
+      text-wrap: nowrap;
+    }
+  }
+  text-wrap: initial;
+}
+
+.prose :where(code):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
+  text-wrap: nowrap;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/4e721_crates_turbopack-tests_tests_snapshot_css_css-modules_input_index_11cf9f11.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/4e721_crates_turbopack-tests_tests_snapshot_css_css-modules_input_index_11cf9f11.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/b1abf_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_76a2527b.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/b1abf_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_76a2527b.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                   | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css
+
+```javascript
+.module-style {
+  grid-template-areas: 'checkbox avatar content actions menu';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/b1abf_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_css_d109b7a3._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/b1abf_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_css_d109b7a3._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css-modules_input_8f2e7f32._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css-modules_input_8f2e7f32._.js.map.md
@@ -1,0 +1,47 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module)`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 11
+- **Generated Lines**: 15
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                       | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module) | N/A  |
+| 6:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module) | N/A  |
+| 7:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module) | N/A  |
+| 13:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+| 15:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+| 15:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+| 15:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+| 15:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+| 15:219    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+| 15:220    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+| 15:230    | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js                             | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module)
+
+```javascript
+__turbopack_context__.v({
+  'module-style': 'style-module__cu3fEW__module-style',
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js
+
+```javascript
+import style from './style.module.css'
+
+console.log(style, import('./style.module.css'))
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/08d19_foo_style_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/08d19_foo_style_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,26 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                     | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.css
+
+```javascript
+.foo-style { color: green; }
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/08d19_foo_style_css_4412d076._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/08d19_foo_style_css_4412d076._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/08d19_foo_style_module_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/08d19_foo_style_module_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,26 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                            | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css
+
+```javascript
+.foo-module-style { color: blue; }
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/4e721_crates_turbopack-tests_tests_snapshot_css_css_input_imported_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/4e721_crates_turbopack-tests_tests_snapshot_css_css_input_imported_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                       | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css
+
+```javascript
+.imported {
+  color: cyan;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/4e721_crates_turbopack-tests_tests_snapshot_css_css_input_imported_css_f101d1d1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/4e721_crates_turbopack-tests_tests_snapshot_css_css_input_imported_css_f101d1d1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 4
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                       | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------- | ---- |
+| 4:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css
+
+```javascript
+.imported {
+  color: cyan;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/4e721_crates_turbopack-tests_tests_snapshot_css_css_input_style_module_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/4e721_crates_turbopack-tests_tests_snapshot_css_css_input_style_module_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,45 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css | N/A  |
+| 2:47      | 3:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css | N/A  |
+| 2:169     | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css | N/A  |
+| 2:227     | 14:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css
+
+```javascript
+.module-style {
+  color: magenta;
+  > h1,
+  + .inner {
+    background: purple;
+  }
+}
+
+.composed-module-style {
+  composes: foo-module-style from 'foo/style.module.css';
+  color: green;
+}
+
+.another-composed-module-style {
+  composes: foo-module-style from 'foo/style.module.css';
+  color: yellow;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_6dc4af09._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_6dc4af09._.js.map.md
@@ -1,0 +1,84 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css [test] (css module)`
+
+## Mappings Overview
+
+- **Total Mappings**: 22
+- **Generated Lines**: 29
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                                | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)                  | N/A  |
+| 6:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)                  | N/A  |
+| 7:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)                  | N/A  |
+| 8:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)                  | N/A  |
+| 9:0       | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)                  | N/A  |
+| 10:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)                  | N/A  |
+| 16:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 17:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:8      | 7:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:11     | 7:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:12     | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:208    | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:209    | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:219    | 7:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:221    | 7:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:440    | 7:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:441    | 7:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 23:451    | 7:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js                                              | N/A  |
+| 27:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css [test] (css module) | N/A  |
+| 28:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css [test] (css module) | N/A  |
+| 29:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css [test] (css module) | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css [test] (css module)
+
+```javascript
+__turbopack_context__.v({
+  'another-composed-module-style':
+    'style-module__Iu_hLa__another-composed-module-style' +
+    ' ' +
+    __turbopack_context__.i(
+      '[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css [test] (css module)'
+    )['foo-module-style'],
+  'composed-module-style':
+    'style-module__Iu_hLa__composed-module-style' +
+    ' ' +
+    __turbopack_context__.i(
+      '[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css [test] (css module)'
+    )['foo-module-style'],
+  inner: 'style-module__Iu_hLa__inner',
+  'module-style': 'style-module__Iu_hLa__module-style',
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/index.js
+
+```javascript
+import 'foo/style.css'
+import 'foo'
+import './style.css'
+import fooStyle from 'foo/style.module.css'
+import style from './style.module.css'
+
+console.log(style, fooStyle, import('foo'))
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css [test] (css module)
+
+```javascript
+__turbopack_context__.v({
+  'foo-module-style': 'style-module__CEkn7G__foo-module-style',
+})
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_94f90ccb._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_94f90ccb._.css.map.md
@@ -1,0 +1,87 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 9
+- **Generated Lines**: 21
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                            | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.css        | N/A  |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css                      | N/A  |
+| 10:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css                      | N/A  |
+| 15:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.css                         | N/A  |
+| 18:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css | N/A  |
+| 21:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css                  | N/A  |
+| 21:47     | 3:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css                  | N/A  |
+| 21:169    | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css                  | N/A  |
+| 21:227    | 14:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css                  | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.css
+
+```javascript
+.foo-style { color: green; }
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css
+
+```javascript
+.imported {
+  color: cyan;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.css
+
+```javascript
+@import url('./imported.css');
+/* De-duplicate similar imports */
+@import url('../input/imported.css');
+/* But not if they have different attributes */
+@import url('./imported.css') layer(layer) print;
+.style {
+  color: yellow;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/node_modules/foo/style.module.css
+
+```javascript
+.foo-module-style { color: blue; }
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.module.css
+
+```javascript
+.module-style {
+  color: magenta;
+  > h1,
+  + .inner {
+    background: purple;
+  }
+}
+
+.composed-module-style {
+  composes: foo-module-style from 'foo/style.module.css';
+  color: green;
+}
+
+.another-composed-module-style {
+  composes: foo-module-style from 'foo/style.module.css';
+  color: yellow;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_index_9703408d.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_index_9703408d.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_style_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/css/output/turbopack_crates_turbopack-tests_tests_snapshot_css_css_input_style_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,33 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                    | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/css/input/style.css
+
+```javascript
+@import url('./imported.css');
+/* De-duplicate similar imports */
+@import url('../input/imported.css');
+/* But not if they have different attributes */
+@import url('./imported.css') layer(layer) print;
+.style {
+  color: yellow;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_0b2172c2._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_0b2172c2._.css.map.md
@@ -1,0 +1,85 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/1.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 5
+- **Generated Lines**: 14
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css | N/A  |
+| 11:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css | N/A  |
+| 14:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css
+
+```javascript
+@import 'a.css';
+
+.e {
+  content: '1 3';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css
+
+```javascript
+@import 'e.css';
+
+.d {
+  content: '2 4';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css
+
+```javascript
+@import 'd.css';
+
+.c {
+  content: '3 5';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css
+
+```javascript
+@import 'c.css';
+
+.b {
+  content: '4 1';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css
+
+```javascript
+@import 'b.css';
+
+.a {
+  content: '5 2';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/1.css
+
+```javascript
+@import 'a.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_1_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_1_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,25 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/1.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/1.css
+
+```javascript
+@import 'a.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_2_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_2_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,25 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/2.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/2.css
+
+```javascript
+@import 'c.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_5b2f9846._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_5b2f9846._.css.map.md
@@ -1,0 +1,42 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 2
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css
+
+```javascript
+@import 'y.css';
+
+.x {
+  content: '1 2';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css
+
+```javascript
+@import 'x.css';
+
+.y {
+  content: '2 1';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_6e021331._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_6e021331._.css.map.md
@@ -1,0 +1,85 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/2.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 5
+- **Generated Lines**: 14
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css | N/A  |
+| 11:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css | N/A  |
+| 14:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css
+
+```javascript
+@import 'c.css';
+
+.b {
+  content: '4 1';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css
+
+```javascript
+@import 'b.css';
+
+.a {
+  content: '5 2';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css
+
+```javascript
+@import 'a.css';
+
+.e {
+  content: '1 3';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css
+
+```javascript
+@import 'e.css';
+
+.d {
+  content: '2 4';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css
+
+```javascript
+@import 'd.css';
+
+.c {
+  content: '3 5';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/2.css
+
+```javascript
+@import 'c.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_99c586b3._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_99c586b3._.css.map.md
@@ -1,0 +1,42 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 2
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css
+
+```javascript
+@import 'x.css';
+
+.y {
+  content: '2 1';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css
+
+```javascript
+@import 'y.css';
+
+.x {
+  content: '1 2';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_a01bb184._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_a01bb184._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_a_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_a_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/a.css
+
+```javascript
+@import 'b.css';
+
+.a {
+  content: '5 2';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_b_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_b_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/b.css
+
+```javascript
+@import 'c.css';
+
+.b {
+  content: '4 1';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_c_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_c_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/c.css
+
+```javascript
+@import 'd.css';
+
+.c {
+  content: '3 5';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_d_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_d_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/d.css
+
+```javascript
+@import 'e.css';
+
+.d {
+  content: '2 4';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_e_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_e_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/e.css
+
+```javascript
+@import 'a.css';
+
+.e {
+  content: '1 3';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_fba71ce2._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_fba71ce2._.css.map.md
@@ -1,0 +1,54 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/k.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/j.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/i.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 3
+- **Generated Lines**: 8
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/k.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/j.css | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/i.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/k.css
+
+```javascript
+@import 'i.css';
+
+.k {
+  content: '1';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/j.css
+
+```javascript
+@import 'k.css';
+
+.j {
+  content: '2';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/i.css
+
+```javascript
+@import 'j.css';
+
+.i {
+  content: '3';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_i_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_i_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/i.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/i.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/i.css
+
+```javascript
+@import 'j.css';
+
+.i {
+  content: '3';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_index_2a740bfb.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_index_2a740bfb.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_index_55bab8d2.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_index_55bab8d2.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_j_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_j_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/j.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/j.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/j.css
+
+```javascript
+@import 'k.css';
+
+.j {
+  content: '2';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_k_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_k_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/k.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/k.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/k.css
+
+```javascript
+@import 'i.css';
+
+.k {
+  content: '1';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_x_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_x_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/x.css
+
+```javascript
+@import 'y.css';
+
+.x {
+  content: '1 2';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_y_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle_input_y_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                  | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle/input/y.css
+
+```javascript
+@import 'x.css';
+
+.y {
+  content: '2 1';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_1_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,27 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css
+
+```javascript
+@import 'a.css';
+@import 'x.css';
+@import 'y.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,26 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css
+
+```javascript
+@import 'y.css';
+@import 'x.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_2bc55788._.css.map.md
@@ -1,0 +1,110 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css`
+7. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css`
+8. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 7
+- **Generated Lines**: 20
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css | N/A  |
+| 11:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css | N/A  |
+| 14:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css | N/A  |
+| 17:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css | N/A  |
+| 20:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css
+
+```javascript
+@import 'c.css';
+
+.b {
+  content: '4 1';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css
+
+```javascript
+@import 'b.css';
+
+.a {
+  content: '5 2';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css
+
+```javascript
+@import 'a.css';
+
+.e {
+  content: '1 3';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css
+
+```javascript
+@import 'e.css';
+
+.d {
+  content: '2 4';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css
+
+```javascript
+@import 'd.css';
+
+.c {
+  content: '3 5';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css
+
+```javascript
+@import 'c.css';
+
+.y {
+  content: '7 6';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css
+
+```javascript
+@import 'a.css';
+
+.x {
+  content: '6 7';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/2.css
+
+```javascript
+@import 'y.css';
+@import 'x.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_542ea1fb._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_542ea1fb._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_a_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css
+
+```javascript
+@import 'b.css';
+
+.a {
+  content: '5 2';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_b_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css
+
+```javascript
+@import 'c.css';
+
+.b {
+  content: '4 1';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_c_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css
+
+```javascript
+@import 'd.css';
+
+.c {
+  content: '3 5';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_d_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css
+
+```javascript
+@import 'e.css';
+
+.d {
+  content: '2 4';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_e_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css
+
+```javascript
+@import 'a.css';
+
+.e {
+  content: '1 3';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_ea25098c._.css.map.md
@@ -1,0 +1,111 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css`
+7. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css`
+8. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 7
+- **Generated Lines**: 20
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css | N/A  |
+| 11:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css | N/A  |
+| 14:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css | N/A  |
+| 17:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css | N/A  |
+| 20:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/e.css
+
+```javascript
+@import 'a.css';
+
+.e {
+  content: '1 3';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/d.css
+
+```javascript
+@import 'e.css';
+
+.d {
+  content: '2 4';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/c.css
+
+```javascript
+@import 'd.css';
+
+.c {
+  content: '3 5';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/b.css
+
+```javascript
+@import 'c.css';
+
+.b {
+  content: '4 1';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/a.css
+
+```javascript
+@import 'b.css';
+
+.a {
+  content: '5 2';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css
+
+```javascript
+@import 'a.css';
+
+.x {
+  content: '6 7';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css
+
+```javascript
+@import 'c.css';
+
+.y {
+  content: '7 6';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/1.css
+
+```javascript
+@import 'a.css';
+@import 'x.css';
+@import 'y.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_3103954c.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_3103954c.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_index_d9d7a2bc.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_x_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/x.css
+
+```javascript
+@import 'a.css';
+
+.x {
+  content: '6 7';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/output/turbopack_crates_turbopack-tests_tests_snapshot_css_cycle2_input_y_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                   | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/cycle2/input/y.css
+
+```javascript
+@import 'c.css';
+
+.y {
+  content: '7 6';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/4e721_crates_turbopack-tests_tests_snapshot_css_embed-url_input_index_fb2786b6.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/4e721_crates_turbopack-tests_tests_snapshot_css_embed-url_input_index_fb2786b6.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/4e721_crates_turbopack-tests_tests_snapshot_css_embed-url_input_style_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/4e721_crates_turbopack-tests_tests_snapshot_css_embed-url_input_style_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                          | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.css
+
+```javascript
+.style {
+  cursor: url(./image.png);
+  list-style-image: url(image.png);
+  background-image: url('image.png');
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/b1abf_turbopack-tests_tests_snapshot_css_embed-url_input_style_module_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/b1abf_turbopack-tests_tests_snapshot_css_embed-url_input_style_module_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                 | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css
+
+```javascript
+.module-style {
+  cursor: url(./image.png);
+  list-style-image: url(image.png);
+  background-image: url('./image.png');
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/turbopack_crates_turbopack-tests_tests_snapshot_css_embed-url_input_00f6db8e._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/turbopack_crates_turbopack-tests_tests_snapshot_css_embed-url_input_00f6db8e._.css.map.md
@@ -1,0 +1,42 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 2
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                 | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css | N/A  |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.css        | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css
+
+```javascript
+.module-style {
+  cursor: url(./image.png);
+  list-style-image: url(image.png);
+  background-image: url('./image.png');
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.css
+
+```javascript
+.style {
+  cursor: url(./image.png);
+  list-style-image: url(image.png);
+  background-image: url('image.png');
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/turbopack_crates_turbopack-tests_tests_snapshot_css_embed-url_input_4242144a._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/turbopack_crates_turbopack-tests_tests_snapshot_css_embed-url_input_4242144a._.js.map.md
@@ -1,0 +1,48 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css [test] (css module)`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 11
+- **Generated Lines**: 16
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                     | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css [test] (css module) | N/A  |
+| 6:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css [test] (css module) | N/A  |
+| 7:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css [test] (css module) | N/A  |
+| 13:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+| 16:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+| 16:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+| 16:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+| 16:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+| 16:217    | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+| 16:218    | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+| 16:228    | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js                             | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/style.module.css [test] (css module)
+
+```javascript
+__turbopack_context__.v({
+  'module-style': 'style-module__3oVw9q__module-style',
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/input/index.js
+
+```javascript
+import style from './style.module.css'
+import './style.css'
+
+console.log(style, import('./style.module.css'), import('./style.css'))
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/turbopack_crates_turbopack-tests_tests_snapshot_css_embed-url_input_dfe8423f._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/embed-url/output/turbopack_crates_turbopack-tests_tests_snapshot_css_embed-url_input_dfe8423f._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/output/4c35f_tests_snapshot_css_protocol-dependent-import_input_index_27f91733.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/output/4c35f_tests_snapshot_css_protocol-dependent-import_input_index_27f91733.css.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/input/index.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 4
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                          | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ---- |
+| 4:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/input/index.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/input/index.css
+
+```javascript
+@import url('//example.com/something.css');
+@import '//somewhere.com/example.css';
+
+.foo {
+  background: red;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/output/4c35f_tests_snapshot_css_protocol-dependent-import_input_index_3598d8f7.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/output/4c35f_tests_snapshot_css_protocol-dependent-import_input_index_3598d8f7.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/output/4c35f_tests_snapshot_css_protocol-dependent-import_input_index_6ff0de3a.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/protocol-dependent-import/output/4c35f_tests_snapshot_css_protocol-dependent-import_input_index_6ff0de3a.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/4c35f_tests_snapshot_css_relative-uri-import_input_another_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/4c35f_tests_snapshot_css_relative-uri-import_input_another_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/another.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                      | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/another.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/another.css
+
+```javascript
+.bar {
+  background-color: green;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/4e721_crates_turbopack-tests_tests_snapshot_css_relative-uri-import_input_7ad52761._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/4e721_crates_turbopack-tests_tests_snapshot_css_relative-uri-import_input_7ad52761._.css.map.md
@@ -1,0 +1,52 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/another.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/other.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/index.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 3
+- **Generated Lines**: 8
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                      | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/another.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/other.css   | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/index.css   | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/another.css
+
+```javascript
+.bar {
+  background-color: green;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/other.css
+
+```javascript
+@import 'another.css';
+
+.foo {
+  background-color: red;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/index.css
+
+```javascript
+@import 'other.css';
+
+body {
+  background-color: blue;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_index_28191c1f.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_index_28191c1f.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_index_8ff7551e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_index_8ff7551e.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_index_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_index_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/index.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                    | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/index.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/index.css
+
+```javascript
+@import 'other.css';
+
+body {
+  background-color: blue;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_other_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_css_relative-uri-import_input_other_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/other.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                    | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/other.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/relative-uri-import/input/other.css
+
+```javascript
+@import 'another.css';
+
+.foo {
+  background-color: red;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_a_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_a_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/a.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                         | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/a.css
+
+```javascript
+.a {
+  content: '1';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b0_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b0_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b0.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                          | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b0.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b0.css
+
+```javascript
+.b0 {
+  content: '2';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b1_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b1_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                          | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css
+
+```javascript
+@import 'b1a.css';
+@import 'b1b.css';
+
+.b1 {
+  content: '5';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b1a_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b1a_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css
+
+```javascript
+.b1a {
+  content: '3';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b1b_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b1b_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css
+
+```javascript
+.b1b {
+  content: '4';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b2_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b2_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b2.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                          | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b2.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b2.css
+
+```javascript
+.b2 {
+  content: '6';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b3_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b3_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                          | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css
+
+```javascript
+@import 'b3a.css';
+@import 'b3b.css';
+
+.b3 {
+  content: '11';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b3a_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b3a_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css
+
+```javascript
+@import 'shared.css';
+
+.b3a {
+  content: '9';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b3b_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b3b_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css
+
+```javascript
+.b3a {
+  content: '10';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b4_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b4_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                          | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css
+
+```javascript
+@import 'b4a.css';
+@import 'b4b.css';
+
+.b4 {
+  content: '14';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b4a_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b4a_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css
+
+```javascript
+@import 'shared.css';
+
+.b4a {
+  content: '12';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b4b_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b4b_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css
+
+```javascript
+@import 'shared.css';
+
+.b4b {
+  content: '13';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_b_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,34 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                         | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b.css
+
+```javascript
+@import 'b0.css';
+@import 'b1.css';
+@import 'b2.css';
+@import 'b3.css';
+@import 'b4.css';
+
+.b {
+  content: '16';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_c_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_c_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/c.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                         | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/c.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/c.css
+
+```javascript
+@import 'shared.css';
+
+.c {
+  content: '17';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_entry_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_entry_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,27 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry.css
+
+```javascript
+@import 'a.css';
+@import 'b.css';
+@import 'c.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_index_991c6db2.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_index_991c6db2.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_index_fc583b08.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/4e721_crates_turbopack-tests_tests_snapshot_css_split-shared_input_index_fc583b08.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/b1abf_turbopack-tests_tests_snapshot_css_split-shared_input_entry2_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/b1abf_turbopack-tests_tests_snapshot_css_split-shared_input_entry2_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,26 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry2.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry2.css
+
+```javascript
+@import 'b4.css';
+@import 'b3.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/b1abf_turbopack-tests_tests_snapshot_css_split-shared_input_shared1_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/b1abf_turbopack-tests_tests_snapshot_css_split-shared_input_shared1_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css
+
+```javascript
+.shared {
+  content: '7';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/b1abf_turbopack-tests_tests_snapshot_css_split-shared_input_shared_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/b1abf_turbopack-tests_tests_snapshot_css_split-shared_input_shared_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,30 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                              | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css
+
+```javascript
+@import 'shared1.css';
+
+.shared {
+  content: '8';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_0a7658f6._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_0a7658f6._.css.map.md
@@ -1,0 +1,212 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/a.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b0.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b2.css`
+7. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css`
+8. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css`
+9. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css`
+10. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css`
+11. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css`
+12. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css`
+13. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css`
+14. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css`
+15. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b.css`
+16. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/c.css`
+17. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 16
+- **Generated Lines**: 47
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/a.css       | N/A  |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b0.css      | N/A  |
+| 8:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css     | N/A  |
+| 11:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css     | N/A  |
+| 14:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css      | N/A  |
+| 17:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b2.css      | N/A  |
+| 20:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css | N/A  |
+| 23:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css  | N/A  |
+| 26:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css     | N/A  |
+| 29:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css     | N/A  |
+| 32:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css      | N/A  |
+| 35:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css     | N/A  |
+| 38:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css     | N/A  |
+| 41:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css      | N/A  |
+| 44:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b.css       | N/A  |
+| 47:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/c.css       | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/a.css
+
+```javascript
+.a {
+  content: '1';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b0.css
+
+```javascript
+.b0 {
+  content: '2';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css
+
+```javascript
+.b1a {
+  content: '3';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css
+
+```javascript
+.b1b {
+  content: '4';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css
+
+```javascript
+@import 'b1a.css';
+@import 'b1b.css';
+
+.b1 {
+  content: '5';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b2.css
+
+```javascript
+.b2 {
+  content: '6';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css
+
+```javascript
+.shared {
+  content: '7';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css
+
+```javascript
+@import 'shared1.css';
+
+.shared {
+  content: '8';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css
+
+```javascript
+@import 'shared.css';
+
+.b3a {
+  content: '9';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css
+
+```javascript
+.b3a {
+  content: '10';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css
+
+```javascript
+@import 'b3a.css';
+@import 'b3b.css';
+
+.b3 {
+  content: '11';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css
+
+```javascript
+@import 'shared.css';
+
+.b4a {
+  content: '12';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css
+
+```javascript
+@import 'shared.css';
+
+.b4b {
+  content: '13';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css
+
+```javascript
+@import 'b4a.css';
+@import 'b4b.css';
+
+.b4 {
+  content: '14';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b.css
+
+```javascript
+@import 'b0.css';
+@import 'b1.css';
+@import 'b2.css';
+@import 'b3.css';
+@import 'b4.css';
+
+.b {
+  content: '16';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/c.css
+
+```javascript
+@import 'shared.css';
+
+.c {
+  content: '17';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry.css
+
+```javascript
+@import 'a.css';
+@import 'b.css';
+@import 'c.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_3ca1f629._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_3ca1f629._.css.map.md
@@ -1,0 +1,51 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 3
+- **Generated Lines**: 8
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css | N/A  |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css | N/A  |
+| 8:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css  | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1a.css
+
+```javascript
+.b1a {
+  content: '3';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1b.css
+
+```javascript
+.b1b {
+  content: '4';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b1.css
+
+```javascript
+@import 'b1a.css';
+@import 'b1b.css';
+
+.b1 {
+  content: '5';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_7654011c._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_7654011c._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_e3f0ee03._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/output/turbopack_crates_turbopack-tests_tests_snapshot_css_split-shared_input_e3f0ee03._.css.map.md
@@ -1,0 +1,120 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css`
+7. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css`
+8. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css`
+9. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry2.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 8
+- **Generated Lines**: 23
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css | N/A  |
+| 5:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css  | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css     | N/A  |
+| 11:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css     | N/A  |
+| 14:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css      | N/A  |
+| 17:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css     | N/A  |
+| 20:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css     | N/A  |
+| 23:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css      | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared1.css
+
+```javascript
+.shared {
+  content: '7';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/shared.css
+
+```javascript
+@import 'shared1.css';
+
+.shared {
+  content: '8';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4a.css
+
+```javascript
+@import 'shared.css';
+
+.b4a {
+  content: '12';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4b.css
+
+```javascript
+@import 'shared.css';
+
+.b4b {
+  content: '13';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b4.css
+
+```javascript
+@import 'b4a.css';
+@import 'b4b.css';
+
+.b4 {
+  content: '14';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3a.css
+
+```javascript
+@import 'shared.css';
+
+.b3a {
+  content: '9';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3b.css
+
+```javascript
+.b3a {
+  content: '10';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/b3.css
+
+```javascript
+@import 'b3a.css';
+@import 'b3b.css';
+
+.b3 {
+  content: '11';
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/input/entry2.css
+
+```javascript
+@import 'b4.css';
+@import 'b3.css';
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/output/b1abf_turbopack-tests_tests_snapshot_css_url-in-supports-query_input_index_160b9ebb.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/output/b1abf_turbopack-tests_tests_snapshot_css_url-in-supports-query_input_index_160b9ebb.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/output/b1abf_turbopack-tests_tests_snapshot_css_url-in-supports-query_input_index_2a114409.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/output/b1abf_turbopack-tests_tests_snapshot_css_url-in-supports-query_input_index_2a114409.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/output/b1abf_turbopack-tests_tests_snapshot_css_url-in-supports-query_input_style_ce5c14b9.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/output/b1abf_turbopack-tests_tests_snapshot_css_url-in-supports-query_input_style_ce5c14b9.css.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/input/style.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 2
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                      | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/input/style.css | N/A  |
+| 2:53      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/input/style.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/url-in-supports-query/input/style.css
+
+```javascript
+@supports ((-webkit-mask: url('')) or (mask: url(''))) {
+  .supports-url-in-query {
+    color: red;
+  }
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/output/4e721_crates_turbopack-tests_tests_snapshot_cssmodules_composes_input_8bd35093._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/output/4e721_crates_turbopack-tests_tests_snapshot_cssmodules_composes_input_8bd35093._.js.map.md
@@ -1,0 +1,41 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css [test] (css module)`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 5
+- **Generated Lines**: 14
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                           | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css [test] (css module) | N/A  |
+| 6:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css [test] (css module) | N/A  |
+| 7:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css [test] (css module) | N/A  |
+| 8:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css [test] (css module) | N/A  |
+| 14:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.js                             | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css [test] (css module)
+
+```javascript
+__turbopack_context__.v({
+  className: 'index-module__H6xp9G__className',
+  subClass:
+    'index-module__H6xp9G__subClass' + ' ' + 'index-module__H6xp9G__className',
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.js
+
+```javascript
+import { subClass } from './index.module.css'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/output/4e721_crates_turbopack-tests_tests_snapshot_cssmodules_composes_input_index_c44bfeab.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/output/4e721_crates_turbopack-tests_tests_snapshot_cssmodules_composes_input_index_c44bfeab.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/output/b1abf_turbopack-tests_tests_snapshot_cssmodules_composes_input_index_module_22660277.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/output/b1abf_turbopack-tests_tests_snapshot_cssmodules_composes_input_index_module_22660277.css.map.md
@@ -1,0 +1,35 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 2
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                       | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css | N/A  |
+| 2:59      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/composes/input/index.module.css
+
+```javascript
+.className {
+  background: red;
+  color: yellow;
+}
+
+.subClass {
+  composes: className;
+  background: blue;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/4c35f_tests_snapshot_cssmodules_relative-uri-import_input_index_940d8f7e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/4c35f_tests_snapshot_cssmodules_relative-uri-import_input_index_940d8f7e.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/4c35f_tests_snapshot_cssmodules_relative-uri-import_input_index_module_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/4c35f_tests_snapshot_cssmodules_relative-uri-import_input_index_module_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                  | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css
+
+```javascript
+.bar {
+  composes: foo from 'other.module.css';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/4c35f_tests_snapshot_cssmodules_relative-uri-import_input_other_module_css_20ccc9f1._.single.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/4c35f_tests_snapshot_cssmodules_relative-uri-import_input_other_module_css_20ccc9f1._.single.css.map.md
@@ -1,0 +1,28 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 2
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                  | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css
+
+```javascript
+.foo {
+  background-color: red;
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_cssmodules_relative-uri-import_input_5a7b6f11._.css.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_cssmodules_relative-uri-import_input_5a7b6f11._.css.map.md
@@ -1,0 +1,38 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css`
+
+## Mappings Overview
+
+- **Total Mappings**: 2
+- **Generated Lines**: 5
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                  | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 2:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css | N/A  |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css
+
+```javascript
+.foo {
+  background-color: red;
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css
+
+```javascript
+.bar {
+  composes: foo from 'other.module.css';
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_cssmodules_relative-uri-import_input_65c88461._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/output/b1abf_turbopack-tests_tests_snapshot_cssmodules_relative-uri-import_input_65c88461._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css [test] (css module)`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css [test] (css module)`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 7
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                                      | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 5:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css [test] (css module) | N/A  |
+| 6:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css [test] (css module) | N/A  |
+| 7:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css [test] (css module) | N/A  |
+| 11:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css [test] (css module) | N/A  |
+| 12:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css [test] (css module) | N/A  |
+| 13:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css [test] (css module) | N/A  |
+| 19:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.js                             | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css [test] (css module)
+
+```javascript
+__turbopack_context__.v({
+  foo: 'other-module__NjlEuq__foo',
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.module.css [test] (css module)
+
+```javascript
+__turbopack_context__.v({
+  bar:
+    'index-module__jZ0vmq__bar' +
+    ' ' +
+    __turbopack_context__.i(
+      '[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/other.module.css [test] (css module)'
+    )['foo'],
+})
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cssmodules/relative-uri-import/input/index.js
+
+```javascript
+import { foo } from './index.module.css'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/output/4c35f_tests_snapshot_dynamic-request_very-dynamic_input_index_3e7886b8.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/output/4c35f_tests_snapshot_dynamic-request_very-dynamic_input_index_3e7886b8.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/output/4c35f_tests_snapshot_dynamic-request_very-dynamic_input_index_c4e3aa79.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/output/4c35f_tests_snapshot_dynamic-request_very-dynamic_input_index_c4e3aa79.js.map.md
@@ -1,0 +1,92 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 54
+- **Generated Lines**: 35
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                        | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------ | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 8:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 16:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 16:6      | 4:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 16:16     | 4:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 16:21     | 4:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 16:27     | 4:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 17:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 17:51     | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 17:52     | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 17:62     | 6:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 17:63     | 6:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 17:72     | 6:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 17:73     | 6:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:51     | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:52     | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:62     | 7:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:63     | 7:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:72     | 7:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:73     | 7:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 18:81     | 7:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:0      | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:51     | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:52     | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:62     | 8:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:63     | 8:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:72     | 8:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:73     | 8:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 19:81     | 8:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 20:4      | 8:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 21:4      | 8:42     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 22:1      | 8:50     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 33:0      | 14:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 33:40     | 14:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 33:41     | 14:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 33:51     | 14:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 33:52     | 14:3     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 33:64     | 14:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 33:65     | 14:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:1      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:4      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:44     | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:45     | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:60     | 15:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:60     | 15:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 34:62     | 15:13    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 35:0      | 17:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| 35:4      | 17:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js | N/A  |
+| ...       | ...      | ...                                                                                                                | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/dynamic-request/very-dynamic/input/index.js
+
+```javascript
+import child_process from 'node:child_process'
+import fs, { readFileSync } from 'node:fs'
+
+const unknown = Math.random()
+
+child_process.spawnSync(unknown)
+child_process.spawnSync('node', unknown)
+child_process.spawnSync('node', [unknown, unknown])
+
+require(unknown)
+
+import(unknown)
+
+fs.readFileSync(unknown)
+readFileSync(unknown)
+
+new URL(unknown, import.meta.url)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/4e721_crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_e110ac77.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/4e721_crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_e110ac77.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/turbopack_crates_turbopack-tests_tests_snapshot_6fdc60d8._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/turbopack_crates_turbopack-tests_tests_snapshot_6fdc60d8._.js.map.md
@@ -1,0 +1,119 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/jsx-dev-runtime.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/index.js`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/styled/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 47
+- **Generated Lines**: 55
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                           | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------- | ---- |
+| 6:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 6:36      | 1:36     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 8:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 9:0       | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:6      | 6:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:35     | 6:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:36     | 6:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:39     | 6:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:239    | 6:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:240    | 6:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:250    | 6:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 13:250    | 6:26     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 16:0      | 10:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 16:9      | 10:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 16:25     | 10:25    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 16:27     | 10:27    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 16:35     | 10:35    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 16:37     | 10:37    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 17:4      | 11:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 17:25     | 12:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 17:256    | 12:5     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 18:8      | 13:6     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 18:19     | 13:17    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 18:22     | 13:20    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 18:23     | 13:21    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 20:6      | 15:6     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 20:7      | 15:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 21:18     | 17:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 27:0      | 20:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 28:0      | 22:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 28:8      | 22:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 28:11     | 22:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 28:12     | 22:12    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 28:26     | 22:26    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js                 | N/A  |
+| 36:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/jsx-dev-runtime.js | N/A  |
+| 36:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/jsx-dev-runtime.js | N/A  |
+| 37:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/jsx-dev-runtime.js | N/A  |
+| 37:11     | 2:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/jsx-dev-runtime.js | N/A  |
+| 38:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/jsx-dev-runtime.js | N/A  |
+| 46:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/index.js           | N/A  |
+| 46:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/index.js           | N/A  |
+| 47:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/index.js           | N/A  |
+| 47:11     | 2:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/index.js           | N/A  |
+| 48:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/index.js           | N/A  |
+| 54:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/styled/index.js          | N/A  |
+| 55:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/styled/index.js          | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js
+
+```javascript
+/** @jsxImportSource @emotion/react */
+
+import { jsx } from '@emotion/react'
+import styled from '@emotion/styled'
+
+const StyledButton = styled.button`
+  background: blue;
+`
+
+function ClassNameButton({ children }) {
+  return (
+    <button
+      className={css`
+        background: blue;
+      `}
+    >
+      {children}
+    </button>
+  )
+}
+
+// ... (2 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/jsx-dev-runtime.js
+
+```javascript
+export function jsxDEV() {
+  return 'purposefully empty stub for @emotion/react/jsx-dev-runtime.js'
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/react/index.js
+
+```javascript
+export function jsx() {
+  return 'purposefully empty stub for @emotion/react/index.js'
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@emotion/styled/index.js
+
+```javascript
+'purposefully empty stub'
+'@emtion/styled/index.js'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/env/env/output/turbopack_crates_turbopack-tests_tests_snapshot_env_env_input_a18b44b7._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/env/env/output/turbopack_crates_turbopack-tests_tests_snapshot_env_env_input_a18b44b7._.js.map.md
@@ -1,0 +1,90 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 55
+- **Generated Lines**: 21
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                       | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 7:6       | 1:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 7:12      | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 7:20      | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 7:23      | 1:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 7:26      | 1:26     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 8:4       | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 8:7       | 1:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 8:15      | 1:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 8:18      | 1:41     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 9:0       | 1:41     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 10:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 10:3      | 3:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 10:4      | 3:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 10:16     | 3:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 10:19     | 3:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 11:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 11:3      | 4:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 11:4      | 4:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 11:13     | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 11:16     | 4:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 12:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 12:3      | 5:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 12:4      | 5:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 12:10     | 5:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 12:13     | 5:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 13:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 13:3      | 6:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 13:4      | 6:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 13:13     | 6:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 13:16     | 6:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js | N/A  |
+| 19:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 19:8      | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 19:11     | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 19:12     | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 19:20     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 19:23     | 1:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 19:24     | 1:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 19:30     | 1:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:8      | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:11     | 2:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:12     | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:20     | 2:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:23     | 2:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:24     | 2:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 20:30     | 2:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 21:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| 21:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js     | N/A  |
+| ...       | ...      | ...                                                                                               | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js
+
+```javascript
+const env = (process.env = { ...process.env })
+
+env['ALLFOOBAR'] = foobarfoobar
+env['BARFOO'] = barfoo
+env['FOO'] = foo
+env['FOOBAR'] = foobar
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/env/env/input/index.js
+
+```javascript
+console.log(process.env.FOOBAR)
+console.log(process.env.BARFOO)
+console.log(process.env.ALLFOOBAR)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/env/env/output/turbopack_crates_turbopack-tests_tests_snapshot_env_env_input_index_106873bb.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/env/env/output/turbopack_crates_turbopack-tests_tests_snapshot_env_env_input_index_106873bb.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/4c35f_tests_snapshot_evaluated_entrry_runtime_entry_input_index_23249686.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/4c35f_tests_snapshot_evaluated_entrry_runtime_entry_input_index_23249686.js.map.md
@@ -1,0 +1,29 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                          | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/input/index.js | N/A  |
+| 7:8       | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/input/index.js | N/A  |
+| 7:11      | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/input/index.js | N/A  |
+| 7:12      | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/input/index.js
+
+```javascript
+console.log('hello world')
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/4c35f_tests_snapshot_evaluated_entrry_runtime_entry_input_index_c1ec8af8.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/4c35f_tests_snapshot_evaluated_entrry_runtime_entry_input_index_c1ec8af8.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/example/example/output/4e721_crates_turbopack-tests_tests_snapshot_example_example_input_index_74ebec2a.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/example/example/output/4e721_crates_turbopack-tests_tests_snapshot_example_example_input_index_74ebec2a.js.map.md
@@ -1,0 +1,29 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/example/example/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/example/example/input/index.js | N/A  |
+| 7:8       | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/example/example/input/index.js | N/A  |
+| 7:11      | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/example/example/input/index.js | N/A  |
+| 7:12      | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/example/example/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/example/example/input/index.js
+
+```javascript
+console.log('hello world')
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/example/example/output/4e721_crates_turbopack-tests_tests_snapshot_example_example_input_index_ac1892c4.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/example/example/output/4e721_crates_turbopack-tests_tests_snapshot_example_example_input_index_ac1892c4.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/4e721_crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_23f31a5c.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/4e721_crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_23f31a5c.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/turbopack_crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_02fc4644._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/turbopack_crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_02fc4644._.js.map.md
@@ -1,0 +1,79 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 25
+- **Generated Lines**: 36
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js | N/A  |
+| 7:14      | 1:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js | N/A  |
+| 8:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js | N/A  |
+| 8:8       | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js | N/A  |
+| 8:13      | 2:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js | N/A  |
+| 8:16      | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js | N/A  |
+| 13:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js        | N/A  |
+| 13:7      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js        | N/A  |
+| 15:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js        | N/A  |
+| 15:352    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js        | N/A  |
+| 15:394    | 3:42     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js        | N/A  |
+| 22:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js        | N/A  |
+| 22:7      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js        | N/A  |
+| 24:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js        | N/A  |
+| 24:338    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js        | N/A  |
+| 24:401    | 3:63     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js        | N/A  |
+| 25:1      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js        | N/A  |
+| 25:75     | 4:74     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js        | N/A  |
+| 32:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js    | N/A  |
+| 32:7      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js    | N/A  |
+| 34:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js    | N/A  |
+| 36:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js    | N/A  |
+| 36:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js    | N/A  |
+| 36:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js    | N/A  |
+| 36:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js    | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js
+
+```javascript
+// commonjs.js
+exports.hello = 'World'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js
+
+```javascript
+// c.js
+export * from './commonjs.js'
+// This would be handled by existing logic
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js
+
+```javascript
+// b.js
+export * from './c'
+// This would not be handled, but still need __turbopack__cjs__
+// as there are properties dynamically added by __turbopack__cjs__ in c.js
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js
+
+```javascript
+// a.js
+import * as B from './b'
+console.log(B)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/4e721_crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_97f0a853._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/4e721_crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_97f0a853._.js.map.md
@@ -1,0 +1,62 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 27
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                      | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 7:7       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 7:14      | 1:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 8:4       | 1:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 8:9       | 1:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 9:4       | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 9:9       | 1:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 10:0      | 1:34     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs | N/A  |
+| 16:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js       | N/A  |
+| 19:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js       | N/A  |
+| 19:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js       | N/A  |
+| 19:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js       | N/A  |
+| 19:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js       | N/A  |
+| 25:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js     | N/A  |
+| 27:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js     | N/A  |
+| 27:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js     | N/A  |
+| 27:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js     | N/A  |
+| 27:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js     | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs
+
+```javascript
+module.exports = { foo: 1, bar: 2 }
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js
+
+```javascript
+export * from './exported.cjs'
+
+console.log('Hoist test')
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js
+
+```javascript
+import * as foo from './mod.js'
+
+console.log(foo)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/b1abf_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_54ca0799.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/b1abf_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_54ca0799.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_14b2f0d4.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_14b2f0d4.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/turbopack_crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_8e1e0275._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/turbopack_crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_8e1e0275._.js.map.md
@@ -1,0 +1,39 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 7
+- **Generated Lines**: 18
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs  | N/A  |
+| 12:8      | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs  | N/A  |
+| 12:11     | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs  | N/A  |
+| 12:12     | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs  | N/A  |
+| 12:42     | 1:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs  | N/A  |
+| 12:45     | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs  | N/A  |
+| 18:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs
+
+```javascript
+console.log(import.meta.url)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/index.js
+
+```javascript
+import './mod.cjs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_2057b4c5._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_2057b4c5._.js.map.md
@@ -1,0 +1,61 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 21
+- **Generated Lines**: 25
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                    | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 12:9      | 1:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 13:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 13:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 13:15     | 2:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 13:16     | 2:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 13:46     | 2:26     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 13:49     | 2:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 14:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 15:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 15:9      | 4:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 16:4      | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 16:12     | 5:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 16:15     | 5:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 16:16     | 5:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 16:46     | 5:26     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 16:49     | 5:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 17:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 18:0      | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 19:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs  | N/A  |
+| 25:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/mod.mjs
+
+```javascript
+function foo() {
+  console.log(import.meta.url)
+}
+function bar() {
+  console.log(import.meta.url)
+}
+
+foo()
+bar()
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/input/index.js
+
+```javascript
+import './mod.mjs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/b1abf_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_3257cbaa.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/b1abf_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_3257cbaa.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_f8b72a0c._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_f8b72a0c._.js.map.md
@@ -1,0 +1,37 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/mod.mjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 5
+- **Generated Lines**: 18
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                   | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/mod.mjs  | N/A  |
+| 12:30     | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/mod.mjs  | N/A  |
+| 12:33     | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/mod.mjs  | N/A  |
+| 12:36     | 1:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/mod.mjs  | N/A  |
+| 18:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/mod.mjs
+
+```javascript
+import.meta.foo = 1
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/input/index.js
+
+```javascript
+import './mod.mjs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/b1abf_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_f47a3466.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/b1abf_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_f47a3466.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_4681c863._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_4681c863._.js.map.md
@@ -1,0 +1,36 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/mod.mjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 18
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                  | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------ | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/mod.mjs  | N/A  |
+| 12:8      | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/mod.mjs  | N/A  |
+| 12:11     | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/mod.mjs  | N/A  |
+| 18:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/mod.mjs
+
+```javascript
+console.log(import.meta)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/input/index.js
+
+```javascript
+import './mod.mjs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/b1abf_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_d8af8bd1.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/b1abf_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_d8af8bd1.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_e09539c1.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_e09539c1.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/turbopack_crates_turbopack-tests_tests_snapshot_import-meta_esm_input_187fac24._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/turbopack_crates_turbopack-tests_tests_snapshot_import-meta_esm_input_187fac24._.js.map.md
@@ -1,0 +1,39 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 7
+- **Generated Lines**: 18
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 12:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs  | N/A  |
+| 12:8      | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs  | N/A  |
+| 12:11     | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs  | N/A  |
+| 12:12     | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs  | N/A  |
+| 12:42     | 1:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs  | N/A  |
+| 12:45     | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs  | N/A  |
+| 18:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/mod.mjs
+
+```javascript
+console.log(import.meta.url)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/esm/input/index.js
+
+```javascript
+import './mod.mjs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_9ea94cf2.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/output/4e721_crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_9ea94cf2.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/output/turbopack_crates_turbopack-tests_tests_snapshot_import-meta_url_input_61767652._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/output/turbopack_crates_turbopack-tests_tests_snapshot_import-meta_url_input_61767652._.js.map.md
@@ -1,0 +1,58 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 21
+- **Generated Lines**: 23
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 15:6      | 1:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 16:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 16:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 16:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 16:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:6      | 4:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:16     | 5:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:20     | 5:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:21     | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:22     | 5:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:28     | 5:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:32     | 5:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:36     | 5:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:40     | 6:3      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:44     | 6:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:45     | 6:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:53     | 6:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 17:56     | 6:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs  | N/A  |
+| 23:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/mod.mjs
+
+```javascript
+const assetUrl = new URL('./asset.txt', import.meta.url)
+
+console.log(assetUrl)
+fetch(assetUrl)
+  .then((res) => res.text())
+  .then(console.log)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/import-meta/url/input/index.js
+
+```javascript
+import './mod.mjs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/output/4e721_crates_turbopack-tests_tests_snapshot_imports_duplicate-binding_input_8498b7ee._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/output/4e721_crates_turbopack-tests_tests_snapshot_imports_duplicate-binding_input_8498b7ee._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 17
+- **Generated Lines**: 23
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                     | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:0       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js | N/A  |
+| 9:6       | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js | N/A  |
+| 9:14      | 1:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js | N/A  |
+| 10:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js | N/A  |
+| 10:11     | 2:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js | N/A  |
+| 11:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js | N/A  |
+| 19:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 21:0      | 3:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 21:9      | 3:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 22:4      | 4:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 22:12     | 4:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 22:15     | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 22:16     | 4:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 22:221    | 4:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 22:222    | 4:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 22:230    | 4:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+| 23:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/table.js
+
+```javascript
+export const Table = () => {
+  return 'table'
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js
+
+```javascript
+import { Table } from './table'
+
+export function Table() {
+  console.log(Table)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/output/b1abf_turbopack-tests_tests_snapshot_imports_duplicate-binding_input_index_4c65d925.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/output/b1abf_turbopack-tests_tests_snapshot_imports_duplicate-binding_input_index_4c65d925.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_23ea6f5e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_23ea6f5e.js.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 6
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                           | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js | N/A  |
+| 7:177     | 1:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js | N/A  |
+| 7:181     | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js | N/A  |
+| 7:182     | 1:28     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js | N/A  |
+| 7:190     | 1:36     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js | N/A  |
+| 7:193     | 1:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/index.js
+
+```javascript
+import('./vercel.mjs').then(console.log)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_7cb8de49.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_7cb8de49.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_vercel_mjs_3f552831._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_vercel_mjs_3f552831._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_vercel_mjs_7f2965b8._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_dynamic_input_vercel_mjs_7f2965b8._.js.map.md
@@ -1,0 +1,26 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/vercel.mjs`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 9
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                             | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------- | ---- |
+| 9:39      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/vercel.mjs | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/dynamic/input/vercel.mjs
+
+```javascript
+export default 'turbopack'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_cjs_18e98be7._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_cjs_18e98be7._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_cjs_1ec8d7d5._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_cjs_1ec8d7d5._.js.map.md
@@ -1,0 +1,29 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                     | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+| 7:7       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+| 7:14      | 1:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs
+
+```javascript
+module.exports = 'turbopack'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_mjs_2b2136b9._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_mjs_2b2136b9._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_mjs_9a2c4881._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4c35f_tests_snapshot_imports_ignore-comments_input_vercel_mjs_9a2c4881._.js.map.md
@@ -1,0 +1,26 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.mjs`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 9
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                     | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:39      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.mjs | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.mjs
+
+```javascript
+export default 'turbopack'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4e721_crates_turbopack-tests_tests_snapshot_imports_ignore-comments_input_7f940ff3._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/4e721_crates_turbopack-tests_tests_snapshot_imports_ignore-comments_input_7f940ff3._.js.map.md
@@ -1,0 +1,104 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 57
+- **Generated Lines**: 47
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                     | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+| 7:7       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+| 7:14      | 1:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs | N/A  |
+| 33:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 33:185    | 1:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 33:189    | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 33:190    | 1:28     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 33:198    | 1:36     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 33:201    | 1:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 34:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 34:185    | 2:50     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 34:189    | 2:54     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 34:190    | 2:55     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 34:198    | 2:63     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 34:201    | 2:66     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 35:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 35:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 35:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 36:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 36:4      | 4:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 37:0      | 8:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 37:90     | 8:90     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 38:0      | 9:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 38:6      | 9:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 38:7      | 9:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 38:30     | 9:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 38:33     | 9:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 39:0      | 10:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 39:6      | 10:6     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 39:7      | 10:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 39:32     | 10:32    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 39:35     | 10:35    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 40:0      | 12:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 40:40     | 12:40    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 41:0      | 13:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 41:8      | 13:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 41:31     | 13:31    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 41:34     | 13:34    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 42:0      | 14:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 42:8      | 14:8     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 42:33     | 14:33    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 42:36     | 14:36    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 43:0      | 16:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 43:4      | 16:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 44:0      | 19:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 44:4      | 19:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 45:0      | 23:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 45:9      | 23:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| 45:13     | 23:20    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js   | N/A  |
+| ...       | ...      | ...                                                                                                             | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/vercel.cjs
+
+```javascript
+module.exports = 'turbopack'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/input/index.js
+
+```javascript
+import('./vercel.mjs').then(console.log)
+import(/* webpackIgnore: false */ './vercel.mjs').then(console.log)
+console.log(require('./vercel.cjs'))
+new Worker(
+  /* turbopackIgnore: false */ new URL('./vercel.cjs', import.meta.url)
+)
+
+// turbopack shouldn't attempt to bundle these, and they should be preserved in the output
+import(/* webpackIgnore: true */ './ignore.mjs')
+import(/* turbopackIgnore: true */ './ignore.mjs')
+
+// this should work for cjs requires too
+require(/* webpackIgnore: true */ './ignore.cjs')
+require(/* turbopackIgnore: true */ './ignore.cjs')
+
+new Worker(
+  /* turbopackIgnore: true */ new URL('./ignore-worker.cjs', import.meta.url)
+)
+new Worker(
+  /* webpackIgnore: true */ new URL('./ignore-worker.cjs', import.meta.url)
+
+// ... (5 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/b1abf_turbopack-tests_tests_snapshot_imports_ignore-comments_input_index_ab68907b.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/ignore-comments/output/b1abf_turbopack-tests_tests_snapshot_imports_ignore-comments_input_index_ab68907b.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/output/4e721_crates_turbopack-tests_tests_snapshot_imports_json_input_index_3adbad6e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/output/4e721_crates_turbopack-tests_tests_snapshot_imports_json_input_index_3adbad6e.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/output/turbopack_crates_turbopack-tests_tests_snapshot_imports_json_input_52abdb3f._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/output/turbopack_crates_turbopack-tests_tests_snapshot_imports_json_input_52abdb3f._.js.map.md
@@ -1,0 +1,48 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 20
+- **Generated Lines**: 20
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                        | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------- | ---- |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 16:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:8      | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:11     | 2:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:12     | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:185    | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:186    | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:196    | 2:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:197    | 2:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 18:201    | 2:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:185    | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:186    | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:196    | 4:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:197    | 4:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+| 20:207    | 4:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js
+
+```javascript
+import pkg from './package.json'
+console.log(pkg.name)
+import invalid from './invalid.json'
+console.log(invalid['this-is'])
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/output/4e721_crates_turbopack-tests_tests_snapshot_imports_order_input_index_c55d6616.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/output/4e721_crates_turbopack-tests_tests_snapshot_imports_order_input_index_c55d6616.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/output/turbopack_crates_turbopack-tests_tests_snapshot_imports_order_input_152f317f._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/output/turbopack_crates_turbopack-tests_tests_snapshot_imports_order_input_152f317f._.js.map.md
@@ -1,0 +1,67 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/posts.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 28
+- **Generated Lines**: 22
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                         | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------- | ---- |
+| 9:39      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/posts.ts | N/A  |
+| 10:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/posts.ts | N/A  |
+| 10:8      | 2:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/posts.ts | N/A  |
+| 11:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/posts.ts | N/A  |
+| 17:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:202    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:203    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:213    | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:214    | 3:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 19:216    | 3:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:4      | 4:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:5      | 4:5      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:195    | 4:5      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:196    | 4:5      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:206    | 4:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:207    | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:209    | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 20:211    | 4:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 21:4      | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 21:12     | 5:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 21:16     | 5:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 21:17     | 5:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+| 22:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/posts.ts
+
+```javascript
+export default {
+  js: true,
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/order/input/index.js
+
+```javascript
+import posts from './posts'
+
+console.log(posts.js)
+if (!posts.js) {
+  process.exit(1)
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_a96ffd5e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_a96ffd5e.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_bdab1dc6.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_bdab1dc6.js.map.md
@@ -1,0 +1,33 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 6
+- **Generated Lines**: 12
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                     | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js | N/A  |
+| 7:6       | 1:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js | N/A  |
+| 12:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js | N/A  |
+| 12:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js | N/A  |
+| 12:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js | N/A  |
+| 12:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js
+
+```javascript
+const dne = require('does-not-exist/path')
+
+console.log(dne)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_4187ef70.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_4187ef70.js.map.md
@@ -1,0 +1,40 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 12
+- **Generated Lines**: 14
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                     | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------- | ---- |
+| 13:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 13:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 13:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 13:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:13     | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:14     | 4:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:15     | 4:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+| 14:19     | 4:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js
+
+```javascript
+import dne from 'does-not-exist/path'
+
+console.log(dne)
+console.log({}[dne])
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_ea67b27e.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/b1abf_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_ea67b27e.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/4c35f_tests_snapshot_imports_static-and-dynamic_input_vercel_mjs_e8655245._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/4c35f_tests_snapshot_imports_static-and-dynamic_input_vercel_mjs_e8655245._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_ab9cac73._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_ab9cac73._.js.map.md
@@ -1,0 +1,50 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/vercel.mjs`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 15
+- **Generated Lines**: 18
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                        | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------ | ---- |
+| 9:39      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/vercel.mjs | N/A  |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 17:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 17:8      | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 17:11     | 2:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 17:12     | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 17:223    | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 17:224    | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 17:234    | 2:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 18:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 18:188    | 4:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 18:192    | 4:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 18:193    | 4:28     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 18:201    | 4:36     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+| 18:204    | 4:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js   | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/vercel.mjs
+
+```javascript
+export default 'turbopack'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/input/index.js
+
+```javascript
+import img from './vercel.mjs'
+console.log(img)
+
+import('./vercel.mjs').then(console.log)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/b1abf_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_index_e513865a.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/b1abf_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_index_e513865a.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/output/4e721_crates_turbopack-tests_tests_snapshot_imports_static_input_index_daa2755b.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/output/4e721_crates_turbopack-tests_tests_snapshot_imports_static_input_index_daa2755b.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/output/turbopack_crates_turbopack-tests_tests_snapshot_imports_static_input_89ddd9a2._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/output/turbopack_crates_turbopack-tests_tests_snapshot_imports_static_input_89ddd9a2._.js.map.md
@@ -1,0 +1,34 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 8
+- **Generated Lines**: 12
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                          | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------- | ---- |
+| 10:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+| 12:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+| 12:8      | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+| 12:11     | 2:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+| 12:12     | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+| 12:203    | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+| 12:204    | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+| 12:214    | 2:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/static/input/index.js
+
+```javascript
+import img from './vercel.svg'
+console.log(img)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/4c35f_tests_snapshot_imports_subpath-imports-nested_input_index_678a448a.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/4c35f_tests_snapshot_imports_subpath-imports-nested_input_index_678a448a.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/b1abf_turbopack-tests_tests_snapshot_imports_subpath-imports-nested_input_2e0531bf._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/b1abf_turbopack-tests_tests_snapshot_imports_subpath-imports-nested_input_2e0531bf._.js.map.md
@@ -1,0 +1,56 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 14
+- **Generated Lines**: 27
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                 | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:39      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js          | N/A  |
+| 17:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js | N/A  |
+| 19:39     | 2:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js | N/A  |
+| 19:250    | 2:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js | N/A  |
+| 19:251    | 2:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js | N/A  |
+| 19:261    | 2:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js | N/A  |
+| 25:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+| 27:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+| 27:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+| 27:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+| 27:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+| 27:235    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+| 27:236    | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+| 27:246    | 3:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js        | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js
+
+```javascript
+export default 'foo'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js
+
+```javascript
+import foo from '#foo'
+export default foo
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js
+
+```javascript
+import foo from './nested'
+
+console.log(foo)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/output/4e721_crates_turbopack-tests_tests_snapshot_imports_subpath-imports_input_1e655205._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/output/4e721_crates_turbopack-tests_tests_snapshot_imports_subpath-imports_input_1e655205._.js.map.md
@@ -1,0 +1,100 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/foo.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/dep/index.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/pat.js`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/import.mjs`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/require.cjs`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 34
+- **Generated Lines**: 54
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                       | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:39      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/foo.js       | N/A  |
+| 17:39     | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/dep/index.js | N/A  |
+| 25:39     | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/pat.js       | N/A  |
+| 33:39     | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/import.mjs   | N/A  |
+| 39:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/require.cjs  | N/A  |
+| 39:7      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/require.cjs  | N/A  |
+| 39:14     | 1:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/require.cjs  | N/A  |
+| 39:17     | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/require.cjs  | N/A  |
+| 45:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 46:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 47:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 48:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 53:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 53:6      | 5:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:8      | 7:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:11     | 7:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:12     | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:213    | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:214    | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:224    | 7:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:226    | 7:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:436    | 7:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:437    | 7:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:447    | 7:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:449    | 7:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:650    | 7:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:651    | 7:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:661    | 7:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:663    | 7:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:868    | 7:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:869    | 7:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:879    | 7:48     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+| 54:881    | 7:50     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js     | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/foo.js
+
+```javascript
+export default 'foo'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/dep/index.js
+
+```javascript
+export default 'dep'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/pat.js
+
+```javascript
+export default 'pat'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/import.mjs
+
+```javascript
+export default 'import'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/require.cjs
+
+```javascript
+module.exports = 'require'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/input/index.js
+
+```javascript
+import foo from '#foo'
+import dep from '#dep'
+import pattern from '#pattern/pat.js'
+import conditionalImport from '#conditional'
+const conditionalRequire = require('#conditional')
+
+console.log(foo, dep, pattern, conditionalImport, conditionalRequire)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/output/b1abf_turbopack-tests_tests_snapshot_imports_subpath-imports_input_index_39ca13c7.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/imports/subpath-imports/output/b1abf_turbopack-tests_tests_snapshot_imports_subpath-imports_input_index_39ca13c7.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/output/2b719_intermediate-tree-shake_rename-side-effect-free-facade_input_index_0b6a7b01.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/output/2b719_intermediate-tree-shake_rename-side-effect-free-facade_input_index_0b6a7b01.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/output/457d9_snapshot_intermediate-tree-shake_rename-side-effect-free-facade_input_71bae14d._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/output/457d9_snapshot_intermediate-tree-shake_rename-side-effect-free-facade_input_71bae14d._.js.map.md
@@ -1,0 +1,49 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 14
+- **Generated Lines**: 18
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 9:8       | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 9:11      | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 9:12      | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 9:307     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 9:308     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 9:313     | 3:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js              | N/A  |
+| 17:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js | N/A  |
+| 17:6      | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js | N/A  |
+| 17:10     | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js | N/A  |
+| 18:0      | 2:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js | N/A  |
+| 18:6      | 2:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js | N/A  |
+| 18:17     | 2:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/index.js
+
+```javascript
+import { a0 } from 'lib'
+
+console.log(a0)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/rename-side-effect-free-facade/input/node_modules/lib/a.js
+
+```javascript
+export const a = 'a'
+export const a_unused = 'a_unused'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_80df1e23._.js.map.md
@@ -1,0 +1,84 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 37
+- **Generated Lines**: 27
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                                      | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:8       | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:11      | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:12      | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:13      | 3:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:20      | 3:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:22      | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:23      | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:26      | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:282     | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:283     | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:292     | 3:28     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:292     | 3:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 9:297     | 3:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js                  | N/A  |
+| 17:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 17:4      | 2:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 17:10     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 18:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 18:4      | 3:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 18:10     | 3:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 19:0      | 5:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 19:9      | 5:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 20:4      | 6:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 20:11     | 6:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 20:17     | 6:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 21:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 22:0      | 9:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 22:9      | 9:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 23:4      | 10:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 23:11     | 10:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 24:0      | 11:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 25:0      | 13:7     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 25:9      | 13:16    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 26:4      | 14:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 26:11     | 14:9     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+| 27:0      | 15:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/index.js
+
+```javascript
+import { getCat } from 'lib'
+
+console.log(`I like ${getCat()}`)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/input/node_modules/lib/index.js
+
+```javascript
+let cat = 'cat'
+let dog = 'dog'
+
+export function getChimera() {
+  return cat + dog
+}
+
+export function getCat() {
+  return cat
+}
+
+export function getDog() {
+  return dog
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_index_9261d0d3.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/intermediate-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_intermediate-tree-shake_tree-shake-test-1_input_index_9261d0d3.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/mdx/error/output/turbopack_crates_turbopack-tests_tests_snapshot_mdx_error_input_index_c71b8497.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/mdx/error/output/turbopack_crates_turbopack-tests_tests_snapshot_mdx_error_input_index_c71b8497.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/mdx/error/output/turbopack_crates_turbopack-tests_tests_snapshot_mdx_error_input_index_e6acdd0c.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/mdx/error/output/turbopack_crates_turbopack-tests_tests_snapshot_mdx_error_input_index_e6acdd0c.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/output/b1abf_turbopack-tests_tests_snapshot_minification_paren-remover_input_index_032d7ee7.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/output/b1abf_turbopack-tests_tests_snapshot_minification_paren-remover_input_index_032d7ee7.js.map.md
@@ -1,0 +1,97 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 112
+- **Generated Lines**: 26
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                      | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:9       | 1:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:22      | 1:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:24      | 1:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:35      | 1:35     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:37      | 1:37     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:53      | 1:53     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:55      | 1:55     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 7:64      | 1:64     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:4       | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:8       | 2:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:21      | 2:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:27      | 2:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:35      | 2:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:38      | 2:36     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:43      | 2:41     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:44      | 2:42     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:50      | 3:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:64      | 3:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:78      | 3:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:79      | 3:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:92      | 3:46     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:93      | 3:47     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:96      | 4:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:113     | 5:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 8:120     | 6:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 9:4       | 7:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 9:8       | 7:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 10:4      | 8:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 10:27     | 8:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 11:4      | 10:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 11:99     | 10:97    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 12:4      | 11:2     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 12:8      | 11:6     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 12:19     | 11:17    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 12:25     | 11:23    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 12:30     | 11:28    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 12:33     | 11:31    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:8      | 12:4     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:28     | 12:24    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:33     | 12:29    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:36     | 12:32    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:37     | 13:6     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:42     | 13:11    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:45     | 13:14    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:46     | 13:15    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:56     | 13:25    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:57     | 13:26    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| 13:59     | 13:28    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js | N/A  |
+| ...       | ...      | ...                                                                                                              | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/input/index.js
+
+```javascript
+function toFixed(value, maxDecimals, roundingFunction, optionals) {
+  var splitValue = value.toString().split('.'),
+    minDecimals = maxDecimals - (optionals || 0),
+    optionalsRegExp,
+    power,
+    output
+  var boundedPrecisions
+  // var unused = 'xxxx';
+
+  // Use the smallest precision value possible to avoid errors from floating point representation
+  if (splitValue.length === 2) {
+    boundedPrecisions = Math.min(
+      Math.max(splitValue[1].length, minDecimals),
+      maxDecimals
+    )
+  } else {
+    boundedPrecisions = minDecimals
+  }
+
+  power = Math.pow(10, boundedPrecisions)
+
+// ... (16 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/output/b1abf_turbopack-tests_tests_snapshot_minification_paren-remover_input_index_e6372175.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/output/b1abf_turbopack-tests_tests_snapshot_minification_paren-remover_input_index_e6372175.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/b1abf_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_9361e400.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/b1abf_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_9361e400.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/b1abf_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_b66fe26f.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/b1abf_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_b66fe26f.js.map.md
@@ -1,0 +1,26 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 1
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                       | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/input/index.js
+
+```javascript
+import fs from 'node:fs'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/pack-3279/output/4e721_crates_turbopack-tests_tests_snapshot_node_pack-3279_input_index_1caaec18.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/pack-3279/output/4e721_crates_turbopack-tests_tests_snapshot_node_pack-3279_input_index_1caaec18.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/pack-3279/output/4e721_crates_turbopack-tests_tests_snapshot_node_pack-3279_input_index_93fe9f72.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/pack-3279/output/4e721_crates_turbopack-tests_tests_snapshot_node_pack-3279_input_index_93fe9f72.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_dynamic_input_d33fdf1c._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_dynamic_input_d33fdf1c._.js.map.md
@@ -1,0 +1,68 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 31
+- **Generated Lines**: 24
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                         | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 9:6       | 3:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 9:16      | 3:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 10:4      | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 11:1      | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:6      | 4:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:13     | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:14     | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:17     | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:245    | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:246    | 4:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:254    | 4:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:254    | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:256    | 4:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:263    | 4:26     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:264    | 4:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:266    | 4:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 12:268    | 4:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 13:4      | 4:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 14:1      | 4:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js                            | N/A  |
+| 22:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 22:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 22:15     | 1:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 22:18     | 1:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 22:20     | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 22:24     | 1:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 23:0      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 23:2      | 2:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+| 24:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/index.js
+
+```javascript
+import { spawn } from 'child_process'
+
+const program = ['ls']
+const proc = spawn(program[0], ['-la'])
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/input/node_modules/child_process/index.js
+
+```javascript
+export function spawn(cmd, args) {
+  //
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_dynamic_input_index_3af700a3.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_dynamic/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_dynamic_input_index_3af700a3.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_bf21d136._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_bf21d136._.js.map.md
@@ -1,0 +1,64 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 28
+- **Generated Lines**: 22
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                           | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:4       | 3:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:8       | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:9       | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:12      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:242     | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:243     | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:251     | 3:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:251     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:253     | 3:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:261     | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:265     | 3:26     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:266     | 3:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:268     | 3:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 9:270     | 3:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 10:4      | 3:32     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 11:4      | 3:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 12:1      | 3:60     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js                            | N/A  |
+| 20:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 20:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 20:15     | 1:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 20:18     | 1:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 20:20     | 1:27     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 20:24     | 1:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 21:0      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 21:2      | 2:4      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+| 22:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js
+
+```javascript
+import { spawn } from 'child_process'
+
+let x = spawn(process.argv[0], ['-e', "console.log('foo');"])
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js
+
+```javascript
+export function spawn(cmd, args) {
+  //
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_4ae67b76.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/4e721_crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_4ae67b76.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/4c35f_tests_snapshot_runtime_default_build_runtime_input_index_ba3c9491.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/4c35f_tests_snapshot_runtime_default_build_runtime_input_index_ba3c9491.js.map.md
@@ -1,0 +1,29 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js | N/A  |
+| 7:8       | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js | N/A  |
+| 7:11      | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js | N/A  |
+| 7:12      | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js
+
+```javascript
+console.log('Hello, world!')
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/[turbopack]_runtime.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/[turbopack]_runtime.js.map.md
@@ -1,0 +1,209 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[turbopack]/shared/runtime-utils.ts`
+2. `turbopack:///[turbopack]/shared-node/base-externals-utils.ts`
+3. `turbopack:///[turbopack]/shared-node/node-externals-utils.ts`
+4. `turbopack:///[turbopack]/shared-node/node-wasm-utils.ts`
+5. `turbopack:///[turbopack]/nodejs/runtime.ts`
+
+## Mappings Overview
+
+- **Total Mappings**: 2554
+- **Generated Lines**: 716
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                      | Name |
+| --------- | -------- | ------------------------------------------------ | ---- |
+| 4:0       | 1:0      | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 9:1       | 6:1      | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 9:4       | 8:0      | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 9:56      | 8:52     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 9:59      | 10:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 9:104     | 10:45    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 10:0      | 20:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 10:6      | 20:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 10:27     | 20:27    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 10:34     | 20:34    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 11:0      | 51:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 11:6      | 51:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 11:23     | 51:23    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 11:30     | 51:30    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 11:39     | 51:39    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 11:40     | 51:40    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 11:54     | 51:54    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:0      | 52:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:6      | 52:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:20     | 52:20    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:27     | 52:27    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:38     | 52:38    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:53     | 52:53    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:60     | 52:60    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 12:71     | 52:71    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:0      | 54:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:9      | 54:9     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:20     | 55:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:23     | 55:10    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:25     | 56:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:29     | 56:19    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:31     | 57:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 13:38     | 57:45    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:4      | 59:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:8      | 59:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:9      | 59:7     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:24     | 59:22    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:28     | 59:26    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:29     | 59:27    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:34     | 59:32    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:41     | 59:39    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:48     | 59:46    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:62     | 59:60    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:63     | 59:61    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:68     | 59:66    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 14:74     | 59:72    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 15:0      | 60:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 16:0      | 62:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 16:9      | 62:9     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 16:30     | 63:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| ...       | ...      | ...                                              | ...  |
+
+## Source Contents
+
+### turbopack:///[turbopack]/shared/runtime-utils.ts
+
+```javascript
+/**
+ * This file contains runtime types and functions that are shared between all
+ * TurboPack ECMAScript runtimes.
+ *
+ * It will be prepended to the runtime code of each runtime.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="./runtime-types.d.ts" />
+
+type EsmNamespaceObject = Record<string, any>
+
+// @ts-ignore Defined in `dev-base.ts`
+declare function getOrInstantiateModuleFromParent<M>(
+  id: ModuleId,
+  sourceModule: M
+): M
+
+const REEXPORTED_OBJECTS = Symbol('reexported objects')
+
+// ... (548 more lines)
+```
+
+### turbopack:///[turbopack]/shared-node/base-externals-utils.ts
+
+```javascript
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="../shared/runtime-utils.ts" />
+
+/// A 'base' utilities to support runtime can have externals.
+/// Currently this is for node.js / edge runtime both.
+/// If a fn requires node.js specific behavior, it should be placed in `node-external-utils` instead.
+
+async function externalImport(id: DependencySpecifier) {
+  let raw
+  try {
+    raw = await import(id)
+  } catch (err) {
+    // TODO(alexkirsz) This can happen when a client-side module tries to load
+    // an external module we don't provide a shim for (e.g. querystring, url).
+    // For now, we fail semi-silently, but in the future this should be a
+    // compilation error.
+    throw new Error(`Failed to load external module ${id}: ${err}`)
+  }
+
+
+// ... (38 more lines)
+```
+
+### turbopack:///[turbopack]/shared-node/node-externals-utils.ts
+
+```javascript
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+declare var RUNTIME_PUBLIC_PATH: string
+declare var RELATIVE_ROOT_PATH: string
+declare var ASSET_PREFIX: string
+
+const path = require('path')
+
+const relativePathToRuntimeRoot = path.relative(RUNTIME_PUBLIC_PATH, '.')
+// Compute the relative path to the `distDir`.
+const relativePathToDistRoot = path.join(
+  relativePathToRuntimeRoot,
+  RELATIVE_ROOT_PATH
+)
+const RUNTIME_ROOT = path.resolve(__filename, relativePathToRuntimeRoot)
+// Compute the absolute path to the root, by stripping distDir from the absolute path to this file.
+const ABSOLUTE_ROOT = path.resolve(__filename, relativePathToDistRoot)
+
+/**
+ * Returns an absolute path to the given module path.
+
+// ... (12 more lines)
+```
+
+### turbopack:///[turbopack]/shared-node/node-wasm-utils.ts
+
+```javascript
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="../shared/runtime-utils.ts" />
+
+function readWebAssemblyAsResponse(path: string) {
+  const { createReadStream } = require('fs') as typeof import('fs')
+  const { Readable } = require('stream') as typeof import('stream')
+
+  const stream = createReadStream(path)
+
+  // @ts-ignore unfortunately there's a slight type mismatch with the stream.
+  return new Response(Readable.toWeb(stream), {
+    headers: {
+      'content-type': 'application/wasm',
+    },
+  })
+}
+
+async function compileWebAssemblyFromPath(
+  path: string
+
+// ... (19 more lines)
+```
+
+### turbopack:///[turbopack]/nodejs/runtime.ts
+
+```javascript
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="../shared/runtime-utils.ts" />
+/// <reference path="../shared-node/base-externals-utils.ts" />
+/// <reference path="../shared-node/node-externals-utils.ts" />
+/// <reference path="../shared-node/node-wasm-utils.ts" />
+
+enum SourceType {
+  /**
+   * The module was instantiated because it was included in an evaluated chunk's
+   * runtime.
+   */
+  Runtime = 0,
+  /**
+   * The module was instantiated because a parent module imported it.
+   */
+  Parent = 1,
+}
+
+type SourceInfo =
+
+// ... (349 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/index.entry.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/index.entry.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/output/b1abf_turbopack-tests_tests_snapshot_runtime_default_dev_runtime_input_index_73aab4ae.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/output/b1abf_turbopack-tests_tests_snapshot_runtime_default_dev_runtime_input_index_73aab4ae.js.map.md
@@ -1,0 +1,209 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[turbopack]/shared/runtime-utils.ts`
+2. `turbopack:///[turbopack]/browser/runtime/base/runtime-base.ts`
+3. `turbopack:///[turbopack]/browser/runtime/base/dev-base.ts`
+4. `turbopack:///[turbopack]/browser/runtime/dom/runtime-backend-dom.ts`
+5. `turbopack:///[turbopack]/browser/runtime/dom/dev-backend-dom.ts`
+
+## Mappings Overview
+
+- **Total Mappings**: 5650
+- **Generated Lines**: 1728
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                      | Name |
+| --------- | -------- | ------------------------------------------------ | ---- |
+| 15:0      | 1:0      | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 20:1      | 6:1      | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 20:4      | 8:0      | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 20:56     | 8:52     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 20:59     | 10:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 20:104    | 10:45    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 21:0      | 20:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 21:6      | 20:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 21:27     | 20:27    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 21:34     | 20:34    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 22:0      | 51:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 22:6      | 51:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 22:23     | 51:23    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 22:30     | 51:30    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 22:39     | 51:39    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 22:40     | 51:40    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 22:54     | 51:54    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:0      | 52:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:6      | 52:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:20     | 52:20    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:27     | 52:27    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:38     | 52:38    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:53     | 52:53    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:60     | 52:60    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 23:71     | 52:71    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:0      | 54:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:9      | 54:9     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:20     | 55:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:23     | 55:10    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:25     | 56:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:29     | 56:19    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:31     | 57:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 24:38     | 57:45    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:4      | 59:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:8      | 59:6     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:9      | 59:7     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:24     | 59:22    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:28     | 59:26    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:29     | 59:27    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:34     | 59:32    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:41     | 59:39    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:48     | 59:46    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:62     | 59:60    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:63     | 59:61    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:68     | 59:66    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 25:74     | 59:72    | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 26:0      | 60:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 27:0      | 62:0     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 27:9      | 62:9     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| 27:30     | 63:2     | turbopack:///[turbopack]/shared/runtime-utils.ts | N/A  |
+| ...       | ...      | ...                                              | ...  |
+
+## Source Contents
+
+### turbopack:///[turbopack]/shared/runtime-utils.ts
+
+```javascript
+/**
+ * This file contains runtime types and functions that are shared between all
+ * TurboPack ECMAScript runtimes.
+ *
+ * It will be prepended to the runtime code of each runtime.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="./runtime-types.d.ts" />
+
+type EsmNamespaceObject = Record<string, any>
+
+// @ts-ignore Defined in `dev-base.ts`
+declare function getOrInstantiateModuleFromParent<M>(
+  id: ModuleId,
+  sourceModule: M
+): M
+
+const REEXPORTED_OBJECTS = Symbol('reexported objects')
+
+// ... (548 more lines)
+```
+
+### turbopack:///[turbopack]/browser/runtime/base/runtime-base.ts
+
+```javascript
+/**
+ * This file contains runtime types and functions that are shared between all
+ * Turbopack *development* ECMAScript runtimes.
+ *
+ * It will be appended to the runtime code of each runtime right after the
+ * shared runtime utils.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="../base/globals.d.ts" />
+/// <reference path="../../../shared/runtime-utils.ts" />
+
+// Used in WebWorkers to tell the runtime about the chunk base path
+declare var TURBOPACK_WORKER_LOCATION: string
+// Used in WebWorkers to tell the runtime about the current chunk url since it can't be detected via document.currentScript
+// Note it's stored in reversed order to use push and pop
+declare var TURBOPACK_NEXT_CHUNK_URLS: ChunkUrl[] | undefined
+
+// Injected by rust code
+
+// ... (374 more lines)
+```
+
+### turbopack:///[turbopack]/browser/runtime/base/dev-base.ts
+
+```javascript
+/// <reference path="./dev-globals.d.ts" />
+/// <reference path="./dev-protocol.d.ts" />
+/// <reference path="./dev-extensions.ts" />
+
+/**
+ * This file contains runtime types and functions that are shared between all
+ * Turbopack *development* ECMAScript runtimes.
+ *
+ * It will be appended to the runtime code of each runtime right after the
+ * shared runtime utils.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+const devModuleCache: ModuleCache<HotModule> = Object.create(null)
+
+// This file must not use `import` and `export` statements. Otherwise, it
+// becomes impossible to augment interfaces declared in `<reference>`d files
+// (e.g. `Module`). Hence, the need for `import()` here.
+type RefreshRuntimeGlobals =
+
+// ... (1095 more lines)
+```
+
+### turbopack:///[turbopack]/browser/runtime/dom/runtime-backend-dom.ts
+
+```javascript
+/**
+ * This file contains the runtime code specific to the Turbopack development
+ * ECMAScript DOM runtime.
+ *
+ * It will be appended to the base development runtime code.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="../../../browser/runtime/base/runtime-base.ts" />
+/// <reference path="../../../shared/runtime-types.d.ts" />
+
+type ChunkResolver = {
+  resolved: boolean
+  loadingStarted: boolean
+  resolve: () => void
+  reject: (error?: Error) => void
+  promise: Promise<any>
+}
+
+
+// ... (203 more lines)
+```
+
+### turbopack:///[turbopack]/browser/runtime/dom/dev-backend-dom.ts
+
+```javascript
+/**
+ * This file contains the runtime code specific to the Turbopack development
+ * ECMAScript DOM runtime.
+ *
+ * It will be appended to the base development runtime code.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/// <reference path="../base/runtime-base.ts" />
+/// <reference path="../base/dev-base.ts" />
+/// <reference path="./runtime-backend-dom.ts" />
+/// <reference path="../../../shared/require-type.d.ts" />
+
+let DEV_BACKEND: DevRuntimeBackend
+;(() => {
+  DEV_BACKEND = {
+    unloadChunk(chunkUrl) {
+      deleteResolver(chunkUrl)
+
+
+// ... (106 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/output/b1abf_turbopack-tests_tests_snapshot_runtime_default_dev_runtime_input_index_9cac9e61.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/output/b1abf_turbopack-tests_tests_snapshot_runtime_default_dev_runtime_input_index_9cac9e61.js.map.md
@@ -1,0 +1,29 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 4
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                       | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/input/index.js | N/A  |
+| 7:8       | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/input/index.js | N/A  |
+| 7:11      | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/input/index.js | N/A  |
+| 7:12      | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/input/index.js
+
+```javascript
+console.log('Hello, world!')
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/output/4c35f_tests_snapshot_scope-hoisting_duplicate-imports_input_index_682284e0.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/output/4c35f_tests_snapshot_scope-hoisting_duplicate-imports_input_index_682284e0.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/output/b1abf_turbopack-tests_tests_snapshot_scope-hoisting_duplicate-imports_input_739fb2d3._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/output/b1abf_turbopack-tests_tests_snapshot_scope-hoisting_duplicate-imports_input_739fb2d3._.js.map.md
@@ -1,0 +1,83 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/shared.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 29
+- **Generated Lines**: 31
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                             | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/shared.js | N/A  |
+| 7:7       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/shared.js | N/A  |
+| 7:14      | 1:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/shared.js | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/shared.js | N/A  |
+| 21:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:17     | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:233    | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:234    | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 23:244    | 3:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js      | N/A  |
+| 27:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 27:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 27:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 27:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 27:17     | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 27:234    | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 27:235    | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 27:245    | 4:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js      | N/A  |
+| 31:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+| 31:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+| 31:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+| 31:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+| 31:17     | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+| 31:234    | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+| 31:235    | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+| 31:245    | 4:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js      | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/shared.js
+
+```javascript
+module.exports = 'shared'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/a.js
+
+```javascript
+import shared from './shared.js'
+
+console.log('a', shared)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js
+
+```javascript
+import './a.js'
+import shared from './shared.js'
+
+console.log('a', shared)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js
+
+```javascript
+import './b.js'
+import shared from './shared.js'
+
+console.log('c', shared)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/4c35f_tests_snapshot_scope-hoisting_split-shared_input_big_index_6f69a308.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/4c35f_tests_snapshot_scope-hoisting_split-shared_input_big_index_6f69a308.js.map.md
@@ -1,0 +1,62 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/other.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 7
+- **Generated Lines**: 68
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                           | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------- | ---- |
+| 13:39     | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/other.js | N/A  |
+| 13:40     | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/other.js | N/A  |
+| 66:0      | 54:0     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/other.js | N/A  |
+| 66:1      | 54:1     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/other.js | N/A  |
+| 68:40     | 3:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js | N/A  |
+| 68:71     | 3:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js | N/A  |
+| 68:77     | 3:25     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/other.js
+
+```javascript
+export default `
+v8XyDjNBXwWR6pNaTwYLp5bfUJ1P8nN4Yigyk9c9S9Xt5JHt28veqF0SRPGEmShfRPTn2LnHWZbPWw5FDmaTfLPdX4NfEzJYzehn
+T6Qw1dW8tnJ3VJUHHE0QUch181CwhbSHbRvzCzwJ66gJ5PWLzpCit6mZ2ZaGuM3kg6Gmmj301bwKWvY0EhFLW26YiDJYyFeb8uR6
+NqBFFqm409pvFhfRdyZWWdBuEdd2TTdQxUgpBd6d147SKeRDj0HyrXKZNc0gd5Cj9pX8grD16fThjEE1uvkn3vPS8HkB7VXcC2Vq
+UebF0aQGxrMnWffrjvxme63giD0ZTxeVGtmC5ZqeLyPEeCb2Lm2zuBdRnGNSk3JTNgM71FA7xTGyZZunNFS4bNkcJi5RB9AiteZE
+Nz718p8qXRG1iZKnQZ8em8dwn1kb5qgggB2qqywKBXupBz3ebCWVMvE15AeDUNZaMuWZvQFMvBykkACHF6keYBEHVJtAyHndnEdp
+TpihHzavvY0UEfqeRjQvQm0Y8FXWZqbEmz6j4EjBSX5KdARxhbALan4QCKSRYNxpxMk1UxZf4rakhFitehV2WE3NX7pPdbVhXdza
+gxTa9m7KazYVnR5E9NkuJDvPL1STLyhZeP96pGZcR0QRpqUN3r9AMMaSec4Hir5b4PJu4UKtwXZxvm6dZ7KFLn3Rf4fe4yCCrREa
+LpmSKuP2JpbqCgc3ewnhkD87TRu1rEaXfFFgvw6ZhwGHf2bAJKJ7GA9QGzGBmrmRPHprjUnfzGMaSxUCxHmftAPTm2L644neCXuj
+3f8z9EY7Bqa1nagKyPi9DpZyDAGe2i0NzugGhB8xbW3K7xAKCEmhf5wZJ6RnQZDa4mqiLSxSz8gqGBu8Q5ALg4ybkbK6McwgR5QV
+A0ag6Fb9dRV3Au8DPzKN1peK6G3bGEf5L03uxa6khMAjjN6zQbGi2HZTNv9wfYVn4QTbeBXTcWQgDnCZzE9WaBXhWcrS0GfiQD8m
+vbFQXik86nXtAhiNtu0g560xUCXZJbz5D9W31cg80UnReCDTLibP1D3JMbndT7J7ANSG82t8bjkNkaUi43xp6uinnMXQFhH1vk1c
+1rrhV0jLndXicquu3CDQBycRPV2ZSXtwgnaD2YWZdcpCTky7bAEq3NuxSYutTr0cD2YkeJJc9hQ1bDqVLf471XURanD9FJqKfkYb
+NeQNEYphDk3Y6cZ5TP2wfqGiKhbp7YMGSXnbNfi8nzbFhwHaRaC7HJiwD4eKGt26RBt9qPAR7Nt8FHXHgLdrWMViixakXKK8jyDa
+VtaR5XSfSV6w1UuzTA05kEgTyXtRmzpYfvtiEB2bedjAguhbHxqwvMSpva5KehiTX0jRuKJr1pStb4UdzDpuX712xLZEaZXEd3rp
+KgriyjYhAPfQvzjcYpW4b34iq3Yx2Mc2ALhVUtZkBiKcn0UwC2uX5T5USF77qYjpmf05f0rP6um9d5azE86QzU7zNFz9mC4PDuL6
+tTebfB9bF6FP0GB5YNQBF7rEEwMXwQnC0immdXiX3PXy4JjzDR7kZtbjNe3n3rUjF4SCdEzeGyBfzLiXNMCmyFYvdVkW610vr4HR
+K3YNPjA9auMgxUySKqW1MtJGyuCEKAvZ3bU3i4qEV0fvGwiqbqMyMkLhBcG7PaMtdX34CDBiUfJd0NgDax7brjEBT0wKSw4qacK8
+GuNmpt9jh1uZxxEMew5FRA0ERzaLQEw3VDX92iSdexrmVHLebH9N2p0DAyFpLc1fQHGekZBU7CA1VqhMc7AeLkf3pcwFr7TmdHzq
+c7V5E05XMduLxYbnGNmiVC55NA6C08aGkbxYD9Km7LTLXBEYKHmqKcW4Nf4UbSxQY1xvk1uS2ABrbGGVPf3rJZFVpLVvL2m1FCWW
+
+// ... (34 more lines)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js
+
+```javascript
+import big from './other.js'
+
+export default big.length
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/4c35f_tests_snapshot_scope-hoisting_split-shared_input_x_inner_9793feec.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/4c35f_tests_snapshot_scope-hoisting_split-shared_input_x_inner_9793feec.js.map.md
@@ -1,0 +1,35 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 9
+- **Generated Lines**: 9
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:0       | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:8       | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:11      | 2:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:12      | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:17      | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:234     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:235     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+| 9:245     | 2:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/inner.js
+
+```javascript
+import big from '../big'
+console.log('x', big)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/4c35f_tests_snapshot_scope-hoisting_split-shared_input_y_middle_aa5cba2d.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/4c35f_tests_snapshot_scope-hoisting_split-shared_input_y_middle_aa5cba2d.js.map.md
@@ -1,0 +1,35 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 9
+- **Generated Lines**: 13
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 11:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:8      | 2:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:11     | 2:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:12     | 2:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:17     | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:234    | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:235    | 2:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+| 13:245    | 2:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js
+
+```javascript
+import big from '../big'
+console.log('y', big)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/b1abf_turbopack-tests_tests_snapshot_scope-hoisting_split-shared_input_d89f123b._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/b1abf_turbopack-tests_tests_snapshot_scope-hoisting_split-shared_input_d89f123b._.js.map.md
@@ -1,0 +1,48 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/index.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 8
+- **Generated Lines**: 20
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                         | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/index.js | N/A  |
+| 7:11      | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/index.js | N/A  |
+| 7:205     | 1:36     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/index.js | N/A  |
+| 13:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/index.js | N/A  |
+| 13:11     | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/index.js | N/A  |
+| 13:206    | 1:37     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/index.js | N/A  |
+| 19:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/index.js   | N/A  |
+| 20:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/index.js   | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/x/index.js
+
+```javascript
+setTimeout(() => import('./inner'), 500)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/index.js
+
+```javascript
+setTimeout(() => import('./middle'), 1000)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/index.js
+
+```javascript
+import './x/index'
+import './y/index'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/b1abf_turbopack-tests_tests_snapshot_scope-hoisting_split-shared_input_index_b598fcca.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/b1abf_turbopack-tests_tests_snapshot_scope-hoisting_split-shared_input_index_b598fcca.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/4c35f_tests_snapshot_source_maps_input-source-map-merged_input_index_95f03461.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/4c35f_tests_snapshot_source_maps_input-source-map-merged_input_index_95f03461.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/4c35f_tests_snapshot_source_maps_input-source-map-merged_input_index_e9baadb1.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/4c35f_tests_snapshot_source_maps_input-source-map-merged_input_index_e9baadb1.js.map.md
@@ -1,0 +1,50 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 11
+- **Generated Lines**: 15
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                      | Name |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 11:0      | 4:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 11:9      | 4:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 11:32     | 4:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 11:33     | 4:43     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 11:35     | 4:52     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 12:4      | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 12:11     | 5:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 12:13     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 12:15     | 5:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 12:16     | 5:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts | N/A  |
+| 15:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/index.js        | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts
+
+```javascript
+// Compile with pnpm tsc turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts --sourceMap --inlineSources --target esnext
+// tsc compile errors can be ignored
+type Fn<T> = () => T
+export function runExternalSourceMapped<T>(fn: Fn<T>): T {
+  return fn()
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/index.js
+
+```javascript
+import { runExternalSourceMapped } from './sourcemapped.js'
+
+runExternalSourceMapped()
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/output/4c35f_tests_snapshot_source_maps_input-source-map_input_index_5f788300.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/output/4c35f_tests_snapshot_source_maps_input-source-map_input_index_5f788300.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/output/b1abf_turbopack-tests_tests_snapshot_source_maps_input-source-map_input_965ec6d6._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/output/b1abf_turbopack-tests_tests_snapshot_source_maps_input-source-map_input_965ec6d6._.js.map.md
@@ -1,0 +1,59 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 20
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                               | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:0       | 4:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 9:9       | 4:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 9:32      | 4:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 9:33      | 4:43     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 9:35      | 4:52     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 10:4      | 5:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 10:11     | 5:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 10:13     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 10:15     | 5:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 10:16     | 5:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 11:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 11:1      | 6:1      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts | N/A  |
+| 17:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+| 19:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+| 19:1      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+| 19:4      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+| 19:222    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+| 19:223    | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+| 19:249    | 3:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+| 19:249    | 3:22     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js        | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/sourcemapped.ts
+
+```javascript
+// Compile with pnpm tsc turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.ts --sourceMap --inlineSources --target esnext
+// tsc compile errors can be ignored
+type Fn<T> = () => T
+export function runExternalSourceMapped<T>(fn: Fn<T>): T {
+  return fn()
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js
+
+```javascript
+import { runExternalSourceMapped } from './sourcemapped.js'
+
+runExternalSourceMapped()
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_709b281d.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_709b281d.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e27.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_fc734e27.js.map.md
@@ -1,0 +1,32 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 6
+- **Generated Lines**: 7
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                               | Name |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js | N/A  |
+| 7:8       | 1:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js | N/A  |
+| 7:11      | 1:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js | N/A  |
+| 7:12      | 1:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js | N/A  |
+| 7:21      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js | N/A  |
+| 7:54      | 2:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js
+
+```javascript
+console.log('test')
+//# sourceMappingURL=index.js.map
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_merged-unicode_input_795dc95a._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/output/4e721_crates_turbopack-tests_tests_snapshot_source_maps_merged-unicode_input_795dc95a._.js.map.md
@@ -1,0 +1,148 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/jsx-runtime.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/index1.js`
+5. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/index2.js`
+6. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 107
+- **Generated Lines**: 78
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                     | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/jsx-runtime.js          | N/A  |
+| 7:7       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/jsx-runtime.js          | N/A  |
+| 7:14      | 1:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/jsx-runtime.js          | N/A  |
+| 7:17      | 1:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/jsx-runtime.js          | N/A  |
+| 7:18      | 1:18     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/jsx-runtime.js          | N/A  |
+| 19:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 19:77     | 1:77     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 20:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 20:81     | 2:81     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 21:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 21:90     | 3:90     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 22:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 22:87     | 4:87     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 23:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 23:59     | 5:59     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 24:0      | 6:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 24:6      | 6:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 24:37     | 6:37     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 25:0      | 7:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 25:9      | 7:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 25:38     | 7:45     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 25:44     | 7:51     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 25:46     | 7:53     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 25:50     | 7:57     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 25:53     | 7:60     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 26:0      | 8:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 26:9      | 8:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 26:43     | 8:50     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 26:49     | 8:56     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 26:51     | 8:58     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 26:55     | 8:62     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 26:58     | 8:65     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 27:0      | 9:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 27:6      | 9:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 27:28     | 9:35     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 27:32     | 9:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 27:36     | 9:43     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 27:38     | 9:45     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js        | N/A  |
+| 31:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 33:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 33:61     | 2:61     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 34:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 34:6      | 3:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 34:33     | 3:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 34:38     | 3:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 34:120    | 3:120    | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 35:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 35:61     | 4:61     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 36:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| 36:6      | 5:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js | N/A  |
+| ...       | ...      | ...                                                                                                                             | ...  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/jsx-runtime.js
+
+```javascript
+module.exports = {}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/reflect-utils.js
+
+```javascript
+// This regex will have fast negatives meaning valid identifiers may not pass
+// this test. However this is only used during static generation to provide hints
+// about why a page bailed out of some or all prerendering and we can use bracket notation
+// for example while `ಠ_ಠ` is a valid identifier it's ok to print `searchParams['ಠ_ಠ']`
+// even if this would have been fine too `searchParams.ಠ_ಠ`
+const isDefinitelyAValidIdentifier = /s/
+export function describeStringPropertyAccess(target, prop) {}
+export function describeHasCheckingStringProperty(target, prop) {}
+export const wellKnownProperties = new Set([])
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/collect-segment-data.js
+
+```javascript
+import { jsx as _jsx } from './jsx-runtime'
+// eslint-disable-next-line import/no-extraneous-dependencies
+const createFromReadableStream = 123 //import { createFromReadableStream } from 'react-server-dom-webpack/client.edge';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const prerender = 123 // import { unstable_prerender as prerender } from 'react-server-dom-webpack/static.edge';
+const streamFromBuffer = 1,
+  streamToBuffer = 1 // import { streamFromBuffer, streamToBuffer } from '../stream-utils/node-web-streams-helper';
+const waitAtLeastOneReactRenderTask = 1 //import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler';
+// import  './segment-value-encoding';
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/index1.js
+
+```javascript
+import './entry-base.js'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/index2.js
+
+```javascript
+import './entry-base.js'
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/index.js
+
+```javascript
+// "entry-base.js [app-rsc] (ecmascript) <module evaluation>" with
+// ["reflect-utils.js [app-rsc] (ecmascript)",
+// "params.js [app-rsc] (ecmascript)",
+// "segment-value-encoding.js [app-rsc] (ecmascript)",
+// "collect-segment-data.js [app-rsc] (ecmascript)",
+// "entry-base.js [app-rsc] (ecmascript) <locals>"]
+
+// "entry-base.js [test] (ecmascript) <module evaluation>" with
+// ["reflect-utils.js [test] (ecmascript)",
+// "params.js [test] (ecmascript)",
+// "segment-value-encoding.js [test] (ecmascript)",
+//  "collect-segment-data.js [test] (ecmascript)",
+//  "entry-base.js [test] (ecmascript) <locals>"]
+
+if (Date.now() > 0) {
+  require('./index1.js')
+}
+if (Date.now() > 0) {
+  require('./index2.js')
+}
+
+// ... (1 more lines)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/output/b1abf_turbopack-tests_tests_snapshot_source_maps_merged-unicode_input_index_a93cc521.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/output/b1abf_turbopack-tests_tests_snapshot_source_maps_merged-unicode_input_index_a93cc521.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/4c35f_tests_snapshot_styled_components_styled_components_input_index_68ca0f74.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/4c35f_tests_snapshot_styled_components_styled_components_input_index_68ca0f74.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/turbopack_crates_turbopack-tests_tests_snapshot_398e2526._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/turbopack_crates_turbopack-tests_tests_snapshot_398e2526._.js.map.md
@@ -1,0 +1,58 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/styled-components/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 22
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                               | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:0       | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:6       | 3:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:17      | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:218     | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:219     | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:229     | 3:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:230     | 3:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 9:236     | 3:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 12:2      | 3:30     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 12:3      | 3:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 14:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 14:1      | 5:1      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 15:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 15:8      | 7:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 15:11     | 7:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 15:12     | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js | N/A  |
+| 21:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/styled-components/index.js            | N/A  |
+| 22:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/styled-components/index.js            | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/input/index.js
+
+```javascript
+import styled from 'styled-components'
+
+const MyButton = styled.button`
+  background: blue;
+`
+
+console.log(MyButton)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/styled-components/index.js
+
+```javascript
+'purposefully empty stub'
+'styled-components/index.js'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/4c35f_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_578d8117.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/4c35f_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_578d8117.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/turbopack_crates_turbopack-tests_tests_snapshot_b56e07c9._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/turbopack_crates_turbopack-tests_tests_snapshot_b56e07c9._.js.map.md
@@ -1,0 +1,88 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/react/jsx-dev-runtime.js`
+4. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 33
+- **Generated Lines**: 49
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                                             | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 11:0      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js                 | N/A  |
+| 11:9      | 1:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js                 | N/A  |
+| 12:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js                 | N/A  |
+| 12:25     | 2:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js                 | N/A  |
+| 12:243    | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js                 | N/A  |
+| 13:18     | 2:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js                 | N/A  |
+| 19:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js                 | N/A  |
+| 25:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 26:0      | 2:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:0      | 4:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:8      | 4:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:11     | 4:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:12     | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:244    | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:245    | 4:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:255    | 4:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:257    | 4:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:505    | 4:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:506    | 4:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 29:516    | 4:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js                       | N/A  |
+| 37:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/react/jsx-dev-runtime.js                                            | N/A  |
+| 37:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/react/jsx-dev-runtime.js                                            | N/A  |
+| 38:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/react/jsx-dev-runtime.js                                            | N/A  |
+| 38:11     | 2:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/react/jsx-dev-runtime.js                                            | N/A  |
+| 39:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/react/jsx-dev-runtime.js                                            | N/A  |
+| 47:0      | 1:15     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+| 47:9      | 1:24     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+| 48:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+| 48:12     | 2:10     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+| 48:16     | 2:14     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+| 48:41     | 2:39     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+| 48:43     | 2:41     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+| 49:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js
+
+```javascript
+export default function MyApp() {
+  return <div>App</div>
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/app/index.js
+
+```javascript
+import MyApp from 'component'
+import ThirdPartyComponent from 'third_party_component'
+
+console.log(MyApp, ThirdPartyComponent)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/react/jsx-dev-runtime.js
+
+```javascript
+export function jsxDEV() {
+  return 'purposefully empty stub for react/jsx-dev-runtime.js'
+}
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/third_party_component/index.js
+
+```javascript
+export default function ThirdPartyComponent() {
+  return <div>Should not be transformed</div>
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/b1abf_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_ff8b5e8f.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/b1abf_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_ff8b5e8f.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/turbopack_crates_turbopack-tests_tests_snapshot_bff03a32._.js.map.md
@@ -1,0 +1,56 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/@swc/helpers/_/_class_call_check.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 20
+- **Generated Lines**: 22
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                              | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 8:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 8:4       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 8:4       | 1:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 8:10      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 8:19      | 1:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 10:30     | 1:6      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:8      | 3:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:11     | 3:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:12     | 3:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:17     | 3:17     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:19     | 3:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:20     | 3:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:28     | 3:28     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 12:29     | 3:29     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js          | N/A  |
+| 20:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node*modules/@swc/helpers/*/\_class_call_check.js | N/A  |
+| 20:9      | 1:16     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node*modules/@swc/helpers/*/\_class_call_check.js | N/A  |
+| 21:4      | 2:2      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node*modules/@swc/helpers/*/\_class_call_check.js | N/A  |
+| 21:11     | 2:9      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node*modules/@swc/helpers/*/\_class_call_check.js | N/A  |
+| 22:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node*modules/@swc/helpers/*/\_class_call_check.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/input/index.js
+
+```javascript
+class Foo {}
+
+console.log(Foo, [].includes('foo'))
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node*modules/@swc/helpers/*/\_class_call_check.js
+
+```javascript
+export function _() {
+  return 'purposefully empty stub for @swc/helpers/_/_class_call_check.js'
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/output/4e721_crates_turbopack-tests_tests_snapshot_tree-shaking_dce_input_index_4146abb8.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/output/4e721_crates_turbopack-tests_tests_snapshot_tree-shaking_dce_input_index_4146abb8.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_dce_input_d299a335._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/output/turbopack_crates_turbopack-tests_tests_snapshot_tree-shaking_dce_input_d299a335._.js.map.md
@@ -1,0 +1,31 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 2
+- **Generated Lines**: 15
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                            | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------ | ---- |
+| 13:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/input/index.js | N/A  |
+| 15:0      | 3:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/tree-shaking/dce/input/index.js
+
+```javascript
+import { baz } from './module'
+
+if (1 + 1 == 3) {
+  baz()
+}
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/b1abf_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_50efc170._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/b1abf_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_50efc170._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/prop.js`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                       | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:0       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/prop.js  | N/A  |
+| 9:6       | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/prop.js  | N/A  |
+| 9:13      | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/prop.js  | N/A  |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:218    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:219    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:226    | 5:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:228    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:434    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:435    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:442    | 5:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:444    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:650    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:651    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+| 19:658    | 5:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/prop.js
+
+```javascript
+export const prop = 1
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/input/index.js
+
+```javascript
+import { prop as globalFoo } from 'foo'
+import { prop as localFoo } from './foo'
+import { prop as atFoo } from '@/foo'
+
+console.log(globalFoo, localFoo, atFoo)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/b1abf_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_index_ade2713f.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/b1abf_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_index_ade2713f.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/4c35f_tests_snapshot_typescript_tsconfig-baseurl_input_index_ts_379e0361._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/4c35f_tests_snapshot_typescript_tsconfig-baseurl_input_index_ts_379e0361._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/b1abf_turbopack-tests_tests_snapshot_typescript_tsconfig-baseurl_input_88264193._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/b1abf_turbopack-tests_tests_snapshot_typescript_tsconfig-baseurl_input_88264193._.js.map.md
@@ -1,0 +1,69 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/prop.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts`
+3. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/node_modules/bar/index.js`
+
+## Mappings Overview
+
+- **Total Mappings**: 24
+- **Generated Lines**: 29
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                        | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:0       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/prop.ts                   | N/A  |
+| 9:6       | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/prop.ts                   | N/A  |
+| 9:13      | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/prop.ts                   | N/A  |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 16:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:0      | 7:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:8      | 7:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:11     | 7:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:12     | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:218    | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:219    | 7:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:226    | 7:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:228    | 7:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:434    | 7:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:435    | 7:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:442    | 7:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:444    | 7:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:650    | 7:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:651    | 7:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:658    | 7:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 21:660    | 7:40     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts                  | N/A  |
+| 29:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/node_modules/bar/index.js | N/A  |
+| 29:6      | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/node_modules/bar/index.js | N/A  |
+| 29:12     | 1:19     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/node_modules/bar/index.js | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/prop.ts
+
+```javascript
+export const prop = 1
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/index.ts
+
+```javascript
+import { prop as globalFoo } from 'foo'
+import { prop as localFoo } from './foo'
+import { prop as atFoo } from '@/foo'
+
+import * as bar from 'bar'
+
+console.log(globalFoo, localFoo, atFoo, bar)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/input/node_modules/bar/index.js
+
+```javascript
+export const bar = 'bar'
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/output/457d9_snapshot_typescript_tsconfig-extends-module-full-path_input_index_ts_a9f00214._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/output/457d9_snapshot_typescript_tsconfig-extends-module-full-path_input_index_ts_a9f00214._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/output/turbopack_crates_turbopack-tests_tests_snapshot_f038421b._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/output/turbopack_crates_turbopack-tests_tests_snapshot_f038421b._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                        | Name |
+| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:207    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:208    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:215    | 5:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:217    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:412    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:413    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:420    | 5:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:422    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:617    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:618    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 11:625    | 5:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts | N/A  |
+| 19:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts                           | N/A  |
+| 19:6      | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts                           | N/A  |
+| 19:13     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts                           | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/input/index.ts
+
+```javascript
+import { prop as globalFoo } from 'foo'
+import { prop as localFoo } from './foo'
+import { prop as atFoo } from '@/foo'
+
+console.log(globalFoo, localFoo, atFoo)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts
+
+```javascript
+export const prop = 1
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/output/4c35f_tests_snapshot_typescript_tsconfig-extends-module_input_index_ts_48ff2ca5._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/output/4c35f_tests_snapshot_typescript_tsconfig-extends-module_input_index_ts_48ff2ca5._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/output/turbopack_crates_turbopack-tests_tests_snapshot_cff3cff1._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/output/turbopack_crates_turbopack-tests_tests_snapshot_cff3cff1._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                              | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 7:0       | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:207    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:208    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:215    | 5:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:217    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:412    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:413    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:420    | 5:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:422    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:617    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:618    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 11:625    | 5:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts | N/A  |
+| 19:0      | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts                 | N/A  |
+| 19:6      | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts                 | N/A  |
+| 19:13     | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts                 | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/input/index.ts
+
+```javascript
+import { prop as globalFoo } from 'foo'
+import { prop as localFoo } from './foo'
+import { prop as atFoo } from '@/foo'
+
+console.log(globalFoo, localFoo, atFoo)
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/node_modules/tsconfig-mod/prop.ts
+
+```javascript
+export const prop = 1
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/output/4c35f_tests_snapshot_typescript_tsconfig-extends-relative-dir_input_ef6815c7._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/output/4c35f_tests_snapshot_typescript_tsconfig-extends-relative-dir_input_ef6815c7._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/prop.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                    | Name |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ | ---- |
+| 9:0       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/prop.ts  | N/A  |
+| 9:6       | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/prop.ts  | N/A  |
+| 9:13      | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/prop.ts  | N/A  |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:237    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:238    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:245    | 5:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:247    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:472    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:473    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:480    | 5:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:482    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:707    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:708    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+| 19:715    | 5:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/prop.ts
+
+```javascript
+export const prop = 1
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/input/index.ts
+
+```javascript
+import { prop as globalFoo } from 'foo'
+import { prop as localFoo } from './foo'
+import { prop as atFoo } from '@/foo'
+
+console.log(globalFoo, localFoo, atFoo)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/output/4c35f_tests_snapshot_typescript_tsconfig-extends-relative-dir_input_index_ts_0b5ae5a5._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/output/4c35f_tests_snapshot_typescript_tsconfig-extends-relative-dir_input_index_ts_0b5ae5a5._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/output/4c35f_tests_snapshot_typescript_tsconfig-extends-without-ext_input_fcdb4390._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/output/4c35f_tests_snapshot_typescript_tsconfig-extends-without-ext_input_fcdb4390._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/prop.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                                   | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:0       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/prop.ts  | N/A  |
+| 9:6       | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/prop.ts  | N/A  |
+| 9:13      | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/prop.ts  | N/A  |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:236    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:237    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:244    | 5:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:246    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:470    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:471    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:478    | 5:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:480    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:704    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:705    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+| 19:712    | 5:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/prop.ts
+
+```javascript
+export const prop = 1
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/input/index.ts
+
+```javascript
+import { prop as globalFoo } from 'foo'
+import { prop as localFoo } from './foo'
+import { prop as atFoo } from '@/foo'
+
+console.log(globalFoo, localFoo, atFoo)
+```

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/output/4c35f_tests_snapshot_typescript_tsconfig-extends-without-ext_input_index_ts_73c8fc18._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/output/4c35f_tests_snapshot_typescript_tsconfig-extends-without-ext_input_index_ts_73c8fc18._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/output/4c35f_tests_snapshot_typescript_tsconfig-extends_input_index_ts_315599c8._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/output/4c35f_tests_snapshot_typescript_tsconfig-extends_input_index_ts_315599c8._.js.map.md
@@ -1,0 +1,15 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+## Mappings Overview
+
+- **Total Mappings**: 0
+- **Generated Lines**: 1
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File | Name |
+| --------- | -------- | ----------- | ---- |

--- a/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/output/b1abf_turbopack-tests_tests_snapshot_typescript_tsconfig-extends_input_39e68707._.js.map.md
+++ b/turbopack/crates/turbopack-tests/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/output/b1abf_turbopack-tests_tests_snapshot_typescript_tsconfig-extends_input_39e68707._.js.map.md
@@ -1,0 +1,55 @@
+# Source Map Visualization
+
+## Basic Information
+
+## Source Files
+
+1. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/prop.ts`
+2. `turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts`
+
+## Mappings Overview
+
+- **Total Mappings**: 19
+- **Generated Lines**: 19
+
+## Mapping Details (First 50 entries)
+
+| Generated | Original | Source File                                                                                                       | Name |
+| --------- | -------- | ----------------------------------------------------------------------------------------------------------------- | ---- |
+| 9:0       | 1:7      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/prop.ts  | N/A  |
+| 9:6       | 1:13     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/prop.ts  | N/A  |
+| 9:13      | 1:20     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/prop.ts  | N/A  |
+| 15:0      | 1:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:0      | 5:0      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:8      | 5:8      | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:11     | 5:11     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:12     | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:218    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:219    | 5:12     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:226    | 5:21     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:228    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:434    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:435    | 5:23     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:442    | 5:31     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:444    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:650    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:651    | 5:33     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+| 19:658    | 5:38     | turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts | N/A  |
+
+## Source Contents
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/prop.ts
+
+```javascript
+export const prop = 1
+```
+
+### turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/input/index.ts
+
+```javascript
+import { prop as globalFoo } from 'foo'
+import { prop as localFoo } from './foo'
+import { prop as atFoo } from '@/foo'
+
+console.log(globalFoo, localFoo, atFoo)
+```


### PR DESCRIPTION
### What?

Visualize source maps

### Why?

Snapshot testing source map is very hard

### How?

Closes PACK-4926
