### PR TITLE
Only retry deploy tests for canary

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -3,6 +3,7 @@ name: retry-deploy-tests
 on:
   workflow_run:
     workflows: ['test-e2e-deploy-release']
+    branches: [canary]
     types:
       - completed
 

--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -3,7 +3,6 @@ name: retry-deploy-tests
 on:
   workflow_run:
     workflows: ['test-e2e-deploy-release']
-    branches: [canary]
     types:
       - completed
 
@@ -19,6 +18,7 @@ jobs:
     # Retry the test-e2e-deploy-release workflow up to 2 times
     if: >-
       ${{ 
+        github.event.workflow_run.display_title == 'test-e2e-deploy canary'
         github.event.workflow_run.conclusion == 'failure' &&
         github.repository == 'vercel/next.js' &&
         github.event.workflow_run.run_attempt < 2

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -22,6 +22,8 @@ env:
   TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
   DD_ENV: 'ci'
 
+run-name: test-e2e-deploy ${{ inputs.nextVersion }}
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This avoids retrying/alerting if triggering the deploy tests with a custom next tarball. The `run_name` is available as `display_title` [per docs here](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run:~:text=The%20event%2Dspecific%20title%20associated%20with%20the%20run%20or%20the%20run%2Dname%20if%20set%2C%20or%20the%20value%20of%20run%2Dname%20if%20it%20is%20set%20in%20the%20workflow) 

x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1751485507582049)