### PR TITLE
[sourcemaps] Improve ignore-listing performance

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -208,7 +208,14 @@ function getSourcemappedFrameIfPossible(
     line: frame.lineNumber ?? 1,
   })
 
-  let ignored = sourceMapIgnoreListsEverything(sourceMapPayload)
+  const applicableSourceMap = findApplicableSourceMapPayload(
+    frame.lineNumber ?? 0,
+    frame.column ?? 0,
+    sourceMapPayload
+  )
+  let ignored =
+    applicableSourceMap !== undefined &&
+    sourceMapIgnoreListsEverything(applicableSourceMap)
   if (sourcePosition.source === null) {
     return {
       stack: {
@@ -223,11 +230,6 @@ function getSourcemappedFrameIfPossible(
     }
   }
 
-  const applicableSourceMap = findApplicableSourceMapPayload(
-    frame.lineNumber ?? 0,
-    frame.column ?? 0,
-    sourceMapPayload
-  )
   // TODO(veil): Upstream a method to sourcemap consumer that immediately says if a frame is ignored or not.
   if (applicableSourceMap === undefined) {
     console.error('No applicable source map found in sections for frame', frame)


### PR DESCRIPTION
This improves performance of finding the relevant section in Index Source Maps by using binary search (O(N) -> O(log N)).

This allows us to improve the performance of the fast path for checking if a source is ignore-listed in Index Source Maps:
Instead of checking if every section in Index Source Maps ignores everything, we just find the relevant section (now O(log N) instead of O(N)) and check if that section ignores everything.