### PR TITLE
[dynamicIO] Track module loading in dev always

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1221,6 +1221,9 @@ async function renderToHTMLOrFlightImpl(
       if (!renderOpts.experimental.dynamicIO) {
         return false
       }
+      if (renderOpts.dev) {
+        return true
+      }
       const workUnitStore = workUnitAsyncStorage.getStore()
       return !!(
         workUnitStore &&


### PR DESCRIPTION
In dev we prerender and render concurrently. The former to validate dynamicIO rules. The latter to stream a response as soon as possible. If we only track module loading during prerenders it is possible to kick off loading a chunk during the render and then not observe that chunk load during prerender, leading to an early abort before all modules have had a chance to load.

To solve this we simply always track module loading in dev.