### PR TITLE
[Segment Cache] Support third-party redirects in output: "export" mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "scheduler-experimental-builtin": "npm:scheduler@0.0.0-experimental-73aa744b-20250702",
     "seedrandom": "3.0.5",
     "semver": "7.3.7",
+    "serve-handler": "6.1.6",
     "shell-quote": "1.7.3",
     "strip-ansi": "6.0.0",
     "styled-jsx": "5.1.6",

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2073,6 +2073,8 @@ async function renderToStream(
         formState
       ),
       isStaticGeneration: generateStaticHTML,
+      isBuildTimePrerendering: ctx.workStore.isBuildTimePrerendering === true,
+      buildId: ctx.workStore.buildId,
       getServerInsertedHTML,
       getServerInsertedMetadata,
       validateRootLayout: dev,
@@ -2219,6 +2221,8 @@ async function renderToStream(
           formState
         ),
         isStaticGeneration: generateStaticHTML,
+        isBuildTimePrerendering: ctx.workStore.isBuildTimePrerendering === true,
+        buildId: ctx.workStore.buildId,
         getServerInsertedHTML: makeGetServerInsertedHTML({
           polyfills,
           renderServerInsertedHTML,
@@ -3403,6 +3407,9 @@ async function prerenderToStream(
             ),
             getServerInsertedHTML,
             getServerInsertedMetadata,
+            isBuildTimePrerendering:
+              ctx.workStore.isBuildTimePrerendering === true,
+            buildId: ctx.workStore.buildId,
           }),
           dynamicAccess: consumeDynamicAccess(
             serverDynamicTracking,
@@ -3636,6 +3643,9 @@ async function prerenderToStream(
             ),
             getServerInsertedHTML,
             getServerInsertedMetadata,
+            isBuildTimePrerendering:
+              ctx.workStore.isBuildTimePrerendering === true,
+            buildId: ctx.workStore.buildId,
           }),
           dynamicAccess: dynamicTracking.dynamicAccesses,
           // TODO: Should this include the SSR pass?
@@ -3728,6 +3738,9 @@ async function prerenderToStream(
             formState
           ),
           isStaticGeneration: true,
+          isBuildTimePrerendering:
+            ctx.workStore.isBuildTimePrerendering === true,
+          buildId: ctx.workStore.buildId,
           getServerInsertedHTML,
           getServerInsertedMetadata,
         }),
@@ -3906,6 +3919,9 @@ async function prerenderToStream(
             formState
           ),
           isStaticGeneration: true,
+          isBuildTimePrerendering:
+            ctx.workStore.isBuildTimePrerendering === true,
+          buildId: ctx.workStore.buildId,
           getServerInsertedHTML: makeGetServerInsertedHTML({
             polyfills,
             renderServerInsertedHTML,

--- a/packages/next/src/shared/lib/segment-cache/output-export-prefetch-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/output-export-prefetch-encoding.ts
@@ -1,0 +1,61 @@
+// In output: export mode, the build id is added to the start of the HTML
+// document, directly after the doctype declaration. During a prefetch, the
+// client performs a range request to get the build id, so it can check whether
+// the target page belongs to the same build.
+//
+// The first 64 bytes of the document are requested. The exact number isn't
+// too important; it must be larger than the build id + doctype + closing and
+// ending comment markers, but it doesn't need to match the end of the
+// comment exactly.
+//
+// Build ids are 21 bytes long in the default implementation, though this
+// can be overridden in the Next.js config. For the purposes of this check,
+// it's OK to only match the start of the id, so we'll truncate it if exceeds
+// a certain length.
+
+const DOCTYPE_PREFIX = '<!DOCTYPE html>' // 15 bytes
+const MAX_BUILD_ID_LENGTH = 24
+
+// Request the first 64 bytes. The Range header is inclusive of the end value.
+export const DOC_PREFETCH_RANGE_HEADER_VALUE = 'bytes=0-63'
+
+function escapeBuildId(buildId: string) {
+  // If the build id is longer than the given limit, it's OK for our purposes
+  // to only match the beginning.
+  const truncated = buildId.slice(0, MAX_BUILD_ID_LENGTH)
+  // Replace hyphens with underscores so it doesn't break the HTML comment.
+  // (Unlikely, but if this did happen it would break the whole document.)
+  return truncated.replace(/-/g, '_')
+}
+
+export function insertBuildIdComment(originalHtml: string, buildId: string) {
+  if (
+    // Skip if the build id contains a closing comment marker.
+    buildId.includes('-->') ||
+    // React always inserts a doctype at the start of the document. Skip if it
+    // isn't present. Shouldn't happen; suggests an issue elsewhere.
+    !originalHtml.startsWith(DOCTYPE_PREFIX)
+  ) {
+    // Return the original HTML unchanged. This means the document will not
+    // be prefetched.
+    // TODO: The build id comment is currently only used during prefetches, but
+    // if we eventually use this mechanism for regular navigations, we may need
+    // to error during build if we fail to insert it for some reason.
+    return originalHtml
+  }
+  // The comment must be inserted after the doctype.
+  return originalHtml.replace(
+    DOCTYPE_PREFIX,
+    DOCTYPE_PREFIX + '<!--' + escapeBuildId(buildId) + '-->'
+  )
+}
+
+export function doesExportedHtmlMatchBuildId(
+  partialHtmlDocument: string,
+  buildId: string
+) {
+  // Check whether the document starts with the expected buildId.
+  return partialHtmlDocument.startsWith(
+    DOCTYPE_PREFIX + '<!--' + escapeBuildId(buildId) + '-->'
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       semver:
         specifier: 7.3.7
         version: 7.3.7
+      serve-handler:
+        specifier: 6.1.6
+        version: 6.1.6
       shell-quote:
         specifier: 1.7.3
         version: 1.7.3
@@ -7382,6 +7385,10 @@ packages:
   constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
 
+  content-disposition@0.5.2:
+    resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@0.5.3:
     resolution: {integrity: sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==}
     engines: {node: '>= 0.6'}
@@ -11873,12 +11880,20 @@ packages:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
     hasBin: true
 
+  mime-db@1.33.0:
+    resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.47.0:
     resolution: {integrity: sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==}
     engines: {node: '>= 0.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.18:
+    resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
@@ -12825,6 +12840,9 @@ packages:
 
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+
+  path-to-regexp@3.3.0:
+    resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
   path-to-regexp@6.1.0:
     resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
@@ -13943,6 +13961,10 @@ packages:
   randomfill@1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
+  range-parser@1.2.0:
+    resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
+    engines: {node: '>= 0.6'}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -14748,6 +14770,9 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
+  serve-handler@6.1.6:
+    resolution: {integrity: sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==}
+
   serve-index@1.9.1:
     resolution: {integrity: sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==}
     engines: {node: '>= 0.8.0'}
@@ -15329,7 +15354,7 @@ packages:
   superagent@3.8.3:
     resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superstruct@1.0.3:
     resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}
@@ -23580,6 +23605,8 @@ snapshots:
 
   constants-browserify@1.0.0: {}
 
+  content-disposition@0.5.2: {}
+
   content-disposition@0.5.3:
     dependencies:
       safe-buffer: 5.1.2
@@ -29868,9 +29895,15 @@ snapshots:
       bn.js: 4.11.9
       brorand: 1.1.0
 
+  mime-db@1.33.0: {}
+
   mime-db@1.47.0: {}
 
   mime-db@1.52.0: {}
+
+  mime-types@2.1.18:
+    dependencies:
+      mime-db: 1.33.0
 
   mime-types@2.1.35:
     dependencies:
@@ -30926,6 +30959,8 @@ snapshots:
   path-to-regexp@0.1.12: {}
 
   path-to-regexp@0.1.7: {}
+
+  path-to-regexp@3.3.0: {}
 
   path-to-regexp@6.1.0: {}
 
@@ -32058,6 +32093,8 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
+  range-parser@1.2.0: {}
+
   range-parser@1.2.1: {}
 
   raw-body@2.4.0:
@@ -33132,6 +33169,16 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  serve-handler@6.1.6:
+    dependencies:
+      bytes: 3.0.0
+      content-disposition: 0.5.2
+      mime-types: 2.1.18
+      minimatch: 3.1.2
+      path-is-inside: 1.0.2
+      path-to-regexp: 3.3.0
+      range-parser: 1.2.0
 
   serve-index@1.9.1:
     dependencies:

--- a/test/e2e/app-dir/segment-cache/export/server.mjs
+++ b/test/e2e/app-dir/segment-cache/export/server.mjs
@@ -1,37 +1,41 @@
-import express from 'express'
+// import express from 'express'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'node:http'
 
+// output: "export" mode was originally designed to work seamlessly with the
+// "serve" package, which uses "server-handler" internally. It has built-in
+// conventions for things like .html extensions and trailing slashes. Apps that
+// use a different server like ngnix need configuration to match this behavior.
+// TODO: We should improve our documentation around this.
+import handler from 'serve-handler'
+
 const OUT_DIR = join(dirname(fileURLToPath(import.meta.url)), 'out')
 
-const app = express()
+export const server = createServer((request, response) => {
+  // Redirect /redirect-to-target-page to /target-page. Notice that we only have
+  // to redirect the path of the page, not any other resources.
+  if (request.url === '/redirect-to-target-page') {
+    console.log('Redirecting to /target-page')
+    response.writeHead(302, { Location: '/target-page' })
+    response.end()
+    return
+  }
 
-// Redirect /redirect-to-target-page/* to /target-page/*
-app.get('/redirect-to-target-page/:file?', (req, res) => {
-  const { file } = req.params
-  const newUrl = file ? `/target-page/${file}` : '/target-page'
-  console.log(`Redirecting to ${newUrl}`)
-  res.redirect(302, newUrl)
-})
-
-// Rewrite /rewrite-to-target-page/* to /target-page/*
-// NOTE: This intentionally uses `app.use` instead of `app.get` because
-// the latter doesn't let you modify the `req.url` property.
-app.use((req, res, next) => {
-  const url = req.originalUrl
-  if (/^\/rewrite-to-target-page\/?[^/]*$/.test(url)) {
-    const newUrl = req.originalUrl.replace(
+  // Rewrite /rewrite-to-target-page to /target-page
+  // NOTE: This simulates a rewrite using a proxy, which is not something we
+  // officially support or document. It's just here to illustrate how it would
+  // be done in theory.
+  if (/^\/rewrite-to-target-page\/?[^/]*$/.test(request.url)) {
+    const newUrl = request.url.replace(
       '/rewrite-to-target-page',
       '/target-page'
     )
-    console.log(`Rewriting to ${newUrl}`)
-    req.url = newUrl
+    console.log(`Rewriting ${request.url} to ${newUrl}`)
+    request.url = newUrl
   }
-  next()
+
+  return handler(request, response, {
+    public: OUT_DIR,
+  })
 })
-
-// Serve static files from the out directory
-app.use(express.static(OUT_DIR, { extensions: ['html'] }))
-
-export const server = createServer(app)


### PR DESCRIPTION
In output: "export" mode, we can't use headers to request a particular segment. Instead, we encode the extra request information into the URL. This is not part of the "public" interface of the app; it's an internal Next.js implementation detail that the app developer should not need to concern themselves with.

For example, to request a segment:

- Path passed to <Link>:   /path/to/page
- Path passed to fetch:    /path/to/page/__next-segments/_tree

*(This is not the exact protocol, just an illustration.)*

Before we do that, though, we need to account for redirects. Even in output: "export" mode, a proxy might redirect the page to a different location, but we shouldn't assume or expect that they also redirect all the segment files, too.

To check whether the page is redirected, we perform a range request of the first N bytes of the HTML document, just enough to verify the document comes from the same build. The canonical URL is determined from the response.

Then we can use the canonical URL to request the route tree.

Note: We could embed the route tree into the HTML document, to avoid a second request. We're not doing that currently because it would make the HTML document larger and affect normal page loads.