### PR TITLE
Test for instrumentation hook search order

### DIFF
--- a/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
+++ b/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
@@ -74,6 +74,12 @@ describe('Instrumentation Hook', () => {
     })
   })
 
+  describeCase('prefer-src', ({ next }) => {
+    it('prefer-src should use the src/instrumentation.js hook', async () => {
+      await check(() => next.cliOutput, /instrumentation hook on nodejs/)
+    })
+  })
+
   describeCase('general', ({ next, isNextDev }) => {
     it('should not overlap with a instrumentation page', async () => {
       const page = await next.render('/instrumentation')

--- a/test/e2e/instrumentation-hook/prefer-src/instrumentation.js
+++ b/test/e2e/instrumentation-hook/prefer-src/instrumentation.js
@@ -1,0 +1,3 @@
+export function register() {
+  require('this should fail')
+}

--- a/test/e2e/instrumentation-hook/prefer-src/next.config.js
+++ b/test/e2e/instrumentation-hook/prefer-src/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/e2e/instrumentation-hook/prefer-src/pages/index.tsx
+++ b/test/e2e/instrumentation-hook/prefer-src/pages/index.tsx
@@ -1,0 +1,9 @@
+export default function Page() {
+  return <p>Node</p>
+}
+
+export function getServerSideProps() {
+  return {
+    props: {},
+  }
+}

--- a/test/e2e/instrumentation-hook/prefer-src/src/instrumentation.js
+++ b/test/e2e/instrumentation-hook/prefer-src/src/instrumentation.js
@@ -1,0 +1,9 @@
+export function register() {
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    console.log('instrumentation hook on the edge')
+  } else if (process.env.NEXT_RUNTIME === 'nodejs') {
+    console.log('instrumentation hook on nodejs')
+  } else {
+    require('this should fail')
+  }
+}


### PR DESCRIPTION
Webpack/Turbopack Dev/Build (and potentially even the deployed version) don't agree on whether to prefer `src/instrumentation` or `instrumentation`.