### PR TITLE
Turbopack: lazily create syntax contexts for scope hoisting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9756,6 +9756,7 @@ dependencies = [
  "bitvec",
  "bytes-str",
  "codspeed-criterion-compat",
+ "dashmap 6.1.0",
  "data-encoding",
  "either",
  "indexmap 2.9.0",

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -27,6 +27,7 @@ num-traits = "0.2.15"
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 petgraph = { workspace = true }
+dashmap = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
Previously, if 10k modules are merged together, it would create 10k syntax context for each of the 10k modules. That involves a TLS and a `Mutex`.
Most of these are never used, so instead create the contexts lazily with some interior mutability.
Now this step doesn't show up in the trace at all anymore (in one case, cutting build time from 10s to 5s)

https://vercel.slack.com/archives/C06PPGZ0FD3/p1751475796580989?thread_ts=1751302539.808369&cid=C06PPGZ0FD3

Closes PACK-4986