### PR TITLE
Fix future Rust warnings

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-07-02"
+channel = "nightly-2025-06-04"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-06-04"
+channel = "nightly-2025-07-02"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-tasks-backend/src/backend/dynamic_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/dynamic_storage.rs
@@ -75,11 +75,11 @@ impl DynamicStorage {
         })
     }
 
-    pub fn get(&self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRef> {
+    pub fn get(&self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRef<'_>> {
         self.get_map(key.ty()).and_then(|m| m.get(key))
     }
 
-    pub fn get_mut(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRefMut> {
+    pub fn get_mut(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRefMut<'_>> {
         self.get_map_mut(key.ty()).and_then(|m| m.get_mut(key))
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -441,7 +441,7 @@ macro_rules! generate_inner_storage {
                 self.dynamic.count(ty)
             }
 
-            pub fn get(&self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRef> {
+            pub fn get(&self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRef<'_>> {
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemKey: self, key, option_ref, get(): $($config)*);
                 self.dynamic.get(key)
@@ -453,7 +453,7 @@ macro_rules! generate_inner_storage {
                 self.dynamic.contains_key(key)
             }
 
-            pub fn get_mut(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRefMut> {
+            pub fn get_mut(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRefMut<'_>> {
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemKey: self, key, option_ref_mut, get_mut(): $($config)*);
                 self.dynamic.get_mut(key)

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -45,7 +45,7 @@ impl TurboFn<'_> {
         orig_signature: &Signature,
         definition_context: DefinitionContext,
         args: FunctionArguments,
-    ) -> Option<TurboFn> {
+    ) -> Option<TurboFn<'_>> {
         if !orig_signature.generics.params.is_empty() {
             orig_signature
                 .generics

--- a/turbopack/crates/turbo-tasks/src/debug/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/debug/mod.rs
@@ -69,17 +69,17 @@ pub trait ValueDebug {
 ///
 /// [autoref specialization]: https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md
 pub trait ValueDebugFormat {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString;
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_>;
 }
 
 impl ValueDebugFormat for String {
-    fn value_debug_format(&self, _depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, _depth: usize) -> ValueDebugFormatString<'_> {
         ValueDebugFormatString::Sync(format!("{self:#?}"))
     }
 }
 
 impl ValueDebugFormat for RcStr {
-    fn value_debug_format(&self, _: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, _: usize) -> ValueDebugFormatString<'_> {
         ValueDebugFormatString::Sync(self.to_string())
     }
 }
@@ -93,7 +93,7 @@ impl<T> ValueDebugFormat for &T
 where
     T: Debug,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -106,7 +106,7 @@ impl<T> ValueDebugFormat for Option<T>
 where
     T: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -133,7 +133,7 @@ impl<T> ValueDebugFormat for Vec<T>
 where
     T: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -164,7 +164,7 @@ impl<T, const N: usize> ValueDebugFormat for SmallVec<[T; N]>
 where
     T: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -195,7 +195,7 @@ impl<K> ValueDebugFormat for AutoSet<K>
 where
     K: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -227,7 +227,7 @@ where
     K: Debug,
     V: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -264,7 +264,7 @@ where
     K: Debug,
     V: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -300,7 +300,7 @@ impl<T> ValueDebugFormat for FxIndexSet<T>
 where
     T: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -329,7 +329,7 @@ where
     K: ValueDebugFormat,
     V: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }
@@ -370,7 +370,7 @@ macro_rules! tuple_impls {
         impl<$($name: ValueDebugFormat),+> ValueDebugFormat for ($($name,)+)
         {
             #[allow(non_snake_case)]
-            fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+            fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
                 if depth == 0 {
                     return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
                 }

--- a/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
@@ -120,7 +120,7 @@ where
 
     /// Returns an iterator over the nodes in postorder topological order,
     /// starting from the roots.
-    pub fn postorder_topological(&self) -> PostorderTopologicalIter<T> {
+    pub fn postorder_topological(&self) -> PostorderTopologicalIter<'_, T> {
         PostorderTopologicalIter {
             adjacency_map: &self.adjacency_map,
             stack: self

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -86,7 +86,7 @@ where
     T: VcValueType,
     VcReadTarget<T>: ValueDebugFormat + 'static,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         let value = &**self;
         value.value_debug_format(depth)
     }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -560,7 +560,7 @@ impl<T> ValueDebugFormat for Vc<T>
 where
     T: Upcast<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         ValueDebugFormatString::Async(Box::pin(async move {
             Ok({
                 let vc_value_debug = Vc::upcast::<Box<dyn ValueDebug>>(*self);

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -314,7 +314,7 @@ impl<T> ValueDebugFormat for ResolvedVc<T>
 where
     T: Upcast<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         self.node.value_debug_format(depth)
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
@@ -130,7 +130,7 @@ impl<T> ValueDebugFormat for AliasMap<T>
 where
     T: ValueDebugFormat,
 {
-    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         if depth == 0 {
             return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
         }

--- a/turbopack/crates/turbopack-create-test-app/src/test_app_builder.rs
+++ b/turbopack/crates/turbopack-create-test-app/src/test_app_builder.rs
@@ -18,7 +18,7 @@ fn decide(remaining: usize, min_remaining_decisions: usize) -> bool {
         true
     } else {
         let urgency = min_remaining_decisions / remaining;
-        (min_remaining_decisions * 11 * 7 * 5) % urgency == 0
+        (min_remaining_decisions * 11 * 7 * 5).is_multiple_of(urgency)
     }
 }
 
@@ -29,7 +29,7 @@ fn decide_early(remaining: usize, min_remaining_decisions: usize) -> bool {
         true
     } else {
         let urgency = min_remaining_decisions / remaining / remaining;
-        (min_remaining_decisions * 11 * 7 * 5) % urgency == 0
+        (min_remaining_decisions * 11 * 7 * 5).is_multiple_of(urgency)
     }
 }
 
@@ -172,7 +172,7 @@ impl TestAppBuilder {
 
             let leaf = remaining_modules == 0
                 || (!queue.is_empty()
-                    && (queue.len() + remaining_modules) % (self.flatness + 1) == 0);
+                    && (queue.len() + remaining_modules).is_multiple_of(self.flatness + 1));
             if leaf {
                 let maybe_use_client = if self.leaf_client_components {
                     r#""use client";"#

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -354,7 +354,7 @@ impl EvalContext {
         let mut values = vec![];
 
         for idx in 0..(e.quasis.len() + e.exprs.len()) {
-            if idx % 2 == 0 {
+            if idx.is_multiple_of(2) {
                 let idx = idx / 2;
                 let e = &e.quasis[idx];
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -118,7 +118,7 @@ impl ConstantString {
         }
     }
 
-    pub fn as_atom(&self) -> Cow<Atom> {
+    pub fn as_atom(&self) -> Cow<'_, Atom> {
         match self {
             Self::Atom(s) => Cow::Borrowed(s),
             Self::RcStr(s) => Cow::Owned(s.as_str().into()),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/data.rs
@@ -19,7 +19,7 @@ pub enum EcmascriptChunkData<'a> {
 }
 
 impl EcmascriptChunkData<'_> {
-    pub fn new(chunk_data: &ChunkData) -> EcmascriptChunkData {
+    pub fn new(chunk_data: &ChunkData) -> EcmascriptChunkData<'_> {
         let ChunkData {
             path,
             included,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -2381,7 +2381,7 @@ impl CodeGenResultComments {
         std::mem::replace(self, CodeGenResultComments::Empty)
     }
 
-    fn consumable(&self) -> CodeGenResultCommentsConsumable {
+    fn consumable(&self) -> CodeGenResultCommentsConsumable<'_> {
         match self {
             CodeGenResultComments::Single {
                 comments,

--- a/turbopack/crates/turbopack/src/graph/mod.rs
+++ b/turbopack/crates/turbopack/src/graph/mod.rs
@@ -138,7 +138,11 @@ async fn aggregate_more(node: ResolvedVc<AggregatedGraph>) -> Result<Vc<Aggregat
     // only one kind of aggregation can't eliminate cycles with that
     // number of nodes. Alternating the aggregation will get rid of all
     // cycles
-    let aggregation = if depth > 0 && depth % 2 == 0 { 3 } else { 2 };
+    let aggregation = if depth > 0 && depth.is_multiple_of(2) {
+        3
+    } else {
+        2
+    };
     for _ in 0..aggregation {
         for &node in in_progress.iter() {
             content.insert(node);

--- a/turbopack/xtask/src/nft_bench.rs
+++ b/turbopack/xtask/src/nft_bench.rs
@@ -16,11 +16,11 @@ struct BenchSuite {
 impl Tabled for BenchSuite {
     const LENGTH: usize = 4;
 
-    fn fields(&self) -> Vec<Cow<str>> {
-        fn g(s: &str) -> Cow<str> {
+    fn fields(&self) -> Vec<Cow<'_, str>> {
+        fn g(s: &str) -> Cow<'_, str> {
             Cow::Owned(s.green().to_string())
         }
-        fn r(s: &str) -> Cow<str> {
+        fn r(s: &str) -> Cow<'_, str> {
             Cow::Owned(s.red().to_string())
         }
         if self.is_faster {


### PR DESCRIPTION
I tried to upgrade to nightly-2025-07-02, but rust-analyzer is just completely broken:

![Bildschirmfoto 2025-07-03 um 08.52.48.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sjZSbv6AFeuDg7Gb9rma/56c6fece-893c-41fb-98e6-fa225b325225.png)

So I reverted that again but here are all fixes to the new compiler warnings:
```
warning: lifetime flowing from input to output with different syntax can be confusing
  --> turbopack/crates/turbo-tasks/src/read_ref.rs:89:27
   |
89 |     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
   |                           ^^^^^                   ---------------------- the lifetime gets resolved as `'_`
   |                           |
   |                           this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
89 |     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
   |                                                                         ++++

```

Closes PACK-4991