### PR TITLE
Check if target workflow is enabled before triggering front sync

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -187,8 +187,3 @@ jobs:
                 "Sync triggered with immediately-close=true due to test failure."
               );
             }
-      - name: Log workflow skip
-        if: steps.check-workflow-enabled.outputs.result != 'true'
-        run: |
-          echo "Skipping sync trigger because target workflow is not enabled"
-          echo "Target workflow state: ${{ steps.check-workflow-enabled.outputs.result }}"

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -25,95 +25,95 @@ env:
 run-name: test-e2e-deploy ${{ inputs.nextVersion || 'canary' }}
 
 jobs:
-  # setup:
-  #   runs-on: ubuntu-latest
-  #   if: github.repository_owner == 'vercel'
-  #   steps:
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ env.NODE_LTS_VERSION }}
-  #         check-latest: true
+  setup:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'vercel'
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          check-latest: true
 
-  #     - name: Setup pnpm
-  #       run: |
-  #         npm i -g corepack@0.31
-  #         corepack enable
+      - name: Setup pnpm
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
 
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 25
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 25
 
-  #     - name: Setup test project
-  #       run: |
-  #         pnpm install
-  #         pnpm run build
-  #         node scripts/run-e2e-test-project-reset.mjs
+      - name: Setup test project
+        run: |
+          pnpm install
+          pnpm run build
+          node scripts/run-e2e-test-project-reset.mjs
 
-  # test-deploy:
-  #   name: test deploy
-  #   needs: setup
-  #   uses: ./.github/workflows/build_reusable.yml
-  #   secrets: inherit
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
-  #   with:
-  #     afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
-  #     skipNativeBuild: 'yes'
-  #     skipNativeInstall: 'no'
-  #     stepName: 'test-deploy-${{ matrix.group }}'
-  #     timeout_minutes: 180
-  #     runs_on_labels: '["ubuntu-latest"]'
+  test-deploy:
+    name: test deploy
+    needs: setup
+    uses: ./.github/workflows/build_reusable.yml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
+    with:
+      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+      skipNativeBuild: 'yes'
+      skipNativeInstall: 'no'
+      stepName: 'test-deploy-${{ matrix.group }}'
+      timeout_minutes: 180
+      runs_on_labels: '["ubuntu-latest"]'
 
-  # report-test-results-to-datadog:
-  #   needs: test-deploy
-  #   if: ${{ always() }}
+  report-test-results-to-datadog:
+    needs: test-deploy
+    if: ${{ always() }}
 
-  #   runs-on: ubuntu-latest
-  #   name: report test results to datadog
-  #   steps:
-  #     - name: Download test report artifacts
-  #       id: download-test-reports
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         pattern: test-reports-*
-  #         path: test
-  #         merge-multiple: true
+    runs-on: ubuntu-latest
+    name: report test results to datadog
+    steps:
+      - name: Download test report artifacts
+        id: download-test-reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-reports-*
+          path: test
+          merge-multiple: true
 
-  #     - name: Upload test report to datadog
-  #       run: |
-  #         if [ -d ./test/test-junit-report ]; then
-  #           DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
-  #         fi
+      - name: Upload test report to datadog
+        run: |
+          if [ -d ./test/test-junit-report ]; then
+            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
+          fi
 
   front-sync:
-    # needs: test-deploy
-    # if: ${{ always() && github.repository_owner == 'vercel' && github.event_name == 'release' }}
+    needs: test-deploy
+    if: ${{ always() && github.repository_owner == 'vercel' && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v4
-      # - id: nextPackageInfo
-      #   name: Get `next` package info
-      #   run: |
-      #     cd packages/next
-      #     {
-      #       echo 'value<<EOF'
-      #       cat package.json
-      #       echo EOF
-      #     } >> "$GITHUB_OUTPUT"
-      # - id: version
-      #   name: Extract `next` version
-      #   run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
-      # - id: test-result
-      #   name: Set test result variable
-      #   run: echo 'immediately-close=${{ needs.test-deploy.result != 'success' && 'true' || 'false' }}' >> "$GITHUB_OUTPUT"
-      # - name: Check token
-      #   run: gh auth status
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+      - uses: actions/checkout@v4
+      - id: nextPackageInfo
+        name: Get `next` package info
+        run: |
+          cd packages/next 
+          {
+            echo 'value<<EOF'
+            cat package.json
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - id: version
+        name: Extract `next` version
+        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
+      - id: test-result
+        name: Set test result variable
+        run: echo 'immediately-close=${{ needs.test-deploy.result != 'success' && 'true' || 'false' }}' >> "$GITHUB_OUTPUT"
+      - name: Check token
+        run: gh auth status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
       - uses: actions/github-script@v7
         name: Check if target workflow is enabled
         id: check-workflow-enabled
@@ -142,51 +142,51 @@ jobs:
               console.error('Error checking workflow status:', error);
               return 'false';
             }
-      # - uses: actions/github-script@v7
-      #   name: Trigger vercel/front sync
-      #   id: trigger-front-sync
-      #   if: steps.check-workflow-enabled.outputs.result == 'true'
-      #   with:
-      #     retries: 3
-      #     retry-exempt-status-codes: 400,401,404
-      #     # Default github token cannot dispatch events to the remote repo, it should be
-      #     # a PAT with Actions write access (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
-      #     github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
-      #     # Note `workflow_id` and `inputs` are contract between vercel/front,
-      #     # if these need to be changed both side should be updated accordingly.
-      #     script: |
-      #       const immediatelyClose = '${{ steps.test-result.outputs.immediately-close }}';
-      #       const inputs = {
-      #         version: "${{ steps.version.outputs.value }}",
-      #       };
+      - uses: actions/github-script@v7
+        name: Trigger vercel/front sync
+        id: trigger-front-sync
+        if: steps.check-workflow-enabled.outputs.result == 'true'
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,404
+          # Default github token cannot dispatch events to the remote repo, it should be
+          # a PAT with Actions write access (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
+          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+          # Note `workflow_id` and `inputs` are contract between vercel/front,
+          # if these need to be changed both side should be updated accordingly.
+          script: |
+            const immediatelyClose = '${{ steps.test-result.outputs.immediately-close }}';
+            const inputs = {
+              version: "${{ steps.version.outputs.value }}",
+            };
 
-      #       if (immediatelyClose === 'true') {
-      #         inputs['immediately-close'] = 'true';
-      #       }
+            if (immediatelyClose === 'true') {
+              inputs['immediately-close'] = 'true';
+            }
 
-      #       await github.request(
-      #         "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
-      #         {
-      #           owner: "vercel",
-      #           repo: "front",
-      #           workflow_id: "cron-update-next.yml",
-      #           ref: "main",
-      #           inputs: inputs,
-      #         }
-      #       );
-      #       // Ideally we'd include a URL to this specific sync.
-      #       // However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
-      #       console.info(
-      #         "Sync started in https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch"
-      #       );
-      #       console.info(
-      #         "This may not start a new sync if one is already in progress. Check the logs of the cron-update-next Workflow run."
-      #       );
-      #       if (immediatelyClose === 'true') {
-      #         console.info(
-      #           "Sync triggered with immediately-close=true due to test failure."
-      #         );
-      #       }
+            await github.request(
+              "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+              {
+                owner: "vercel",
+                repo: "front",
+                workflow_id: "cron-update-next.yml",
+                ref: "main",
+                inputs: inputs,
+              }
+            );
+            // Ideally we'd include a URL to this specific sync.
+            // However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
+            console.info(
+              "Sync started in https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch"
+            );
+            console.info(
+              "This may not start a new sync if one is already in progress. Check the logs of the cron-update-next Workflow run."
+            );
+            if (immediatelyClose === 'true') {
+              console.info(
+                "Sync triggered with immediately-close=true due to test failure."
+              );
+            }
       - name: Log workflow skip
         if: steps.check-workflow-enabled.outputs.result != 'true'
         run: |

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -25,95 +25,95 @@ env:
 run-name: test-e2e-deploy ${{ inputs.nextVersion || 'canary' }}
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'vercel'
-    steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_LTS_VERSION }}
-          check-latest: true
+  # setup:
+  #   runs-on: ubuntu-latest
+  #   if: github.repository_owner == 'vercel'
+  #   steps:
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: ${{ env.NODE_LTS_VERSION }}
+  #         check-latest: true
 
-      - name: Setup pnpm
-        run: |
-          npm i -g corepack@0.31
-          corepack enable
+  #     - name: Setup pnpm
+  #       run: |
+  #         npm i -g corepack@0.31
+  #         corepack enable
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 25
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 25
 
-      - name: Setup test project
-        run: |
-          pnpm install
-          pnpm run build
-          node scripts/run-e2e-test-project-reset.mjs
+  #     - name: Setup test project
+  #       run: |
+  #         pnpm install
+  #         pnpm run build
+  #         node scripts/run-e2e-test-project-reset.mjs
 
-  test-deploy:
-    name: test deploy
-    needs: setup
-    uses: ./.github/workflows/build_reusable.yml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
-    with:
-      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
-      skipNativeBuild: 'yes'
-      skipNativeInstall: 'no'
-      stepName: 'test-deploy-${{ matrix.group }}'
-      timeout_minutes: 180
-      runs_on_labels: '["ubuntu-latest"]'
+  # test-deploy:
+  #   name: test deploy
+  #   needs: setup
+  #   uses: ./.github/workflows/build_reusable.yml
+  #   secrets: inherit
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
+  #   with:
+  #     afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+  #     skipNativeBuild: 'yes'
+  #     skipNativeInstall: 'no'
+  #     stepName: 'test-deploy-${{ matrix.group }}'
+  #     timeout_minutes: 180
+  #     runs_on_labels: '["ubuntu-latest"]'
 
-  report-test-results-to-datadog:
-    needs: test-deploy
-    if: ${{ always() }}
+  # report-test-results-to-datadog:
+  #   needs: test-deploy
+  #   if: ${{ always() }}
 
-    runs-on: ubuntu-latest
-    name: report test results to datadog
-    steps:
-      - name: Download test report artifacts
-        id: download-test-reports
-        uses: actions/download-artifact@v4
-        with:
-          pattern: test-reports-*
-          path: test
-          merge-multiple: true
+  #   runs-on: ubuntu-latest
+  #   name: report test results to datadog
+  #   steps:
+  #     - name: Download test report artifacts
+  #       id: download-test-reports
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: test-reports-*
+  #         path: test
+  #         merge-multiple: true
 
-      - name: Upload test report to datadog
-        run: |
-          if [ -d ./test/test-junit-report ]; then
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
-          fi
+  #     - name: Upload test report to datadog
+  #       run: |
+  #         if [ -d ./test/test-junit-report ]; then
+  #           DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
+  #         fi
 
   front-sync:
-    needs: test-deploy
-    if: ${{ always() && github.repository_owner == 'vercel' && github.event_name == 'release' }}
+    # needs: test-deploy
+    # if: ${{ always() && github.repository_owner == 'vercel' && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - id: nextPackageInfo
-        name: Get `next` package info
-        run: |
-          cd packages/next 
-          {
-            echo 'value<<EOF'
-            cat package.json
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-      - id: version
-        name: Extract `next` version
-        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
-      - id: test-result
-        name: Set test result variable
-        run: echo 'immediately-close=${{ needs.test-deploy.result != 'success' && 'true' || 'false' }}' >> "$GITHUB_OUTPUT"
-      - name: Check token
-        run: gh auth status
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+      # - uses: actions/checkout@v4
+      # - id: nextPackageInfo
+      #   name: Get `next` package info
+      #   run: |
+      #     cd packages/next
+      #     {
+      #       echo 'value<<EOF'
+      #       cat package.json
+      #       echo EOF
+      #     } >> "$GITHUB_OUTPUT"
+      # - id: version
+      #   name: Extract `next` version
+      #   run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
+      # - id: test-result
+      #   name: Set test result variable
+      #   run: echo 'immediately-close=${{ needs.test-deploy.result != 'success' && 'true' || 'false' }}' >> "$GITHUB_OUTPUT"
+      # - name: Check token
+      #   run: gh auth status
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
       - uses: actions/github-script@v7
         name: Check if target workflow is enabled
         id: check-workflow-enabled
@@ -142,51 +142,51 @@ jobs:
               console.error('Error checking workflow status:', error);
               return 'false';
             }
-      - uses: actions/github-script@v7
-        name: Trigger vercel/front sync
-        id: trigger-front-sync
-        if: steps.check-workflow-enabled.outputs.result == 'true'
-        with:
-          retries: 3
-          retry-exempt-status-codes: 400,401,404
-          # Default github token cannot dispatch events to the remote repo, it should be
-          # a PAT with Actions write access (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
-          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
-          # Note `workflow_id` and `inputs` are contract between vercel/front,
-          # if these need to be changed both side should be updated accordingly.
-          script: |
-            const immediatelyClose = '${{ steps.test-result.outputs.immediately-close }}';
-            const inputs = {
-              version: "${{ steps.version.outputs.value }}",
-            };
+      # - uses: actions/github-script@v7
+      #   name: Trigger vercel/front sync
+      #   id: trigger-front-sync
+      #   if: steps.check-workflow-enabled.outputs.result == 'true'
+      #   with:
+      #     retries: 3
+      #     retry-exempt-status-codes: 400,401,404
+      #     # Default github token cannot dispatch events to the remote repo, it should be
+      #     # a PAT with Actions write access (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
+      #     github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+      #     # Note `workflow_id` and `inputs` are contract between vercel/front,
+      #     # if these need to be changed both side should be updated accordingly.
+      #     script: |
+      #       const immediatelyClose = '${{ steps.test-result.outputs.immediately-close }}';
+      #       const inputs = {
+      #         version: "${{ steps.version.outputs.value }}",
+      #       };
 
-            if (immediatelyClose === 'true') {
-              inputs['immediately-close'] = 'true';
-            }
+      #       if (immediatelyClose === 'true') {
+      #         inputs['immediately-close'] = 'true';
+      #       }
 
-            await github.request(
-              "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
-              {
-                owner: "vercel",
-                repo: "front",
-                workflow_id: "cron-update-next.yml",
-                ref: "main",
-                inputs: inputs,
-              }
-            );
-            // Ideally we'd include a URL to this specific sync.
-            // However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
-            console.info(
-              "Sync started in https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch"
-            );
-            console.info(
-              "This may not start a new sync if one is already in progress. Check the logs of the cron-update-next Workflow run."
-            );
-            if (immediatelyClose === 'true') {
-              console.info(
-                "Sync triggered with immediately-close=true due to test failure."
-              );
-            }
+      #       await github.request(
+      #         "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+      #         {
+      #           owner: "vercel",
+      #           repo: "front",
+      #           workflow_id: "cron-update-next.yml",
+      #           ref: "main",
+      #           inputs: inputs,
+      #         }
+      #       );
+      #       // Ideally we'd include a URL to this specific sync.
+      #       // However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
+      #       console.info(
+      #         "Sync started in https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch"
+      #       );
+      #       console.info(
+      #         "This may not start a new sync if one is already in progress. Check the logs of the cron-update-next Workflow run."
+      #       );
+      #       if (immediatelyClose === 'true') {
+      #         console.info(
+      #           "Sync triggered with immediately-close=true due to test failure."
+      #         );
+      #       }
       - name: Log workflow skip
         if: steps.check-workflow-enabled.outputs.result != 'true'
         run: |

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -115,8 +115,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
       - uses: actions/github-script@v7
+        name: Check if target workflow is enabled
+        id: check-workflow-enabled
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,404
+          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+          result-encoding: string
+          script: |
+            try {
+              const response = await github.request(
+                "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}",
+                {
+                  owner: "vercel",
+                  repo: "front",
+                  workflow_id: "cron-update-next.yml",
+                }
+              );
+              
+              const isEnabled = response.data.state === 'active';
+              console.info(`Target workflow state: ${response.data.state}`);
+              console.info(`Target workflow enabled: ${isEnabled}`);
+              
+              return isEnabled ? 'true' : 'false';
+            } catch (error) {
+              console.error('Error checking workflow status:', error);
+              return 'false';
+            }
+      - uses: actions/github-script@v7
         name: Trigger vercel/front sync
         id: trigger-front-sync
+        if: steps.check-workflow-enabled.outputs.result == 'true'
         with:
           retries: 3
           retry-exempt-status-codes: 400,401,404
@@ -158,3 +187,8 @@ jobs:
                 "Sync triggered with immediately-close=true due to test failure."
               );
             }
+      - name: Log workflow skip
+        if: steps.check-workflow-enabled.outputs.result != 'true'
+        run: |
+          echo "Skipping sync trigger because target workflow is not enabled"
+          echo "Target workflow state: ${{ steps.check-workflow-enabled.outputs.result }}"


### PR DESCRIPTION
This change adds a check to ensure the front sync workflow is enabled before attempting to trigger it. Previously, when the workflow was disabled, the dispatch would fail and cause false alerts about deployment test failures.

Now, if the workflow is disabled, the sync trigger is skipped with clear logging. The on-call person should be aware that the workflow is disabled and can manually rerun the sync once the workflow is re-enabled.

I tested this by commenting out the tests and just running the check if workflow is enabled step and it worked:
![CleanShot 2025-07-08 at 14 57 48](https://github.com/user-attachments/assets/e56e3e2c-61c2-4c56-935a-025d508d3fa2)


Closes PACK-5032