### PR TITLE
[use-cache] track cache read earlier when encrypting bound args

### DIFF
--- a/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise-nested/page.tsx
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise-nested/page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { setTimeout } from 'timers/promises'
 
 async function getUncachedData() {
-  await setTimeout(100)
+  await setTimeout(0)
 
   return Math.random()
 }

--- a/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise/page.tsx
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/app/uncached-promise/page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { setTimeout } from 'timers/promises'
 
 async function fetchUncachedData() {
-  await setTimeout(100)
+  await setTimeout(0)
 
   return Math.random()
 }


### PR DESCRIPTION
bound args need to be encrypted for use cache functions and currently we track the read slightly later than will be necessary when we sync the latest React. This change moves the tracking to be as early as possible (as soon as the input signal is aborted or when the bound args are finished being serialized, whichever is first).