### PR TITLE
fix(packages/next-bundle-analyzer): file extension of webpack bundle analyzer report

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -17,7 +17,7 @@ module.exports =
               ? `./analyze/client.html`
               : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
                   options.nextRuntime
-                }.html`,
+                }${analyzerMode==="json" ? "json":"html"}`,
           })
         )
 

--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -5,7 +5,7 @@ module.exports =
       return nextConfig
     }
 
-    const extension = analyzerMode==="json" ? ".json":".html"; 
+    const extension = analyzerMode === 'json' ? '.json' : '.html'
 
     return Object.assign({}, nextConfig, {
       webpack(config, options) {

--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -5,6 +5,8 @@ module.exports =
       return nextConfig
     }
 
+    const extension = analyzerMode==="json" ? ".json":".html"; 
+
     return Object.assign({}, nextConfig, {
       webpack(config, options) {
         const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
@@ -14,10 +16,10 @@ module.exports =
             logLevel,
             openAnalyzer,
             reportFilename: !options.nextRuntime
-              ? `./analyze/client.html`
+              ? `./analyze/client${extension}`
               : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
                   options.nextRuntime
-                }${analyzerMode==="json" ? ".json":".html"}`,
+                }${extension}`,
           })
         )
 

--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -17,7 +17,7 @@ module.exports =
               ? `./analyze/client.html`
               : `../${options.nextRuntime === 'nodejs' ? '../' : ''}analyze/${
                   options.nextRuntime
-                }${analyzerMode==="json" ? "json":"html"}`,
+                }${analyzerMode==="json" ? ".json":".html"}`,
           })
         )
 


### PR DESCRIPTION
### Issue

When `analyzerMode` is selected as `json`, the bundle analyzer still emits a `.html` file. 

### Fix

Added a check for `analyzerMode` === `json` to determine file extension. 


