### PR TITLE
fix(CI): Update llvm when building native musl targets

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -247,7 +247,8 @@ jobs:
             build: >-
               set -ex &&
               apk update &&
-              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
+              apk del llvm &&
+              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm llvm-dev &&
               rustup show &&
               rustup target add x86_64-unknown-linux-musl &&
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
@@ -288,7 +289,8 @@ jobs:
             build: >-
               set -ex &&
               apk update &&
-              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm-dev &&
+              apk del llvm &&
+              apk add --no-cache libc6-compat pkgconfig dav1d libdav1d dav1d-dev clang-static llvm llvm-dev &&
               export JEMALLOC_SYS_WITH_LG_PAGE=16 &&
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}" &&
               rustup show &&


### PR DESCRIPTION
Tested locally with

```
podman run --platform=linux/amd64 -t -i ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine bash
```

We must ensure llvm16 is removed before installing llvm20 and llvm20-dev, as there's a file conflict between llvm16 and llvm20-dev.

Full build-and-deploy run: [https://github.com/vercel/next.js/actions/runs/16128142342](https://github.com/vercel/next.js/actions/runs/16128189670)

Closes PACK-5022