### PR TITLE
Remove unneccesary step that's making workflow fail

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -108,10 +108,6 @@ jobs:
       - id: test-result
         name: Set test result variable
         run: echo 'immediately-close=${{ needs.test-deploy.result != 'success' && 'true' || 'false' }}' >> "$GITHUB_OUTPUT"
-      - name: Check token
-        run: gh auth status
-        env:
-          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
       - uses: actions/github-script@v7
         name: Trigger vercel/front sync
         id: trigger-front-sync


### PR DESCRIPTION
This step was causing the front-sync job to fail. I'm not totally sure how it was working before, some other workflow must have logged in at some point. This is just a debug step anyway, so I think we can delete it. **I confirmed that the next step worked just fine.** We could also add a step that runs `gh login` if we think it would actually be useful.


Closes PACK-4976