### PR TITLE
Turbopack: move write_version feature to env var

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -18,8 +18,6 @@ default = []
 # A binary built with this option **is not portable**, the directory
 # path will be embedded into the binary.
 dynamic_embed_contents = []
-# Write a hashed version of each file to allow to debug conflicting writes
-write_version = []
 
 [lints]
 workspace = true

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -32,7 +32,7 @@ use std::{
     io::{self, BufRead, BufReader, ErrorKind, Read},
     mem::take,
     path::{MAIN_SEPARATOR, Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 
@@ -786,8 +786,12 @@ impl FileSystem for DiskFileSystem {
                         #[cfg(target_family = "unix")]
                         f.set_permissions(file.meta.permissions.into())?;
                         f.flush()?;
-                        #[cfg(feature = "write_version")]
-                        {
+
+                        static WRITE_VERSION: LazyLock<bool> = LazyLock::new(|| {
+                            std::env::var_os("TURBOPACK_WRITE_VERSION")
+                                .is_some_and(|v| v == "1" || v == "true")
+                        });
+                        if *WRITE_VERSION {
                             let mut full_path = full_path.to_owned();
                             let hash = hash_xxh3_hash64(file);
                             let ext = full_path.extension();

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -788,7 +788,7 @@ impl FileSystem for DiskFileSystem {
                         f.flush()?;
 
                         static WRITE_VERSION: LazyLock<bool> = LazyLock::new(|| {
-                            std::env::var_os("TURBOPACK_WRITE_VERSION")
+                            std::env::var_os("TURBO_ENGINE_WRITE_VERSION")
                                 .is_some_and(|v| v == "1" || v == "true")
                         });
                         if *WRITE_VERSION {


### PR DESCRIPTION
This is useful for debugging infinite file write loop situations. Put it behind the env var `TURBO_ENGINE_WRITE_VERSION=1` to be able to debug this if other people want to debug this without recompiling Next.js

Closes PACK-5000