### PR TITLE
[segment explorer] redesign file pills and boundary trigger

### DIFF
--- a/packages/next/src/next-devtools/components/tooltip.css
+++ b/packages/next/src/next-devtools/components/tooltip.css
@@ -11,7 +11,6 @@
   font-size: 14px;
   line-height: 1.4;
   pointer-events: none;
-  white-space: nowrap;
 }
 
 .tooltip-arrow {

--- a/packages/next/src/next-devtools/components/tooltip.css
+++ b/packages/next/src/next-devtools/components/tooltip.css
@@ -10,8 +10,8 @@
   border-radius: 8px;
   font-size: 14px;
   line-height: 1.4;
-  min-width: 200px;
   pointer-events: none;
+  white-space: nowrap;
 }
 
 .tooltip-arrow {

--- a/packages/next/src/next-devtools/components/tooltip.tsx
+++ b/packages/next/src/next-devtools/components/tooltip.tsx
@@ -35,9 +35,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       const portalNode = ownerDocument.querySelector('nextjs-portal')!
       return portalNode.shadowRoot! as ShadowRoot
     })
-    const shadowRootRef = useRef<HTMLElement>(
-      shadowRoot as unknown as HTMLElement
-    )
+    const shadowRootRef = useRef<ShadowRoot>(shadowRoot)
     if (!title) {
       return children
     }
@@ -51,6 +49,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
             }}
           />
 
+          {/* x-ref: https://github.com/mui/base-ui/issues/2224 */}
+          {/* @ts-expect-error remove this expect-error once shadowRoot is supported as container */}
           <BaseTooltip.Portal container={shadowRootRef}>
             <BaseTooltip.Positioner
               side={direction}

--- a/packages/next/src/next-devtools/components/tooltip.tsx
+++ b/packages/next/src/next-devtools/components/tooltip.tsx
@@ -41,7 +41,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     }
     return (
       <BaseTooltip.Provider>
-        <BaseTooltip.Root delay={0}>
+        <BaseTooltip.Root delay={400}>
           <BaseTooltip.Trigger
             ref={ref}
             render={(triggerProps) => {

--- a/packages/next/src/next-devtools/components/tooltip.tsx
+++ b/packages/next/src/next-devtools/components/tooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useRef, useState } from 'react'
 import { Tooltip as BaseTooltip } from '@base-ui-components/react/tooltip'
 import { cx } from '../dev-overlay/utils/cx'
 import './tooltip.css'
@@ -7,22 +7,22 @@ type TooltipDirection = 'top' | 'bottom' | 'left' | 'right'
 
 interface TooltipProps {
   children: React.ReactNode
-  title: string
+  title: string | null
   direction?: TooltipDirection
-  container?: HTMLElement | React.RefObject<HTMLElement>
   arrowSize?: number
   offset?: number
   bgcolor?: string
   color?: string
+  className?: string
 }
 
 export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   function Tooltip(
     {
+      className,
       children,
       title,
       direction = 'top',
-      container,
       arrowSize = 6,
       offset = 8,
       bgcolor = '#000',
@@ -30,6 +30,17 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     },
     ref
   ) {
+    const [shadowRoot] = useState<ShadowRoot>(() => {
+      const ownerDocument = document
+      const portalNode = ownerDocument.querySelector('nextjs-portal')!
+      return portalNode.shadowRoot! as ShadowRoot
+    })
+    const shadowRootRef = useRef<HTMLElement>(
+      shadowRoot as unknown as HTMLElement
+    )
+    if (!title) {
+      return children
+    }
     return (
       <BaseTooltip.Provider>
         <BaseTooltip.Root delay={0}>
@@ -40,7 +51,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
             }}
           />
 
-          <BaseTooltip.Portal {...(container && { container })}>
+          <BaseTooltip.Portal container={shadowRootRef}>
             <BaseTooltip.Positioner
               side={direction}
               sideOffset={offset + arrowSize}
@@ -53,7 +64,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
               }
             >
               <BaseTooltip.Popup
-                className="tooltip"
+                className={cx('tooltip', className)}
                 style={
                   {
                     backgroundColor: bgcolor,

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
@@ -84,14 +84,15 @@ export function useClickOutside(
   rootRef: React.RefObject<HTMLElement | null>,
   triggerRef: React.RefObject<HTMLButtonElement | null>,
   active: boolean,
-  close: () => void
+  close: () => void,
+  ownerDocument?: Document
 ) {
   useEffect(() => {
     if (!active) {
       return
     }
 
-    const ownerDocument = rootRef.current?.ownerDocument
+    const ownerDocumentEl = ownerDocument || rootRef.current?.ownerDocument
 
     function handleClickOutside(event: MouseEvent) {
       const target = event.target as HTMLElement
@@ -124,15 +125,15 @@ export function useClickOutside(
       }
     }
 
-    ownerDocument?.addEventListener('mousedown', handleClickOutside)
-    ownerDocument?.addEventListener('keydown', handleKeyDown)
+    ownerDocumentEl?.addEventListener('mousedown', handleClickOutside)
+    ownerDocumentEl?.addEventListener('keydown', handleKeyDown)
 
     return () => {
-      ownerDocument?.removeEventListener('mousedown', handleClickOutside)
-      ownerDocument?.removeEventListener('keydown', handleKeyDown)
+      ownerDocumentEl?.removeEventListener('mousedown', handleClickOutside)
+      ownerDocumentEl?.removeEventListener('keydown', handleKeyDown)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active])
+  }, [active, rootRef, triggerRef])
 }
 
 //////////////////////////////////////////////////////////////////////////////////////

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.css
@@ -1,48 +1,80 @@
 .segment-boundary-trigger {
-  margin-left: auto;
-  gap: 8px;
-}
-
-.segment-boundary-trigger-button {
-  width: 24px;
-  height: 24px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 4px;
+  padding: 4px 6px;
+  line-height: 16px;
   font-weight: 500;
   color: var(--color-gray-1000);
-  border-radius: 6px;
-  background: transparent;
+  border-radius: 999px;
   border: none;
+  font-size: var(--size-12);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
 }
 
-.segment-boundary-trigger-button svg {
-  width: 20px;
-  height: 20px;
+.segment-boundary-trigger-text {
+  font-size: var(--size-12);
+  font-weight: 500;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.segment-boundary-trigger-button:hover {
-  background: var(--color-gray-400);
-  color: var(--color-gray-1000);
+.segment-boundary-trigger-text .plus-icon {
+  transition: transform 0.25s ease;
+}
+
+.segment-boundary-trigger-text:hover .plus-icon {
+  color: var(--color-gray-800);
+}
+
+.segment-boundary-trigger svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
+.segment-boundary-trigger:hover svg {
+  color: var(--color-gray-700);
+}
+
+.segment-boundary-trigger[disabled] svg,
+.segment-boundary-trigger[disabled]:hover svg {
+  color: var(--color-gray-400);
+  cursor: not-allowed;
+}
+
+.segment-boundary-trigger--boundary {
+  background: var(--color-background-100);
+  box-shadow: inset 0 0 0 1px var(--color-gray-400);
+}
+
+.segment-boundary-trigger--boundary:hover {
+  background: var(--color-gray-200);
 }
 
 .segment-boundary-dropdown {
   padding: 8px;
   background: var(--color-background-100);
   border: 1px solid var(--color-gray-400);
-  border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 16px;
   min-width: 120px;
+  user-select: none;
+  cursor: default;
+  box-shadow: 0px 16px 24px -8px var(--color-gray-1000);
 }
 
 .segment-boundary-dropdown-positioner {
-  z-index: 2147483648;
+  z-index: var(--top-z-index);
 }
 
 .segment-boundary-dropdown-item {
   display: flex;
   align-items: center;
-  padding: 10px 8px;
+  padding: 8px;
   line-height: 20px;
   font-size: 14px;
   border-radius: 6px;
@@ -78,8 +110,10 @@
   border-bottom-right-radius: 4px;
 }
 
-.segment-boundary-dropdown-divider {
-  height: 1px;
-  background: var(--color-gray-400);
-  margin: 8px 0;
+.segment-boundary-group-label {
+  padding: 8px;
+  font-size: 13px;
+  line-height: 16px;
+  font-weight: 400;
+  color: var(--color-gray-900);
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.css
@@ -64,7 +64,7 @@
   min-width: 120px;
   user-select: none;
   cursor: default;
-  box-shadow: 0px 16px 24px -8px var(--color-gray-1000);
+  box-shadow: 0px 4px 8px -4px color-mix(in srgb, var(--color-gray-900) 4%, transparent);
 }
 
 .segment-boundary-dropdown-positioner {

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -1,39 +1,105 @@
 import './segment-boundary-trigger.css'
-import { useCallback, useState, useRef } from 'react'
+import { useCallback, useState, useRef, useMemo } from 'react'
 import { Menu } from '@base-ui-components/react/menu'
 import type { SegmentNodeState } from '../../../userspace/app/segment-explorer-node'
+import {
+  isBoundaryFile,
+  normalizeBoundaryFilename,
+} from '../../../../server/app-render/segment-explorer-path'
+import { cx } from '../../utils/cx'
+import { useClickOutside } from '../errors/dev-tools-indicator/utils'
+
+const composeRefs = (...refs: (React.Ref<HTMLButtonElement> | undefined)[]) => {
+  return (node: HTMLButtonElement | null) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(node)
+      } else if (ref) {
+        ref.current = node
+      }
+    })
+  }
+}
 
 export function SegmentBoundaryTrigger({
-  onSelectBoundary,
-  offset,
+  nodeState,
   boundaries,
 }: {
-  onSelectBoundary: SegmentNodeState['setBoundaryType']
-  offset: number
+  nodeState: SegmentNodeState
   boundaries: Record<'not-found' | 'loading' | 'error', string | null>
 }) {
+  const currNode = nodeState
+  const {
+    pagePath,
+    boundaryType,
+    type,
+    setBoundaryType: onSelectBoundary,
+  } = currNode
+  const fileType = type
+
+  const [isOpen, setIsOpen] = useState(false)
+  // TODO: move this shadowRoot ref util to a shared hook or into context
   const [shadowRoot] = useState<ShadowRoot>(() => {
     const ownerDocument = document
     const portalNode = ownerDocument.querySelector('nextjs-portal')!
     return portalNode.shadowRoot! as ShadowRoot
   })
   const shadowRootRef = useRef<ShadowRoot>(shadowRoot)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popupRef = useRef<HTMLDivElement>(null)
+
+  // Click outside of popup should close the menu
+  useClickOutside(
+    popupRef,
+    triggerRef,
+    isOpen,
+    () => {
+      setIsOpen(false)
+    },
+    triggerRef.current?.ownerDocument
+  )
+
+  const firstDefinedBoundary = Object.values(boundaries).find((v) => v !== null)
+  const possibleExtension = firstDefinedBoundary
+    ? firstDefinedBoundary.split('.')?.pop()
+    : 'js'
+
+  const fileNames = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(boundaries).map(([key, filePath]) => {
+        const fileName = normalizeBoundaryFilename(
+          (filePath || '').split('/').pop() || `${key}.${possibleExtension}`
+        )
+        return [key, fileName]
+      })
+    ) as Record<keyof typeof boundaries, string>
+  }, [boundaries, possibleExtension])
+
+  const fileName = (pagePath || '').split('/').pop() || ''
+  const isBoundary = isBoundaryFile(fileType)
+  const pageFileName = normalizeBoundaryFilename(
+    boundaryType
+      ? `page.${possibleExtension}`
+      : fileName || `page.${possibleExtension}`
+  )
+
+  const isPageOrBoundary = fileType && !isBoundary
 
   const triggerOptions = [
     {
-      label: 'Trigger Loading',
+      label: fileNames.loading,
       value: 'loading',
       icon: <LoadingIcon />,
       disabled: !boundaries.loading,
     },
     {
-      label: 'Trigger Error',
+      label: fileNames.error,
       value: 'error',
       icon: <ErrorIcon />,
       disabled: !boundaries.error,
     },
     {
-      label: 'Trigger Not Found',
+      label: fileNames['not-found'],
       value: 'not-found',
       icon: <NotFoundIcon />,
       disabled: !boundaries['not-found'],
@@ -41,10 +107,23 @@ export function SegmentBoundaryTrigger({
   ]
 
   const resetOption = {
-    label: 'Reset',
+    label: boundaryType ? 'Reset' : pageFileName,
     value: 'reset',
     icon: <ResetIcon />,
+    disabled: boundaryType === null,
   }
+
+  const openInEditor = useCallback(({ filePath }: { filePath: string }) => {
+    const params = new URLSearchParams({
+      file: filePath,
+      isAppRelativePath: '1',
+    })
+    fetch(
+      `${
+        process.env.__NEXT_ROUTER_BASEPATH || ''
+      }/__nextjs_launch-editor?${params.toString()}`
+    )
+  }, [])
 
   const handleSelect = useCallback(
     (value: string) => {
@@ -57,84 +136,85 @@ export function SegmentBoundaryTrigger({
         case 'reset':
           onSelectBoundary(null)
           break
+        case 'open-editor':
+          if (pagePath) {
+            openInEditor({ filePath: pagePath })
+          }
+          break
         default:
           break
       }
     },
-    [onSelectBoundary]
+    [onSelectBoundary, pagePath, openInEditor]
   )
 
+  const MergedRefTrigger = (
+    triggerProps: React.ComponentProps<'button'> & {
+      ref?: React.Ref<HTMLButtonElement>
+    }
+  ) => {
+    const mergedRef = composeRefs(triggerProps.ref, triggerRef)
+    return <Trigger {...triggerProps} ref={mergedRef} />
+  }
+
   return (
-    <div className="segment-boundary-trigger">
-      <Menu.Root delay={0}>
-        <Menu.Trigger
-          className="segment-boundary-trigger-button"
-          data-nextjs-dev-overlay-segment-boundary-trigger-button
-          render={(triggerProps) => (
-            <button {...triggerProps} type="button">
-              <DropdownIcon />
-            </button>
-          )}
-        />
-
-        {/* @ts-expect-error remove this expect-error once shadowRoot is supported as container */}
-        <Menu.Portal container={shadowRootRef}>
-          <Menu.Positioner
-            className="segment-boundary-dropdown-positioner"
-            side="bottom"
-            align="center"
-            sideOffset={offset}
-            arrowPadding={8}
-          >
-            <Menu.Popup className="segment-boundary-dropdown">
-              {triggerOptions.map((option) => (
-                <Menu.Item
-                  key={option.value}
-                  className="segment-boundary-dropdown-item"
-                  onClick={() => handleSelect(option.value)}
-                  disabled={option.disabled}
-                >
-                  {option.icon}
-                  {option.label}
-                </Menu.Item>
-              ))}
-
-              <div className="segment-boundary-dropdown-divider" />
-
-              <Menu.Item
-                key={resetOption.value}
-                className="segment-boundary-dropdown-item"
-                onClick={() => handleSelect(resetOption.value)}
-              >
-                {resetOption.icon}
-                {resetOption.label}
-              </Menu.Item>
-            </Menu.Popup>
-          </Menu.Positioner>
-        </Menu.Portal>
-      </Menu.Root>
-    </div>
-  )
-}
-
-/**
- * Inline svg icons for the dropdown trigger.
- * The child svg icons like `rect` are fixed size, so they can be used as shared scalable icons.
- */
-function DropdownIcon() {
-  return (
-    <svg
-      width="20px"
-      height="20px"
-      viewBox="0 0 16 16"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M2.5 6.5C3.32843 6.5 4 7.17157 4 8C4 8.82843 3.32843 9.5 2.5 9.5C1.67157 9.5 1 8.82843 1 8C1 7.17157 1.67157 6.5 2.5 6.5ZM8 6.5C8.82843 6.5 9.5 7.17157 9.5 8C9.5 8.82843 8.82843 9.5 8 9.5C7.17157 9.5 6.5 8.82843 6.5 8C6.5 7.17157 7.17157 6.5 8 6.5ZM13.5 6.5C14.3284 6.5 15 7.17157 15 8C15 8.82843 14.3284 9.5 13.5 9.5C12.6716 9.5 12 8.82843 12 8C12 7.17157 12.6716 6.5 13.5 6.5Z"
-        fill="currentColor"
+    <Menu.Root delay={0} modal={false} open={isOpen} onOpenChange={setIsOpen}>
+      <Menu.Trigger
+        className={cx(
+          'segment-boundary-trigger',
+          !isPageOrBoundary && 'segment-boundary-trigger--boundary'
+        )}
+        data-nextjs-dev-overlay-segment-boundary-trigger-button
+        render={MergedRefTrigger}
       />
-    </svg>
+
+      {/* @ts-expect-error remove this expect-error once shadowRoot is supported as container */}
+      <Menu.Portal container={shadowRootRef}>
+        <Menu.Positioner
+          className="segment-boundary-dropdown-positioner"
+          side="bottom"
+          align="center"
+          sideOffset={6}
+          arrowPadding={8}
+          ref={popupRef}
+        >
+          <Menu.Popup className="segment-boundary-dropdown">
+            {
+              <Menu.Group>
+                <Menu.GroupLabel className="segment-boundary-group-label">
+                  Trigger overrides
+                </Menu.GroupLabel>
+                {triggerOptions.map((option) => (
+                  <Menu.Item
+                    key={option.value}
+                    className="segment-boundary-dropdown-item"
+                    onClick={() => handleSelect(option.value)}
+                    disabled={option.disabled}
+                  >
+                    {option.icon}
+                    {option.label}
+                  </Menu.Item>
+                ))}
+              </Menu.Group>
+            }
+
+            <Menu.Group>
+              {
+                <Menu.Item
+                  key={resetOption.value}
+                  className="segment-boundary-dropdown-item"
+                  onClick={() => handleSelect(resetOption.value)}
+                  disabled={resetOption.disabled}
+                >
+                  {resetOption.icon}
+                  {resetOption.label}
+                </Menu.Item>
+              }
+            </Menu.Group>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
   )
 }
 
@@ -233,5 +313,32 @@ function ResetIcon() {
         fill="currentColor"
       />
     </svg>
+  )
+}
+
+function SwitchIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg strokeLinejoin="round" viewBox="0 0 16 16" {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8.7071 2.39644C8.31658 2.00592 7.68341 2.00592 7.29289 2.39644L4.46966 5.21966L3.93933 5.74999L4.99999 6.81065L5.53032 6.28032L7.99999 3.81065L10.4697 6.28032L11 6.81065L12.0607 5.74999L11.5303 5.21966L8.7071 2.39644ZM5.53032 9.71966L4.99999 9.18933L3.93933 10.25L4.46966 10.7803L7.29289 13.6035C7.68341 13.9941 8.31658 13.9941 8.7071 13.6035L11.5303 10.7803L12.0607 10.25L11 9.18933L10.4697 9.71966L7.99999 12.1893L5.53032 9.71966Z"
+        fill="currentColor"
+      ></path>
+    </svg>
+  )
+}
+
+export function Trigger(props: React.ComponentProps<'button'>) {
+  return (
+    <button
+      {...props}
+      className={cx('segment-boundary-trigger', props.className)}
+      role="button"
+    >
+      <span className="segment-boundary-trigger-text">
+        <SwitchIcon className="plus-icon" />
+      </span>
+    </button>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -183,7 +183,7 @@ export function SegmentBoundaryTrigger({
             {
               <Menu.Group>
                 <Menu.GroupLabel className="segment-boundary-group-label">
-                  Trigger overrides
+                  Toggle Overrides
                 </Menu.GroupLabel>
                 {triggerOptions.map((option) => (
                   <Menu.Item

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -122,7 +122,8 @@ export function SegmentBoundaryTrigger({
       `${
         process.env.__NEXT_ROUTER_BASEPATH || ''
       }/__nextjs_launch-editor?${params.toString()}`
-    )
+      // Log the failures to console, not track them as console errors in error overlay
+    ).catch(console.warn)
   }, [])
 
   const handleSelect = useCallback(

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
@@ -21,6 +21,7 @@
   color: var(--color-gray-1000);
   font-family: var(--font-mono);
   white-space: nowrap;
+  line-height: 20px;
 }
 
 .segment-explorer-item {
@@ -99,13 +100,13 @@
   color: var(--color-amber-900);
 }
 
-.segment-explorer-file-label svg {
+.segment-explorer-file-label .code-icon {
   opacity: 0;
   margin-left: 0;
   width: 0;
   transition: all 0.15s ease-in-out;
 }
-.segment-explorer-file-label:hover svg {
+.segment-explorer-file-label:hover .code-icon {
   opacity: 1;
   width: 12px;
   margin-left: 4px;

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
@@ -1,7 +1,6 @@
 .segment-explorer-content {
   font-size: var(--size-14);
   padding: 0 8px;
-  width: 100%;
   width: 700px;
   height: 400px;
   max-width: calc(100vw - 40px);
@@ -86,7 +85,6 @@
   justify-content: center;
   padding: 4px 6px;
   border-radius: 16px;
-  font-size: 11px;
   line-height: 16px;
   font-size: var(--size-12);
   font-weight: 500;

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
@@ -1,6 +1,11 @@
 .segment-explorer-content {
   font-size: var(--size-14);
   padding: 0 8px;
+  width: 100%;
+  width: 700px;
+  height: 400px;
+  max-width: calc(100vw - 40px);
+  max-height: calc(100vh - 240px);
 }
 
 .segment-explorer-page-route-bar {
@@ -54,7 +59,7 @@
 }
 
 .segment-explorer-filename--path {
-  margin-right: 8px;
+  margin-right: auto;
 }
 .segment-explorer-filename--path small {
   display: inline-block;
@@ -68,57 +73,119 @@
 .segment-explorer-files {
   display: inline-flex;
   gap: 8px;
+  margin-left: auto;
+}
+
+.segment-explorer-files + .segment-boundary-trigger {
+  margin-left: 8px;
 }
 
 .segment-explorer-file-label {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 20px;
-  padding: 2px 6px;
+  padding: 4px 6px;
   border-radius: 16px;
+  font-size: 11px;
+  line-height: 16px;
   font-size: var(--size-12);
   font-weight: 500;
   user-select: none;
   cursor: pointer;
-}
-
-.segment-explorer-file-label:hover {
-  filter: brightness(1.05);
-}
-
-.segment-explorer-file-label--layout,
-.segment-explorer-file-label--template,
-.segment-explorer-file-label--default {
   background-color: var(--color-gray-300);
   color: var(--color-gray-1000);
 }
-.segment-explorer-file-label--page {
-  background-color: var(--color-blue-300);
-  color: var(--color-blue-900);
-}
-.segment-explorer-file-label--not-found,
-.segment-explorer-file-label--forbidden,
-.segment-explorer-file-label--unauthorized {
+
+.segment-explorer-file-label--overridden {
   background-color: var(--color-amber-300);
   color: var(--color-amber-900);
 }
-.segment-explorer-file-label--loading {
-  background-color: var(--color-green-300);
-  color: var(--color-green-900);
+
+.segment-explorer-file-label svg {
+  opacity: 0;
+  margin-left: 0;
+  width: 0;
+  transition: all 0.15s ease-in-out;
 }
-.segment-explorer-file-label--error,
-.segment-explorer-file-label--global-error {
-  background-color: var(--color-red-300);
-  color: var(--color-red-900);
+.segment-explorer-file-label:hover svg {
+  opacity: 1;
+  width: 12px;
+  margin-left: 4px;
 }
+
+.segment-explorer-file-label:hover {
+  filter: brightness(0.95);
+}
+
 .segment-explorer-file-label--builtin {
   background-color: transparent;
   color: var(--color-gray-900);
   border: 1px dashed var(--color-gray-500);
+  height: 24px;
   cursor: default;
 }
 .segment-explorer-file-label--builtin svg {
   margin-left: 4px;
   margin-right: -4px;
+}
+
+/* Footer styles */
+.segment-explorer-footer {
+  padding: 8px;
+  border-top: 1px solid var(--color-gray-400);
+  background-color: var(--color-background-100);
+  user-select: none;
+}
+
+.segment-explorer-footer-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px;
+  background: var(--color-background-100);
+  border: 1px solid var(--color-gray-400);
+  border-radius: 6px;
+  color: var(--color-gray-1000);
+  font-size: var(--size-14);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.segment-explorer-footer-button:hover:not(:disabled) {
+  background: var(--color-gray-200);
+}
+
+.segment-explorer-footer-button--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.segment-explorer-footer-text {
+  text-align: center;
+}
+
+.segment-explorer-footer-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  background: var(--color-amber-300);
+  color: var(--color-amber-900);
+  border-radius: 10px;
+  font-size: var(--size-12);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.segment-explorer-file-label-tooltip--sm {
+  white-space: nowrap;
+}
+
+.segment-explorer-file-label-tooltip--lg {
+  min-width: 200px;
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -4,9 +4,9 @@ import {
   type SegmentTrieNode,
 } from '../../segment-explorer-trie'
 import { cx } from '../../utils/cx'
-import { SegmentBoundaryTrigger } from './segment-boundary-trigger'
+import { SegmentBoundaryTrigger, Trigger } from './segment-boundary-trigger'
 import { Tooltip } from '../../../components/tooltip'
-import { useRef, useState } from 'react'
+import { useRef, useState, useCallback, useMemo } from 'react'
 import {
   BUILTIN_PREFIX,
   getBoundaryOriginFileType,
@@ -18,11 +18,80 @@ const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
 }
 
+// Utility functions for global boundary management
+function traverseTreeAndResetBoundaries(node: SegmentTrieNode) {
+  // Reset this node's boundary if it has setBoundaryType function
+  if (node.value?.setBoundaryType) {
+    node.value.setBoundaryType(null)
+  }
+
+  // Recursively traverse children
+  Object.values(node.children).forEach((child) => {
+    if (child) {
+      traverseTreeAndResetBoundaries(child)
+    }
+  })
+}
+
+function countActiveBoundaries(node: SegmentTrieNode): number {
+  let count = 0
+
+  // Count this node's boundary override if it's active
+  // Only count when there's a non ":boundary" type and it has an active override (boundaryType is not null)
+  // This means the file is showing an overridden boundary instead of its original file
+  if (
+    node.value?.setBoundaryType &&
+    node.value.boundaryType !== null &&
+    !isBoundaryFile(node.value.type)
+  ) {
+    count++
+  }
+
+  // Recursively count children
+  Object.values(node.children).forEach((child) => {
+    if (child) {
+      count += countActiveBoundaries(child)
+    }
+  })
+
+  return count
+}
+
 function PageRouteBar({ page }: { page: string }) {
   return (
     <div className="segment-explorer-page-route-bar">
       <BackArrowIcon />
       <span className="segment-explorer-page-route-bar-path">{page}</span>
+    </div>
+  )
+}
+
+function SegmentExplorerFooter({
+  activeBoundariesCount,
+  onGlobalReset,
+}: {
+  activeBoundariesCount: number
+  onGlobalReset: () => void
+}) {
+  const hasActiveOverrides = activeBoundariesCount > 0
+
+  return (
+    <div className="segment-explorer-footer">
+      <button
+        className={`segment-explorer-footer-button ${!hasActiveOverrides ? 'segment-explorer-footer-button--disabled' : ''}`}
+        onClick={hasActiveOverrides ? onGlobalReset : undefined}
+        disabled={!hasActiveOverrides}
+        type="button"
+      >
+        <span className="segment-explorer-footer-text">
+          Clear Segment Overrides
+        </span>
+        {hasActiveOverrides && (
+          <span className="segment-explorer-footer-badge">
+            {activeBoundariesCount}
+          </span>
+        )}
+      </button>
     </div>
   )
 }
@@ -35,6 +104,19 @@ export function PageSegmentTree({
   page: string
 }) {
   const tree = useSegmentTree()
+
+  // Count active boundaries for the badge
+  const activeBoundariesCount = useMemo(() => {
+    return isAppRouter ? countActiveBoundaries(tree) : 0
+  }, [tree, isAppRouter])
+
+  // Global reset handler
+  const handleGlobalReset = useCallback(() => {
+    if (isAppRouter) {
+      traverseTreeAndResetBoundaries(tree)
+    }
+  }, [tree, isAppRouter])
+
   return (
     <div data-nextjs-devtools-panel-segments-explorer>
       {isAppRouter && <PageRouteBar page={page} />}
@@ -48,6 +130,12 @@ export function PageSegmentTree({
           <p>Route Info currently is only available for the App Router.</p>
         )}
       </div>
+      {isAppRouter && (
+        <SegmentExplorerFooter
+          activeBoundariesCount={activeBoundariesCount}
+          onGlobalReset={handleGlobalReset}
+        />
+      )}
     </div>
   )
 }
@@ -71,30 +159,42 @@ function PageSegmentTreeLayerPresentation({
   const childrenKeys = Object.keys(node.children)
 
   const sortedChildrenKeys = childrenKeys.sort((a, b) => {
-    // Prioritize if it's a file convention like layout or page,
-    // then the rest parallel routes.
+    // Prioritize files with extensions over directories
     const aHasExt = a.includes('.')
     const bHasExt = b.includes('.')
     if (aHasExt && !bHasExt) return -1
     if (!aHasExt && bHasExt) return 1
-    // Otherwise sort alphabetically
 
-    // If it's file, sort by order: layout > template > page
+    // For files, sort by priority: layout > template > page > boundaries > others
     if (aHasExt && bHasExt) {
       const aType = node.children[a]?.value?.type
       const bType = node.children[b]?.value?.type
 
-      if (aType === 'layout' && bType !== 'layout') return -1
-      if (aType !== 'layout' && bType === 'layout') return 1
-      if (aType === 'template' && bType !== 'template') return -1
-      if (aType !== 'template' && bType === 'template') return 1
+      // Define priority order
+      const getTypePriority = (type: string | undefined): number => {
+        if (!type) return 5
+        if (type === 'layout') return 1
+        if (type === 'template') return 2
+        if (type === 'page') return 3
+        if (isBoundaryFile(type)) return 4
+        return 5
+      }
 
-      // If both are the same type, sort by pagePath
+      const aPriority = getTypePriority(aType)
+      const bPriority = getTypePriority(bType)
+
+      // Sort by priority first
+      if (aPriority !== bPriority) {
+        return aPriority - bPriority
+      }
+
+      // If same priority, sort by file path
       const aFilePath = node.children[a]?.value?.pagePath || ''
       const bFilePath = node.children[b]?.value?.pagePath || ''
       return aFilePath.localeCompare(bFilePath)
     }
 
+    // For directories, sort alphabetically
     return a.localeCompare(b)
   })
 
@@ -103,7 +203,6 @@ function PageSegmentTreeLayerPresentation({
 
   const folderChildrenKeys: string[] = []
   const filesChildrenKeys: string[] = []
-  let pageChild = null
 
   for (const childKey of sortedChildrenKeys) {
     const childNode = node.children[childKey]
@@ -119,19 +218,29 @@ function PageSegmentTreeLayerPresentation({
     folderChildrenKeys.push(childKey)
   }
 
-  for (const fileChildSegment of filesChildrenKeys) {
-    const childNode = node.children[fileChildSegment]
+  let firstChild = null
+
+  for (let i = sortedChildrenKeys.length - 1; i >= 0; i--) {
+    const childNode = node.children[sortedChildrenKeys[i]]
     if (!childNode || !childNode.value) continue
 
-    // If it's a page node, we can use it as the page child
-    if (
-      childNode.value.type !== 'layout' &&
-      childNode.value.type !== 'template'
-    ) {
-      pageChild = childNode
-      break // We only need one page child
+    const isBoundary = isBoundaryFile(childNode.value.type)
+
+    if (!firstChild && !isBoundary) {
+      firstChild = childNode
+      break
     }
   }
+  let firstBoundaryChild = null
+  for (const childKey of sortedChildrenKeys) {
+    const childNode = node.children[childKey]
+    if (!childNode || !childNode.value) continue
+    if (isBoundaryFile(childNode.value.type)) {
+      firstBoundaryChild = childNode
+      break
+    }
+  }
+  firstChild = firstChild || firstBoundaryChild
 
   const hasFilesChildren = filesChildrenKeys.length > 0
   const boundaries: Record<'not-found' | 'loading' | 'error', string | null> = {
@@ -152,6 +261,14 @@ function PageSegmentTreeLayerPresentation({
       }
     }
   })
+
+  const filesChildrenKeysBesidesSelectedBoundary = filesChildrenKeys
+
+  const isChildPageOrBoundary =
+    firstChild &&
+    firstChild.value &&
+    firstChild.value.type !== 'layout' &&
+    firstChild.value.type !== 'template'
 
   return (
     <>
@@ -177,64 +294,92 @@ function PageSegmentTreeLayerPresentation({
                 </span>
               )}
               {/* display all the file segments in this level */}
-              {filesChildrenKeys.length > 0 && (
+              {filesChildrenKeysBesidesSelectedBoundary.length > 0 && (
                 <span className="segment-explorer-files">
-                  {filesChildrenKeys.map((fileChildSegment) => {
-                    const childNode = node.children[fileChildSegment]
-                    if (!childNode || !childNode.value) {
-                      return null
-                    }
-                    // If it's boundary node, which marks the existence of the boundary not the rendered status,
-                    // we don't need to present in the rendered files.
-                    if (isBoundaryFile(childNode.value.type)) {
-                      return null
-                    }
-                    const filePath = childNode.value.pagePath
-                    const lastSegment = filePath.split('/').pop() || ''
-                    const isBuiltin = filePath.startsWith(BUILTIN_PREFIX)
-                    const fileName = normalizeBoundaryFilename(lastSegment)
+                  {filesChildrenKeysBesidesSelectedBoundary.map(
+                    (fileChildSegment) => {
+                      const childNode = node.children[fileChildSegment]
+                      if (!childNode || !childNode.value) {
+                        return null
+                      }
+                      // If it's boundary node, which marks the existence of the boundary not the rendered status,
+                      // we don't need to present in the rendered files.
+                      if (isBoundaryFile(childNode.value.type)) {
+                        return null
+                      }
+                      // If it's a page/default file, don't show it as a separate label since it's represented by the dropdown button
+                      // if (
+                      //   childNode.value.type === 'page' ||
+                      //   childNode.value.type === 'default'
+                      // ) {
+                      //   return null
+                      // }
+                      const filePath = childNode.value.pagePath
+                      const lastSegment = filePath.split('/').pop() || ''
+                      const isBuiltin = filePath.startsWith(BUILTIN_PREFIX)
+                      const fileName = normalizeBoundaryFilename(lastSegment)
 
-                    return (
-                      <span
-                        key={fileChildSegment}
-                        onClick={() => {
-                          if (isBuiltin) return
-                          openInEditor({ filePath })
-                        }}
-                        className={cx(
-                          'segment-explorer-file-label',
-                          `segment-explorer-file-label--${childNode.value.type}`,
-                          isBuiltin && 'segment-explorer-file-label--builtin'
-                        )}
-                      >
-                        {fileName}
-                        {isBuiltin && (
-                          <Tooltip
-                            direction="right"
-                            title={`The default Next.js not found is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`}
-                            // x-ref: https://github.com/mui/base-ui/issues/2224
-                            // @ts-expect-error remove this expect-error once shadowRoot is supported as container
-                            container={shadowRootRef}
-                            offset={12}
-                            bgcolor="var(--color-gray-1000)"
-                            color="var(--color-gray-100)"
+                      const tooltipMessage = isBuiltin
+                        ? `The default Next.js ${childNode.value.type} is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`
+                        : null
+
+                      const isOverridden = childNode.value.boundaryType !== null
+
+                      return (
+                        <Tooltip
+                          key={fileChildSegment}
+                          className={
+                            'segment-explorer-file-label-tooltip--' +
+                            (isBuiltin ? 'lg' : 'sm')
+                          }
+                          direction={isBuiltin ? 'right' : 'top'}
+                          title={tooltipMessage}
+                          // x-ref: https://github.com/mui/base-ui/issues/2224
+                          // @ts-expect-error remove this expect-error once shadowRoot is supported as container
+                          container={shadowRootRef}
+                          offset={12}
+                          bgcolor="var(--color-gray-1000)"
+                          color="var(--color-gray-100)"
+                        >
+                          <span
+                            className={cx(
+                              'segment-explorer-file-label',
+                              `segment-explorer-file-label--${childNode.value.type}`,
+                              isBuiltin &&
+                                'segment-explorer-file-label--builtin',
+                              isOverridden &&
+                                'segment-explorer-file-label--overridden'
+                            )}
+                            onClick={() => {
+                              openInEditor({ filePath })
+                            }}
                           >
-                            <InfoIcon />
-                          </Tooltip>
-                        )}
-                      </span>
-                    )
-                  })}
+                            <span className="segment-explorer-file-label-text">
+                              {fileName}
+                            </span>
+                            {isBuiltin ? (
+                              <InfoIcon />
+                            ) : (
+                              <EditIcon className="edit-icon" />
+                            )}
+                          </span>
+                        </Tooltip>
+                      )
+                    }
+                  )}
                 </span>
               )}
-              {/* TODO: only show triggers in dev panel remove this once the new panel UI is stable */}
-              {pageChild && pageChild.value && (
+              {firstChild && firstChild.value && isChildPageOrBoundary && (
                 <SegmentBoundaryTrigger
-                  offset={6}
-                  onSelectBoundary={pageChild.value.setBoundaryType}
+                  nodeState={firstChild?.value || null}
                   boundaries={boundaries}
+                  // onSelectBoundary={firstChild.value.setBoundaryType}
+                  // pagePath={firstChild.value.pagePath}
+                  // boundaryType={firstChild.value.boundaryType}
+                  // fileType={firstChild.value.type}
                 />
               )}
+              {!isChildPageOrBoundary && <Trigger disabled />}
             </div>
           </div>
         </div>
@@ -310,6 +455,27 @@ function BackArrowIcon() {
       xmlns="http://www.w3.org/2000/svg"
     >
       <path d="M4.5 11.25C4.5 11.3881 4.61193 11.5 4.75 11.5H14.4395L11.9395 9L13 7.93945L16.7803 11.7197L16.832 11.7764C17.0723 12.0709 17.0549 12.5057 16.7803 12.7803L13 16.5605L11.9395 15.5L14.4395 13H4.75C3.7835 13 3 12.2165 3 11.25V4.25H4.5V11.25Z" />
+    </svg>
+  )
+}
+
+// Icon of edit pen
+function EditIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      strokeLinejoin="round"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M7.22763 14.1819L10.2276 2.18193L10.4095 1.45432L8.95432 1.09052L8.77242 1.81812L5.77242 13.8181L5.59051 14.5457L7.04573 14.9095L7.22763 14.1819ZM3.75002 12.0607L3.21969 11.5304L0.39647 8.70713C0.00594559 8.31661 0.00594559 7.68344 0.39647 7.29292L3.21969 4.46969L3.75002 3.93936L4.81068 5.00002L4.28035 5.53035L1.81068 8.00003L4.28035 10.4697L4.81068 11L3.75002 12.0607ZM12.25 12.0607L12.7804 11.5304L15.6036 8.70713C15.9941 8.31661 15.9941 7.68344 15.6036 7.29292L12.7804 4.46969L12.25 3.93936L11.1894 5.00002L11.7197 5.53035L14.1894 8.00003L11.7197 10.4697L11.1894 11L12.25 12.0607Z"
+        fill="currentColor"
+      />
     </svg>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -371,12 +371,8 @@ function PageSegmentTreeLayerPresentation({
               )}
               {firstChild && firstChild.value && isChildPageOrBoundary && (
                 <SegmentBoundaryTrigger
-                  nodeState={firstChild?.value || null}
+                  nodeState={firstChild.value}
                   boundaries={boundaries}
-                  // onSelectBoundary={firstChild.value.setBoundaryType}
-                  // pagePath={firstChild.value.pagePath}
-                  // boundaryType={firstChild.value.boundaryType}
-                  // fileType={firstChild.value.type}
                 />
               )}
               {!isChildPageOrBoundary && <Trigger disabled />}

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -6,7 +6,7 @@ import {
 import { cx } from '../../utils/cx'
 import { SegmentBoundaryTrigger, Trigger } from './segment-boundary-trigger'
 import { Tooltip } from '../../../components/tooltip'
-import { useRef, useState, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import {
   BUILTIN_PREFIX,
   getBoundaryOriginFileType,
@@ -149,13 +149,6 @@ function PageSegmentTreeLayerPresentation({
   node: SegmentTrieNode
   level: number
 }) {
-  const [shadowRoot] = useState<ShadowRoot | null>(() => {
-    const portal = document.querySelector('nextjs-portal')
-    if (!portal) return null
-    return portal.shadowRoot as ShadowRoot
-  })
-  // This is a workaround as base-ui popup container only accepts shadowRoot when it's in a ref.
-  const shadowRootRef = useRef<ShadowRoot>(shadowRoot)
   const childrenKeys = Object.keys(node.children)
 
   const sortedChildrenKeys = childrenKeys.sort((a, b) => {
@@ -334,9 +327,6 @@ function PageSegmentTreeLayerPresentation({
                           }
                           direction={isBuiltin ? 'right' : 'top'}
                           title={tooltipMessage}
-                          // x-ref: https://github.com/mui/base-ui/issues/2224
-                          // @ts-expect-error remove this expect-error once shadowRoot is supported as container
-                          container={shadowRootRef}
                           offset={12}
                           bgcolor="var(--color-gray-1000)"
                           color="var(--color-gray-100)"
@@ -360,7 +350,7 @@ function PageSegmentTreeLayerPresentation({
                             {isBuiltin ? (
                               <InfoIcon />
                             ) : (
-                              <EditIcon className="edit-icon" />
+                              <CodeIcon className="code-icon" />
                             )}
                           </span>
                         </Tooltip>
@@ -455,8 +445,7 @@ function BackArrowIcon() {
   )
 }
 
-// Icon of edit pen
-function EditIcon(props: React.SVGProps<SVGSVGElement>) {
+function CodeIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       width="12"

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -28,6 +28,7 @@ import type {
 import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
 import {
   BOUNDARY_PREFIX,
+  BOUNDARY_SUFFIX,
   getConventionPathByType,
 } from './segment-explorer-path'
 
@@ -565,7 +566,7 @@ async function createComponentTreeInternal({
         // Add a suffix to avoid conflict with the segment view node representing rendered file.
         // existence: not-found.tsx@boundary
         // rendered: not-found.tsx
-        const fileNameSuffix = '@boundary'
+        const fileNameSuffix = BOUNDARY_SUFFIX
         const segmentViewBoundaries = isSegmentViewEnabled ? (
           <>
             {notFoundFilePath && (

--- a/test/development/app-dir/segment-explorer/app/no-layout/framework/blog/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/no-layout/framework/blog/layout.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <h2>Layout - /no-layout/framework/blog</h2>
+      {children}
+      <Link href="/no-layout/framework">To /no-layout/framework</Link>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/no-layout/framework/blog/not-found.tsx
+++ b/test/development/app-dir/segment-explorer/app/no-layout/framework/blog/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>Not Found - /no-layout/framework/blog/not-found</div>
+}

--- a/test/development/app-dir/segment-explorer/app/no-layout/framework/blog/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/no-layout/framework/blog/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Page - /no-layout/framework/blog</div>
+}

--- a/test/development/app-dir/segment-explorer/app/no-layout/framework/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/no-layout/framework/layout.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <h1>Layout - /no-layout/framework</h1>
+      {children}
+      <Link href="/no-layout">To /no-layout</Link>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/no-layout/not-found.tsx
+++ b/test/development/app-dir/segment-explorer/app/no-layout/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>Not Found - /no-layout</div>
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes/@bar/error.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes/@bar/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <div>Error @bar</div>
+}

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -206,4 +206,18 @@ describe('segment-explorer', () => {
      default.tsx"
     `)
   })
+
+  it('should display boundary selector when a segment has only boundary files', async () => {
+    const browser = await next.browser('/no-layout/framework/blog')
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
+     "app/
+     layout.tsx
+     no-layout/
+     framework/
+     layout.tsx
+     blog/
+     layout.tsx
+     page.tsx"
+    `)
+  })
 })


### PR DESCRIPTION
### Highlights

* We expand the panel size and change the `...` menu to a switcher to let you view rendering boundaries
* Show a code icon on the file labels when hover, indicating that you can open them in editor
 
https://github.com/user-attachments/assets/d08dc1d2-40da-4564-b3ad-68944da3d8ff

