### PR TITLE
Ensure default run name is correct for deploy tests

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -22,7 +22,7 @@ env:
   TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
   DD_ENV: 'ci'
 
-run-name: test-e2e-deploy ${{ inputs.nextVersion }}
+run-name: test-e2e-deploy ${{ inputs.nextVersion || 'canary' }}
 
 jobs:
   setup:


### PR DESCRIPTION
Looks like when the retry workflow is triggered from the release workflow it doesn't have the default input like it should so this adds the fallback inline for the run-name. 