### PR TITLE
feat(build): optimize filterUniqueParamsCombinations to generate sub-combinations

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -719,5 +719,6 @@
   "718": "Invariant: projectDir is required for node runtime",
   "719": "Failed to get source map for '%s'. This is a bug in Next.js",
   "720": "A client prerender store should not be used for a route handler.",
-  "721": "Render in Browser"
+  "721": "Render in Browser",
+  "722": "Unable to match pathname to a dynamic route"
 }

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -4,8 +4,11 @@ import {
   assignErrorIfEmpty,
   generateParamPrefixCombinations,
   filterUniqueParams,
+  generateRouteStaticParams,
 } from './app'
 import type { PrerenderedRoute } from './types'
+import type { WorkStore } from '../../server/app-render/work-async-storage.external'
+import type { AppSegment } from '../segment-config/app/app-segments'
 
 describe('assignErrorIfEmpty', () => {
   it('should assign throwOnEmptyStaticShell true for a static route with no children', () => {
@@ -642,5 +645,385 @@ describe('generateParamPrefixCombinations', () => {
 
     // Should return empty array when there are no route params to work with
     expect(unique).toEqual([])
+  })
+})
+
+type TestAppSegment = Pick<AppSegment, 'config' | 'generateStaticParams'>
+
+// Mock WorkStore for testing
+const createMockWorkStore = (fetchCache?: WorkStore['fetchCache']) => ({
+  fetchCache,
+})
+
+// Helper to create mock segments
+const createMockSegment = (
+  generateStaticParams?: (options: { params?: Params }) => Promise<Params[]>,
+  config?: TestAppSegment['config']
+): TestAppSegment => ({
+  config,
+  generateStaticParams,
+})
+
+describe('generateRouteStaticParams', () => {
+  describe('Basic functionality', () => {
+    it('should return empty array for empty segments', async () => {
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams([], store)
+      expect(result).toEqual([])
+    })
+
+    it('should return empty array for segments without generateStaticParams', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(),
+        createMockSegment(),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([])
+    })
+
+    it('should process single segment with generateStaticParams', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ id: '1' }, { id: '2' }]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([{ id: '1' }, { id: '2' }])
+    })
+
+    it('should process multiple segments with generateStaticParams', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [
+          { category: 'tech' },
+          { category: 'sports' },
+        ]),
+        createMockSegment(async ({ params }) => [
+          { slug: `${params?.category}-post-1` },
+          { slug: `${params?.category}-post-2` },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([
+        { category: 'tech', slug: 'tech-post-1' },
+        { category: 'tech', slug: 'tech-post-2' },
+        { category: 'sports', slug: 'sports-post-1' },
+        { category: 'sports', slug: 'sports-post-2' },
+      ])
+    })
+  })
+
+  describe('Parameter inheritance', () => {
+    it('should inherit parent parameters', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }, { lang: 'fr' }]),
+        createMockSegment(async ({ params }) => [
+          { category: `${params?.lang}-tech` },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([
+        { lang: 'en', category: 'en-tech' },
+        { lang: 'fr', category: 'fr-tech' },
+      ])
+    })
+
+    it('should handle mixed segments (some with generateStaticParams, some without)', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }]),
+        createMockSegment(), // No generateStaticParams
+        createMockSegment(async ({ params }) => [
+          { slug: `${params?.lang}-slug` },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([{ lang: 'en', slug: 'en-slug' }])
+    })
+  })
+
+  describe('Empty and undefined handling', () => {
+    it('should handle empty generateStaticParams results', async () => {
+      const segments: TestAppSegment[] = [createMockSegment(async () => [])]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([])
+    })
+
+    it('should handle generateStaticParams returning empty array with parent params', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }]),
+        createMockSegment(async () => []), // Empty result
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([{ lang: 'en' }])
+    })
+
+    it('should handle missing parameters in parent params', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }, {}]),
+        createMockSegment(async ({ params }) => [
+          { category: `${params?.lang || 'default'}-tech` },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([
+        { lang: 'en', category: 'en-tech' },
+        { category: 'default-tech' },
+      ])
+    })
+  })
+
+  describe('FetchCache configuration', () => {
+    it('should set fetchCache on store when segment has fetchCache config', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ id: '1' }], {
+          fetchCache: 'force-cache',
+        }),
+      ]
+      const store = createMockWorkStore()
+      await generateRouteStaticParams(segments, store)
+      expect(store.fetchCache).toBe('force-cache')
+    })
+
+    it('should not modify fetchCache when segment has no fetchCache config', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ id: '1' }]),
+      ]
+      const store = createMockWorkStore('force-cache')
+      await generateRouteStaticParams(segments, store)
+      expect(store.fetchCache).toBe('force-cache')
+    })
+
+    it('should update fetchCache for multiple segments', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ category: 'tech' }], {
+          fetchCache: 'force-cache',
+        }),
+        createMockSegment(async () => [{ slug: 'post' }], {
+          fetchCache: 'default-cache',
+        }),
+      ]
+      const store = createMockWorkStore()
+      await generateRouteStaticParams(segments, store)
+      // Should have the last fetchCache value
+      expect(store.fetchCache).toBe('default-cache')
+    })
+  })
+
+  describe('Array parameter values', () => {
+    it('should handle array parameter values', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [
+          { slug: ['a', 'b'] },
+          { slug: ['c', 'd', 'e'] },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([{ slug: ['a', 'b'] }, { slug: ['c', 'd', 'e'] }])
+    })
+
+    it('should handle mixed array and string parameters', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }]),
+        createMockSegment(async ({ params }) => [
+          { slug: [`${params?.lang}`, 'post'] },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([{ lang: 'en', slug: ['en', 'post'] }])
+    })
+  })
+
+  describe('Deep nesting scenarios', () => {
+    it('should handle deeply nested segments', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ a: '1' }]),
+        createMockSegment(async ({ params }) => [{ b: `${params?.a}-2` }]),
+        createMockSegment(async ({ params }) => [{ c: `${params?.b}-3` }]),
+        createMockSegment(async ({ params }) => [{ d: `${params?.c}-4` }]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([{ a: '1', b: '1-2', c: '1-2-3', d: '1-2-3-4' }])
+    })
+
+    it('should handle many parameter combinations', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ x: '1' }, { x: '2' }]),
+        createMockSegment(async () => [{ y: 'a' }, { y: 'b' }]),
+        createMockSegment(async () => [{ z: 'i' }, { z: 'ii' }]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([
+        { x: '1', y: 'a', z: 'i' },
+        { x: '1', y: 'a', z: 'ii' },
+        { x: '1', y: 'b', z: 'i' },
+        { x: '1', y: 'b', z: 'ii' },
+        { x: '2', y: 'a', z: 'i' },
+        { x: '2', y: 'a', z: 'ii' },
+        { x: '2', y: 'b', z: 'i' },
+        { x: '2', y: 'b', z: 'ii' },
+      ])
+    })
+  })
+
+  describe('Error handling', () => {
+    it('should handle generateStaticParams throwing an error', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => {
+          throw new Error('Test error')
+        }),
+      ]
+      const store = createMockWorkStore()
+      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
+        'Test error'
+      )
+    })
+
+    it('should handle generateStaticParams returning a rejected promise', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => {
+          return Promise.reject(new Error('Async error'))
+        }),
+      ]
+      const store = createMockWorkStore()
+      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
+        'Async error'
+      )
+    })
+
+    it('should handle partially failing generateStaticParams', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ category: 'tech' }]),
+        createMockSegment(async ({ params }) => {
+          if (params?.category === 'tech') {
+            throw new Error('Tech not allowed')
+          }
+          return [{ slug: 'post' }]
+        }),
+      ]
+      const store = createMockWorkStore()
+      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
+        'Tech not allowed'
+      )
+    })
+  })
+
+  describe('Complex real-world scenarios', () => {
+    it('should handle i18n routing pattern', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [
+          { lang: 'en' },
+          { lang: 'fr' },
+          { lang: 'es' },
+        ]),
+        createMockSegment(async ({ params: _params }) => [
+          { category: 'tech' },
+          { category: 'sports' },
+        ]),
+        createMockSegment(async ({ params }) => [
+          { slug: `${params?.lang}-${params?.category}-post-1` },
+          { slug: `${params?.lang}-${params?.category}-post-2` },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toHaveLength(12) // 3 langs × 2 categories × 2 slugs
+      expect(result).toContainEqual({
+        lang: 'en',
+        category: 'tech',
+        slug: 'en-tech-post-1',
+      })
+      expect(result).toContainEqual({
+        lang: 'fr',
+        category: 'sports',
+        slug: 'fr-sports-post-2',
+      })
+    })
+
+    it('should handle e-commerce routing pattern', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(), // Static segment
+        createMockSegment(async () => [
+          { category: 'electronics' },
+          { category: 'clothing' },
+        ]),
+        createMockSegment(async ({ params }) => {
+          if (params?.category === 'electronics') {
+            return [{ subcategory: 'phones' }, { subcategory: 'laptops' }]
+          }
+          return [{ subcategory: 'shirts' }, { subcategory: 'pants' }]
+        }),
+        createMockSegment(async ({ params }) => [
+          { product: `${params?.subcategory}-item-1` },
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toEqual([
+        {
+          category: 'electronics',
+          subcategory: 'phones',
+          product: 'phones-item-1',
+        },
+        {
+          category: 'electronics',
+          subcategory: 'laptops',
+          product: 'laptops-item-1',
+        },
+        {
+          category: 'clothing',
+          subcategory: 'shirts',
+          product: 'shirts-item-1',
+        },
+        { category: 'clothing', subcategory: 'pants', product: 'pants-item-1' },
+      ])
+    })
+
+    it('should handle blog with optional catch-all', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(), // Static segment
+        createMockSegment(async () => [{ year: '2023' }, { year: '2024' }]),
+        createMockSegment(async ({ params: _params }) => [
+          { month: '01' },
+          { month: '02' },
+        ]),
+        createMockSegment(async ({ params }) => [
+          { slug: [`${params?.year}-${params?.month}-post`] },
+          { slug: [] }, // Empty for optional catch-all
+        ]),
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toHaveLength(8) // 2 years × 2 months × 2 slug variations
+      expect(result).toContainEqual({
+        year: '2023',
+        month: '01',
+        slug: ['2023-01-post'],
+      })
+      expect(result).toContainEqual({ year: '2024', month: '02', slug: [] })
+    })
+  })
+
+  describe('Performance considerations', () => {
+    it('should handle recursive calls without stack overflow', async () => {
+      const segments: TestAppSegment[] = []
+      for (let i = 0; i < 5000; i++) {
+        segments.push(
+          createMockSegment(async () => [{ [`param${i}`]: `value${i}` }])
+        )
+      }
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store)
+      expect(result).toHaveLength(1)
+      expect(Object.keys(result[0])).toHaveLength(5000)
+    })
   })
 })

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -140,22 +140,29 @@ export function generateParamPrefixCombinations(
       // Build the sub-combination with parameters from index 0 to i (inclusive).
       for (let j = 0; j <= i; j++) {
         const routeKey = routeParamKeys[j]
-        const value = params[routeKey]
 
-        // Only add to combination if the value exists in the original params.
-        if (value !== undefined) {
-          combination[routeKey] = value
+        // Check if the parameter exists in the original params object and has a defined value
+        if (
+          !params.hasOwnProperty(routeKey) ||
+          params[routeKey] === undefined
+        ) {
+          // If the parameter doesn't exist or is undefined, we've reached the end of available
+          // parameters for this combination, so break out of the loop
+          break
         }
 
+        const value = params[routeKey]
+
+        // Add to combination (we know value is not undefined due to check above)
+        combination[routeKey] = value
+
         // Construct a part of the key using the route parameter key and its value.
-        // A type prefix (`A:` for Array, `S:` for String, `U:` for undefined) is added to the value
+        // A type prefix (`A:` for Array, `S:` for String) is added to the value
         // to prevent collisions. This ensures that different types with the same
         // string representation are treated as distinct.
         let valuePart: string
         if (Array.isArray(value)) {
           valuePart = `A:${value.join(',')}`
-        } else if (value === undefined) {
-          valuePart = `U:undefined`
         } else {
           valuePart = `S:${value}`
         }

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -17,6 +17,7 @@ import { normalizePathname, encodeParam } from './utils'
 import escapePathDelimiters from '../../shared/lib/router/utils/escape-path-delimiters'
 import { createIncrementalCache } from '../../export/helpers/create-incremental-cache'
 import type { NextConfigComplete } from '../../server/config-shared'
+import type { WorkStore } from '../../server/app-render/work-async-storage.external'
 
 /**
  * Filters out duplicate parameters from a list of parameters.
@@ -508,6 +509,87 @@ export function assignErrorIfEmpty(
 }
 
 /**
+ * Processes app directory segments to build route parameters from generateStaticParams functions.
+ * This function walks through the segments array and calls generateStaticParams for each segment that has it,
+ * combining parent parameters with child parameters to build the complete parameter combinations.
+ * Uses iterative processing instead of recursion for better performance.
+ *
+ * @param segments - Array of app directory segments to process
+ * @param store - Work store for tracking fetch cache configuration
+ * @returns Promise that resolves to an array of all parameter combinations
+ */
+export async function generateRouteStaticParams(
+  segments: Pick<AppSegment, 'config' | 'generateStaticParams'>[],
+  store: Pick<WorkStore, 'fetchCache'>
+): Promise<Params[]> {
+  // Early return if no segments to process
+  if (segments.length === 0) return []
+
+  // Use iterative processing with a work queue to avoid recursion overhead
+  interface WorkItem {
+    segmentIndex: number
+    params: Params[]
+  }
+
+  const queue: WorkItem[] = [{ segmentIndex: 0, params: [] }]
+  let currentParams: Params[] = []
+
+  while (queue.length > 0) {
+    const { segmentIndex, params } = queue.shift()!
+
+    // If we've processed all segments, this is our final result
+    if (segmentIndex >= segments.length) {
+      currentParams = params
+      break
+    }
+
+    const current = segments[segmentIndex]
+
+    // Skip segments without generateStaticParams and continue to next
+    if (typeof current.generateStaticParams !== 'function') {
+      queue.push({ segmentIndex: segmentIndex + 1, params })
+      continue
+    }
+
+    // Configure fetchCache if specified
+    if (current.config?.fetchCache !== undefined) {
+      store.fetchCache = current.config.fetchCache
+    }
+
+    const nextParams: Params[] = []
+
+    // If there are parent params, we need to process them.
+    if (params.length > 0) {
+      // Process each parent parameter combination
+      for (const parentParams of params) {
+        const result = await current.generateStaticParams({
+          params: parentParams,
+        })
+
+        if (result.length > 0) {
+          // Merge parent params with each result item
+          for (const item of result) {
+            nextParams.push({ ...parentParams, ...item })
+          }
+        } else {
+          // No results, just pass through parent params
+          nextParams.push(parentParams)
+        }
+      }
+    } else {
+      // No parent params, call generateStaticParams with empty object
+      const result = await current.generateStaticParams({ params: {} })
+      nextParams.push(...result)
+    }
+
+    // Add next segment to work queue
+    queue.push({ segmentIndex: segmentIndex + 1, params: nextParams })
+  }
+
+  return currentParams
+}
+
+/**
  * Builds the static paths for an app using `generateStaticParams`.
  *
  * @param params - The parameters for the build.
@@ -603,61 +685,8 @@ export async function buildAppStaticPaths({
     previouslyRevalidatedTags: [],
   })
 
-  const routeParams = await ComponentMod.workAsyncStorage.run(
-    store,
-    async () => {
-      async function builtRouteParams(
-        parentsParams: Params[] = [],
-        idx = 0
-      ): Promise<Params[]> {
-        // If we don't have any more to process, then we're done.
-        if (idx === segments.length) return parentsParams
-
-        const current = segments[idx]
-
-        if (
-          typeof current.generateStaticParams !== 'function' &&
-          idx < segments.length
-        ) {
-          return builtRouteParams(parentsParams, idx + 1)
-        }
-
-        const params: Params[] = []
-
-        if (current.generateStaticParams) {
-          // fetchCache can be used to inform the fetch() defaults used inside
-          // of generateStaticParams. revalidate and dynamic options don't come into
-          // play within generateStaticParams.
-          if (typeof current.config?.fetchCache !== 'undefined') {
-            store.fetchCache = current.config.fetchCache
-          }
-
-          if (parentsParams.length > 0) {
-            for (const parentParams of parentsParams) {
-              const result = await current.generateStaticParams({
-                params: parentParams,
-              })
-
-              for (const item of result) {
-                params.push({ ...parentParams, ...item })
-              }
-            }
-          } else {
-            const result = await current.generateStaticParams({ params: {} })
-
-            params.push(...result)
-          }
-        }
-
-        if (idx < segments.length) {
-          return builtRouteParams(params, idx + 1)
-        }
-
-        return params
-      }
-
-      return builtRouteParams()
-    }
+  const routeParams = await ComponentMod.workAsyncStorage.run(store, () =>
+    generateRouteStaticParams(segments, store)
   )
 
   await afterRunner.executeAfter()

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -166,7 +166,9 @@ export async function handler(
 
   let { isOnDemandRevalidate } = prepareResult
 
-  const prerenderInfo = routeModule.match(pathname, prerenderManifest)
+  const prerenderInfo =
+    routeModule.match(pathname, prerenderManifest) ??
+    prerenderManifest.dynamicRoutes[normalizedSrcPage]
   const isPrerendered = !!prerenderManifest.routes[resolvedPathname]
 
   let isSSG = Boolean(

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -166,7 +166,7 @@ export async function handler(
 
   let { isOnDemandRevalidate } = prepareResult
 
-  const prerenderInfo = prerenderManifest.dynamicRoutes[normalizedSrcPage]
+  const prerenderInfo = routeModule.match(pathname, prerenderManifest)
   const isPrerendered = prerenderManifest.routes[resolvedPathname]
 
   let isSSG = Boolean(
@@ -663,10 +663,17 @@ export async function handler(
         let fallbackResponse: ResponseCacheEntry | null | undefined
 
         if (isRoutePPREnabled && !isRSCRequest) {
+          const cacheKey =
+            typeof prerenderInfo.fallback === 'string'
+              ? prerenderInfo.fallback
+              : isProduction
+                ? normalizedSrcPage
+                : null
+
           // We use the response cache here to handle the revalidation and
           // management of the fallback shell.
           fallbackResponse = await routeModule.handleResponse({
-            cacheKey: isProduction ? normalizedSrcPage : null,
+            cacheKey,
             req,
             nextConfig,
             routeKind: RouteKind.APP_PAGE,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -664,7 +664,7 @@ export async function handler(
 
         if (isRoutePPREnabled && !isRSCRequest) {
           const cacheKey =
-            typeof prerenderInfo.fallback === 'string'
+            typeof prerenderInfo?.fallback === 'string'
               ? prerenderInfo.fallback
               : isProduction
                 ? normalizedSrcPage

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -166,9 +166,7 @@ export async function handler(
 
   let { isOnDemandRevalidate } = prepareResult
 
-  const prerenderInfo =
-    routeModule.match(pathname, prerenderManifest) ??
-    prerenderManifest.dynamicRoutes[normalizedSrcPage]
+  const prerenderInfo = routeModule.match(pathname, prerenderManifest)
   const isPrerendered = !!prerenderManifest.routes[resolvedPathname]
 
   let isSSG = Boolean(

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -167,7 +167,7 @@ export async function handler(
   let { isOnDemandRevalidate } = prepareResult
 
   const prerenderInfo = routeModule.match(pathname, prerenderManifest)
-  const isPrerendered = prerenderManifest.routes[resolvedPathname]
+  const isPrerendered = !!prerenderManifest.routes[resolvedPathname]
 
   let isSSG = Boolean(
     prerenderInfo ||

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -75,6 +75,7 @@ import {
   getInstrumentationModule,
 } from '../lib/router-utils/instrumentation-globals.external'
 import type { PrerenderManifest } from '../../build'
+import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 
 // Load ReactDevOverlay only when needed
 let PagesDevOverlayBridgeImpl: PagesDevOverlayBridgeType
@@ -887,8 +888,22 @@ export default class DevServer extends Server {
             existingManifest.routes[staticPath] = {} as any
           }
           existingManifest.dynamicRoutes[pathname] = {
+            dataRoute: null,
+            dataRouteRegex: null,
             fallback: fallbackModeToFallbackField(res.value.fallbackMode, page),
-          } as any
+            fallbackRevalidate: false,
+            fallbackExpire: undefined,
+            fallbackHeaders: undefined,
+            fallbackStatus: undefined,
+            fallbackRootParams: undefined,
+            fallbackSourceRoute: pathname,
+            prefetchDataRoute: undefined,
+            prefetchDataRouteRegex: undefined,
+            routeRegex: getRouteRegex(pathname).re.source,
+            experimentalPPR: undefined,
+            renderingMode: undefined,
+            allowHeader: [],
+          }
 
           const updatedManifest = JSON.stringify(existingManifest)
 

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -281,6 +281,12 @@ export async function setupFsCheck(opts: {
     }
 
     for (const route of routesManifest.dynamicRoutes) {
+      // If a route is marked as skipInternalRouting, it's not for the internal
+      // router, and instead has been added to support external routers.
+      if (route.skipInternalRouting) {
+        continue
+      }
+
       dynamicRoutes.push({
         ...route,
         match: getRouteMatcher(getRouteRegex(route.page)),

--- a/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.test.ts
+++ b/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.test.ts
@@ -74,5 +74,45 @@ describe('PrerenderManifestMatcher', () => {
         expect(result).toBe(specificRoute)
       })
     })
+
+    describe('no match scenarios', () => {
+      it('should return null when no matching route is found', () => {
+        const route = createMockDynamicRoute({
+          fallbackSourceRoute: '/[category]/[id]',
+        })
+
+        const manifest = createMockPrerenderManifest({
+          '/products/[id]': route,
+        })
+
+        const matcher = new PrerenderManifestMatcher(
+          '/[category]/[id]',
+          manifest
+        )
+
+        const result = matcher.match('/non-matching-path')
+
+        expect(result).toBe(null)
+      })
+
+      it('should return null when no routes match the fallback source route', () => {
+        const route = createMockDynamicRoute({
+          fallbackSourceRoute: '/products/[id]',
+        })
+
+        const manifest = createMockPrerenderManifest({
+          '/products/[id]': route,
+        })
+
+        const matcher = new PrerenderManifestMatcher(
+          '/[category]/[id]',
+          manifest
+        )
+
+        const result = matcher.match('/products/123')
+
+        expect(result).toBe(null)
+      })
+    })
   })
 })

--- a/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.test.ts
+++ b/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.test.ts
@@ -73,6 +73,22 @@ describe('PrerenderManifestMatcher', () => {
 
         expect(result).toBe(specificRoute)
       })
+
+      it('should handle when the fallbackSourceRoute is not set', () => {
+        const route = createMockDynamicRoute({
+          fallbackSourceRoute: undefined,
+        })
+
+        const manifest = createMockPrerenderManifest({
+          '/products/[id]': route,
+        })
+
+        const matcher = new PrerenderManifestMatcher('/products/[id]', manifest)
+
+        const result = matcher.match('/products/123')
+
+        expect(result).toBe(route)
+      })
     })
 
     describe('no match scenarios', () => {

--- a/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.test.ts
+++ b/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.test.ts
@@ -1,0 +1,78 @@
+import { PrerenderManifestMatcher } from './prerender-manifest-matcher'
+import type {
+  PrerenderManifest,
+  DynamicPrerenderManifestRoute,
+} from '../../../../build'
+import { RenderingMode } from '../../../../build/rendering-mode'
+
+// Helper function to create a mock PrerenderManifest
+function createMockPrerenderManifest(
+  dynamicRoutes: Record<string, DynamicPrerenderManifestRoute> = {}
+): PrerenderManifest {
+  return {
+    version: 4,
+    routes: {},
+    dynamicRoutes,
+    notFoundRoutes: [],
+    preview: {
+      previewModeId: 'test-preview-id',
+      previewModeEncryptionKey: 'test-encryption-key',
+      previewModeSigningKey: 'test-signing-key',
+    },
+  }
+}
+
+// Helper function to create a mock DynamicPrerenderManifestRoute
+function createMockDynamicRoute(
+  overrides: Partial<DynamicPrerenderManifestRoute> = {}
+): DynamicPrerenderManifestRoute {
+  return {
+    dataRoute: null,
+    dataRouteRegex: null,
+    fallback: null,
+    fallbackRevalidate: false,
+    fallbackExpire: undefined,
+    fallbackHeaders: undefined,
+    fallbackStatus: undefined,
+    fallbackRootParams: undefined,
+    fallbackSourceRoute: undefined,
+    prefetchDataRoute: undefined,
+    prefetchDataRouteRegex: undefined,
+    routeRegex: '^/[^/]+(?:/[^/]+)?/?$',
+    experimentalPPR: undefined,
+    renderingMode: RenderingMode.STATIC,
+    allowHeader: ['host'],
+    ...overrides,
+  }
+}
+
+describe('PrerenderManifestMatcher', () => {
+  describe('match', () => {
+    describe('successful matches', () => {
+      it('should respect route specificity order', () => {
+        const specificRoute = createMockDynamicRoute({
+          fallbackSourceRoute: '/[category]/[id]',
+        })
+
+        const catchAllRoute = createMockDynamicRoute({
+          fallbackSourceRoute: '/[category]/[id]',
+        })
+
+        // Order matters - more specific routes should come first
+        const manifest = createMockPrerenderManifest({
+          '/products/[id]': specificRoute,
+          '/[category]/[id]': catchAllRoute,
+        })
+
+        const matcher = new PrerenderManifestMatcher(
+          '/[category]/[id]',
+          manifest
+        )
+
+        const result = matcher.match('/products/123')
+
+        expect(result).toBe(specificRoute)
+      })
+    })
+  })
+})

--- a/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.ts
+++ b/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.ts
@@ -55,7 +55,9 @@ export class PrerenderManifestMatcher {
    * @param pathname - The pathname to match.
    * @returns The dynamic route that matches the pathname.
    */
-  public match(pathname: string): DeepReadonly<DynamicPrerenderManifestRoute> {
+  public match(
+    pathname: string
+  ): DeepReadonly<DynamicPrerenderManifestRoute> | null {
     // Iterate over the matchers. They're already in the correct order of
     // specificity as they were inserted into the prerender manifest that way
     // and iterating over them with Object.entries guarantees that.
@@ -71,6 +73,6 @@ export class PrerenderManifestMatcher {
       }
     }
 
-    throw new Error('Unable to match pathname to a dynamic route')
+    return null
   }
 }

--- a/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.ts
+++ b/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.ts
@@ -42,8 +42,10 @@ export class PrerenderManifestMatcher {
     prerenderManifest: DeepReadonly<PrerenderManifest>
   ) {
     this.matchers = Object.entries(prerenderManifest.dynamicRoutes)
-      .filter(([, route]) => {
-        return route.fallbackSourceRoute === pathname
+      .filter(([source, route]) => {
+        // If the pathname is a fallback source route, or the source route is
+        // the same as the pathname, then we should include it in the matchers.
+        return route.fallbackSourceRoute === pathname || source === pathname
       })
       .map(([source, route]) => ({ source, route }))
   }

--- a/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.ts
+++ b/packages/next/src/server/route-modules/app-page/helpers/prerender-manifest-matcher.ts
@@ -1,0 +1,76 @@
+import type {
+  DynamicPrerenderManifestRoute,
+  PrerenderManifest,
+} from '../../../../build'
+import type { DeepReadonly } from '../../../../shared/lib/deep-readonly'
+import {
+  getRouteMatcher,
+  type RouteMatchFn,
+} from '../../../../shared/lib/router/utils/route-matcher'
+import { getRouteRegex } from '../../../../shared/lib/router/utils/route-regex'
+
+/**
+ * A matcher for a dynamic route.
+ */
+type Matcher = {
+  /**
+   * The matcher for the dynamic route. This is lazily created when the matcher
+   * is first used.
+   */
+  matcher?: RouteMatchFn
+
+  /**
+   * The source of the dynamic route.
+   */
+  source: string
+
+  /**
+   * The route that matches the source.
+   */
+  route: DeepReadonly<DynamicPrerenderManifestRoute>
+}
+
+/**
+ * A matcher for the prerender manifest.
+ *
+ * This class is used to match the pathname to the dynamic route.
+ */
+export class PrerenderManifestMatcher {
+  private readonly matchers: Array<Matcher>
+  constructor(
+    pathname: string,
+    prerenderManifest: DeepReadonly<PrerenderManifest>
+  ) {
+    this.matchers = Object.entries(prerenderManifest.dynamicRoutes)
+      .filter(([, route]) => {
+        return route.fallbackSourceRoute === pathname
+      })
+      .map(([source, route]) => ({ source, route }))
+  }
+
+  /**
+   * Match the pathname to the dynamic route. If no match is found, an error is
+   * thrown.
+   *
+   * @param pathname - The pathname to match.
+   * @returns The dynamic route that matches the pathname.
+   */
+  public match(pathname: string): DeepReadonly<DynamicPrerenderManifestRoute> {
+    // Iterate over the matchers. They're already in the correct order of
+    // specificity as they were inserted into the prerender manifest that way
+    // and iterating over them with Object.entries guarantees that.
+    for (const matcher of this.matchers) {
+      // Lazily create the matcher, this is only done once per matcher.
+      if (!matcher.matcher) {
+        matcher.matcher = getRouteMatcher(getRouteRegex(matcher.source))
+      }
+
+      const match = matcher.matcher(pathname)
+      if (match) {
+        return matcher.route
+      }
+    }
+
+    throw new Error('Unable to match pathname to a dynamic route')
+  }
+}

--- a/test/e2e/app-dir/sub-shell-generation/app/[lang]/[slug]/page.tsx
+++ b/test/e2e/app-dir/sub-shell-generation/app/[lang]/[slug]/page.tsx
@@ -1,0 +1,13 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ lang: string; slug: string }>
+}) {
+  const { slug } = await params
+
+  return <p>slug: {slug}</p>
+}
+
+export function generateStaticParams({ params }: { params: { lang: string } }) {
+  return params.lang === 'fr' ? [{ slug: '1' }] : []
+}

--- a/test/e2e/app-dir/sub-shell-generation/app/[lang]/[slug]/page.tsx
+++ b/test/e2e/app-dir/sub-shell-generation/app/[lang]/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { getSentinelValue } from '../../sentinel'
+
 export default async function Page({
   params,
 }: {
@@ -5,7 +7,12 @@ export default async function Page({
 }) {
   const { slug } = await params
 
-  return <p>slug: {slug}</p>
+  return (
+    <>
+      <p id="page">Page: ({getSentinelValue()})</p>
+      <p>slug: {slug}</p>
+    </>
+  )
 }
 
 export function generateStaticParams({ params }: { params: { lang: string } }) {

--- a/test/e2e/app-dir/sub-shell-generation/app/[lang]/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation/app/[lang]/layout.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react'
+import { setTimeout } from 'timers/promises'
+
+export default async function LangLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ lang: string }>
+}) {
+  const { lang } = await params
+
+  if (lang === 'en') {
+    // Simulate uncached I/O. This should lead to a build-time error, because we
+    // expect a fallback shell to be generated for /en/[slug]. It would be a
+    // prerender error at runtime if we tried to generate a route shell at
+    // runtime for /en/foo instead.
+    await setTimeout(100)
+  }
+
+  return (
+    <>
+      <h1>lang: {lang}</h1>
+      <main>{children}</main>
+    </>
+  )
+}
+
+export function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'fr' }]
+}

--- a/test/e2e/app-dir/sub-shell-generation/app/[lang]/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation/app/[lang]/layout.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from 'react'
-import { setTimeout } from 'timers/promises'
+import { ReactNode, Suspense } from 'react'
+import { getSentinelValue } from '../sentinel'
 
 export default async function LangLayout({
   children,
@@ -10,18 +10,15 @@ export default async function LangLayout({
 }) {
   const { lang } = await params
 
-  if (lang === 'en') {
-    // Simulate uncached I/O. This should lead to a build-time error, because we
-    // expect a fallback shell to be generated for /en/[slug]. It would be a
-    // prerender error at runtime if we tried to generate a route shell at
-    // runtime for /en/foo instead.
-    await setTimeout(100)
-  }
-
   return (
     <>
+      <div id="lang-layout">Lang Layout: ({getSentinelValue()})</div>
       <h1>lang: {lang}</h1>
-      <main>{children}</main>
+      <main>
+        <Suspense fallback={<p id="loading">Loading...</p>}>
+          {children}
+        </Suspense>
+      </main>
     </>
   )
 }

--- a/test/e2e/app-dir/sub-shell-generation/app/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation/app/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation/app/layout.tsx
@@ -1,9 +1,17 @@
-import { ReactNode } from 'react'
+'use cache'
 
-export default function Root({ children }: { children: ReactNode }) {
+import { ReactNode, Suspense } from 'react'
+import { getSentinelValue } from './sentinel'
+
+export default async function Root({ children }: { children: ReactNode }) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <div id="root-layout">Root Layout: ({getSentinelValue()})</div>
+        <Suspense fallback={<p id="loading">Loading...</p>}>
+          {children}
+        </Suspense>
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/sub-shell-generation/app/sentinel.ts
+++ b/test/e2e/app-dir/sub-shell-generation/app/sentinel.ts
@@ -1,0 +1,7 @@
+const { PHASE_PRODUCTION_BUILD } = require('next/constants')
+
+export function getSentinelValue() {
+  return process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+    ? 'buildtime'
+    : 'runtime'
+}

--- a/test/e2e/app-dir/sub-shell-generation/next.config.js
+++ b/test/e2e/app-dir/sub-shell-generation/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -1,0 +1,28 @@
+import { isNextDev, nextTestSetup } from 'e2e-utils'
+
+describe('sub-shell-generation', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipStart: !isNextDev,
+  })
+
+  if (isNextStart) {
+    it('should fail with a validation error at build time', async () => {
+      await expect(next.build()).toReject()
+    })
+  }
+
+  it('should not fail when requesting /en/foo', async () => {
+    if (isNextStart) {
+      try {
+        await next.start()
+      } catch {
+        // Ignoring for now, until the build actually fails, in which case this
+        // whole test will be obsolete, and the test above will be sufficient.
+      }
+    }
+
+    const res = await next.fetch('/en/foo')
+    expect(res.status).toBe(200)
+  })
+})

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -1,28 +1,84 @@
-import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
+import * as cheerio from 'cheerio'
 
 describe('sub-shell-generation', () => {
-  const { next, isNextStart } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipStart: !isNextDev,
   })
 
-  if (isNextStart) {
-    it('should fail with a validation error at build time', async () => {
-      await expect(next.build()).toReject()
-    })
+  if (isNextDev) {
+    it.skip('skipping dev test', () => {})
+    return
   }
 
-  it('should not fail when requesting /en/foo', async () => {
-    if (isNextStart) {
-      try {
-        await next.start()
-      } catch {
-        // Ignoring for now, until the build actually fails, in which case this
-        // whole test will be obsolete, and the test above will be sufficient.
-      }
-    }
+  describe('should serve the correct shell', () => {
+    describe.each([
+      [
+        '/[lang]/[slug]',
+        {
+          page: 'Page: (runtime)',
+          langLayout: 'Lang Layout: (runtime)',
+          rootLayout: 'Root Layout: (buildtime)',
+        },
+        ['/es/1', '/es/2', '/jp/1', '/jp/2'],
+        true,
+      ],
+      [
+        '/en/[slug]',
+        {
+          page: 'Page: (runtime)',
+          langLayout: 'Lang Layout: (buildtime)',
+          rootLayout: 'Root Layout: (buildtime)',
+        },
+        ['/en/1', '/en/2', '/en/3', '/en/4'],
+        true,
+      ],
+      [
+        '/fr/[slug]',
+        {
+          page: 'Page: (runtime)',
+          langLayout: 'Lang Layout: (buildtime)',
+          rootLayout: 'Root Layout: (buildtime)',
+        },
+        ['/fr/2', '/fr/3', '/fr/4', '/fr/5'],
+        true,
+      ],
+      [
+        '/fr/1',
+        {
+          page: 'Page: (buildtime)',
+          langLayout: 'Lang Layout: (buildtime)',
+          rootLayout: 'Root Layout: (buildtime)',
+        },
+        ['/fr/1'],
+        false,
+      ],
+    ])('%s', (shell, { page, langLayout, rootLayout }, paths, isPostponed) => {
+      it.each(paths)('should serve the correct shell for %s', async (path) => {
+        const res = await next.fetch(path)
+        expect(res.status).toBe(200)
 
-    const res = await next.fetch('/en/foo')
-    expect(res.status).toBe(200)
+        if (isNextDeploy) {
+          expect(res.headers.get('x-matched-path')).toBe(shell)
+        } else {
+          expect(res.headers.get('x-nextjs-postponed')).toBe(
+            isPostponed ? '1' : null
+          )
+        }
+
+        const html = await res.text()
+        const $ = cheerio.load(html)
+
+        expect({
+          page: $('#page').text(),
+          langLayout: $('#lang-layout').text(),
+          rootLayout: $('#root-layout').text(),
+        }).toEqual({
+          page,
+          langLayout,
+          rootLayout,
+        })
+      })
+    })
   })
 })

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -20,7 +20,7 @@ describe('sub-shell-generation', () => {
           langLayout: 'Lang Layout: (runtime)',
           rootLayout: 'Root Layout: (buildtime)',
         },
-        ['/es/1', '/es/2', '/jp/1', '/jp/2'],
+        ['/es/1', '/es/2'],
         true,
       ],
       [
@@ -30,7 +30,7 @@ describe('sub-shell-generation', () => {
           langLayout: 'Lang Layout: (buildtime)',
           rootLayout: 'Root Layout: (buildtime)',
         },
-        ['/en/1', '/en/2', '/en/3', '/en/4'],
+        ['/en/1', '/en/2'],
         true,
       ],
       [
@@ -40,7 +40,7 @@ describe('sub-shell-generation', () => {
           langLayout: 'Lang Layout: (buildtime)',
           rootLayout: 'Root Layout: (buildtime)',
         },
-        ['/fr/2', '/fr/3', '/fr/4', '/fr/5'],
+        ['/fr/2', '/fr/3'],
         true,
       ],
       [


### PR DESCRIPTION
### What?

Optimizes the `generateParamPrefixCombinations` function (previously `filterUniqueRootParamsCombinations`) to generate all unique sub-combinations of route parameters while ensuring partial shells include complete sets of root parameters.

### Why?

The previous implementation only generated combinations at the root parameter level, which was insufficient for PPR (Partial Prerendering) shells. PPR needs all possible prefix combinations of route parameters to create effective shells for nested routes. For example, for a route `/[lang]/[region]/[slug]`, we need shells for:
- `/[lang]/[region]` (complete root params)
- `/[lang]/[region]/[slug]` (full route)

Without proper sub-combinations, nested routes couldn't benefit from PPR shell optimization, leading to performance degradation.

### How?

- Renamed `filterUniqueRootParamsCombinations` to `generateParamPrefixCombinations` to better reflect its expanded functionality
- Added logic to generate all prefix combinations of route parameters, not just root-level combinations
- Implemented root parameter validation to ensure partial shells only include complete sets of root parameters
- Added comprehensive test coverage for edge cases including undefined parameters, missing keys, and parameter collisions
- Optimized the algorithm to skip invalid combinations early when root parameters are incomplete

The function now generates prefix combinations systematically while maintaining backward compatibility and preventing invalid partial routes.

NAR-159