### PR TITLE
Reuse resolvedPathname from prepare

### DIFF
--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -21,7 +21,6 @@ import {
   fromNodeOutgoingHttpHeaders,
   toNodeOutgoingHttpHeaders,
 } from '../../server/web/utils'
-import { decodePathParams } from '../../server/lib/router-utils/decode-path-params'
 import { getCacheControlHeader } from '../../server/lib/cache-control'
 import { INFINITE_CACHE, NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
@@ -114,29 +113,15 @@ export async function handler(
     buildId,
     params,
     nextConfig,
-    parsedUrl,
     isDraftMode,
     prerenderManifest,
     routerServerContext,
     isOnDemandRevalidate,
     revalidateOnlyGenerated,
+    resolvedPathname,
   } = prepareResult
 
   const normalizedSrcPage = normalizeAppPath(srcPage)
-
-  // TODO: rework this to not be necessary as a middleware
-  // rewrite should not need to pass this context like this
-  // maybe we rely on rewrite header instead
-  let resolvedPathname = getRequestMeta(req, 'rewroteURL')
-
-  if (!resolvedPathname) {
-    resolvedPathname = parsedUrl.pathname || '/'
-  }
-
-  if (resolvedPathname === '/index') {
-    resolvedPathname = '/'
-  }
-  resolvedPathname = decodePathParams(resolvedPathname)
 
   let isIsr = Boolean(
     prerenderManifest.dynamicRoutes[normalizedSrcPage] ||

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -52,13 +52,13 @@ import type { RouteKind } from '../route-kind'
 import type { BaseNextRequest } from '../base-http'
 import type { I18NConfig, NextConfigComplete } from '../config-shared'
 import ResponseCache, { type ResponseGenerator } from '../response-cache'
+import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import {
   RouterServerContextSymbol,
   routerServerGlobal,
   type RouterServerContext,
 } from '../lib/router-utils/router-server-context'
 import { decodePathParams } from '../lib/router-utils/decode-path-params'
-import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 
 /**
  * RouteModuleOptions is the options that are passed to the route module, other
@@ -769,7 +769,9 @@ export abstract class RouteModule<
     if (resolvedPathname === '/index') {
       resolvedPathname = '/'
     }
-    resolvedPathname = decodePathParams(resolvedPathname)
+    try {
+      resolvedPathname = decodePathParams(resolvedPathname)
+    } catch (_) {}
 
     return {
       query,


### PR DESCRIPTION
This applies the fixed `resolvedPathname` from https://github.com/vercel/next.js/pull/81144 to the other route handlers that were trying to build this value as well so we use single source of truth. 

Validated against our deploy tests https://github.com/vercel/vercel/actions/runs/16038359282/job/45254959257?pr=13520 and https://github.com/vercel/next.js/actions/runs/16038663582/job/45255920639