### PR TITLE
feat: resizable panel

### DIFF
--- a/packages/next/.storybook/main.ts
+++ b/packages/next/.storybook/main.ts
@@ -1,7 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-webpack5'
-
 import { join, dirname } from 'path'
-
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-footer.tsx
@@ -52,6 +52,7 @@ export const DEVTOOLS_PANEL_FOOTER_STYLES = css`
     align-items: center;
     border-top: 1px solid var(--color-gray-400);
     border-radius: 0 0 var(--rounded-xl) var(--rounded-xl);
+    height: auto;
   }
 
   [data-nextjs-devtools-panel-footer-tab-group] {

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
@@ -1,0 +1,145 @@
+.resize-container {
+  position: absolute;
+  /* todo: better z index */
+  z-index: 10;
+  /* todo: is this needed */
+  background: transparent;
+}
+
+.resize-line {
+  position: absolute;
+  /* todo smarter z index */
+  z-index: -1;
+  pointer-events: none;
+  /* a normal exit animation curve- at this point the exit animation is */
+  /* immediately responsive so we don't need a bespoke curve */
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  /* todo: better var? */
+  border: 1px solid var(--color-gray-100);
+}
+
+/* start really fast because we start super hidden initially behind the panel, otherwise feels like an unintended animation delay */
+.resize-container:hover ~ .resize-line {
+  transition: transform 0.2s cubic-bezier(0.05, 0.9, 0.2, 1); /* Fast start for animate in */
+}
+
+.resize-container.right,
+.resize-container.left {
+  top: 0;
+  height: 100%;
+  width: 25px;
+  cursor: ew-resize;
+}
+
+/* todo: don't hard code all these values/use vars */
+
+.resize-container.bottom,
+.resize-container.top {
+  left: 0;
+  width: 100%;
+  height: 25px;
+  cursor: ns-resize;
+}
+
+.resize-container.top {
+  top: -12px;
+}
+.resize-container.bottom {
+  bottom: -12px;
+}
+.resize-container.left {
+  left: -12px;
+}
+.resize-container.right {
+  right: -12px;
+}
+
+.resize-container.top-left,
+.resize-container.top-right,
+.resize-container.bottom-left,
+.resize-container.bottom-right {
+  width: 32px;
+  height: 32px;
+  z-index: 15;
+}
+
+.resize-container.top-left {
+  top: -16px;
+  left: -16px;
+  cursor: nwse-resize;
+}
+.resize-container.top-right {
+  top: -16px;
+  right: -16px;
+  cursor: nesw-resize;
+}
+.resize-container.bottom-left {
+  bottom: -16px;
+  left: -16px;
+  cursor: nesw-resize;
+}
+.resize-container.bottom-right {
+  bottom: -16px;
+  right: -16px;
+  cursor: nwse-resize;
+}
+
+.resize-line.top,
+.resize-line.bottom {
+  height: 28px;
+  width: 100%;
+  background-color: var(--color-background-100);
+}
+
+.resize-line.left,
+.resize-line.right {
+  width: 28px;
+  height: 100%;
+  background-color: var(--color-background-100);
+}
+
+.resize-line.top {
+  top: -12px;
+  left: calc(-1 * var(--border-left, 2px));
+  width: calc(100% + var(--border-horizontal, 4px));
+  border-radius: var(--rounded-md) var(--rounded-md) 0 0;
+  transform: translateY(28px);
+}
+
+.resize-line.bottom {
+  bottom: -12px;
+  left: calc(-1 * var(--border-left, 2px));
+  width: calc(100% + var(--border-horizontal, 4px));
+  border-radius: 0 0 var(--rounded-md) var(--rounded-md);
+  transform: translateY(-28px);
+}
+
+.resize-line.left {
+  top: calc(-1 * var(--border-top, 2px));
+  left: -12px;
+  height: calc(100% + var(--border-vertical, 4px));
+  border-radius: var(--rounded-md) 0 0 var(--rounded-md);
+  transform: translateX(28px);
+}
+
+.resize-line.right {
+  top: calc(-1 * var(--border-top, 2px));
+  right: -12px;
+  height: calc(100% + var(--border-vertical, 4px));
+  border-radius: 0 var(--rounded-md) var(--rounded-md) 0;
+  transform: translateX(-28px);
+}
+
+.resize-container.right:hover ~ .resize-line.right,
+.resize-container.left:hover ~ .resize-line.left,
+.resize-line.right.dragging,
+.resize-line.left.dragging {
+  transform: translateX(0);
+}
+
+.resize-container.bottom:hover ~ .resize-line.bottom,
+.resize-container.top:hover ~ .resize-line.top,
+.resize-line.bottom.dragging,
+.resize-line.top.dragging {
+  transform: translateY(0);
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
@@ -143,3 +143,20 @@
 .resize-line.top.dragging {
   transform: translateY(0);
 }
+
+/* make sure that we don't show multiple handles at once
+ * we should only ever show the currently resizing handle
+ * regardless of hover state 
+ */
+.resize-container.no-hover.right:hover ~ .resize-line.right {
+  transform: translateX(-28px);
+}
+.resize-container.no-hover.left:hover ~ .resize-line.left {
+  transform: translateX(28px);
+}
+.resize-container.no-hover.bottom:hover ~ .resize-line.bottom {
+  transform: translateY(-28px);
+}
+.resize-container.no-hover.top:hover ~ .resize-line.top {
+  transform: translateY(28px);
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
@@ -1,6 +1,7 @@
 import { useState, useLayoutEffect } from 'react'
 import type { Corners } from '../../../shared'
 import { useResize, type ResizeDirection } from './resize-provider'
+import './resize-handle.css'
 
 const STORAGE_KEY_DIMENSIONS = 'nextjs-devtools-dimensions'
 
@@ -153,7 +154,7 @@ export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
           className={`resize-line ${direction} ${draggingDirection === direction ? 'dragging' : ''}`}
           style={
             {
-              // we want the resize line to appear to come out of the back
+              // We want the resize line to appear to come out of the back
               // of the div flush with the full box, otherwise there are a
               // few px missing and it looks jank
               '--border-horizontal': `${totalHorizontalBorder}px`,
@@ -166,153 +167,6 @@ export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
           }
         />
       )}
-      <style jsx>{`
-        .resize-container {
-          position: absolute;
-          /* todo: better z index */
-          z-index: 10;
-          /* todo: is this needed */
-          background: transparent;
-        }
-
-        .resize-line {
-          position: absolute;
-          /* todo smarter z index */
-          z-index: -1;
-          pointer-events: none;
-          /* a normal exit animation curve- at this point the exit animation is */
-          /* immediately responsive so we don't need a bespoke curve */
-          transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-          /* todo: better var? */
-          border: 1px solid var(--color-gray-100);
-        }
-
-        /* start really fast because we start super hidden initially behind the panel, otherwise feels like an unintended animation delay */
-        .resize-container:hover ~ .resize-line {
-          transition: transform 0.2s cubic-bezier(0.05, 0.9, 0.2, 1); /* Fast start for animate in */
-        }
-
-        .resize-container.right,
-        .resize-container.left {
-          top: 0;
-          height: 100%;
-          width: 25px;
-          cursor: ew-resize;
-        }
-
-        /* todo: don't hard code all these values/use vars */
-
-        .resize-container.bottom,
-        .resize-container.top {
-          left: 0;
-          width: 100%;
-          height: 25px;
-          cursor: ns-resize;
-        }
-
-        .resize-container.top {
-          top: -12px;
-        }
-        .resize-container.bottom {
-          bottom: -12px;
-        }
-        .resize-container.left {
-          left: -12px;
-        }
-        .resize-container.right {
-          right: -12px;
-        }
-
-        .resize-container.top-left,
-        .resize-container.top-right,
-        .resize-container.bottom-left,
-        .resize-container.bottom-right {
-          width: 32px;
-          height: 32px;
-          z-index: 15;
-        }
-
-        .resize-container.top-left {
-          top: -16px;
-          left: -16px;
-          cursor: nwse-resize;
-        }
-        .resize-container.top-right {
-          top: -16px;
-          right: -16px;
-          cursor: nesw-resize;
-        }
-        .resize-container.bottom-left {
-          bottom: -16px;
-          left: -16px;
-          cursor: nesw-resize;
-        }
-        .resize-container.bottom-right {
-          bottom: -16px;
-          right: -16px;
-          cursor: nwse-resize;
-        }
-
-        .resize-line.top,
-        .resize-line.bottom {
-          height: 28px;
-          width: 100%;
-          background-color: var(--color-background-100);
-        }
-
-        .resize-line.left,
-        .resize-line.right {
-          width: 28px;
-          height: 100%;
-          background-color: var(--color-background-100);
-        }
-
-        .resize-line.top {
-          top: -12px;
-          left: calc(-1 * var(--border-left, 2px));
-          width: calc(100% + var(--border-horizontal, 4px));
-          border-radius: var(--rounded-md) var(--rounded-md) 0 0;
-          transform: translateY(28px);
-        }
-
-        .resize-line.bottom {
-          bottom: -12px;
-          left: calc(-1 * var(--border-left, 2px));
-          width: calc(100% + var(--border-horizontal, 4px));
-          border-radius: 0 0 var(--rounded-md) var(--rounded-md);
-          transform: translateY(-28px);
-        }
-
-        .resize-line.left {
-          top: calc(-1 * var(--border-top, 2px));
-          left: -12px;
-          height: calc(100% + var(--border-vertical, 4px));
-          border-radius: var(--rounded-md) 0 0 var(--rounded-md);
-          transform: translateX(28px);
-        }
-
-        .resize-line.right {
-          top: calc(-1 * var(--border-top, 2px));
-          right: -12px;
-          height: calc(100% + var(--border-vertical, 4px));
-          border-radius: 0 var(--rounded-md) var(--rounded-md) 0;
-          transform: translateX(-28px);
-        }
-
-        .resize-container.right:hover ~ .resize-line.right,
-        .resize-container.left:hover ~ .resize-line.left,
-        .resize-line.right.dragging,
-        .resize-line.left.dragging {
-          transform: translateX(0);
-        }
-
-        .resize-container.bottom:hover ~ .resize-line.bottom,
-        .resize-container.top:hover ~ .resize-line.top,
-        .resize-line.bottom.dragging,
-        .resize-line.top.dragging {
-          transform: translateY(0);
-        }
-      `}</style>
     </>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
@@ -1,0 +1,455 @@
+import { useState, useLayoutEffect } from 'react'
+import type { Corners } from '../../../shared'
+import { useResize, type ResizeDirection } from './resize-provider'
+
+const STORAGE_KEY_DIMENSIONS = 'nextjs-devtools-dimensions'
+
+export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
+  const {
+    resizeRef,
+    minWidth,
+    minHeight,
+    devToolsPosition,
+    draggingDirection,
+    setDraggingDirection,
+  } = useResize()
+  const [borderWidths, setBorderWidths] = useState({
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  })
+
+  // TODO(rob): if parallel with >2 sides (user resizes panel to be max width/height)
+  // then we need to relax disabled resize heuristic
+  const shouldShowHandle = () => {
+    const getOppositeCorner = (corner: Corners): ResizeDirection => {
+      switch (corner) {
+        case 'top-left':
+          return 'bottom-right'
+        case 'top-right':
+          return 'bottom-left'
+        case 'bottom-left':
+          return 'top-right'
+        case 'bottom-right':
+          return 'top-left'
+        default: {
+          corner satisfies never
+          return null!
+        }
+      }
+    }
+
+    // we block the sides of the corner its in (bottom-left has bottom and left sides blocked from resizing)
+    // because there shouldn't be anywhere to resize, and if the user decides to resize from that point it
+    // would be unhandled/slightly janky (the component would have to re-magnetic-snap after the resize)
+    if (devToolsPosition.split('-').includes(direction)) return false
+
+    // same logic as above, but the only corner resize that makes
+    // sense is the corner fully exposed (the opposing corner)
+    const isCorner = direction.includes('-')
+    if (isCorner) {
+      const opposite = getOppositeCorner(devToolsPosition)
+      return direction === opposite
+    }
+
+    return true
+  }
+
+  // we want the resize lines to be flush with the entire true width of the containers box
+  // and we don't want the user of ResizeHandle to have to tell us the border width
+  useLayoutEffect(() => {
+    if (!resizeRef.current) return
+
+    const element = resizeRef.current
+    const computedStyle = window.getComputedStyle(element)
+
+    const borderTop = parseFloat(computedStyle.borderTopWidth) || 0
+    const borderRight = parseFloat(computedStyle.borderRightWidth) || 0
+    const borderBottom = parseFloat(computedStyle.borderBottomWidth) || 0
+    const borderLeft = parseFloat(computedStyle.borderLeftWidth) || 0
+
+    setBorderWidths({
+      top: borderTop,
+      right: borderRight,
+      bottom: borderBottom,
+      left: borderLeft,
+    })
+  }, [resizeRef])
+
+  const handleMouseDown = (mouseDownEvent: React.MouseEvent) => {
+    mouseDownEvent.preventDefault()
+    if (!resizeRef.current) return
+    setDraggingDirection(direction)
+
+    const element = resizeRef.current
+    const initialRect = element.getBoundingClientRect()
+    const initialLeft = element.offsetLeft
+    const initialTop = element.offsetTop
+    const startX = mouseDownEvent.clientX
+    const startY = mouseDownEvent.clientY
+
+    const handleMouseMove = (mouseMoveEvent: MouseEvent) => {
+      const deltaX = mouseMoveEvent.clientX - startX
+      const deltaY = mouseMoveEvent.clientY - startY
+
+      const { newWidth, newHeight, newLeft, newTop } = getNewDimensions(
+        direction,
+        deltaX,
+        deltaY,
+        initialRect,
+        initialLeft,
+        initialTop,
+        minWidth,
+        minHeight
+      )
+
+      element.style.width = `${newWidth}px`
+      element.style.height = `${newHeight}px`
+
+      if (direction.includes('left') || direction === 'left') {
+        element.style.left = `${newLeft}px`
+      }
+      if (direction.includes('top') || direction === 'top') {
+        element.style.top = `${newTop}px`
+      }
+    }
+
+    const handleMouseUp = () => {
+      setDraggingDirection(null)
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+
+      // invariant ref exists
+      const { width, height } = resizeRef.current!.getBoundingClientRect()
+      localStorage.setItem(
+        STORAGE_KEY_DIMENSIONS,
+        JSON.stringify({ width, height })
+      )
+    }
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+  }
+
+  if (!shouldShowHandle()) {
+    return null
+  }
+  const totalHorizontalBorder = borderWidths.left + borderWidths.right
+  const totalVerticalBorder = borderWidths.top + borderWidths.bottom
+
+  const isCornerHandle = direction.includes('-')
+
+  return (
+    <>
+      {/* this is what actually captures the events, its partially on the container, and partially off */}
+      <div
+        className={`resize-container ${direction}`}
+        onMouseDown={handleMouseDown}
+      />
+
+      {/* this panel appears to capture the click, but its just a visual indicator for user of the resize target */}
+      {!isCornerHandle && (
+        <div
+          className={`resize-line ${direction} ${draggingDirection === direction ? 'dragging' : ''}`}
+          style={
+            {
+              // we want the resize line to appear to come out of the back
+              // of the div flush with the full box, otherwise there are a
+              // few px missing and it looks jank
+              '--border-horizontal': `${totalHorizontalBorder}px`,
+              '--border-vertical': `${totalVerticalBorder}px`,
+              '--border-top': `${borderWidths.top}px`,
+              '--border-right': `${borderWidths.right}px`,
+              '--border-bottom': `${borderWidths.bottom}px`,
+              '--border-left': `${borderWidths.left}px`,
+            } as React.CSSProperties
+          }
+        />
+      )}
+      <style jsx>{`
+        .resize-container {
+          position: absolute;
+          /* todo: better z index */
+          z-index: 10;
+          /* todo: is this needed */
+          background: transparent;
+        }
+
+        .resize-line {
+          position: absolute;
+          /* todo smarter z index */
+          z-index: -1;
+          pointer-events: none;
+          /* a normal exit animation curve- at this point the exit animation is */
+          /* immediately responsive so we don't need a bespoke curve */
+          transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+          /* todo: better var? */
+          border: 1px solid var(--color-gray-100);
+        }
+
+        /* start really fast because we start super hidden initially behind the panel, otherwise feels like an unintended animation delay */
+        .resize-container:hover ~ .resize-line {
+          transition: transform 0.2s cubic-bezier(0.05, 0.9, 0.2, 1); /* Fast start for animate in */
+        }
+
+        .resize-container.right,
+        .resize-container.left {
+          top: 0;
+          height: 100%;
+          width: 25px;
+          cursor: ew-resize;
+        }
+
+        /* todo: don't hard code all these values/use vars */
+
+        .resize-container.bottom,
+        .resize-container.top {
+          left: 0;
+          width: 100%;
+          height: 25px;
+          cursor: ns-resize;
+        }
+
+        .resize-container.top {
+          top: -12px;
+        }
+        .resize-container.bottom {
+          bottom: -12px;
+        }
+        .resize-container.left {
+          left: -12px;
+        }
+        .resize-container.right {
+          right: -12px;
+        }
+
+        .resize-container.top-left,
+        .resize-container.top-right,
+        .resize-container.bottom-left,
+        .resize-container.bottom-right {
+          width: 32px;
+          height: 32px;
+          z-index: 15;
+        }
+
+        .resize-container.top-left {
+          top: -16px;
+          left: -16px;
+          cursor: nwse-resize;
+        }
+        .resize-container.top-right {
+          top: -16px;
+          right: -16px;
+          cursor: nesw-resize;
+        }
+        .resize-container.bottom-left {
+          bottom: -16px;
+          left: -16px;
+          cursor: nesw-resize;
+        }
+        .resize-container.bottom-right {
+          bottom: -16px;
+          right: -16px;
+          cursor: nwse-resize;
+        }
+
+        .resize-line.top,
+        .resize-line.bottom {
+          height: 28px;
+          width: 100%;
+          background-color: var(--color-background-100);
+        }
+
+        .resize-line.left,
+        .resize-line.right {
+          width: 28px;
+          height: 100%;
+          background-color: var(--color-background-100);
+        }
+
+        .resize-line.top {
+          top: -12px;
+          left: calc(-1 * var(--border-left, 2px));
+          width: calc(100% + var(--border-horizontal, 4px));
+          border-radius: var(--rounded-md) var(--rounded-md) 0 0;
+          transform: translateY(28px);
+        }
+
+        .resize-line.bottom {
+          bottom: -12px;
+          left: calc(-1 * var(--border-left, 2px));
+          width: calc(100% + var(--border-horizontal, 4px));
+          border-radius: 0 0 var(--rounded-md) var(--rounded-md);
+          transform: translateY(-28px);
+        }
+
+        .resize-line.left {
+          top: calc(-1 * var(--border-top, 2px));
+          left: -12px;
+          height: calc(100% + var(--border-vertical, 4px));
+          border-radius: var(--rounded-md) 0 0 var(--rounded-md);
+          transform: translateX(28px);
+        }
+
+        .resize-line.right {
+          top: calc(-1 * var(--border-top, 2px));
+          right: -12px;
+          height: calc(100% + var(--border-vertical, 4px));
+          border-radius: 0 var(--rounded-md) var(--rounded-md) 0;
+          transform: translateX(-28px);
+        }
+
+        .resize-container.right:hover ~ .resize-line.right,
+        .resize-container.left:hover ~ .resize-line.left,
+        .resize-line.right.dragging,
+        .resize-line.left.dragging {
+          transform: translateX(0);
+        }
+
+        .resize-container.bottom:hover ~ .resize-line.bottom,
+        .resize-container.top:hover ~ .resize-line.top,
+        .resize-line.bottom.dragging,
+        .resize-line.top.dragging {
+          transform: translateY(0);
+        }
+      `}</style>
+    </>
+  )
+}
+
+const getNewDimensions = (
+  direction: ResizeDirection,
+  deltaX: number,
+  deltaY: number,
+  initialRect: DOMRect,
+  initialLeft: number,
+  initialTop: number,
+  minWidth: number,
+  minHeight: number
+) => {
+  const maxWidth = window.innerWidth * 0.95
+  const maxHeight = window.innerHeight * 0.95
+
+  switch (direction) {
+    case 'right':
+      return {
+        newWidth: Math.min(
+          maxWidth,
+          Math.max(minWidth, initialRect.width + deltaX)
+        ),
+        newHeight: initialRect.height,
+        newLeft: initialLeft,
+        newTop: initialTop,
+      }
+
+    case 'left': {
+      const newWidth = Math.min(
+        maxWidth,
+        Math.max(minWidth, initialRect.width - deltaX)
+      )
+      const widthDiff = newWidth - initialRect.width
+      return {
+        newWidth,
+        newHeight: initialRect.height,
+        newLeft: initialLeft - widthDiff,
+        newTop: initialTop,
+      }
+    }
+
+    case 'bottom':
+      return {
+        newWidth: initialRect.width,
+        newHeight: Math.min(
+          maxHeight,
+          Math.max(minHeight, initialRect.height + deltaY)
+        ),
+        newLeft: initialLeft,
+        newTop: initialTop,
+      }
+
+    case 'top': {
+      const newHeight = Math.min(
+        maxHeight,
+        Math.max(minHeight, initialRect.height - deltaY)
+      )
+      const heightDiff = newHeight - initialRect.height
+      return {
+        newWidth: initialRect.width,
+        newHeight,
+        newLeft: initialLeft,
+        newTop: initialTop - heightDiff,
+      }
+    }
+
+    case 'top-left': {
+      const newWidth = Math.min(
+        maxWidth,
+        Math.max(minWidth, initialRect.width - deltaX)
+      )
+      const newHeight = Math.min(
+        maxHeight,
+        Math.max(minHeight, initialRect.height - deltaY)
+      )
+      const widthDiff = newWidth - initialRect.width
+      const heightDiff = newHeight - initialRect.height
+      return {
+        newWidth,
+        newHeight,
+        newLeft: initialLeft - widthDiff,
+        newTop: initialTop - heightDiff,
+      }
+    }
+
+    case 'top-right': {
+      const newHeight = Math.min(
+        maxHeight,
+        Math.max(minHeight, initialRect.height - deltaY)
+      )
+      const heightDiff = newHeight - initialRect.height
+      return {
+        newWidth: Math.min(
+          maxWidth,
+          Math.max(minWidth, initialRect.width + deltaX)
+        ),
+        newHeight,
+        newLeft: initialLeft,
+        newTop: initialTop - heightDiff,
+      }
+    }
+
+    case 'bottom-left': {
+      const newWidth = Math.min(
+        maxWidth,
+        Math.max(minWidth, initialRect.width - deltaX)
+      )
+      const widthDiff = newWidth - initialRect.width
+      return {
+        newWidth,
+        newHeight: Math.min(
+          maxHeight,
+          Math.max(minHeight, initialRect.height + deltaY)
+        ),
+        newLeft: initialLeft - widthDiff,
+        newTop: initialTop,
+      }
+    }
+
+    case 'bottom-right':
+      return {
+        newWidth: Math.min(
+          maxWidth,
+          Math.max(minWidth, initialRect.width + deltaX)
+        ),
+        newHeight: Math.min(
+          maxHeight,
+          Math.max(minHeight, initialRect.height + deltaY)
+        ),
+        newLeft: initialLeft,
+        newTop: initialTop,
+      }
+    default: {
+      direction satisfies never
+      return null!
+    }
+  }
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
@@ -144,7 +144,7 @@ export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
     <>
       {/* this is what actually captures the events, its partially on the container, and partially off */}
       <div
-        className={`resize-container ${direction}`}
+        className={`resize-container ${direction} ${draggingDirection && draggingDirection !== direction ? 'no-hover' : ''}`}
         onMouseDown={handleMouseDown}
       />
 

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
@@ -1,6 +1,5 @@
 import {
   createContext,
-  useCallback,
   useContext,
   useLayoutEffect,
   useState,
@@ -30,6 +29,41 @@ interface ResizeContextValue {
 
 const ResizeContext = createContext<ResizeContextValue>(null!)
 
+const constrainDimensions = (params: {
+  width: number
+  height: number
+  minWidth: number
+  minHeight: number
+}) => {
+  const maxWidth = window.innerWidth * 0.95
+  const maxHeight = window.innerHeight * 0.95
+
+  return {
+    width: Math.min(maxWidth, Math.max(params.minWidth, params.width)),
+    height: Math.min(maxHeight, Math.max(params.minHeight, params.height)),
+  }
+}
+
+const parseResizeLocalStorage = () => {
+  const savedDimensions = localStorage.getItem(STORAGE_KEY_DIMENSIONS)
+  if (!savedDimensions) return null
+  try {
+    const parsed = JSON.parse(savedDimensions)
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof parsed.width === 'number' &&
+      typeof parsed.height === 'number'
+    ) {
+      return { width: parsed.width, height: parsed.height }
+    }
+    return null
+  } catch (e) {
+    localStorage.removeItem(STORAGE_KEY_DIMENSIONS)
+    return null
+  }
+}
+
 interface ResizeProviderProps {
   value: {
     resizeRef: RefObject<HTMLElement | null>
@@ -46,19 +80,6 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
   const [draggingDirection, setDraggingDirection] =
     useState<ResizeDirection | null>(null)
 
-  const constrainDimensions = useCallback(
-    (width: number, height: number) => {
-      const maxWidth = window.innerWidth * 0.95
-      const maxHeight = window.innerHeight * 0.95
-
-      return {
-        width: Math.min(maxWidth, Math.max(minWidth, width)),
-        height: Math.min(maxHeight, Math.max(minHeight, height)),
-      }
-    },
-    [minHeight, minWidth]
-  )
-
   useLayoutEffect(() => {
     const applyConstrainedDimensions = () => {
       if (!value.resizeRef.current) return
@@ -70,21 +91,18 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
       // an optimization if this is too expensive is to maintain the current
       // container size in a ref and update it on resize, which is essentially
       // what we're doing here, just dumber
-      const savedDimensions = localStorage.getItem(STORAGE_KEY_DIMENSIONS)
-      if (!savedDimensions) return
-
-      try {
-        const parsed = JSON.parse(savedDimensions)
-        const { width, height } = constrainDimensions(
-          parsed.width,
-          parsed.height
-        )
-
-        value.resizeRef.current.style.width = `${width}px`
-        value.resizeRef.current.style.height = `${height}px`
-      } catch (e) {
-        localStorage.removeItem(STORAGE_KEY_DIMENSIONS)
+      const dim = parseResizeLocalStorage()
+      if (!dim) {
+        return
       }
+      const { height, width } = constrainDimensions({
+        ...dim,
+        minWidth: minWidth ?? 100,
+        minHeight: minHeight ?? 80,
+      })
+
+      value.resizeRef.current.style.width = `${width}px`
+      value.resizeRef.current.style.height = `${height}px`
     }
 
     applyConstrainedDimensions()
@@ -92,7 +110,7 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
     window.addEventListener('resize', applyConstrainedDimensions)
     return () =>
       window.removeEventListener('resize', applyConstrainedDimensions)
-  }, [value.resizeRef, minWidth, minHeight, constrainDimensions])
+  }, [value.resizeRef, minWidth, minHeight])
 
   return (
     <ResizeContext.Provider

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
@@ -1,0 +1,119 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useState,
+  type RefObject,
+} from 'react'
+import type { Corners } from '../../../shared'
+const STORAGE_KEY_DIMENSIONS = 'nextjs-devtools-dimensions'
+
+export type ResizeDirection =
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+
+interface ResizeContextValue {
+  resizeRef: RefObject<HTMLElement | null>
+  minWidth: number
+  minHeight: number
+  devToolsPosition: Corners
+  draggingDirection: ResizeDirection | null
+  setDraggingDirection: (direction: ResizeDirection | null) => void
+}
+
+const ResizeContext = createContext<ResizeContextValue>(null!)
+
+interface ResizeProviderProps {
+  value: {
+    resizeRef: RefObject<HTMLElement | null>
+    minWidth?: number
+    minHeight?: number
+    devToolsPosition: Corners
+  }
+  children: React.ReactNode
+}
+
+export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
+  const minWidth = value.minWidth ?? 100
+  const minHeight = value.minHeight ?? 80
+  const [draggingDirection, setDraggingDirection] =
+    useState<ResizeDirection | null>(null)
+
+  const constrainDimensions = useCallback(
+    (width: number, height: number) => {
+      const maxWidth = window.innerWidth * 0.95
+      const maxHeight = window.innerHeight * 0.95
+
+      return {
+        width: Math.min(maxWidth, Math.max(minWidth, width)),
+        height: Math.min(maxHeight, Math.max(minHeight, height)),
+      }
+    },
+    [minHeight, minWidth]
+  )
+
+  useLayoutEffect(() => {
+    const applyConstrainedDimensions = () => {
+      if (!value.resizeRef.current) return
+
+      // this feels weird to read local storage on resize, but we don't
+      // track the dimensions of the container, and this is better than
+      // getBoundingClientReact
+
+      // an optimization if this is too expensive is to maintain the current
+      // container size in a ref and update it on resize, which is essentially
+      // what we're doing here, just dumber
+      const savedDimensions = localStorage.getItem(STORAGE_KEY_DIMENSIONS)
+      if (!savedDimensions) return
+
+      try {
+        const parsed = JSON.parse(savedDimensions)
+        const { width, height } = constrainDimensions(
+          parsed.width,
+          parsed.height
+        )
+
+        value.resizeRef.current.style.width = `${width}px`
+        value.resizeRef.current.style.height = `${height}px`
+      } catch (e) {
+        localStorage.removeItem(STORAGE_KEY_DIMENSIONS)
+      }
+    }
+
+    applyConstrainedDimensions()
+
+    window.addEventListener('resize', applyConstrainedDimensions)
+    return () =>
+      window.removeEventListener('resize', applyConstrainedDimensions)
+  }, [value.resizeRef, minWidth, minHeight, constrainDimensions])
+
+  return (
+    <ResizeContext.Provider
+      value={{
+        resizeRef: value.resizeRef,
+        minWidth,
+        minHeight,
+        devToolsPosition: value.devToolsPosition,
+        draggingDirection,
+        setDraggingDirection,
+      }}
+    >
+      {children}
+    </ResizeContext.Provider>
+  )
+}
+
+export const useResize = () => {
+  const context = useContext(ResizeContext)
+  if (!context) {
+    throw new Error('useResize must be used within a Resize provider')
+  }
+  return context
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx
@@ -39,6 +39,14 @@ export function Draggable({
   })
 
   function onDragEnd(translation: Point, velocity: Point) {
+    const distance = Math.sqrt(
+      translation.x * translation.x + translation.y * translation.y
+    )
+    if (distance === 0) {
+      ref.current?.style.removeProperty('translate')
+      return
+    }
+
     const projectedPosition = {
       x: translation.x + project(velocity.x),
       y: translation.y + project(velocity.y),

--- a/packages/next/src/next-devtools/dev-overlay/components/overlay/overlay.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overlay/overlay.tsx
@@ -3,6 +3,7 @@ import { lock, unlock } from './body-locker'
 
 export type OverlayProps = React.HTMLAttributes<HTMLDivElement> & {
   fixed?: boolean
+  ref?: React.Ref<HTMLDivElement>
 }
 
 const Overlay: React.FC<OverlayProps> = function Overlay({


### PR DESCRIPTION
Closes NEXT-4599

This pr introduces the ability to resize panels in devtools

### Details
- we dynamically show a drag area on the sides of the panels to make it easier to find the drag target of the panel
- remove all media queries for panel sizing and rely on resizing + min/max heights as source of truth 
- handles vertical, horizontal, diagonal resizing
- clamp panel width/height to viewport incase user resizes

### Example
https://github.com/user-attachments/assets/9053f716-ca79-440b-add4-a841ff84427d




