### PR TITLE
Remove incorrect PostCSS config type

### DIFF
--- a/docs/01-app/02-guides/tailwind-css.mdx
+++ b/docs/01-app/02-guides/tailwind-css.mdx
@@ -22,8 +22,7 @@ npm install -D tailwindcss @tailwindcss/postcss postcss
 
 Create a `postcss.config.mjs` file in the root of your project and add the `@tailwindcss/postcss` plugin to your PostCSS configuration:
 
-```js filename="postcss.config.mjs" highlight={4}
-/** @type {import('tailwindcss').Config} */
+```js filename="postcss.config.mjs" highlight={3}
 export default {
   plugins: {
     '@tailwindcss/postcss': {},


### PR DESCRIPTION
### What?

Currently the docs is incorrectly suggesting to type the PostCSS config with types from Tailwind CSS. This pull request removed the wrong types.

If desired one can correctly type the config with the [`postcss-load-config`](https://github.com/postcss/postcss-load-config/blob/main/src/index.d.ts#L52-L60) package:

```js
/** @type {import('postcss-load-config').Config} */
const config = {
    plugins: {
        '@tailwindcss/postcss': {},
    },
}

export default config
```

However if your package manager does not hoist the package, you need to install it separately just for the types, which does not seem to be worth it.

### Why?

### How?
