### PR TITLE
[turbopack] Remove unused no_move_vec code

### DIFF
--- a/turbopack/crates/turbo-tasks/src/util.rs
+++ b/turbopack/crates/turbo-tasks/src/util.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use super::{
     id_factory::{IdFactory, IdFactoryWithReuse},
-    no_move_vec::NoMoveVec,
     once_map::*,
 };
 


### PR DESCRIPTION
A `pub use` statement was obscuring that half the code is dead.


Closes PACK-5006