### PR TITLE
wip: lazy not-found

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -34,6 +34,7 @@ import {
   MATCHED_PATH_HEADER,
   RSC_SEGMENTS_DIR_SUFFIX,
   RSC_SEGMENT_SUFFIX,
+  RSC_NOT_FOUND_SUFFIX,
 } from '../lib/constants'
 import { FileType, fileExists } from '../lib/file-exists'
 import { findPagesDir } from '../lib/find-pages-dir'
@@ -158,6 +159,7 @@ import {
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_REWRITTEN_PATH_HEADER,
   NEXT_REWRITTEN_QUERY_HEADER,
+  NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER,
 } from '../client/components/app-router-headers'
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext, type MappedPages } from './build-context'
@@ -447,6 +449,8 @@ export type RoutesManifest = {
     prefetchSegmentHeader: typeof NEXT_ROUTER_SEGMENT_PREFETCH_HEADER
     prefetchSegmentDirSuffix: typeof RSC_SEGMENTS_DIR_SUFFIX
     prefetchSegmentSuffix: typeof RSC_SEGMENT_SUFFIX
+    notFoundSuffix: typeof RSC_NOT_FOUND_SUFFIX
+    includeNotFoundHeader: typeof NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER
   }
   rewriteHeaders: {
     pathHeader: typeof NEXT_REWRITTEN_PATH_HEADER
@@ -1361,7 +1365,7 @@ export default async function build(
               header: RSC_HEADER,
               // This vary header is used as a default. It is technically re-assigned in `base-server`,
               // and may include an additional Vary option for `Next-URL`.
-              varyHeader: `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}, ${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}`,
+              varyHeader: `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}, ${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}, ${NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER}`,
               prefetchHeader: NEXT_ROUTER_PREFETCH_HEADER,
               didPostponeHeader: NEXT_DID_POSTPONE_HEADER,
               contentTypeHeader: RSC_CONTENT_TYPE_HEADER,
@@ -1370,6 +1374,8 @@ export default async function build(
               prefetchSegmentHeader: NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
               prefetchSegmentSuffix: RSC_SEGMENT_SUFFIX,
               prefetchSegmentDirSuffix: RSC_SEGMENTS_DIR_SUFFIX,
+              notFoundSuffix: RSC_NOT_FOUND_SUFFIX,
+              includeNotFoundHeader: NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER,
             },
             rewriteHeaders: {
               pathHeader: NEXT_REWRITTEN_PATH_HEADER,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -214,6 +214,22 @@ async function createTreeCodeFromPath(
       parallelSegments.push(['children', ''])
     } else {
       parallelSegments.push(...resolveParallelSegments(segmentPath))
+
+      // convert the not-found.tsx into a parallel route
+      // TODO: implement Turbopack change
+      // TODO: do not pass this to Layout
+      // TODO: ban parallel route with this name
+      const notFoundPath = await resolver(
+        `${appDirPrefix}${
+          segmentPath.endsWith('/') ? segmentPath : segmentPath + '/'
+        }not-found`
+      )
+      if (notFoundPath) {
+        parallelSegments.push(...resolveParallelSegments(segmentPath), [
+          '@__not_found__', // TODO: (1) define this into a constant, (2) error if user defines the same name for parallel route
+          notFoundPath, // segment value is the resolved path for the not-found page
+        ])
+      }
     }
 
     let metadata: Awaited<ReturnType<typeof createStaticMetadataFromRoute>> =
@@ -232,6 +248,20 @@ async function createTreeCodeFromPath(
     }
 
     for (const [parallelKey, parallelSegment] of parallelSegments) {
+      if (parallelKey === '@__not_found__') {
+        const resolvedNotFoundPath = parallelSegment as string
+        const varName = `page${nestedCollectedDeclarations.length}`
+        nestedCollectedDeclarations.push([varName, resolvedNotFoundPath])
+        props[normalizeParallelKey(parallelKey)] = `[
+          '${PAGE_SEGMENT_KEY}',
+          {},
+          {
+            page: [${varName}, ${JSON.stringify(resolvedNotFoundPath)}],
+          }
+        ]`
+        continue
+      }
+
       // if parallelSegment is the page segment (ie, `page$` and not ['page$']), it gets loaded into the __PAGE__ slot
       // as it's the page for the current route.
       if (parallelSegment === PAGE_SEGMENT) {

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -16,6 +16,10 @@ export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
 export const NEXT_URL = 'Next-Url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 
+// TODO: make this a more general naming for lazy loaded parts of the page
+export const NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER =
+  'Next-Router-Include-Not-Found' as const
+
 export const FLIGHT_HEADERS = [
   RSC_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -20,6 +20,7 @@ import {
   NEXT_HMR_REFRESH_HEADER,
   NEXT_DID_POSTPONE_HEADER,
   NEXT_ROUTER_STALE_TIME_HEADER,
+  NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER,
 } from '../app-router-headers'
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
@@ -40,6 +41,7 @@ export interface FetchServerResponseOptions {
   readonly nextUrl: string | null
   readonly prefetchKind?: PrefetchKind
   readonly isHmrRefresh?: boolean
+  readonly isNotFoundSegment?: boolean
 }
 
 export type FetchServerResponseResult = {
@@ -61,6 +63,9 @@ export type RequestHeaders = {
   [NEXT_HMR_REFRESH_HEADER]?: '1'
   // A header that is only added in test mode to assert on fetch priority
   'Next-Test-Fetch-Priority'?: RequestInit['priority']
+  // TODO: change cache busting to account for this to prevent
+  // cache poisoning??
+  [NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER]?: '1'
 }
 
 export function urlToUrlWithoutFlightMarker(url: string): URL {
@@ -117,7 +122,8 @@ export async function fetchServerResponse(
   url: URL,
   options: FetchServerResponseOptions
 ): Promise<FetchServerResponseResult> {
-  const { flightRouterState, nextUrl, prefetchKind } = options
+  const { flightRouterState, nextUrl, prefetchKind, isNotFoundSegment } =
+    options
 
   const headers: RequestHeaders = {
     // Enable flight response
@@ -145,6 +151,10 @@ export async function fetchServerResponse(
 
   if (nextUrl) {
     headers[NEXT_URL] = nextUrl
+  }
+
+  if (isNotFoundSegment) {
+    headers[NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER] = '1'
   }
 
   try {

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -75,6 +75,7 @@ export class ExportError extends Error {
   code = 'NEXT_EXPORT_ERROR'
 }
 
+// TODO: does not support lazy not found mode
 async function exportAppImpl(
   dir: string,
   options: Readonly<ExportAppOptions>,

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -11,6 +11,7 @@ export const PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER =
 export const RSC_PREFETCH_SUFFIX = '.prefetch.rsc'
 export const RSC_SEGMENTS_DIR_SUFFIX = '.segments'
 export const RSC_SEGMENT_SUFFIX = '.segment.rsc'
+export const RSC_NOT_FOUND_SUFFIX = '.not-found.rsc'
 export const RSC_SUFFIX = '.rsc'
 export const ACTION_SUFFIX = '.action'
 export const NEXT_DATA_SUFFIX = '.json'

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -54,6 +54,7 @@ import {
   RSC_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_HMR_REFRESH_HASH_COOKIE,
+  NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER,
 } from '../../client/components/app-router-headers'
 import { createMetadataContext } from '../../lib/metadata/metadata-context'
 import { createRequestStoreForRender } from '../async-storage/request-store'
@@ -228,6 +229,7 @@ export type AppRenderContext = {
   requestTimestamp: number
   appUsingSizeAdjustment: boolean
   flightRouterState?: FlightRouterState
+  includeNotFound: boolean
   requestId: string
   pagePath: string
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>
@@ -266,6 +268,7 @@ interface ParsedRequestHeaders {
   readonly isDevWarmupRequest: boolean
   readonly isHmrRefresh: boolean
   readonly isRSCRequest: boolean
+  readonly includeNotFound: boolean
   readonly nonce: string | undefined
   readonly previouslyRevalidatedTags: string[]
 }
@@ -313,6 +316,9 @@ function parseRequestHeaders(
     options.previewModeId
   )
 
+  const includeNotFound =
+    headers[NEXT_ROUTER_INCLUDE_NOT_FOUND_HEADER.toLowerCase()] === '1'
+
   return {
     flightRouterState,
     isPrefetchRequest,
@@ -322,6 +328,7 @@ function parseRequestHeaders(
     isDevWarmupRequest,
     nonce,
     previouslyRevalidatedTags,
+    includeNotFound,
   }
 }
 
@@ -1333,6 +1340,7 @@ async function renderToHTMLOrFlightImpl(
     isDevWarmupRequest,
     isHmrRefresh,
     nonce,
+    includeNotFound,
   } = parsedRequestHeaders
 
   const { isStaticGeneration, fallbackRouteParams } = workStore
@@ -1396,6 +1404,7 @@ async function renderToHTMLOrFlightImpl(
     res,
     sharedContext,
     implicitTags,
+    includeNotFound,
   }
 
   getTracer().setRootSpanAttribute('next.route', pagePath)

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -106,8 +106,9 @@ export async function walkTreeWithFlightRouterState({
     !flightRouterState ||
     // Segment in router state does not match current segment
     !matchSegment(actualSegment, flightRouterState[0]) ||
+    // TODO: Make a separate PR to just remove the "parallelRoutesKeys.length === 0" condition.
     // Last item in the tree
-    parallelRoutesKeys.length === 0 ||
+    // parallelRoutesKeys.length === 0 ||
     // Explicit refresh
     flightRouterState[3] === 'refetch'
 
@@ -252,6 +253,10 @@ export async function walkTreeWithFlightRouterState({
   // Walk through all parallel routes.
   for (const parallelRouteKey of parallelRoutesKeys) {
     const parallelRoute = parallelRoutes[parallelRouteKey]
+
+    if (parallelRouteKey === '__not_found__' && !ctx.includeNotFound) {
+      continue
+    }
 
     const subPaths = await walkTreeWithFlightRouterState({
       ctx,

--- a/packages/next/src/server/normalizers/request/not-found-rsc.ts
+++ b/packages/next/src/server/normalizers/request/not-found-rsc.ts
@@ -1,0 +1,13 @@
+import type { PathnameNormalizer } from './pathname-normalizer'
+
+import { RSC_NOT_FOUND_SUFFIX } from '../../../lib/constants'
+import { SuffixPathnameNormalizer } from './suffix'
+
+export class NotFoundRSCPathnameNormalizer
+  extends SuffixPathnameNormalizer
+  implements PathnameNormalizer
+{
+  constructor() {
+    super(RSC_NOT_FOUND_SUFFIX)
+  }
+}

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -236,6 +236,11 @@ export interface RequestMeta {
    * specific flags in future)
    */
   minimalMode?: boolean
+
+  /**
+   * Whether the request is for the not found page.
+   */
+  isIncludeNotFound?: boolean
 }
 
 /**

--- a/test/e2e/app-dir/lazy-not-found/app/about/page.tsx
+++ b/test/e2e/app-dir/lazy-not-found/app/about/page.tsx
@@ -1,0 +1,24 @@
+// its a client component, so its always static....
+// so when you refetch the not found tree, it doesn't run
+// any actual compute..
+// TODO: so maybe we should fetch from a different endpoint??
+'use client'
+
+import { notFound } from 'next/navigation'
+import { useState } from 'react'
+
+export default function AboutPage() {
+  // notFound()
+  const [error, setError] = useState(false)
+
+  if (error) {
+    notFound()
+  }
+
+  return (
+    <div>
+      About Page
+      <button onClick={() => setError(true)}>Not Found</button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/lazy-not-found/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/lazy-not-found/app/dynamic/page.tsx
@@ -1,0 +1,5 @@
+export default function DynamicPage() {
+  return <div>Dynamic Page - {Date.now()}</div>
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/lazy-not-found/app/gone/page.tsx
+++ b/test/e2e/app-dir/lazy-not-found/app/gone/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function GonePage() {
+  notFound()
+}

--- a/test/e2e/app-dir/lazy-not-found/app/layout.tsx
+++ b/test/e2e/app-dir/lazy-not-found/app/layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/lazy-not-found/app/not-found.tsx
+++ b/test/e2e/app-dir/lazy-not-found/app/not-found.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function NotFound() {
+  return <div>Not Found</div>
+}

--- a/test/e2e/app-dir/lazy-not-found/app/page.tsx
+++ b/test/e2e/app-dir/lazy-not-found/app/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+import React from 'react'
+
+export default function Page() {
+  return (
+    <div>
+      Home Page
+      <Link href="/about">Go to about</Link>
+      <Link href="/dynamic">Go to dynamic</Link>
+      <Link href="/gone">Go to gone</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/lazy-not-found/index.test.ts
+++ b/test/e2e/app-dir/lazy-not-found/index.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// TODO: complete this test
+describe('Lazy Not Found', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('todo', async () => {
+    // const browser =
+    await next.browser('/')
+    await new Promise((resolve) => setTimeout(resolve, 60000))
+  })
+})

--- a/test/e2e/app-dir/lazy-not-found/next.config.ts
+++ b/test/e2e/app-dir/lazy-not-found/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+export default {
+  experimental: {
+    clientSegmentCache: true,
+  },
+} satisfies NextConfig


### PR DESCRIPTION
- [ ] Fix React error when loading `/gone`
- [ ] Cache revalidation
- [ ] `Vary` header
- [ ] `output: "export"` mode
- [ ] Disable lazy not found in static generation
- [ ] Update cache-poisoning, Vary