### PR TITLE
Turbopack: Panic on infinite recursion instead of hanging 

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1113,6 +1113,7 @@ impl AggregationUpdateQueue {
                     let upper_ids = get_uppers(&upper);
 
                     // Add the same amount of follower edges
+                    assert!(upper_id != task_id, "Circular dependency");
                     if update_count!(upper, Follower { task: task_id }, count) {
                         // May optimize the task
                         if count!(upper, Follower).is_power_of_two() {
@@ -1618,6 +1619,7 @@ impl AggregationUpdateQueue {
                 && upper_aggregation_number <= follower_aggregation_number
             {
                 // It's a follower of the upper node
+                assert!(upper_id != new_follower_id, "Circular dependency");
                 if update_count!(
                     upper,
                     Follower {
@@ -1671,6 +1673,7 @@ impl AggregationUpdateQueue {
             let mut uppers_count: Option<usize> = None;
             let mut persistent_uppers = 0;
             swap_retain(&mut upper_ids, |&mut upper_id| {
+                assert!(upper_id != new_follower_id, "Circular dependency");
                 if update_count!(follower, Upper { task: upper_id }, 1) {
                     // It's a new upper
                     let uppers_count = uppers_count.get_or_insert_with(|| {
@@ -1822,6 +1825,7 @@ impl AggregationUpdateQueue {
                             return true;
                         }
                         // It's a follower of the upper node
+                        assert!(upper_id != *follower_id, "Circular dependency");
                         if update_count!(upper, Follower { task: *follower_id }, 1) {
                             // May optimize the task
                             if count!(upper, Follower).is_power_of_two() {
@@ -1864,6 +1868,7 @@ impl AggregationUpdateQueue {
                         // For performance reasons this should stay `Meta` and not `All`
                         TaskDataCategory::Meta,
                     );
+                    assert!(upper_id != inner_id, "Circular dependency");
                     if update_count!(inner, Upper { task: upper_id }, 1) {
                         if count!(inner, Upper).is_power_of_two() {
                             self.push_optimize_task(inner_id);
@@ -2024,6 +2029,7 @@ impl AggregationUpdateQueue {
             let _span = trace_span!("new follower").entered();
 
             // It's a follower of the upper node
+            assert!(upper_id != new_follower_id, "Circular dependency");
             if update_count!(
                 upper,
                 Follower {
@@ -2077,6 +2083,7 @@ impl AggregationUpdateQueue {
                 // For performance reasons this should stay `Meta` and not `All`
                 TaskDataCategory::Meta,
             );
+            assert!(upper_id != new_follower_id, "Circular dependency");
             if update_count!(inner, Upper { task: upper_id }, 1) {
                 if count!(inner, Upper).is_power_of_two() {
                     self.push_optimize_task(new_follower_id);
@@ -2258,6 +2265,7 @@ impl AggregationUpdateQueue {
                 // followers
                 let children: Vec<_> = get_many!(task, Child { task } => task);
                 for child_id in children {
+                    assert!(task_id != child_id, "Circular dependency");
                     task.add_new(CachedDataItem::Follower {
                         task: child_id,
                         value: 1,


### PR DESCRIPTION
### What?

Panic when there is a cycle in the call graph (infinite recursion).

We maybe could create a better error message that includes the task names of the cycle by walking the `children` of the task and finding the cycle. That's a task for the next person running into a cycle.