### PR TITLE
[build] remove devtool from client chunks in prod

### DIFF
--- a/packages/next/src/client/app-globals.ts
+++ b/packages/next/src/client/app-globals.ts
@@ -1,0 +1,7 @@
+// imports polyfill from `@next/polyfill-module` after build.
+import '../build/polyfills/polyfill-module'
+
+// Only setup devtools in development
+if (process.env.NODE_ENV !== 'production') {
+  require('../next-devtools/userspace/app/app-dev-overlay-setup') as typeof import('../next-devtools/userspace/app/app-dev-overlay-setup')
+}

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -1,8 +1,4 @@
-// imports polyfill from `@next/polyfill-module` after build.
-import '../build/polyfills/polyfill-module'
-
-import '../next-devtools/userspace/app/app-dev-overlay-setup'
-
+import './app-globals'
 import ReactDOMClient from 'react-dom/client'
 import React, { use } from 'react'
 // TODO: Explicitly import from client.browser

--- a/packages/next/src/client/app-next-turbopack.ts
+++ b/packages/next/src/client/app-next-turbopack.ts
@@ -1,8 +1,4 @@
 import { appBootstrap } from './app-bootstrap'
-import {
-  getComponentStack,
-  getOwnerStack,
-} from '../next-devtools/userspace/app/errors/stitched-error'
 import { isRecoverableError } from './react-client-callbacks/on-recoverable-error'
 
 window.next.version += '-turbo'
@@ -17,6 +13,8 @@ appBootstrap(() => {
     hydrate(instrumentationHooks)
   } finally {
     if (process.env.NODE_ENV !== 'production') {
+      const { getComponentStack, getOwnerStack } =
+        require('../next-devtools/userspace/app/errors/stitched-error') as typeof import('../next-devtools/userspace/app/errors/stitched-error')
       const { renderAppDevOverlay } =
         require('next/dist/compiled/next-devtools') as typeof import('next/dist/compiled/next-devtools')
       renderAppDevOverlay(getComponentStack, getOwnerStack, isRecoverableError)

--- a/packages/next/src/next-devtools/userspace/app/errors/index.ts
+++ b/packages/next/src/next-devtools/userspace/app/errors/index.ts
@@ -1,0 +1,3 @@
+export { originConsoleError } from './intercept-console-error'
+export { handleClientError } from './use-error-handler'
+export { decorateDevError } from './stitched-error'

--- a/packages/next/src/next-devtools/userspace/app/errors/stitched-error.ts
+++ b/packages/next/src/next-devtools/userspace/app/errors/stitched-error.ts
@@ -28,3 +28,17 @@ export function setOwnerStackIfAvailable(error: Error): void {
     setOwnerStack(error, React.captureOwnerStack())
   }
 }
+
+export function decorateDevError(
+  thrownValue: unknown,
+  errorInfo: React.ErrorInfo
+) {
+  const error = coerceError(thrownValue)
+  setOwnerStackIfAvailable(error)
+  // TODO: change to passing down errorInfo later
+  // In development mode, pass along the component stack to the error
+  if (errorInfo.componentStack) {
+    setComponentStack(error, errorInfo.componentStack)
+  }
+  return error
+}

--- a/test/production/app-dir/browser-chunks/browser-chunks.test.ts
+++ b/test/production/app-dir/browser-chunks/browser-chunks.test.ts
@@ -34,7 +34,7 @@ describe('browser-chunks', () => {
 
   it('must not bundle any dev overlay into browser chunks', () => {
     const devOverlaySources = sources.filter((source) => {
-      return source.includes('next-devtools/dev-overlay')
+      return source.includes('next-devtools')
     })
 
     if (devOverlaySources.length > 0) {


### PR DESCRIPTION
Exclude devtool overlay polyfills of console interception and error callbacks in prod. Webpack cannot tree-shake the imported modules when the exports from them are only used in dev, so we need to do dynamic require to load devtools in the client entry which exist for both dev and production.

Update the sourcemap paths assertion in `test/production/app-dir/browser-chunks/browser-chunks.test.ts` to `next-devtools` to cover all the devtool cases.