### PR TITLE
Turbopack: more efficient hanging detection implementation when not enabled

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1219,7 +1219,7 @@ impl AggregationUpdateQueue {
             None
         };
         if let Some(reason) = should_schedule {
-            let description = ctx.get_task_desc_fn(task_id);
+            let description = ctx.get_task_event_note(task_id);
             if task.add(CachedDataItem::new_scheduled(reason, description)) {
                 ctx.schedule(task_id);
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -27,7 +27,7 @@ impl ConnectChildOperation {
         if !ctx.should_track_children() {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
             if !task.has_key(&CachedDataItemKey::Output {}) {
-                let description = ctx.get_task_desc_fn(child_task_id);
+                let description = ctx.get_task_event_note(child_task_id);
                 let should_schedule = task.add(CachedDataItem::new_scheduled(
                     TaskExecutionReason::Connect,
                     description,
@@ -80,7 +80,7 @@ impl ConnectChildOperation {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
 
             if !task.has_key(&CachedDataItemKey::Output {}) {
-                let description = ctx.get_task_desc_fn(child_task_id);
+                let description = ctx.get_task_event_note(child_task_id);
                 let should_schedule = task.add(CachedDataItem::new_scheduled(
                     TaskExecutionReason::Connect,
                     description,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -296,7 +296,7 @@ pub fn make_task_dirty_internal(
     };
 
     if should_schedule {
-        let description = ctx.get_task_desc_fn(task_id);
+        let description = ctx.get_task_event_note(task_id);
         if task.add(CachedDataItem::new_scheduled(
             TaskExecutionReason::Invalidated,
             description,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -60,7 +60,7 @@ pub trait ExecuteContext<'e>: Sized {
     where
         T: Clone + Into<AnyOperation>;
     fn suspending_requested(&self) -> bool;
-    fn get_task_desc_fn(&self, task_id: TaskId) -> impl Fn() -> String + Send + Sync + 'static;
+    fn get_task_event_note(&self, task_id: TaskId) -> impl Fn() -> String + Send + Sync + 'static;
     fn get_task_description(&self, task_id: TaskId) -> String;
     fn should_track_children(&self) -> bool;
     fn should_track_dependencies(&self) -> bool;
@@ -260,8 +260,8 @@ where
         self.backend.suspending_requested()
     }
 
-    fn get_task_desc_fn(&self, task_id: TaskId) -> impl Fn() -> String + Send + Sync + 'static {
-        self.backend.get_task_desc_fn(task_id)
+    fn get_task_event_note(&self, task_id: TaskId) -> impl Fn() -> String + Send + Sync + 'static {
+        self.backend.get_task_event_note(task_id)
     }
 
     fn get_task_description(&self, task_id: TaskId) -> String {

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     TypedSharedReference, ValueTypeId,
     backend::TurboTasksExecutionError,
     event::{Event, EventListener},
-    registry,
+    listen_event, new_event, registry,
 };
 
 use crate::{
@@ -89,12 +89,14 @@ pub struct ActivenessState {
 }
 
 impl ActivenessState {
-    pub fn new(id: TaskId) -> Self {
+    pub fn new(_id: TaskId) -> Self {
         Self {
             active_counter: 0,
             root_ty: None,
             active_until_clean: false,
-            all_clean_event: Event::new(move || format!("ActivenessState::all_clean_event {id:?}")),
+            all_clean_event: new_event!(move || format!(
+                "ActivenessState::all_clean_event {_id:?}"
+            )),
         }
     }
 
@@ -534,9 +536,9 @@ transient_traits!(InProgressCellState);
 impl Eq for InProgressCellState {}
 
 impl InProgressCellState {
-    pub fn new(task_id: TaskId, cell: CellId) -> Self {
+    pub fn new(_task_id: TaskId, _cell: CellId) -> Self {
         InProgressCellState {
-            event: Event::new(move || format!("InProgressCellState::event ({task_id} {cell:?})")),
+            event: new_event!(move || format!("InProgressCellState::event ({_task_id} {_cell:?})")),
         }
     }
 }
@@ -725,11 +727,11 @@ impl CachedDataItem {
 
     pub fn new_scheduled(
         reason: TaskExecutionReason,
-        description: impl Fn() -> String + Sync + Send + 'static,
+        _description: impl Fn() -> String + Sync + Send + 'static,
     ) -> Self {
         CachedDataItem::InProgress {
             value: InProgressState::Scheduled {
-                done_event: Event::new(move || format!("{} done_event", description())),
+                done_event: new_event!(move || format!("{} done_event", _description())),
                 reason,
             },
         }
@@ -737,11 +739,11 @@ impl CachedDataItem {
 
     pub fn new_scheduled_with_listener(
         reason: TaskExecutionReason,
-        description: impl Fn() -> String + Sync + Send + 'static,
-        note: impl Fn() -> String + Sync + Send + 'static,
+        _description: impl Fn() -> String + Sync + Send + 'static,
+        _note: impl Fn() -> String + Sync + Send + 'static,
     ) -> (Self, EventListener) {
-        let done_event = Event::new(move || format!("{} done_event", description()));
-        let listener = done_event.listen_with_note(note);
+        let done_event = new_event!(move || format!("{} done_event", _description()));
+        let listener = listen_event!(done_event, _note);
         (
             CachedDataItem::InProgress {
                 value: InProgressState::Scheduled { done_event, reason },

--- a/turbopack/crates/turbo-tasks-fs/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/benches/mod.rs
@@ -11,7 +11,7 @@ use criterion::{
 };
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::runtime::Runtime;
-use turbo_tasks::event::Event;
+use turbo_tasks::event::new_event;
 use turbo_tasks_fs::rope::{Rope, RopeBuilder};
 
 fn bench_file_watching(c: &mut Criterion) {
@@ -32,7 +32,7 @@ fn bench_file_watching(c: &mut Criterion) {
         BenchmarkId::new("bench_file_watching", "change file"),
         move |b| {
             let (tx, rx) = channel();
-            let event = Arc::new(Event::new(|| "test event".to_string()));
+            let event = Arc::new(new_event!(|| "test event".to_string()));
 
             let mut watcher = RecommendedWatcher::new(tx, Config::default()).unwrap();
             watcher.watch(temp_path, RecursiveMode::Recursive).unwrap();

--- a/turbopack/crates/turbo-tasks-fs/src/mutex_map.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/mutex_map.rs
@@ -3,7 +3,7 @@ use std::{collections::hash_map::Entry, hash::Hash, marker::PhantomData};
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use turbo_tasks::event::Event;
+use turbo_tasks::{event::Event, new_event};
 
 pub struct MutexMap<K> {
     map: Mutex<FxHashMap<K, Option<(Event, usize)>>>,
@@ -30,7 +30,7 @@ impl<'a, K: Eq + Hash + Clone> MutexMap<K> {
                             event.listen()
                         }
                         None => {
-                            let event = Event::new(|| "MutexMap".to_string());
+                            let event = new_event!(|| "MutexMap".to_string());
                             let listener = event.listen();
                             *state = Some((event, 0));
                             listener

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -20,6 +20,7 @@ use turbo_tasks::{
     backend::{CellContent, TaskCollectiblesMap, TypedCellContent},
     event::{Event, EventListener},
     message_queue::CompilationEvent,
+    new_event,
     test_helpers::with_turbo_tasks_for_testing,
     util::{SharedError, StaticOrArc},
 };
@@ -51,7 +52,7 @@ impl VcStorage {
         let i = {
             let mut tasks = self.tasks.lock().unwrap();
             let i = tasks.len();
-            tasks.push(Task::Spawned(Event::new(move || {
+            tasks.push(Task::Spawned(new_event!(move || {
                 format!("Task({i})::event")
             })));
             i

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -22,6 +22,7 @@ use crate::{
     emit,
     event::{Event, EventListener},
     manager::turbo_tasks_future_scope,
+    new_event,
     trace::TraceRawVcs,
     util::SharedError,
 };
@@ -85,7 +86,7 @@ impl EffectInstance {
                     EffectState::NotStarted(_) => {
                         let EffectState::NotStarted(inner) = std::mem::replace(
                             &mut *guard,
-                            EffectState::Started(Event::new(|| "Effect".to_string())),
+                            EffectState::Started(new_event!(|| "Effect".to_string())),
                         ) else {
                             unreachable!();
                         };

--- a/turbopack/crates/turbo-tasks/src/event.rs
+++ b/turbopack/crates/turbo-tasks/src/event.rs
@@ -211,28 +211,51 @@ pub fn no_note() -> String {
     String::new()
 }
 
+pub fn ignore_note(_note: impl Fn() -> String + Sync + Send + 'static) {
+    // This function must be removed by DCE.
+    // This code triggers a build error when it's not removed.
+    unsafe {
+        unsafe extern "C" {
+            fn trigger_link_error() -> !;
+        }
+        trigger_link_error();
+    }
+}
+
 #[cfg(not(feature = "hanging_detection"))]
 #[macro_export]
 macro_rules! listen_event {
-    ($self:expr, $note:expr) => {
+    ($self:expr, $note:expr) => {{
+        // This makes sure the code is checked, but not included in the final result.
+        if false {
+            $crate::event::ignore_note($note);
+        }
         $self.listen()
-    };
+    }};
 }
 
 #[cfg(not(feature = "hanging_detection"))]
 #[macro_export]
 macro_rules! new_event {
-    ($description:expr) => {
+    ($description:expr) => {{
+        // This makes sure the code is checked, but not included in the final result.
+        if false {
+            $crate::event::ignore_note($description);
+        }
         $crate::event::Event::new()
-    };
+    }};
 }
 
 #[cfg(not(feature = "hanging_detection"))]
 #[macro_export]
 macro_rules! event_note {
-    ($note:expr) => {
+    ($note:expr) => {{
+        // This makes sure the code is checked, but not included in the final result.
+        if false {
+            $crate::event::ignore_note($note);
+        }
         $crate::event::no_note
-    };
+    }};
 }
 
 #[cfg(feature = "hanging_detection")]


### PR DESCRIPTION
### What?

use macros to avoid constructing notes and descriptions when not enabled.
This also avoids looking up the task type for every task when hanging detection is not enabled.

Closes PACK-5047