### PR TITLE
wip

### DIFF
--- a/not-staged-diffs.txt
+++ b/not-staged-diffs.txt
@@ -1,0 +1,2255 @@
+diff --git a/packages/next/.storybook/main.ts b/packages/next/.storybook/main.ts
+index 91222d9918..17fa7d000c 100644
+--- a/packages/next/.storybook/main.ts
++++ b/packages/next/.storybook/main.ts
+@@ -1,5 +1,7 @@
+ import type { StorybookConfig } from '@storybook/react-webpack5'
+-import { join, dirname } from 'path'
++import { join, dirname, resolve } from 'path'
++import { fileURLToPath } from 'url'
++
+ /**
+  * This function is used to resolve the absolute path of a package.
+  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
+@@ -7,6 +9,9 @@ import { join, dirname } from 'path'
+ function getAbsolutePath(value: string): any {
+   return dirname(require.resolve(join(value, 'package.json')))
+ }
++import { createRequire } from 'module'
++const require = createRequire(import.meta.url)
++
+ const config: StorybookConfig = {
+   stories: ['../src/next-devtools/**/*.stories.tsx'],
+   addons: [
+@@ -32,5 +37,48 @@ const config: StorybookConfig = {
+       },
+     },
+   }),
++  webpackFinal: async (config) => {
++    // Find and override CSS rule to use the devtool style injection
++    const cssRule = config.module?.rules?.find((rule) => {
++      if (typeof rule !== 'object' || !rule) return false
++      if ('test' in rule && rule.test instanceof RegExp) {
++        return rule.test.test('.css')
++      }
++      return false
++    })
++
++    if (
++      cssRule &&
++      typeof cssRule === 'object' &&
++      'use' in cssRule &&
++      Array.isArray(cssRule.use)
++    ) {
++      // Find the style-loader in the use array
++      const styleLoaderIndex = cssRule.use.findIndex((loader) => {
++        if (typeof loader === 'string') return loader.includes('style-loader')
++        if (typeof loader === 'object' && loader && 'loader' in loader) {
++          return loader.loader?.includes('style-loader')
++        }
++        return false
++      })
++
++      if (styleLoaderIndex !== -1) {
++        // Replace with our custom configuration
++        cssRule.use[styleLoaderIndex] = {
++          loader: require.resolve('style-loader'),
++          options: {
++            injectType: 'styleTag',
++            insert: resolve(
++              dirname(fileURLToPath(import.meta.url)),
++              '../src/build/webpack/loaders/devtool/devtool-style-inject.js'
++            ),
++          },
++        }
++      }
++    }
++
++    return config
++  },
+ }
++
+ export default config
+diff --git a/packages/next/src/next-devtools/components/tooltip.tsx b/packages/next/src/next-devtools/components/tooltip.tsx
+index bf1a7162c0..02ba294640 100644
+--- a/packages/next/src/next-devtools/components/tooltip.tsx
++++ b/packages/next/src/next-devtools/components/tooltip.tsx
+@@ -7,7 +7,7 @@ type TooltipDirection = 'top' | 'bottom' | 'left' | 'right'
+ 
+ interface TooltipProps {
+   children: React.ReactNode
+-  title: string
++  title: string | null
+   direction?: TooltipDirection
+   container?: HTMLElement | React.RefObject<HTMLElement>
+   arrowSize?: number
+@@ -32,6 +32,9 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
+     },
+     ref
+   ) {
++    if (!title) {
++      return children
++    }
+     return (
+       <BaseTooltip.Provider>
+         <BaseTooltip.Root delay={0}>
+diff --git a/packages/next/src/next-devtools/dev-overlay.browser.tsx b/packages/next/src/next-devtools/dev-overlay.browser.tsx
+index a5a44d8555..6e1b9f2ab3 100644
+--- a/packages/next/src/next-devtools/dev-overlay.browser.tsx
++++ b/packages/next/src/next-devtools/dev-overlay.browser.tsx
+@@ -18,9 +18,17 @@ import {
+   ACTION_RENDERING_INDICATOR_HIDE,
+   ACTION_RENDERING_INDICATOR_SHOW,
+   ACTION_DEVTOOL_UPDATE_ROUTE_STATE,
++  type OverlayState,
++  type DispatcherEvent,
+ } from './dev-overlay/shared'
+ 
+-import { startTransition, useInsertionEffect } from 'react'
++import {
++  createContext,
++  startTransition,
++  useContext,
++  useInsertionEffect,
++  type ActionDispatch,
++} from 'react'
+ import { createRoot } from 'react-dom/client'
+ import { FontStyles } from './dev-overlay/font/font-styles'
+ import type { HydrationErrorState } from './shared/hydration-error'
+@@ -208,14 +216,26 @@ function DevOverlayRoot({
+     <>
+       {/* Fonts can only be loaded outside the Shadow DOM. */}
+       <FontStyles />
+-      <DevOverlay
+-        state={state}
+-        dispatch={dispatch}
+-        getSquashedHydrationErrorDetails={getSquashedHydrationErrorDetails}
+-      />
++      <DevOverlayContext
++        value={{
++          dispatch,
++          getSquashedHydrationErrorDetails,
++          state,
++        }}
++      >
++        <DevOverlay />
++      </DevOverlayContext>
+     </>
+   )
+ }
++export const DevOverlayContext = createContext<{
++  state: OverlayState & {
++    routerType: 'pages' | 'app'
++  }
++  dispatch: ActionDispatch<[action: DispatcherEvent]>
++  getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
++}>(null!)
++export const useDevOverlayContext = () => useContext(DevOverlayContext)
+ 
+ let isPagesMounted = false
+ let isAppMounted = false
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx
+index 4d957bad50..5f6b5dcc50 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx
+@@ -1,12 +1,12 @@
+ import type { Meta, StoryObj } from '@storybook/react'
+ import type { OverlayState } from '../../shared'
+ 
+-import { DevToolsIndicator } from './devtools-indicator'
++import { DevToolsIndicatorNew } from './devtools-indicator'
+ import { INITIAL_OVERLAY_STATE } from '../../shared'
+ import { withShadowPortal } from '../../storybook/with-shadow-portal'
+ 
+-const meta: Meta<typeof DevToolsIndicator> = {
+-  component: DevToolsIndicator,
++const meta: Meta<typeof DevToolsIndicatorNew> = {
++  component: DevToolsIndicatorNew,
+   parameters: {
+     layout: 'centered',
+   },
+@@ -37,7 +37,7 @@ const meta: Meta<typeof DevToolsIndicator> = {
+ }
+ 
+ export default meta
+-type Story = StoryObj<typeof DevToolsIndicator>
++type Story = StoryObj<typeof DevToolsIndicatorNew>
+ 
+ const state: OverlayState = {
+   ...INITIAL_OVERLAY_STATE,
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
+index 182f4ef0f8..7257afca7f 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
+@@ -16,35 +16,23 @@ import {
+   ACTION_ERROR_OVERLAY_OPEN,
+ } from '../../shared'
+ import { Draggable } from '../errors/dev-tools-indicator/draggable'
++import { useDevOverlayContext } from '../../../dev-overlay.browser'
++import { useRenderErrorContext } from '../../dev-overlay'
++import { usePanelContext } from '../../menu/context'
+ 
+ export const INDICATOR_PADDING = 20
+ 
+-export function DevToolsIndicator({
+-  state,
+-  dispatch,
+-  errorCount,
+-  isBuildError,
+-}: {
+-  state: OverlayState
+-  dispatch: OverlayDispatch
+-  errorCount: number
+-  isBuildError: boolean
+-}) {
+-  const [open, setOpen] = useState(false)
++export function DevToolsIndicatorNew() {
++  const { state, dispatch } = useDevOverlayContext()
++  const { setOpen, triggerRef, setPanel } = usePanelContext()
+ 
+   const [vertical, horizontal] = state.devToolsPosition.split('-', 2)
+ 
+-  const enableErrorOverlayMode = () => {
+-    dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
+-    // Open the DevTools panel to view as error overlay mode.
+-    dispatch({ type: ACTION_DEVTOOLS_PANEL_OPEN })
+-  }
+-
+-  const toggleDevToolsPanel = () => {
+-    dispatch({ type: ACTION_DEVTOOLS_PANEL_TOGGLE })
+-  }
++  // console.log('rendering next logo')
+ 
+   return (
++    // what is this toast doing??
++    // why are u hiding my precious
+     <Toast
+       data-nextjs-toast
+       style={
+@@ -54,16 +42,17 @@ export function DevToolsIndicator({
+           boxShadow: 'none',
+           [vertical]: `${INDICATOR_PADDING}px`,
+           [horizontal]: `${INDICATOR_PADDING}px`,
+-          visibility:
+-            state.isDevToolsPanelOpen || state.isErrorOverlayOpen
+-              ? 'hidden'
+-              : 'visible',
++          // visibility:
++          //   state.isDevToolsPanelOpen || state.isErrorOverlayOpen
++          //     ? 'hidden'
++          //     : 'visible' <-- todo add hiding,
+         } as CSSProperties
+       }
+     >
+       <Draggable
+         padding={INDICATOR_PADDING}
+-        onDragStart={() => setOpen(false)}
++        // er i don't think this makes sense in the context of the refactor, come back to this
++        onDragStart={() => setOpen(null)}
+         position={state.devToolsPosition}
+         setPosition={(p) => {
+           dispatch({
+@@ -75,19 +64,12 @@ export function DevToolsIndicator({
+       >
+         {/* Trigger */}
+         <NextLogo
+-          aria-haspopup="menu"
+-          aria-expanded={open}
+-          aria-controls="nextjs-dev-tools-menu"
+-          aria-label={`${open ? 'Close' : 'Open'} Next.js Dev Tools`}
+-          data-nextjs-dev-tools-button
+-          disabled={state.disableDevIndicator}
+-          issueCount={errorCount}
+-          onTriggerClick={toggleDevToolsPanel}
+-          toggleErrorOverlay={enableErrorOverlayMode}
+-          isDevBuilding={state.buildingIndicator}
+-          isDevRendering={state.renderingIndicator}
+-          isBuildError={isBuildError}
+-          scale={state.scale}
++          onTriggerClick={() => {
++            // dispatch({ type: ACTION_DEVTOOLS_PANEL_TOGGLE })
++            // onTriggerClick()
++            setPanel(prev => prev === 'panel-selector' ? null : 'panel-selector')
++          }}
++          ref={triggerRef}
+         />
+       </Draggable>
+     </Toast>
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+index a575bbbd1b..bcbd6e51b4 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+@@ -7,50 +7,51 @@ import { useMinimumLoadingTimeMultiple } from './hooks/use-minimum-loading-time-
+ import { Cross } from '../../icons/cross'
+ import { Warning } from '../../icons/warning'
+ import { css } from '../../utils/css'
+-
+-interface Props extends React.ComponentProps<'button'> {
+-  issueCount: number
+-  isDevBuilding: boolean
+-  isDevRendering: boolean
+-  isBuildError: boolean
+-  onTriggerClick: () => void
+-  toggleErrorOverlay: () => void
+-  scale: DevToolsScale
+-}
++import { useDevOverlayContext } from '../../../dev-overlay.browser'
++import { useRenderErrorContext } from '../../dev-overlay'
++import {
++  ACTION_DEVTOOLS_PANEL_OPEN,
++  ACTION_DEVTOOLS_PANEL_TOGGLE,
++  ACTION_ERROR_OVERLAY_OPEN,
++} from '../../shared'
++import { usePanelContext } from '../../menu/context'
++import { OVERLAYS } from '../errors/dev-tools-indicator/dev-tools-indicator'
+ 
+ const SHORT_DURATION_MS = 150
+ 
+-export function NextLogo({
+-  disabled,
+-  issueCount,
+-  isDevBuilding,
+-  isDevRendering,
+-  isBuildError,
+-  onTriggerClick,
+-  toggleErrorOverlay,
+-  scale = 1,
+-  ...props
+-}: Props) {
+-  const SIZE = 36 / scale
+-
+-  const hasError = issueCount > 0
++export function NextLogo({onTriggerClick, ...buttonProps}: {onTriggerClick: () => void} &React.ComponentProps<'button'>) {
++  const { state, dispatch } = useDevOverlayContext()
++  const { totalErrorCount } = useRenderErrorContext()
++  const SIZE = 36 / state.scale
++  // const [open, setOpen] = useState(false)
++  // todo: rename better: its indicator menu open something something
++  // also wait we are duplicating this totally need to dedupe
++  const { open, setOpen, setPanel } = usePanelContext()
++  const isMenuOpen = open === OVERLAYS.Root
++
++  const hasError = totalErrorCount > 0
+   const [isErrorExpanded, setIsErrorExpanded] = useState(hasError)
+   const [dismissed, setDismissed] = useState(false)
+-  const newErrorDetected = useUpdateAnimation(issueCount, SHORT_DURATION_MS)
++  const newErrorDetected = useUpdateAnimation(
++    totalErrorCount,
++    SHORT_DURATION_MS
++  )
+ 
+   const triggerRef = useRef<HTMLButtonElement | null>(null)
+   const ref = useRef<HTMLDivElement | null>(null)
+   const measuredWidth = useMeasureWidth(ref)
+ 
+   const isLoading = useMinimumLoadingTimeMultiple(
+-    isDevBuilding || isDevRendering
++    state.buildingIndicator || state.renderingIndicator
+   )
+-  const isExpanded = isErrorExpanded || disabled
++  const isExpanded = isErrorExpanded || state.disableDevIndicator
+   const width = measuredWidth === 0 ? 'auto' : measuredWidth
+ 
+   useEffect(() => {
+     setIsErrorExpanded(hasError)
+   }, [hasError])
++  console.log('its time for next logo',state.disableDevIndicator);
++  
+ 
+   return (
+     <div
+@@ -61,7 +62,10 @@ export function NextLogo({
+           '--duration-short': `${SHORT_DURATION_MS}ms`,
+           // if the indicator is disabled, hide the badge
+           // also allow the "disabled" state be dismissed, as long as there are no build errors
+-          display: disabled && (!hasError || dismissed) ? 'none' : 'block',
++          display:
++            state.disableDevIndicator && (!hasError || dismissed)
++              ? 'none'
++              : 'block',
+         } as React.CSSProperties
+       }
+     >
+@@ -396,15 +400,31 @@ export function NextLogo({
+       >
+         <div ref={ref}>
+           {/* Children */}
+-          {!disabled && (
++          {!state.disableDevIndicator && (
+             <button
++            id="next-logo"
+               ref={triggerRef}
+               data-next-mark
+               data-next-mark-loading={isLoading}
+-              onClick={onTriggerClick}
+-              {...props}
++              onClick={() => {
++
++                onTriggerClick()
++                // this is really stupid, especially with setOpen
++                // setPanel(prev => prev === 'panel-selector' ? null : 'panel-selector')
++                // dispatch({ type: ACTION_DEVTOOLS_PANEL_TOGGLE })
++              }}
++              disabled={state.disableDevIndicator}
++              aria-haspopup="menu"
++              aria-expanded={isMenuOpen}
++              aria-controls="nextjs-dev-tools-menu"
++              aria-label={`${isMenuOpen ? 'Close' : 'Open'} Next.js Dev Tools`}
++              data-nextjs-dev-tools-button
++              {...buttonProps}
+             >
+-              <NextMark isLoading={isLoading} isDevBuilding={isDevBuilding} />
++              <NextMark
++                isLoading={isLoading}
++                isDevBuilding={state.buildingIndicator}
++              />
+             </button>
+           )}
+           {isExpanded && (
+@@ -412,42 +432,46 @@ export function NextLogo({
+               <button
+                 data-issues-open
+                 aria-label="Open issues overlay"
+-                onClick={toggleErrorOverlay}
++                onClick={() => {
++                  dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
++                  // Open the DevTools panel to view as error overlay mode.
++                  dispatch({ type: ACTION_DEVTOOLS_PANEL_OPEN })
++                }}
+               >
+-                {disabled && (
++                {state.disableDevIndicator && (
+                   <div data-disabled-icon>
+                     <Warning />
+                   </div>
+                 )}
+                 <AnimateCount
+                   // Used the key to force a re-render when the count changes.
+-                  key={issueCount}
++                  key={totalErrorCount}
+                   animate={newErrorDetected}
+                   data-issues-count-animation
+                 >
+-                  {issueCount}
++                  {totalErrorCount}
+                 </AnimateCount>{' '}
+                 <div>
+                   Issue
+-                  {issueCount > 1 && (
++                  {totalErrorCount > 1 && (
+                     <span
+                       aria-hidden
+                       data-issues-count-plural
+                       // This only needs to animate once the count changes from 1 -> 2,
+                       // otherwise it should stay static between re-renders.
+-                      data-animate={newErrorDetected && issueCount === 2}
++                      data-animate={newErrorDetected && totalErrorCount === 2}
+                     >
+                       s
+                     </span>
+                   )}
+                 </div>
+               </button>
+-              {!isBuildError && (
++              {!state.buildError && (
+                 <button
+                   data-issues-collapse
+                   aria-label="Collapse issues badge"
+                   onClick={() => {
+-                    if (disabled) {
++                    if (state.disableDevIndicator) {
+                       setDismissed(true)
+                     } else {
+                       setIsErrorExpanded(false)
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx
+index ade104a5bc..d34bf58577 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx
+@@ -37,10 +37,6 @@ export function DevToolsPanelTab({
+     case 'settings':
+       return (
+         <SettingsTab
+-          devToolsPosition={devToolsPosition}
+-          scale={scale}
+-          handlePositionChange={handlePositionChange}
+-          handleScaleChange={handleScaleChange}
+         />
+       )
+     case 'route':
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
+index 7a1106b713..f62097b4f6 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
+@@ -7,8 +7,7 @@ function SegmentsExplorer({
+   routerType: 'app' | 'pages'
+   page: string
+ }) {
+-  const isAppRouter = routerType === 'app'
+-  return <PageSegmentTree isAppRouter={isAppRouter} page={page} />
++  return <PageSegmentTree />
+ }
+ 
+ export function SegmentsExplorerTab({
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/settings-tab.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/settings-tab.tsx
+index a3d79d7be0..993b167312 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/settings-tab.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/settings-tab.tsx
+@@ -2,12 +2,20 @@ import type { Corners } from '../../../shared'
+ 
+ import { useTheme } from '../hooks/use-theme'
+ import { Select } from '../../select/select'
+-import { STORAGE_KEY_THEME, NEXT_DEV_TOOLS_SCALE } from '../../../shared'
++import {
++  STORAGE_KEY_THEME,
++  NEXT_DEV_TOOLS_SCALE,
++  ACTION_DEVTOOLS_POSITION,
++  STORAGE_KEY_POSITION,
++  ACTION_DEVTOOLS_SCALE,
++  STORAGE_KEY_SCALE,
++} from '../../../shared'
+ import { css } from '../../../utils/css'
+ import LightIcon from '../../../icons/light-icon'
+ import DarkIcon from '../../../icons/dark-icon'
+ import SystemIcon from '../../../icons/system-icon'
+ import EyeIcon from '../../../icons/eye-icon'
++import { useDevOverlayContext } from '../../../../dev-overlay.browser'
+ 
+ function ThemeIcon({ theme }: { theme: 'dark' | 'light' | 'system' }) {
+   switch (theme) {
+@@ -22,17 +30,7 @@ function ThemeIcon({ theme }: { theme: 'dark' | 'light' | 'system' }) {
+   }
+ }
+ 
+-export function SettingsTab({
+-  devToolsPosition,
+-  scale,
+-  handlePositionChange,
+-  handleScaleChange,
+-}: {
+-  devToolsPosition: Corners
+-  scale: number
+-  handlePositionChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
+-  handleScaleChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
+-}) {
++export function SettingsTab() {
+   const [theme, setTheme] = useTheme()
+ 
+   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+@@ -73,6 +71,7 @@ export function SettingsTab({
+       // https://github.com/vercel/next.js/pull/80005
+     })
+   }
++  const { dispatch, state } = useDevOverlayContext()
+ 
+   function hide() {
+     fetch('/__nextjs_disable_dev_indicator', {
+@@ -112,8 +111,14 @@ export function SettingsTab({
+         <Select
+           id="position"
+           name="position"
+-          value={devToolsPosition}
+-          onChange={handlePositionChange}
++          value={state.devToolsPosition}
++          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
++            dispatch({
++              type: ACTION_DEVTOOLS_POSITION,
++              devToolsPosition: e.target.value as Corners,
++            })
++            localStorage.setItem(STORAGE_KEY_POSITION, e.target.value)
++          }}
+         >
+           <option value="bottom-left">Bottom Left</option>
+           <option value="bottom-right">Bottom Right</option>
+@@ -132,8 +137,14 @@ export function SettingsTab({
+         <Select
+           id="size"
+           name="size"
+-          value={scale}
+-          onChange={handleScaleChange}
++          value={state.scale}
++          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
++            dispatch({
++              type: ACTION_DEVTOOLS_SCALE,
++              scale: Number(e.target.value),
++            })
++            localStorage.setItem(STORAGE_KEY_SCALE, e.target.value)
++          }}
+         >
+           {Object.entries(NEXT_DEV_TOOLS_SCALE).map(([key, value]) => {
+             return (
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+index 40cdd2198a..c739706693 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+@@ -252,14 +252,38 @@ export function DevToolsPanel({
+ 
+             {!isFullscreen && (
+               <>
+-                <ResizeHandle direction="top" />
+-                <ResizeHandle direction="right" />
+-                <ResizeHandle direction="bottom" />
+-                <ResizeHandle direction="left" />
+-                <ResizeHandle direction="top-left" />
+-                <ResizeHandle direction="top-right" />
+-                <ResizeHandle direction="bottom-left" />
+-                <ResizeHandle direction="bottom-right" />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="top"
++                />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="right"
++                />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="bottom"
++                />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="left"
++                />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="top-left"
++                />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="top-right"
++                />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="bottom-left"
++                />
++                <ResizeHandle
++                  position={state.devToolsPanelPosition}
++                  direction="bottom-right"
++                />
+               </>
+             )}
+           </>
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
+index 24ce1b80ce..f1dc4a28d6 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
+@@ -11,7 +11,7 @@
+   /* todo smarter z index */
+   z-index: -1;
+   pointer-events: none;
+-  /* a normal exit animation curve- at this point the exit animation is */
++  /* a normal exit animation curve- aat this point the exit animation is */
+   /* immediately responsive so we don't need a bespoke curve */
+   transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+   /* todo: better var? */
+@@ -20,14 +20,14 @@
+ 
+ /* start really fast because we start super hidden initially behind the panel, otherwise feels like an unintended animation delay */
+ .resize-container:hover ~ .resize-line {
+-  transition: transform 0.2s cubic-bezier(0.05, 0.9, 0.2, 1); /* Fast start for animate in */
++  transition: transform 0.25s cubic-bezier(0.23, 1, 0.32, 1);
+ }
+ 
+ .resize-container.right,
+ .resize-container.left {
+   top: 0;
+   height: 100%;
+-  width: 25px;
++  width: 15px;
+   cursor: ew-resize;
+ }
+ 
+@@ -37,97 +37,97 @@
+ .resize-container.top {
+   left: 0;
+   width: 100%;
+-  height: 25px;
++  height: 15px;
+   cursor: ns-resize;
+ }
+ 
+ .resize-container.top {
+-  top: -12px;
++  top: -7px;
+ }
+ .resize-container.bottom {
+-  bottom: -12px;
++  bottom: -7px;
+ }
+ .resize-container.left {
+-  left: -12px;
++  left: -7px;
+ }
+ .resize-container.right {
+-  right: -12px;
++  right: -7px;
+ }
+ 
+ .resize-container.top-left,
+ .resize-container.top-right,
+ .resize-container.bottom-left,
+ .resize-container.bottom-right {
+-  width: 32px;
+-  height: 32px;
++  width: 22px;
++  height: 22px;
+   z-index: 15;
+ }
+ 
+ .resize-container.top-left {
+-  top: -16px;
+-  left: -16px;
++  top: -11px;
++  left: -11px;
+   cursor: nwse-resize;
+ }
+ .resize-container.top-right {
+-  top: -16px;
+-  right: -16px;
++  top: -11px;
++  right: -11px;
+   cursor: nesw-resize;
+ }
+ .resize-container.bottom-left {
+-  bottom: -16px;
+-  left: -16px;
++  bottom: -11px;
++  left: -11px;
+   cursor: nesw-resize;
+ }
+ .resize-container.bottom-right {
+-  bottom: -16px;
+-  right: -16px;
++  bottom: -11px;
++  right: -11px;
+   cursor: nwse-resize;
+ }
+ 
+ .resize-line.top,
+ .resize-line.bottom {
+-  height: 28px;
++  height: 18px;
+   width: 100%;
+   background-color: var(--color-background-100);
+ }
+ 
+ .resize-line.left,
+ .resize-line.right {
+-  width: 28px;
++  width: 18px;
+   height: 100%;
+   background-color: var(--color-background-100);
+ }
+ 
+ .resize-line.top {
+-  top: -12px;
++  top: -7px;
+   left: calc(-1 * var(--border-left, 2px));
+   width: calc(100% + var(--border-horizontal, 4px));
+   border-radius: var(--rounded-md) var(--rounded-md) 0 0;
+-  transform: translateY(28px);
++  transform: translateY(18px);
+ }
+ 
+ .resize-line.bottom {
+-  bottom: -12px;
++  bottom: -7px;
+   left: calc(-1 * var(--border-left, 2px));
+   width: calc(100% + var(--border-horizontal, 4px));
+   border-radius: 0 0 var(--rounded-md) var(--rounded-md);
+-  transform: translateY(-28px);
++  transform: translateY(-18px);
+ }
+ 
+ .resize-line.left {
+   top: calc(-1 * var(--border-top, 2px));
+-  left: -12px;
++  left: -7px;
+   height: calc(100% + var(--border-vertical, 4px));
+   border-radius: var(--rounded-md) 0 0 var(--rounded-md);
+-  transform: translateX(28px);
++  transform: translateX(18px);
+ }
+ 
+ .resize-line.right {
+   top: calc(-1 * var(--border-top, 2px));
+-  right: -12px;
++  right: -7px;
+   height: calc(100% + var(--border-vertical, 4px));
+   border-radius: 0 var(--rounded-md) var(--rounded-md) 0;
+-  transform: translateX(-28px);
++  transform: translateX(-18px);
+ }
+ 
+ .resize-container.right:hover ~ .resize-line.right,
+@@ -149,14 +149,14 @@
+  * regardless of hover state 
+  */
+ .resize-container.no-hover.right:hover ~ .resize-line.right {
+-  transform: translateX(-28px);
++  transform: translateX(-20px);
+ }
+ .resize-container.no-hover.left:hover ~ .resize-line.left {
+-  transform: translateX(28px);
++  transform: translateX(20px);
+ }
+ .resize-container.no-hover.bottom:hover ~ .resize-line.bottom {
+-  transform: translateY(-28px);
++  transform: translateY(-20px);
+ }
+ .resize-container.no-hover.top:hover ~ .resize-line.top {
+-  transform: translateY(28px);
++  transform: translateY(20px);
+ }
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
+index bdf08d81d6..d231ab82e8 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
+@@ -3,14 +3,19 @@ import type { Corners } from '../../../shared'
+ import { useResize, type ResizeDirection } from './resize-provider'
+ import './resize-handle.css'
+ 
+-const STORAGE_KEY_DIMENSIONS = 'nextjs-devtools-dimensions'
+-
+-export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
++export const ResizeHandle = ({
++  direction,
++  position,
++}: {
++  direction: ResizeDirection
++  position: Corners
++}) => {
+   const {
+     resizeRef,
+     minWidth,
+     minHeight,
+-    devToolsPosition,
++    storageKey,
++    // devToolsPosition,
+     draggingDirection,
+     setDraggingDirection,
+   } = useResize()
+@@ -44,13 +49,13 @@ export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
+     // we block the sides of the corner its in (bottom-left has bottom and left sides blocked from resizing)
+     // because there shouldn't be anywhere to resize, and if the user decides to resize from that point it
+     // would be unhandled/slightly janky (the component would have to re-magnetic-snap after the resize)
+-    if (devToolsPosition.split('-').includes(direction)) return false
++    if (position.split('-').includes(direction)) return false
+ 
+     // same logic as above, but the only corner resize that makes
+     // sense is the corner fully exposed (the opposing corner)
+     const isCorner = direction.includes('-')
+     if (isCorner) {
+-      const opposite = getOppositeCorner(devToolsPosition)
++      const opposite = getOppositeCorner(position)
+       return direction === opposite
+     }
+ 
+@@ -123,10 +128,7 @@ export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
+ 
+       // invariant ref exists
+       const { width, height } = resizeRef.current!.getBoundingClientRect()
+-      localStorage.setItem(
+-        STORAGE_KEY_DIMENSIONS,
+-        JSON.stringify({ width, height })
+-      )
++      localStorage.setItem(storageKey, JSON.stringify({ width, height }))
+     }
+     document.addEventListener('mousemove', handleMouseMove)
+     document.addEventListener('mouseup', handleMouseUp)
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
+index ae1360e60b..e1d39172bc 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
+@@ -22,9 +22,10 @@ interface ResizeContextValue {
+   resizeRef: RefObject<HTMLElement | null>
+   minWidth: number
+   minHeight: number
+-  devToolsPosition: Corners
++  // devToolsPosition: Corners
+   draggingDirection: ResizeDirection | null
+   setDraggingDirection: (direction: ResizeDirection | null) => void
++  storageKey: string
+ }
+ 
+ const ResizeContext = createContext<ResizeContextValue>(null!)
+@@ -44,8 +45,8 @@ const constrainDimensions = (params: {
+   }
+ }
+ 
+-const parseResizeLocalStorage = () => {
+-  const savedDimensions = localStorage.getItem(STORAGE_KEY_DIMENSIONS)
++const parseResizeLocalStorage = (key: string) => {
++  const savedDimensions = localStorage.getItem(key)
+   if (!savedDimensions) return null
+   try {
+     const parsed = JSON.parse(savedDimensions)
+@@ -59,7 +60,7 @@ const parseResizeLocalStorage = () => {
+     }
+     return null
+   } catch (e) {
+-    localStorage.removeItem(STORAGE_KEY_DIMENSIONS)
++    localStorage.removeItem(key)
+     return null
+   }
+ }
+@@ -70,6 +71,7 @@ interface ResizeProviderProps {
+     minWidth?: number
+     minHeight?: number
+     devToolsPosition: Corners
++    storageKey?: string
+   }
+   children: React.ReactNode
+ }
+@@ -80,6 +82,8 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
+   const [draggingDirection, setDraggingDirection] =
+     useState<ResizeDirection | null>(null)
+ 
++  const storageKey = value.storageKey ?? STORAGE_KEY_DIMENSIONS
++
+   useLayoutEffect(() => {
+     const applyConstrainedDimensions = () => {
+       if (!value.resizeRef.current) return
+@@ -91,7 +95,7 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
+       // an optimization if this is too expensive is to maintain the current
+       // container size in a ref and update it on resize, which is essentially
+       // what we're doing here, just dumber
+-      const dim = parseResizeLocalStorage()
++      const dim = parseResizeLocalStorage(storageKey)
+       if (!dim) {
+         return
+       }
+@@ -110,7 +114,7 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
+     window.addEventListener('resize', applyConstrainedDimensions)
+     return () =>
+       window.removeEventListener('resize', applyConstrainedDimensions)
+-  }, [value.resizeRef, minWidth, minHeight])
++  }, [value.resizeRef, minWidth, minHeight, storageKey])
+ 
+   return (
+     <ResizeContext.Provider
+@@ -118,9 +122,10 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
+         resizeRef: value.resizeRef,
+         minWidth,
+         minHeight,
+-        devToolsPosition: value.devToolsPosition,
++        // devToolsPosition: value.devToolsPosition,
+         draggingDirection,
+         setDraggingDirection,
++        storageKey,
+       }}
+     >
+       {children}
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+index 8105241149..74ef66f23c 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+@@ -1,11 +1,11 @@
+ import type { Meta, StoryObj } from '@storybook/react'
+-import { DevToolsIndicator } from './dev-tools-indicator'
++import { DevOverlayStoryWrapper } from '../../../storybook/DevOverlayStoryWrapper'
+ import { withShadowPortal } from '../../../storybook/with-shadow-portal'
+ import type { VersionInfo } from '../../../../../server/dev/parse-version-info'
+ import type { OverlayState } from '../../../shared'
+ 
+-const meta: Meta<typeof DevToolsIndicator> = {
+-  component: DevToolsIndicator,
++const meta: Meta<typeof DevOverlayStoryWrapper> = {
++  component: DevOverlayStoryWrapper,
+   parameters: {
+     layout: 'centered',
+   },
+@@ -36,7 +36,7 @@ const meta: Meta<typeof DevToolsIndicator> = {
+ }
+ 
+ export default meta
+-type Story = StoryObj<typeof DevToolsIndicator>
++type Story = StoryObj<typeof DevOverlayStoryWrapper>
+ 
+ // Mock version info for stories
+ const mockVersionInfo: VersionInfo = {
+@@ -68,36 +68,31 @@ const state: OverlayState = {
+ }
+ 
+ export const StaticRoute: Story = {
+-  args: {
+-    errorCount: 0,
+-    state,
+-    dispatch: () => {},
+-  },
++  render: () => (
++    <DevOverlayStoryWrapper initialState={state} runtimeErrors={[]} />
++  ),
+ }
+ 
+ export const DynamicRoute: Story = {
+-  args: {
+-    errorCount: 0,
+-    state: {
+-      ...state,
+-      staticIndicator: false,
+-    },
+-    dispatch: () => {},
+-  },
++  render: () => (
++    <DevOverlayStoryWrapper
++      initialState={{ ...state, staticIndicator: false }}
++      runtimeErrors={[]}
++    />
++  ),
+ }
+ 
+ export const SingleError: Story = {
+-  args: {
+-    errorCount: 1,
+-    state,
+-    dispatch: () => {},
+-  },
++  render: () => (
++    <DevOverlayStoryWrapper initialState={state} runtimeErrors={[{} as any]} />
++  ),
+ }
+ 
+ export const MultipleErrors: Story = {
+-  args: {
+-    errorCount: 3,
+-    state,
+-    dispatch: () => {},
+-  },
++  render: () => (
++    <DevOverlayStoryWrapper
++      initialState={state}
++      runtimeErrors={[{}, {}, {}] as any}
++    />
++  ),
+ }
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+index b943ec67e0..3d481fc574 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+@@ -3,8 +3,6 @@ import {
+   ACTION_ERROR_OVERLAY_OPEN,
+   ACTION_ERROR_OVERLAY_TOGGLE,
+   STORAGE_KEY_POSITION,
+-  type OverlayDispatch,
+-  type OverlayState,
+ } from '../../../shared'
+ 
+ import { useState, useEffect, useRef, createContext, useContext } from 'react'
+@@ -27,20 +25,16 @@ import {
+ } from './dev-tools-info/preferences'
+ import { Draggable } from './draggable'
+ import { SegmentsExplorer } from './dev-tools-info/segments-explorer'
++import { useDevOverlayContext } from '../../../../dev-overlay.browser'
++import { useRenderErrorContext } from '../../../dev-overlay'
++import { css } from '../../../utils/css'
+ 
+ // TODO: add E2E tests to cover different scenarios
+ 
+ export function DevToolsIndicator({
+-  state,
+-  errorCount,
+-  isBuildError,
+-  ...props
++  scale,
++  setScale,
+ }: {
+-  state: OverlayState
+-  dispatch: OverlayDispatch
+-  errorCount: number
+-  isBuildError: boolean
+-
+   scale: DevToolsScale
+   setScale: (value: DevToolsScale) => void
+ }) {
+@@ -49,23 +43,15 @@ export function DevToolsIndicator({
+ 
+   return (
+     <DevToolsPopover
+-      routerType={state.routerType}
+-      semver={state.versionInfo.installed}
+-      issueCount={errorCount}
+-      isDevBuilding={state.buildingIndicator}
+-      isDevRendering={state.renderingIndicator}
+-      isStaticRoute={state.staticIndicator}
++      isDevToolsIndicatorVisible={isDevToolsIndicatorVisible}
++      scale={scale}
++      setScale={setScale}
+       hide={() => {
+         setIsDevToolsIndicatorVisible(false)
+         fetch('/__nextjs_disable_dev_indicator', {
+           method: 'POST',
+         })
+       }}
+-      isTurbopack={!!process.env.TURBOPACK}
+-      disabled={state.disableDevIndicator || !isDevToolsIndicatorVisible}
+-      isBuildError={isBuildError}
+-      page={state.page}
+-      {...props}
+     />
+   )
+ }
+@@ -80,7 +66,7 @@ interface C {
+ 
+ const Context = createContext({} as C)
+ 
+-const OVERLAYS = {
++export const OVERLAYS = {
+   Root: 'root',
+   Turbo: 'turbo',
+   Route: 'route',
+@@ -93,45 +79,34 @@ export type Overlays = (typeof OVERLAYS)[keyof typeof OVERLAYS]
+ const INDICATOR_PADDING = 20
+ 
+ function DevToolsPopover({
+-  routerType,
+-  disabled,
+-  issueCount,
+-  isDevBuilding,
+-  isDevRendering,
+-  isStaticRoute,
+-  isTurbopack,
+-  isBuildError,
+   hide,
+-  dispatch,
+   scale,
+   setScale,
+-  page,
++  isDevToolsIndicatorVisible,
+ }: {
+-  routerType: 'pages' | 'app'
+-  disabled: boolean
+-  issueCount: number
+-  isStaticRoute: boolean
+-  semver: string | undefined
+-  isDevBuilding: boolean
+-  isDevRendering: boolean
+-  isTurbopack: boolean
+-  isBuildError: boolean
+   hide: () => void
+-  dispatch: OverlayDispatch
+   scale: DevToolsScale
+   setScale: (value: DevToolsScale) => void
+-  page: string
++  isDevToolsIndicatorVisible: boolean
+ }) {
++  const { state, dispatch } = useDevOverlayContext()
++  const routerType = state.routerType
++  const issueCount = useRenderErrorContext().totalErrorCount
++  const isDevBuilding = state.buildingIndicator
++  const isDevRendering = state.renderingIndicator
++  const isStaticRoute = state.staticIndicator
++  const isTurbopack = !!process.env.TURBOPACK
++  const disabled = state.disableDevIndicator || !isDevToolsIndicatorVisible
++  const page = state.page
++
+   const menuRef = useRef<HTMLDivElement>(null)
+   const triggerRef = useRef<HTMLButtonElement | null>(null)
+-
+   const [open, setOpen] = useState<Overlays | null>(null)
+   const [position, setPosition] = useState(getInitialPosition())
+   const [selectedIndex, setSelectedIndex] = useState(-1)
+ 
+   const isMenuOpen = open === OVERLAYS.Root
+   const isTurbopackInfoOpen = open === OVERLAYS.Turbo
+-  const isRouteInfoOpen = open === OVERLAYS.Route
+   const isPreferencesOpen = open === OVERLAYS.Preferences
+   const isSegmentExplorerOpen = open === OVERLAYS.SegmentExplorer
+ 
+@@ -240,7 +215,10 @@ function DevToolsPopover({
+     if (open === OVERLAYS.Root) {
+       setOpen(null)
+     } else {
++      console.log('opening overlays', OVERLAYS.Root)
++
+       setOpen(OVERLAYS.Root)
++      // flush sync?
+       setTimeout(() => {
+         select('first')
+       })
+@@ -302,20 +280,13 @@ function DevToolsPopover({
+           toggleErrorOverlay={toggleErrorOverlay}
+           isDevBuilding={isDevBuilding}
+           isDevRendering={isDevRendering}
+-          isBuildError={isBuildError}
++          isBuildError={state.buildError !== null}
+           scale={scale}
+         />
+       </Draggable>
+ 
+       {/* Route Info */}
+-      <RouteInfo
+-        isOpen={isRouteInfoOpen}
+-        close={closeToRootMenu}
+-        triggerRef={triggerRef}
+-        style={popover}
+-        routerType={routerType}
+-        routeType={isStaticRoute ? 'Static' : 'Dynamic'}
+-      />
++      <RouteInfo />
+ 
+       {/* Turbopack Info */}
+       <TurbopackInfo
+@@ -524,7 +495,7 @@ function IssueCount({ children }: { children: number }) {
+ 
+ //////////////////////////////////////////////////////////////////////////////////////
+ 
+-export const DEV_TOOLS_INDICATOR_STYLES = `
++export const DEV_TOOLS_INDICATOR_STYLES = css`
+   .dev-tools-indicator-menu {
+     -webkit-font-smoothing: antialiased;
+     display: flex;
+@@ -535,6 +506,7 @@ export const DEV_TOOLS_INDICATOR_STYLES = `
+     background-clip: padding-box;
+     box-shadow: var(--shadow-menu);
+     border-radius: var(--rounded-xl);
++    /* this was changed to absolute, we have it fixed for the other dev indicator menu  along with removing border incase something went wrong we should revert this*/
+     position: absolute;
+     font-family: var(--font-stack-sans);
+     z-index: 3;
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+index 31380461ee..a4c29d252f 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+@@ -1,6 +1,7 @@
+ import { useRef } from 'react'
+ import { MENU_DURATION_MS, useClickOutside, useFocusTrap } from '../utils'
+ import { useDelayedRender } from '../../../../hooks/use-delayed-render'
++import { css } from '../../../../utils/css'
+ 
+ export interface DevToolsInfoPropsCore {
+   isOpen: boolean
+@@ -42,15 +43,38 @@ export function DevToolsInfo({
+   if (!mounted) {
+     return null
+   }
+-
++  // TODO: this is a case of me changing styles for new that will break
++  // old, need to fork
+   return (
+     <div
+       tabIndex={-1}
+       role="dialog"
+       ref={ref}
+-      data-info-popover
++      // data-info-popover
+       {...props}
+       data-rendered={rendered}
++
++      style={{
++        // height: '100%'
++        WebkitFontSmoothing: 'antialiased',
++        display: 'flex',
++        flexDirection: 'column',
++        alignItems: 'flex-start',
++        // background: 'var(--color-background-100)',
++        // border: '1px solid var(--color-gray-alpha-400)',
++        // backgroundClip: 'padding-box',
++        boxShadow: 'var(--shadow-menu)',
++        borderRadius: 'var(--rounded-xl)',
++        position: 'absolute',
++        fontFamily: 'var(--font-stack-sans)',
++        zIndex: 3,
++        overflow: 'hidden',
++        opacity: rendered ? 1 : 0,
++        outline: 0,
++        minWidth: '350px',
++        transition: 'opacity var(--animate-out-duration-ms) var(--animate-out-timing-function)',
++        scale: rendered ? 1 : undefined,
++      }}
+     >
+       <div className="dev-tools-info-container">
+         <div className="dev-tools-info-header">
+@@ -84,7 +108,7 @@ export function DevToolsInfo({
+   )
+ }
+ 
+-export const DEV_TOOLS_INFO_STYLES = `
++export const DEV_TOOLS_INFO_STYLES = css`
+   [data-info-popover] {
+     -webkit-font-smoothing: antialiased;
+     display: flex;
+@@ -135,7 +159,7 @@ export const DEV_TOOLS_INFO_STYLES = `
+   .dev-tools-info-close-button {
+     all: unset;
+     width: 20px;
+-    height: 20px;    
++    height: 20px;
+     display: flex;
+     align-items: center;
+     justify-content: center;
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+index 4c18da6e5c..9bcd60ebe5 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+@@ -1,6 +1,7 @@
+ import type { HTMLProps } from 'react'
+ import type { DevToolsInfoPropsCore } from './dev-tools-info'
+ import { DevToolsInfo } from './dev-tools-info'
++import { useDevOverlayContext } from '../../../../../dev-overlay.browser'
+ 
+ function StaticRouteContent({ routerType }: { routerType: 'pages' | 'app' }) {
+   return (
+@@ -110,32 +111,36 @@ const learnMoreLink = {
+   },
+ } as const
+ 
+-export function RouteInfo({
+-  routeType,
+-  routerType,
+-  ...props
+-}: {
+-  routeType: 'Static' | 'Dynamic'
+-  routerType: 'pages' | 'app'
+-} & DevToolsInfoPropsCore &
+-  HTMLProps<HTMLDivElement>) {
+-  const isStaticRoute = routeType === 'Static'
++export function RouteInfoBody() {
++  const { state } = useDevOverlayContext()
+ 
+-  const learnMore = isStaticRoute
+-    ? learnMoreLink[routerType].static
+-    : learnMoreLink[routerType].dynamic
++  const isStaticRoute = state.staticIndicator
+ 
++  return isStaticRoute ? (
++    <StaticRouteContent routerType={state.routerType} />
++  ) : (
++    <DynamicRouteContent routerType={state.routerType} />
++  )
++}
++
++export function RouteInfo() {
++  const { state } = useDevOverlayContext()
++
++  const routeType = state.staticIndicator ? 'Static' : 'Dynamic'
++
++  const learnMore = state.staticIndicator
++    ? learnMoreLink[state.routerType].static
++    : learnMoreLink[state.routerType].dynamic
++// FOR OLD UI NEED TO PASS DOWN THE EVENT HANDLERS
+   return (
+     <DevToolsInfo
+       title={`${routeType} Route`}
+       learnMoreLink={learnMore}
+-      {...props}
++      close={() => {}}
++      isOpen={true}
++      triggerRef={{ current: null }}
+     >
+-      {isStaticRoute ? (
+-        <StaticRouteContent routerType={routerType} />
+-      ) : (
+-        <DynamicRouteContent routerType={routerType} />
+-      )}
++      <RouteInfoBody />
+     </DevToolsInfo>
+   )
+ }
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
+index edc1f3b6d7..c652dc764b 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
+@@ -2,19 +2,16 @@ import { PageSegmentTree } from '../../../overview/segment-explorer'
+ import { DevToolsInfo, type DevToolsInfoPropsCore } from './dev-tools-info'
+ 
+ export function SegmentsExplorer({
+-  routerType,
+-  page,
+   ...props
+ }: DevToolsInfoPropsCore &
+   React.HTMLProps<HTMLDivElement> & {
+     routerType: 'app' | 'pages'
+     page: string
+   }) {
+-  const isAppRouter = routerType === 'app'
+   return (
+     <DevToolsInfo title="Route Info" {...props}>
+       <div data-nextjs-segments-explorer>
+-        <PageSegmentTree isAppRouter={isAppRouter} page={page} />
++        <PageSegmentTree />
+       </div>
+     </DevToolsInfo>
+   )
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+index 9fef23500e..688ae1375b 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+@@ -2,15 +2,9 @@ import { DevToolsInfo, type DevToolsInfoPropsCore } from './dev-tools-info'
+ import { CopyButton } from '../../../copy-button'
+ import type { HTMLProps } from 'react'
+ 
+-export function TurbopackInfo(
+-  props: DevToolsInfoPropsCore & HTMLProps<HTMLDivElement>
+-) {
++export function TurbopackInfoBody() {
+   return (
+-    <DevToolsInfo
+-      title="Turbopack"
+-      learnMoreLink="https://nextjs.org/docs/app/api-reference/turbopack"
+-      {...props}
+-    >
++    <>
+       <article className="dev-tools-info-article">
+         <p className="dev-tools-info-paragraph">
+           Turbopack is an incremental bundler optimized for JavaScript and
+@@ -96,6 +90,20 @@ export function TurbopackInfo(
+           </pre>
+         </div>
+       </div>
++    </>
++  )
++}
++
++export function TurbopackInfo(
++  props: DevToolsInfoPropsCore & HTMLProps<HTMLDivElement>
++) {
++  return (
++    <DevToolsInfo
++      title="Turbopack"
++      learnMoreLink="https://nextjs.org/docs/app/api-reference/turbopack"
++      {...props}
++    >
++      <TurbopackInfoBody />
+     </DevToolsInfo>
+   )
+ }
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx
+index 71e1ae9994..7b2d991467 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx
+@@ -1,5 +1,6 @@
+ import type { Corners } from '../../../shared'
+ import { useCallback, useLayoutEffect, useRef } from 'react'
++import { useDragContext } from './drag-context'
+ 
+ interface Point {
+   x: number
+@@ -19,6 +20,7 @@ export function Draggable({
+   onDragStart,
+   dragHandleSelector,
+   disableDrag = false,
++  avoidZone,
+   ...props
+ }: {
+   children: React.ReactElement
+@@ -28,9 +30,16 @@ export function Draggable({
+   onDragStart?: () => void
+   dragHandleSelector?: string
+   disableDrag?: boolean
++  style?: React.CSSProperties
++  avoidZone?: {
++    square: number
++    corner: Corners
++    padding: number
++  }
+ }) {
+   const { ref, animate, ...drag } = useDrag({
+     disabled: disableDrag,
++    handles: useDragContext()?.handles,
+     threshold: 5,
+     onDragStart,
+     onDragEnd,
+@@ -94,49 +103,54 @@ export function Draggable({
+       const isRight = corner.includes('right')
+       const isBottom = corner.includes('bottom')
+ 
+-      return {
+-        x: isRight
+-          ? window.innerWidth - scrollbarWidth - offset - triggerWidth
+-          : 0,
+-        y: isBottom ? window.innerHeight - offset - triggerHeight : 0,
++      // Base positions flush against the chosen corner
++      let x = isRight
++        ? window.innerWidth - scrollbarWidth - offset - triggerWidth
++        : 0
++      let y = isBottom ? window.innerHeight - offset - triggerHeight : 0
++
++      // Apply avoidZone offset if this corner is occupied. We only move along
++      // the vertical axis to keep the panel within the viewport. For bottom
++      // corners we move the panel up, for top corners we move it down.
++      if (avoidZone && avoidZone.corner === corner) {
++        const delta = avoidZone.square + avoidZone.padding
++        if (isBottom) {
++          // move up
++          y -= delta
++        } else {
++          // move down
++          y += delta
++        }
+       }
++
++      return { x, y }
+     }
+ 
+     const basePosition = getAbsolutePosition(currentCorner)
+ 
+-    // Calculate all corner positions relative to the current corner
++    // Helper to compute relative translation from the current corner.
++    function rel(pos: Point): Point {
++      return {
++        x: pos.x - basePosition.x,
++        y: pos.y - basePosition.y,
++      }
++    }
++
+     return {
+-      'top-left': {
+-        x: 0 - basePosition.x,
+-        y: 0 - basePosition.y,
+-      },
+-      'top-right': {
+-        x:
+-          window.innerWidth -
+-          scrollbarWidth -
+-          offset -
+-          triggerWidth -
+-          basePosition.x,
+-        y: 0 - basePosition.y,
+-      },
+-      'bottom-left': {
+-        x: 0 - basePosition.x,
+-        y: window.innerHeight - offset - triggerHeight - basePosition.y,
+-      },
+-      'bottom-right': {
+-        x:
+-          window.innerWidth -
+-          scrollbarWidth -
+-          offset -
+-          triggerWidth -
+-          basePosition.x,
+-        y: window.innerHeight - offset - triggerHeight - basePosition.y,
+-      },
++      'top-left': rel(getAbsolutePosition('top-left')),
++      'top-right': rel(getAbsolutePosition('top-right')),
++      'bottom-left': rel(getAbsolutePosition('bottom-left')),
++      'bottom-right': rel(getAbsolutePosition('bottom-right')),
+     }
+   }
+ 
+   return (
+-    <div {...props} ref={ref} {...drag} style={{ touchAction: 'none' }}>
++    <div
++      {...props}
++      ref={ref}
++      {...drag}
++      style={{ touchAction: 'none', ...props.style }}
++    >
+       {children}
+     </div>
+   )
+@@ -150,6 +164,7 @@ interface UseDragOptions {
+   onAnimationEnd?: (corner: Corner) => void
+   threshold: number // Minimum movement before drag starts
+   dragHandleSelector?: string
++  handles?: Set<HTMLElement>
+ }
+ 
+ interface Velocity {
+@@ -234,18 +249,32 @@ export function useDrag(options: UseDragOptions) {
+   }
+ 
+   function isValidDragHandle(target: EventTarget | null): boolean {
+-    if (!options.dragHandleSelector || !ref.current || !target) {
+-      return true // If no selector provided, entire element is draggable
++    if (!target || !ref.current) return true
++
++    if (options.handles && options.handles.size > 0) {
++      let node: HTMLElement | null = target as HTMLElement
++      while (node && node !== ref.current) {
++        if (options.handles.has(node)) return true
++        node = node.parentElement
++      }
++      return false
+     }
+ 
+-    const element = target as Element
+-    if (!element.matches) {
++    if (options.dragHandleSelector) {
++      const selector = options.dragHandleSelector
++      const element = target as Element
++      if (element.matches && element.matches(selector)) return true
++      let parent = element.parentElement
++      while (parent && parent !== ref.current) {
++        if (parent.matches && parent.matches(selector)) {
++          return true
++        }
++        parent = parent.parentElement
++      }
+       return false
+     }
+ 
+-    // Check if the target element directly matches the drag handle selector
+-    // This excludes children elements, only allowing drag from the exact element
+-    return element.matches(options.dragHandleSelector)
++    return true
+   }
+ 
+   function onPointerDown(e: React.PointerEvent) {
+@@ -253,7 +282,7 @@ export function useDrag(options: UseDragOptions) {
+       return // ignore right click
+     }
+ 
+-    // Check if the pointer down event is on a valid drag handle
++    // Restrict drag initiation to valid handles if any registered
+     if (!isValidDragHandle(e.target)) {
+       return
+     }
+@@ -328,6 +357,13 @@ export function useDrag(options: UseDragOptions) {
+     options.onDragEnd?.(translation.current, velocity)
+   }
+ 
++  if (options.disabled) {
++    return {
++      ref,
++      animate,
++    }
++  }
++
+   return {
+     ref,
+     onPointerDown,
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
+index 58f2fed02b..552f12ebaa 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
+@@ -100,19 +100,21 @@ export function useClickOutside(
+         return
+       }
+ 
++      const cushion = 10
++
+       if (
+         !(rootRef.current?.getBoundingClientRect()
+-          ? event.clientX >= rootRef.current.getBoundingClientRect()!.left &&
+-            event.clientX <= rootRef.current.getBoundingClientRect()!.right &&
+-            event.clientY >= rootRef.current.getBoundingClientRect()!.top &&
+-            event.clientY <= rootRef.current.getBoundingClientRect()!.bottom
++          ? event.clientX >= rootRef.current.getBoundingClientRect()!.left - cushion &&
++            event.clientX <= rootRef.current.getBoundingClientRect()!.right + cushion &&
++            event.clientY >= rootRef.current.getBoundingClientRect()!.top - cushion &&
++            event.clientY <= rootRef.current.getBoundingClientRect()!.bottom + cushion
+           : false) &&
+         !(triggerRef.current?.getBoundingClientRect()
+-          ? event.clientX >= triggerRef.current.getBoundingClientRect()!.left &&
++          ? event.clientX >= triggerRef.current.getBoundingClientRect()!.left - cushion &&
+             event.clientX <=
+-              triggerRef.current.getBoundingClientRect()!.right &&
+-            event.clientY >= triggerRef.current.getBoundingClientRect()!.top &&
+-            event.clientY <= triggerRef.current.getBoundingClientRect()!.bottom
++              triggerRef.current.getBoundingClientRect()!.right + cushion &&
++            event.clientY >= triggerRef.current.getBoundingClientRect()!.top - cushion &&
++            event.clientY <= triggerRef.current.getBoundingClientRect()!.bottom + cushion
+           : false)
+       ) {
+         close()
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx
+index d329f6d8f9..a0b4152add 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx
+@@ -10,49 +10,29 @@ import { Errors } from '../../../container/errors'
+ import { useDelayedRender } from '../../../hooks/use-delayed-render'
+ import type { ReadyRuntimeError } from '../../../utils/get-error-by-type'
+ import type { HydrationErrorState } from '../../../../shared/hydration-error'
++import { useDevOverlayContext } from '../../../../dev-overlay.browser'
++import { useRenderErrorContext } from '../../../dev-overlay'
+ 
+ const transitionDurationMs = 200
+ 
+ export interface ErrorBaseProps {
+   rendered: boolean
+   transitionDurationMs: number
+-  isTurbopack: boolean
+-  versionInfo: OverlayState['versionInfo']
+-  errorCount: number
+ }
+ 
+-export function ErrorOverlay({
+-  state,
+-  dispatch,
+-  getSquashedHydrationErrorDetails,
+-  runtimeErrors,
+-  errorCount,
+-}: {
+-  state: OverlayState
+-  dispatch: OverlayDispatch
+-  getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
+-  runtimeErrors: ReadyRuntimeError[]
+-  errorCount: number
+-}) {
+-  const isTurbopack = !!process.env.TURBOPACK
++export function ErrorOverlay() {
++  const { state } = useDevOverlayContext()
++  const { runtimeErrors } = useRenderErrorContext()
+ 
+   // This hook lets us do an exit animation before unmounting the component
+   const { mounted, rendered } = useDelayedRender(state.isErrorOverlayOpen, {
+     exitDelay: transitionDurationMs,
+   })
+ 
+-  const commonProps = {
+-    rendered,
+-    transitionDurationMs,
+-    isTurbopack,
+-    versionInfo: state.versionInfo,
+-    errorCount,
+-  }
+-
+   if (state.buildError !== null) {
+     return (
+       <BuildError
+-        {...commonProps}
++        transitionDurationMs={transitionDurationMs}
+         message={state.buildError}
+         // This is not a runtime error, forcedly display error overlay
+         rendered
+@@ -74,14 +54,6 @@ export function ErrorOverlay({
+   }
+ 
+   return (
+-    <Errors
+-      {...commonProps}
+-      debugInfo={state.debugInfo}
+-      getSquashedHydrationErrorDetails={getSquashedHydrationErrorDetails}
+-      runtimeErrors={runtimeErrors}
+-      onClose={() => {
+-        dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
+-      }}
+-    />
++    <Errors transitionDurationMs={transitionDurationMs} rendered={rendered} />
+   )
+ }
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/errors/overlay/overlay.tsx b/packages/next/src/next-devtools/dev-overlay/components/errors/overlay/overlay.tsx
+index 99cc804677..d451e401a8 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/errors/overlay/overlay.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/errors/overlay/overlay.tsx
+@@ -1,10 +1,11 @@
++import { css } from '../../../utils/css'
+ import { Overlay, type OverlayProps } from '../../overlay/overlay'
+ 
+ export function ErrorOverlayOverlay({ children, ...props }: OverlayProps) {
+   return <Overlay {...props}>{children}</Overlay>
+ }
+ 
+-export const OVERLAY_STYLES = `
++export const OVERLAY_STYLES = css`
+   [data-nextjs-dialog-overlay] {
+     padding: initial;
+     top: 10vh;
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx b/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
+index 5695631976..6de7efacaa 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
+@@ -1,4 +1,6 @@
+-const styles = `
++import { css } from "../../utils/css"
++
++const styles = css`
+   [data-nextjs-dialog-overlay] {
+     position: fixed;
+     top: 0;
+diff --git a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+index 2c58525667..e979c34882 100644
+--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+@@ -16,6 +16,8 @@ import {
+   isBoundaryFile,
+   normalizeBoundaryFilename,
+ } from '../../../../server/app-render/segment-explorer-path'
++import { ExternalIcon } from '../../icons/external'
++import { useDevOverlayContext } from '../../../dev-overlay.browser'
+ 
+ const isFileNode = (node: SegmentTrieNode) => {
+   return !!node.value?.type && !!node.value?.pagePath
+@@ -99,15 +101,13 @@ function SegmentExplorerFooter({
+   )
+ }
+ 
+-export function PageSegmentTree({
+-  isAppRouter,
+-  page,
+-}: {
+-  isAppRouter: boolean
+-  page: string
+-}) {
++export function PageSegmentTree() {
+   const tree = useSegmentTree()
++  const {state}  = useDevOverlayContext()
++
++  const isAppRouter = state.routerType === 'app'
+ 
++  
+   // Count active boundaries for the badge
+   const activeBoundariesCount = useMemo(() => {
+     return isAppRouter ? countActiveBoundaries(tree) : 0
+@@ -122,7 +122,7 @@ export function PageSegmentTree({
+ 
+   return (
+     <div data-nextjs-devtools-panel-segments-explorer>
+-      {isAppRouter && <PageRouteBar page={page} />}
++      {isAppRouter && <PageRouteBar page={state.page} />}
+       <div
+         className="segment-explorer-content"
+         data-nextjs-devtool-segment-explorer
+@@ -316,7 +316,7 @@ function PageSegmentTreeLayerPresentation({
+ 
+                       const tooltipMessage = isBuiltin
+                         ? `The default Next.js ${childNode.value.type} is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`
+-                        : `Open in editor`
++                        : null // `Open in editor`
+ 
+                       return (
+                         <Tooltip
+@@ -346,7 +346,7 @@ function PageSegmentTreeLayerPresentation({
+                             }}
+                           >
+                             {fileName}
+-                            {isBuiltin && <InfoIcon />}
++                            {isBuiltin ? <InfoIcon /> : <ExternalIcon />}
+                           </span>
+                         </Tooltip>
+                       )
+diff --git a/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx b/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
+index 5c0dc1976b..87b8ee5901 100644
+--- a/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
+@@ -16,6 +16,7 @@ const meta: Meta<typeof Errors> = {
+ export default meta
+ type Story = StoryObj<typeof Errors>
+ 
++// todo: update the stories to be wrapped in context providers necessary, instead of passing props directly, before they expected props
+ export const Default: Story = {
+   args: {
+     getSquashedHydrationErrorDetails: () => null,
+diff --git a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+index 556d225e4f..d641d99aa2 100644
+--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+@@ -18,6 +18,9 @@ import type { ReadyRuntimeError } from '../utils/get-error-by-type'
+ import type { ErrorBaseProps } from '../components/errors/error-overlay/error-overlay'
+ import type { HydrationErrorState } from '../../shared/hydration-error'
+ import { useActiveRuntimeError } from '../hooks/use-active-runtime-error'
++import { useDevOverlayContext } from '../../dev-overlay.browser'
++import { useRenderErrorContext } from '../dev-overlay'
++import { ACTION_ERROR_OVERLAY_CLOSE } from '../shared'
+ 
+ export interface ErrorsProps extends ErrorBaseProps {
+   getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
+@@ -111,15 +114,15 @@ export function useErrorDetails(
+   }, [error, getSquashedHydrationErrorDetails])
+ }
+ 
+-export function Errors({
+-  getSquashedHydrationErrorDetails,
+-  runtimeErrors,
+-  debugInfo,
+-  onClose,
+-  ...props
+-}: ErrorsProps) {
++export function Errors({transitionDurationMs,rendered}:{transitionDurationMs: number, rendered:boolean}) {
+   const dialogResizerRef = useRef<HTMLDivElement | null>(null)
+ 
++  const {getSquashedHydrationErrorDetails, dispatch,state} = useDevOverlayContext()
++  const {runtimeErrors} = useRenderErrorContext()
++  const onClose = () => {
++    dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
++  }
++
+   const {
+     isLoading,
+     errorCode,
+@@ -162,13 +165,15 @@ export function Errors({
+         )
+       }
+       onClose={isServerError ? undefined : onClose}
+-      debugInfo={debugInfo}
++      debugInfo={state.debugInfo}
+       error={error}
+       runtimeErrors={runtimeErrors}
+       activeIdx={activeIdx}
+       setActiveIndex={setActiveIndex}
+       dialogResizerRef={dialogResizerRef}
+-      {...props}
++      // {...props}
++      transitionDurationMs={transitionDurationMs}
++      rendered={rendered}
+     >
+       <div className="error-overlay-notes-container">
+         {notes ? (
+diff --git a/packages/next/src/next-devtools/dev-overlay/dev-overlay.stories.tsx b/packages/next/src/next-devtools/dev-overlay/dev-overlay.stories.tsx
+index 68ab6c82e0..0cb6974fe4 100644
+--- a/packages/next/src/next-devtools/dev-overlay/dev-overlay.stories.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/dev-overlay.stories.tsx
+@@ -10,6 +10,7 @@ import {
+   storybookDefaultOverlayState,
+   useStorybookOverlayReducer,
+ } from './storybook/use-overlay-reducer'
++import { DevOverlayContext } from '../dev-overlay.browser'
+ 
+ const meta: Meta<typeof DevOverlay> = {
+   component: DevOverlay,
+@@ -39,7 +40,8 @@ function getNoSquashedHydrationErrorDetails() {
+ 
+ const initialState: OverlayState = {
+   ...storybookDefaultOverlayState,
+-  errors,
++  // todo: i think hidden when errors for some reason
++  errors: [],
+ }
+ 
+ export const Default: Story = {
+@@ -47,6 +49,7 @@ export const Default: Story = {
+     const [state, dispatch] = useStorybookOverlayReducer(initialState)
+     return (
+       <>
++        {/* get lots of real hard examples so we have better debug */}
+         <img
+           src={imgApp}
+           style={{
+@@ -55,19 +58,22 @@ export const Default: Story = {
+             objectFit: 'contain',
+           }}
+         />
+-        <DevOverlay
+-          state={state}
+-          dispatch={dispatch}
+-          getSquashedHydrationErrorDetails={
+-            // Testing like App Router where we no longer quash hydration errors
+-            getNoSquashedHydrationErrorDetails
+-          }
+-        />
++        <DevOverlayContext
++          value={{
++            dispatch,
++            getSquashedHydrationErrorDetails:
++              getNoSquashedHydrationErrorDetails,
++            state,
++          }}
++        >
++          <DevOverlay />
++        </DevOverlayContext>
+       </>
+     )
+   },
+ }
+ 
++// todo: fix story with "Context arg provider" wrapper
+ export const WithPanel: Story = {
+   beforeEach: () => {
+     process.env.__NEXT_DEVTOOL_NEW_PANEL_UI = 'true'
+@@ -90,12 +96,12 @@ export const WithPanel: Story = {
+           }}
+         />
+         <DevOverlay
+-          state={state}
+-          dispatch={dispatch}
+-          getSquashedHydrationErrorDetails={
+-            // Testing like App Router where we no longer quash hydration errors
+-            getNoSquashedHydrationErrorDetails
+-          }
++        // state={state}
++        // dispatch={dispatch}
++        // getSquashedHydrationErrorDetails={
++        //   // Testing like App Router where we no longer quash hydration errors
++        //   getNoSquashedHydrationErrorDetails
++        // }
+         />
+       </>
+     )
+diff --git a/packages/next/src/next-devtools/dev-overlay/dev-overlay.tsx b/packages/next/src/next-devtools/dev-overlay/dev-overlay.tsx
+index c05bd092bf..d5f814fba9 100644
+--- a/packages/next/src/next-devtools/dev-overlay/dev-overlay.tsx
++++ b/packages/next/src/next-devtools/dev-overlay/dev-overlay.tsx
+@@ -1,11 +1,18 @@
+ import {
+   ACTION_DEVTOOLS_PANEL_OPEN,
+   ACTION_ERROR_OVERLAY_OPEN,
++  type DispatcherEvent,
+   type OverlayDispatch,
+   type OverlayState,
+ } from './shared'
+ 
+-import { useState } from 'react'
++import {
++  createContext,
++  useContext,
++  useRef,
++  useState,
++  type ActionDispatch,
++} from 'react'
+ 
+ import { ShadowPortal } from './components/shadow-portal'
+ import { Base } from './styles/base'
+@@ -13,23 +20,30 @@ import { ComponentStyles } from './styles/component-styles'
+ import { CssReset } from './styles/css-reset'
+ import { Colors } from './styles/colors'
+ import { ErrorOverlay } from './components/errors/error-overlay/error-overlay'
+-import { DevToolsIndicator } from './components/errors/dev-tools-indicator/dev-tools-indicator'
++import {
++  DevToolsIndicator,
++  type Overlays,
++} from './components/errors/dev-tools-indicator/dev-tools-indicator'
+ import { RenderError } from './container/runtime-error/render-error'
+ import { DarkTheme } from './styles/dark-theme'
+ import { useDevToolsScale } from './components/errors/dev-tools-indicator/dev-tools-info/preferences'
+ import type { HydrationErrorState } from '../shared/hydration-error'
+-import { DevToolsIndicator as DevToolsIndicatorNew } from './components/devtools-indicator/devtools-indicator'
++import { DevToolsIndicatorNew as DevToolsIndicatorNew } from './components/devtools-indicator/devtools-indicator'
+ import { DevToolsPanel } from './components/devtools-panel/devtools-panel'
++import type { ReadyRuntimeError } from './utils/get-error-by-type'
++import { useDevOverlayContext } from '../dev-overlay.browser'
++import { PanelRouter } from './menu/panel-router'
++import { PanelContext, type PanelStateKind } from './menu/context'
++
++export const RenderErrorContext = createContext<{
++  runtimeErrors: ReadyRuntimeError[]
++  totalErrorCount: number
++}>(null!)
+ 
+-export function DevOverlay({
+-  state,
+-  dispatch,
+-  getSquashedHydrationErrorDetails,
+-}: {
+-  state: OverlayState
+-  dispatch: OverlayDispatch
+-  getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
+-}) {
++export const useRenderErrorContext = () => useContext(RenderErrorContext)
++
++export function DevOverlay() {
++  const { dispatch, state } = useDevOverlayContext()
+   const [scale, setScale] = useDevToolsScale()
+   const [isPrevBuildError, setIsPrevBuildError] = useState(false)
+ 
+@@ -47,7 +61,13 @@ export function DevOverlay({
+     }
+     setIsPrevBuildError(isBuildError)
+   }
++  // stupid state same thing
++  const [panel, setPanel] = useState<PanelStateKind | null>(null)
++  const [open, setOpen] = useState<Overlays | null>(null)
+ 
++  const triggerRef = useRef<HTMLButtonElement>(null)
++  // // @ts-expect-error
++  // process.env.__NEXT_DEVTOOL_NEW_PANEL_UI = true
+   return (
+     <ShadowPortal>
+       <CssReset />
+@@ -58,56 +78,34 @@ export function DevOverlay({
+       <ComponentStyles />
+       <DarkTheme />
+ 
++      {/* todo: render error should provide this context, probably shouldn't have render props at all tbh */}
+       <RenderError state={state} dispatch={dispatch} isAppDir={true}>
+         {({ runtimeErrors, totalErrorCount }) => {
+           return (
+-            <>
+-              {state.showIndicator &&
+-                (process.env.__NEXT_DEVTOOL_NEW_PANEL_UI ? (
+-                  <>
+-                    <DevToolsIndicatorNew
+-                      state={state}
+-                      dispatch={dispatch}
+-                      errorCount={totalErrorCount}
+-                      isBuildError={isBuildError}
+-                    />
+-
+-                    {(state.isDevToolsPanelOpen ||
+-                      state.isErrorOverlayOpen) && (
+-                      <DevToolsPanel
+-                        state={state}
+-                        dispatch={dispatch}
+-                        issueCount={totalErrorCount}
+-                        runtimeErrors={runtimeErrors}
+-                        getSquashedHydrationErrorDetails={
+-                          getSquashedHydrationErrorDetails
+-                        }
+-                      />
+-                    )}
+-                  </>
+-                ) : (
+-                  <>
+-                    <DevToolsIndicator
+-                      scale={scale}
+-                      setScale={setScale}
+-                      state={state}
+-                      dispatch={dispatch}
+-                      errorCount={totalErrorCount}
+-                      isBuildError={isBuildError}
+-                    />
+-
+-                    <ErrorOverlay
+-                      state={state}
+-                      dispatch={dispatch}
+-                      getSquashedHydrationErrorDetails={
+-                        getSquashedHydrationErrorDetails
+-                      }
+-                      runtimeErrors={runtimeErrors}
+-                      errorCount={totalErrorCount}
+-                    />
+-                  </>
+-                ))}
+-            </>
++            <PanelContext
++              value={{
++                triggerRef,
++                panel,
++                setPanel,
++                open,
++                setOpen,
++              }}
++            >
++              <RenderErrorContext value={{ runtimeErrors, totalErrorCount }}>
++                {state.showIndicator &&
++                  (process.env.__NEXT_DEVTOOL_NEW_PANEL_UI ? (
++                    <>
++                      <PanelRouter />
++                      <DevToolsIndicatorNew />
++                    </>
++                  ) : (
++                    <>
++                      <DevToolsIndicator scale={scale} setScale={setScale} />
++                      <ErrorOverlay />
++                    </>
++                  ))}
++              </RenderErrorContext>
++            </PanelContext>
+           )
+         }}
+       </RenderError>
+diff --git a/packages/next/src/next-devtools/dev-overlay/shared.ts b/packages/next/src/next-devtools/dev-overlay/shared.ts
+index 68dc51a9bf..52c159bf1b 100644
+--- a/packages/next/src/next-devtools/dev-overlay/shared.ts
++++ b/packages/next/src/next-devtools/dev-overlay/shared.ts
+@@ -49,6 +49,7 @@ export interface OverlayState {
+   isErrorOverlayOpen: boolean
+   isDevToolsPanelOpen: boolean
+   devToolsPosition: Corners
++  devToolsPanelPosition: Corners
+   scale: number
+   page: string
+ }
+@@ -79,11 +80,13 @@ export const ACTION_DEVTOOLS_PANEL_CLOSE = 'devtools-panel-close'
+ export const ACTION_DEVTOOLS_PANEL_TOGGLE = 'devtools-panel-toggle'
+ 
+ export const ACTION_DEVTOOLS_POSITION = 'devtools-position'
++export const ACTION_DEVTOOLS_PANEL_POSITION = 'devtools-panel-position'
+ export const ACTION_DEVTOOLS_SCALE = 'devtools-scale'
+ export const ACTION_RESTART_SERVER_BUTTON = 'restart-server-button'
+ 
+ export const STORAGE_KEY_THEME = '__nextjs-dev-tools-theme'
+ export const STORAGE_KEY_POSITION = '__nextjs-dev-tools-position'
++export const STORAGE_KEY_PANEL_POSITION = '__nextjs-dev-tools-panel-position'
+ export const STORAGE_KEY_SCALE = '__nextjs-dev-tools-scale'
+ export const STORAGE_KEY_ACTIVE_TAB = '__nextjs-devtools-active-tab'
+ 
+@@ -172,6 +175,11 @@ export interface DevToolsIndicatorPositionAction {
+   devToolsPosition: Corners
+ }
+ 
++export interface DevToolsPanelPositionAction {
++  type: typeof ACTION_DEVTOOLS_PANEL_POSITION
++  devToolsPanelPosition: Corners
++}
++
+ export interface DevToolsScaleAction {
+   type: typeof ACTION_DEVTOOLS_SCALE
+   scale: number
+@@ -209,6 +217,7 @@ export type DispatcherEvent =
+   | DevToolsPanelCloseAction
+   | DevToolsPanelToggleAction
+   | DevToolsIndicatorPositionAction
++  | DevToolsPanelPositionAction
+   | DevToolsScaleAction
+   | DevToolUpdateRouteStateAction
+   | RestartServerButtonAction
+@@ -231,6 +240,42 @@ function getStackIgnoringStrictMode(stack: string | undefined) {
+ const shouldDisableDevIndicator =
+   process.env.__NEXT_DEV_INDICATOR?.toString() === 'false'
+ 
++// todo redo
++function getStoredPosition(): Corners {
++  if (typeof localStorage !== 'undefined') {
++    const stored = localStorage.getItem(STORAGE_KEY_POSITION)
++    if (
++      stored &&
++      ['top-left', 'top-right', 'bottom-left', 'bottom-right'].includes(stored)
++    ) {
++      return stored as Corners
++    }
++  }
++  const envPosition = process.env.__NEXT_DEV_INDICATOR_POSITION
++  if (
++    envPosition &&
++    ['top-left', 'top-right', 'bottom-left', 'bottom-right'].includes(
++      envPosition
++    )
++  ) {
++    return envPosition as Corners
++  }
++  return 'bottom-left'
++}
++
++function getStoredPanelPosition(): Corners | null {
++  if (typeof localStorage !== 'undefined') {
++    const stored = localStorage.getItem(STORAGE_KEY_PANEL_POSITION)
++    if (
++      stored &&
++      ['top-left', 'top-right', 'bottom-left', 'bottom-right'].includes(stored)
++    ) {
++      return stored as Corners
++    }
++  }
++  return null
++}
++
+ export const INITIAL_OVERLAY_STATE: Omit<
+   OverlayState,
+   'isErrorOverlayOpen' | 'routerType'
+@@ -254,7 +299,8 @@ export const INITIAL_OVERLAY_STATE: Omit<
+   debugInfo: { devtoolsFrontendUrl: undefined },
+   isDevToolsPanelOpen: false,
+   showRestartServerButton: false,
+-  devToolsPosition: 'bottom-left',
++  devToolsPosition: getStoredPosition(),
++  devToolsPanelPosition: getStoredPanelPosition() ?? 'bottom-left',
+   scale: NEXT_DEV_TOOLS_SCALE.Medium,
+   page: '',
+ }
+@@ -431,6 +477,13 @@ export function useErrorOverlayReducer(
+         case ACTION_DEVTOOLS_POSITION: {
+           return { ...state, devToolsPosition: action.devToolsPosition }
+         }
++        // todo remove
++        case ACTION_DEVTOOLS_PANEL_POSITION: {
++          return {
++            ...state,
++            devToolsPanelPosition: action.devToolsPanelPosition,
++          }
++        }
+         case ACTION_DEVTOOLS_SCALE: {
+           return { ...state, scale: action.scale }
+         }
+diff --git a/packages/next/src/next-devtools/dev-overlay/storybook/use-overlay-reducer.ts b/packages/next/src/next-devtools/dev-overlay/storybook/use-overlay-reducer.ts
+index be8fa3eb44..bf0655b722 100644
+--- a/packages/next/src/next-devtools/dev-overlay/storybook/use-overlay-reducer.ts
++++ b/packages/next/src/next-devtools/dev-overlay/storybook/use-overlay-reducer.ts
+@@ -3,6 +3,7 @@ import type { DispatcherEvent, OverlayState } from '../shared'
+ import { useReducer } from 'react'
+ import {
+   ACTION_DEVTOOLS_POSITION,
++  ACTION_DEVTOOLS_PANEL_POSITION,
+   ACTION_DEVTOOLS_PANEL_CLOSE,
+   ACTION_DEVTOOLS_PANEL_TOGGLE,
+   ACTION_ERROR_OVERLAY_CLOSE,
+@@ -49,6 +50,10 @@ export function useStorybookOverlayReducer(initialState?: OverlayState) {
+         case ACTION_DEVTOOLS_POSITION: {
+           return { ...state, devToolsPosition: action.devToolsPosition }
+         }
++        // todo remove
++        case ACTION_DEVTOOLS_PANEL_POSITION: {
++          return { ...state, devToolsPanelPosition: action.devToolsPanelPosition }
++        }
+         case ACTION_DEVTOOLS_SCALE: {
+           return { ...state, scale: action.scale }
+         }

--- a/packages/next/.storybook/main.ts
+++ b/packages/next/.storybook/main.ts
@@ -1,5 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-webpack5'
-import { join, dirname } from 'path'
+import { join, dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
@@ -7,6 +9,9 @@ import { join, dirname } from 'path'
 function getAbsolutePath(value: string): any {
   return dirname(require.resolve(join(value, 'package.json')))
 }
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+
 const config: StorybookConfig = {
   stories: ['../src/next-devtools/**/*.stories.tsx'],
   addons: [
@@ -32,5 +37,48 @@ const config: StorybookConfig = {
       },
     },
   }),
+  webpackFinal: async (config) => {
+    // Find and override CSS rule to use the devtool style injection
+    const cssRule = config.module?.rules?.find((rule) => {
+      if (typeof rule !== 'object' || !rule) return false
+      if ('test' in rule && rule.test instanceof RegExp) {
+        return rule.test.test('.css')
+      }
+      return false
+    })
+
+    if (
+      cssRule &&
+      typeof cssRule === 'object' &&
+      'use' in cssRule &&
+      Array.isArray(cssRule.use)
+    ) {
+      // Find the style-loader in the use array
+      const styleLoaderIndex = cssRule.use.findIndex((loader) => {
+        if (typeof loader === 'string') return loader.includes('style-loader')
+        if (typeof loader === 'object' && loader && 'loader' in loader) {
+          return loader.loader?.includes('style-loader')
+        }
+        return false
+      })
+
+      if (styleLoaderIndex !== -1) {
+        // Replace with our custom configuration
+        cssRule.use[styleLoaderIndex] = {
+          loader: require.resolve('style-loader'),
+          options: {
+            injectType: 'styleTag',
+            insert: resolve(
+              dirname(fileURLToPath(import.meta.url)),
+              '../src/build/webpack/loaders/devtool/devtool-style-inject.js'
+            ),
+          },
+        }
+      }
+    }
+
+    return config
+  },
 }
+
 export default config

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -507,6 +507,7 @@ export default function OuterLayoutRouter({
   forbidden,
   unauthorized,
   gracefullyDegrade,
+  segmentViewBoundaries,
 }: {
   parallelRouterKey: string
   error: ErrorComponent | undefined
@@ -519,6 +520,7 @@ export default function OuterLayoutRouter({
   forbidden: React.ReactNode | undefined
   unauthorized: React.ReactNode | undefined
   gracefullyDegrade?: boolean
+  segmentViewBoundaries?: React.ReactNode
 }) {
   const context = useContext(LayoutRouterContext)
   if (!context) {
@@ -659,13 +661,14 @@ export default function OuterLayoutRouter({
     )
 
     if (process.env.NODE_ENV !== 'production') {
-      const SegmentStateProvider = (
+      const { SegmentStateProvider } =
         require('../../next-devtools/userspace/app/segment-explorer-node') as typeof import('../../next-devtools/userspace/app/segment-explorer-node')
-      )
-        .SegmentStateProvider as typeof import('../../next-devtools/userspace/app/segment-explorer-node').SegmentStateProvider as typeof import('../../next-devtools/userspace/app/segment-explorer-node').SegmentStateProvider
 
       child = (
-        <SegmentStateProvider key={stateKey}>{child}</SegmentStateProvider>
+        <SegmentStateProvider key={stateKey}>
+          {child}
+          {segmentViewBoundaries}
+        </SegmentStateProvider>
       )
     }
 

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -615,6 +615,21 @@ export default function OuterLayoutRouter({
       ? RenderChildren
       : ErrorBoundary
 
+    let segmentBoundaryTriggerNode: React.ReactNode = null
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER
+    ) {
+      const { SegmentBoundaryTriggerNode } =
+        require('../../next-devtools/userspace/app/segment-explorer-node') as typeof import('../../next-devtools/userspace/app/segment-explorer-node')
+
+      segmentBoundaryTriggerNode = (
+        <>
+          <SegmentBoundaryTriggerNode />
+        </>
+      )
+    }
+
     // TODO: The loading module data for a segment is stored on the parent, then
     // applied to each of that parent segment's parallel route slots. In the
     // simple case where there's only one parallel route (the `children` slot),
@@ -647,6 +662,7 @@ export default function OuterLayoutRouter({
                       cacheNode={cacheNode}
                       segmentPath={segmentPath}
                     />
+                    {segmentBoundaryTriggerNode}
                   </RedirectBoundary>
                 </HTTPAccessFallbackBoundary>
               </LoadingBoundary>

--- a/packages/next/src/next-devtools/components/tooltip.css
+++ b/packages/next/src/next-devtools/components/tooltip.css
@@ -10,7 +10,6 @@
   border-radius: 8px;
   font-size: 14px;
   line-height: 1.4;
-  min-width: 200px;
   pointer-events: none;
 }
 

--- a/packages/next/src/next-devtools/components/tooltip.tsx
+++ b/packages/next/src/next-devtools/components/tooltip.tsx
@@ -14,11 +14,13 @@ interface TooltipProps {
   offset?: number
   bgcolor?: string
   color?: string
+  className?: string
 }
 
 export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   function Tooltip(
     {
+      className,
       children,
       title,
       direction = 'top',
@@ -53,7 +55,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
               }
             >
               <BaseTooltip.Popup
-                className="tooltip"
+                className={cx('tooltip', className)}
                 style={
                   {
                     backgroundColor: bgcolor,

--- a/packages/next/src/next-devtools/components/tooltip.tsx
+++ b/packages/next/src/next-devtools/components/tooltip.tsx
@@ -7,7 +7,7 @@ type TooltipDirection = 'top' | 'bottom' | 'left' | 'right'
 
 interface TooltipProps {
   children: React.ReactNode
-  title: string
+  title: string | null
   direction?: TooltipDirection
   container?: HTMLElement | React.RefObject<HTMLElement>
   arrowSize?: number
@@ -32,6 +32,9 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     },
     ref
   ) {
+    if (!title) {
+      return children
+    }
     return (
       <BaseTooltip.Provider>
         <BaseTooltip.Root delay={0}>

--- a/packages/next/src/next-devtools/dev-overlay.browser.tsx
+++ b/packages/next/src/next-devtools/dev-overlay.browser.tsx
@@ -18,9 +18,17 @@ import {
   ACTION_RENDERING_INDICATOR_HIDE,
   ACTION_RENDERING_INDICATOR_SHOW,
   ACTION_DEVTOOL_UPDATE_ROUTE_STATE,
+  type OverlayState,
+  type DispatcherEvent,
 } from './dev-overlay/shared'
 
-import { startTransition, useInsertionEffect } from 'react'
+import {
+  createContext,
+  startTransition,
+  useContext,
+  useInsertionEffect,
+  type ActionDispatch,
+} from 'react'
 import { createRoot } from 'react-dom/client'
 import { FontStyles } from './dev-overlay/font/font-styles'
 import type { HydrationErrorState } from './shared/hydration-error'
@@ -208,14 +216,26 @@ function DevOverlayRoot({
     <>
       {/* Fonts can only be loaded outside the Shadow DOM. */}
       <FontStyles />
-      <DevOverlay
-        state={state}
-        dispatch={dispatch}
-        getSquashedHydrationErrorDetails={getSquashedHydrationErrorDetails}
-      />
+      <DevOverlayContext
+        value={{
+          dispatch,
+          getSquashedHydrationErrorDetails,
+          state,
+        }}
+      >
+        <DevOverlay />
+      </DevOverlayContext>
     </>
   )
 }
+export const DevOverlayContext = createContext<{
+  state: OverlayState & {
+    routerType: 'pages' | 'app'
+  }
+  dispatch: ActionDispatch<[action: DispatcherEvent]>
+  getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
+}>(null!)
+export const useDevOverlayContext = () => useContext(DevOverlayContext)
 
 let isPagesMounted = false
 let isAppMounted = false

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import type { OverlayState } from '../../shared'
 
-import { DevToolsIndicator } from './devtools-indicator'
+import { DevToolsIndicatorNew } from './devtools-indicator'
 import { INITIAL_OVERLAY_STATE } from '../../shared'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
 
-const meta: Meta<typeof DevToolsIndicator> = {
-  component: DevToolsIndicator,
+const meta: Meta<typeof DevToolsIndicatorNew> = {
+  component: DevToolsIndicatorNew,
   parameters: {
     layout: 'centered',
   },
@@ -37,7 +37,7 @@ const meta: Meta<typeof DevToolsIndicator> = {
 }
 
 export default meta
-type Story = StoryObj<typeof DevToolsIndicator>
+type Story = StoryObj<typeof DevToolsIndicatorNew>
 
 const state: OverlayState = {
   ...INITIAL_OVERLAY_STATE,

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
@@ -16,35 +16,23 @@ import {
   ACTION_ERROR_OVERLAY_OPEN,
 } from '../../shared'
 import { Draggable } from '../errors/dev-tools-indicator/draggable'
+import { useDevOverlayContext } from '../../../dev-overlay.browser'
+import { useRenderErrorContext } from '../../dev-overlay'
+import { usePanelContext } from '../../menu/context'
 
 export const INDICATOR_PADDING = 20
 
-export function DevToolsIndicator({
-  state,
-  dispatch,
-  errorCount,
-  isBuildError,
-}: {
-  state: OverlayState
-  dispatch: OverlayDispatch
-  errorCount: number
-  isBuildError: boolean
-}) {
-  const [open, setOpen] = useState(false)
+export function DevToolsIndicatorNew() {
+  const { state, dispatch } = useDevOverlayContext()
+  const { setOpen, triggerRef, setPanel } = usePanelContext()
 
   const [vertical, horizontal] = state.devToolsPosition.split('-', 2)
 
-  const enableErrorOverlayMode = () => {
-    dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
-    // Open the DevTools panel to view as error overlay mode.
-    dispatch({ type: ACTION_DEVTOOLS_PANEL_OPEN })
-  }
-
-  const toggleDevToolsPanel = () => {
-    dispatch({ type: ACTION_DEVTOOLS_PANEL_TOGGLE })
-  }
+  // console.log('rendering next logo')
 
   return (
+    // what is this toast doing??
+    // why are u hiding my precious
     <Toast
       data-nextjs-toast
       style={
@@ -54,16 +42,17 @@ export function DevToolsIndicator({
           boxShadow: 'none',
           [vertical]: `${INDICATOR_PADDING}px`,
           [horizontal]: `${INDICATOR_PADDING}px`,
-          visibility:
-            state.isDevToolsPanelOpen || state.isErrorOverlayOpen
-              ? 'hidden'
-              : 'visible',
+          // visibility:
+          //   state.isDevToolsPanelOpen || state.isErrorOverlayOpen
+          //     ? 'hidden'
+          //     : 'visible' <-- todo add hiding,
         } as CSSProperties
       }
     >
       <Draggable
         padding={INDICATOR_PADDING}
-        onDragStart={() => setOpen(false)}
+        // er i don't think this makes sense in the context of the refactor, come back to this
+        onDragStart={() => setOpen(null)}
         position={state.devToolsPosition}
         setPosition={(p) => {
           dispatch({
@@ -75,19 +64,12 @@ export function DevToolsIndicator({
       >
         {/* Trigger */}
         <NextLogo
-          aria-haspopup="menu"
-          aria-expanded={open}
-          aria-controls="nextjs-dev-tools-menu"
-          aria-label={`${open ? 'Close' : 'Open'} Next.js Dev Tools`}
-          data-nextjs-dev-tools-button
-          disabled={state.disableDevIndicator}
-          issueCount={errorCount}
-          onTriggerClick={toggleDevToolsPanel}
-          toggleErrorOverlay={enableErrorOverlayMode}
-          isDevBuilding={state.buildingIndicator}
-          isDevRendering={state.renderingIndicator}
-          isBuildError={isBuildError}
-          scale={state.scale}
+          onTriggerClick={() => {
+            // dispatch({ type: ACTION_DEVTOOLS_PANEL_TOGGLE })
+            // onTriggerClick()
+            setPanel(prev => prev === 'panel-selector' ? null : 'panel-selector')
+          }}
+          ref={triggerRef}
         />
       </Draggable>
     </Toast>

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/devtools-panel-tab.tsx
@@ -37,10 +37,6 @@ export function DevToolsPanelTab({
     case 'settings':
       return (
         <SettingsTab
-          devToolsPosition={devToolsPosition}
-          scale={scale}
-          handlePositionChange={handlePositionChange}
-          handleScaleChange={handleScaleChange}
         />
       )
     case 'route':

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
@@ -7,8 +7,7 @@ function SegmentsExplorer({
   routerType: 'app' | 'pages'
   page: string
 }) {
-  const isAppRouter = routerType === 'app'
-  return <PageSegmentTree isAppRouter={isAppRouter} page={page} />
+  return <PageSegmentTree />
 }
 
 export function SegmentsExplorerTab({

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/settings-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/settings-tab.tsx
@@ -2,12 +2,20 @@ import type { Corners } from '../../../shared'
 
 import { useTheme } from '../hooks/use-theme'
 import { Select } from '../../select/select'
-import { STORAGE_KEY_THEME, NEXT_DEV_TOOLS_SCALE } from '../../../shared'
+import {
+  STORAGE_KEY_THEME,
+  NEXT_DEV_TOOLS_SCALE,
+  ACTION_DEVTOOLS_POSITION,
+  STORAGE_KEY_POSITION,
+  ACTION_DEVTOOLS_SCALE,
+  STORAGE_KEY_SCALE,
+} from '../../../shared'
 import { css } from '../../../utils/css'
 import LightIcon from '../../../icons/light-icon'
 import DarkIcon from '../../../icons/dark-icon'
 import SystemIcon from '../../../icons/system-icon'
 import EyeIcon from '../../../icons/eye-icon'
+import { useDevOverlayContext } from '../../../../dev-overlay.browser'
 
 function ThemeIcon({ theme }: { theme: 'dark' | 'light' | 'system' }) {
   switch (theme) {
@@ -22,17 +30,7 @@ function ThemeIcon({ theme }: { theme: 'dark' | 'light' | 'system' }) {
   }
 }
 
-export function SettingsTab({
-  devToolsPosition,
-  scale,
-  handlePositionChange,
-  handleScaleChange,
-}: {
-  devToolsPosition: Corners
-  scale: number
-  handlePositionChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
-  handleScaleChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
-}) {
+export function SettingsTab() {
   const [theme, setTheme] = useTheme()
 
   const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -73,6 +71,7 @@ export function SettingsTab({
       // https://github.com/vercel/next.js/pull/80005
     })
   }
+  const { dispatch, state } = useDevOverlayContext()
 
   function hide() {
     fetch('/__nextjs_disable_dev_indicator', {
@@ -112,8 +111,14 @@ export function SettingsTab({
         <Select
           id="position"
           name="position"
-          value={devToolsPosition}
-          onChange={handlePositionChange}
+          value={state.devToolsPosition}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+            dispatch({
+              type: ACTION_DEVTOOLS_POSITION,
+              devToolsPosition: e.target.value as Corners,
+            })
+            localStorage.setItem(STORAGE_KEY_POSITION, e.target.value)
+          }}
         >
           <option value="bottom-left">Bottom Left</option>
           <option value="bottom-right">Bottom Right</option>
@@ -132,8 +137,14 @@ export function SettingsTab({
         <Select
           id="size"
           name="size"
-          value={scale}
-          onChange={handleScaleChange}
+          value={state.scale}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+            dispatch({
+              type: ACTION_DEVTOOLS_SCALE,
+              scale: Number(e.target.value),
+            })
+            localStorage.setItem(STORAGE_KEY_SCALE, e.target.value)
+          }}
         >
           {Object.entries(NEXT_DEV_TOOLS_SCALE).map(([key, value]) => {
             return (

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel.tsx
@@ -252,14 +252,38 @@ export function DevToolsPanel({
 
             {!isFullscreen && (
               <>
-                <ResizeHandle direction="top" />
-                <ResizeHandle direction="right" />
-                <ResizeHandle direction="bottom" />
-                <ResizeHandle direction="left" />
-                <ResizeHandle direction="top-left" />
-                <ResizeHandle direction="top-right" />
-                <ResizeHandle direction="bottom-left" />
-                <ResizeHandle direction="bottom-right" />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="top"
+                />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="right"
+                />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="bottom"
+                />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="left"
+                />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="top-left"
+                />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="top-right"
+                />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="bottom-left"
+                />
+                <ResizeHandle
+                  position={state.devToolsPanelPosition}
+                  direction="bottom-right"
+                />
               </>
             )}
           </>

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.css
@@ -11,7 +11,7 @@
   /* todo smarter z index */
   z-index: -1;
   pointer-events: none;
-  /* a normal exit animation curve- at this point the exit animation is */
+  /* a normal exit animation curve- aat this point the exit animation is */
   /* immediately responsive so we don't need a bespoke curve */
   transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   /* todo: better var? */
@@ -20,14 +20,14 @@
 
 /* start really fast because we start super hidden initially behind the panel, otherwise feels like an unintended animation delay */
 .resize-container:hover ~ .resize-line {
-  transition: transform 0.2s cubic-bezier(0.05, 0.9, 0.2, 1); /* Fast start for animate in */
+  transition: transform 0.25s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .resize-container.right,
 .resize-container.left {
   top: 0;
   height: 100%;
-  width: 25px;
+  width: 22px;
   cursor: ew-resize;
 }
 
@@ -37,97 +37,97 @@
 .resize-container.top {
   left: 0;
   width: 100%;
-  height: 25px;
+  height: 22px;
   cursor: ns-resize;
 }
 
 .resize-container.top {
-  top: -12px;
+  top: -7px;
 }
 .resize-container.bottom {
-  bottom: -12px;
+  bottom: -7px;
 }
 .resize-container.left {
-  left: -12px;
+  left: -7px;
 }
 .resize-container.right {
-  right: -12px;
+  right: -7px;
 }
 
 .resize-container.top-left,
 .resize-container.top-right,
 .resize-container.bottom-left,
 .resize-container.bottom-right {
-  width: 32px;
-  height: 32px;
+  width: 26px;
+  height: 26px;
   z-index: 15;
 }
 
 .resize-container.top-left {
-  top: -16px;
-  left: -16px;
+  top: -5px;
+  left: -5px;
   cursor: nwse-resize;
 }
 .resize-container.top-right {
-  top: -16px;
-  right: -16px;
+  top: -5px;
+  right: -5px;
   cursor: nesw-resize;
 }
 .resize-container.bottom-left {
-  bottom: -16px;
-  left: -16px;
+  bottom: -5px;
+  left: -5px;
   cursor: nesw-resize;
 }
 .resize-container.bottom-right {
-  bottom: -16px;
-  right: -16px;
+  bottom: -5px;
+  right: -5px;
   cursor: nwse-resize;
 }
 
 .resize-line.top,
 .resize-line.bottom {
-  height: 28px;
+  height: 18px;
   width: 100%;
   background-color: var(--color-background-100);
 }
 
 .resize-line.left,
 .resize-line.right {
-  width: 28px;
+  width: 18px;
   height: 100%;
   background-color: var(--color-background-100);
 }
 
 .resize-line.top {
-  top: -12px;
+  top: -7px;
   left: calc(-1 * var(--border-left, 2px));
   width: calc(100% + var(--border-horizontal, 4px));
   border-radius: var(--rounded-md) var(--rounded-md) 0 0;
-  transform: translateY(28px);
+  transform: translateY(18px);
 }
 
 .resize-line.bottom {
-  bottom: -12px;
+  bottom: -7px;
   left: calc(-1 * var(--border-left, 2px));
   width: calc(100% + var(--border-horizontal, 4px));
   border-radius: 0 0 var(--rounded-md) var(--rounded-md);
-  transform: translateY(-28px);
+  transform: translateY(-18px);
 }
 
 .resize-line.left {
   top: calc(-1 * var(--border-top, 2px));
-  left: -12px;
+  left: -7px;
   height: calc(100% + var(--border-vertical, 4px));
   border-radius: var(--rounded-md) 0 0 var(--rounded-md);
-  transform: translateX(28px);
+  transform: translateX(18px);
 }
 
 .resize-line.right {
   top: calc(-1 * var(--border-top, 2px));
-  right: -12px;
+  right: -7px;
   height: calc(100% + var(--border-vertical, 4px));
   border-radius: 0 var(--rounded-md) var(--rounded-md) 0;
-  transform: translateX(-28px);
+  transform: translateX(-18px);
 }
 
 .resize-container.right:hover ~ .resize-line.right,
@@ -149,14 +149,14 @@
  * regardless of hover state 
  */
 .resize-container.no-hover.right:hover ~ .resize-line.right {
-  transform: translateX(-28px);
+  transform: translateX(-20px);
 }
 .resize-container.no-hover.left:hover ~ .resize-line.left {
-  transform: translateX(28px);
+  transform: translateX(20px);
 }
 .resize-container.no-hover.bottom:hover ~ .resize-line.bottom {
-  transform: translateY(-28px);
+  transform: translateY(-20px);
 }
 .resize-container.no-hover.top:hover ~ .resize-line.top {
-  transform: translateY(28px);
+  transform: translateY(20px);
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
@@ -3,14 +3,19 @@ import type { Corners } from '../../../shared'
 import { useResize, type ResizeDirection } from './resize-provider'
 import './resize-handle.css'
 
-const STORAGE_KEY_DIMENSIONS = 'nextjs-devtools-dimensions'
-
-export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
+export const ResizeHandle = ({
+  direction,
+  position,
+}: {
+  direction: ResizeDirection
+  position: Corners
+}) => {
   const {
     resizeRef,
     minWidth,
     minHeight,
-    devToolsPosition,
+    storageKey,
+    // devToolsPosition,
     draggingDirection,
     setDraggingDirection,
   } = useResize()
@@ -44,13 +49,13 @@ export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
     // we block the sides of the corner its in (bottom-left has bottom and left sides blocked from resizing)
     // because there shouldn't be anywhere to resize, and if the user decides to resize from that point it
     // would be unhandled/slightly janky (the component would have to re-magnetic-snap after the resize)
-    if (devToolsPosition.split('-').includes(direction)) return false
+    if (position.split('-').includes(direction)) return false
 
     // same logic as above, but the only corner resize that makes
     // sense is the corner fully exposed (the opposing corner)
     const isCorner = direction.includes('-')
     if (isCorner) {
-      const opposite = getOppositeCorner(devToolsPosition)
+      const opposite = getOppositeCorner(position)
       return direction === opposite
     }
 
@@ -123,10 +128,7 @@ export const ResizeHandle = ({ direction }: { direction: ResizeDirection }) => {
 
       // invariant ref exists
       const { width, height } = resizeRef.current!.getBoundingClientRect()
-      localStorage.setItem(
-        STORAGE_KEY_DIMENSIONS,
-        JSON.stringify({ width, height })
-      )
+      localStorage.setItem(storageKey, JSON.stringify({ width, height }))
     }
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-provider.tsx
@@ -22,9 +22,10 @@ interface ResizeContextValue {
   resizeRef: RefObject<HTMLElement | null>
   minWidth: number
   minHeight: number
-  devToolsPosition: Corners
+  // devToolsPosition: Corners
   draggingDirection: ResizeDirection | null
   setDraggingDirection: (direction: ResizeDirection | null) => void
+  storageKey: string
 }
 
 const ResizeContext = createContext<ResizeContextValue>(null!)
@@ -44,8 +45,8 @@ const constrainDimensions = (params: {
   }
 }
 
-const parseResizeLocalStorage = () => {
-  const savedDimensions = localStorage.getItem(STORAGE_KEY_DIMENSIONS)
+const parseResizeLocalStorage = (key: string) => {
+  const savedDimensions = localStorage.getItem(key)
   if (!savedDimensions) return null
   try {
     const parsed = JSON.parse(savedDimensions)
@@ -59,7 +60,7 @@ const parseResizeLocalStorage = () => {
     }
     return null
   } catch (e) {
-    localStorage.removeItem(STORAGE_KEY_DIMENSIONS)
+    localStorage.removeItem(key)
     return null
   }
 }
@@ -70,6 +71,7 @@ interface ResizeProviderProps {
     minWidth?: number
     minHeight?: number
     devToolsPosition: Corners
+    storageKey?: string
   }
   children: React.ReactNode
 }
@@ -79,6 +81,8 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
   const minHeight = value.minHeight ?? 80
   const [draggingDirection, setDraggingDirection] =
     useState<ResizeDirection | null>(null)
+
+  const storageKey = value.storageKey ?? STORAGE_KEY_DIMENSIONS
 
   useLayoutEffect(() => {
     const applyConstrainedDimensions = () => {
@@ -91,7 +95,7 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
       // an optimization if this is too expensive is to maintain the current
       // container size in a ref and update it on resize, which is essentially
       // what we're doing here, just dumber
-      const dim = parseResizeLocalStorage()
+      const dim = parseResizeLocalStorage(storageKey)
       if (!dim) {
         return
       }
@@ -110,7 +114,7 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
     window.addEventListener('resize', applyConstrainedDimensions)
     return () =>
       window.removeEventListener('resize', applyConstrainedDimensions)
-  }, [value.resizeRef, minWidth, minHeight])
+  }, [value.resizeRef, minWidth, minHeight, storageKey])
 
   return (
     <ResizeContext.Provider
@@ -118,9 +122,10 @@ export const ResizeProvider = ({ value, children }: ResizeProviderProps) => {
         resizeRef: value.resizeRef,
         minWidth,
         minHeight,
-        devToolsPosition: value.devToolsPosition,
+        // devToolsPosition: value.devToolsPosition,
         draggingDirection,
         setDraggingDirection,
+        storageKey,
       }}
     >
       {children}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { DevToolsIndicator } from './dev-tools-indicator'
+import { DevOverlayStoryWrapper } from '../../../storybook/DevOverlayStoryWrapper'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
 import type { VersionInfo } from '../../../../../server/dev/parse-version-info'
 import type { OverlayState } from '../../../shared'
 
-const meta: Meta<typeof DevToolsIndicator> = {
-  component: DevToolsIndicator,
+const meta: Meta<typeof DevOverlayStoryWrapper> = {
+  component: DevOverlayStoryWrapper,
   parameters: {
     layout: 'centered',
   },
@@ -36,7 +36,7 @@ const meta: Meta<typeof DevToolsIndicator> = {
 }
 
 export default meta
-type Story = StoryObj<typeof DevToolsIndicator>
+type Story = StoryObj<typeof DevOverlayStoryWrapper>
 
 // Mock version info for stories
 const mockVersionInfo: VersionInfo = {
@@ -68,36 +68,31 @@ const state: OverlayState = {
 }
 
 export const StaticRoute: Story = {
-  args: {
-    errorCount: 0,
-    state,
-    dispatch: () => {},
-  },
+  render: () => (
+    <DevOverlayStoryWrapper initialState={state} runtimeErrors={[]} />
+  ),
 }
 
 export const DynamicRoute: Story = {
-  args: {
-    errorCount: 0,
-    state: {
-      ...state,
-      staticIndicator: false,
-    },
-    dispatch: () => {},
-  },
+  render: () => (
+    <DevOverlayStoryWrapper
+      initialState={{ ...state, staticIndicator: false }}
+      runtimeErrors={[]}
+    />
+  ),
 }
 
 export const SingleError: Story = {
-  args: {
-    errorCount: 1,
-    state,
-    dispatch: () => {},
-  },
+  render: () => (
+    <DevOverlayStoryWrapper initialState={state} runtimeErrors={[{} as any]} />
+  ),
 }
 
 export const MultipleErrors: Story = {
-  args: {
-    errorCount: 3,
-    state,
-    dispatch: () => {},
-  },
+  render: () => (
+    <DevOverlayStoryWrapper
+      initialState={state}
+      runtimeErrors={[{}, {}, {}] as any}
+    />
+  ),
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+interface DevToolsHeaderProps {
+  title: React.ReactNode
+  onBack: () => void
+  children?: React.ReactNode
+}
+export function DevToolsHeader({
+  title,
+  onBack,
+  children,
+  ref,
+}: DevToolsHeaderProps & { ref?: React.Ref<HTMLDivElement> }) {
+  return (
+    <div className="dev-tools-info-header" ref={ref}>
+      <button
+        className="dev-tools-info-close-button"
+        onClick={onBack}
+        aria-label="Go back"
+      >
+        <IconChevronLeft />
+      </button>
+      <h3 className="dev-tools-info-title" style={{ margin: 0 }}>
+        {title}
+      </h3>
+      {children}
+    </div>
+  )
+}
+
+function IconChevronLeft() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5.14645 8.70703C4.75595 8.31651 4.75595 7.68349 5.14645 7.29297L10.5 1.93945L11.5605 3L6.56051 8L11.5605 13L10.5 14.0605L5.14645 8.70703Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info-2.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info-2.tsx
@@ -1,0 +1,249 @@
+import { useRef } from 'react'
+import { MENU_DURATION_MS, useClickOutside, useFocusTrap } from '../utils'
+import { useDelayedRender } from '../../../../hooks/use-delayed-render'
+import { css } from '../../../../utils/css'
+
+export interface DevToolsInfoPropsCore {
+  isOpen: boolean
+  triggerRef: React.RefObject<HTMLButtonElement | null>
+  close: () => void
+}
+
+export interface DevToolsInfoProps extends DevToolsInfoPropsCore {
+  title: React.ReactNode
+  children: React.ReactNode
+  learnMoreLink?: string
+}
+
+export function DevToolsInfo2({
+  title,
+  children,
+  learnMoreLink,
+  isOpen,
+  triggerRef,
+  close,
+  ...props
+}: DevToolsInfoProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  const { mounted, rendered } = useDelayedRender(isOpen, {
+    // Intentionally no fade in, makes the UI feel more immediate
+    enterDelay: 0,
+    // Graceful fade out to confirm that the UI did not break
+    exitDelay: MENU_DURATION_MS,
+  })
+
+  useFocusTrap(ref, triggerRef, isOpen, () => {
+    // Bring focus to close button, so the user can easily close the overlay
+    closeButtonRef.current?.focus()
+  })
+  useClickOutside(ref, triggerRef, isOpen, close)
+
+  if (!mounted) {
+    return null
+  }
+  // TODO: this is a case of me changing styles for new that will break
+  // old, need to fork
+  return (
+    <div
+      tabIndex={-1}
+      role="dialog"
+      ref={ref}
+      // remove this if it breaks shit, its influencing real
+      // data-info-popover
+      {...props}
+      data-rendered={rendered}
+
+      style={{
+        // height: '100%'
+        WebkitFontSmoothing: 'antialiased',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        // background: 'var(--color-background-100)',
+        // border: '1px solid var(--color-gray-alpha-400)',
+        // backgroundClip: 'padding-box',
+        boxShadow: 'var(--shadow-menu)',
+        borderRadius: 'var(--rounded-xl)',
+        position: 'absolute',
+        fontFamily: 'var(--font-stack-sans)',
+        zIndex: 3,
+        overflow: 'hidden',
+        opacity: rendered ? 1 : 0,
+        outline: 0,
+        minWidth: '350px',
+        transition: 'opacity var(--animate-out-duration-ms) var(--animate-out-timing-function)',
+        scale: rendered ? 1 : undefined,
+      }}
+    >
+      <div className="dev-tools-info-container">
+        <div className="dev-tools-info-header">
+          <button
+            ref={closeButtonRef}
+            className="dev-tools-info-close-button"
+            onClick={close}
+            aria-label="Close dialog"
+          >
+            <IconChevronLeft />
+          </button>
+          <h3 className="dev-tools-info-title">{title}</h3>
+        </div>
+        <div className="dev-tools-info-body">
+          {children}
+          {learnMoreLink && (
+            <div className="dev-tools-info-button-container">
+              <a
+                className="dev-tools-info-learn-more-button"
+                href={learnMoreLink}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                Learn More
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const DEV_TOOLS_INFO_STYLES = css`
+  [data-info-popover] {
+    -webkit-font-smoothing: antialiased;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    background: var(--color-background-100);
+    border: 1px solid var(--color-gray-alpha-400);
+    background-clip: padding-box;
+    box-shadow: var(--shadow-menu);
+    border-radius: var(--rounded-xl);
+    position: absolute;
+    font-family: var(--font-stack-sans);
+    z-index: 3;
+    overflow: hidden;
+    opacity: 0;
+    outline: 0;
+    min-width: 350px;
+    transition: opacity var(--animate-out-duration-ms)
+      var(--animate-out-timing-function);
+
+    &[data-rendered='true'] {
+      opacity: 1;
+      scale: 1;
+    }
+
+    button:focus-visible {
+      outline: var(--focus-ring);
+    }
+  }
+
+  .dev-tools-info-container {
+    width: 100%;
+  }
+
+  .dev-tools-info-body {
+    padding: 16px;
+  }
+
+  .dev-tools-info-header {
+    height: 48px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--color-gray-alpha-400);
+  }
+
+  .dev-tools-info-close-button {
+    all: unset;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-gray-900);
+    transition: color 150ms ease;
+    translate: 0 1px;
+    border-radius: 3px;
+
+    &:hover {
+      color: var(--color-gray-1000);
+    }
+  }
+
+  .dev-tools-info-title {
+    color: var(--color-gray-1000);
+    font-size: var(--size-14);
+    font-weight: 500;
+    line-height: var(--size-20);
+    margin: 0;
+  }
+
+  .dev-tools-info-section-title {
+    padding: 8px 0px;
+    color: var(--color-gray-1000);
+    font-size: var(--size-16);
+    font-weight: 600;
+    line-height: var(--size-20);
+    margin: 0;
+  }
+
+  .dev-tools-info-article {
+    padding: 8px 6px;
+    color: var(--color-gray-1000);
+    font-size: var(--size-14);
+    line-height: var(--size-20);
+    margin: 0;
+  }
+  .dev-tools-info-paragraph {
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .dev-tools-info-button-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .dev-tools-info-learn-more-button {
+    align-content: center;
+    padding: 0 8px;
+    height: var(--size-28);
+    font-size: var(--size-14);
+    font-weight: 500;
+    line-height: var(--size-20);
+    transition: background var(--duration-short) ease;
+    color: var(--color-background-100);
+    border-radius: var(--rounded-md-2);
+    background: var(--color-gray-1000);
+    margin-left: auto;
+  }
+
+  .dev-tools-info-learn-more-button:hover {
+    text-decoration: none;
+    color: var(--color-background-100);
+    opacity: 0.9;
+  }
+`
+
+function IconChevronLeft() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5.14645 8.70703C4.75595 8.31651 4.75595 7.68349 5.14645 7.29297L10.5 1.93945L11.5605 3L6.56051 8L11.5605 13L10.5 14.0605L5.14645 8.70703Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/route-info.tsx
@@ -1,6 +1,7 @@
 import type { HTMLProps } from 'react'
 import type { DevToolsInfoPropsCore } from './dev-tools-info'
 import { DevToolsInfo } from './dev-tools-info'
+import { useDevOverlayContext } from '../../../../../dev-overlay.browser'
 
 function StaticRouteContent({ routerType }: { routerType: 'pages' | 'app' }) {
   return (
@@ -110,32 +111,38 @@ const learnMoreLink = {
   },
 } as const
 
-export function RouteInfo({
-  routeType,
-  routerType,
-  ...props
-}: {
-  routeType: 'Static' | 'Dynamic'
-  routerType: 'pages' | 'app'
-} & DevToolsInfoPropsCore &
-  HTMLProps<HTMLDivElement>) {
-  const isStaticRoute = routeType === 'Static'
+export function RouteInfoBody() {
+  const { state } = useDevOverlayContext()
 
-  const learnMore = isStaticRoute
-    ? learnMoreLink[routerType].static
-    : learnMoreLink[routerType].dynamic
+  const isStaticRoute = state.staticIndicator
 
+  return isStaticRoute ? (
+    <StaticRouteContent routerType={state.routerType} />
+  ) : (
+    <DynamicRouteContent routerType={state.routerType} />
+  )
+}
+
+export function RouteInfo({ isOpen,close,...props}: { isOpen: boolean , close: () => void} & HTMLProps<HTMLDivElement>) {
+  const { state } = useDevOverlayContext()
+
+  const routeType = state.staticIndicator ? 'Static' : 'Dynamic'
+
+  const learnMore = state.staticIndicator
+    ? learnMoreLink[state.routerType].static
+    : learnMoreLink[state.routerType].dynamic
+// FOR OLD UI NEED TO PASS DOWN THE EVENT HANDLERS
   return (
     <DevToolsInfo
       title={`${routeType} Route`}
       learnMoreLink={learnMore}
+      close={close}
+      isOpen={isOpen}
+      triggerRef={{ current: null }}
       {...props}
+      // style={style}
     >
-      {isStaticRoute ? (
-        <StaticRouteContent routerType={routerType} />
-      ) : (
-        <DynamicRouteContent routerType={routerType} />
-      )}
+      <RouteInfoBody />
     </DevToolsInfo>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
@@ -2,19 +2,16 @@ import { PageSegmentTree } from '../../../overview/segment-explorer'
 import { DevToolsInfo, type DevToolsInfoPropsCore } from './dev-tools-info'
 
 export function SegmentsExplorer({
-  routerType,
-  page,
   ...props
 }: DevToolsInfoPropsCore &
   React.HTMLProps<HTMLDivElement> & {
     routerType: 'app' | 'pages'
     page: string
   }) {
-  const isAppRouter = routerType === 'app'
   return (
     <DevToolsInfo title="Route Info" {...props}>
       <div data-nextjs-segments-explorer>
-        <PageSegmentTree isAppRouter={isAppRouter} page={page} />
+        <PageSegmentTree />
       </div>
     </DevToolsInfo>
   )

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/segments-explorer.tsx
@@ -22,6 +22,13 @@ export function SegmentsExplorer({
 
 export const SEGMENTS_EXPLORER_STYLES = `
   [data-nextjs-segments-explorer] {
+    min-width: 768px;
     margin: -16px;
+  }
+
+  @media (max-width: 768px) {
+    [data-nextjs-segments-explorer] {
+      min-width: 90vw;
+    }
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/turbopack-info.tsx
@@ -2,15 +2,9 @@ import { DevToolsInfo, type DevToolsInfoPropsCore } from './dev-tools-info'
 import { CopyButton } from '../../../copy-button'
 import type { HTMLProps } from 'react'
 
-export function TurbopackInfo(
-  props: DevToolsInfoPropsCore & HTMLProps<HTMLDivElement>
-) {
+export function TurbopackInfoBody() {
   return (
-    <DevToolsInfo
-      title="Turbopack"
-      learnMoreLink="https://nextjs.org/docs/app/api-reference/turbopack"
-      {...props}
-    >
+    <>
       <article className="dev-tools-info-article">
         <p className="dev-tools-info-paragraph">
           Turbopack is an incremental bundler optimized for JavaScript and
@@ -96,6 +90,20 @@ export function TurbopackInfo(
           </pre>
         </div>
       </div>
+    </>
+  )
+}
+
+export function TurbopackInfo(
+  props: DevToolsInfoPropsCore & HTMLProps<HTMLDivElement>
+) {
+  return (
+    <DevToolsInfo
+      title="Turbopack"
+      learnMoreLink="https://nextjs.org/docs/app/api-reference/turbopack"
+      {...props}
+    >
+      <TurbopackInfoBody />
     </DevToolsInfo>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/drag-context.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/drag-context.tsx
@@ -1,0 +1,89 @@
+// Drag context to coordinate Draggable and its DragHandle children
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+} from 'react'
+
+interface DragContextValue {
+  register: (el: HTMLElement) => void
+  unregister: (el: HTMLElement) => void
+  handles: Set<HTMLElement>
+  disabled: boolean
+}
+
+const DragContext = createContext<DragContextValue | null>(null)
+
+export function DragProvider({
+  children,
+  disabled = false,
+}: {
+  children: React.ReactNode
+  disabled?: boolean
+}) {
+  const handlesRef = useRef<Set<HTMLElement>>(new Set())
+
+  const register = useCallback((el: HTMLElement) => {
+    handlesRef.current.add(el)
+  }, [])
+
+  const unregister = useCallback((el: HTMLElement) => {
+    handlesRef.current.delete(el)
+  }, [])
+
+  const value = useMemo<DragContextValue>(
+    () => ({ register, unregister, handles: handlesRef.current, disabled }),
+    [register, unregister, disabled]
+  )
+
+  return <DragContext.Provider value={value}>{children}</DragContext.Provider>
+}
+
+export function useDragContext() {
+  return useContext(DragContext)
+}
+
+export function DragHandle({ 
+  children, 
+  ref, 
+  ...props 
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) {
+  const internalRef = useRef<HTMLDivElement>(null)
+  const ctx = useDragContext()
+
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      internalRef.current = node ?? null
+      if (typeof ref === 'function') {
+        ref(node)
+      } else if (ref && typeof ref === 'object') {
+        ;(
+          ref as React.MutableRefObject<HTMLDivElement | null>
+        ).current = node
+      }
+    },
+    [ref]
+  )
+
+  React.useEffect(() => {
+    if (!ctx || !internalRef.current || ctx.disabled) return
+    const el = internalRef.current
+    ctx.register(el)
+    return () => ctx.unregister(el)
+  }, [ctx])
+
+  return (
+    <div
+      ref={setRef}
+      {...props}
+      style={{
+        cursor: ctx?.disabled ? 'default' : 'grab',
+        ...(props.style || {}),
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
@@ -84,14 +84,15 @@ export function useClickOutside(
   rootRef: React.RefObject<HTMLElement | null>,
   triggerRef: React.RefObject<HTMLButtonElement | null>,
   active: boolean,
-  close: () => void
+  close: () => void,
+  ownerDocument?: Document
 ) {
   useEffect(() => {
     if (!active) {
       return
     }
 
-    const ownerDocument = rootRef.current?.ownerDocument
+    const ownerDocumentEl = ownerDocument || rootRef.current?.ownerDocument
 
     function handleClickOutside(event: MouseEvent) {
       const target = event.target as HTMLElement
@@ -124,15 +125,15 @@ export function useClickOutside(
       }
     }
 
-    ownerDocument?.addEventListener('mousedown', handleClickOutside)
-    ownerDocument?.addEventListener('keydown', handleKeyDown)
+    ownerDocumentEl?.addEventListener('mousedown', handleClickOutside)
+    ownerDocumentEl?.addEventListener('keydown', handleKeyDown)
 
     return () => {
-      ownerDocument?.removeEventListener('mousedown', handleClickOutside)
-      ownerDocument?.removeEventListener('keydown', handleKeyDown)
+      ownerDocumentEl?.removeEventListener('mousedown', handleClickOutside)
+      ownerDocumentEl?.removeEventListener('keydown', handleKeyDown)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active])
+  }, [active, rootRef, triggerRef])
 }
 
 //////////////////////////////////////////////////////////////////////////////////////

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/utils.ts
@@ -100,19 +100,21 @@ export function useClickOutside(
         return
       }
 
+      const cushion = 10
+
       if (
         !(rootRef.current?.getBoundingClientRect()
-          ? event.clientX >= rootRef.current.getBoundingClientRect()!.left &&
-            event.clientX <= rootRef.current.getBoundingClientRect()!.right &&
-            event.clientY >= rootRef.current.getBoundingClientRect()!.top &&
-            event.clientY <= rootRef.current.getBoundingClientRect()!.bottom
+          ? event.clientX >= rootRef.current.getBoundingClientRect()!.left - cushion &&
+            event.clientX <= rootRef.current.getBoundingClientRect()!.right + cushion &&
+            event.clientY >= rootRef.current.getBoundingClientRect()!.top - cushion &&
+            event.clientY <= rootRef.current.getBoundingClientRect()!.bottom + cushion
           : false) &&
         !(triggerRef.current?.getBoundingClientRect()
-          ? event.clientX >= triggerRef.current.getBoundingClientRect()!.left &&
+          ? event.clientX >= triggerRef.current.getBoundingClientRect()!.left - cushion &&
             event.clientX <=
-              triggerRef.current.getBoundingClientRect()!.right &&
-            event.clientY >= triggerRef.current.getBoundingClientRect()!.top &&
-            event.clientY <= triggerRef.current.getBoundingClientRect()!.bottom
+              triggerRef.current.getBoundingClientRect()!.right + cushion &&
+            event.clientY >= triggerRef.current.getBoundingClientRect()!.top - cushion &&
+            event.clientY <= triggerRef.current.getBoundingClientRect()!.bottom + cushion
           : false)
       ) {
         close()

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx
@@ -10,49 +10,29 @@ import { Errors } from '../../../container/errors'
 import { useDelayedRender } from '../../../hooks/use-delayed-render'
 import type { ReadyRuntimeError } from '../../../utils/get-error-by-type'
 import type { HydrationErrorState } from '../../../../shared/hydration-error'
+import { useDevOverlayContext } from '../../../../dev-overlay.browser'
+import { useRenderErrorContext } from '../../../dev-overlay'
 
 const transitionDurationMs = 200
 
 export interface ErrorBaseProps {
   rendered: boolean
   transitionDurationMs: number
-  isTurbopack: boolean
-  versionInfo: OverlayState['versionInfo']
-  errorCount: number
 }
 
-export function ErrorOverlay({
-  state,
-  dispatch,
-  getSquashedHydrationErrorDetails,
-  runtimeErrors,
-  errorCount,
-}: {
-  state: OverlayState
-  dispatch: OverlayDispatch
-  getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
-  runtimeErrors: ReadyRuntimeError[]
-  errorCount: number
-}) {
-  const isTurbopack = !!process.env.TURBOPACK
+export function ErrorOverlay() {
+  const { state } = useDevOverlayContext()
+  const { runtimeErrors } = useRenderErrorContext()
 
   // This hook lets us do an exit animation before unmounting the component
   const { mounted, rendered } = useDelayedRender(state.isErrorOverlayOpen, {
     exitDelay: transitionDurationMs,
   })
 
-  const commonProps = {
-    rendered,
-    transitionDurationMs,
-    isTurbopack,
-    versionInfo: state.versionInfo,
-    errorCount,
-  }
-
   if (state.buildError !== null) {
     return (
       <BuildError
-        {...commonProps}
+        transitionDurationMs={transitionDurationMs}
         message={state.buildError}
         // This is not a runtime error, forcedly display error overlay
         rendered
@@ -74,14 +54,6 @@ export function ErrorOverlay({
   }
 
   return (
-    <Errors
-      {...commonProps}
-      debugInfo={state.debugInfo}
-      getSquashedHydrationErrorDetails={getSquashedHydrationErrorDetails}
-      runtimeErrors={runtimeErrors}
-      onClose={() => {
-        dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
-      }}
-    />
+    <Errors transitionDurationMs={transitionDurationMs} rendered={rendered} />
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/overlay/overlay.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/overlay/overlay.tsx
@@ -1,10 +1,11 @@
+import { css } from '../../../utils/css'
 import { Overlay, type OverlayProps } from '../../overlay/overlay'
 
 export function ErrorOverlayOverlay({ children, ...props }: OverlayProps) {
   return <Overlay {...props}>{children}</Overlay>
 }
 
-export const OVERLAY_STYLES = `
+export const OVERLAY_STYLES = css`
   [data-nextjs-dialog-overlay] {
     padding: initial;
     top: 10vh;

--- a/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
@@ -1,4 +1,6 @@
-const styles = `
+import { css } from "../../utils/css"
+
+const styles = css`
   [data-nextjs-dialog-overlay] {
     position: fixed;
     top: 0;

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -5,9 +5,11 @@ import type { SegmentNodeState } from '../../../userspace/app/segment-explorer-n
 export function SegmentBoundaryTrigger({
   onSelectBoundary,
   offset,
+  boundaries,
 }: {
   onSelectBoundary: SegmentNodeState['setBoundaryType']
   offset: number
+  boundaries: Record<'not-found' | 'loading' | 'error', string | null>
 }) {
   const [shadowRoot] = useState<ShadowRoot>(() => {
     const ownerDocument = document
@@ -17,9 +19,24 @@ export function SegmentBoundaryTrigger({
   const shadowRootRef = useRef<ShadowRoot>(shadowRoot)
 
   const triggerOptions = [
-    { label: 'Trigger Loading', value: 'loading', icon: <LoadingIcon /> },
-    { label: 'Trigger Error', value: 'error', icon: <ErrorIcon /> },
-    { label: 'Trigger Not Found', value: 'not-found', icon: <NotFoundIcon /> },
+    {
+      label: 'Trigger Loading',
+      value: 'loading',
+      icon: <LoadingIcon />,
+      disabled: !boundaries.loading,
+    },
+    {
+      label: 'Trigger Error',
+      value: 'error',
+      icon: <ErrorIcon />,
+      disabled: !boundaries.error,
+    },
+    {
+      label: 'Trigger Not Found',
+      value: 'not-found',
+      icon: <NotFoundIcon />,
+      disabled: !boundaries['not-found'],
+    },
   ]
 
   const resetOption = {
@@ -74,6 +91,7 @@ export function SegmentBoundaryTrigger({
                   key={option.value}
                   className="segment-boundary-dropdown-item"
                   onClick={() => handleSelect(option.value)}
+                  disabled={option.disabled}
                 >
                   {option.icon}
                   {option.label}
@@ -274,9 +292,14 @@ export const styles = `
     width: 100%;
   }
 
+  .segment-boundary-dropdown-item[data-disabled] {
+    color: var(--color-gray-400);
+    cursor: not-allowed;
+  }
+
   .segment-boundary-dropdown-item svg {
     margin-right: 12px;
-    color: var(--color-gray-900);
+    color: currentColor;
   }
 
   .segment-boundary-dropdown-item:hover {

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -2,7 +2,10 @@ import { useCallback, useState, useRef, useMemo } from 'react'
 import { Menu } from '@base-ui-components/react/menu'
 import type { SegmentNodeState } from '../../../userspace/app/segment-explorer-node'
 import { ChevronDownIcon } from '../../icons/chevron-down'
-import { normalizeBoundaryFilename } from '../../../../server/app-render/segment-explorer-path'
+import {
+  isBoundaryFile,
+  normalizeBoundaryFilename,
+} from '../../../../server/app-render/segment-explorer-path'
 import { cx } from '../../utils/cx'
 import { useClickOutside } from '../errors/dev-tools-indicator/utils'
 
@@ -71,9 +74,9 @@ export function SegmentBoundaryTrigger({
   }, [boundaries, possibleExtension])
 
   const fileName = (pagePath || '').split('/').pop() || ''
-  const isBoundaryFile = fileType.startsWith('boundary:')
+  const isBoundary = isBoundaryFile(fileType)
   const pageFileName = normalizeBoundaryFilename(
-    isBoundaryFile
+    isBoundary
       ? fileName // Show the selected boundary file name when overridden
       : fileName || `page.${possibleExtension}`
   )
@@ -154,8 +157,8 @@ export function SegmentBoundaryTrigger({
     [onSelectBoundary, pagePath, openInEditor]
   )
 
-  // For layout/template files, just render a simple button to open in editor
-  if (fileType === 'layout' || fileType === 'template') {
+  // For non-page files, just render a simple button to open in editor
+  if (fileType !== 'page' && !fileType.startsWith('boundary:')) {
     return (
       <button
         className="segment-boundary-trigger"

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -120,7 +120,7 @@ export function SegmentBoundaryTrigger({
   const hasBoundaries = Object.values(boundaries).some(
     (boundary) => boundary !== null
   )
-  const isPageFile = fileType === 'page'
+  const isPageOrBoundary = fileType && !isBoundaryFile(fileType)
 
   const openInEditor = useCallback(({ filePath }: { filePath: string }) => {
     const params = new URLSearchParams({
@@ -158,7 +158,10 @@ export function SegmentBoundaryTrigger({
   )
 
   // For non-page files, just render a simple button to open in editor
-  if (fileType !== 'page' && !fileType.startsWith('boundary:')) {
+  if (
+    !(fileType === 'page' || fileType === 'default') &&
+    !isBoundaryFile(fileType)
+  ) {
     return (
       <button
         className="segment-boundary-trigger"
@@ -172,11 +175,6 @@ export function SegmentBoundaryTrigger({
     )
   }
 
-  // Don't render the dropdown if there are no boundaries and no page file
-  if (!hasBoundaries && !isPageFile) {
-    return null
-  }
-
   const Trigger = (
     triggerProps: React.ComponentProps<'button'> & {
       ref?: React.Ref<HTMLButtonElement>
@@ -187,7 +185,7 @@ export function SegmentBoundaryTrigger({
     return (
       <button {...triggerProps} ref={mergedRef} type="button">
         <span className="segment-boundary-trigger-text">
-          {isPageFile
+          {isPageOrBoundary
             ? pageFileName
             : boundaryType === null
               ? // TODO(pran): improve the UX of the default boundary selector
@@ -206,7 +204,7 @@ export function SegmentBoundaryTrigger({
       <Menu.Trigger
         className={cx(
           'segment-boundary-trigger',
-          !isPageFile && 'segment-boundary-trigger--boundary',
+          !isPageOrBoundary && 'segment-boundary-trigger--boundary',
           isOverridden && 'segment-boundary-trigger--overridden'
         )}
         data-nextjs-dev-overlay-segment-boundary-trigger-button

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -16,6 +16,8 @@ import {
   isBoundaryFile,
   normalizeBoundaryFilename,
 } from '../../../../server/app-render/segment-explorer-path'
+import { ExternalIcon } from '../../icons/external'
+import { useDevOverlayContext } from '../../../dev-overlay.browser'
 
 const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
@@ -99,15 +101,13 @@ function SegmentExplorerFooter({
   )
 }
 
-export function PageSegmentTree({
-  isAppRouter,
-  page,
-}: {
-  isAppRouter: boolean
-  page: string
-}) {
+export function PageSegmentTree() {
   const tree = useSegmentTree()
+  const {state}  = useDevOverlayContext()
 
+  const isAppRouter = state.routerType === 'app'
+
+  
   // Count active boundaries for the badge
   const activeBoundariesCount = useMemo(() => {
     return isAppRouter ? countActiveBoundaries(tree) : 0
@@ -122,7 +122,7 @@ export function PageSegmentTree({
 
   return (
     <div data-nextjs-devtools-panel-segments-explorer>
-      {isAppRouter && <PageRouteBar page={page} />}
+      {isAppRouter && <PageRouteBar page={state.page} />}
       <div
         className="segment-explorer-content"
         data-nextjs-devtool-segment-explorer
@@ -316,7 +316,7 @@ function PageSegmentTreeLayerPresentation({
 
                       const tooltipMessage = isBuiltin
                         ? `The default Next.js ${childNode.value.type} is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`
-                        : `Open in editor`
+                        : null // `Open in editor`
 
                       return (
                         <Tooltip
@@ -346,7 +346,7 @@ function PageSegmentTreeLayerPresentation({
                             }}
                           >
                             {fileName}
-                            {isBuiltin && <InfoIcon />}
+                            {isBuiltin ? <InfoIcon /> : <ExternalIcon />}
                           </span>
                         </Tooltip>
                       )

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -133,6 +133,23 @@ function PageSegmentTreeLayerPresentation({
   }
 
   const hasFilesChildren = filesChildrenKeys.length > 0
+  const boundaries: Record<'not-found' | 'loading' | 'error', string | null> = {
+    'not-found': null,
+    loading: null,
+    error: null,
+  }
+
+  filesChildrenKeys.forEach((childKey) => {
+    const childNode = node.children[childKey]
+    if (!childNode || !childNode.value) return
+    if (childNode.value.type.startsWith('boundary:')) {
+      const boundaryType = childNode.value.type.split(':')[1] as
+        | 'not-found'
+        | 'loading'
+        | 'error'
+      boundaries[boundaryType] = childNode.value.pagePath || null
+    }
+  })
 
   return (
     <>
@@ -163,6 +180,11 @@ function PageSegmentTreeLayerPresentation({
                   {filesChildrenKeys.map((fileChildSegment) => {
                     const childNode = node.children[fileChildSegment]
                     if (!childNode || !childNode.value) {
+                      return null
+                    }
+                    // If it's boundary node, which marks the existence of the boundary not the rendered status,
+                    // we don't need to present in the rendered files.
+                    if (childNode.value.type.startsWith('boundary:')) {
                       return null
                     }
                     const filePath = childNode.value.pagePath
@@ -208,6 +230,7 @@ function PageSegmentTreeLayerPresentation({
                 <SegmentBoundaryTrigger
                   offset={6}
                   onSelectBoundary={pageChild.value.setBoundaryType}
+                  boundaries={boundaries}
                 />
               )}
             </div>

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof Errors> = {
 export default meta
 type Story = StoryObj<typeof Errors>
 
+// todo: update the stories to be wrapped in context providers necessary, instead of passing props directly, before they expected props
 export const Default: Story = {
   args: {
     getSquashedHydrationErrorDetails: () => null,

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -18,6 +18,9 @@ import type { ReadyRuntimeError } from '../utils/get-error-by-type'
 import type { ErrorBaseProps } from '../components/errors/error-overlay/error-overlay'
 import type { HydrationErrorState } from '../../shared/hydration-error'
 import { useActiveRuntimeError } from '../hooks/use-active-runtime-error'
+import { useDevOverlayContext } from '../../dev-overlay.browser'
+import { useRenderErrorContext } from '../dev-overlay'
+import { ACTION_ERROR_OVERLAY_CLOSE } from '../shared'
 
 export interface ErrorsProps extends ErrorBaseProps {
   getSquashedHydrationErrorDetails: (error: Error) => HydrationErrorState | null
@@ -111,14 +114,14 @@ export function useErrorDetails(
   }, [error, getSquashedHydrationErrorDetails])
 }
 
-export function Errors({
-  getSquashedHydrationErrorDetails,
-  runtimeErrors,
-  debugInfo,
-  onClose,
-  ...props
-}: ErrorsProps) {
+export function Errors({transitionDurationMs,rendered}:{transitionDurationMs: number, rendered:boolean}) {
   const dialogResizerRef = useRef<HTMLDivElement | null>(null)
+
+  const {getSquashedHydrationErrorDetails, dispatch,state} = useDevOverlayContext()
+  const {runtimeErrors} = useRenderErrorContext()
+  const onClose = () => {
+    dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
+  }
 
   const {
     isLoading,
@@ -162,13 +165,15 @@ export function Errors({
         )
       }
       onClose={isServerError ? undefined : onClose}
-      debugInfo={debugInfo}
+      debugInfo={state.debugInfo}
       error={error}
       runtimeErrors={runtimeErrors}
       activeIdx={activeIdx}
       setActiveIndex={setActiveIndex}
       dialogResizerRef={dialogResizerRef}
-      {...props}
+      // {...props}
+      transitionDurationMs={transitionDurationMs}
+      rendered={rendered}
     >
       <div className="error-overlay-notes-container">
         {notes ? (

--- a/packages/next/src/next-devtools/dev-overlay/dev-overlay.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/dev-overlay.stories.tsx
@@ -10,6 +10,7 @@ import {
   storybookDefaultOverlayState,
   useStorybookOverlayReducer,
 } from './storybook/use-overlay-reducer'
+import { DevOverlayContext } from '../dev-overlay.browser'
 
 const meta: Meta<typeof DevOverlay> = {
   component: DevOverlay,
@@ -39,35 +40,45 @@ function getNoSquashedHydrationErrorDetails() {
 
 const initialState: OverlayState = {
   ...storybookDefaultOverlayState,
-  errors,
+  // todo: i think hidden when errors for some reason
+  errors: [],
 }
 
 export const Default: Story = {
   render: function DevOverlayStory() {
     const [state, dispatch] = useStorybookOverlayReducer(initialState)
     return (
-      <>
-        <img
+      <div
+        style={{
+          height: '100vh',
+          backgroundColor: "black"
+     }} 
+      >
+        {/* get lots of real hard examples so we have better debug */}
+        {/* <img
           src={imgApp}
           style={{
             width: '100%',
             height: '100vh',
             objectFit: 'contain',
           }}
-        />
-        <DevOverlay
-          state={state}
-          dispatch={dispatch}
-          getSquashedHydrationErrorDetails={
-            // Testing like App Router where we no longer quash hydration errors
-            getNoSquashedHydrationErrorDetails
-          }
-        />
-      </>
+        /> */}
+        <DevOverlayContext
+          value={{
+            dispatch,
+            getSquashedHydrationErrorDetails:
+              getNoSquashedHydrationErrorDetails,
+            state,
+          }}
+        >
+          <DevOverlay />
+        </DevOverlayContext>
+      </div>
     )
   },
 }
 
+// todo: fix story with "Context arg provider" wrapper
 export const WithPanel: Story = {
   beforeEach: () => {
     process.env.__NEXT_DEVTOOL_NEW_PANEL_UI = 'true'
@@ -90,12 +101,12 @@ export const WithPanel: Story = {
           }}
         />
         <DevOverlay
-          state={state}
-          dispatch={dispatch}
-          getSquashedHydrationErrorDetails={
-            // Testing like App Router where we no longer quash hydration errors
-            getNoSquashedHydrationErrorDetails
-          }
+        // state={state}
+        // dispatch={dispatch}
+        // getSquashedHydrationErrorDetails={
+        //   // Testing like App Router where we no longer quash hydration errors
+        //   getNoSquashedHydrationErrorDetails
+        // }
         />
       </>
     )

--- a/packages/next/src/next-devtools/dev-overlay/menu/context.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/context.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, type Dispatch, type SetStateAction } from "react";
+import type { Overlays } from "../components/errors/dev-tools-indicator/dev-tools-indicator";
+
+export const MenuContext = createContext<{
+  closeMenu: () => void
+  selectedIndex: number
+  setSelectedIndex: Dispatch<SetStateAction<number>>
+}>(null!)
+export const useMenuContext = () => useContext(MenuContext)
+
+export type PanelStateKind =
+  | 'preferences'
+  | 'route-info'
+  | 'segment-explorer'
+  | 'panel-selector'
+  | 'turbo-info'
+
+
+export const PanelContext = createContext<{
+  panel: PanelStateKind | null
+  setPanel: Dispatch<SetStateAction<PanelStateKind | null>>
+  open: Overlays | null
+  triggerRef: React.RefObject<HTMLButtonElement | null>,
+setOpen: Dispatch<SetStateAction<Overlays | null>>  
+}>(null!)
+
+export const usePanelContext = () => useContext(PanelContext)

--- a/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/dev-overlay-menu.tsx
@@ -1,0 +1,396 @@
+import { useDevOverlayContext } from '../../dev-overlay.browser'
+import {
+  MENU_DURATION_MS,
+  useClickOutside,
+} from '../components/errors/dev-tools-indicator/utils'
+import { useRenderErrorContext } from '../dev-overlay'
+import { useDelayedRender } from '../hooks/use-delayed-render'
+import GearIcon from '../icons/gear-icon'
+import { ACTION_ERROR_OVERLAY_OPEN } from '../shared'
+import { MenuContext, usePanelContext } from './context'
+import { useRef, useState, type CSSProperties } from 'react'
+import { MenuItem } from './menu-item'
+import { getIndicatorOffset } from '../utils/indicator-metrics'
+import { INDICATOR_PADDING } from '../components/devtools-indicator/devtools-indicator'
+import { css } from '../utils/css'
+
+/**
+ *
+ * SYNC WITH REAL MENU THIS IS MISSING A LOT
+ */
+export const DevtoolMenu = ({
+  closeOnClickOutside = true,
+  onClose,
+}: {
+  closeOnClickOutside?: boolean
+  onClose?: () => void
+}) => {
+  const isTurbopack = !!process.env.TURBOPACK
+  const { dispatch, state } = useDevOverlayContext()
+  const { totalErrorCount } = useRenderErrorContext()
+  const { panel, setPanel, triggerRef } = usePanelContext()
+  // const { mounted: menuMounted, rendered: menuRendered } = useDelayedRender(
+  //   panel === 'panel-selector',
+  //   {
+  //     // Intentionally no fade in, makes the UI feel more immediate
+  //     enterDelay: 0,
+  //     // Graceful fade out to confirm that the UI did not break
+  //     exitDelay: MENU_DURATION_MS,
+  //   }
+  // )
+  const [vertical, horizontal] = state.devToolsPosition.split('-', 2)
+
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useClickOutside(menuRef, triggerRef, closeOnClickOutside, () => {
+    onClose?.()
+  })
+
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+
+  function closeMenu() {
+    setPanel((prev) => (prev === 'panel-selector' ? null : prev))
+    setTimeout(() => setSelectedIndex(-1), MENU_DURATION_MS)
+  }
+  const indicatorOffset = getIndicatorOffset(state)
+
+  const [indicatorVertical, indicatorHorizontal] = state.devToolsPosition.split(
+    '-',
+    2
+  )
+
+  const verticalOffset =
+    vertical === indicatorVertical && horizontal === indicatorHorizontal
+      ? indicatorOffset
+      : INDICATOR_PADDING
+
+  const positionStyle = {
+    [vertical]: `${verticalOffset}px`,
+    [horizontal]: `${INDICATOR_PADDING}px`,
+    [vertical === 'top' ? 'bottom' : 'top']: 'auto',
+    [horizontal === 'left' ? 'right' : 'left']: 'auto',
+  } as CSSProperties
+
+  return (
+    <div
+      ref={menuRef}
+      // what reef is this again
+      // ref={menuRef}
+      id="nextjs-dev-tools-menu"
+      role="menu"
+      dir="ltr"
+      aria-orientation="vertical"
+      aria-label="Next.js Dev Tools Items"
+      tabIndex={-1}
+      style={{
+        WebkitFontSmoothing: 'antialiased',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        background: 'var(--color-background-100)',
+        backgroundClip: 'padding-box',
+        boxShadow: 'var(--shadow-menu)',
+        borderRadius: 'var(--rounded-xl)',
+        position: 'fixed',
+        fontFamily: 'var(--font-stack-sans)',
+        zIndex: 3,
+        overflow: 'hidden',
+        opacity: 1,
+        // outline: 0,
+        minWidth: '248px',
+        transition:
+          'opacity var(--animate-out-duration-ms) var(--animate-out-timing-function)',
+        // scale: 1,
+        border: '1px solid var(--color-gray-200)',
+        ...positionStyle,
+      }}
+      // todo reimpl this
+      // onKeyDown={onMenuKeydown}
+      // data-rendered
+      // style={{
+      //   // this is probably totally broken, hold up
+      //   bottom: 'calc(100% + 8px)',
+      //   left: '8px', // maybe fixed now?
+
+      // }}
+      // style={{
+      //   border: '2px solid var(--color-gray-200)',
+      //   // fix calcs they are wrong
+      //   // position: 'absolute',
+      //   ...positionStyle,
+      //   // ...(vertical === 'bottom'
+      //   //   ? { bottom: 'calc(100% + 65px)' }
+      //   //   : { top: 'calc(100% + 20px)' }),
+      //   // ...(horizontal === 'left'
+      //   //   ? { left: '20px' }
+      //   //   : { right: '8px', left: 'auto' }),
+      // }}
+    >
+      {/* this provider should be higher in tree? eh maybe not */}
+      <MenuContext
+        value={{
+          closeMenu,
+          selectedIndex,
+          setSelectedIndex,
+        }}
+      >
+        <div style={{ padding: '6px', width: '100%' }}>
+          {/* how is this not distributed */}
+          {totalErrorCount > 0 && (
+            <MenuItem
+              title={`${totalErrorCount} ${totalErrorCount === 1 ? 'issue' : 'issues'} found. Click to view details in the dev overlay.`}
+              index={0}
+              label="Issues"
+              value={<IssueCount>{totalErrorCount}</IssueCount>}
+              onClick={function openErrorOverlay() {
+                // setOpen(null)
+                setPanel(null)
+                if (totalErrorCount > 0) {
+                  dispatch({
+                    type: ACTION_ERROR_OVERLAY_OPEN,
+                  })
+                }
+              }}
+            />
+          )}
+          <MenuItem
+            title={`Current route is ${state.staticIndicator ? 'static' : 'dynamic'}.`}
+            label="Route"
+            index={1}
+            value={state.staticIndicator ? 'Static' : 'Dynamic'}
+            onClick={
+              () => setPanel('route-info')
+
+              // setOpen(OVERLAYS.Route)
+            }
+            data-nextjs-route-type={
+              state.staticIndicator ? 'static' : 'dynamic'
+            }
+          />
+          {!!process.env.TURBOPACK ? (
+            <MenuItem
+              title="Turbopack is enabled."
+              label="Turbopack"
+              value="Enabled"
+            />
+          ) : (
+            <MenuItem
+              index={2}
+              title="Learn about Turbopack and how to enable it in your application."
+              label="Try Turbopack"
+              value={<ChevronRight />}
+              onClick={
+                () => setPanel('turbo-info')
+                // setOpen(OVERLAYS.Turbo)
+                // null
+                // todo dunno yet
+              }
+            />
+          )}
+          {/* todo: fix index */}
+             <MenuItem
+            data-segment-explorer
+            label="Route Info"
+            value={<ChevronRight />}
+            onClick={
+              () => setPanel('segment-explorer')
+              // setOpen(OVERLAYS.SegmentExplorer)
+            }
+            index={isTurbopack ? 3 : 4}
+          />
+        </div>
+
+        <div className="dev-tools-indicator-footer">
+          <MenuItem
+            data-preferences
+            label="Preferences"
+            value={<GearIcon />}
+            onClick={
+              () => setPanel('preferences')
+              // setOpen(OVERLAYS.Preferences)
+            }
+            index={isTurbopack ? 2 : 3}
+          />
+       
+          {/* {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER ? (
+           
+          ) : null} */}
+        </div>
+      </MenuContext>
+    </div>
+  )
+}
+
+function IssueCount({ children }: { children: number }) {
+  return (
+    <span
+      className="dev-tools-indicator-issue-count"
+      data-has-issues={children > 0}
+    >
+      <span className="dev-tools-indicator-issue-count-indicator" />
+      {children}
+    </span>
+  )
+}
+
+function ChevronRight() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+    >
+      <path
+        fill="#666"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M5.50011 1.93945L6.03044 2.46978L10.8537 7.293C11.2442 7.68353 11.2442 8.31669 10.8537 8.70722L6.03044 13.5304L5.50011 14.0608L4.43945 13.0001L4.96978 12.4698L9.43945 8.00011L4.96978 3.53044L4.43945 3.00011L5.50011 1.93945Z"
+      />
+    </svg>
+  )
+}
+
+// .dev-tools-indicator-menu {
+//   -webkit-font-smoothing: antialiased;
+//   display: flex;
+//   flex-direction: column;
+//   align-items: flex-start;
+//   background: var(--color-background-100);
+//   /* border: 1px solid var(--color-gray-alpha-400); */
+//   background-clip: padding-box;
+//   box-shadow: var(--shadow-menu);
+//   border-radius: var(--rounded-xl);
+//   /*  todo: may need to port this for the other indicator menu :( */
+//   position: fixed;
+//   font-family: var(--font-stack-sans);
+//   z-index: 3;
+//   overflow: hidden;
+//   opacity: 0;
+//   outline: 0;
+//   min-width: 248px;
+//   transition: opacity var(--animate-out-duration-ms)
+//     var(--animate-out-timing-function);
+
+//   &[data-rendered='true'] {
+//     opacity: 1;
+//     scale: 1;
+//   }
+// }
+
+// .dev-tools-indicator-inner {
+//   padding: 6px;
+//   width: 100%;
+// }
+// export const DEV_TOOLS_INDICATOR_STYLES_NEW = css`
+
+//   .dev-tools-indicator-item {
+//     display: flex;
+//     align-items: center;
+//     padding: 8px 6px;
+//     height: var(--size-36);
+//     border-radius: 6px;
+//     text-decoration: none !important;
+//     user-select: none;
+//     white-space: nowrap;
+
+//     svg {
+//       width: var(--size-16);
+//       height: var(--size-16);
+//     }
+
+//     &:focus-visible {
+//       outline: 0;
+//     }
+//   }
+
+//   .dev-tools-indicator-footer {
+//     background: var(--color-background-200);
+//     padding: 6px;
+//     border-top: 1px solid var(--color-gray-400);
+//     width: 100%;
+//   }
+
+//   .dev-tools-indicator-item[data-selected='true'] {
+//     cursor: pointer;
+//     background-color: var(--color-gray-200);
+//   }
+
+//   .dev-tools-indicator-label {
+//     font-size: var(--size-14);
+//     line-height: var(--size-20);
+//     color: var(--color-gray-1000);
+//   }
+
+//   .dev-tools-indicator-value {
+//     font-size: var(--size-14);
+//     line-height: var(--size-20);
+//     color: var(--color-gray-900);
+//     margin-left: auto;
+//   }
+
+//   .dev-tools-indicator-issue-count {
+//     --color-primary: var(--color-gray-800);
+//     --color-secondary: var(--color-gray-100);
+//     display: flex;
+//     flex-direction: row;
+//     align-items: center;
+//     justify-content: center;
+//     gap: 8px;
+//     min-width: var(--size-40);
+//     height: var(--size-24);
+//     background: var(--color-background-100);
+//     border: 1px solid var(--color-gray-alpha-400);
+//     background-clip: padding-box;
+//     box-shadow: var(--shadow-small);
+//     padding: 2px;
+//     color: var(--color-gray-1000);
+//     border-radius: 128px;
+//     font-weight: 500;
+//     font-size: var(--size-13);
+//     font-variant-numeric: tabular-nums;
+
+//     &[data-has-issues='true'] {
+//       --color-primary: var(--color-red-800);
+//       --color-secondary: var(--color-red-100);
+//     }
+
+//     .dev-tools-indicator-issue-count-indicator {
+//       width: var(--size-8);
+//       height: var(--size-8);
+//       background: var(--color-primary);
+//       box-shadow: 0 0 0 2px var(--color-secondary);
+//       border-radius: 50%;
+//     }
+//   }
+
+//   .dev-tools-indicator-shortcut {
+//     display: flex;
+//     gap: 4px;
+
+//     kbd {
+//       width: var(--size-20);
+//       height: var(--size-20);
+//       display: flex;
+//       justify-content: center;
+//       align-items: center;
+//       border-radius: var(--rounded-md);
+//       border: 1px solid var(--color-gray-400);
+//       font-family: var(--font-stack-sans);
+//       background: var(--color-background-100);
+//       color: var(--color-gray-1000);
+//       text-align: center;
+//       font-size: var(--size-12);
+//       line-height: var(--size-16);
+//     }
+//   }
+
+//   .dev-tools-grabbing {
+//     cursor: grabbing;
+
+//     > * {
+//       pointer-events: none;
+//     }
+//   }
+// `

--- a/packages/next/src/next-devtools/dev-overlay/menu/menu-item.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/menu-item.tsx
@@ -1,0 +1,60 @@
+import { useMenuContext } from './context'
+
+export function MenuItem({
+  index,
+  label,
+  value,
+  onClick,
+  href,
+  ...props
+}: {
+  index?: number
+  title?: string
+  label: string
+  value: React.ReactNode
+  href?: string
+  onClick?: () => void
+}) {
+  const isInteractive =
+    typeof onClick === 'function' || typeof href === 'string'
+  const { closeMenu, selectedIndex, setSelectedIndex } = useMenuContext()
+  const selected = selectedIndex === index
+
+  function click() {
+    if (isInteractive) {
+      onClick?.()
+      closeMenu()
+      if (href) {
+        window.open(href, '_blank', 'noopener, noreferrer')
+      }
+    }
+  }
+
+  return (
+    <div
+      className="dev-tools-indicator-item"
+      data-index={index}
+      data-selected={selected}
+      onClick={click}
+      // Needs `onMouseMove` instead of enter to work together
+      // with keyboard and mouse input
+      onMouseMove={() => {
+        if (isInteractive && index !== undefined && selectedIndex !== index) {
+          setSelectedIndex(index)
+        }
+      }}
+      onMouseLeave={() => setSelectedIndex(-1)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          click()
+        }
+      }}
+      role={isInteractive ? 'menuitem' : undefined}
+      tabIndex={selected ? 0 : -1}
+      {...props}
+    >
+      <span className="dev-tools-indicator-label">{label}</span>
+      <span className="dev-tools-indicator-value">{value}</span>
+    </div>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -1,0 +1,186 @@
+import { usePanelContext } from './context'
+import { DevtoolMenu } from './dev-overlay-menu'
+import { DevtoolPanelV2 } from '../panel/panel'
+import { SettingsTab } from '../components/devtools-panel/devtools-panel-tab/settings-tab'
+import { RouteInfoBody } from '../components/errors/dev-tools-indicator/dev-tools-info/route-info'
+import { PageSegmentTree } from '../components/overview/segment-explorer'
+import { TurbopackInfoBody } from '../components/errors/dev-tools-indicator/dev-tools-info/turbopack-info'
+import { DevToolsHeader } from '../components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header'
+import { useDelayedRender } from '../hooks/use-delayed-render'
+import {
+  MENU_CURVE,
+  MENU_DURATION_MS,
+} from '../components/errors/dev-tools-indicator/utils'
+import { useDevOverlayContext } from '../../dev-overlay.browser'
+// import { useDevOverlayContext } from '../dev-overlay.browser'
+
+function PanelRoute({
+  active,
+  children,
+}: {
+  active: boolean
+  children: React.ReactNode
+}) {
+  const { mounted, rendered } = useDelayedRender(active, {
+    enterDelay: 0,
+    exitDelay: MENU_DURATION_MS,
+  })
+
+  if (!mounted) return null
+
+  return (
+    <div
+      style={{
+        opacity: rendered ? 1 : 0,
+        transition: `opacity ${MENU_DURATION_MS}ms ${MENU_CURVE}`,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+// todo: use activity to manage state
+export const PanelRouter = () => {
+  const { panel, setPanel } = usePanelContext()
+  const { state } = useDevOverlayContext()
+
+  return (
+    <>
+      <PanelRoute active={panel === 'panel-selector'}>
+        <DevtoolMenu
+          onClose={() => {
+            setPanel(null)
+          }}
+        />
+      </PanelRoute>
+
+      <PanelRoute active={panel === 'preferences'}>
+        <DevtoolPanelV2
+          name="preferences"
+          // draggable={false}
+          // resizable={false}
+          // sizeConfig={{
+
+          //   kind: 'fixed',
+          //   height: 300,
+          //   width: 400,
+          // }}
+          sizeConfig={{
+            kind: 'resizable',
+            // todo till refactor for strings
+            maxHeight: 1500,
+            maxWidth: 1500,
+            minHeight: 200,
+            minWidth: 200,
+          }}
+          closeOnClickOutside
+          onClose={() => {
+            setPanel('panel-selector')
+          }}
+          header={
+            <DevToolsHeader
+              title="Preferences"
+              onBack={() => setPanel('panel-selector')}
+            />
+          }
+        >
+          <SettingsTab />
+        </DevtoolPanelV2>
+      </PanelRoute>
+
+      <PanelRoute active={panel === 'route-info'}>
+        <DevtoolPanelV2
+          // style={{
+          //   padding: '10px'
+          // }}
+          name="route-info"
+          // draggable={false}
+          // resizable={false}
+          // sizeConfig={{
+          //   kind: 'fixed',
+          //   height: 300,
+          //   width: 400,
+          // }}
+          sizeConfig={{
+            kind: 'resizable',
+            // todo till refactor for strings
+            maxHeight: 1500,
+            maxWidth: 1500,
+            minHeight: 200,
+            minWidth: 200,
+          }}
+          onClose={() => {
+            setPanel('panel-selector')
+          }}
+          closeOnClickOutside
+          // onClose={( ) =>}
+          header={
+            <DevToolsHeader
+              title={`${state.staticIndicator ? 'Static' : 'Dynamic'} Route`}
+              onBack={() => setPanel('panel-selector')}
+            />
+          }
+        >
+          <RouteInfoBody />
+        </DevtoolPanelV2>
+      </PanelRoute>
+
+      <PanelRoute active={panel === 'segment-explorer'}>
+        <DevtoolPanelV2
+          name="segment-explorer"
+          sizeConfig={{
+            kind: 'resizable',
+            // todo till refactor for strings
+            maxHeight: 1500,
+            maxWidth: 1500,
+            minHeight: 200,
+            minWidth: 200,
+          }}
+          header={
+            <DevToolsHeader
+              title="Segment Explorer"
+              onBack={() => setPanel('panel-selector')}
+            />
+          }
+        >
+          <PageSegmentTree />
+        </DevtoolPanelV2>
+      </PanelRoute>
+
+      <PanelRoute active={panel === 'turbo-info'}>
+        {/* todo dedupe all these names */}
+        <DevtoolPanelV2
+          name="turbo-info"
+          // sizeConfig={{
+          //   kind: 'fixed',
+          //   height: 400,
+          //   width: 500,
+          // }}
+          sizeConfig={{
+            kind: 'resizable',
+            // todo till refactor for strings
+            maxHeight: 1500,
+            maxWidth: 1500,
+            minHeight: 200,
+            minWidth: 200,
+          }}
+          // draggable={false}
+          onClose={() => {
+            setPanel('panel-selector')
+          }}
+          // resizable={false}
+          closeOnClickOutside
+          header={
+            <DevToolsHeader
+              title="Turbopack Info"
+              onBack={() => setPanel('panel-selector')}
+            />
+          }
+        >
+          <TurbopackInfoBody />
+        </DevtoolPanelV2>
+      </PanelRoute>
+    </>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/panel/panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/panel/panel.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import { useDevOverlayContext } from '../../dev-overlay.browser'
+import { ResizeProvider } from '../components/devtools-panel/resize/resize-provider'
+import { usePanelContext } from '../menu/context'
+import { Overlay } from '../components/overlay'
+import { INDICATOR_PADDING } from '../components/devtools-indicator/devtools-indicator'
+import { getIndicatorOffset } from '../utils/indicator-metrics'
+import { Draggable } from '../components/errors/dev-tools-indicator/draggable'
+import {
+  ACTION_DEVTOOLS_PANEL_POSITION,
+  ACTION_DEVTOOLS_POSITION,
+  STORAGE_KEY_PANEL_POSITION,
+  type Corners,
+} from '../shared'
+import { ResizeHandle } from '../components/devtools-panel/resize/resize-handle'
+import {
+  DragHandle,
+  DragProvider,
+} from '../components/errors/dev-tools-indicator/drag-context'
+import { useClickOutside } from '../components/errors/dev-tools-indicator/utils'
+
+export function DevtoolPanelV2({
+  header,
+  children,
+  draggable = true,
+  sizeConfig = {
+    kind: 'resizable',
+    minWidth: 400,
+    minHeight: 350,
+    maxWidth: 1000,
+    maxHeight: 1000,
+  },
+  name,
+  closeOnClickOutside = false,
+  onClose,
+  ...containerProps
+}: {
+  name: string
+  header: React.ReactNode
+  children: React.ReactNode
+  draggable?: boolean
+  // todo: allow strings we do this so stupid
+  sizeConfig?:
+    | {
+        kind: 'resizable'
+        minWidth: number
+        minHeight: number
+        maxWidth: number
+        maxHeight: number
+      }
+    | {
+        kind: 'fixed'
+        height: number
+        width: number
+      }
+  closeOnClickOutside?: boolean
+  onClose?: () => void
+} & React.HTMLProps<HTMLDivElement>) {
+  // might need this, we will see
+  const [prevIsErrorOverlayOpen, setPrevIsErrorOverlayOpen] = useState(false)
+
+  const { dispatch, state } = useDevOverlayContext()
+  // i don't know if this is even needed with this state
+  if (state.isErrorOverlayOpen !== prevIsErrorOverlayOpen) {
+    if (state.isErrorOverlayOpen) {
+      // We should always show the issues tab initially if we're
+      // programmatically opening the panel to highlight errors.
+    }
+    setPrevIsErrorOverlayOpen(state.isErrorOverlayOpen)
+  }
+  const storagePositionKey = `${STORAGE_KEY_PANEL_POSITION}-${name}`
+
+  const panelPosition: string = useMemo(() => {
+    if (typeof window !== 'undefined') {
+      return (
+        localStorage.getItem(storagePositionKey) ||
+        state.devToolsPanelPosition ||
+        state.devToolsPosition
+      )
+    }
+    return state.devToolsPosition
+  }, [storagePositionKey, state.devToolsPanelPosition, state.devToolsPosition])
+
+  const [vertical, horizontal] = panelPosition.split('-', 2)
+  const resizeRef = useRef<HTMLDivElement>(null)
+  const { triggerRef } = usePanelContext()
+
+  useClickOutside(resizeRef, triggerRef, closeOnClickOutside, () => {
+    onClose?.()
+  })
+
+  const indicatorOffset = getIndicatorOffset(state)
+
+  const [indicatorVertical, indicatorHorizontal] = state.devToolsPosition.split(
+    '-',
+    2
+  )
+
+  const verticalOffset =
+    vertical === indicatorVertical && horizontal === indicatorHorizontal
+      ? indicatorOffset
+      : INDICATOR_PADDING
+
+  const positionStyle = {
+    [vertical]: `${verticalOffset}px`,
+    [horizontal]: `${INDICATOR_PADDING}px`,
+    [vertical === 'top' ? 'bottom' : 'top']: 'auto',
+    [horizontal === 'left' ? 'right' : 'left']: 'auto',
+  } as CSSProperties
+
+  const isResizable = sizeConfig.kind === 'resizable'
+  const minWidth = isResizable ? sizeConfig.minWidth : undefined
+  const minHeight = isResizable ? sizeConfig.minHeight : undefined
+  const maxWidth = isResizable ? sizeConfig.maxWidth : undefined
+  const maxHeight = isResizable ? sizeConfig.maxHeight : undefined
+
+  const fixedWidth = !isResizable ? sizeConfig.width : undefined
+  const fixedHeight = !isResizable ? sizeConfig.height : undefined
+
+  const resizeStorageKey = `${name}-panel-resize`
+
+  const { storedWidth, storedHeight } = useMemo(() => {
+    if (typeof window === 'undefined')
+      return { storedWidth: undefined, storedHeight: undefined }
+    try {
+      const stored = JSON.parse(
+        window.localStorage.getItem(resizeStorageKey) || 'null'
+      ) as { width?: number; height?: number } | null
+      return {
+        storedWidth: stored?.width,
+        storedHeight: stored?.height,
+      }
+    } catch {
+      return { storedWidth: undefined, storedHeight: undefined }
+    }
+  }, [resizeStorageKey])
+
+  return (
+    <ResizeProvider
+      value={{
+        resizeRef,
+
+        minWidth,
+        minHeight,
+        devToolsPosition: state.devToolsPosition,
+        storageKey: resizeStorageKey,
+      }}
+    >
+      <div
+        ref={resizeRef}
+        data-nextjs-devtools-panel-overlay
+        // data-nextjs-dialog-overlay
+
+        data-gaga
+        style={{
+          position: 'fixed',
+          // top: 0,
+          // right: 0,
+          // bottom: 0,
+          // left: 0,
+          zIndex: 2147483646,
+          // display: 'flex',
+          // alignContent: 'center',
+          // alignItems: 'center',
+          // padding: 'initial',
+          // top: '10vh',
+          // flexDirection: 'column',
+          // padding: '10vh 15px 0',
+          ...positionStyle,
+          ...(isResizable
+            ? {
+                minWidth,
+                minHeight,
+                maxWidth,
+                maxHeight,
+                width: storedWidth ? `${storedWidth}px` : undefined,
+                height: storedHeight ? `${storedHeight}px` : undefined,
+              }
+            : {
+                height: storedHeight ? `${storedHeight}px` : fixedHeight,
+                width: storedWidth
+                  ? `${storedWidth}px`
+                  : fixedWidth !== undefined
+                    ? fixedWidth
+                    : '100%',
+              }),
+        }}
+      >
+        <DragProvider disabled={!draggable}>
+          <Draggable
+            avoidZone={{
+              corner: state.devToolsPosition,
+              square: 36 / state.scale,
+              padding: INDICATOR_PADDING,
+            }}
+            data-nextjs-devtools-panel-draggable
+            padding={INDICATOR_PADDING}
+            onDragStart={() => {}}
+            position={panelPosition as Corners}
+            setPosition={(p) => {
+              localStorage.setItem(storagePositionKey, p)
+              dispatch({
+                type: ACTION_DEVTOOLS_PANEL_POSITION,
+                devToolsPanelPosition: p,
+              })
+            }}
+            // dragHandleSelector="[data-nextjs-devtools-panel-header], [data-nextjs-devtools-panel-footer], [data-nextjs-devtools-panel-draggable]"
+            style={{
+              overflow: 'auto',
+            }}
+            disableDrag={!draggable}
+          >
+            <>
+              <div
+                {...containerProps}
+                style={{
+                  position: 'relative',
+                  width: '100%',
+                  height: '100%',
+                  border: '1px solid var(--color-gray-200)',
+                  borderRadius: 'var(--rounded-xl)',
+                  background: 'var(--color-background-200)',
+                  overflow: 'auto',
+                  ...containerProps.style,
+                }}
+              >
+                <DragHandle>{header}</DragHandle>
+                {children}
+              </div>
+              {isResizable && (
+                <>
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="top"
+                  />
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="right"
+                  />
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="bottom"
+                  />
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="left"
+                  />
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="top-left"
+                  />
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="top-right"
+                  />
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="bottom-left"
+                  />
+                  <ResizeHandle
+                    position={state.devToolsPanelPosition}
+                    direction="bottom-right"
+                  />
+                </>
+              )}
+            </>
+          </Draggable>
+        </DragProvider>
+      </div>
+    </ResizeProvider>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
@@ -97,6 +97,7 @@ function createTrie<Value = string>({
   function remove(value: Value) {
     let currentNode = root
     const segments = getCharacters(value)
+
     const stack: TrieNode<Value>[] = []
     let found = true
     for (const segment of segments) {

--- a/packages/next/src/next-devtools/dev-overlay/storybook/DevOverlayStoryWrapper.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/storybook/DevOverlayStoryWrapper.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import { DevOverlay } from '../dev-overlay'
+import { DevOverlayContext } from '../../dev-overlay.browser'
+import { RenderErrorContext } from '../dev-overlay'
+import { PanelContext, type PanelStateKind } from '../menu/context'
+import {
+  useStorybookOverlayReducer,
+  storybookDefaultOverlayState,
+} from './use-overlay-reducer'
+import type { OverlayState } from '../shared'
+import type { ReadyRuntimeError } from '../utils/get-error-by-type'
+import type { Overlays } from '../components/errors/dev-tools-indicator/dev-tools-indicator'
+
+type WrapperProps = {
+  initialState?: Partial<OverlayState>
+  runtimeErrors?: ReadyRuntimeError[]
+  children?: never
+}
+
+export function DevOverlayStoryWrapper({
+  initialState,
+  runtimeErrors = [],
+}: WrapperProps) {
+  const mergedState: OverlayState = {
+    ...storybookDefaultOverlayState,
+    ...initialState,
+  } as OverlayState
+
+  const [state, dispatch] = useStorybookOverlayReducer(mergedState)
+  const [panel, setPanel] = useState<null | PanelStateKind>(null)
+  const [open, setOpen] = useState<null | Overlays>(null)
+
+  const totalErrorCount = runtimeErrors.length
+
+  return (
+    <DevOverlayContext
+      value={{ state, dispatch, getSquashedHydrationErrorDetails: () => null }}
+    >
+      <PanelContext value={{ panel, setPanel, open, setOpen }}>
+        <RenderErrorContext value={{ runtimeErrors, totalErrorCount }}>
+          <DevOverlay />
+        </RenderErrorContext>
+      </PanelContext>
+    </DevOverlayContext>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/storybook/use-overlay-reducer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/storybook/use-overlay-reducer.ts
@@ -3,6 +3,7 @@ import type { DispatcherEvent, OverlayState } from '../shared'
 import { useReducer } from 'react'
 import {
   ACTION_DEVTOOLS_POSITION,
+  ACTION_DEVTOOLS_PANEL_POSITION,
   ACTION_DEVTOOLS_PANEL_CLOSE,
   ACTION_DEVTOOLS_PANEL_TOGGLE,
   ACTION_ERROR_OVERLAY_CLOSE,
@@ -48,6 +49,10 @@ export function useStorybookOverlayReducer(initialState?: OverlayState) {
         }
         case ACTION_DEVTOOLS_POSITION: {
           return { ...state, devToolsPosition: action.devToolsPosition }
+        }
+        // todo remove
+        case ACTION_DEVTOOLS_PANEL_POSITION: {
+          return { ...state, devToolsPanelPosition: action.devToolsPanelPosition }
         }
         case ACTION_DEVTOOLS_SCALE: {
           return { ...state, scale: action.scale }

--- a/packages/next/src/next-devtools/dev-overlay/utils/indicator-metrics.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/indicator-metrics.ts
@@ -1,0 +1,13 @@
+import { INDICATOR_PADDING } from '../components/devtools-indicator/devtools-indicator'
+import type { OverlayState } from '../shared'
+
+const BASE_LOGO_SIZE = 36
+const INDICATOR_GAP = 9
+
+export function getIndicatorSquare(state: OverlayState): number {
+  return BASE_LOGO_SIZE / state.scale
+}
+
+export function getIndicatorOffset(state: OverlayState): number {
+  return INDICATOR_PADDING + getIndicatorSquare(state) + INDICATOR_GAP
+}

--- a/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
+++ b/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
@@ -31,15 +31,14 @@ function SegmentTrieNode({
   pagePath: string
 }): React.ReactNode {
   const { boundaryType, setBoundaryType } = useSegmentState()
-  const nodeState: SegmentNodeState = useMemo(
-    () => ({
+  const nodeState: SegmentNodeState = useMemo(() => {
+    return {
       type,
       pagePath,
       boundaryType,
       setBoundaryType,
-    }),
-    [type, pagePath, boundaryType, setBoundaryType]
-  )
+    }
+  }, [type, pagePath, boundaryType, setBoundaryType])
 
   // Use `useLayoutEffect` to ensure the state is updated during suspense.
   // `useEffect` won't work as the state is preserved during suspense.
@@ -143,7 +142,10 @@ export function SegmentStateProvider({ children }: { children: ReactNode }) {
   return (
     <SegmentStateContext.Provider
       key={errorBoundaryKey}
-      value={{ boundaryType, setBoundaryType: setBoundaryTypeAndReload }}
+      value={{
+        boundaryType,
+        setBoundaryType: setBoundaryTypeAndReload,
+      }}
     >
       {children}
     </SegmentStateContext.Provider>

--- a/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
+++ b/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
@@ -76,6 +76,19 @@ export function SegmentViewStateNode({ page }: { page: string }) {
   return null
 }
 
+export function SegmentBoundaryTriggerNode() {
+  const { boundaryType } = useSegmentState()
+  let segmentNode: React.ReactNode = null
+  if (boundaryType === 'loading') {
+    segmentNode = <LoadingSegmentNode />
+  } else if (boundaryType === 'not-found') {
+    segmentNode = <NotFoundSegmentNode />
+  } else if (boundaryType === 'error') {
+    segmentNode = <ErrorSegmentNode />
+  }
+  return segmentNode
+}
+
 export function SegmentViewNode({
   type,
   pagePath,
@@ -85,22 +98,9 @@ export function SegmentViewNode({
   pagePath: string
   children?: ReactNode
 }): React.ReactNode {
-  const { boundaryType } = useSegmentState()
-
-  const isChildBoundary = type !== 'layout' && type !== 'template'
-
-  let segmentNode = (
+  const segmentNode = (
     <SegmentTrieNode key={type} type={type} pagePath={pagePath} />
   )
-  if (boundaryType && boundaryType !== type && isChildBoundary) {
-    if (boundaryType === 'loading') {
-      segmentNode = <LoadingSegmentNode />
-    } else if (boundaryType === 'not-found') {
-      segmentNode = <NotFoundSegmentNode />
-    } else if (boundaryType === 'error') {
-      segmentNode = <ErrorSegmentNode />
-    }
-  }
 
   return (
     <>

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -26,7 +26,11 @@ import type {
   UseCachePageComponentProps,
 } from '../use-cache/use-cache-wrapper'
 import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
-import { getConventionPathByType } from './segment-explorer-path'
+import {
+  BOUNDARY_PREFIX,
+  BOUNDARY_SUFFIX,
+  getConventionPathByType,
+} from './segment-explorer-path'
 
 /**
  * Use the provided loader tree to create the React Component tree.
@@ -562,24 +566,24 @@ async function createComponentTreeInternal({
         // Add a suffix to avoid conflict with the segment view node representing rendered file.
         // existence: not-found.tsx@boundary
         // rendered: not-found.tsx
-        const fileNameSuffix = '@boundary'
+        const fileNameSuffix = BOUNDARY_SUFFIX
         const segmentViewBoundaries = isSegmentViewEnabled ? (
           <>
             {notFoundFilePath && (
               <SegmentViewNode
-                type={'boundary:not-found'}
+                type={`${BOUNDARY_PREFIX}not-found`}
                 pagePath={notFoundFilePath + fileNameSuffix}
               />
             )}
             {loadingFilePath && (
               <SegmentViewNode
-                type={'boundary:loading'}
+                type={`${BOUNDARY_PREFIX}loading`}
                 pagePath={loadingFilePath + fileNameSuffix}
               />
             )}
             {errorFilePath && (
               <SegmentViewNode
-                type={'boundary:error'}
+                type={`${BOUNDARY_PREFIX}error`}
                 pagePath={errorFilePath + fileNameSuffix}
               />
             )}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -410,15 +410,16 @@ async function createComponentTreeInternal({
     <MetadataOutlet ready={getMetadataReady} />
   )
 
-  const notFoundElement = await createBoundaryConventionElement({
-    ctx,
-    conventionName: 'not-found',
-    Component: NotFound,
-    styles: notFoundStyles,
-    tree,
-  })
+  const [notFoundElement, notFoundFilePath] =
+    await createBoundaryConventionElement({
+      ctx,
+      conventionName: 'not-found',
+      Component: NotFound,
+      styles: notFoundStyles,
+      tree,
+    })
 
-  const forbiddenElement = await createBoundaryConventionElement({
+  const [forbiddenElement] = await createBoundaryConventionElement({
     ctx,
     conventionName: 'forbidden',
     Component: Forbidden,
@@ -426,7 +427,7 @@ async function createComponentTreeInternal({
     tree,
   })
 
-  const unauthorizedElement = await createBoundaryConventionElement({
+  const [unauthorizedElement] = await createBoundaryConventionElement({
     ctx,
     conventionName: 'unauthorized',
     Component: Unauthorized,
@@ -546,8 +547,8 @@ async function createComponentTreeInternal({
         )
 
         const templateFilePath = getConventionPathByType(tree, dir, 'template')
-
         const errorFilePath = getConventionPathByType(tree, dir, 'error')
+        const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
 
         const wrappedErrorStyles =
           isSegmentViewEnabled && errorFilePath ? (
@@ -557,6 +558,34 @@ async function createComponentTreeInternal({
           ) : (
             errorStyles
           )
+
+        // Add a suffix to avoid conflict with the segment view node representing rendered file.
+        // existence: not-found.tsx@boundary
+        // rendered: not-found.tsx
+        const fileNameSuffix = '@boundary'
+        const segmentViewBoundaries = isSegmentViewEnabled ? (
+          <>
+            {notFoundFilePath && (
+              <SegmentViewNode
+                type={'boundary:not-found'}
+                pagePath={notFoundFilePath + fileNameSuffix}
+              />
+            )}
+            {loadingFilePath && (
+              <SegmentViewNode
+                type={'boundary:loading'}
+                pagePath={loadingFilePath + fileNameSuffix}
+              />
+            )}
+            {errorFilePath && (
+              <SegmentViewNode
+                type={'boundary:error'}
+                pagePath={errorFilePath + fileNameSuffix}
+              />
+            )}
+            {/* do not surface forbidden and unauthorized boundaries yet as they're unstable */}
+          </>
+        ) : null
 
         return [
           parallelRouteKey,
@@ -581,6 +610,7 @@ async function createComponentTreeInternal({
             notFound={notFoundComponent}
             forbidden={forbiddenComponent}
             unauthorized={unauthorizedComponent}
+            {...(isSegmentViewEnabled && { segmentViewBoundaries })}
             // Since gracefullyDegrade only applies to bots, only
             // pass it when we're in a bot context to avoid extra bytes.
             {...(gracefullyDegrade && { gracefullyDegrade })}
@@ -603,8 +633,8 @@ async function createComponentTreeInternal({
   }
 
   let loadingElement = Loading ? <Loading key="l" /> : null
+  const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
   if (isSegmentViewEnabled && loadingElement) {
-    const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
     if (loadingFilePath) {
       loadingElement = (
         <SegmentViewNode
@@ -1098,12 +1128,14 @@ async function createBoundaryConventionElement({
     </>
   ) : undefined
 
+  const pagePath = getConventionPathByType(tree, dir, conventionName)
+
   const wrappedElement =
     isSegmentViewEnabled && element ? (
       <SegmentViewNode
         key={cacheNodeKey + '-' + conventionName}
         type={conventionName}
-        pagePath={getConventionPathByType(tree, dir, conventionName)!}
+        pagePath={pagePath!}
       >
         {element}
       </SegmentViewNode>
@@ -1111,5 +1143,5 @@ async function createBoundaryConventionElement({
       element
     )
 
-  return wrappedElement
+  return [wrappedElement, pagePath] as const
 }

--- a/packages/next/src/server/app-render/segment-explorer-path.ts
+++ b/packages/next/src/server/app-render/segment-explorer-path.ts
@@ -30,10 +30,16 @@ export function normalizeConventionFilePath(
   return relativePath
 }
 
+export const BOUNDARY_SUFFIX = '@boundary'
 export function normalizeBoundaryFilename(filename: string) {
   return filename
     .replace(new RegExp(`^${BUILTIN_PREFIX}`), '')
-    .replace(/@boundary$/, '')
+    .replace(new RegExp(`${BOUNDARY_SUFFIX}$`), '')
+}
+
+export const BOUNDARY_PREFIX = 'boundary:'
+export function isBoundaryFile(fileType: string) {
+  return fileType.startsWith(BOUNDARY_PREFIX)
 }
 
 export function getConventionPathByType(

--- a/packages/next/src/server/app-render/segment-explorer-path.ts
+++ b/packages/next/src/server/app-render/segment-explorer-path.ts
@@ -1,5 +1,7 @@
 import type { LoaderTree } from '../lib/app-dir-module'
 
+export const BUILTIN_PREFIX = '__next_builtin__'
+
 export function normalizeConventionFilePath(
   projectDir: string,
   conventionPath: string | undefined
@@ -22,10 +24,16 @@ export function normalizeConventionFilePath(
   if (nextInternalPrefixRegex.test(relativePath)) {
     relativePath = relativePath.replace(nextInternalPrefixRegex, '')
     // Add a special prefix to let segment explorer know it's a built-in component
-    relativePath = `__next_builtin__${relativePath}`
+    relativePath = `${BUILTIN_PREFIX}${relativePath}`
   }
 
   return relativePath
+}
+
+export function normalizeBoundaryFilename(filename: string) {
+  return filename
+    .replace(new RegExp(`^${BUILTIN_PREFIX}`), '')
+    .replace(/@boundary$/, '')
 }
 
 export function getConventionPathByType(

--- a/test/development/app-dir/segment-explorer/app/parallel-routes/@bar/error.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes/@bar/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <div>Error @bar</div>
+}

--- a/test/development/app-dir/segment-explorer/app/parallel-routes/@foo/not-found.tsx
+++ b/test/development/app-dir/segment-explorer/app/parallel-routes/@foo/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>Not Found @foo</div>
+}

--- a/test/development/app-dir/segment-explorer/app/vercel/framework/blog/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/vercel/framework/blog/layout.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <h2>Layout - /vercel/framework/blog</h2>
+      {children}
+      <Link href="/vercel/framework">To /vercel/framework</Link>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/vercel/framework/blog/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/vercel/framework/blog/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Page - /vercel/framework/blog</div>
+}

--- a/test/development/app-dir/segment-explorer/app/vercel/framework/layout.tsx
+++ b/test/development/app-dir/segment-explorer/app/vercel/framework/layout.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <h1>Layout - /vercel/framework</h1>
+      {children}
+      <Link href="/vercel">To /vercel</Link>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-explorer/app/vercel/not-found.tsx
+++ b/test/development/app-dir/segment-explorer/app/vercel/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>Not Found - /vercel</div>
+}

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -28,15 +28,16 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      parallel-routes/
      layout.tsx
      page.tsx
      @bar/
      layout.tsx
-     page.tsx
+     boundary
      @foo/
      layout.tsx
-     page.tsx"
+     boundary"
     `)
   })
 
@@ -45,6 +46,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      parallel-routes-edge/
      layout.tsx
      page.tsx
@@ -62,6 +64,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      (v2)/
      layout.tsx
      blog / (team)/
@@ -79,6 +82,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      soft-navigation / a/
      page.tsx"
     `)
@@ -91,6 +95,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      soft-navigation / b/
      page.tsx"
     `)
@@ -101,6 +106,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      (all) / file-segments/
      layout.tsx
      template.tsx
@@ -137,27 +143,32 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      boundary/
      layout.tsx
-     not-found.tsx"
+     boundary"
     `)
 
     await browser.loadPage(`${next.url}/boundary?name=forbidden`)
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      boundary/
      layout.tsx
-     forbidden.tsx"
+     forbidden.tsx
+     boundary"
     `)
 
     await browser.loadPage(`${next.url}/boundary?name=unauthorized`)
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      boundary/
      layout.tsx
-     unauthorized.tsx"
+     unauthorized.tsx
+     boundary"
     `)
   })
 
@@ -174,9 +185,10 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      search/
      layout.tsx
-     loading.tsx"
+     boundary"
     `)
   })
 
@@ -185,8 +197,9 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      runtime-error / boundary/
-     error.tsx"
+     boundary"
     `)
   })
 
@@ -195,6 +208,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
      "app/
      layout.tsx
+     boundary
      parallel-default/
      layout.tsx
      default.tsx


### PR DESCRIPTION
Todos:
- bug causing drag animation target location and calculated panel position to be off by a few px, causing a snap on animation end
- how to deal with a panel thats moved to a corner, and then closed
  - jaring since the menu to select a new panel is in a different corner
- minor ui stuff styling not transferred over in refactor
- some accessibility not transferred over in refactor
- determine if we should sync panel position across reload right now, or save of the future
- missing a couple panel wrappers for a couple menu items
- update segment explorer to be compatible with detachable panel UI
- polish on UI defaults
- transition when panel recalculates static position based on the logo being dragged to a new corner
- update stories that were configurable via props with new storybook wrapper to be compatible with context 