### PR TITLE
[test] Dedicate suite for React's Server Request performance track

### DIFF
--- a/test/development/app-dir/react-performance-track/app/fetch/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/fetch/page.tsx
@@ -1,0 +1,16 @@
+async function abstraction() {
+  const response = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  )
+  await response.json()
+}
+
+export default async function FetchPage() {
+  await abstraction()
+  const response = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  )
+  await response.json()
+
+  return <p>Done</p>
+}

--- a/test/development/app-dir/react-performance-track/app/layout.tsx
+++ b/test/development/app-dir/react-performance-track/app/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode, Suspense } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/development/app-dir/react-performance-track/app/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/page.tsx
@@ -1,0 +1,5 @@
+const error = new Error('test')
+export default function Page() {
+  console.error(error)
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/react-performance-track/app/set-timeout/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/set-timeout/page.tsx
@@ -1,0 +1,12 @@
+import { setTimeout } from 'timers/promises'
+
+async function abstraction(timeoutMS: number) {
+  await setTimeout(timeoutMS)
+}
+
+export default async function SetTimeoutPage() {
+  await abstraction(5)
+  await setTimeout(1000)
+
+  return <p>Done</p>
+}

--- a/test/development/app-dir/react-performance-track/instrumentation-client.ts
+++ b/test/development/app-dir/react-performance-track/instrumentation-client.ts
@@ -1,0 +1,33 @@
+export {}
+
+declare global {
+  interface Window {
+    reactServerRequests: Array<{
+      name: string
+      properties: any
+    }>
+  }
+
+  interface PerformanceEntry {
+    detail?: any
+  }
+}
+
+window.reactServerRequests = []
+
+// We're trying to mock how the Chrome DevTools performance panel will display
+// React performance data. React might decide to use console.timeStamp instead
+// or any other method that will be picked up by the performance panel so this
+// logic may have to be adjusted when updating React. A change here, doesn't
+// mean it's a breaking change in React nor Next.js.
+new PerformanceObserver((entries) => {
+  for (const entry of entries.getEntries()) {
+    if (entry.detail?.devtools?.track === 'Server Requests ⚛') {
+      window.reactServerRequests.push({
+        name: entry.name,
+        properties: entry.detail.devtools.properties,
+      })
+    }
+  }
+  console.log(window.reactServerRequests)
+}).observe({ entryTypes: ['measure'] })

--- a/test/development/app-dir/react-performance-track/next.config.js
+++ b/test/development/app-dir/react-performance-track/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  // Some flag to enable react@experimental
+  experimental: { taint: true },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('react-performance-track', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should show setTimeout', async () => {
+    const browser = await next.browser('/set-timeout')
+
+    const track = await browser.eval('window.reactServerRequests')
+    expect(track).toEqual([
+      { name: 'setTimeout', properties: [] },
+      { name: 'setTimeout', properties: [] },
+    ])
+  })
+
+  it('should show fetch', async () => {
+    const browser = await next.browser('/fetch')
+
+    const track = await browser.eval('window.reactServerRequests')
+    // FIXME: Should show await fetch and await response.json()
+    expect(track).toEqual([])
+  })
+})


### PR DESCRIPTION
We're testing this here since framework integration via `filterStackTrace` determines what React uses to determine the name of the Performance entry.