### PR TITLE
[segment explorer] reset error and not-found boundary

### DIFF
--- a/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
+++ b/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { useState, createContext, useContext, use, useMemo } from 'react'
+import {
+  useState,
+  createContext,
+  useContext,
+  use,
+  useMemo,
+  useCallback,
+} from 'react'
 import { useLayoutEffect } from 'react'
 import { dispatcher } from 'next/dist/compiled/next-devtools'
 import { notFound } from '../../../client/components/not-found'
@@ -117,8 +124,27 @@ export function SegmentStateProvider({ children }: { children: ReactNode }) {
     'not-found' | 'error' | 'loading' | null
   >(null)
 
+  const [errorBoundaryKey, setErrorBoundaryKey] = useState(0)
+  const reloadBoundary = useCallback(
+    () => setErrorBoundaryKey((prev) => prev + 1),
+    []
+  )
+
+  const setBoundaryTypeAndReload = useCallback(
+    (type: 'not-found' | 'error' | 'loading' | null) => {
+      if (type === null) {
+        reloadBoundary()
+      }
+      setBoundaryType(type)
+    },
+    [reloadBoundary]
+  )
+
   return (
-    <SegmentStateContext.Provider value={{ boundaryType, setBoundaryType }}>
+    <SegmentStateContext.Provider
+      key={errorBoundaryKey}
+      value={{ boundaryType, setBoundaryType: setBoundaryTypeAndReload }}
+    >
       {children}
     </SegmentStateContext.Provider>
   )


### PR DESCRIPTION
### Description

Add a `key` prop to the segment state boundary and change the key when we call reset, this way it will force the children re-render with the new state where the boundaries will get reset and the simulated error will be gone since we're rendering the page component now.

Reseting the error boundary only won't help, it will still get the error from `getDerivedStateFromError` class method and apply to the state. This approach will reset the state group of layout-router, and ensure we keep rendering the page segment (or anything by default).

### Video

https://github.com/user-attachments/assets/f6fc21da-abc1-41fc-857f-136a203f6039


Closes NEXT-4583