### PR TITLE
[dev-tools] Consistent focus states for buttons

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -338,8 +338,7 @@ export const DEVTOOLS_PANEL_STYLES = css`
     padding: 4px 12px;
     font-size: 14px;
     font-weight: 500;
-
-    transition: all 0.2s ease;
+    transition: background-color 200ms ease;
 
     &:hover {
       background-color: var(--color-gray-200);
@@ -387,7 +386,9 @@ export const DEVTOOLS_PANEL_STYLES = css`
     padding: 6px;
     color: var(--color-gray-1000);
     border-radius: 4px;
-    transition: all 0.2s ease;
+    transition-property: background-color, color;
+    transition-duration: 200ms;
+    transition-timing-function: ease;
 
     &:hover {
       background-color: var(--color-gray-200);

--- a/packages/next/src/next-devtools/dev-overlay/styles/base.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/styles/base.tsx
@@ -141,7 +141,7 @@ export function Base({ scale = 1 }: { scale?: DevToolsScale }) {
           &:hover {
             color: var(--color-blue-900);
           }
-          &:focus {
+          &:focus-visible {
             outline: var(--focus-ring);
           }
         }


### PR DESCRIPTION
Trivial PR. Just makes sure we use our `--focus-ring` CSS variable for focus states.

![CleanShot 2025-07-01 at 13 18 05@2x](https://github.com/user-attachments/assets/c3f7aded-0644-4a46-850d-8d5e4e379084)
