### PR TITLE
[sync-react] Set correct PR author

### DIFF
--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -53,4 +53,4 @@ jobs:
         shell: bash
         run: pnpm sync-react --actor "${{ github.actor }}" --commit --create-pull --version "${{ inputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/81134

We checkout and commit with nextjs-bot but then opened the PR as vercel-release-bot. Now we use nextjs-bot for both.