### PR TITLE
Turbopack: fix source map panic

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -2498,14 +2498,17 @@ fn encode_module_into_comment_span(
 
 impl Comments for CodeGenResultCommentsConsumable<'_> {
     fn add_leading(&self, _pos: BytePos, _cmt: Comment) {
-        unimplemented!()
+        unimplemented!("add_leading")
     }
 
     fn add_leading_comments(&self, _pos: BytePos, _comments: Vec<Comment>) {
-        unimplemented!()
+        unimplemented!("add_leading_comments")
     }
 
     fn has_leading(&self, pos: BytePos) -> bool {
+        if pos.is_dummy() {
+            return false;
+        }
         match self {
             Self::Single {
                 comments,
@@ -2524,10 +2527,13 @@ impl Comments for CodeGenResultCommentsConsumable<'_> {
     }
 
     fn move_leading(&self, _from: BytePos, _to: BytePos) {
-        unimplemented!()
+        unimplemented!("move_leading")
     }
 
     fn take_leading(&self, pos: BytePos) -> Option<Vec<Comment>> {
+        if pos.is_dummy() {
+            return None;
+        }
         match self {
             Self::Single {
                 comments,
@@ -2551,6 +2557,9 @@ impl Comments for CodeGenResultCommentsConsumable<'_> {
     }
 
     fn get_leading(&self, pos: BytePos) -> Option<Vec<Comment>> {
+        if pos.is_dummy() {
+            return None;
+        }
         match self {
             Self::Single {
                 comments,
@@ -2574,14 +2583,17 @@ impl Comments for CodeGenResultCommentsConsumable<'_> {
     }
 
     fn add_trailing(&self, _pos: BytePos, _cmt: Comment) {
-        unimplemented!()
+        unimplemented!("add_trailing")
     }
 
     fn add_trailing_comments(&self, _pos: BytePos, _comments: Vec<Comment>) {
-        unimplemented!()
+        unimplemented!("add_trailing_comments")
     }
 
     fn has_trailing(&self, pos: BytePos) -> bool {
+        if pos.is_dummy() {
+            return false;
+        }
         match self {
             Self::Single {
                 comments,
@@ -2600,10 +2612,13 @@ impl Comments for CodeGenResultCommentsConsumable<'_> {
     }
 
     fn move_trailing(&self, _from: BytePos, _to: BytePos) {
-        unimplemented!()
+        unimplemented!("move_trailing")
     }
 
     fn take_trailing(&self, pos: BytePos) -> Option<Vec<Comment>> {
+        if pos.is_dummy() {
+            return None;
+        }
         match self {
             Self::Single {
                 comments,
@@ -2630,6 +2645,9 @@ impl Comments for CodeGenResultCommentsConsumable<'_> {
     }
 
     fn get_trailing(&self, pos: BytePos) -> Option<Vec<Comment>> {
+        if pos.is_dummy() {
+            return None;
+        }
         match self {
             Self::Single {
                 comments,
@@ -2653,7 +2671,7 @@ impl Comments for CodeGenResultCommentsConsumable<'_> {
     }
 
     fn add_pure_comment(&self, _pos: BytePos) {
-        unimplemented!()
+        unimplemented!("add_pure_comment")
     }
 }
 


### PR DESCRIPTION
Fix a panic, related to scope hoisting.
```
An error occurred while generating the chunk item X
Caused by:
- Cannot decode dummy BytePos
```

```
thread 'tokio-runtime-worker' panicked at turbopack/crates/turbopack-ecmascript/src/lib.rs:2431:13:
Cannot decode dummy BytePos
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/59aa1e873028948faaf8b97e5e02d4db340ad7b1/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/59aa1e873028948faaf8b97e5e02d4db340ad7b1/library/core/src/panicking.rs:75:14
   2: <turbopack_ecmascript::CodeGenResultComments>::decode_bytepos
             at next.js/turbopack/crates/turbopack-ecmascript/src/lib.rs:2431:13
   3: <turbopack_ecmascript::CodeGenResultCommentsConsumable as swc_common::comments::Comments>::has_leading
             at next.js/turbopack/crates/turbopack-ecmascript/src/lib.rs:2499:21
   4: <swc_ecma_codegen::Emitter<swc_ecma_codegen::text_writer::basic_impl::JsWriter<&mut alloc::vec::Vec<u8>>, turbopack_ecmascript::CodeGenResultSourceMap>>::has_leading_comment
             at .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/swc_ecma_codegen-15.0.1/src/lib.rs:839:24
   5: <swc_ecma_codegen::Emitter<swc_ecma_codegen::text_writer::basic_impl::JsWriter<&mut alloc::vec::Vec<u8>>, turbopack_ecmascript::CodeGenResultSourceMap>>::has_leading_comment
             at .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/swc_ecma_codegen-15.0.1/src/lib.rs:830:29
```

Closes PACK-4992