### PR TITLE
Always consider `captureOwnerStack` optional

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -664,7 +664,10 @@ function createErrorWithComponentOrOwnerStack(
   componentStack: string
 ) {
   const ownerStack =
-    process.env.NODE_ENV !== 'production' ? React.captureOwnerStack() : null
+    process.env.NODE_ENV !== 'production' && React.captureOwnerStack
+      ? React.captureOwnerStack()
+      : null
+
   const error = new Error(message)
   error.stack = error.name + ': ' + message + (ownerStack ?? componentStack)
   return error

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -47,8 +47,11 @@ export function io(expression: string, type: ApiType) {
 
           const errorWithStack = new Error(message)
 
-          if (process.env.NODE_ENV !== 'production') {
-            const ownerStack = workUnitStore.captureOwnerStack!()
+          if (
+            process.env.NODE_ENV !== 'production' &&
+            workUnitStore.captureOwnerStack
+          ) {
+            const ownerStack = workUnitStore.captureOwnerStack()
 
             if (ownerStack) {
               // TODO: Instead of stitching the stacks here, we should log the


### PR DESCRIPTION
When running `next build` with a custom `NODE_ENV` (e.g. `test` or `development`), the `captureOwnerStack` method is not defined and may lead to errors if called. This change ensures that we only call `captureOwnerStack` if it is defined, preventing potential runtime errors.