### PR TITLE
perf(turbopack): Make `File` => json faster

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1912,7 +1912,8 @@ impl FileContent {
     pub fn parse_json_ref(&self) -> FileJsonContent {
         match self {
             FileContent::Content(file) => {
-                let de = &mut serde_json::Deserializer::from_reader(file.read());
+                let content = file.content.clone().into_bytes();
+                let de = &mut serde_json::Deserializer::from_slice(&content);
                 match serde_path_to_error::deserialize(de) {
                     Ok(data) => FileJsonContent::Content(data),
                     Err(e) => FileJsonContent::Unparsable(Box::new(


### PR DESCRIPTION
### What?

Considering the way `serde_json` works, I expect this to be faster. Also, a JSON string is very likely to be a single `bytes::Bytes` already, so it would not regress the memory usage.

### Why?

<img width="843" alt="image" src="https://github.com/user-attachments/assets/2c5ebb0b-335c-4ca1-aebd-64a6da9e0671" />


Closes PACK-5009