### PR TITLE
[sourcemaps] Stop sending stackframes in third-party chunks

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -633,6 +633,11 @@ async function generateDynamicFlightRenderResult(
     )
   }
 
+  const filterStackFrame =
+    process.env.NODE_ENV !== 'production'
+      ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+          .filterStackFrameDEV
+      : undefined
   // For app dir, use the bundled version of Flight server renderer (renderToReadableStream)
   // which contains the subset React.
   const flightReadableStream = workUnitAsyncStorage.run(
@@ -643,6 +648,7 @@ async function generateDynamicFlightRenderResult(
     {
       onError,
       temporaryReferences: options?.temporaryReferences,
+      filterStackFrame,
     }
   )
 
@@ -734,6 +740,11 @@ async function warmupDevRender(
     ctx
   )
 
+  const filterStackFrame =
+    process.env.NODE_ENV !== 'production'
+      ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+          .filterStackFrameDEV
+      : undefined
   // For app dir, use the bundled version of Flight server renderer (renderToReadableStream)
   // which contains the subset React.
   workUnitAsyncStorage.run(
@@ -742,6 +753,7 @@ async function warmupDevRender(
     rscPayload,
     clientReferenceManifest.clientModules,
     {
+      filterStackFrame,
       onError,
       signal: renderController.signal,
     }
@@ -1865,6 +1877,11 @@ async function renderToStream(
   const setHeader = res.setHeader.bind(res)
   const appendHeader = res.appendHeader.bind(res)
 
+  const filterStackFrame =
+    process.env.NODE_ENV !== 'production'
+      ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+          .filterStackFrameDEV
+      : undefined
   try {
     if (
       // We only want this behavior when running `next dev`
@@ -1902,12 +1919,7 @@ async function renderToStream(
               onError: serverComponentsErrorHandler,
               environmentName: () =>
                 requestStore.prerenderPhase === true ? 'Prerender' : 'Server',
-              filterStackFrame(url: string, _functionName: string): boolean {
-                // The default implementation filters out <anonymous> stack frames
-                // but we want to retain them because current Server Components and
-                // built-in Components in parent stacks don't have source location.
-                return !url.startsWith('node:') && !url.includes('node_modules')
-              },
+              filterStackFrame,
             }
           )
         },
@@ -1943,6 +1955,7 @@ async function renderToStream(
           RSCPayload,
           clientReferenceManifest.clientModules,
           {
+            filterStackFrame,
             onError: serverComponentsErrorHandler,
           }
         )
@@ -2161,6 +2174,7 @@ async function renderToStream(
       errorRSCPayload,
       clientReferenceManifest.clientModules,
       {
+        filterStackFrame,
         onError: serverComponentsErrorHandler,
       }
     )
@@ -2354,12 +2368,18 @@ async function spawnDynamicValidationInDev(
     isNotFound
   )
 
+  const filterStackFrame =
+    process.env.NODE_ENV !== 'production'
+      ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+          .filterStackFrameDEV
+      : undefined
   const pendingInitialServerResult = workUnitAsyncStorage.run(
     initialServerPrerenderStore,
     ComponentMod.prerender,
     initialServerPayload,
     clientReferenceManifest.clientModules,
     {
+      filterStackFrame,
       onError: (err) => {
         const digest = getDigestForWellKnownError(err)
 
@@ -2561,6 +2581,7 @@ async function spawnDynamicValidationInDev(
     ctx,
     isNotFound
   )
+
   const reactServerResult = await createReactServerPrerenderResult(
     prerenderAndAbortInSequentialTasks(
       async () => {
@@ -2573,6 +2594,7 @@ async function spawnDynamicValidationInDev(
           finalAttemptRSCPayload,
           clientReferenceManifest.clientModules,
           {
+            filterStackFrame,
             onError: (err: unknown) => {
               if (
                 finalServerController.signal.aborted &&
@@ -2982,12 +3004,19 @@ async function prerenderToStream(
         res.statusCode === 404
       )
 
+      const filterStackFrame =
+        process.env.NODE_ENV !== 'production'
+          ? (
+              require('../lib/source-maps') as typeof import('../lib/source-maps')
+            ).filterStackFrameDEV
+          : undefined
       const pendingInitialServerResult = workUnitAsyncStorage.run(
         initialServerPrerenderStore,
         ComponentMod.prerender,
         initialServerPayload,
         clientReferenceManifest.clientModules,
         {
+          filterStackFrame,
           onError: (err) => {
             const digest = getDigestForWellKnownError(err)
 
@@ -3196,6 +3225,7 @@ async function prerenderToStream(
                 finalAttemptRSCPayload,
                 clientReferenceManifest.clientModules,
                 {
+                  filterStackFrame,
                   onError: (err: unknown) => {
                     return serverComponentsErrorHandler(err)
                   },
@@ -3464,6 +3494,12 @@ async function prerenderToStream(
         ctx,
         res.statusCode === 404
       )
+      const filterStackFrame =
+        process.env.NODE_ENV !== 'production'
+          ? (
+              require('../lib/source-maps') as typeof import('../lib/source-maps')
+            ).filterStackFrameDEV
+          : undefined
       const reactServerResult = (reactServerPrerenderResult =
         await createReactServerPrerenderResultFromRender(
           workUnitAsyncStorage.run(
@@ -3473,6 +3509,7 @@ async function prerenderToStream(
             RSCPayload,
             clientReferenceManifest.clientModules,
             {
+              filterStackFrame,
               onError: serverComponentsErrorHandler,
             }
           )
@@ -3692,6 +3729,13 @@ async function prerenderToStream(
         ctx,
         res.statusCode === 404
       )
+
+      const filterStackFrame =
+        process.env.NODE_ENV !== 'production'
+          ? (
+              require('../lib/source-maps') as typeof import('../lib/source-maps')
+            ).filterStackFrameDEV
+          : undefined
       const reactServerResult = (reactServerPrerenderResult =
         await createReactServerPrerenderResultFromRender(
           workUnitAsyncStorage.run(
@@ -3700,6 +3744,7 @@ async function prerenderToStream(
             RSCPayload,
             clientReferenceManifest.clientModules,
             {
+              filterStackFrame,
               onError: serverComponentsErrorHandler,
             }
           )
@@ -3864,12 +3909,18 @@ async function prerenderToStream(
       errorType
     )
 
+    const filterStackFrame =
+      process.env.NODE_ENV !== 'production'
+        ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+            .filterStackFrameDEV
+        : undefined
     const errorServerStream = workUnitAsyncStorage.run(
       prerenderLegacyStore,
       ComponentMod.renderToReadableStream,
       errorRSCPayload,
       clientReferenceManifest.clientModules,
       {
+        filterStackFrame,
         onError: serverComponentsErrorHandler,
       }
     )

--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -141,9 +141,16 @@ export const encryptActionBoundArgs = React.cache(
       })
     }
 
+    const filterStackFrame =
+      process.env.NODE_ENV !== 'production'
+        ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+            .filterStackFrameDEV
+        : undefined
+
     // Using Flight to serialize the args into a string.
     const serialized = await streamToString(
       renderToReadableStream(args, clientModules, {
+        filterStackFrame,
         signal: hangingInputAbortSignal,
         onError(err) {
           if (hangingInputAbortSignal?.aborted) {

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -1,3 +1,6 @@
+import { findSourceMap } from 'module'
+import { inspect } from 'util'
+
 /**
  * https://tc39.es/source-map/#index-map
  */
@@ -48,8 +51,8 @@ export function sourceMapIgnoreListsEverything(
  * Equal to the input unless an Index Source Map is used.
  */
 export function findApplicableSourceMapPayload(
-  line: number,
-  column: number,
+  line0: number,
+  column0: number,
   payload: ModernSourceMapPayload
 ): BasicSourceMapPayload | undefined {
   if ('sections' in payload) {
@@ -71,8 +74,8 @@ export function findApplicableSourceMapPayload(
       const offset = section.offset
 
       if (
-        offset.line < line ||
-        (offset.line === line && offset.column <= column)
+        offset.line < line0 ||
+        (offset.line === line0 && offset.column <= column0)
       ) {
         result = section
         left = middle + 1
@@ -84,5 +87,64 @@ export function findApplicableSourceMapPayload(
     return result === null ? undefined : result.map
   } else {
     return payload
+  }
+}
+
+const didWarnAboutInvalidSourceMapDEV = new Set<string>()
+
+export function filterStackFrameDEV(
+  sourceURL: string,
+  functionName: string,
+  line1: number,
+  column1: number
+): boolean {
+  if (sourceURL === '') {
+    // The default implementation filters out <anonymous> stack frames
+    // but we want to retain them because current Server Components and
+    // built-in Components in parent stacks don't have source location.
+    // Filter out frames that show up in Promises to get good names in React's
+    // Server Request track until we come up with a better heuristic.
+    return (
+      functionName !== 'new Promise' &&
+      functionName !== 'Function.withResolvers'
+    )
+  }
+  if (sourceURL.startsWith('node:') || sourceURL.includes('node_modules')) {
+    return false
+  }
+  try {
+    // Node.js loads source maps eagerly so this call is cheap.
+    // TODO: ESM sourcemaps are O(1) but CommonJS sourcemaps are O(Number of CJS modules).
+    // Make sure this doesn't adversely affect performance when CJS is used by Next.js.
+    const sourceMap = findSourceMap(sourceURL)
+    if (sourceMap === undefined) {
+      // No source map assoicated.
+      // TODO: Node.js types should reflect that `findSourceMap` can return `undefined`.
+      return true
+    }
+    const sourceMapPayload = findApplicableSourceMapPayload(
+      line1 - 1,
+      column1 - 1,
+      sourceMap.payload
+    )
+    if (sourceMapPayload === undefined) {
+      // No source map section applicable to the frame.
+      return true
+    }
+    return !sourceMapIgnoreListsEverything(sourceMapPayload)
+  } catch (cause) {
+    if (process.env.NODE_ENV !== 'production') {
+      // TODO: Share cache with patch-error-inspect
+      if (!didWarnAboutInvalidSourceMapDEV.has(sourceURL)) {
+        didWarnAboutInvalidSourceMapDEV.add(sourceURL)
+        // We should not log an actual error instance here because that will re-enter
+        // this codepath during error inspection and could lead to infinite recursion.
+        console.error(
+          `${sourceURL}: Invalid source map. Only conformant source maps can be used to filter stack frames. Cause: ${cause}`
+        )
+      }
+    }
+
+    return true
   }
 }

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -1,5 +1,8 @@
-import { findSourceMap } from 'module'
-import { inspect } from 'util'
+// Edge runtime does not implement `module`
+const findSourceMap =
+  process.env.NEXT_RUNTIME === 'edge'
+    ? () => undefined
+    : (require('module') as typeof import('module')).findSourceMap
 
 /**
  * https://tc39.es/source-map/#index-map

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -109,7 +109,12 @@ export function filterStackFrameDEV(
     // Server Request track until we come up with a better heuristic.
     return (
       functionName !== 'new Promise' &&
-      functionName !== 'Function.withResolvers'
+      functionName !== 'Promise.then' &&
+      functionName !== 'Promise.catch' &&
+      functionName !== 'Promise.finally' &&
+      functionName !== 'Function.withResolvers' &&
+      functionName !== 'Function.all' &&
+      functionName !== 'Function.allSettled'
     )
   }
   if (sourceURL.startsWith('node:') || sourceURL.includes('node_modules')) {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -490,11 +490,18 @@ async function generateCacheEntryImpl(
       stream = prelude
     }
   } else {
+    const filterStackFrame =
+      process.env.NODE_ENV !== 'production'
+        ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+            .filterStackFrameDEV
+        : undefined
+
     stream = renderToReadableStream(
       resultPromise,
       clientReferenceManifest.clientModules,
       {
         environmentName: 'Cache',
+        filterStackFrame,
         temporaryReferences,
         onError: handleError,
       }

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -141,7 +141,12 @@ declare module 'react-server-dom-webpack/server.edge' {
     options?: {
       temporaryReferences?: TemporaryReferenceSet
       environmentName?: string | (() => string)
-      filterStackFrame?: (url: string, functionName: string) => boolean
+      filterStackFrame?: (
+        url: string,
+        functionName: string,
+        lineNumber: number,
+        columnNumber: number
+      ) => boolean
       onError?: (error: unknown) => void
       onPostpone?: (reason: string) => void
       signal?: AbortSignal
@@ -262,7 +267,12 @@ declare module 'react-server-dom-webpack/static' {
     },
     options?: {
       environmentName?: string | (() => string)
-      filterStackFrame?: (url: string, functionName: string) => boolean
+      filterStackFrame?: (
+        url: string,
+        functionName: string,
+        lineNumber: number,
+        columnNumber: number
+      ) => boolean
       identifierPrefix?: string
       signal?: AbortSignal
       temporaryReferences?: TemporaryReferenceSet

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -41,6 +41,7 @@ describe('Dynamic IO Dev Errors', () => {
 
     await browser.elementByCss("[href='/error']").click()
 
+    // TODO: React should not include the anon stack in the Owner Stack.
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "description": "Route "/error" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random",
@@ -51,6 +52,7 @@ describe('Dynamic IO Dev Errors', () => {
          |                       ^",
        "stack": [
          "Page app/error/page.tsx (2:23)",
+         "Page <anonymous>",
          "LogSafely <anonymous>",
        ],
      }

--- a/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
+++ b/test/development/app-dir/owner-stack-react-missing-key-prop/owner-stack-react-missing-key-prop.test.ts
@@ -19,10 +19,11 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
 
     if (isTurbopack) {
       expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at span ()
-         at <anonymous> (app/rsc/page.tsx (7:9))
-         at Page (app/rsc/page.tsx (6:13))"
-        `)
+       "at span ()
+       at <anonymous> (app/rsc/page.tsx (7:9))
+       at Array.map ()
+       at Page (app/rsc/page.tsx (6:13))"
+      `)
       expect(source).toMatchInlineSnapshot(`
          "app/rsc/page.tsx (7:9) @ <anonymous>
 
@@ -36,10 +37,11 @@ describe('app-dir - owner-stack-react-missing-key-prop', () => {
         `)
     } else {
       expect(stackFramesContent).toMatchInlineSnapshot(`
-         "at span ()
-         at eval (app/rsc/page.tsx (7:9))
-         at Page (app/rsc/page.tsx (6:13))"
-        `)
+       "at span ()
+       at eval (app/rsc/page.tsx (7:9))
+       at Array.map ()
+       at Page (app/rsc/page.tsx (6:13))"
+      `)
       expect(source).toMatchInlineSnapshot(`
           "app/rsc/page.tsx (7:9) @ eval
 

--- a/test/development/app-dir/react-performance-track/app/ReactServerRequests.tsx
+++ b/test/development/app-dir/react-performance-track/app/ReactServerRequests.tsx
@@ -11,7 +11,7 @@ const ServerRequestsStore = {
   getSnapshot:
     typeof window === 'undefined'
       ? () => []
-      : window.reactServerRequests.getSnapshot,
+      : window.reactServerRequests.getStoreSnapshot,
   getServerSnapshot: () => reactServerRequestsServerSnapshot,
 }
 
@@ -30,7 +30,11 @@ export function ReactServerRequests() {
           <li key={index}>
             <details>
               <summary>
-                <strong>{request.name}</strong>
+                <strong>
+                  {request.type}: {request.name || '<Unnamed>'}
+                </strong>
+                ({Math.round(request.startTime)}ms–
+                {Math.round(request.endTime)}ms)
               </summary>
               <pre>{JSON.stringify(request.properties, null, 2)}</pre>
             </details>

--- a/test/development/app-dir/react-performance-track/app/fetch/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/fetch/page.tsx
@@ -1,16 +1,10 @@
 async function abstraction() {
-  const response = await fetch(
-    'https://next-data-api-endpoint.vercel.app/api/random'
-  )
-  await response.json()
+  await fetch('https://next-data-api-endpoint.vercel.app/api/random')
 }
 
 export default async function FetchPage() {
   await abstraction()
-  const response = await fetch(
-    'https://next-data-api-endpoint.vercel.app/api/random'
-  )
-  await response.json()
+  await fetch('https://next-data-api-endpoint.vercel.app/api/random')
 
   return <p>Done</p>
 }

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -3,7 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 // Entries are flaky in CI. Without a name and without being able to repro locally,
 // it's impossible to fix. Deactivating while we iterate on the track.
 // It's still useful as a fixture.
-describe.skip('react-performance-track', () => {
+describe('react-performance-track', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
@@ -13,10 +13,12 @@ describe.skip('react-performance-track', () => {
     await browser.elementByCss('[data-react-server-requests-done]')
 
     const track = await browser.eval('window.reactServerRequests.getSnapshot()')
-    expect(track).toEqual([
-      { name: 'setTimeout', properties: [] },
-      { name: 'setTimeout', properties: [] },
-    ])
+    expect(track).toEqual(
+      expect.arrayContaining([
+        { name: 'setTimeout', properties: [] },
+        { name: 'setTimeout', properties: [] },
+      ])
+    )
   })
 
   it('should show fetch', async () => {
@@ -24,12 +26,14 @@ describe.skip('react-performance-track', () => {
     await browser.elementByCss('[data-react-server-requests-done]')
 
     const track = await browser.eval('window.reactServerRequests.getSnapshot()')
-    expect(track).toEqual([
-      {
-        // TODO: Should have a name
-        name: '',
-        properties: [],
-      },
-    ])
+    expect(track).toEqual(
+      expect.arrayContaining([
+        {
+          // TODO: Should include the URL.
+          name: 'fetch',
+          properties: expect.arrayContaining([['status', '200']]),
+        },
+      ])
+    )
   })
 })

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -23,9 +23,9 @@ describe('react-performance-track', () => {
     const track = await browser.eval('window.reactServerRequests.getSnapshot()')
     expect(track).toEqual([
       {
-        // TODO(veil): Should always be `fetch (random)`
-        name: isTurbopack ? 'fetch (random)' : 'fetch',
-        properties: expect.arrayContaining([['status', '200']]),
+        // TODO: Should have a name
+        name: '',
+        properties: [],
       },
     ])
   })

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -1,7 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('react-performance-track', () => {
-  const { isTurbopack, next } = nextTestSetup({
+// Entries are flaky in CI. Without a name and without being able to repro locally,
+// it's impossible to fix. Deactivating while we iterate on the track.
+// It's still useful as a fixture.
+describe.skip('react-performance-track', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
   })
 
@@ -13,8 +16,6 @@ describe('react-performance-track', () => {
     expect(track).toEqual([
       { name: 'setTimeout', properties: [] },
       { name: 'setTimeout', properties: [] },
-      // CI only
-      { name: '', properties: [] },
     ])
   })
 

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -29,8 +29,6 @@ describe('react-performance-track', () => {
         name: '',
         properties: [],
       },
-      // CI only
-      { name: '', properties: [] },
     ])
   })
 })

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -13,6 +13,8 @@ describe('react-performance-track', () => {
     expect(track).toEqual([
       { name: 'setTimeout', properties: [] },
       { name: 'setTimeout', properties: [] },
+      // CI only
+      { name: '', properties: [] },
     ])
   })
 
@@ -27,6 +29,8 @@ describe('react-performance-track', () => {
         name: '',
         properties: [],
       },
+      // CI only
+      { name: '', properties: [] },
     ])
   })
 })

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -605,6 +605,8 @@ describe('Dynamic IO Errors', () => {
              > 59 |   const response = await fetch(
                   |                          ^",
                  "stack": [
+                   "Promise.then <anonymous>",
+                   "Promise.catch <anonymous>",
                    "fetchRandom app/dynamic-root/page.tsx (59:26)",
                    "FetchingComponent app/dynamic-root/page.tsx (45:56)",
                    "Page app/dynamic-root/page.tsx (22:9)",
@@ -619,6 +621,8 @@ describe('Dynamic IO Errors', () => {
              > 59 |   const response = await fetch(
                   |                          ^",
                  "stack": [
+                   "Promise.then <anonymous>",
+                   "Promise.catch <anonymous>",
                    "fetchRandom app/dynamic-root/page.tsx (59:26)",
                    "FetchingComponent app/dynamic-root/page.tsx (45:56)",
                    "Page app/dynamic-root/page.tsx (27:7)",

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -605,8 +605,6 @@ describe('Dynamic IO Errors', () => {
              > 59 |   const response = await fetch(
                   |                          ^",
                  "stack": [
-                   "Promise.then <anonymous>",
-                   "Promise.catch <anonymous>",
                    "fetchRandom app/dynamic-root/page.tsx (59:26)",
                    "FetchingComponent app/dynamic-root/page.tsx (45:56)",
                    "Page app/dynamic-root/page.tsx (22:9)",
@@ -621,8 +619,6 @@ describe('Dynamic IO Errors', () => {
              > 59 |   const response = await fetch(
                   |                          ^",
                  "stack": [
-                   "Promise.then <anonymous>",
-                   "Promise.catch <anonymous>",
                    "fetchRandom app/dynamic-root/page.tsx (59:26)",
                    "FetchingComponent app/dynamic-root/page.tsx (45:56)",
                    "Page app/dynamic-root/page.tsx (27:7)",

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -408,11 +408,12 @@ describe('app-dir - server source maps', () => {
         )
         // Expect the invalid sourcemap warning only once per render.
         // Dynamic I/O renders three times.
+        // One from filterStackFrameDEV.
         expect(
           normalizeCliOutput(next.cliOutput.slice(outputIndex)).split(
             'Invalid source map.'
           ).length - 1
-        ).toEqual(3)
+        ).toEqual(4)
       }
     } else {
       // Bundlers silently drop invalid sourcemaps.

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -495,8 +495,6 @@ describe('app-dir - server source maps', () => {
              "<FIXME-file-protocol>",
              "eval rsc:/Prerender/webpack-internal:///(rsc)/app/module-evaluation/page.js (5:65)",
              "<FIXME-file-protocol>",
-             "Function.all <anonymous>",
-             "Function.all <anonymous>",
              "Page <anonymous>",
            ],
          }


### PR DESCRIPTION
Third-party chunks are chunks where everything is ignore-listed.
Instead of sending these frames, sourcemapping them, and then filtering them out, we can just skip them entirely with a fast-path that just checks if every source in a chunk is ignore-listed.

Turbopack and Webpack implement this chunking heuristic where they put most third-party code into a single chunk.

We cannot identify 3rd party chunks based off of source maps in the Edge runtime since [Edge runtime runtime doesn't support `module`](https://vercel.com/docs/functions/runtimes/edge#compatible-node.js-modules). It's only dev so we could fake it but that's quite involved to make sure only internal usage of `module` is allowed. Edge runtime will not have the Server Request track anyway.

This is especially critical for extracting names for React's Server Request track which uses `filterStackFrame` to determine the name of an entry.

There's probably some test we could add to ensure the Flight data does not contain Next.js stackframe. Testing Server Request track entries is good enough.