### PR TITLE
[segment explorer] refactor boundary trigger with ui primitives

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
@@ -52,7 +52,6 @@ export function DevToolsIndicator({
           '--animate-out-duration-ms': `${MENU_DURATION_MS}ms`,
           '--animate-out-timing-function': MENU_CURVE,
           boxShadow: 'none',
-          zIndex: 2147483647,
           [vertical]: `${INDICATOR_PADDING}px`,
           [horizontal]: `${INDICATOR_PADDING}px`,
           visibility:

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -271,7 +271,6 @@ function DevToolsPopover({
           '--animate-out-duration-ms': `${MENU_DURATION_MS}ms`,
           '--animate-out-timing-function': MENU_CURVE,
           boxShadow: 'none',
-          zIndex: 2147483647,
           [vertical]: `${INDICATOR_PADDING}px`,
           [horizontal]: `${INDICATOR_PADDING}px`,
         } as CSSProperties

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -97,7 +97,7 @@ export const DEV_TOOLS_INFO_STYLES = `
     border-radius: var(--rounded-xl);
     position: absolute;
     font-family: var(--font-stack-sans);
-    z-index: 1000;
+    z-index: 3;
     overflow: hidden;
     opacity: 0;
     outline: 0;

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
@@ -22,6 +22,6 @@ export function SegmentsExplorer({
 
 export const SEGMENTS_EXPLORER_STYLES = `
   [data-nextjs-segments-explorer] {
-    margin: -12px -8px;
+    margin: -16px;
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -205,14 +205,12 @@ function PageSegmentTreeLayerPresentation({
                 </span>
               )}
               {/* TODO: only show triggers in dev panel remove this once the new panel UI is stable */}
-              {process.env.__NEXT_DEVTOOL_NEW_PANEL_UI &&
-                pageChild &&
-                pageChild.value && (
-                  <SegmentBoundaryTrigger
-                    offset={6}
-                    onSelectBoundary={pageChild.value.setBoundaryType}
-                  />
-                )}
+              {pageChild && pageChild.value && (
+                <SegmentBoundaryTrigger
+                  offset={6}
+                  onSelectBoundary={pageChild.value.setBoundaryType}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/toast/styles.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/toast/styles.ts
@@ -1,8 +1,8 @@
 const styles = `
   .nextjs-toast {
     position: fixed;
+    z-index: 2147483647;
     max-width: 420px;
-    z-index: 9000;
     box-shadow: 0px 16px 32px
       rgba(0, 0, 0, 0.25);
   }

--- a/test/development/app-dir/segment-explorer/app/parallel-routes/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes/layout.tsx
@@ -1,10 +1,15 @@
 export default function Layout({ children, bar, foo }) {
   return (
-    <div>
+    <main
+      style={{
+        backgroundColor: '#fff',
+        zIndex: 300,
+      }}
+    >
       <h1>Parallel Routes Layout</h1>
       <div id="nested-children">{children}</div>
       <div id="foo-slot">{foo}</div>
       <div id="bar-slot">{bar}</div>
-    </div>
+    </main>
   )
 }


### PR DESCRIPTION
Like what we've done with tooltip, using the menu primitive to rebuild trigger menu.

* Fix the weird z-index situation, and only use one large z-index for the next devtool indicator button
* Rewrite the dropdown menu with base-ui menu

https://github.com/user-attachments/assets/24901c1b-474f-47fa-a98c-a4ef5a26a120

Closes NEXT-4598