### PR TITLE
[segment explorer] fix route path in top navbar

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -64,6 +64,7 @@ export function DevToolsIndicator({
       isTurbopack={!!process.env.TURBOPACK}
       disabled={state.disableDevIndicator || !isDevToolsIndicatorVisible}
       isBuildError={isBuildError}
+      page={state.page}
       {...props}
     />
   )
@@ -104,6 +105,7 @@ function DevToolsPopover({
   dispatch,
   scale,
   setScale,
+  page,
 }: {
   routerType: 'pages' | 'app'
   disabled: boolean
@@ -118,6 +120,7 @@ function DevToolsPopover({
   dispatch: OverlayDispatch
   scale: DevToolsScale
   setScale: (value: DevToolsScale) => void
+  page: string
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -343,8 +346,7 @@ function DevToolsPopover({
           triggerRef={triggerRef}
           style={popover}
           routerType={routerType}
-          // dummy page for legacy segment explorer, will be removed in the future
-          page={''}
+          page={page}
         />
       ) : null}
 

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -18,11 +18,10 @@ const isFileNode = (node: SegmentTrieNode) => {
 }
 
 function PageRouteBar({ page }: { page: string }) {
-  const pagePath = `/app${page}`
   return (
     <div className="segment-explorer-page-route-bar">
       <BackArrowIcon />
-      <span className="segment-explorer-page-route-bar-path">{pagePath}</span>
+      <span className="segment-explorer-page-route-bar-path">{page}</span>
     </div>
   )
 }


### PR DESCRIPTION
* Remove the `app` prefix in top bar of route info as we only need to know the pathname. It's also removed in the new design
* `state.page` was only passed for panel ui but missing in segment explorer of dock indicator 