### PR TITLE
fix(next-swc): Apply SWC minifier bugfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "29.4.0"
+version = "29.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991fb5308ade9fb838316d0f1790bf2df25b0cafa6ac2515450e8003107201ae"
+checksum = "09ac3e1a8ead74c190396c066998edd40ab2b2f93f61e90c033ff67deaf22d5f"
 dependencies = [
  "binding_macros",
  "par-core",
@@ -8022,9 +8022,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c357c7ff7ae2bf50adbe89c04ed94c9b99d34563df69386aba15a05e4560fc9a"
+checksum = "209cc62665a5a6f7cded15c198a27b5aed49f8f4bc2b1c14ebec61c02889b2e6"
 dependencies = [
  "bitflags 2.9.1",
  "indexmap 2.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "29.4.1"
+version = "29.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3e1a8ead74c190396c066998edd40ab2b2f93f61e90c033ff67deaf22d5f"
+checksum = "b41f837258f84d0d6d0a1dd8bbd277bbab34de9fa2180b6bc6e838f652b304c9"
 dependencies = [
  "binding_macros",
  "par-core",
@@ -8040,9 +8040,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "18.0.1"
+version = "18.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938751c806f23256256e6839914ab33e4ac6e79a3fa2e717d004469881d2e3df"
+checksum = "f9d4bc1a89ef29769cf3e16c79a79836f21a7a3975fa34a9b748d0a9d3771daf"
 dependencies = [
  "indexmap 2.9.0",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "29.4.1", features = [
+swc_core = { version = "29.4.2", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,7 +298,7 @@ turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
-swc_core = { version = "29.4.0", features = [
+swc_core = { version = "29.4.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
   "parallel_rayon",


### PR DESCRIPTION
### What?

Update `swc_core` to `v29.4.2` 

### Why?

To apply https://github.com/swc-project/swc/pull/10740 and https://github.com/swc-project/swc/pull/10741

Closes PACK-4969