### PR TITLE
Fix NEXT_CPU_PROF during development

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -1,3 +1,5 @@
+// Start CPU profile if it wasn't already started.
+import './cpu-profile'
 import { getNetworkHost } from '../../lib/get-network-host'
 
 if (performance.getEntriesByName('next-start').length === 0) {


### PR DESCRIPTION
## What?

`next dev` spawns a forked process that wouldn't be instrumented because `cpu-profile.ts` only runs in `cli/next-dev.ts` which is the process that boots the forked process. This adds the initialization to the forked process too. 

Closes PACK-4999