### PR TITLE
[sourcemaps] Stop sending anonymous stack frames

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1899,12 +1899,7 @@ async function renderToStream(
               onError: serverComponentsErrorHandler,
               environmentName: () =>
                 requestStore.prerenderPhase === true ? 'Prerender' : 'Server',
-              filterStackFrame(url: string, _functionName: string): boolean {
-                // The default implementation filters out <anonymous> stack frames
-                // but we want to retain them because current Server Components and
-                // built-in Components in parent stacks don't have source location.
-                return !url.startsWith('node:') && !url.includes('node_modules')
-              },
+              filterStackFrame: undefined,
             }
           )
         },

--- a/test/development/app-dir/react-performance-track/app/headers/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/headers/page.tsx
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers'
+
+async function abstraction() {
+  await headers()
+}
+
+export default async function HeadersPage() {
+  await abstraction()
+  await headers()
+
+  return <p>Done</p>
+}


### PR DESCRIPTION
Server Components in parent stacks should have a location nowadays due to https://github.com/facebook/react/pull/33629.

Build-in components may not be as valueable. The correct fix for ignore-listing anonymous frame would check if the frames below are also ignore-listed.

I need to do this now since React also uses `filterStackFrame` to decide how to name Server Requests. Omitting the `new Promise` is more valueable than including host Components in parent stacks.