### PR TITLE
Turbopack: fix instrumentation-edge layer name

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1567,7 +1567,7 @@ impl Project {
                 self.execution_context(),
             ),
             Layer::new_with_user_friendly_name(
-                rcstr!("instrumentation"),
+                rcstr!("instrumentation-edge"),
                 rcstr!("Edge Instrumentation"),
             ),
         )))


### PR DESCRIPTION
A typo

Regression from https://github.com/vercel/next.js/pull/80388

Closes PACK-5014