### PR TITLE
Remove source maps before publishing to npm, reduce package size by 38%

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "types": "lerna run types --stream",
     "types:test-lib": "tsc --project test/lib/tsconfig.json",
     "check-precompiled": "./scripts/check-pre-compiled.sh",
-    "prepublishOnly": "turbo run build",
+    "prepublishOnly": "turbo run build && find ./packages/*/dist -name '*.map' -delete",
     "lint-staged": "lint-staged",
     "next-with-deps": "./scripts/next-with-deps.sh",
     "next": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"--trace-deprecation --enable-source-maps\" next",


### PR DESCRIPTION
Source maps are useful for maintainers and contributors to test new features and debug issues, but they balloon the distributed package over 100MB. These source maps offer little value to the end-user. Contrast the size of [next](https://www.npmjs.com/package/next) with [nuxt](https://www.npmjs.com/package/nuxt)
