### PR TITLE
[turbopack] Remove a vec clone from `primary_chunkable_referenced_modules` 

### DIFF
--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal},
 };
 
@@ -285,9 +285,8 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
     Ok(Vc::cell(modules))
 }
 
-type ModulesVec = Vec<ResolvedVc<Box<dyn Module>>>;
 #[turbo_tasks::value(transparent)]
-pub struct ModulesWithRefData(Vec<(ChunkingType, ExportUsage, ModulesVec)>);
+pub struct ModulesWithRefData(Vec<(ChunkingType, ExportUsage, ReadRef<Modules>)>);
 
 /// Aggregates all primary [Module]s referenced by an [Module] via [ChunkableModuleReference]s.
 /// This does not include transitively referenced [Module]s, only includes
@@ -296,7 +295,7 @@ pub struct ModulesWithRefData(Vec<(ChunkingType, ExportUsage, ModulesVec)>);
 /// [Module]: crate::module::Module
 #[turbo_tasks::function]
 pub async fn primary_chunkable_referenced_modules(
-    module: Vc<Box<dyn Module>>,
+    module: ResolvedVc<Box<dyn Module>>,
     include_traced: bool,
 ) -> Result<Vc<ModulesWithRefData>> {
     let modules = module
@@ -317,7 +316,6 @@ pub async fn primary_chunkable_referenced_modules(
                     .resolve()
                     .await?
                     .primary_modules()
-                    .owned()
                     .await?;
                 let export = (*reference.export_usage().await?).clone();
 


### PR DESCRIPTION
Remove a vec clone when resolving module primary references.  Since it is stored in a turbotask we can just pass around a ReadRef to the Vec.

By avoiding the copy we make the `ModulesWithRefData` type a little smaller and should speed up the loop, the cost is some additional indirection when iterating, however all callers only iterate once so this ends up as a win in all cases.


Closes PACK-5005