### PR TITLE
[devtool] inject css as styleTag rather than singletonStyleTag

### DIFF
--- a/packages/next/next-devtools.webpack-config.js
+++ b/packages/next/next-devtools.webpack-config.js
@@ -97,7 +97,7 @@ module.exports = ({ dev, ...rest }) => {
             {
               loader: 'style-loader',
               options: {
-                injectType: 'singletonStyleTag',
+                injectType: 'styleTag',
                 insert: require.resolve(
                   './src/build/webpack/loaders/devtool/devtool-style-inject.js'
                 ),

--- a/packages/next/next-devtools.webpack-config.js
+++ b/packages/next/next-devtools.webpack-config.js
@@ -97,6 +97,9 @@ module.exports = ({ dev, ...rest }) => {
             {
               loader: 'style-loader',
               options: {
+                // Explicitly set the injectType to 'styleTag' which is also the default behavior.
+                // We've experienced `singletonStyleTag` that the later updated styles not being applied.
+                // Keep using `styleTag` to ensure when new styles injected the style can also be updated.
                 injectType: 'styleTag',
                 insert: require.resolve(
                   './src/build/webpack/loaders/devtool/devtool-style-inject.js'


### PR DESCRIPTION
Change the style-loader injection for devtool from `singletonStyleTag` to `styleTag` (which is also default).
The original setting was configured in #81236 , @mischnic a case where the style is inserted but not applied.

Using `styleTag` will insert multi styleTag which can force it layout again when the style is added