### PR TITLE
Disable Turbopack manifest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -244,7 +244,6 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
-        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json"
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_DEV=1
         export NEXT_TEST_MODE=dev
@@ -276,7 +275,6 @@ jobs:
     with:
       nodeVersion: 18.18.2
       afterBuild: |
-        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json"
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_DEV=1
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
@@ -310,7 +308,6 @@ jobs:
     with:
       nodeVersion: 18.18.2
       afterBuild: |
-        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json"
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_BUILD=1
         export NEXT_TEST_MODE=start
@@ -335,7 +332,6 @@ jobs:
     with:
       nodeVersion: 18.18.2
       afterBuild: |
-        export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json"
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_BUILD=1
 

--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -2,9 +2,9 @@
 name: Update Turbopack test manifest
 
 on:
-  schedule:
-    # Every day at 7AM UTC https://crontab.guru/#0_7_*_*_*
-    - cron: '0 7 * * *'
+  # schedule:
+  # Every day at 7AM UTC https://crontab.guru/#0_7_*_*_*
+  # - cron: '0 7 * * *'
   workflow_dispatch:
 
 jobs:

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -155,10 +155,6 @@ async function main() {
           NEXT_TEST_VERSION: nextTestVersion,
           IS_TURBOPACK_TEST: '1',
           TURBOPACK_BUILD: testMode === 'start' ? '1' : undefined,
-          NEXT_EXTERNAL_TESTS_FILTERS:
-            testMode === 'dev'
-              ? 'test/turbopack-dev-tests-manifest.json'
-              : 'test/turbopack-build-tests-manifest.json',
         },
       })
     }


### PR DESCRIPTION
- Don't create update PRs anymore for the manifests
- Don't read the manifest when running tests

Closes PACK-4980