### PR TITLE
[dynamicIO] do not continue prerender after error in prospective render

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2423,15 +2423,17 @@ async function spawnDynamicValidationInDev(
     }
   }
 
+  let didErrorBeforeAbort = false
   if (initialServerResult) {
-    const initialClientController = new AbortController()
+    const initialClientRenderController = new AbortController()
+    const initialClientPrerenderController = new AbortController()
     const initialClientPrerenderStore: PrerenderStore = {
       type: 'prerender-client',
       phase: 'render',
       rootParams,
       implicitTags,
-      renderSignal: initialClientController.signal,
-      controller: initialClientController,
+      renderSignal: initialClientRenderController.signal,
+      controller: initialClientPrerenderController,
       // For HTML Generation the only cache tracked activity
       // is module loading, which has it's own cache signal
       cacheSignal: null,
@@ -2461,7 +2463,7 @@ async function spawnDynamicValidationInDev(
         nonce={nonce}
       />,
       {
-        signal: initialClientController.signal,
+        signal: initialClientRenderController.signal,
         onError: (err) => {
           const digest = getDigestForWellKnownError(err)
 
@@ -2475,15 +2477,10 @@ async function spawnDynamicValidationInDev(
             return undefined
           }
 
-          if (initialClientController.signal.aborted) {
+          if (initialClientRenderController.signal.aborted) {
             // These are expected errors that might error the prerender. we ignore them.
-          } else if (
-            process.env.NEXT_DEBUG_BUILD ||
-            process.env.__NEXT_VERBOSE_LOGGING
-          ) {
-            // We don't normally log these errors because we are going to retry anyway but
-            // it can be useful for debugging Next.js itself to get visibility here when needed
-            printDebugThrownValueForProspectiveRender(err, workStore.route)
+          } else {
+            didErrorBeforeAbort = true
           }
         },
         // We don't need bootstrap scripts in this prerender
@@ -2511,7 +2508,20 @@ async function spawnDynamicValidationInDev(
     // Promises passed to client were already awaited above (assuming that they came from cached functions)
     trackPendingModules(cacheSignal)
     await cacheSignal.cacheReady()
-    initialClientController.abort()
+    initialClientRenderController.abort()
+  }
+
+  if (didErrorBeforeAbort) {
+    resolveValidation(
+      <LogSafely
+        fn={() => {
+          console.error(
+            'Next.js could not validate whether this page would produce a static shell due to an unrelated error.'
+          )
+        }}
+      />
+    )
+    return
   }
 
   const finalServerController = new AbortController()
@@ -3039,15 +3049,17 @@ async function prerenderToStream(
         }
       }
 
+      let didErrorBeforeAbort = false
       if (initialServerResult) {
-        const initialClientController = new AbortController()
+        const initialClientRenderController = new AbortController()
+        const initialClientPrerenderController = new AbortController()
         const initialClientPrerenderStore: PrerenderStore = {
           type: 'prerender-client',
           phase: 'render',
           rootParams,
           implicitTags,
-          renderSignal: initialClientController.signal,
-          controller: initialClientController,
+          renderSignal: initialClientRenderController.signal,
+          controller: initialClientPrerenderController,
           // For HTML Generation the only cache tracked activity
           // is module loading, which has it's own cache signal
           cacheSignal: null,
@@ -3077,8 +3089,8 @@ async function prerenderToStream(
             nonce={nonce}
           />,
           {
-            signal: initialClientController.signal,
-            onError: (err) => {
+            signal: initialClientRenderController.signal,
+            onError: (err, errorInfo) => {
               const digest = getDigestForWellKnownError(err)
 
               if (digest) {
@@ -3091,15 +3103,11 @@ async function prerenderToStream(
                 return undefined
               }
 
-              if (initialClientController.signal.aborted) {
+              if (initialClientRenderController.signal.aborted) {
                 // These are expected errors that might error the prerender. we ignore them.
-              } else if (
-                process.env.NEXT_DEBUG_BUILD ||
-                process.env.__NEXT_VERBOSE_LOGGING
-              ) {
-                // We don't normally log these errors because we are going to retry anyway but
-                // it can be useful for debugging Next.js itself to get visibility here when needed
-                printDebugThrownValueForProspectiveRender(err, workStore.route)
+              } else {
+                didErrorBeforeAbort = true
+                return htmlRendererErrorHandler(err, errorInfo)
               }
             },
             bootstrapScripts: [bootstrapScript],
@@ -3126,7 +3134,29 @@ async function prerenderToStream(
         // Promises passed to client were already awaited above (assuming that they came from cached functions)
         trackPendingModules(cacheSignal)
         await cacheSignal.cacheReady()
-        initialClientController.abort()
+        initialClientRenderController.abort()
+      }
+
+      if (didErrorBeforeAbort) {
+        return {
+          digestErrorsMap: reactServerErrorsByDigest,
+          ssrErrors: allCapturedErrors,
+          // TODO we should not be using return to model a build failing condition.
+          // We use an empty readable stream to satisfy the expected type but really
+          // this is an exceptional case
+          stream: new ReadableStream({
+            start(controller) {
+              controller.close()
+            },
+          }),
+          dynamicAccess: null,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: initialServerPrerenderStore.revalidate,
+          collectedExpire: initialServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(initialServerPrerenderStore.stale),
+          collectedTags: initialServerPrerenderStore.tags,
+          renderResumeDataCache: undefined,
+        }
       }
 
       let serverIsDynamic = false

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -423,4 +423,157 @@ describe.each(
       })
     }
   })
+
+  describe('Error Attribution with Sync IO - module scope Error with sync IO', () => {
+    const { next, isTurbopack, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/sync-attribution/module-error',
+      skipStart: !isNextDev,
+      skipDeployment: true,
+      buildOptions: inPrerenderDebugMode ? ['--debug-prerender'] : undefined,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      it('should show a collapsed redbox error', async () => {
+        const browser = await next.browser('/')
+
+        if (isTurbopack) {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           [
+             {
+               "description": "Next.js could not validate whether this page would produce a static shell due to an unrelated error.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "LogSafely <anonymous> (0:0)",
+               ],
+             },
+             {
+               "description": "boom",
+               "environmentLabel": null,
+               "label": "Runtime Error",
+               "source": "app/client.tsx (7:9) @ [project]/app/client.tsx [app-ssr] (ecmascript)
+           >  7 |   throw new Error('boom')
+                |         ^",
+               "stack": [
+                 "[project]/app/client.tsx [app-ssr] (ecmascript) app/client.tsx (7:9)",
+               ],
+             },
+           ]
+          `)
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           [
+             {
+               "description": "Next.js could not validate whether this page would produce a static shell due to an unrelated error.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "LogSafely <anonymous> (0:0)",
+               ],
+             },
+             {
+               "description": "boom",
+               "environmentLabel": null,
+               "label": "Runtime Error",
+               "source": "app/client.tsx (7:9) @ eval
+           >  7 |   throw new Error('boom')
+                |         ^",
+               "stack": [
+                 "eval app/client.tsx (7:9)",
+                 "<FIXME-next-dist-dir>",
+                 "<FIXME-next-dist-dir>",
+               ],
+             },
+           ]
+          `)
+        }
+      })
+    } else {
+      it('should error the build with a reason to the module error', async () => {
+        try {
+          await next.build()
+        } catch {
+          // we expect the build to fail
+        }
+
+        const output = getPrerenderOutput(next.cliOutput, {
+          isMinified: !inPrerenderDebugMode,
+        })
+
+        if (isTurbopack) {
+          if (inPrerenderDebugMode) {
+            expect(output).toMatchInlineSnapshot(`
+             "Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: boom
+                 at <module number> (turbopack:///[project]/app/client.tsx:7:8)
+                 at instantiateModule (<turbopack-runtime>)
+                 at getOrInstantiateModuleFromParent (<turbopack-runtime>)
+                 at commonJsRequire (<turbopack-runtime>)
+                5 |
+                6 | if (typeof window === 'undefined') {
+             >  7 |   throw new Error('boom')
+                  |        ^
+                8 | }
+                9 |
+               10 | export function ClientComponent() { {
+               digest: '<error-digest>'
+             }
+
+             > Export encountered errors on following paths:
+             	/page: /"
+            `)
+          } else {
+            expect(output).toMatchInlineSnapshot(`
+             "Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: boom
+                 at a (<next-dist-dir>)
+                 at b (<next-dist-dir>)
+                 at c (<next-dist-dir>)
+                 at d (<next-dist-dir>) {
+               digest: '<error-digest>'
+             }
+             Export encountered an error on /page: /, exiting the build."
+            `)
+          }
+        } else {
+          if (inPrerenderDebugMode) {
+            expect(output).toMatchInlineSnapshot(`
+             "Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: boom
+                 at <module number> (webpack:///app/client.tsx:7:8)
+                 at Object.__webpack_require__ [as require] (webpack:///webpack/bootstrap:21:0)
+                5 |
+                6 | if (typeof window === 'undefined') {
+             >  7 |   throw new Error('boom')
+                  |        ^
+                8 | }
+                9 |
+               10 | export function ClientComponent() { {
+               digest: '<error-digest>'
+             }
+
+             > Export encountered errors on following paths:
+             	/page: /"
+            `)
+          } else {
+            expect(output).toMatchInlineSnapshot(`
+             "Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: boom
+                 at a (<next-dist-dir>)
+                 at Object.c [as require] (.next/server/webpack-runtime.js:1:127) {
+               digest: '<error-digest>'
+             }
+             Export encountered an error on /page: /, exiting the build."
+            `)
+          }
+        }
+      })
+    }
+  })
 })

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/app/client.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/app/client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+const date = new Date()
+export { date }
+
+if (typeof window === 'undefined') {
+  throw new Error('boom')
+}
+
+export function ClientComponent() {
+  return <div>Client Component</div>
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/app/layout.tsx
@@ -1,0 +1,15 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+        <div>
+          We add extra content here because it increases the size of the dev RSC
+          payload which exercises the preloading of the RSC chunks more. We want
+          a greater page weight than this simple test would otherwise have
+          produced.
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/app/page.tsx
@@ -1,0 +1,18 @@
+import { ClientComponent } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <section>
+        <p>
+          This module calls `new Date()` in module scope. it then errors. We
+          expect to see the module error and not a sync IO error in build logs
+          and dev error overlays
+        </p>
+      </section>
+      <section>
+        <ClientComponent />
+      </section>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-attribution/module-error/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-errors/utils.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/utils.ts
@@ -1,6 +1,7 @@
 // Used to deterministically stub out minified local names in stack traces.
 const abc = 'abcdefghijklmnopqrstuvwxyz'
 const hostElementsUsedInFixtures = ['html', 'body', 'main', 'div']
+import escapeStringRegexp from 'escape-string-regexp'
 
 export function getPrerenderOutput(
   cliOutput: string,
@@ -37,10 +38,16 @@ export function getPrerenderOutput(
           .replace(/at \S+ \(.next[^)]+\)/, replaceNextDistStackFrame)
           .replace(/at (\S+) \(<anonymous>\)/, replaceAnonymousStackFrame)
       } else {
-        line = line.replace(
-          /at (\S+) \((webpack:\/\/)\/src[^)]+\)/,
-          `at $1 ($2<next-src>)`
-        )
+        line = line
+          .replace(
+            /at (\S+) \((webpack:\/\/)\/src[^)]+\)/,
+            `at $1 ($2<next-src>)`
+          )
+          .replace(
+            /at (\S+) \([^)]+\[turbopack\]_runtime\.js[^)]+\)/,
+            `at $1 (<turbopack-runtime>)`
+          )
+          .replace(/at \d+ (\([^)]+\))/, `at <module number> $1`)
       }
 
       line = line
@@ -57,4 +64,20 @@ export function getPrerenderOutput(
   }
 
   return lines.join('\n').trim()
+}
+
+export function assertLog(
+  logs: Array<{ source: string; message: string }>,
+  environment: 'Server' | 'Prerender' | 'Cache',
+  message: string
+) {
+  expect(logs.map((l) => l.message)).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(
+        new RegExp(
+          `^.*${escapeStringRegexp(message)}.*  \\b${environment}\\b  $`
+        )
+      ),
+    ])
+  )
 }


### PR DESCRIPTION
When the prospective prerender errors we currently ignore the result and continue through. Since modules can error, this can lead to situations where the final render assumes all modules are already loaded, when they are not, and this can lead to misattribution of dynamicIO reasons. We don't normally retry renders, and we don't need to do so in this case either.