### PR TITLE
chore: Update `with-supabase` example to use `getClaims()`

### DIFF
--- a/examples/with-supabase/.env.example
+++ b/examples/with-supabase/.env.example
@@ -1,4 +1,4 @@
 # Update these with your Supabase details from your project settings > API
 # https://app.supabase.com/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY=your-anon-key

--- a/examples/with-supabase/app/protected/page.tsx
+++ b/examples/with-supabase/app/protected/page.tsx
@@ -7,8 +7,8 @@ import { FetchDataSteps } from "@/components/tutorial/fetch-data-steps";
 export default async function ProtectedPage() {
   const supabase = await createClient();
 
-  const { data, error } = await supabase.auth.getUser();
-  if (error || !data?.user) {
+  const { data, error } = await supabase.auth.getClaims();
+  if (error || !data?.claims) {
     redirect("/auth/login");
   }
 
@@ -24,7 +24,7 @@ export default async function ProtectedPage() {
       <div className="flex flex-col gap-2 items-start">
         <h2 className="font-bold text-2xl mb-4">Your user details</h2>
         <pre className="text-xs font-mono p-3 rounded border max-h-32 overflow-auto">
-          {JSON.stringify(data.user, null, 2)}
+          {JSON.stringify(data.claims, null, 2)}
         </pre>
       </div>
       <div>

--- a/examples/with-supabase/components/auth-button.tsx
+++ b/examples/with-supabase/components/auth-button.tsx
@@ -6,9 +6,12 @@ import { LogoutButton } from "./logout-button";
 export async function AuthButton() {
   const supabase = await createClient();
 
+  // You can also use getUser() which will be slower.
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data,
+  } = await supabase.auth.getClaims();
+
+  const user = data?.claims
 
   return user ? (
     <div className="flex items-center gap-4">

--- a/examples/with-supabase/components/auth-button.tsx
+++ b/examples/with-supabase/components/auth-button.tsx
@@ -7,11 +7,9 @@ export async function AuthButton() {
   const supabase = await createClient();
 
   // You can also use getUser() which will be slower.
-  const {
-    data,
-  } = await supabase.auth.getClaims();
+  const { data } = await supabase.auth.getClaims();
 
-  const user = data?.claims
+  const user = data?.claims;
 
   return user ? (
     <div className="flex items-center gap-4">

--- a/examples/with-supabase/lib/supabase/client.ts
+++ b/examples/with-supabase/lib/supabase/client.ts
@@ -3,6 +3,6 @@ import { createBrowserClient } from "@supabase/ssr";
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
   );
 }

--- a/examples/with-supabase/lib/supabase/middleware.ts
+++ b/examples/with-supabase/lib/supabase/middleware.ts
@@ -7,14 +7,17 @@ export async function updateSession(request: NextRequest) {
     request,
   });
 
-  // If the env vars are not set, skip middleware check. You can remove this once you setup the project.
+  // If the env vars are not set, skip middleware check. You can remove this
+  // once you setup the project.
   if (!hasEnvVars) {
     return supabaseResponse;
   }
 
+  // With Fluid compute, don't put this client in a global environment
+  // variable. Always create a new one on each request.
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
     {
       cookies: {
         getAll() {
@@ -36,14 +39,15 @@ export async function updateSession(request: NextRequest) {
   );
 
   // Do not run code between createServerClient and
-  // supabase.auth.getUser(). A simple mistake could make it very hard to debug
+  // supabase.auth.getClaims(). A simple mistake could make it very hard to debug
   // issues with users being randomly logged out.
 
-  // IMPORTANT: DO NOT REMOVE auth.getUser()
-
+  // IMPORTANT: If you remove getClaims() and you use server-side rendering
+  // with the Supabase client, your users may be randomly logged out.
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data
+  } = await supabase.auth.getClaims();
+  const user = data?.claims
 
   if (
     request.nextUrl.pathname !== "/" &&

--- a/examples/with-supabase/lib/supabase/middleware.ts
+++ b/examples/with-supabase/lib/supabase/middleware.ts
@@ -44,10 +44,8 @@ export async function updateSession(request: NextRequest) {
 
   // IMPORTANT: If you remove getClaims() and you use server-side rendering
   // with the Supabase client, your users may be randomly logged out.
-  const {
-    data
-  } = await supabase.auth.getClaims();
-  const user = data?.claims
+  const { data } = await supabase.auth.getClaims();
+  const user = data?.claims;
 
   if (
     request.nextUrl.pathname !== "/" &&

--- a/examples/with-supabase/lib/supabase/server.ts
+++ b/examples/with-supabase/lib/supabase/server.ts
@@ -1,12 +1,17 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
+/**
+ * Especially important if using Fluid compute: Don't put this client in a
+ * global variable. Always create a new client within each function when using
+ * it.
+ */
 export async function createClient() {
   const cookieStore = await cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
     {
       cookies: {
         getAll() {

--- a/examples/with-supabase/lib/utils.ts
+++ b/examples/with-supabase/lib/utils.ts
@@ -8,4 +8,4 @@ export function cn(...inputs: ClassValue[]) {
 // This check can be removed, it is just for tutorial purposes
 export const hasEnvVars =
   process.env.NEXT_PUBLIC_SUPABASE_URL &&
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY

--- a/examples/with-supabase/lib/utils.ts
+++ b/examples/with-supabase/lib/utils.ts
@@ -8,4 +8,4 @@ export function cn(...inputs: ClassValue[]) {
 // This check can be removed, it is just for tutorial purposes
 export const hasEnvVars =
   process.env.NEXT_PUBLIC_SUPABASE_URL &&
-  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY;


### PR DESCRIPTION
Updates the `with-supabase` example to use the new and much faster (when project is configured with asymmetric JWT support) `supabase.auth.getClaims()` function instead of `getUser()`.
