### PR TITLE
[turbopack] Move static type ID variables into getters

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-shared/src/ident.rs
+++ b/turbopack/crates/turbo-tasks-macros-shared/src/ident.rs
@@ -186,15 +186,6 @@ pub fn get_type_ident(ty: &Type) -> Option<Ident> {
         }
     }
 }
-
-pub fn get_read_ref_ident(ident: &Ident) -> Ident {
-    Ident::new(&(ident.to_string() + "ReadRef"), ident.span())
-}
-
-pub fn get_trait_ref_ident(ident: &Ident) -> Ident {
-    Ident::new(&(ident.to_string() + "TraitRef"), ident.span())
-}
-
 pub fn get_trait_default_impl_function_ident(trait_ident: &Ident, ident: &Ident) -> Ident {
     Ident::new(
         &format!(
@@ -206,43 +197,9 @@ pub fn get_trait_default_impl_function_ident(trait_ident: &Ident, ident: &Ident)
     )
 }
 
-pub fn get_trait_type_id_ident(ident: &Ident) -> Ident {
-    Ident::new(
-        &format!("{}_TRAIT_TYPE_ID", ident.to_string().to_uppercase()),
-        ident.span(),
-    )
-}
-pub fn get_trait_type_vtable_registry(ident: &Ident) -> Ident {
-    Ident::new(
-        &format!(
-            "{}_TRAIT_TYPE_VTABLE_REGISTRY",
-            ident.to_string().to_uppercase()
-        ),
-        ident.span(),
-    )
-}
-
-pub fn get_trait_default_impl_function_id_ident(trait_ident: &Ident, ident: &Ident) -> Ident {
-    Ident::new(
-        &format!(
-            "{}_DEFAULT_IMPL_{}_FUNCTION_ID",
-            trait_ident.to_string().to_uppercase(),
-            ident.to_string().to_uppercase()
-        ),
-        ident.span(),
-    )
-}
-
 pub fn get_value_type_ident(ident: &Ident) -> Ident {
     Ident::new(
         &format!("{}_VALUE_TYPE", ident.to_string().to_uppercase()),
-        ident.span(),
-    )
-}
-
-pub fn get_value_type_id_ident(ident: &Ident) -> Ident {
-    Ident::new(
-        &format!("{}_VALUE_TYPE_ID", ident.to_string().to_uppercase()),
         ident.span(),
     )
 }

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -12,8 +12,7 @@ use syn::{
     spanned::Spanned,
 };
 use turbo_tasks_macros_shared::{
-    get_register_value_type_ident, get_value_type_id_ident, get_value_type_ident,
-    get_value_type_init_ident,
+    get_register_value_type_ident, get_value_type_ident, get_value_type_init_ident,
 };
 
 enum IntoMode {
@@ -458,7 +457,6 @@ pub fn value_type_and_register(
 ) -> proc_macro2::TokenStream {
     let value_type_init_ident = get_value_type_init_ident(ident);
     let value_type_ident = get_value_type_ident(ident);
-    let value_type_id_ident = get_value_type_id_ident(ident);
     let register_value_type_ident = get_register_value_type_ident(ident);
 
     let (impl_generics, where_clause) = if let Some(generics) = generics {
@@ -485,11 +483,6 @@ pub fn value_type_and_register(
                     )
                 })
             });
-        #[doc(hidden)]
-        static #value_type_id_ident: turbo_tasks::macro_helpers::Lazy<turbo_tasks::ValueTypeId> =
-            turbo_tasks::macro_helpers::Lazy::new(|| {
-                turbo_tasks::registry::get_value_type_id(*#value_type_ident)
-            });
 
 
         #[doc(hidden)]
@@ -511,7 +504,12 @@ pub fn value_type_and_register(
             type CellMode = #cell_mode;
 
             fn get_value_type_id() -> turbo_tasks::ValueTypeId {
-                *#value_type_id_ident
+                static ident: turbo_tasks::macro_helpers::Lazy<turbo_tasks::ValueTypeId> =
+                turbo_tasks::macro_helpers::Lazy::new(|| {
+                    turbo_tasks::registry::get_value_type_id(*#value_type_ident)
+                });
+
+                *ident
             }
         }
     }

--- a/turbopack/crates/turbo-tasks/src/completion.rs
+++ b/turbopack/crates/turbo-tasks/src/completion.rs
@@ -37,7 +37,9 @@ impl Completion {
         // This is the same code that Completion::cell uses except that it
         // only updates the cell when it is empty (Completion::cell opted-out of
         // that via `#[turbo_tasks::value(cell = "new")]`)
-        let cell = turbo_tasks::macro_helpers::find_cell_by_type(*COMPLETION_VALUE_TYPE_ID);
+        let cell = turbo_tasks::macro_helpers::find_cell_by_type(
+            <Completion as crate::VcValueType>::get_value_type_id(),
+        );
         cell.conditional_update(|old| old.is_none().then_some(Completion));
         let raw: RawVc = cell.into();
         raw.into()

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -15,8 +15,8 @@ use serde_json::Value as JsonValue;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{
     Completion, FxIndexMap, NonLocalValue, OperationVc, RawVc, ResolvedVc, TaskInput,
-    TryJoinIterExt, Vc, apply_effects, duration_span, fxindexmap, mark_finished, prevent_gc,
-    trace::TraceRawVcs, util::SharedError,
+    TryJoinIterExt, Vc, VcValueType, apply_effects, duration_span, fxindexmap, mark_finished,
+    prevent_gc, trace::TraceRawVcs, util::SharedError,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
@@ -371,7 +371,9 @@ pub fn custom_evaluate(evaluate_context: impl EvaluateContext) -> Vc<JavaScriptE
 
     // We create a new cell in this task, which will be updated from the
     // [compute_evaluate_stream] task.
-    let cell = turbo_tasks::macro_helpers::find_cell_by_type(*JAVASCRIPTEVALUATION_VALUE_TYPE_ID);
+    let cell = turbo_tasks::macro_helpers::find_cell_by_type(
+        <JavaScriptEvaluation as VcValueType>::get_value_type_id(),
+    );
 
     // We initialize the cell with a stream that is open, but has no values.
     // The first [compute_evaluate_stream] pipe call will pick up that stream.

--- a/turbopack/crates/turbopack-node/src/render/render_proxy.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_proxy.rs
@@ -9,8 +9,8 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    RawVc, ResolvedVc, TaskInput, ValueToString, Vc, duration_span, mark_finished, prevent_gc,
-    trace::TraceRawVcs, util::SharedError,
+    RawVc, ResolvedVc, TaskInput, ValueToString, Vc, VcValueType, duration_span, mark_finished,
+    prevent_gc, trace::TraceRawVcs, util::SharedError,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
@@ -177,7 +177,9 @@ fn render_stream(options: RenderStreamOptions) -> Vc<RenderStream> {
 
     // We create a new cell in this task, which will be updated from the
     // [render_stream_internal] task.
-    let cell = turbo_tasks::macro_helpers::find_cell_by_type(*RENDERSTREAM_VALUE_TYPE_ID);
+    let cell = turbo_tasks::macro_helpers::find_cell_by_type(
+        <RenderStream as VcValueType>::get_value_type_id(),
+    );
 
     // We initialize the cell with a stream that is open, but has no values.
     // The first [render_stream_internal] pipe call will pick up that stream.

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -9,8 +9,8 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{
-    RawVc, ResolvedVc, TaskInput, ValueToString, Vc, duration_span, mark_finished, prevent_gc,
-    trace::TraceRawVcs, util::SharedError,
+    RawVc, ResolvedVc, TaskInput, ValueToString, Vc, VcValueType, duration_span, mark_finished,
+    prevent_gc, trace::TraceRawVcs, util::SharedError,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
@@ -228,7 +228,9 @@ fn render_stream(options: RenderStreamOptions) -> Vc<RenderStream> {
 
     // We create a new cell in this task, which will be updated from the
     // [render_stream_internal] task.
-    let cell = turbo_tasks::macro_helpers::find_cell_by_type(*RENDERSTREAM_VALUE_TYPE_ID);
+    let cell = turbo_tasks::macro_helpers::find_cell_by_type(
+        <RenderStream as VcValueType>::get_value_type_id(),
+    );
 
     // We initialize the cell with a stream that is open, but has no values.
     // The first [render_stream_internal] pipe call will pick up that stream.


### PR DESCRIPTION
Simplify some of the static macro variables by moving them into their only callsites.

Delete dead `ident` factories

Just a tiny cleanup motivated by reading through the `registry` codegen and realizing that many of the `ident`s aren't needed.

Closes PACK-4973