### PR TITLE
Turbopack: alias to `next/dist/api/*` in import map

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -399,6 +399,8 @@ pub async fn get_next_edge_import_map(
         ),
     );
 
+    insert_pages_api_aliases(&mut import_map, project_path.clone());
+
     insert_next_shared_aliases(
         &mut import_map,
         project_path.clone(),


### PR DESCRIPTION
In SSR/Browser App Router contexts, importing `next/dynamic` wasn't aliased to `next/dist/api/navigation` with Turbopack.
