### PR TITLE
fix(turbopack) Adjust tree loader to respect parent module overrides

### DIFF
--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/(main)/layout.js
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/(main)/layout.js
@@ -1,0 +1,3 @@
+export default function MainLayout({ children }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/(main)/not-found.js
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/(main)/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1 id="not-found-heading">Group Not Found Page</h1>
+}

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/(main)/page.js
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/(main)/page.js
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Home() {
+  notFound()
+}

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/layout.js
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/layout.js
@@ -1,0 +1,8 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/not-found.js
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1 id="not-found-heading">Root Not Found Page</h1>
+}

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox } from 'next-test-utils'
+
+describe('app dir - not found with nested layouts and custom not-found', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should render the custom not-found page when notFound() is thrown from a page within the group', async () => {
+    const browser = await next.browser('/')
+    await assertNoRedbox(browser)
+    const heading = await browser.elementByCss('h1#not-found-heading')
+    expect(await heading.text()).toBe('Group Not Found Page')
+  })
+})

--- a/test/e2e/app-dir/not-found-with-nested-layouts/app/(main)/layout.js
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/app/(main)/layout.js
@@ -1,0 +1,3 @@
+export default function MainLayout({ children }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/not-found-with-nested-layouts/app/(main)/page.js
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/app/(main)/page.js
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Home() {
+  notFound()
+}

--- a/test/e2e/app-dir/not-found-with-nested-layouts/app/layout.js
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/app/layout.js
@@ -1,0 +1,8 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/not-found-with-nested-layouts/app/not-found.js
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1 id="not-found-heading">Custom Not Found Page</h1>
+}

--- a/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox } from 'next-test-utils'
+
+describe('app dir - not found with nested layouts', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should render the custom not-found page when notFound() is thrown from a page', async () => {
+    const browser = await next.browser('/')
+    await assertNoRedbox(browser)
+    const heading = await browser.elementByCss('h1#not-found-heading')
+    expect(await heading.text()).toBe('Custom Not Found Page')
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -3841,6 +3841,24 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts": {
+    "passed": [
+      "app dir - not found with nested layouts and custom not-found should render the custom not-found page when notFound() is thrown from a page within the group"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts": {
+    "passed": [
+      "app dir - not found with nested layouts should render the custom not-found page when notFound() is thrown from a page"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts": {
     "passed": [
       "not-found-with-pages should prefer the app router 404 over the pages router 404 when both are present",

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -7695,6 +7695,24 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts": {
+    "passed": [
+      "app dir - not found with nested layouts and custom not-found should render the custom not-found page when notFound() is thrown from a page within the group"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
+  "test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts": {
+    "passed": [
+      "app dir - not found with nested layouts should render the custom not-found page when notFound() is thrown from a page"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts": {
     "passed": [
       "not-found-with-pages should prefer the app router 404 over the pages router 404 when both are present"


### PR DESCRIPTION
## Fix not-found page inheritance in nested layouts

### What?
This PR fixes an issue where custom not-found pages weren't properly inherited in nested layouts. Previously, when a page within a route group threw a `notFound()` error, it wouldn't correctly use the group's custom not-found page if there was also a custom layout.

### How?
- Added a new `check_and_update_module_references` helper function to manage module inheritance
- Implemented proper parent-child relationship for special pages (not-found, forbidden, unauthorized, global-error)
- Added test cases for not-found pages with nested layouts and route groups
- Ensured custom not-found pages are properly rendered when notFound() is thrown from pages in nested layouts

Fixes #PACK-4496