### PR TITLE
[dynamicIO] Use owner stacks for dynamic validation errors

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -410,7 +410,7 @@ async function exportAppImpl(
       authInterrupts: !!nextConfig.experimental.authInterrupts,
     },
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
-    hasNonMinifiedSourceMappedStacks:
+    hasReadableErrorStacks:
       nextConfig.experimental.serverSourceMaps === true &&
       (process.env.TURBOPACK
         ? nextConfig.experimental.turbopackMinify === false

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -410,6 +410,12 @@ async function exportAppImpl(
       authInterrupts: !!nextConfig.experimental.authInterrupts,
     },
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
+    hasNonMinifiedSourceMappedStacks:
+      nextConfig.experimental.serverSourceMaps === true &&
+      (process.env.TURBOPACK
+        ? nextConfig.experimental.turbopackMinify === false
+        : nextConfig.experimental.serverMinification === false) &&
+      nextConfig.experimental.enablePrerenderSourceMaps === true,
   }
 
   const { publicRuntimeConfig } = nextConfig

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -412,6 +412,8 @@ async function exportAppImpl(
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
     hasReadableErrorStacks:
       nextConfig.experimental.serverSourceMaps === true &&
+      // TODO(NDX-531): Checking (and setting) the minify flags should be
+      // unnecessary once name mapping is fixed.
       (process.env.TURBOPACK
         ? nextConfig.experimental.turbopackMinify === false
         : nextConfig.experimental.serverMinification === false) &&

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2651,7 +2651,7 @@ async function spawnDynamicValidationInDev(
                   const componentStack = errorInfo.componentStack
                   if (typeof componentStack === 'string') {
                     trackAllowedDynamicAccess(
-                      workStore.route,
+                      workStore,
                       componentStack,
                       dynamicValidation,
                       clientDynamicTracking
@@ -3277,7 +3277,7 @@ async function prerenderToStream(
                     ).componentStack
                     if (typeof componentStack === 'string') {
                       trackAllowedDynamicAccess(
-                        workStore.route,
+                        workStore,
                         componentStack,
                         dynamicValidation,
                         clientDynamicTracking

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -664,7 +664,7 @@ async function warmupDevRender(
 ): Promise<RenderResult> {
   const {
     clientReferenceManifest,
-    componentMod,
+    componentMod: ComponentMod,
     getDynamicParamFromSegment,
     implicitTags,
     renderOpts,
@@ -684,7 +684,7 @@ async function warmupDevRender(
   }
 
   const rootParams = getRootParams(
-    componentMod.tree,
+    ComponentMod.tree,
     getDynamicParamFromSegment
   )
 
@@ -725,6 +725,7 @@ async function warmupDevRender(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash: req.cookies[NEXT_HMR_REFRESH_HASH_COOKIE],
+    captureOwnerStack: ComponentMod.captureOwnerStack,
   }
 
   const rscPayload = await workUnitAsyncStorage.run(
@@ -737,7 +738,7 @@ async function warmupDevRender(
   // which contains the subset React.
   workUnitAsyncStorage.run(
     prerenderStore,
-    componentMod.renderToReadableStream,
+    ComponentMod.renderToReadableStream,
     rscPayload,
     clientReferenceManifest.clientModules,
     {
@@ -2309,6 +2310,9 @@ async function spawnDynamicValidationInDev(
   // to cut the render off.
   const cacheSignal = new CacheSignal()
 
+  const captureOwnerStackClient = React.captureOwnerStack
+  const captureOwnerStackServer = ComponentMod.captureOwnerStack
+
   // The resume data cache here should use a fresh instance as it's
   // performing a fresh prerender. If we get to implementing the
   // prerendering of an already prerendered page, we should use the passed
@@ -2334,6 +2338,7 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
+    captureOwnerStack: captureOwnerStackServer,
   }
 
   // We're not going to use the result of this render because the only time it could be used
@@ -2448,6 +2453,7 @@ async function spawnDynamicValidationInDev(
       prerenderResumeDataCache,
       renderResumeDataCache: null,
       hmrRefreshHash: undefined,
+      captureOwnerStack: captureOwnerStackClient,
     }
 
     const prerender = (
@@ -2541,6 +2547,7 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
+    captureOwnerStack: captureOwnerStackServer,
   }
 
   const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -2611,6 +2618,7 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
+    captureOwnerStack: captureOwnerStackClient,
   }
 
   let dynamicValidation = createDynamicValidationState()
@@ -2957,6 +2965,7 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
+        captureOwnerStack: undefined, // Not available in production.
       })
 
       // We're not going to use the result of this render because the only time it could be used
@@ -3064,6 +3073,7 @@ async function prerenderToStream(
           prerenderResumeDataCache,
           renderResumeDataCache,
           hmrRefreshHash: undefined,
+          captureOwnerStack: undefined, // Not available in production.
         }
 
         const prerender = (
@@ -3157,6 +3167,7 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
+        captureOwnerStack: undefined, // Not available in production.
       })
 
       const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -3229,6 +3240,7 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
+        captureOwnerStack: undefined, // Not available in production.
       }
 
       let clientIsDynamic = false

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -648,7 +648,8 @@ export function trackAllowedDynamicAccess(
     )
     return
   } else {
-    const message = `Route "${route}": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
+    // TODO: Guide users to run `next dev` to inspect the error.
+    const message = `Route "${route}": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
     const error = createErrorWithComponentOrOwnerStack(message, componentStack)
     dynamicValidation.dynamicErrors.push(error)
     return

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -714,7 +714,7 @@ export function throwIfDisallowedDynamic(
     if (serverDynamic.syncDynamicErrorWithStack) {
       // There is no shell and the server did something sync dynamic likely
       // leading to an early termination of the prerender before the shell
-      // could be completed.We terminate the build/validating render.
+      // could be completed. We terminate the build/validating render.
       logDisallowedDynamicError(
         workStore,
         serverDynamic.syncDynamicErrorWithStack

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -649,18 +649,24 @@ export function trackAllowedDynamicAccess(
     return
   } else {
     const message = `Route "${route}": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
-    const error = createErrorWithComponentStack(message, componentStack)
+    const error = createErrorWithComponentOrOwnerStack(message, componentStack)
     dynamicValidation.dynamicErrors.push(error)
     return
   }
 }
 
-function createErrorWithComponentStack(
+/**
+ * In dev mode, we prefer using the owner stack, otherwise the provided
+ * component stack is used.
+ */
+function createErrorWithComponentOrOwnerStack(
   message: string,
   componentStack: string
 ) {
+  // `captureOwnerStack` is only provided in dev mode.
+  const ownerStack = React.captureOwnerStack?.()
   const error = new Error(message)
-  error.stack = 'Error: ' + message + componentStack
+  error.stack = error.name + ': ' + message + (ownerStack ?? componentStack)
   return error
 }
 

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -663,8 +663,8 @@ function createErrorWithComponentOrOwnerStack(
   message: string,
   componentStack: string
 ) {
-  // `captureOwnerStack` is only provided in dev mode.
-  const ownerStack = React.captureOwnerStack?.()
+  const ownerStack =
+    process.env.NODE_ENV !== 'production' ? React.captureOwnerStack() : null
   const error = new Error(message)
   error.stack = error.name + ': ' + message + (ownerStack ?? componentStack)
   return error
@@ -682,11 +682,11 @@ function logDisallowedDynamicError(workStore: WorkStore, error: Error): void {
   if (!workStore.dev) {
     if (workStore.hasReadableErrorStacks) {
       console.error(
-        `To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "${workStore.route}" in your browser to investigate the error using the Next.js DevTools.`
+        `To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "${workStore.route}" in your browser to investigate the error.`
       )
     } else {
       console.error(`To get a more detailed stack trace and pinpoint the issue, try one of the following:
-  - Start the app in development mode by running \`next dev\`, then open "${workStore.route}" in your browser to investigate the error using the Next.js DevTools.
+  - Start the app in development mode by running \`next dev\`, then open "${workStore.route}" in your browser to investigate the error.
   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.`)
     }
   }

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -680,7 +680,7 @@ function logDisallowedDynamicError(workStore: WorkStore, error: Error): void {
   console.error(error)
 
   if (!workStore.dev) {
-    if (workStore.hasNonMinifiedSourceMappedStacks) {
+    if (workStore.hasReadableErrorStacks) {
       console.error(
         `To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "${workStore.route}" in your browser to investigate the error using the Next.js DevTools.`
       )

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -616,7 +616,7 @@ const hasViewportRegex = new RegExp(
 const hasOutletRegex = new RegExp(`\\n\\s+at ${OUTLET_BOUNDARY_NAME}[\\n\\s]`)
 
 export function trackAllowedDynamicAccess(
-  route: string,
+  workStore: WorkStore,
   componentStack: string,
   dynamicValidation: DynamicValidationState,
   clientDynamic: DynamicTrackingState
@@ -648,8 +648,7 @@ export function trackAllowedDynamicAccess(
     )
     return
   } else {
-    // TODO: Guide users to run `next dev` to inspect the error.
-    const message = `Route "${route}": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
+    const message = `Route "${workStore.route}": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
     const error = createErrorWithComponentOrOwnerStack(message, componentStack)
     dynamicValidation.dynamicErrors.push(error)
     return
@@ -677,6 +676,22 @@ export enum PreludeState {
   Errored = 2,
 }
 
+function logDisallowedDynamicError(workStore: WorkStore, error: Error): void {
+  console.error(error)
+
+  if (!workStore.dev) {
+    if (workStore.hasNonMinifiedSourceMappedStacks) {
+      console.error(
+        `To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "${workStore.route}" in your browser to investigate the error using the Next.js DevTools.`
+      )
+    } else {
+      console.error(`To get a more detailed stack trace and pinpoint the issue, try one of the following:
+  - Start the app in development mode by running \`next dev\`, then open "${workStore.route}" in your browser to investigate the error using the Next.js DevTools.
+  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.`)
+    }
+  }
+}
+
 export function throwIfDisallowedDynamic(
   workStore: WorkStore,
   prelude: PreludeState,
@@ -684,7 +699,7 @@ export function throwIfDisallowedDynamic(
   serverDynamic: DynamicTrackingState
 ): void {
   if (workStore.invalidDynamicUsageError) {
-    console.error(workStore.invalidDynamicUsageError)
+    logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
     throw new StaticGenBailoutError()
   }
 
@@ -699,9 +714,11 @@ export function throwIfDisallowedDynamic(
     if (serverDynamic.syncDynamicErrorWithStack) {
       // There is no shell and the server did something sync dynamic likely
       // leading to an early termination of the prerender before the shell
-      // could be completed.
-      console.error(serverDynamic.syncDynamicErrorWithStack)
-      // We terminate the build/validating render
+      // could be completed.We terminate the build/validating render.
+      logDisallowedDynamicError(
+        workStore,
+        serverDynamic.syncDynamicErrorWithStack
+      )
       throw new StaticGenBailoutError()
     }
 
@@ -711,7 +728,7 @@ export function throwIfDisallowedDynamic(
     const dynamicErrors = dynamicValidation.dynamicErrors
     if (dynamicErrors.length > 0) {
       for (let i = 0; i < dynamicErrors.length; i++) {
-        console.error(dynamicErrors[i])
+        logDisallowedDynamicError(workStore, dynamicErrors[i])
       }
 
       throw new StaticGenBailoutError()

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -10,6 +10,9 @@ export {
 // eslint-disable-next-line import/no-extraneous-dependencies
 export { unstable_prerender as prerender } from 'react-server-dom-webpack/static'
 
+// eslint-disable-next-line import/no-extraneous-dependencies
+export { captureOwnerStack } from 'react'
+
 export { default as LayoutRouter } from '../../client/components/layout-router'
 export { default as RenderFromTemplateContext } from '../../client/components/render-from-template-context'
 export { workAsyncStorage } from '../app-render/work-async-storage.external'

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -264,6 +264,14 @@ export interface RenderOptsPartial {
   isDebugDynamicAccesses?: boolean
 
   /**
+   * This is true when:
+   * - source maps are generated
+   * - source maps are applied
+   * - minification is disabled
+   */
+  hasNonMinifiedSourceMappedStacks?: boolean
+
+  /**
    * The maximum length of the headers that are emitted by React and added to
    * the response.
    */

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -269,7 +269,7 @@ export interface RenderOptsPartial {
    * - source maps are applied
    * - minification is disabled
    */
-  hasNonMinifiedSourceMappedStacks?: boolean
+  hasReadableErrorStacks?: boolean
 
   /**
    * The maximum length of the headers that are emitted by React and added to

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -43,7 +43,7 @@ export interface WorkStore {
    * - source maps are applied
    * - minification is disabled
    */
-  readonly hasNonMinifiedSourceMappedStacks?: boolean
+  readonly hasReadableErrorStacks?: boolean
 
   readonly isRevalidate?: boolean
 

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -36,6 +36,15 @@ export interface WorkStore {
 
   readonly isOnDemandRevalidate?: boolean
   readonly isBuildTimePrerendering?: boolean
+
+  /**
+   * This is true when:
+   * - source maps are generated
+   * - source maps are applied
+   * - minification is disabled
+   */
+  readonly hasNonMinifiedSourceMappedStacks?: boolean
+
   readonly isRevalidate?: boolean
 
   forceDynamic?: boolean

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -142,6 +142,11 @@ export interface PrerenderStoreModern extends CommonWorkUnitStore {
    * subsequent dynamic render.
    */
   readonly hmrRefreshHash: string | undefined
+
+  /**
+   * Only available in dev mode.
+   */
+  readonly captureOwnerStack: undefined | (() => string | null)
 }
 
 export interface PrerenderStorePPR extends CommonWorkUnitStore {

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -65,6 +65,7 @@ export type WorkStoreContext = {
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
     | 'dev'
+    | 'hasNonMinifiedSourceMappedStacks'
   > &
     RequestLifecycleOpts &
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
@@ -123,6 +124,8 @@ export function createWorkStore({
     cacheLifeProfiles: renderOpts.cacheLifeProfiles,
     isRevalidate: renderOpts.isRevalidate,
     isBuildTimePrerendering: renderOpts.nextExport,
+    hasNonMinifiedSourceMappedStacks:
+      renderOpts.hasNonMinifiedSourceMappedStacks,
     fetchCache: renderOpts.fetchCache,
     isOnDemandRevalidate: renderOpts.isOnDemandRevalidate,
 

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -65,7 +65,7 @@ export type WorkStoreContext = {
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
     | 'dev'
-    | 'hasNonMinifiedSourceMappedStacks'
+    | 'hasReadableErrorStacks'
   > &
     RequestLifecycleOpts &
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
@@ -124,8 +124,7 @@ export function createWorkStore({
     cacheLifeProfiles: renderOpts.cacheLifeProfiles,
     isRevalidate: renderOpts.isRevalidate,
     isBuildTimePrerendering: renderOpts.nextExport,
-    hasNonMinifiedSourceMappedStacks:
-      renderOpts.hasNonMinifiedSourceMappedStacks,
+    hasReadableErrorStacks: renderOpts.hasReadableErrorStacks,
     fetchCache: renderOpts.fetchCache,
     isOnDemandRevalidate: renderOpts.isOnDemandRevalidate,
 

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -46,6 +46,19 @@ export function io(expression: string, type: ApiType) {
           }
           const errorWithStack = new Error(message)
 
+          if (workUnitStore.captureOwnerStack) {
+            const ownerStack = workUnitStore.captureOwnerStack()
+
+            if (ownerStack) {
+              // TODO: Instead of stitching the stacks here, we should log the
+              // original error as-is when it occurs (i.e. here), and let
+              // `patchErrorInspect` handle adding the owner stack, instead of
+              // logging it deferred in the `LogSafely` component via
+              // `throwIfDisallowedDynamic`.
+              applyOwnerStack(errorWithStack, ownerStack)
+            }
+          }
+
           abortOnSynchronousPlatformIOAccess(
             workStore.route,
             expression,
@@ -62,4 +75,24 @@ export function io(expression: string, type: ApiType) {
       trackSynchronousPlatformIOAccessInDev(requestStore)
     }
   }
+}
+
+function applyOwnerStack(error: Error, ownerStack: string) {
+  let stack = ownerStack
+
+  if (error.stack) {
+    const frames: string[] = []
+
+    for (const frame of error.stack.split('\n')) {
+      if (frame.includes('at react-stack-bottom-frame')) {
+        break
+      }
+
+      frames.push(frame)
+    }
+
+    stack = frames.join('\n') + stack
+  }
+
+  error.stack = error.name + ': ' + error.message + stack
 }

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -47,11 +47,8 @@ export function io(expression: string, type: ApiType) {
 
           const errorWithStack = new Error(message)
 
-          if (
-            process.env.NODE_ENV !== 'production' &&
-            workUnitStore.captureOwnerStack
-          ) {
-            const ownerStack = workUnitStore.captureOwnerStack()
+          if (process.env.NODE_ENV !== 'production') {
+            const ownerStack = workUnitStore.captureOwnerStack!()
 
             if (ownerStack) {
               // TODO: Instead of stitching the stacks here, we should log the

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -46,15 +46,21 @@ export function io(expression: string, type: ApiType) {
           }
 
           const errorWithStack = new Error(message)
-          const ownerStack = workUnitStore.captureOwnerStack?.()
 
-          if (ownerStack) {
-            // TODO: Instead of stitching the stacks here, we should log the
-            // original error as-is when it occurs (i.e. here), and let
-            // `patchErrorInspect` handle adding the owner stack, instead of
-            // logging it deferred in the `LogSafely` component via
-            // `throwIfDisallowedDynamic`.
-            applyOwnerStack(errorWithStack, ownerStack)
+          if (
+            process.env.NODE_ENV !== 'production' &&
+            workUnitStore.captureOwnerStack
+          ) {
+            const ownerStack = workUnitStore.captureOwnerStack()
+
+            if (ownerStack) {
+              // TODO: Instead of stitching the stacks here, we should log the
+              // original error as-is when it occurs (i.e. here), and let
+              // `patchErrorInspect` handle adding the owner stack, instead of
+              // logging it deferred in the `LogSafely` component via
+              // `throwIfDisallowedDynamic`.
+              applyOwnerStack(errorWithStack, ownerStack)
+            }
           }
 
           abortOnSynchronousPlatformIOAccess(

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -44,19 +44,17 @@ export function io(expression: string, type: ApiType) {
                 'Unknown expression type in abortOnSynchronousPlatformIOAccess.'
               )
           }
+
           const errorWithStack = new Error(message)
+          const ownerStack = workUnitStore.captureOwnerStack?.()
 
-          if (workUnitStore.captureOwnerStack) {
-            const ownerStack = workUnitStore.captureOwnerStack()
-
-            if (ownerStack) {
-              // TODO: Instead of stitching the stacks here, we should log the
-              // original error as-is when it occurs (i.e. here), and let
-              // `patchErrorInspect` handle adding the owner stack, instead of
-              // logging it deferred in the `LogSafely` component via
-              // `throwIfDisallowedDynamic`.
-              applyOwnerStack(errorWithStack, ownerStack)
-            }
+          if (ownerStack) {
+            // TODO: Instead of stitching the stacks here, we should log the
+            // original error as-is when it occurs (i.e. here), and let
+            // `patchErrorInspect` handle adding the owner stack, instead of
+            // logging it deferred in the `LogSafely` component via
+            // `throwIfDisallowedDynamic`.
+            applyOwnerStack(errorWithStack, ownerStack)
           }
 
           abortOnSynchronousPlatformIOAccess(
@@ -83,15 +81,15 @@ function applyOwnerStack(error: Error, ownerStack: string) {
   if (error.stack) {
     const frames: string[] = []
 
-    for (const frame of error.stack.split('\n')) {
-      if (frame.includes('at react-stack-bottom-frame')) {
+    for (const frame of error.stack.split('\n').slice(1)) {
+      if (frame.includes('react_stack_bottom_frame')) {
         break
       }
 
       frames.push(frame)
     }
 
-    stack = frames.join('\n') + stack
+    stack = '\n' + frames.join('\n') + stack
   }
 
   error.stack = error.name + ': ' + error.message + stack

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -401,6 +401,7 @@ export class AppRouteRouteModule extends RouteModule<
               prerenderResumeDataCache: null,
               renderResumeDataCache: null,
               hmrRefreshHash: undefined,
+              captureOwnerStack: undefined,
             })
 
           let prospectiveResult
@@ -492,6 +493,7 @@ export class AppRouteRouteModule extends RouteModule<
             prerenderResumeDataCache: null,
             renderResumeDataCache: null,
             hmrRefreshHash: undefined,
+            captureOwnerStack: undefined,
           })
 
           let responseHandled = false

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -104,7 +104,7 @@ describe('Dynamic IO Dev Errors', () => {
       )
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
          "environmentLabel": "Server",
          "label": "Console Error",
          "source": null,
@@ -130,7 +130,7 @@ describe('Dynamic IO Dev Errors', () => {
       )
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
          "environmentLabel": "Server",
          "label": "Console Error",
          "source": "app/no-accessed-data/page.js (1:31) @ Page

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -87,21 +87,17 @@ describe('Dynamic IO Dev Errors', () => {
       expect(normalizedCliOutput).toContain(
         `\nError: Route "/no-accessed-data": ` +
           `A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. ` +
-          `We don't have the exact line number added to error messages yet but you can see which component in the stack below. ` +
           `See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense` +
-          (isTurbopack
-            ? '\n    at Page (<FIXME-file-protocol>/app/no-accessed-data/page.js:1:30)' +
-              '\n    at main (<anonymous>)' +
-              '\n    at body (<anonymous>)' +
-              '\n    at html (<anonymous>)' +
-              '\n    at Root [Server] (<anonymous>)' +
-              '\n> 1 | export default async function Page() {' +
-              '\n    |                              ^' +
-              '\n  2 |   await new Promise((r) => setTimeout(r, 200))'
-            : '\n    at Page (app/no-accessed-data/page.js:1:30)' +
-              // TODO(veil): Should be ignore-listed (see https://linear.app/vercel/issue/NDX-464/next-internals-not-ignore-listed-in-terminal-in-webpack#comment-1164a36a)
-              '\n    at InnerLayoutRouter (..')
+          '\n    at Page (<FIXME-file-protocol>/app/no-accessed-data/page.js:1:30)' +
+          '\n> 1 | export default async function Page() {' +
+          '\n    |                              ^' +
+          '\n  2 |   await new Promise((r) => setTimeout(r, 200))' +
+          '\n  3 |   return <p>Page</p>' +
+          '\n  4 | }'
       )
+
+      // TODO(veil): Source mapping breaks due to double-encoding of the square
+      // brackets.
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
@@ -110,10 +106,6 @@ describe('Dynamic IO Dev Errors', () => {
          "source": null,
          "stack": [
            "<FIXME-file-protocol>",
-           "main <anonymous>",
-           "body <anonymous>",
-           "html <anonymous>",
-           "Root [Server] <anonymous>",
            "LogSafely <anonymous>",
          ],
        }
@@ -122,12 +114,15 @@ describe('Dynamic IO Dev Errors', () => {
       expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
         `\nError: Route "/no-accessed-data": ` +
           `A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. ` +
-          `We don't have the exact line number added to error messages yet but you can see which component in the stack below. ` +
           `See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense` +
           '\n    at Page (app/no-accessed-data/page.js:1:30)' +
-          // TODO(veil): Should be ignore-listed (see https://linear.app/vercel/issue/NDX-464/next-internals-not-ignore-listed-in-terminal-in-webpack#comment-1164a36a)
-          '\n    at InnerLayoutRouter (..'
+          '\n> 1 | export default async function Page() {' +
+          '\n    |                              ^' +
+          '\n  2 |   await new Promise((r) => setTimeout(r, 200))' +
+          '\n  3 |   return <p>Page</p>' +
+          '\n  4 | }'
       )
+
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
@@ -138,10 +133,6 @@ describe('Dynamic IO Dev Errors', () => {
            |                               ^",
          "stack": [
            "Page app/no-accessed-data/page.js (1:31)",
-           "main <anonymous>",
-           "body <anonymous>",
-           "html <anonymous>",
-           "Root [Server] <anonymous>",
            "LogSafely <anonymous>",
          ],
        }

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -12,6 +12,9 @@ describe('Dynamic IO Dev Errors', () => {
   it('should show a red box error on the SSR render', async () => {
     const browser = await next.browser('/error')
 
+    // TODO(veil): The "Page <anonymous>" frame should be omitted.
+    // Interestingly, it only appears on initial load, and not when
+    // soft-navigating to the page (see test below).
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "description": "Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
@@ -22,6 +25,7 @@ describe('Dynamic IO Dev Errors', () => {
          |                       ^",
        "stack": [
          "Page app/error/page.tsx (2:23)",
+         "Page <anonymous>",
          "LogSafely <anonymous>",
        ],
      }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -11,10 +11,10 @@ describe.each(
         },
       ]
     : [
-        {
-          inPrerenderDebugMode: false,
-          name: 'Build Without --prerender-debug',
-        },
+        // {
+        //   inPrerenderDebugMode: false,
+        //   name: 'Build Without --prerender-debug',
+        // },
         {
           inPrerenderDebugMode: true,
           name: 'Build With --prerender-debug',
@@ -74,11 +74,13 @@ describe.each(
            "description": "Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/page.tsx (35:23) @ RandomReadingComponent
-         > 35 |   const random = Math.random()
-              |                       ^",
+           "source": "app/page.tsx (32:15) @ getRandomNumber
+         > 32 |   return Math.random()
+              |               ^",
            "stack": [
-             "RandomReadingComponent app/page.tsx (35:23)",
+             "getRandomNumber app/page.tsx (32:15)",
+             "RandomReadingComponent app/page.tsx (40:18)",
+             "Page app/page.tsx (18:11)",
              "LogSafely <anonymous>",
            ],
          }
@@ -100,14 +102,16 @@ describe.each(
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                 at RandomReadingComponent (turbopack:///[project]/app/page.tsx:35:22)
-               33 |     use(new Promise((r) => process.nextTick(r)))
-               34 |   }
-             > 35 |   const random = Math.random()
-                  |                      ^
-               36 |   return (
-               37 |     <div>
-               38 |       <span id="rand">{random}</span>
+                 at getRandomNumber (turbopack:///[project]/app/page.tsx:32:14)
+                 at RandomReadingComponent (turbopack:///[project]/app/page.tsx:40:17)
+               30 |
+               31 | function getRandomNumber() {
+             > 32 |   return Math.random()
+                  |              ^
+               33 | }
+               34 |
+               35 | function RandomReadingComponent() {
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -117,6 +121,9 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
                  at a (<next-dist-dir>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -125,14 +132,16 @@ describe.each(
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                 at RandomReadingComponent (webpack:///app/page.tsx:35:22)
-               33 |     use(new Promise((r) => process.nextTick(r)))
-               34 |   }
-             > 35 |   const random = Math.random()
-                  |                      ^
-               36 |   return (
-               37 |     <div>
-               38 |       <span id="rand">{random}</span>
+                 at getRandomNumber (webpack:///app/page.tsx:32:14)
+                 at RandomReadingComponent (webpack:///app/page.tsx:40:17)
+               30 |
+               31 | function getRandomNumber() {
+             > 32 |   return Math.random()
+                  |              ^
+               33 | }
+               34 |
+               35 | function RandomReadingComponent() {
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -142,6 +151,9 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
                  at a (<next-dist-dir>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -111,7 +111,7 @@ describe.each(
                33 | }
                34 |
                35 | function RandomReadingComponent() {
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -122,7 +122,7 @@ describe.each(
              "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
                  at a (<next-dist-dir>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -141,7 +141,7 @@ describe.each(
                33 | }
                34 |
                35 | function RandomReadingComponent() {
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -152,7 +152,7 @@ describe.each(
              "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
                  at a (<next-dist-dir>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -11,10 +11,10 @@ describe.each(
         },
       ]
     : [
-        // {
-        //   inPrerenderDebugMode: false,
-        //   name: 'Build Without --prerender-debug',
-        // },
+        {
+          inPrerenderDebugMode: false,
+          name: 'Build Without --prerender-debug',
+        },
         {
           inPrerenderDebugMode: true,
           name: 'Build With --prerender-debug',

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -170,22 +170,18 @@ describe.each(
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
+        // TODO(veil): Source mapping breaks due to double-encoding of the
+        // square brackets.
         if (isTurbopack) {
           await expect(browser).toDisplayCollapsedRedbox(`
            {
-             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": null,
              "stack": [
                "<FIXME-file-protocol>",
-               "section <anonymous>",
-               "main <anonymous>",
                "<FIXME-file-protocol>",
-               "main <anonymous>",
-               "body <anonymous>",
-               "html <anonymous>",
-               "Root [Server] <anonymous>",
                "LogSafely <anonymous>",
              ],
            }
@@ -193,7 +189,7 @@ describe.each(
         } else {
           await expect(browser).toDisplayCollapsedRedbox(`
            {
-             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/page.tsx (33:16) @ RequestData
@@ -201,13 +197,7 @@ describe.each(
                 |                ^",
              "stack": [
                "RequestData app/page.tsx (33:16)",
-               "section <anonymous>",
-               "main <anonymous>",
                "Page app/page.tsx (27:9)",
-               "main <anonymous>",
-               "body <anonymous>",
-               "html <anonymous>",
-               "Root [Server] <anonymous>",
                "LogSafely <anonymous>",
              ],
            }
@@ -229,7 +219,7 @@ describe.each(
         if (isTurbopack) {
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at section (<anonymous>)
                  at main (<anonymous>)
                  at RenderFromTemplateContext (<anonymous>)
@@ -243,7 +233,7 @@ describe.each(
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at a (<anonymous>)
                  at main (<anonymous>)
                  at b (<next-dist-dir>)
@@ -267,7 +257,7 @@ describe.each(
         } else {
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at section (<anonymous>)
                  at main (<anonymous>)
                  at InnerLayoutRouter (webpack://<next-src>)
@@ -298,7 +288,7 @@ describe.each(
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at a (<anonymous>)
                  at main (<anonymous>)
                  at b (<next-dist-dir>)

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -128,7 +128,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -139,7 +139,7 @@ describe.each(
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -157,7 +157,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -168,7 +168,7 @@ describe.each(
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -253,7 +253,7 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -279,7 +279,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -312,7 +312,7 @@ describe.each(
                335 |   segmentPath,
                336 |   cacheNode,
                337 |   url,
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -338,7 +338,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -425,7 +425,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -436,7 +436,7 @@ describe.each(
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -454,7 +454,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -465,7 +465,7 @@ describe.each(
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -109,6 +109,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -118,6 +119,9 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -134,6 +138,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -143,6 +148,9 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -226,6 +234,7 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -250,6 +259,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -281,6 +293,7 @@ describe.each(
                335 |   segmentPath,
                336 |   cacheNode,
                337 |   url,
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -305,6 +318,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -371,6 +387,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -380,6 +397,9 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -396,6 +416,7 @@ describe.each(
                6 |
                7 |   return (
                8 |     <main>
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -405,6 +426,9 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                  at a (<next-dist-dir>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -70,20 +70,39 @@ describe.each(
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
-        await expect(browser).toDisplayCollapsedRedbox(`
-         {
-           "description": "Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
-           "environmentLabel": "Server",
-           "label": "Console Error",
-           "source": "app/client.tsx (5:16) @ SyncIO
-         > 5 |   const data = new Date().toISOString()
-             |                ^",
-           "stack": [
-             "SyncIO app/client.tsx (5:16)",
-             "LogSafely <anonymous>",
-           ],
-         }
-        `)
+        if (isTurbopack) {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/client.tsx (5:16) @ SyncIO
+           > 5 |   const data = new Date().toISOString()
+               |                ^",
+             "stack": [
+               "SyncIO app/client.tsx (5:16)",
+               "<FIXME-file-protocol>",
+               "LogSafely <anonymous>",
+             ],
+           }
+          `)
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/client.tsx (5:16) @ SyncIO
+           > 5 |   const data = new Date().toISOString()
+               |                ^",
+             "stack": [
+               "SyncIO app/client.tsx (5:16)",
+               "Page app/page.tsx (22:9)",
+               "LogSafely <anonymous>",
+             ],
+           }
+          `)
+        }
       })
     } else {
       it('should error the build with a reason related to sync IO access', async () => {
@@ -348,20 +367,39 @@ describe.each(
       it('should show a collapsed redbox error', async () => {
         const browser = await next.browser('/')
 
-        await expect(browser).toDisplayCollapsedRedbox(`
-         {
-           "description": "Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
-           "environmentLabel": "Server",
-           "label": "Console Error",
-           "source": "app/client.tsx (5:16) @ SyncIO
-         > 5 |   const data = new Date().toISOString()
-             |                ^",
-           "stack": [
-             "SyncIO app/client.tsx (5:16)",
-             "LogSafely <anonymous>",
-           ],
-         }
-        `)
+        if (isTurbopack) {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/client.tsx (5:16) @ SyncIO
+           > 5 |   const data = new Date().toISOString()
+               |                ^",
+             "stack": [
+               "SyncIO app/client.tsx (5:16)",
+               "<FIXME-file-protocol>",
+               "LogSafely <anonymous>",
+             ],
+           }
+          `)
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/client.tsx (5:16) @ SyncIO
+           > 5 |   const data = new Date().toISOString()
+               |                ^",
+             "stack": [
+               "SyncIO app/client.tsx (5:16)",
+               "Page app/page.tsx (22:9)",
+               "LogSafely <anonymous>",
+             ],
+           }
+          `)
+        }
       })
     } else {
       it('should error the build with a reason related to sync IO access', async () => {

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -172,7 +172,7 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -196,7 +196,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -227,7 +227,7 @@ describe.each(
                335 |   segmentPath,
                336 |   cacheNode,
                337 |   url,
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -251,7 +251,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -659,12 +659,12 @@ describe.each(
                 8 |   return children
                 9 | }
                10 |
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -689,7 +689,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at m (<next-dist-dir>)
@@ -707,7 +707,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
@@ -739,7 +739,7 @@ describe.each(
                 8 |   return children
                 9 | }
                10 |
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at InnerLayoutRouter (webpack://<next-src>)
                  at RedirectErrorBoundary (webpack://<next-src>)
@@ -762,7 +762,7 @@ describe.each(
                335 |   segmentPath,
                336 |   cacheNode,
                337 |   url,
-             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -787,7 +787,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at m (<next-dist-dir>)
@@ -805,7 +805,7 @@ describe.each(
                  at body (<anonymous>)
                  at html (<anonymous>)
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
-               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -123,7 +123,7 @@ describe.each(
           // square brackets.
           await expect(browser).toDisplayCollapsedRedbox(`
            {
-             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": null,
@@ -137,7 +137,7 @@ describe.each(
         } else {
           await expect(browser).toDisplayCollapsedRedbox(`
            {
-             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+             "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/page.tsx (20:16) @ Dynamic
@@ -168,7 +168,7 @@ describe.each(
         if (isTurbopack) {
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
@@ -179,7 +179,7 @@ describe.each(
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at a (<next-dist-dir>)
                  at b (<next-dist-dir>)
                  at c (<next-dist-dir>)
@@ -201,7 +201,7 @@ describe.each(
         } else {
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at InnerLayoutRouter (webpack://<next-src>)
                  at RedirectErrorBoundary (webpack://<next-src>)
                  at RedirectBoundary (webpack://<next-src>)
@@ -230,7 +230,7 @@ describe.each(
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at a (<next-dist-dir>)
                  at b (<next-dist-dir>)
                  at c (<next-dist-dir>)
@@ -568,7 +568,7 @@ describe.each(
           await expect(browser).toDisplayCollapsedRedbox(`
            [
              {
-               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": null,
@@ -579,7 +579,7 @@ describe.each(
                ],
              },
              {
-               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": null,
@@ -595,7 +595,7 @@ describe.each(
           await expect(browser).toDisplayCollapsedRedbox(`
            [
              {
-               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/page.tsx (35:16) @ FetchingComponent
@@ -608,7 +608,7 @@ describe.each(
                ],
              },
              {
-               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+               "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/page.tsx (35:16) @ FetchingComponent
@@ -639,7 +639,7 @@ describe.each(
         if (isTurbopack) {
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at IndirectionTwo (turbopack:///[project]/app/indirection.tsx:7:33)
                  at main (<anonymous>)
                  at body (<anonymous>)
@@ -651,7 +651,7 @@ describe.each(
                 8 |   return children
                 9 | }
                10 |
-             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
@@ -662,7 +662,7 @@ describe.each(
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at a (<next-dist-dir>)
                  at b (<next-dist-dir>)
                  at c (<next-dist-dir>)
@@ -678,7 +678,7 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
-             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at m (<next-dist-dir>)
                  at n (<next-dist-dir>)
                  at o (<next-dist-dir>)
@@ -700,7 +700,7 @@ describe.each(
         } else {
           if (inPrerenderDebugMode) {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at IndirectionTwo (webpack:///app/indirection.tsx:7:33)
                  at InnerLayoutRouter (webpack://<next-src>)
                  at RedirectErrorBoundary (webpack://<next-src>)
@@ -723,7 +723,7 @@ describe.each(
                 8 |   return children
                 9 | }
                10 |
-             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at InnerLayoutRouter (webpack://<next-src>)
                  at RedirectErrorBoundary (webpack://<next-src>)
                  at RedirectBoundary (webpack://<next-src>)
@@ -752,7 +752,7 @@ describe.each(
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at a (<next-dist-dir>)
                  at b (<next-dist-dir>)
                  at c (<next-dist-dir>)
@@ -768,7 +768,7 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
-             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+             Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at m (<next-dist-dir>)
                  at n (<next-dist-dir>)
                  at o (<next-dist-dir>)

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -172,6 +172,7 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -194,6 +195,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -223,6 +227,7 @@ describe.each(
                335 |   segmentPath,
                336 |   cacheNode,
                337 |   url,
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -245,6 +250,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -651,10 +659,12 @@ describe.each(
                 8 |   return children
                 9 | }
                10 |
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -678,6 +688,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at m (<next-dist-dir>)
                  at n (<next-dist-dir>)
@@ -693,6 +706,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)
@@ -723,6 +739,7 @@ describe.each(
                 8 |   return children
                 9 | }
                10 |
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at InnerLayoutRouter (webpack://<next-src>)
                  at RedirectErrorBoundary (webpack://<next-src>)
@@ -745,6 +762,7 @@ describe.each(
                335 |   segmentPath,
                336 |   cacheNode,
                337 |   url,
+             To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
 
              > Export encountered errors on following paths:
@@ -768,6 +786,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at m (<next-dist-dir>)
                  at n (<next-dist-dir>)
@@ -783,6 +804,9 @@ describe.each(
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+             To get a more detailed stack trace and pinpoint the issue, try one of the following:
+               - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error using the Next.js DevTools.
+               - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              Export encountered an error on /page: /, exiting the build."
             `)

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -119,6 +119,8 @@ describe.each(
         const browser = await next.browser('/')
 
         if (isTurbopack) {
+          // TODO(veil): Source mapping breaks due to double-encoding of the
+          // square brackets.
           await expect(browser).toDisplayCollapsedRedbox(`
            {
              "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
@@ -128,10 +130,6 @@ describe.each(
              "stack": [
                "<FIXME-file-protocol>",
                "<FIXME-file-protocol>",
-               "main <anonymous>",
-               "body <anonymous>",
-               "html <anonymous>",
-               "Root [Server] <anonymous>",
                "LogSafely <anonymous>",
              ],
            }
@@ -148,10 +146,6 @@ describe.each(
              "stack": [
                "Dynamic app/page.tsx (20:16)",
                "Page app/page.tsx (15:7)",
-               "main <anonymous>",
-               "body <anonymous>",
-               "html <anonymous>",
-               "Root [Server] <anonymous>",
                "LogSafely <anonymous>",
              ],
            }
@@ -569,23 +563,18 @@ describe.each(
         const browser = await next.browser('/')
 
         if (isTurbopack) {
+          // TODO(veil): Source mapping breaks due to double-encoding of the
+          // square brackets.
           await expect(browser).toDisplayCollapsedRedbox(`
            [
              {
                "description": "Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
                "environmentLabel": "Server",
                "label": "Console Error",
-               "source": "app/indirection.tsx (7:34) @ IndirectionTwo
-           >  7 | export function IndirectionTwo({ children }) {
-                |                                  ^",
+               "source": null,
                "stack": [
                  "<FIXME-file-protocol>",
-                 "IndirectionTwo app/indirection.tsx (7:34)",
                  "<FIXME-file-protocol>",
-                 "main <anonymous>",
-                 "body <anonymous>",
-                 "html <anonymous>",
-                 "Root [Server] <anonymous>",
                  "LogSafely <anonymous>",
                ],
              },
@@ -597,10 +586,6 @@ describe.each(
                "stack": [
                  "<FIXME-file-protocol>",
                  "<FIXME-file-protocol>",
-                 "main <anonymous>",
-                 "body <anonymous>",
-                 "html <anonymous>",
-                 "Root [Server] <anonymous>",
                  "LogSafely <anonymous>",
                ],
              },
@@ -618,12 +603,7 @@ describe.each(
                 |                ^",
                "stack": [
                  "FetchingComponent app/page.tsx (35:16)",
-                 "IndirectionTwo app/indirection.tsx (7:34)",
-                 "Page app/page.tsx (16:9)",
-                 "main <anonymous>",
-                 "body <anonymous>",
-                 "html <anonymous>",
-                 "Root [Server] <anonymous>",
+                 "Page app/page.tsx (22:9)",
                  "LogSafely <anonymous>",
                ],
              },
@@ -636,11 +616,7 @@ describe.each(
                 |                ^",
                "stack": [
                  "FetchingComponent app/page.tsx (35:16)",
-                 "Page app/page.tsx (16:9)",
-                 "main <anonymous>",
-                 "body <anonymous>",
-                 "html <anonymous>",
-                 "Root [Server] <anonymous>",
+                 "Page app/page.tsx (27:7)",
                  "LogSafely <anonymous>",
                ],
              },

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/app/page.tsx
@@ -1,4 +1,4 @@
-import { Suspense, use } from 'react'
+import React, { Suspense, use } from 'react'
 
 import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
 
@@ -28,11 +28,17 @@ export default async function Page(props: {
   )
 }
 
+function getRandomNumber() {
+  return Math.random()
+}
+
 function RandomReadingComponent() {
   if (typeof window === 'undefined') {
     use(new Promise((r) => process.nextTick(r)))
   }
-  const random = Math.random()
+
+  const random = getRandomNumber()
+
   return (
     <div>
       <span id="rand">{random}</span>

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-random-without-fallback/app/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, use } from 'react'
+import { Suspense, use } from 'react'
 
 import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
 

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -32,7 +32,7 @@ describe('build-output-prerender', () => {
          "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
              at x (<next-dist-dir>)
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
-           - Start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
+           - Start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error.
            - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Export encountered an error on /client/page: /client, exiting the build."
@@ -42,7 +42,7 @@ describe('build-output-prerender', () => {
          "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
              at x (<next-dist-dir>)
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
-           - Start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
+           - Start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error.
            - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Export encountered an error on /client/page: /client, exiting the build."
@@ -97,7 +97,7 @@ describe('build-output-prerender', () => {
              |                           ^
            5 | }
            6 |
-         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Error: Route "/server" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
              at Page (turbopack:///[project]/app/server/page.tsx:13:26)
@@ -107,7 +107,7 @@ describe('build-output-prerender', () => {
               |                          ^
            14 | }
            15 |
-         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error using the Next.js DevTools.
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error.
          Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
          > Export encountered errors on following paths:
@@ -124,7 +124,7 @@ describe('build-output-prerender', () => {
              |                           ^
            5 | }
            6 |
-         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Error: Route "/server" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
              at Page (webpack:///app/server/page.tsx:13:26)
@@ -134,7 +134,7 @@ describe('build-output-prerender', () => {
               |                          ^
            14 | }
            15 |
-         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error using the Next.js DevTools.
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error.
          Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
          > Export encountered errors on following paths:

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -31,6 +31,9 @@ describe('build-output-prerender', () => {
         expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
          "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
              at x (<next-dist-dir>)
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Export encountered an error on /client/page: /client, exiting the build."
         `)
@@ -38,6 +41,9 @@ describe('build-output-prerender', () => {
         expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
          "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
              at x (<next-dist-dir>)
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Export encountered an error on /client/page: /client, exiting the build."
         `)
@@ -91,6 +97,7 @@ describe('build-output-prerender', () => {
              |                           ^
            5 | }
            6 |
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Error: Route "/server" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
              at Page (turbopack:///[project]/app/server/page.tsx:13:26)
@@ -100,6 +107,7 @@ describe('build-output-prerender', () => {
               |                          ^
            14 | }
            15 |
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error using the Next.js DevTools.
          Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
          > Export encountered errors on following paths:
@@ -116,6 +124,7 @@ describe('build-output-prerender', () => {
              |                           ^
            5 | }
            6 |
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error using the Next.js DevTools.
          Error occurred prerendering page "/client". Read more: https://nextjs.org/docs/messages/prerender-error
          Error: Route "/server" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
              at Page (webpack:///app/server/page.tsx:13:26)
@@ -125,6 +134,7 @@ describe('build-output-prerender', () => {
               |                          ^
            14 | }
            15 |
+         To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error using the Next.js DevTools.
          Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
          > Export encountered errors on following paths:


### PR DESCRIPTION
With recent improvements in React, and after switching to the React builds for Node.js in #81048, we can now generate better dynamic validation error stacks in dev mode by utilizing owner stacks instead of component stacks.

For async I/O, we're using the owner stack exclusively. For sync I/O we're appending the owner stack to the call stack. In a future iteration we might instead log the original error as-is where it occurs, and let `patchErrorInspectNodeJS` handle the owner stack appending as a general solution.

Additionally, we're now guiding users in the build-time error messages to using `next dev` for further debugging of dynamic validation errors – or, alternatively, using `next build --debug-prerender`.

closes NAR-149