### PR TITLE
[turbopack] Move global names onto the NativeFunction object

### DIFF
--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -213,7 +213,7 @@ mod ser {
                 unreachable!();
             };
             let mut state = serializer.serialize_seq(Some(2))?;
-            state.serialize_element(&registry::get_function_global_name(native_fn))?;
+            state.serialize_element(native_fn.global_name())?;
             let arg = *arg;
             let arg = native_fn.arg_meta.as_serialize(arg);
             state.serialize_element(arg)?;

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -1,4 +1,5 @@
-use std::{fmt::Debug, hash::Hash, pin::Pin};
+use core::panic;
+use std::{fmt::Debug, hash::Hash, pin::Pin, sync::OnceLock};
 
 use anyhow::Result;
 use futures::Future;
@@ -166,6 +167,8 @@ pub struct NativeFunction {
     /// The functor that creates a functor from inputs. The inner functor
     /// handles the task execution.
     pub(crate) implementation: Box<dyn TaskFn + Send + Sync + 'static>,
+
+    global_name: OnceLock<&'static str>,
 }
 
 impl Debug for NativeFunction {
@@ -191,6 +194,7 @@ impl NativeFunction {
             function_meta,
             arg_meta: ArgMeta::new::<Inputs>(),
             implementation: Box::new(implementation.into_task_fn()),
+            global_name: Default::default(),
         }
     }
 
@@ -213,6 +217,7 @@ impl NativeFunction {
                 ArgMeta::new::<Inputs>()
             },
             implementation: Box::new(implementation.into_task_fn()),
+            global_name: Default::default(),
         }
     }
 
@@ -236,6 +241,7 @@ impl NativeFunction {
                 ArgMeta::new::<Inputs>()
             },
             implementation: Box::new(implementation.into_task_fn_with_this()),
+            global_name: Default::default(),
         }
     }
 
@@ -276,7 +282,20 @@ impl NativeFunction {
         tracing::trace_span!("turbo_tasks::resolve_call", name = self.name, flags = flags)
     }
 
+    /// Returns the global name for this object
+    pub fn global_name(&self) -> &'static str {
+        self.global_name
+            .get()
+            .expect("cannot call `global_name` unless `register` has already been called")
+    }
+
     pub fn register(&'static self, global_name: &'static str) {
+        match self.global_name.set(global_name) {
+            Ok(_) => {}
+            Err(prev) => {
+                panic!("function {global_name} registered twice, previously with {prev}");
+            }
+        }
         register_function(global_name, self);
     }
 }

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -14,8 +14,6 @@ use crate::{
 
 static NAME_TO_FUNCTION: Lazy<RwLock<FxHashMap<&'static str, &'static NativeFunction>>> =
     Lazy::new(RwLock::default);
-static FUNCTION_TO_NAME: Lazy<RwLock<FxHashMap<&'static NativeFunction, &'static str>>> =
-    Lazy::new(RwLock::default);
 
 static VALUE_TYPE_ID_FACTORY: IdFactory<ValueTypeId> = IdFactory::new_const(
     ValueTypeId::MIN.to_non_zero_u64(),
@@ -78,8 +76,6 @@ where
 
 /// Registers a function so it is available for persistence
 pub fn register_function(global_name: &'static str, func: &'static NativeFunction) {
-    let prev = FUNCTION_TO_NAME.write().unwrap().insert(func, global_name);
-    debug_assert!(prev.is_none(), "function {global_name} registered twice?");
     let prev = NAME_TO_FUNCTION.write().unwrap().insert(global_name, func);
     debug_assert!(
         prev.is_none(),
@@ -89,10 +85,6 @@ pub fn register_function(global_name: &'static str, func: &'static NativeFunctio
 
 pub fn get_function_by_global_name(global_name: &str) -> &'static NativeFunction {
     NAME_TO_FUNCTION.read().unwrap().get(global_name).unwrap()
-}
-
-pub fn get_function_global_name(func: &'static NativeFunction) -> &'static str {
-    FUNCTION_TO_NAME.read().unwrap().get(&func).unwrap()
 }
 
 pub fn register_value_type(

--- a/turbopack/crates/turbo-tasks/src/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks/src/task_statistics.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, OnceLock};
 
 use serde::{Serialize, Serializer, ser::SerializeMap};
 
-use crate::{FxDashMap, macro_helpers::NativeFunction, registry};
+use crate::{FxDashMap, macro_helpers::NativeFunction};
 
 /// An API for optionally enabling, updating, and reading aggregated statistics.
 #[derive(Default)]
@@ -73,8 +73,7 @@ impl Serialize for TaskStatistics {
     {
         let mut map = serializer.serialize_map(Some(self.inner.len()))?;
         for entry in &self.inner {
-            let key = registry::get_function_global_name(entry.key());
-            map.serialize_entry(key, entry.value())?;
+            map.serialize_entry(entry.key().global_name(), entry.value())?;
         }
         map.end()
     }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -57,11 +57,6 @@ use crate::{
     },
 };
 
-pub fn register() {
-    turbopack::register();
-    include!(concat!(env!("OUT_DIR"), "/register.rs"));
-}
-
 type Backend = TurboTasksBackend<NoopBackingStorage>;
 
 pub struct TurbopackBuildBuilder {

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -349,18 +349,13 @@ async fn source(
     )))
 }
 
-pub fn register() {
-    turbopack::register();
-    include!(concat!(env!("OUT_DIR"), "/register.rs"));
-}
-
 /// Start a devserver with the given args.
 pub async fn start_server(args: &DevArguments) -> Result<()> {
     let start = Instant::now();
 
     #[cfg(feature = "tokio_console")]
     console_subscriber::init();
-    register();
+    crate::register();
 
     let NormalizedDirs {
         project_dir,


### PR DESCRIPTION
### What?

Instead of a global `&'static NativeFunction`->`&'static str` map, just put the names onto the `NativeFunction` struct and delete the global map.

### Why?

Using a RwLock means every read requires a `fetch_add` to update the reader count, so if lookups are performed on multiple threads we can expect contention on the RwLock reader count.

Using a OnceLock instead just means we need to perform a consistent read which shouldn't trigger cross processor cache traffic.

I don't know that this is a problem, and if it is it would only show up during PC serialization.

Closes PACK-4983