### PR TITLE
Ensure resolvedPathname normalizes trailing slash

### DIFF
--- a/packages/next/src/build/templates/pages.ts
+++ b/packages/next/src/build/templates/pages.ts
@@ -225,7 +225,9 @@ export async function handler(
     const method = req.method || 'GET'
 
     const resolvedUrl = formatUrl({
-      pathname: parsedUrl.pathname,
+      pathname: nextConfig.trailingSlash
+        ? parsedUrl.pathname
+        : removeTrailingSlash(parsedUrl.pathname || '/'),
       // make sure to only add query values from original URL
       query: hasStaticProps ? {} : originalQuery,
     })

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -59,6 +59,7 @@ import {
   type RouterServerContext,
 } from '../lib/router-utils/router-server-context'
 import { decodePathParams } from '../lib/router-utils/decode-path-params'
+import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-trailing-slash'
 
 /**
  * RouteModuleOptions is the options that are passed to the route module, other
@@ -781,6 +782,8 @@ export abstract class RouteModule<
     try {
       resolvedPathname = decodePathParams(resolvedPathname)
     } catch (_) {}
+
+    resolvedPathname = removeTrailingSlash(resolvedPathname)
 
     return {
       query,


### PR DESCRIPTION
Fixes case with trailing slash from refactoring done in https://github.com/vercel/next.js/pull/81144