### PR TITLE
[devtool] styling fixes

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
@@ -5,7 +5,8 @@ const styles = `
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 3;
+    /* secondary z-index, -1 than toast z-index */
+    z-index: 2147483646;
 
     display: flex;
     align-content: center;

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -258,6 +258,7 @@ export const DEV_TOOLS_INFO_RENDER_FILES_STYLES = css`
     font-weight: 500;
     color: var(--color-gray-1000);
     font-family: var(--font-mono);
+    white-space: nowrap;
   }
 
   .segment-explorer-item {


### PR DESCRIPTION
### Styling fixes

* The overlay needs to have the highiest index, it's regressed from the change in #80974 while tweaking around new panel UI
* Noticed the route info needs to be set as nowrap when pathname is super long

| After | Before |
|:-- |:-- |
| ![image](https://github.com/user-attachments/assets/0b4b2583-9b71-4a42-9255-ccd555afb3af) |  ![image](https://github.com/user-attachments/assets/16f5c3ae-2f68-4f53-aaef-983a1e4c88f6)  |
| ![image](https://github.com/user-attachments/assets/8f6f234a-a29b-4c4d-abf9-f75b0cb0b294) | ![image](https://github.com/user-attachments/assets/2aef4bb4-320e-43c3-984e-45d1b28bf0fc) |
