### PR TITLE
[segment explorer] capture defined boundaries

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -507,6 +507,7 @@ export default function OuterLayoutRouter({
   forbidden,
   unauthorized,
   gracefullyDegrade,
+  segmentViewBoundaries,
 }: {
   parallelRouterKey: string
   error: ErrorComponent | undefined
@@ -519,6 +520,7 @@ export default function OuterLayoutRouter({
   forbidden: React.ReactNode | undefined
   unauthorized: React.ReactNode | undefined
   gracefullyDegrade?: boolean
+  segmentViewBoundaries?: React.ReactNode
 }) {
   const context = useContext(LayoutRouterContext)
   if (!context) {
@@ -659,13 +661,14 @@ export default function OuterLayoutRouter({
     )
 
     if (process.env.NODE_ENV !== 'production') {
-      const SegmentStateProvider = (
+      const { SegmentStateProvider } =
         require('../../next-devtools/userspace/app/segment-explorer-node') as typeof import('../../next-devtools/userspace/app/segment-explorer-node')
-      )
-        .SegmentStateProvider as typeof import('../../next-devtools/userspace/app/segment-explorer-node').SegmentStateProvider as typeof import('../../next-devtools/userspace/app/segment-explorer-node').SegmentStateProvider
 
       child = (
-        <SegmentStateProvider key={stateKey}>{child}</SegmentStateProvider>
+        <SegmentStateProvider key={stateKey}>
+          {child}
+          {segmentViewBoundaries}
+        </SegmentStateProvider>
       )
     }
 

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -5,9 +5,11 @@ import type { SegmentNodeState } from '../../../userspace/app/segment-explorer-n
 export function SegmentBoundaryTrigger({
   onSelectBoundary,
   offset,
+  boundaries,
 }: {
   onSelectBoundary: SegmentNodeState['setBoundaryType']
   offset: number
+  boundaries: Record<'not-found' | 'loading' | 'error', string | null>
 }) {
   const [shadowRoot] = useState<ShadowRoot>(() => {
     const ownerDocument = document
@@ -17,9 +19,24 @@ export function SegmentBoundaryTrigger({
   const shadowRootRef = useRef<ShadowRoot>(shadowRoot)
 
   const triggerOptions = [
-    { label: 'Trigger Loading', value: 'loading', icon: <LoadingIcon /> },
-    { label: 'Trigger Error', value: 'error', icon: <ErrorIcon /> },
-    { label: 'Trigger Not Found', value: 'not-found', icon: <NotFoundIcon /> },
+    {
+      label: 'Trigger Loading',
+      value: 'loading',
+      icon: <LoadingIcon />,
+      disabled: !boundaries.loading,
+    },
+    {
+      label: 'Trigger Error',
+      value: 'error',
+      icon: <ErrorIcon />,
+      disabled: !boundaries.error,
+    },
+    {
+      label: 'Trigger Not Found',
+      value: 'not-found',
+      icon: <NotFoundIcon />,
+      disabled: !boundaries['not-found'],
+    },
   ]
 
   const resetOption = {
@@ -74,6 +91,7 @@ export function SegmentBoundaryTrigger({
                   key={option.value}
                   className="segment-boundary-dropdown-item"
                   onClick={() => handleSelect(option.value)}
+                  disabled={option.disabled}
                 >
                   {option.icon}
                   {option.label}
@@ -274,9 +292,14 @@ export const styles = `
     width: 100%;
   }
 
+  .segment-boundary-dropdown-item[data-disabled] {
+    color: var(--color-gray-400);
+    cursor: not-allowed;
+  }
+
   .segment-boundary-dropdown-item svg {
     margin-right: 12px;
-    color: var(--color-gray-900);
+    color: currentColor;
   }
 
   .segment-boundary-dropdown-item:hover {

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -133,6 +133,23 @@ function PageSegmentTreeLayerPresentation({
   }
 
   const hasFilesChildren = filesChildrenKeys.length > 0
+  const boundaries: Record<'not-found' | 'loading' | 'error', string | null> = {
+    'not-found': null,
+    loading: null,
+    error: null,
+  }
+
+  filesChildrenKeys.forEach((childKey) => {
+    const childNode = node.children[childKey]
+    if (!childNode || !childNode.value) return
+    if (childNode.value.type.startsWith('boundary:')) {
+      const boundaryType = childNode.value.type.split(':')[1] as
+        | 'not-found'
+        | 'loading'
+        | 'error'
+      boundaries[boundaryType] = childNode.value.pagePath || null
+    }
+  })
 
   return (
     <>
@@ -163,6 +180,11 @@ function PageSegmentTreeLayerPresentation({
                   {filesChildrenKeys.map((fileChildSegment) => {
                     const childNode = node.children[fileChildSegment]
                     if (!childNode || !childNode.value) {
+                      return null
+                    }
+                    // If it's boundary node, which marks the existence of the boundary not the rendered status,
+                    // we don't need to present in the rendered files.
+                    if (childNode.value.type.startsWith('boundary:')) {
                       return null
                     }
                     const filePath = childNode.value.pagePath
@@ -208,6 +230,7 @@ function PageSegmentTreeLayerPresentation({
                 <SegmentBoundaryTrigger
                   offset={6}
                   onSelectBoundary={pageChild.value.setBoundaryType}
+                  boundaries={boundaries}
                 />
               )}
             </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -11,8 +11,8 @@ import {
 import { Tooltip } from '../../../components/tooltip'
 import { useRef, useState } from 'react'
 import {
-  BOUNDARY_PREFIX,
   BUILTIN_PREFIX,
+  getBoundaryOriginFileType,
   isBoundaryFile,
   normalizeBoundaryFilename,
 } from '../../../../server/app-render/segment-explorer-path'
@@ -147,7 +147,7 @@ function PageSegmentTreeLayerPresentation({
     const childNode = node.children[childKey]
     if (!childNode || !childNode.value) return
     if (isBoundaryFile(childNode.value.type)) {
-      const boundaryType = childNode.value.type.replace(BOUNDARY_PREFIX, '')
+      const boundaryType = getBoundaryOriginFileType(childNode.value.type)
 
       if (boundaryType in boundaries) {
         boundaries[boundaryType as keyof typeof boundaries] =

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -10,8 +10,12 @@ import {
 } from './segment-boundary-trigger'
 import { Tooltip } from '../../../components/tooltip'
 import { useRef, useState } from 'react'
-
-const BUILTIN_PREFIX = '__next_builtin__'
+import {
+  BOUNDARY_PREFIX,
+  BUILTIN_PREFIX,
+  isBoundaryFile,
+  normalizeBoundaryFilename,
+} from '../../../../server/app-render/segment-explorer-path'
 
 const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
@@ -142,12 +146,13 @@ function PageSegmentTreeLayerPresentation({
   filesChildrenKeys.forEach((childKey) => {
     const childNode = node.children[childKey]
     if (!childNode || !childNode.value) return
-    if (childNode.value.type.startsWith('boundary:')) {
-      const boundaryType = childNode.value.type.split(':')[1] as
-        | 'not-found'
-        | 'loading'
-        | 'error'
-      boundaries[boundaryType] = childNode.value.pagePath || null
+    if (isBoundaryFile(childNode.value.type)) {
+      const boundaryType = childNode.value.type.replace(BOUNDARY_PREFIX, '')
+
+      if (boundaryType in boundaries) {
+        boundaries[boundaryType as keyof typeof boundaries] =
+          childNode.value.pagePath || null
+      }
     }
   })
 
@@ -184,13 +189,13 @@ function PageSegmentTreeLayerPresentation({
                     }
                     // If it's boundary node, which marks the existence of the boundary not the rendered status,
                     // we don't need to present in the rendered files.
-                    if (childNode.value.type.startsWith('boundary:')) {
+                    if (isBoundaryFile(childNode.value.type)) {
                       return null
                     }
                     const filePath = childNode.value.pagePath
                     const lastSegment = filePath.split('/').pop() || ''
                     const isBuiltin = filePath.startsWith(BUILTIN_PREFIX)
-                    const fileName = lastSegment.replace(BUILTIN_PREFIX, '')
+                    const fileName = normalizeBoundaryFilename(lastSegment)
 
                     return (
                       <span

--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
@@ -97,6 +97,7 @@ function createTrie<Value = string>({
   function remove(value: Value) {
     let currentNode = root
     const segments = getCharacters(value)
+
     const stack: TrieNode<Value>[] = []
     let found = true
     for (const segment of segments) {

--- a/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
+++ b/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
@@ -31,15 +31,14 @@ function SegmentTrieNode({
   pagePath: string
 }): React.ReactNode {
   const { boundaryType, setBoundaryType } = useSegmentState()
-  const nodeState: SegmentNodeState = useMemo(
-    () => ({
+  const nodeState: SegmentNodeState = useMemo(() => {
+    return {
       type,
       pagePath,
       boundaryType,
       setBoundaryType,
-    }),
-    [type, pagePath, boundaryType, setBoundaryType]
-  )
+    }
+  }, [type, pagePath, boundaryType, setBoundaryType])
 
   // Use `useLayoutEffect` to ensure the state is updated during suspense.
   // `useEffect` won't work as the state is preserved during suspense.
@@ -143,7 +142,10 @@ export function SegmentStateProvider({ children }: { children: ReactNode }) {
   return (
     <SegmentStateContext.Provider
       key={errorBoundaryKey}
-      value={{ boundaryType, setBoundaryType: setBoundaryTypeAndReload }}
+      value={{
+        boundaryType,
+        setBoundaryType: setBoundaryTypeAndReload,
+      }}
     >
       {children}
     </SegmentStateContext.Provider>

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -410,15 +410,16 @@ async function createComponentTreeInternal({
     <MetadataOutlet ready={getMetadataReady} />
   )
 
-  const notFoundElement = await createBoundaryConventionElement({
-    ctx,
-    conventionName: 'not-found',
-    Component: NotFound,
-    styles: notFoundStyles,
-    tree,
-  })
+  const [notFoundElement, notFoundFilePath] =
+    await createBoundaryConventionElement({
+      ctx,
+      conventionName: 'not-found',
+      Component: NotFound,
+      styles: notFoundStyles,
+      tree,
+    })
 
-  const forbiddenElement = await createBoundaryConventionElement({
+  const [forbiddenElement] = await createBoundaryConventionElement({
     ctx,
     conventionName: 'forbidden',
     Component: Forbidden,
@@ -426,7 +427,7 @@ async function createComponentTreeInternal({
     tree,
   })
 
-  const unauthorizedElement = await createBoundaryConventionElement({
+  const [unauthorizedElement] = await createBoundaryConventionElement({
     ctx,
     conventionName: 'unauthorized',
     Component: Unauthorized,
@@ -546,8 +547,8 @@ async function createComponentTreeInternal({
         )
 
         const templateFilePath = getConventionPathByType(tree, dir, 'template')
-
         const errorFilePath = getConventionPathByType(tree, dir, 'error')
+        const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
 
         const wrappedErrorStyles =
           isSegmentViewEnabled && errorFilePath ? (
@@ -557,6 +558,34 @@ async function createComponentTreeInternal({
           ) : (
             errorStyles
           )
+
+        // Add a suffix to avoid conflict with the segment view node representing rendered file.
+        // existence: not-found.tsx@boundary
+        // rendered: not-found.tsx
+        const fileNameSuffix = '@boundary'
+        const segmentViewBoundaries = isSegmentViewEnabled ? (
+          <>
+            {notFoundFilePath && (
+              <SegmentViewNode
+                type={'boundary:not-found'}
+                pagePath={notFoundFilePath + fileNameSuffix}
+              />
+            )}
+            {loadingFilePath && (
+              <SegmentViewNode
+                type={'boundary:loading'}
+                pagePath={loadingFilePath + fileNameSuffix}
+              />
+            )}
+            {errorFilePath && (
+              <SegmentViewNode
+                type={'boundary:error'}
+                pagePath={errorFilePath + fileNameSuffix}
+              />
+            )}
+            {/* do not surface forbidden and unauthorized boundaries yet as they're unstable */}
+          </>
+        ) : null
 
         return [
           parallelRouteKey,
@@ -581,6 +610,7 @@ async function createComponentTreeInternal({
             notFound={notFoundComponent}
             forbidden={forbiddenComponent}
             unauthorized={unauthorizedComponent}
+            {...(isSegmentViewEnabled && { segmentViewBoundaries })}
             // Since gracefullyDegrade only applies to bots, only
             // pass it when we're in a bot context to avoid extra bytes.
             {...(gracefullyDegrade && { gracefullyDegrade })}
@@ -603,8 +633,8 @@ async function createComponentTreeInternal({
   }
 
   let loadingElement = Loading ? <Loading key="l" /> : null
+  const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
   if (isSegmentViewEnabled && loadingElement) {
-    const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
     if (loadingFilePath) {
       loadingElement = (
         <SegmentViewNode
@@ -1098,12 +1128,14 @@ async function createBoundaryConventionElement({
     </>
   ) : undefined
 
+  const pagePath = getConventionPathByType(tree, dir, conventionName)
+
   const wrappedElement =
     isSegmentViewEnabled && element ? (
       <SegmentViewNode
         key={cacheNodeKey + '-' + conventionName}
         type={conventionName}
-        pagePath={getConventionPathByType(tree, dir, conventionName)!}
+        pagePath={pagePath!}
       >
         {element}
       </SegmentViewNode>
@@ -1111,5 +1143,5 @@ async function createBoundaryConventionElement({
       element
     )
 
-  return wrappedElement
+  return [wrappedElement, pagePath] as const
 }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -26,7 +26,10 @@ import type {
   UseCachePageComponentProps,
 } from '../use-cache/use-cache-wrapper'
 import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
-import { getConventionPathByType } from './segment-explorer-path'
+import {
+  BOUNDARY_PREFIX,
+  getConventionPathByType,
+} from './segment-explorer-path'
 
 /**
  * Use the provided loader tree to create the React Component tree.
@@ -567,19 +570,19 @@ async function createComponentTreeInternal({
           <>
             {notFoundFilePath && (
               <SegmentViewNode
-                type={'boundary:not-found'}
+                type={`${BOUNDARY_PREFIX}not-found`}
                 pagePath={notFoundFilePath + fileNameSuffix}
               />
             )}
             {loadingFilePath && (
               <SegmentViewNode
-                type={'boundary:loading'}
+                type={`${BOUNDARY_PREFIX}loading`}
                 pagePath={loadingFilePath + fileNameSuffix}
               />
             )}
             {errorFilePath && (
               <SegmentViewNode
-                type={'boundary:error'}
+                type={`${BOUNDARY_PREFIX}error`}
                 pagePath={errorFilePath + fileNameSuffix}
               />
             )}

--- a/packages/next/src/server/app-render/segment-explorer-path.ts
+++ b/packages/next/src/server/app-render/segment-explorer-path.ts
@@ -42,6 +42,10 @@ export function isBoundaryFile(fileType: string) {
   return fileType.startsWith(BOUNDARY_PREFIX)
 }
 
+export function getBoundaryOriginFileType(fileType: string) {
+  return fileType.replace(BOUNDARY_PREFIX, '')
+}
+
 export function getConventionPathByType(
   tree: LoaderTree,
   dir: string,

--- a/packages/next/src/server/app-render/segment-explorer-path.ts
+++ b/packages/next/src/server/app-render/segment-explorer-path.ts
@@ -1,5 +1,7 @@
 import type { LoaderTree } from '../lib/app-dir-module'
 
+export const BUILTIN_PREFIX = '__next_builtin__'
+
 export function normalizeConventionFilePath(
   projectDir: string,
   conventionPath: string | undefined
@@ -22,10 +24,22 @@ export function normalizeConventionFilePath(
   if (nextInternalPrefixRegex.test(relativePath)) {
     relativePath = relativePath.replace(nextInternalPrefixRegex, '')
     // Add a special prefix to let segment explorer know it's a built-in component
-    relativePath = `__next_builtin__${relativePath}`
+    relativePath = `${BUILTIN_PREFIX}${relativePath}`
   }
 
   return relativePath
+}
+
+export const BOUNDARY_SUFFIX = '@boundary'
+export function normalizeBoundaryFilename(filename: string) {
+  return filename
+    .replace(new RegExp(`^${BUILTIN_PREFIX}`), '')
+    .replace(new RegExp(`${BOUNDARY_SUFFIX}$`), '')
+}
+
+export const BOUNDARY_PREFIX = 'boundary:'
+export function isBoundaryFile(fileType: string) {
+  return fileType.startsWith(BOUNDARY_PREFIX)
 }
 
 export function getConventionPathByType(

--- a/test/development/app-dir/segment-explorer/app/parallel-routes/@foo/not-found.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes/@foo/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>Not Found @foo</div>
+}


### PR DESCRIPTION
Capture defined boundaries (not-found / error / loading) and used to filter which one is available for boundary triggers

The trie will now hold all the defined boundaries, but what's different from the existing rendered boundaries is:

Here's the difference of new defined boundary trie nodes:
```
{
  type: "boundary:<type>"
  pagePath: "<pagePath>@boundary"
}
```
We add a `boundary:` prefix to determine if it's node representing existence;
We add a `@boundary` suffix to the filename cause the <pagePath> part is still need to use for indexing in the trie, but the `@boundary` doesn't matter yet. We'll remove it once we start using the file name in the dropdown panel

Closes NEXT-4330

### Example

When there's only one not-found.tsx, allow to trigger the not-found boundary and disable the rest.

https://github.com/user-attachments/assets/eb5c49a7-4fd2-496b-b778-fb66581908b3

