### PR TITLE
Add @sparticuz/chromium-min to default server externals

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
@@ -34,6 +34,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`
 - `@sparticuz/chromium`
+- `@sparticuz/chromium-min`
 - `@swc/core`
 - `@xenova/transformers`
 - `argon2`

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
@@ -34,6 +34,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`
 - `@sparticuz/chromium`
+- `@sparticuz/chromium-min`
 - `@swc/core`
 - `@xenova/transformers`
 - `argon2`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -15,6 +15,7 @@
   "@react-pdf/renderer",
   "@sentry/profiling-node",
   "@sparticuz/chromium",
+  "@sparticuz/chromium-min",
   "@swc/core",
   "@xenova/transformers",
   "argon2",


### PR DESCRIPTION
This package needs to be externalized to have it's wasm dependencies traced properly for node runtime so this adds it to the default list.