### PR TITLE
Skip alert as well for non-canary e2e deploy

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -40,6 +40,7 @@ jobs:
     # Report the failure to Slack if the test-e2e-deploy-release workflow has failed 2 times
     if: >-
       ${{ 
+        github.event.workflow_run.display_title == 'test-e2e-deploy canary' &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt >= 2 &&
         !github.event.workflow_run.head_repository.fork


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/81207