### PR TITLE
 Turbopack: sourceMappingURL for Node.js runtime chunk

### DIFF
--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{File, FileSystem, FileSystemPath};
+use turbo_tasks_fs::{File, FileSystem, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
@@ -157,9 +157,22 @@ impl Asset for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let code = self.code().await?;
-        Ok(AssetContent::file(
-            File::from(code.source_code().clone()).into(),
-        ))
+
+        let rope = if code.has_source_map() {
+            let mut rope_builder = RopeBuilder::default();
+            rope_builder.concat(code.source_code());
+            let source_map_path = self.source_map().path().await?;
+            write!(
+                rope_builder,
+                "\n\n//# sourceMappingURL={}",
+                urlencoding::encode(source_map_path.file_name())
+            )?;
+            rope_builder.build()
+        } else {
+            code.source_code().clone()
+        };
+
+        Ok(AssetContent::file(File::from(rope).into()))
     }
 }
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/[turbopack]_runtime.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/[turbopack]_runtime.js
@@ -714,3 +714,6 @@ module.exports = {
     getOrInstantiateRuntimeModule,
     loadChunk
 };
+
+
+//# sourceMappingURL=%5Bturbopack%5D_runtime.js.map


### PR DESCRIPTION
The sourcemap chunk was generated, but the comment referencing it was missing.
Copy the logic over from the browser runtime chunk

Closes PACK-5011