### PR TITLE
[turbopack] Defer emitting Issues during `resolve` so we can attach proper source information later.

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1140,7 +1140,7 @@ pub async fn get_next_package(context_directory: FileSystemPath) -> Result<Vc<Fi
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
         node_cjs_resolve_options(context_directory.root().await?.clone_value()),
         // For reporting issues, there simply isn't a better option.
-        context_directory.clone(),
+        context_directory,
         None,
     );
     let source = result

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1139,6 +1139,9 @@ pub async fn get_next_package(context_directory: FileSystemPath) -> Result<Vc<Fi
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
         node_cjs_resolve_options(context_directory.root().await?.clone_value()),
+        // For reporting issues, there simply isn't a better option.
+        context_directory.clone(),
+        None,
     );
     let source = result
         .first_source()

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
         parse::Request,
         pattern::Pattern,
         plugin::{AfterResolvePlugin, AfterResolvePluginCondition},
-        resolve,
+        resolve_without_source,
     },
     source::Source,
 };
@@ -220,7 +220,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             node_cjs_resolve_options(lookup_path.root().await?.clone_value())
         };
         let result_from_original_location = loop {
-            let node_resolved_from_original_location = resolve(
+            let node_resolved_from_original_location = resolve_without_source(
                 lookup_path.clone(),
                 reference_type.clone(),
                 request,
@@ -253,7 +253,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             };
             break result_from_original_location;
         };
-        let node_resolved = resolve(
+        let node_resolved = resolve_without_source(
             self.project_path.clone(),
             reference_type.clone(),
             request,
@@ -371,7 +371,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 // but we need to verify if that would be correct (as in resolves to the same file).
                 let node_resolve_options =
                     node_cjs_resolve_options(lookup_path.root().await?.clone_value());
-                let node_resolved = resolve(
+                let node_resolved = resolve_without_source(
                     self.project_path.clone(),
                     reference_type.clone(),
                     request,

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -30,7 +30,7 @@ pub async fn get_swc_ecma_transform_plugin_rule(
 }
 
 #[cfg(feature = "plugin")]
-pub async fn get_swc_ecma_transform_rule_impl(
+async fn get_swc_ecma_transform_rule_impl(
     project_path: FileSystemPath,
     plugin_configs: &[(RcStr, serde_json::Value)],
     enable_mdx_rs: bool,
@@ -78,11 +78,14 @@ pub async fn get_swc_ecma_transform_rule_impl(
                         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
                         request,
                         resolve_options,
+                        // TODO proper error location, should point at the next config?
+                        project_path.clone(),
+                        None,
                     )
                     .as_raw_module_result(),
                     ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
                     // TODO proper error location
-                    project_path.clone(),
+                    project_path,
                     request,
                     resolve_options,
                     false,

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -116,8 +116,10 @@ pub async fn is_babel_loader_available(project_path: FileSystemPath) -> Result<V
     let result = resolve(
         project_path.clone(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
-        Request::parse(Pattern::Constant("babel-loader/package.json".into())),
-        node_cjs_resolve_options(project_path),
+        Request::parse(Pattern::Constant(rcstr!("babel-loader/package.json"))),
+        node_cjs_resolve_options(project_path.clone()),
+        project_path,
+        None,
     );
     let assets = result.primary_sources().await?;
     Ok(Vc::cell(!assets.is_empty()))

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -61,6 +61,8 @@ pub async fn assert_can_resolve_react_refresh(
             ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
             request,
             resolve_options,
+            path.clone(),
+            None,
         )
         .first_source();
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -35,8 +35,8 @@ use crate::{
     data_uri_source::DataUriSource,
     file_source::FileSource,
     issue::{
-        Issue, IssueDescriptionExt as _, IssueExt, IssueSource,
-        module::emit_unknown_module_type_error, resolve::ResolvingIssue,
+        Issue, IssueDescriptionExt, IssueExt, IssueSource, module::emit_unknown_module_type_error,
+        resolve::ResolvingIssue,
     },
     module::{Module, Modules, OptionModule},
     output::{OutputAsset, OutputAssets},
@@ -1604,11 +1604,12 @@ pub fn resolve(
     original_path: FileSystemPath,
     issue_source: Option<IssueSource>,
 ) -> Vc<ResolveResult> {
-    let result = if cfg!(debug_assertions) {
-        resolve_without_source_operation_wrapper(lookup_path, reference_type, request, options)
-    } else {
-        resolve_without_source(lookup_path, reference_type, request, options)
-    };
+    #[cfg(debug_assertions)]
+    let result =
+        resolve_without_source_operation_wrapper(lookup_path, reference_type, request, options);
+
+    #[cfg(not(debug_assertions))]
+    let result = resolve_without_source(lookup_path, reference_type, request, options);
     emit_and_drop_issues(result, original_path, issue_source)
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3532,11 +3532,14 @@ async fn resolve_as_webpack_runtime(
 
     let options = apply_cjs_specific_options(options);
 
+    let origin_path = origin.origin_path().owned().await?;
     let resolved = resolve(
-        origin.origin_path().await?.parent(),
+        origin_path.parent(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         request,
         options,
+        origin_path,
+        None,
     );
 
     if let Some(source) = *resolved.first_source().await? {

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -163,12 +163,14 @@ impl ModuleReference for WebpackRuntimeAssetReference {
         let options = self.origin.resolve_options(ty.clone()).await?;
 
         let options = apply_cjs_specific_options(options);
-
+        let origin_path = self.origin.origin_path().owned().await?;
         let resolved = resolve(
-            self.origin.origin_path().await?.parent(),
+            origin_path.parent(),
             ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
             *self.request,
             options,
+            origin_path,
+            None,
         );
 
         Ok(resolved

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -581,6 +581,10 @@ impl EvaluateContext for WebpackLoaderContext {
                     ReferenceType::Undefined,
                     request,
                     options,
+                    // TODO(PACK-4879): This is not an ideal path for issues, getting detailed
+                    // source information out of the loader might be impossible though.
+                    lookup_path.clone(),
+                    None,
                 );
 
                 if let Some(source) = *resolved.first_source().await? {

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -127,11 +127,14 @@ pub async fn cjs_resolve_source(
     let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()).await?)
         .resolve()
         .await?;
+    let request_path = origin.origin_path().owned().await?;
     let result = resolve(
-        origin.origin_path().await?.parent(),
+        request_path.parent(),
         ty.clone(),
         *request,
         options,
+        request_path,
+        issue_source,
     );
 
     handle_resolve_source_error(

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -658,8 +658,8 @@ async fn externals_tracing_module_context(ty: ExternalType) -> Result<Vc<ModuleA
         emulate_environment: Some(env),
         loose_errors: true,
         custom_conditions: match ty {
-            ExternalType::CommonJs => vec!["require".into()],
-            ExternalType::EcmaScriptModule => vec!["import".into()],
+            ExternalType::CommonJs => vec![rcstr!("require")],
+            ExternalType::EcmaScriptModule => vec![rcstr!("import")],
             ExternalType::Url | ExternalType::Global | ExternalType::Script => vec![],
         },
         ..Default::default()
@@ -736,6 +736,8 @@ impl AssetContext for ModuleAssetContext {
             reference_type.clone(),
             request,
             resolve_options,
+            origin_path.clone(),
+            None,
         );
 
         let mut result = self.process_resolve_result(result.resolve().await?, reference_type);


### PR DESCRIPTION
# Improve resolution error reporting in Turbopack

This PR enhances the resolution error reporting in Turbopack by separating the resolution process from issue reporting. The key changes include:

- Introduces a new `resolve` function that wraps `resolve_without_source` and handles issue reporting
- Adds a `PendingResolvingIssue` trait to defer issue creation until the appropriate context is available
- Implements `emit_and_drop_issues` to properly emit issues with the correct source information
- Updates all callers to provide proper context for issue reporting
- Adds debug assertions to ensure issues aren't reported with the wrong path

These changes ensure that resolution errors are reported with the correct source path and context, making debugging easier for users.

Fixes #