### PR TITLE
Get package information for swc patching using the package manager 

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -170,7 +170,7 @@
   "169": "invariant: invalid previewModeId",
   "170": "The key \"%s\" under \"env\" in %s is not allowed. https://nextjs.org/docs/messages/env-key-not-allowed",
   "171": "Specified images should be an object received %s.\\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config",
-  "172": "Failed to fetch registry info for %s, got status %s",
+  "172": "Failed to fetch package info for %s using %s. Cause: %s",
   "173": "The packages specified in the 'transpilePackages' conflict with the 'serverExternalPackages': %s",
   "174": "Invariant: required internal revalidate method not passed to api-utils",
   "175": "Invalid response %s",

--- a/packages/next/src/lib/patch-incorrect-lockfile.test.ts
+++ b/packages/next/src/lib/patch-incorrect-lockfile.test.ts
@@ -1,0 +1,84 @@
+import { fetchPkgInfo } from './patch-incorrect-lockfile'
+import { getPkgManager } from './helpers/get-pkg-manager'
+import os from 'os'
+import process from 'process'
+
+jest.mock('./helpers/get-pkg-manager')
+
+const mockGetPkgManager = getPkgManager as jest.MockedFunction<
+  typeof getPkgManager
+>
+
+describe('fetchPkgInfo integration tests', () => {
+  // Change to a temp directory to avoid any interference from existing lockfiles
+  const originalCwd = process.cwd()
+  const testDir = os.tmpdir()
+
+  beforeAll(() => {
+    process.chdir(testDir)
+  })
+
+  afterAll(() => {
+    process.chdir(originalCwd)
+  })
+
+  const testPackages = ['@next/swc-win32-x64-msvc', '@next/swc-linux-x64-gnu']
+
+  const validatePkgInfo = (info: any, pkg: string) => {
+    expect(info).toHaveProperty('os')
+    expect(Array.isArray(info.os)).toBe(true)
+    expect(info.os.length).toBeGreaterThan(0)
+    expect(info).toHaveProperty('cpu')
+    expect(Array.isArray(info.cpu)).toBe(true)
+    expect(info.cpu.length).toBeGreaterThan(0)
+    expect(info).toHaveProperty('engines')
+    expect(info.engines).toHaveProperty('node')
+    expect(info).toHaveProperty('tarball')
+    expect(typeof info.tarball).toBe('string')
+    expect(info).toHaveProperty('integrity')
+    expect(typeof info.integrity).toBe('string')
+    expect(info.cpu).toContain('x64')
+
+    if (pkg.includes('win32')) {
+      expect(info.os).toContain('win32')
+    } else if (pkg.includes('linux')) {
+      expect(info.os).toContain('linux')
+    }
+  }
+
+  describe('npm', () => {
+    it.each(testPackages)(
+      'should fetch package info for %s using npm',
+      async (pkg) => {
+        mockGetPkgManager.mockReturnValue('npm')
+        const info = await fetchPkgInfo(testDir, pkg)
+        validatePkgInfo(info, pkg)
+        expect(mockGetPkgManager).toHaveBeenCalledWith(testDir)
+      }
+    )
+  })
+
+  describe('yarn', () => {
+    it.each(testPackages)(
+      'should fetch package info for %s using yarn',
+      async (pkg) => {
+        mockGetPkgManager.mockReturnValue('yarn')
+        const info = await fetchPkgInfo(testDir, pkg)
+        validatePkgInfo(info, pkg)
+        expect(mockGetPkgManager).toHaveBeenCalledWith(testDir)
+      }
+    )
+  })
+
+  describe('pnpm', () => {
+    it.each(testPackages)(
+      'should fetch package info for %s using pnpm',
+      async (pkg) => {
+        mockGetPkgManager.mockReturnValue('pnpm')
+        const info = await fetchPkgInfo(testDir, pkg)
+        validatePkgInfo(info, pkg)
+        expect(mockGetPkgManager).toHaveBeenCalledWith(testDir)
+      }
+    )
+  })
+})

--- a/packages/next/src/lib/patch-incorrect-lockfile.ts
+++ b/packages/next/src/lib/patch-incorrect-lockfile.ts
@@ -5,28 +5,36 @@ import findUp from 'next/dist/compiled/find-up'
 import nextPkgJson from 'next/package.json'
 import type { UnwrapPromise } from './coalesced-function'
 import { isCI } from '../server/ci-info'
-import { getRegistry } from './helpers/get-registry'
+import { getPkgManager } from './helpers/get-pkg-manager'
+import { execSync } from 'node:child_process'
 
-let registry: string | undefined
+export async function fetchPkgInfo(dir: string, pkg: string) {
+  const pkgManager = getPkgManager(dir)
 
-async function fetchPkgInfo(pkg: string) {
-  if (!registry) registry = getRegistry()
-  const res = await fetch(`${registry}${pkg}`)
+  const command = pkgManager === 'yarn' ? 'info' : 'show'
 
-  if (!res.ok) {
+  try {
+    const pkgSpec = `${pkg}@${nextPkgJson.version}`
+
+    const output = execSync(`${pkgManager} ${command} ${pkgSpec} --json`, {
+      encoding: 'utf8',
+    })
+
+    const rawData = JSON.parse(output)
+    const pkgData = pkgManager === 'yarn' ? rawData.data : rawData
+
+    return {
+      os: pkgData.os,
+      cpu: pkgData.cpu,
+      engines: pkgData.engines,
+      tarball: pkgData.dist?.tarball,
+      integrity: pkgData.dist?.integrity,
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
     throw new Error(
-      `Failed to fetch registry info for ${pkg}, got status ${res.status}`
+      `Failed to fetch package info for ${pkg} using ${pkgManager}. Cause: ${message}`
     )
-  }
-  const data = await res.json()
-  const versionData = data.versions[nextPkgJson.version]
-
-  return {
-    os: versionData.os,
-    cpu: versionData.cpu,
-    engines: versionData.engines,
-    tarball: versionData.dist.tarball,
-    integrity: versionData.dist.integrity,
   }
 }
 
@@ -146,7 +154,7 @@ export async function patchIncorrectLockfile(dir: string) {
       return
     }
     const pkgsData = await Promise.all(
-      missingSwcPkgs.map((pkg) => fetchPkgInfo(pkg))
+      missingSwcPkgs.map((pkg) => fetchPkgInfo(dir, pkg))
     )
 
     for (let i = 0; i < pkgsData.length; i++) {


### PR DESCRIPTION
This PR addresses problems that arise when using a gated package manager, such as Artifactory, instead of a direct NPM connection. The primary issue is the lack of authentication when Next.js performs direct `fetch` requests to the registry, which is often required by enterprise proxy solutions.

### What?
This PR modifies the `fetchPkgInfo` function to utilize the locally configured package manager (e.g., `npm`, `yarn`) to retrieve package information, rather than making direct `fetch` requests to the registry. This is accomplished by executing the package manager's `info` or `show` command with the `--json` flag to parse its output.

### Why?
In enterprise environments, a gated package manager like Artifactory is commonly used to manage dependencies, provide caching, and enforce security policies. These systems often require authentication for any package requests, or they act as a proxy that needs to be configured by the local package manager. When Next.js previously made direct `fetch` requests to the public NPM registry, these requests lacked the necessary authentication headers or proxy configurations, leading to failures. By switching to the project's existing package manager, Next.js inherently leverages the authentication and proxy settings already established by the user's environment, ensuring successful package information retrieval.

### How?
**Leveraging Local Package Manager:** The `fetchPkgInfo` function now uses the project's detected package manager (via an existing `getPkgManager` utility) to retrieve package details.
**Command Execution:** It executes the relevant package manager command (e.g., `npm show` or `yarn info`) with the `--json` flag. This allows the local environment to handle any necessary authentication or proxy configurations.
**Data Parsing:** The JSON output from the package manager command is parsed to extract required package metadata. Yarn behaves a bit differently compared to npm or pnpm. 
