### PR TITLE
[dynamicIO] Don't abort prospective render on sync access during SSR

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2433,14 +2433,15 @@ async function spawnDynamicValidationInDev(
   }
 
   if (initialServerResult) {
-    const initialClientController = new AbortController()
+    const initialClientRenderController = new AbortController()
+    const initialClientPrerenderController = new AbortController()
     const initialClientPrerenderStore: PrerenderStore = {
       type: 'prerender-client',
       phase: 'render',
       rootParams,
       implicitTags,
-      renderSignal: initialClientController.signal,
-      controller: initialClientController,
+      renderSignal: initialClientRenderController.signal,
+      controller: initialClientPrerenderController,
       // For HTML Generation the only cache tracked activity
       // is module loading, which has it's own cache signal
       cacheSignal: null,
@@ -2471,7 +2472,7 @@ async function spawnDynamicValidationInDev(
         nonce={nonce}
       />,
       {
-        signal: initialClientController.signal,
+        signal: initialClientRenderController.signal,
         onError: (err) => {
           const digest = getDigestForWellKnownError(err)
 
@@ -2485,7 +2486,7 @@ async function spawnDynamicValidationInDev(
             return undefined
           }
 
-          if (initialClientController.signal.aborted) {
+          if (initialClientRenderController.signal.aborted) {
             // These are expected errors that might error the prerender. we ignore them.
           } else if (
             process.env.NEXT_DEBUG_BUILD ||
@@ -2521,7 +2522,7 @@ async function spawnDynamicValidationInDev(
     // Promises passed to client were already awaited above (assuming that they came from cached functions)
     trackPendingModules(cacheSignal)
     await cacheSignal.cacheReady()
-    initialClientController.abort()
+    initialClientRenderController.abort()
   }
 
   const finalServerController = new AbortController()
@@ -3053,14 +3054,15 @@ async function prerenderToStream(
       }
 
       if (initialServerResult) {
-        const initialClientController = new AbortController()
+        const initialClientRenderController = new AbortController()
+        const initialClientPrerenderController = new AbortController()
         const initialClientPrerenderStore: PrerenderStore = {
           type: 'prerender-client',
           phase: 'render',
           rootParams,
           implicitTags,
-          renderSignal: initialClientController.signal,
-          controller: initialClientController,
+          renderSignal: initialClientRenderController.signal,
+          controller: initialClientPrerenderController,
           // For HTML Generation the only cache tracked activity
           // is module loading, which has it's own cache signal
           cacheSignal: null,
@@ -3091,7 +3093,7 @@ async function prerenderToStream(
             nonce={nonce}
           />,
           {
-            signal: initialClientController.signal,
+            signal: initialClientRenderController.signal,
             onError: (err) => {
               const digest = getDigestForWellKnownError(err)
 
@@ -3105,7 +3107,7 @@ async function prerenderToStream(
                 return undefined
               }
 
-              if (initialClientController.signal.aborted) {
+              if (initialClientRenderController.signal.aborted) {
                 // These are expected errors that might error the prerender. we ignore them.
               } else if (
                 process.env.NEXT_DEBUG_BUILD ||
@@ -3140,7 +3142,7 @@ async function prerenderToStream(
         // Promises passed to client were already awaited above (assuming that they came from cached functions)
         trackPendingModules(cacheSignal)
         await cacheSignal.cacheReady()
-        initialClientController.abort()
+        initialClientRenderController.abort()
       }
 
       let serverIsDynamic = false

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.module-scope.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.module-scope.test.ts
@@ -25,12 +25,23 @@ describe('Lazy Module Init', () => {
 
     expect(next.cliOutput).toContain('○ /server ')
     expect(next.cliOutput).toContain('○ /client ')
+    expect(next.cliOutput).toContain('◐ /client-page ')
+    expect(next.cliOutput).toContain('◐ /[dyn] ')
     let $
 
     $ = await next.render$('/server')
     expect($('#id').text().length).toBeGreaterThan(0)
 
     $ = await next.render$('/client')
+    expect($('#id').text().length).toBeGreaterThan(0)
+
+    $ = await next.render$('/client-page')
+    expect($('#id').text().length).toBeGreaterThan(0)
+
+    $ = await next.render$('/foo')
+    expect($('#id').text().length).toBeGreaterThan(0)
+
+    $ = await next.render$('/serial-client-sync-io')
     expect($('#id').text().length).toBeGreaterThan(0)
   })
 })

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/build-id.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/build-id.tsx
@@ -1,0 +1,10 @@
+export async function BuildID() {
+  const buildID = require('./lazy-id').buildID
+  await 1
+  return (
+    <dl>
+      <dt>Build ID</dt>
+      <dd id="id">{buildID}</dd>
+    </dl>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/client-lazy-now-1.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/client-lazy-now-1.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const date = Date.now()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/client-lazy-now-2.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/client-lazy-now-2.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const date = Date.now()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/client-lazy-now-3.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/client-lazy-now-3.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const date = Date.now()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/indirection.tsx
@@ -1,0 +1,7 @@
+export default async function Indirection({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/lazy-id.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/lazy-id.ts
@@ -1,0 +1,1 @@
+export const buildID = Date.now() + Math.random()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/serial-client-sync-io/page.tsx
@@ -1,0 +1,32 @@
+import { BuildID } from './build-id'
+import Indirection from './indirection'
+import { date as date1 } from './client-lazy-now-1'
+import { date as date2 } from './client-lazy-now-2'
+import { date as date3 } from './client-lazy-now-3'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page requires a module lazily during rendering. The Module computes
+        a "static" id using the current time and a random number. If these APIs
+        are used while prerendering they would normally trigger a synchronous
+        dynamic bailout. However since these APIs are used in module scope they
+        are not semantically part of the render and should be usable like other
+        "static" values. We demonstrate this with this fixture by asserting that
+        this page still produces a static result and it does not warn for
+        reading current time and random in a prerender.
+      </p>
+      <BuildID />
+      <Indirection>
+        <p>Date 1: {date1}</p>
+      </Indirection>
+      <Indirection>
+        <p>Date 2: {date2}</p>
+      </Indirection>
+      <Indirection>
+        <p>Date 3: {date3}</p>
+      </Indirection>
+    </>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/client-lazy-now-1.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/client-lazy-now-1.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const date = Date.now()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/client-lazy-now-2.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/client-lazy-now-2.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const date = Date.now()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/client-lazy-now-3.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/client-lazy-now-3.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const date = Date.now()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/indirection.tsx
@@ -1,0 +1,7 @@
+export default async function Indirection({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/page.tsx
@@ -4,14 +4,13 @@ export default async function Page() {
   return (
     <>
       <p>
-        This page requires a module lazily during rendering. The Module computes
-        a "static" id using the current time and a random number. If these APIs
-        are used while prerendering they would normally trigger a synchronous
-        dynamic bailout. However since these APIs are used in module scope they
-        are not semantically part of the render and should be usable like other
-        "static" values. We demonstrate this with this fixture by asserting that
-        this page still produces a static result and it does not warn for
-        reading current time and random in a prerender.
+        This page has several client modules that have sync IO in the module
+        scope that will run in serial when prerendering to HTML. The point of
+        this test is to assert that the serial nature does not lead to
+        unexpected sync IO errors. In the past this particular setup would show
+        up as a sync IO error because the later modules did not initialize
+        during the prospective render and thus appeared to use sync IO when
+        being initialized during the final render.
       </p>
       <BuildID />
     </>


### PR DESCRIPTION
When filling caches we never want to let sync IO interrupt the cache filling render. We already handled this for the react-server render where most caches live. But modules are a form of caches and they similarly rely on the prospective render to "fill" their entry. Prior to this change during SSR prerenders a sync IO could cause the prospective render to abort early. This led to the case where the final render would also potentially abort early for something like a serial sync IO in module scope.