### PR TITLE
Docs: paper cuts July 1st 

### DIFF
--- a/docs/01-app/02-guides/caching.mdx
+++ b/docs/01-app/02-guides/caching.mdx
@@ -318,7 +318,7 @@ You can opt out of the Full Route Cache, or in other words, dynamically render c
 
 Next.js has an in-memory client-side router cache that stores the RSC payload of route segments, split by layouts, loading states, and pages.
 
-When a user navigates between routes, Next.js caches the visited route segments and [prefetches](/docs/app/getting-started/linking-and-navigating#prefetching) the routes the user is likely to navigate to. This results in instant back/forward navigation, no full-page reload between navigations, and preservation of React state and browser state.
+When a user navigates between routes, Next.js caches the visited route segments and [prefetches](/docs/app/getting-started/linking-and-navigating#prefetching) the routes the user is likely to navigate to. This results in instant back/forward navigation, no full-page reload between navigations, and preservation of browser state and React state in shared layouts.
 
 With the Router Cache:
 

--- a/docs/01-app/02-guides/redirecting.mdx
+++ b/docs/01-app/02-guides/redirecting.mdx
@@ -81,7 +81,7 @@ export async function createPost(id) {
 > **Good to know**:
 >
 > - `redirect` returns a 307 (Temporary Redirect) status code by default. When used in a Server Action, it returns a 303 (See Other), which is commonly used for redirecting to a success page as a result of a POST request.
-> - `redirect` internally throws an error so it should be called outside of `try/catch` blocks.
+> - `redirect` throws an error so it should be called **outside** the `try` block when using `try/catch` statements.
 > - `redirect` can be called in Client Components during the rendering process but not in event handlers. You can use the [`useRouter` hook](#userouter-hook) instead.
 > - `redirect` also accepts absolute URLs and can be used to redirect to external links.
 > - If you'd like to redirect before the render process, use [`next.config.js`](#redirects-in-nextconfigjs) or [Middleware](#nextresponseredirect-in-middleware).

--- a/docs/01-app/03-api-reference/04-functions/redirect.mdx
+++ b/docs/01-app/03-api-reference/04-functions/redirect.mdx
@@ -47,9 +47,9 @@ The `type` parameter has no effect when used in Server Components.
 
 ## Behavior
 
-- In Server Actions and Route Handlers, `redirect` should be called after the `try/catch` block.
+- In Server Actions and Route Handlers, redirect should be called **outside** the `try` block when using `try/catch` statements.
 - If you prefer to return a 308 (Permanent) HTTP redirect instead of 307 (Temporary), you can use the [`permanentRedirect` function](/docs/app/api-reference/functions/permanentRedirect) instead.
-- `redirect` internally throws an error so it should be called outside of `try/catch` blocks.
+- `redirect` throws an error so it should be called **outside** the `try` block when using `try/catch` statements.
 - `redirect` can be called in Client Components during the rendering process but not in event handlers. You can use the [`useRouter` hook](/docs/app/api-reference/functions/use-router) instead.
 - `redirect` also accepts absolute URLs and can be used to redirect to external links.
 - If you'd like to redirect before the render process, use [`next.config.js`](/docs/app/guides/redirecting#redirects-in-nextconfigjs) or [Middleware](/docs/app/guides/redirecting#nextresponseredirect-in-middleware).

--- a/docs/01-app/03-api-reference/04-functions/unstable_rethrow.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unstable_rethrow.mdx
@@ -6,7 +6,7 @@ version: unstable
 
 `unstable_rethrow` can be used to avoid catching internal errors thrown by Next.js when attempting to handle errors thrown in your application code.
 
-For example, calling the `notFound` function will throw an internal Next.js error and render the [`not-found.js`](/docs/app/api-reference/file-conventions/not-found) component. However, if used inside a `try/catch` block, the error will be caught, preventing `not-found.js` from rendering:
+For example, calling the `notFound` function will throw an internal Next.js error and render the [`not-found.js`](/docs/app/api-reference/file-conventions/not-found) component. However, if used inside the `try` block of a `try/catch` statement, the error will be caught, preventing `not-found.js` from rendering:
 
 ```tsx filename="@/app/ui/component.tsx"
 import { notFound } from 'next/navigation'
@@ -60,5 +60,6 @@ If a route segment is marked to throw an error unless it's static, a Dynamic API
 > **Good to know**:
 >
 > - This method should be called at the top of the catch block, passing the error object as its only argument. It can also be used within a `.catch` handler of a promise.
-> - If you ensure that your calls to APIs that throw are not wrapped in a try/catch then you don't need to use `unstable_rethrow`
+> - You may be able to avoid using `unstable_rethrow` if you encapsulate your API calls that throw and let the **caller** handle the exception.
+> - Only use `unstable_rethrow` if your caught exceptions may include both application errors and framework-controlled exceptions (like `redirect()` or `notFound()`).
 > - Any resource cleanup (like clearing intervals, timers, etc) would have to either happen prior to the call to `unstable_rethrow` or within a `finally` block.


### PR DESCRIPTION
Just a couple of adjustments to Caching docs claim that React State is preserved upon SPA transitions - as of today, without the Activity API, only shared layouts state is preserved.

And we are saying redirect should be called outside try/catch blocks, but rather, it is the try block that's the problem. So I am rephrasing that.

I still think it is best to keep the redirect away from the try/catch statement altogether.