### PR TITLE
[sync-react] Go back to old account for creating the change

### DIFF
--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -26,12 +26,12 @@ jobs:
         with:
           # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
           # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
 
       - name: Set Git author
         run: |
-          git config user.name "nextjs-bot"
-          git config user.email "it+nextjs-bot@vercel.com"
+          git config user.name "vercel-release-bot"
+          git config user.email "infra+release@vercel.com"
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -53,4 +53,4 @@ jobs:
         shell: bash
         run: pnpm sync-react --actor "${{ github.actor }}" --commit --create-pull --version "${{ inputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/81369 

`GH_TOKEN_PULL_REQUESTS ` does not have permissions to create PRs: https://github.com/vercel/next.js/actions/runs/16122436717/job/45491343888

Basically reverting the changes in https://github.com/vercel/next.js/pull/81134 made the the react-sync.

## Test plan

- [x] workflow from this branch works: https://github.com/vercel/next.js/actions/runs/16122680750