### PR TITLE
Revert "[test] Skip flaky cdn-cache-busting test"

### DIFF
--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -101,8 +101,7 @@ describe('segment cache (CDN cache busting)', () => {
     }
   )
 
-  // 50% failure rate of this test in CI.
-  it.skip(
+  it(
     'perform fully prefetched navigation when a third-party proxy ' +
       'performs a redirect',
     async () => {


### PR DESCRIPTION
Reverts vercel/next.js#81429

The test should™ not be flaky anymore after merging #80967. 