### PR TITLE
Turbopack: codegen modules without module graph

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -465,11 +465,8 @@ pub async fn get_client_chunking_context(
     })
     .asset_base_path(asset_prefix)
     .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
+    .export_usage(*export_usage.await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?);
-
-    if let Some(export_usage) = *export_usage.await? {
-        builder = builder.export_usage(export_usage);
-    }
 
     if next_mode.is_development() {
         builder = builder.hot_module_replacement().use_file_source_map_uris();

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -1,8 +1,9 @@
 use std::iter::once;
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TaskInput, Vc};
+use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
     css::chunk::CssChunkType,
@@ -24,6 +25,7 @@ use turbopack_core::{
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
     free_var_references,
+    module_graph::export_usage::OptionExportUsageInfo,
     resolve::{parse::Request, pattern::Pattern},
 };
 use turbopack_ecmascript::chunk::EcmascriptChunkType;
@@ -323,9 +325,7 @@ pub async fn get_client_module_options_context(
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         keep_last_successful_parse: next_mode.is_development(),
-        remove_unused_exports: *next_config
-            .turbopack_remove_unused_exports(next_mode.is_development())
-            .await?,
+        remove_unused_exports: *next_config.turbopack_remove_unused_exports(mode).await?,
         ..Default::default()
     };
 
@@ -397,21 +397,43 @@ pub async fn get_client_module_options_context(
     Ok(module_options_context)
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Serialize, Deserialize)]
+pub struct ClientChunkingContextOptions {
+    pub mode: Vc<NextMode>,
+    pub root_path: FileSystemPath,
+    pub client_root: FileSystemPath,
+    pub client_root_to_root_path: RcStr,
+    pub asset_prefix: Vc<Option<RcStr>>,
+    pub chunk_suffix_path: Vc<Option<RcStr>>,
+    pub environment: Vc<Environment>,
+    pub module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    pub export_usage: Vc<OptionExportUsageInfo>,
+    pub minify: Vc<bool>,
+    pub source_maps: Vc<bool>,
+    pub no_mangling: Vc<bool>,
+    pub scope_hoisting: Vc<bool>,
+}
+
 #[turbo_tasks::function]
 pub async fn get_client_chunking_context(
-    root_path: FileSystemPath,
-    client_root: FileSystemPath,
-    client_root_to_root_path: RcStr,
-    asset_prefix: ResolvedVc<Option<RcStr>>,
-    chunk_suffix_path: ResolvedVc<Option<RcStr>>,
-    environment: ResolvedVc<Environment>,
-    mode: Vc<NextMode>,
-    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
-    minify: Vc<bool>,
-    source_maps: Vc<bool>,
-    no_mangling: Vc<bool>,
-    scope_hoisting: Vc<bool>,
+    options: ClientChunkingContextOptions,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
+    let ClientChunkingContextOptions {
+        mode,
+        root_path,
+        client_root,
+        client_root_to_root_path,
+        asset_prefix,
+        chunk_suffix_path,
+        environment,
+        module_id_strategy,
+        export_usage,
+        minify,
+        source_maps,
+        no_mangling,
+        scope_hoisting,
+    } = options;
+
     let next_mode = mode.await?;
     let asset_prefix = asset_prefix.owned().await?;
     let chunk_suffix_path = chunk_suffix_path.owned().await?;
@@ -424,7 +446,7 @@ pub async fn get_client_chunking_context(
         get_client_assets_path(client_root.clone())
             .await?
             .clone_value(),
-        environment,
+        environment.to_resolved().await?,
         next_mode.runtime_type(),
     )
     .chunk_base_path(asset_prefix.clone())
@@ -443,7 +465,11 @@ pub async fn get_client_chunking_context(
     })
     .asset_base_path(asset_prefix)
     .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
-    .module_id_strategy(module_id_strategy);
+    .module_id_strategy(module_id_strategy.to_resolved().await?);
+
+    if let Some(export_usage) = *export_usage.await? {
+        builder = builder.export_usage(export_usage);
+    }
 
     if next_mode.is_development() {
         builder = builder.hot_module_replacement().use_file_source_map_uris();

--- a/crates/next-core/src/next_client/mod.rs
+++ b/crates/next-core/src/next_client/mod.rs
@@ -3,8 +3,8 @@ pub(crate) mod runtime_entry;
 pub(crate) mod transforms;
 
 pub use context::{
-    ClientContextType, get_client_chunking_context, get_client_compile_time_info,
-    get_client_module_options_context, get_client_resolve_options_context,
-    get_client_runtime_entries,
+    ClientChunkingContextOptions, ClientContextType, get_client_chunking_context,
+    get_client_compile_time_info, get_client_module_options_context,
+    get_client_resolve_options_context, get_client_runtime_entries,
 };
 pub use runtime_entry::{RuntimeEntries, RuntimeEntry};

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
-    module_graph::ModuleGraph,
+    module_graph::{ModuleGraph, export_usage::ModuleExportUsageInfo},
     reference::{ModuleReference, ModuleReferences},
     reference_type::ReferenceType,
     resolve::ModuleResolveResult,
@@ -76,7 +76,7 @@ impl EcmascriptClientReferenceModule {
         // Adapted from https://github.com/facebook/react/blob/c5b9375767e2c4102d7e5559d383523736f1c902/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js#L323-L354
         if let EcmascriptExports::EsmExports(exports) = &*self.client_module.get_exports().await? {
             is_esm = true;
-            let exports = exports.expand_exports(None).await?;
+            let exports = exports.expand_exports(ModuleExportUsageInfo::all()).await?;
 
             if !exports.dynamic_exports.is_empty() {
                 // TODO: throw? warn?

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1644,12 +1644,15 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn turbopack_remove_unused_exports(&self, is_development: bool) -> Vc<bool> {
-        Vc::cell(
-            self.experimental
+    pub async fn turbopack_remove_unused_exports(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
+        Ok(Vc::cell(match *mode.await? {
+            // Ignore configuration in development mode, this is only useful in prod
+            NextMode::Development => false,
+            NextMode::Build => self
+                .experimental
                 .turbopack_remove_unused_exports
-                .unwrap_or(!is_development),
-        )
+                .unwrap_or(true),
+        }))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1645,14 +1645,11 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub async fn turbopack_remove_unused_exports(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(match *mode.await? {
-            // Ignore configuration in development mode, this is only useful in prod
-            NextMode::Development => false,
-            NextMode::Build => self
-                .experimental
+        Ok(Vc::cell(
+            self.experimental
                 .turbopack_remove_unused_exports
-                .unwrap_or(true),
-        }))
+                .unwrap_or(matches!(*mode.await?, NextMode::Build)),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -247,11 +247,8 @@ pub async fn get_edge_chunking_context_with_client_assets(
     } else {
         SourceMapsType::None
     })
-    .module_id_strategy(module_id_strategy.to_resolved().await?);
-
-    if let Some(export_usage) = *export_usage.await? {
-        builder = builder.export_usage(export_usage);
-    }
+    .module_id_strategy(module_id_strategy.to_resolved().await?)
+    .export_usage(*export_usage.await?);
 
     if !next_mode.is_development() {
         builder = builder
@@ -321,11 +318,8 @@ pub async fn get_edge_chunking_context(
     } else {
         SourceMapsType::None
     })
-    .module_id_strategy(module_id_strategy.to_resolved().await?);
-
-    if let Some(export_usage) = *export_usage.await? {
-        builder = builder.export_usage(export_usage);
-    }
+    .module_id_strategy(module_id_strategy.to_resolved().await?)
+    .export_usage(*export_usage.await?);
 
     if !next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{css::chunk::CssChunkType, resolve_options_context::ResolveOptionsContext};
 use turbopack_browser::BrowserChunkingContext;
@@ -12,6 +13,7 @@ use turbopack_core::{
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
     environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
     free_var_references,
+    module_graph::export_usage::OptionExportUsageInfo,
 };
 use turbopack_ecmascript::chunk::EcmascriptChunkType;
 use turbopack_node::execution_context::ExecutionContext;
@@ -185,21 +187,40 @@ pub async fn get_edge_resolve_options_context(
     .cell())
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Serialize, Deserialize)]
+pub struct EdgeChunkingContextOptions {
+    pub mode: Vc<NextMode>,
+    pub root_path: FileSystemPath,
+    pub node_root: FileSystemPath,
+    pub output_root_to_root_path: Vc<RcStr>,
+    pub environment: Vc<Environment>,
+    pub module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    pub export_usage: Vc<OptionExportUsageInfo>,
+    pub turbo_minify: Vc<bool>,
+    pub turbo_source_maps: Vc<bool>,
+    pub no_mangling: Vc<bool>,
+    pub scope_hoisting: Vc<bool>,
+}
+
 #[turbo_tasks::function]
 pub async fn get_edge_chunking_context_with_client_assets(
-    mode: Vc<NextMode>,
-    root_path: FileSystemPath,
-    node_root: FileSystemPath,
-    output_root_to_root_path: ResolvedVc<RcStr>,
+    options: EdgeChunkingContextOptions,
     client_root: FileSystemPath,
     asset_prefix: ResolvedVc<Option<RcStr>>,
-    environment: ResolvedVc<Environment>,
-    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
-    turbo_minify: Vc<bool>,
-    turbo_source_maps: Vc<bool>,
-    no_mangling: Vc<bool>,
-    scope_hoisting: Vc<bool>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
+    let EdgeChunkingContextOptions {
+        mode,
+        root_path,
+        node_root,
+        output_root_to_root_path,
+        environment,
+        module_id_strategy,
+        export_usage,
+        turbo_minify,
+        turbo_source_maps,
+        no_mangling,
+        scope_hoisting,
+    } = options;
     let output_root = node_root.join("server/edge")?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
@@ -209,7 +230,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
         client_root.clone(),
         output_root.join("chunks/ssr")?,
         client_root.join("static/media")?,
-        environment,
+        environment.to_resolved().await?,
         next_mode.runtime_type(),
     )
     .asset_base_path(asset_prefix.owned().await?)
@@ -226,7 +247,11 @@ pub async fn get_edge_chunking_context_with_client_assets(
     } else {
         SourceMapsType::None
     })
-    .module_id_strategy(module_id_strategy);
+    .module_id_strategy(module_id_strategy.to_resolved().await?);
+
+    if let Some(export_usage) = *export_usage.await? {
+        builder = builder.export_usage(export_usage);
+    }
 
     if !next_mode.is_development() {
         builder = builder
@@ -252,27 +277,31 @@ pub async fn get_edge_chunking_context_with_client_assets(
 
 #[turbo_tasks::function]
 pub async fn get_edge_chunking_context(
-    mode: Vc<NextMode>,
-    root_path: FileSystemPath,
-    node_root: FileSystemPath,
-    node_root_to_root_path: ResolvedVc<RcStr>,
-    environment: ResolvedVc<Environment>,
-    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
-    turbo_minify: Vc<bool>,
-    turbo_source_maps: Vc<bool>,
-    no_mangling: Vc<bool>,
-    scope_hoisting: Vc<bool>,
+    options: EdgeChunkingContextOptions,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
+    let EdgeChunkingContextOptions {
+        mode,
+        root_path,
+        node_root,
+        output_root_to_root_path,
+        environment,
+        module_id_strategy,
+        export_usage,
+        turbo_minify,
+        turbo_source_maps,
+        no_mangling,
+        scope_hoisting,
+    } = options;
     let output_root = node_root.join("server/edge")?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
         root_path,
         output_root.clone(),
-        node_root_to_root_path.owned().await?,
+        output_root_to_root_path.owned().await?,
         output_root.clone(),
         output_root.join("chunks")?,
         output_root.join("assets")?,
-        environment,
+        environment.to_resolved().await?,
         next_mode.runtime_type(),
     )
     // Since one can't read files in edge directly, any asset need to be fetched
@@ -292,7 +321,11 @@ pub async fn get_edge_chunking_context(
     } else {
         SourceMapsType::None
     })
-    .module_id_strategy(module_id_strategy);
+    .module_id_strategy(module_id_strategy.to_resolved().await?);
+
+    if let Some(export_usage) = *export_usage.await? {
+        builder = builder.export_usage(export_usage);
+    }
 
     if !next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1,8 +1,9 @@
 use std::iter::once;
 
 use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TaskInput, Vc};
+use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
     css::chunk::CssChunkType,
@@ -23,6 +24,7 @@ use turbopack_core::{
         Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion, RuntimeVersions,
     },
     free_var_references,
+    module_graph::export_usage::OptionExportUsageInfo,
     target::CompileTarget,
 };
 use turbopack_ecmascript::{chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior};
@@ -538,9 +540,7 @@ pub async fn get_server_module_options_context(
             None
         },
         keep_last_successful_parse: next_mode.is_development(),
-        remove_unused_exports: *next_config
-            .turbopack_remove_unused_exports(next_mode.is_development())
-            .await?,
+
         ..Default::default()
     };
 
@@ -948,21 +948,41 @@ pub fn get_server_runtime_entries(
     Vc::cell(runtime_entries)
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Serialize, Deserialize)]
+pub struct ServerChunkingContextOptions {
+    pub mode: Vc<NextMode>,
+    pub root_path: FileSystemPath,
+    pub node_root: FileSystemPath,
+    pub node_root_to_root_path: RcStr,
+    pub environment: Vc<Environment>,
+    pub module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
+    pub export_usage: Vc<OptionExportUsageInfo>,
+    pub turbo_minify: Vc<bool>,
+    pub turbo_source_maps: Vc<bool>,
+    pub no_mangling: Vc<bool>,
+    pub scope_hoisting: Vc<bool>,
+}
+
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context_with_client_assets(
-    mode: Vc<NextMode>,
-    root_path: FileSystemPath,
-    node_root: FileSystemPath,
-    node_root_to_root_path: RcStr,
+    options: ServerChunkingContextOptions,
     client_root: FileSystemPath,
     asset_prefix: Option<RcStr>,
-    environment: ResolvedVc<Environment>,
-    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
-    turbo_minify: Vc<bool>,
-    turbo_source_maps: Vc<bool>,
-    no_mangling: Vc<bool>,
-    scope_hoisting: Vc<bool>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
+    let ServerChunkingContextOptions {
+        mode,
+        root_path,
+        node_root,
+        node_root_to_root_path,
+        environment,
+        module_id_strategy,
+        export_usage,
+        turbo_minify,
+        turbo_source_maps,
+        no_mangling,
+        scope_hoisting,
+    } = options;
+
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
     // different server chunking contexts. OR the build chunking context should
@@ -974,7 +994,7 @@ pub async fn get_server_chunking_context_with_client_assets(
         client_root.clone(),
         node_root.join("server/chunks/ssr")?,
         client_root.join("static/media")?,
-        environment,
+        environment.to_resolved().await?,
         next_mode.runtime_type(),
     )
     .asset_prefix(asset_prefix)
@@ -991,8 +1011,12 @@ pub async fn get_server_chunking_context_with_client_assets(
     } else {
         SourceMapsType::None
     })
-    .module_id_strategy(module_id_strategy)
+    .module_id_strategy(module_id_strategy.to_resolved().await?)
     .file_tracing(next_mode.is_production());
+
+    if let Some(export_usage) = *export_usage.await? {
+        builder = builder.export_usage(export_usage);
+    }
 
     if next_mode.is_development() {
         builder = builder.use_file_source_map_uris();
@@ -1022,17 +1046,21 @@ pub async fn get_server_chunking_context_with_client_assets(
 
 #[turbo_tasks::function]
 pub async fn get_server_chunking_context(
-    mode: Vc<NextMode>,
-    root_path: FileSystemPath,
-    node_root: FileSystemPath,
-    node_root_to_root_path: RcStr,
-    environment: ResolvedVc<Environment>,
-    module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
-    turbo_minify: Vc<bool>,
-    turbo_source_maps: Vc<bool>,
-    no_mangling: Vc<bool>,
-    scope_hoisting: Vc<bool>,
+    options: ServerChunkingContextOptions,
 ) -> Result<Vc<NodeJsChunkingContext>> {
+    let ServerChunkingContextOptions {
+        mode,
+        root_path,
+        node_root,
+        node_root_to_root_path,
+        environment,
+        module_id_strategy,
+        export_usage,
+        turbo_minify,
+        turbo_source_maps,
+        no_mangling,
+        scope_hoisting,
+    } = options;
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
     // different server chunking contexts. OR the build chunking context should
@@ -1044,7 +1072,7 @@ pub async fn get_server_chunking_context(
         node_root.clone(),
         node_root.join("server/chunks")?,
         node_root.join("server/assets")?,
-        environment,
+        environment.to_resolved().await?,
         next_mode.runtime_type(),
     )
     .minify_type(if *turbo_minify.await? {
@@ -1059,8 +1087,12 @@ pub async fn get_server_chunking_context(
     } else {
         SourceMapsType::None
     })
-    .module_id_strategy(module_id_strategy)
+    .module_id_strategy(module_id_strategy.to_resolved().await?)
     .file_tracing(next_mode.is_production());
+
+    if let Some(export_usage) = *export_usage.await? {
+        builder = builder.export_usage(export_usage);
+    }
 
     if next_mode.is_development() {
         builder = builder.use_file_source_map_uris()

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1012,11 +1012,8 @@ pub async fn get_server_chunking_context_with_client_assets(
         SourceMapsType::None
     })
     .module_id_strategy(module_id_strategy.to_resolved().await?)
+    .export_usage(*export_usage.await?)
     .file_tracing(next_mode.is_production());
-
-    if let Some(export_usage) = *export_usage.await? {
-        builder = builder.export_usage(export_usage);
-    }
 
     if next_mode.is_development() {
         builder = builder.use_file_source_map_uris();
@@ -1088,11 +1085,8 @@ pub async fn get_server_chunking_context(
         SourceMapsType::None
     })
     .module_id_strategy(module_id_strategy.to_resolved().await?)
+    .export_usage(*export_usage.await?)
     .file_tracing(next_mode.is_production());
-
-    if let Some(export_usage) = *export_usage.await? {
-        builder = builder.export_usage(export_usage);
-    }
 
     if next_mode.is_development() {
         builder = builder.use_file_source_map_uris()

--- a/crates/next-core/src/next_server/mod.rs
+++ b/crates/next-core/src/next_server/mod.rs
@@ -3,7 +3,8 @@ pub(crate) mod resolve;
 pub(crate) mod transforms;
 
 pub use context::{
-    ServerContextType, get_server_chunking_context, get_server_chunking_context_with_client_assets,
-    get_server_compile_time_info, get_server_module_options_context,
-    get_server_resolve_options_context, get_server_runtime_entries,
+    ServerChunkingContextOptions, ServerContextType, get_server_chunking_context,
+    get_server_chunking_context_with_client_assets, get_server_compile_time_info,
+    get_server_module_options_context, get_server_resolve_options_context,
+    get_server_runtime_entries,
 };

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -21,7 +21,11 @@ use turbopack_core::{
     environment::Environment,
     ident::AssetIdent,
     module::Module,
-    module_graph::{ModuleGraph, chunk_group_info::ChunkGroup},
+    module_graph::{
+        ModuleGraph,
+        chunk_group_info::ChunkGroup,
+        export_usage::{ExportUsageInfo, ModuleExportUsageInfo},
+    },
     output::{OutputAsset, OutputAssets},
 };
 use turbopack_ecmascript::{
@@ -150,6 +154,11 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
+    pub fn export_usage(mut self, export_usage: ResolvedVc<ExportUsageInfo>) -> Self {
+        self.chunking_context.export_usage = Some(export_usage);
+        self
+    }
+
     pub fn chunking_config<T>(mut self, ty: ResolvedVc<T>, chunking_config: ChunkingConfig) -> Self
     where
         T: Upcast<Box<dyn ChunkType>>,
@@ -225,6 +234,8 @@ pub struct BrowserChunkingContext {
     manifest_chunks: bool,
     /// The module id strategy to use
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
+    /// The module export usage info, if available.
+    export_usage: Option<ResolvedVc<ExportUsageInfo>>,
     /// The chunking configs
     chunking_configs: Vec<(ResolvedVc<Box<dyn ChunkType>>, ChunkingConfig)>,
 }
@@ -264,6 +275,7 @@ impl BrowserChunkingContext {
                 current_chunk_method: CurrentChunkMethod::StringLiteral,
                 manifest_chunks: false,
                 module_id_strategy: ResolvedVc::upcast(DevModuleIdStrategy::new_resolved()),
+                export_usage: None,
                 chunking_configs: Default::default(),
             },
         }
@@ -713,5 +725,17 @@ impl ChunkingContext for BrowserChunkingContext {
         } else {
             self.chunk_item_id_from_ident(AsyncLoaderModule::asset_ident_for(module))
         })
+    }
+
+    #[turbo_tasks::function]
+    async fn module_export_usage(
+        self: Vc<Self>,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Result<Vc<ModuleExportUsageInfo>> {
+        if let Some(export_usage) = self.await?.export_usage {
+            Ok(export_usage.await?.used_exports(module))
+        } else {
+            Ok(ModuleExportUsageInfo::all())
+        }
     }
 }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -154,8 +154,8 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn export_usage(mut self, export_usage: ResolvedVc<ExportUsageInfo>) -> Self {
-        self.chunking_context.export_usage = Some(export_usage);
+    pub fn export_usage(mut self, export_usage: Option<ResolvedVc<ExportUsageInfo>>) -> Self {
+        self.chunking_context.export_usage = export_usage;
         self
     }
 

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -343,7 +343,7 @@ async fn build_internal(
             )
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
-            .export_usage(export_usage)
+            .export_usage(Some(export_usage))
             .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
             .minify_type(minify_type);
 
@@ -391,7 +391,7 @@ async fn build_internal(
             )
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
-            .export_usage(export_usage)
+            .export_usage(Some(export_usage))
             .minify_type(minify_type);
 
             match *node_env.await? {

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -35,6 +35,7 @@ use turbopack_core::{
     module_graph::{
         ModuleGraph,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+        export_usage::compute_export_usage_info,
     },
     output::{OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
@@ -314,6 +315,9 @@ async fn build_internal(
             .to_resolved()
             .await?,
     );
+    let export_usage = compute_export_usage_info(module_graph.to_resolved().await?)
+        .resolve_strongly_consistent()
+        .await?;
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match target {
         Target::Browser => {
@@ -339,6 +343,7 @@ async fn build_internal(
             )
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
+            .export_usage(export_usage)
             .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
             .minify_type(minify_type);
 
@@ -386,6 +391,7 @@ async fn build_internal(
             )
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
+            .export_usage(export_usage)
             .minify_type(minify_type);
 
             match *node_env.await? {

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -13,7 +13,10 @@ use crate::{
     environment::Environment,
     ident::AssetIdent,
     module::Module,
-    module_graph::{ModuleGraph, chunk_group_info::ChunkGroup, module_batches::BatchingConfig},
+    module_graph::{
+        ModuleGraph, chunk_group_info::ChunkGroup, export_usage::ModuleExportUsageInfo,
+        module_batches::BatchingConfig,
+    },
     output::{OutputAsset, OutputAssets},
 };
 
@@ -292,6 +295,12 @@ pub trait ChunkingContext {
     fn chunk_item_id_from_module(self: Vc<Self>, module: Vc<Box<dyn Module>>) -> Vc<ModuleId> {
         self.chunk_item_id_from_ident(module.ident())
     }
+
+    #[turbo_tasks::function]
+    async fn module_export_usage(
+        self: Vc<Self>,
+        module: Vc<Box<dyn Module>>,
+    ) -> Result<Vc<ModuleExportUsageInfo>>;
 }
 
 pub trait ChunkingContextExt {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -43,6 +43,7 @@ use crate::{
 
 pub mod async_module_info;
 pub mod chunk_group_info;
+pub mod export_usage;
 pub mod merged_modules;
 pub mod module_batch;
 pub(crate) mod module_batches;

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -12,9 +12,7 @@ use swc_core::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{
-    chunk::ChunkingContext, module_graph::ModuleGraph, reference::ModuleReference,
-};
+use turbopack_core::{chunk::ChunkingContext, reference::ModuleReference};
 
 use crate::{
     ScopeHoistingContext,
@@ -194,30 +192,29 @@ pub enum CodeGen {
 impl CodeGen {
     pub async fn code_generation(
         &self,
-        g: Vc<ModuleGraph>,
         ctx: Vc<Box<dyn ChunkingContext>>,
         scope_hoisting_context: ScopeHoistingContext<'_>,
     ) -> Result<CodeGeneration> {
         match self {
-            Self::AmdDefineWithDependenciesCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::CjsRequireCacheAccess(v) => v.code_generation(g, ctx).await,
-            Self::ConstantConditionCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::ConstantValueCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::DynamicExpression(v) => v.code_generation(g, ctx).await,
-            Self::EsmBinding(v) => v.code_generation(g, ctx, scope_hoisting_context).await,
-            Self::EsmModuleItem(v) => v.code_generation(g, ctx).await,
-            Self::IdentReplacement(v) => v.code_generation(g, ctx).await,
-            Self::ImportMetaBinding(v) => v.code_generation(g, ctx).await,
-            Self::ImportMetaRef(v) => v.code_generation(g, ctx).await,
-            Self::MemberReplacement(v) => v.code_generation(g, ctx).await,
-            Self::Unreachable(v) => v.code_generation(g, ctx).await,
-            Self::CjsRequireAssetReferenceCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::CjsRequireResolveAssetReferenceCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::EsmAsyncAssetReferenceCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::EsmModuleIdAssetReferenceCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::RequireContextAssetReferenceCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::UrlAssetReferenceCodeGen(v) => v.code_generation(g, ctx).await,
-            Self::WorkerAssetReferenceCodeGen(v) => v.code_generation(g, ctx).await,
+            Self::AmdDefineWithDependenciesCodeGen(v) => v.code_generation(ctx).await,
+            Self::CjsRequireCacheAccess(v) => v.code_generation(ctx).await,
+            Self::ConstantConditionCodeGen(v) => v.code_generation(ctx).await,
+            Self::ConstantValueCodeGen(v) => v.code_generation(ctx).await,
+            Self::DynamicExpression(v) => v.code_generation(ctx).await,
+            Self::EsmBinding(v) => v.code_generation(ctx, scope_hoisting_context).await,
+            Self::EsmModuleItem(v) => v.code_generation(ctx).await,
+            Self::IdentReplacement(v) => v.code_generation(ctx).await,
+            Self::ImportMetaBinding(v) => v.code_generation(ctx).await,
+            Self::ImportMetaRef(v) => v.code_generation(ctx).await,
+            Self::MemberReplacement(v) => v.code_generation(ctx).await,
+            Self::Unreachable(v) => v.code_generation(ctx).await,
+            Self::CjsRequireAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
+            Self::CjsRequireResolveAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
+            Self::EsmAsyncAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
+            Self::EsmModuleIdAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
+            Self::RequireContextAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
+            Self::UrlAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
+            Self::WorkerAssetReferenceCodeGen(v) => v.code_generation(ctx).await,
         }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
@@ -92,13 +92,12 @@ impl ChunkableModule for MergedEcmascriptModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
-        module_graph: ResolvedVc<ModuleGraph>,
+        _module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn ChunkItem>> {
         Vc::upcast(
             MergedEcmascriptModuleChunkItem {
                 module: self,
-                module_graph,
                 chunking_context,
             }
             .cell(),
@@ -109,7 +108,6 @@ impl ChunkableModule for MergedEcmascriptModule {
 #[turbo_tasks::value]
 struct MergedEcmascriptModuleChunkItem {
     module: ResolvedVc<MergedEcmascriptModule>,
-    module_graph: ResolvedVc<ModuleGraph>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
@@ -159,11 +157,7 @@ impl EcmascriptChunkItem for MergedEcmascriptModuleChunkItem {
                 let Some(m) = ResolvedVc::try_downcast::<Box<dyn EcmascriptAnalyzable>>(*m) else {
                     anyhow::bail!("Expected EcmascriptAnalyzable in scope hoisting group");
                 };
-                Ok(m.module_content_options(
-                    *self.module_graph,
-                    *self.chunking_context,
-                    async_module_info,
-                ))
+                Ok(m.module_content_options(*self.chunking_context, async_module_info))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -18,7 +18,6 @@ use turbo_tasks::{
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
     issue::IssueSource,
-    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
 };
@@ -157,7 +156,6 @@ impl AmdDefineWithDependenciesCodeGen {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let mut visitors = Vec::new();

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -12,7 +12,6 @@ use turbo_tasks::{
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
     issue::IssueSource,
-    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
 };
@@ -157,7 +156,6 @@ pub struct CjsRequireAssetReferenceCodeGen {
 impl CjsRequireAssetReferenceCodeGen {
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let reference = self.reference.await?;
@@ -281,7 +279,6 @@ pub struct CjsRequireResolveAssetReferenceCodeGen {
 impl CjsRequireResolveAssetReferenceCodeGen {
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let reference = self.reference.await?;
@@ -344,7 +341,6 @@ impl CjsRequireCacheAccess {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let mut visitors = Vec::new();

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use super::AstPath;
 use crate::{
@@ -32,7 +32,6 @@ impl ConstantConditionCodeGen {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let value = self.value;

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -2,9 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
 use turbo_tasks::{NonLocalValue, TaskInput, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{
-    chunk::ChunkingContext, compile_time_info::CompileTimeDefineValue, module_graph::ModuleGraph,
-};
+use turbopack_core::{chunk::ChunkingContext, compile_time_info::CompileTimeDefineValue};
 
 use super::AstPath;
 use crate::{
@@ -36,7 +34,6 @@ impl ConstantValueCodeGen {
     }
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let value = self.value.clone();

--- a/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use super::AstPath;
 use crate::{
@@ -39,7 +39,6 @@ impl DynamicExpression {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let visitor = match self.ty {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -23,6 +23,7 @@ use turbopack_core::{
         OptionStyledString, StyledString,
     },
     module::Module,
+    module_graph::export_usage::ModuleExportUsageInfo,
     reference::ModuleReference,
     reference_type::{EcmaScriptModulesReferenceSubType, ImportWithType},
     resolve::{
@@ -165,7 +166,7 @@ impl ReferencedAsset {
                     && let Some(export) = &export
                     && let EcmascriptExports::EsmExports(exports) = *asset.get_exports().await?
                 {
-                    let exports = exports.expand_exports(None).await?;
+                    let exports = exports.expand_exports(ModuleExportUsageInfo::all()).await?;
                     let esm_export = exports.exports.get(export);
                     match esm_export {
                         Some(EsmExport::LocalBinding(_, _)) => {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -6,7 +6,7 @@ use swc_core::ecma::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use super::EsmAssetReference;
 use crate::{
@@ -57,7 +57,6 @@ impl EsmBinding {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         scope_hoisting_context: ScopeHoistingContext<'_>,
     ) -> Result<CodeGeneration> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -13,7 +13,6 @@ use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption},
     environment::ChunkLoading,
     issue::IssueSource,
-    module_graph::ModuleGraph,
     reference::ModuleReference,
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{
@@ -131,7 +130,6 @@ pub struct EsmAsyncAssetReferenceCodeGen {
 impl EsmAsyncAssetReferenceCodeGen {
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let reference = self.reference.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -10,7 +10,7 @@ use swc_core::{
 use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use crate::{
     code_gen::{CodeGen, CodeGeneration},
@@ -38,7 +38,6 @@ impl ImportMetaBinding {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let rel_path = chunking_context
@@ -98,7 +97,6 @@ impl ImportMetaRef {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let visitor = create_visitor!(self.ast_path, visit_mut_expr, |expr: &mut Expr| {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -7,7 +7,6 @@ use turbo_tasks::{
 };
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext, ChunkingTypeOption, ModuleChunkItemIdExt},
-    module_graph::ModuleGraph,
     reference::ModuleReference,
     resolve::ModuleResolveResult,
 };
@@ -83,7 +82,6 @@ pub struct EsmModuleIdAssetReferenceCodeGen {
 impl EsmModuleIdAssetReferenceCodeGen {
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let mut visitors = Vec::new();

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -11,7 +11,7 @@ use swc_core::{
     quote,
 };
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use crate::{
     code_gen::{CodeGen, CodeGeneration},
@@ -34,7 +34,6 @@ impl EsmModuleItem {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let mut visitors = Vec::new();

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -16,7 +16,6 @@ use turbopack_core::{
     },
     environment::Rendering,
     issue::IssueSource,
-    module_graph::ModuleGraph,
     reference::ModuleReference,
     reference_type::{ReferenceType, UrlReferenceSubType},
     resolve::{
@@ -173,7 +172,6 @@ impl UrlAssetReferenceCodeGen {
     */
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let mut visitors = vec![];

--- a/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use swc_core::{ecma::ast::Expr, quote};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use super::AstPath;
 use crate::{
@@ -24,7 +24,6 @@ impl IdentReplacement {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let value = self.value.clone();

--- a/turbopack/crates/turbopack-ecmascript/src/references/member.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/member.rs
@@ -7,7 +7,7 @@ use swc_core::{
 };
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use super::AstPath;
 use crate::{
@@ -29,7 +29,6 @@ impl MemberReplacement {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let key = self.key.clone();

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -318,7 +318,6 @@ pub struct RequireContextAssetReferenceCodeGen {
 impl RequireContextAssetReferenceCodeGen {
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let module_id = self

--- a/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
@@ -24,7 +24,7 @@ use swc_core::{
     quote,
 };
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
-use turbopack_core::{chunk::ChunkingContext, module_graph::ModuleGraph};
+use turbopack_core::chunk::ChunkingContext;
 
 use crate::{
     code_gen::{AstModifier, CodeGen, CodeGeneration},
@@ -139,7 +139,6 @@ impl Unreachable {
 
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let comments = SwcComments::default();

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -13,7 +13,6 @@ use turbopack_core::{
     chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext},
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, code_gen::CodeGenerationIssue},
     module::Module,
-    module_graph::ModuleGraph,
     reference::ModuleReference,
     reference_type::{ReferenceType, WorkerReferenceSubType},
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request, url_resolve},
@@ -134,7 +133,6 @@ pub struct WorkerAssetReferenceCodeGen {
 impl WorkerAssetReferenceCodeGen {
     pub async fn code_generation(
         &self,
-        _module_graph: Vc<ModuleGraph>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
         let Some(loader) = self.reference.await?.worker_loader_module().await? else {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -4,7 +4,6 @@ use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext},
     ident::AssetIdent,
     module::Module,
-    module_graph::ModuleGraph,
 };
 
 use super::module::EcmascriptModuleFacadeModule;
@@ -20,7 +19,6 @@ use crate::{
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptModuleFacadeChunkItem {
     pub(crate) module: ResolvedVc<EcmascriptModuleFacadeModule>,
-    pub(crate) module_graph: ResolvedVc<ModuleGraph>,
     pub(crate) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
@@ -37,11 +35,10 @@ impl EcmascriptChunkItem for EcmascriptModuleFacadeChunkItem {
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let chunking_context = self.chunking_context;
-        let module_graph = self.module_graph;
 
-        let content =
-            self.module
-                .module_content(*module_graph, *chunking_context, async_module_info);
+        let content = self
+            .module
+            .module_content(*chunking_context, async_module_info);
 
         let async_module_options = self
             .module

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -4,7 +4,6 @@ use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext},
     ident::AssetIdent,
     module::Module,
-    module_graph::ModuleGraph,
 };
 
 use super::module::EcmascriptModuleLocalsModule;
@@ -17,7 +16,6 @@ use crate::{
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptModuleLocalsChunkItem {
     pub(super) module: ResolvedVc<EcmascriptModuleLocalsModule>,
-    pub(super) module_graph: ResolvedVc<ModuleGraph>,
     pub(super) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
@@ -35,7 +33,6 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let module = self.module.await?;
         let chunking_context = self.chunking_context;
-        let module_graph = self.module_graph;
         let original_module = module.module;
 
         let analyze = original_module.analyze();
@@ -44,9 +41,9 @@ impl EcmascriptChunkItem for EcmascriptModuleLocalsChunkItem {
             .async_module
             .module_options(async_module_info);
 
-        let content =
-            self.module
-                .module_content(*module_graph, *chunking_context, async_module_info);
+        let content = self
+            .module
+            .module_content(*chunking_context, async_module_info);
 
         Ok(EcmascriptChunkItemContent::new(
             content,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -28,7 +28,6 @@ use crate::{
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptModulePartChunkItem {
     pub(super) module: ResolvedVc<EcmascriptModulePartAsset>,
-    pub(super) module_graph: ResolvedVc<ModuleGraph>,
     pub(super) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }
 
@@ -48,11 +47,9 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
         let analyze_ref = analyze.await?;
         let async_module_options = analyze_ref.async_module.module_options(async_module_info);
 
-        let content = self.module.module_content(
-            *self.module_graph,
-            *self.chunking_context,
-            async_module_info,
-        );
+        let content = self
+            .module
+            .module_content(*self.chunking_context, async_module_info);
 
         Ok(EcmascriptChunkItemContent::new(
             content,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -88,8 +88,8 @@ impl NodeJsChunkingContextBuilder {
         self
     }
 
-    pub fn export_usage(mut self, export_usage: ResolvedVc<ExportUsageInfo>) -> Self {
-        self.chunking_context.export_usage = Some(export_usage);
+    pub fn export_usage(mut self, export_usage: Option<ResolvedVc<ExportUsageInfo>>) -> Self {
+        self.chunking_context.export_usage = export_usage;
         self
     }
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -16,7 +16,11 @@ use turbopack_core::{
     environment::Environment,
     ident::AssetIdent,
     module::Module,
-    module_graph::{ModuleGraph, chunk_group_info::ChunkGroup},
+    module_graph::{
+        ModuleGraph,
+        chunk_group_info::ChunkGroup,
+        export_usage::{ExportUsageInfo, ModuleExportUsageInfo},
+    },
     output::{OutputAsset, OutputAssets},
 };
 use turbopack_ecmascript::{
@@ -84,6 +88,11 @@ impl NodeJsChunkingContextBuilder {
         self
     }
 
+    pub fn export_usage(mut self, export_usage: ResolvedVc<ExportUsageInfo>) -> Self {
+        self.chunking_context.export_usage = Some(export_usage);
+        self
+    }
+
     pub fn chunking_config<T>(mut self, ty: ResolvedVc<T>, chunking_config: ChunkingConfig) -> Self
     where
         T: Upcast<Box<dyn ChunkType>>,
@@ -134,6 +143,8 @@ pub struct NodeJsChunkingContext {
     manifest_chunks: bool,
     /// The strategy to use for generating module ids
     module_id_strategy: ResolvedVc<Box<dyn ModuleIdStrategy>>,
+    /// The module export usage info, if available.
+    export_usage: Option<ResolvedVc<ExportUsageInfo>>,
     /// Whether to use file:// uris for source map sources
     should_use_file_source_map_uris: bool,
     /// The chunking configs
@@ -170,6 +181,7 @@ impl NodeJsChunkingContext {
                 manifest_chunks: false,
                 should_use_file_source_map_uris: false,
                 module_id_strategy: ResolvedVc::upcast(DevModuleIdStrategy::new_resolved()),
+                export_usage: None,
                 chunking_configs: Default::default(),
             },
         }
@@ -496,5 +508,17 @@ impl ChunkingContext for NodeJsChunkingContext {
         } else {
             self.chunk_item_id_from_ident(AsyncLoaderModule::asset_ident_for(module))
         })
+    }
+
+    #[turbo_tasks::function]
+    async fn module_export_usage(
+        self: Vc<Self>,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> Result<Vc<ModuleExportUsageInfo>> {
+        if let Some(export_usage) = self.await?.export_usage {
+            Ok(export_usage.await?.used_exports(module))
+        } else {
+            Ok(ModuleExportUsageInfo::all())
+        }
     }
 }


### PR DESCRIPTION
- We didn't actually need the module graph in the chunk item, so this now ensures that we only codegen modules once, regardless on how many pages they are (in dev, nothing changes about builds).
- For that, move the export usage information onto the chunking context, just like the module id functionality.

Closes PACK-5001
Closes PACK-4154