### PR TITLE
bugfix: propagate staleTime to seeded prefetch entry

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -4,7 +4,10 @@ import type { FlightDataPath } from '../../../server/app-render/types'
 import { createHrefFromUrl } from './create-href-from-url'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { extractPathFromFlightRouterState } from './compute-changed-path'
-import { createSeededPrefetchCacheEntry } from './prefetch-cache-utils'
+import {
+  createSeededPrefetchCacheEntry,
+  STATIC_STALETIME_MS,
+} from './prefetch-cache-utils'
 import { PrefetchKind, type PrefetchCacheEntry } from './router-reducer-types'
 import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
@@ -132,7 +135,13 @@ export function createInitialRouterState({
         // add a way to split a single Flight stream into static and dynamic
         // parts. But in the meantime we should at least make this work for
         // fully static pages.
-        staleTime: -1,
+        staleTime:
+          // In the old router, there was only a single configurable staleTime (experimental.staleTimes)
+          // As an abundance of caution, this will only set the initial staleTime to the configured value
+          // if we're not leveraging the segment cache, which has its own prefetching semantics.
+          prerendered && !process.env.__NEXT_CLIENT_SEGMENT_CACHE
+            ? STATIC_STALETIME_MS
+            : -1,
       },
       tree: initialState.tree,
       prefetchCache: initialState.prefetchCache,

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -291,7 +291,7 @@ export function createSeededPrefetchCacheEntry({
     kind,
     prefetchTime: Date.now(),
     lastUsedTime: Date.now(),
-    staleTime: -1,
+    staleTime: data.staleTime,
     key: prefetchCacheKey,
     status: PrefetchCacheEntryStatus.fresh,
     url,

--- a/test/e2e/app-dir/app-prefetch/app/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/page.js
@@ -8,6 +8,9 @@ export default function HomePage() {
       <Link href="/static-page" id="to-static-page">
         To Static Page
       </Link>
+      <Link href="/static-page-no-prefetch" id="to-static-page-no-prefetch">
+        To Static Page No Prefetch
+      </Link>
       <Link href="/dynamic-page" id="to-dynamic-page-no-params">
         To Dynamic Page
       </Link>

--- a/test/e2e/app-dir/app-prefetch/app/static-page-no-prefetch/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/static-page-no-prefetch/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default async function Page() {
+  return (
+    <>
+      <p id="static-page-no-prefetch">Static Page No Prefetch</p>
+      <p>
+        <Link href="/" id="to-home">
+          To home
+        </Link>
+      </p>
+    </>
+  )
+}


### PR DESCRIPTION
In #71280, we hooked up the server-side `staleTime` header to the client-side prefetch cache. This means that if the server responds with a staleTime value, the client router will use that rather than the previous heuristic when determining if a prefetch entry can be reused.

However, there was missing functionality to set a proper staleTime value for the initially seeded prefetch entry (aka the first page visit). In the case of customizing staleTimes, this meant that navigations back to the original page would defer back to the old stale heuristic, which would differ from subsequent navigations that were properly seeded with a staleTime.

Separately, I believe that it's problematic that if the `staleTime` header is present, that we honor that and only set a fresh/stale cache status, because the newer heuristic doesn't consider the `reusable` cache status. This should probably be flagged to the clientSegmentCache flag. However, to minimize the changes here, I've only addressed this particular case. 

