### PR TITLE
Turbopack: Use a factory factory (yes, really) to make hanging detection construction lazier

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -820,12 +820,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
     fn get_task_desc_fn(&self, task_id: TaskId) -> impl Fn() -> String + Send + Sync + 'static {
         let task_type = self.lookup_task_type(task_id);
-        Box::new(move || {
+        move || {
             task_type.as_ref().map_or_else(
                 || format!("{task_id:?} transient"),
                 |task_type| format!("{task_id:?} {task_type}"),
             )
-        })
+        }
     }
 
     fn snapshot(&self) -> Option<(Instant, bool)> {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -457,7 +457,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 let reader_desc = reader.map(|r| this.get_task_desc_fn(r));
                 move || {
                     if let Some(reader_desc) = reader_desc.as_ref() {
-                        format!("try_read_task_output from {}", (reader_desc)())
+                        format!("try_read_task_output from {}", reader_desc())
                     } else {
                         "try_read_task_output (untracked)".to_string()
                     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -256,9 +256,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             snapshot_completed: Condvar::new(),
             last_snapshot: AtomicU64::new(0),
             stopping: AtomicBool::new(false),
-            stopping_event: Event::new(|| "TurboTasksBackend::stopping_event".to_string()),
-            idle_start_event: Event::new(|| "TurboTasksBackend::idle_start_event".to_string()),
-            idle_end_event: Event::new(|| "TurboTasksBackend::idle_end_event".to_string()),
+            stopping_event: Event::new(|| || "TurboTasksBackend::stopping_event".to_string()),
+            idle_start_event: Event::new(|| || "TurboTasksBackend::idle_start_event".to_string()),
+            idle_end_event: Event::new(|| || "TurboTasksBackend::idle_end_event".to_string()),
             #[cfg(feature = "verify_aggregation_graph")]
             is_idle: AtomicBool::new(false),
             task_statistics: TaskStatisticsApi::default(),
@@ -453,12 +453,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             reader: Option<TaskId>,
             done_event: &Event,
         ) -> EventListener {
-            let reader_desc = reader.map(|r| this.get_task_desc_fn(r));
             done_event.listen_with_note(move || {
-                if let Some(reader_desc) = reader_desc.as_ref() {
-                    format!("try_read_task_output from {}", reader_desc())
-                } else {
-                    "try_read_task_output (untracked)".to_string()
+                let reader_desc = reader.map(|r| this.get_task_desc_fn(r));
+                move || {
+                    if let Some(reader_desc) = reader_desc.as_ref() {
+                        format!("try_read_task_output from {}", (reader_desc)())
+                    } else {
+                        "try_read_task_output (untracked)".to_string()
+                    }
                 }
             })
         }
@@ -558,7 +560,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     get!(task, Activeness).unwrap()
                 };
                 let listener = activeness.all_clean_event.listen_with_note(move || {
-                    format!("try_read_task_output (strongly consistent) from {reader:?}")
+                    move || format!("try_read_task_output (strongly consistent) from {reader:?}")
                 });
                 drop(task);
                 if !task_ids_to_schedule.is_empty() {
@@ -612,19 +614,21 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             return result;
         }
 
-        let reader_desc = reader.map(|r| self.get_task_desc_fn(r));
         let note = move || {
-            if let Some(reader_desc) = reader_desc.as_ref() {
-                format!("try_read_task_output (recompute) from {}", reader_desc())
-            } else {
-                "try_read_task_output (recompute, untracked)".to_string()
+            let reader_desc = reader.map(|r| self.get_task_desc_fn(r));
+            move || {
+                if let Some(reader_desc) = reader_desc.as_ref() {
+                    format!("try_read_task_output (recompute) from {}", (reader_desc)())
+                } else {
+                    "try_read_task_output (recompute, untracked)".to_string()
+                }
             }
         };
 
         // Output doesn't exist. We need to schedule the task to compute it.
         let (item, listener) = CachedDataItem::new_scheduled_with_listener(
             TaskExecutionReason::OutputNotAvailable,
-            self.get_task_desc_fn(task_id),
+            || self.get_task_desc_fn(task_id),
             note,
         );
         // It's not possible that the task is InProgress at this point. If it is InProgress {
@@ -756,7 +760,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         } else if !is_scheduled
             && task.add(CachedDataItem::new_scheduled(
                 TaskExecutionReason::CellNotAvailable,
-                self.get_task_desc_fn(task_id),
+                || self.get_task_desc_fn(task_id),
             ))
         {
             turbo_tasks.schedule(task_id);
@@ -772,12 +776,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         reader: Option<TaskId>,
         cell: CellId,
     ) -> (EventListener, bool) {
-        let reader_desc = reader.map(|r| self.get_task_desc_fn(r));
         let note = move || {
-            if let Some(reader_desc) = reader_desc.as_ref() {
-                format!("try_read_task_cell (in progress) from {}", reader_desc())
-            } else {
-                "try_read_task_cell (in progress, untracked)".to_string()
+            let reader_desc = reader.map(|r| self.get_task_desc_fn(r));
+            move || {
+                if let Some(reader_desc) = reader_desc.as_ref() {
+                    format!("try_read_task_cell (in progress) from {}", (reader_desc)())
+                } else {
+                    "try_read_task_cell (in progress, untracked)".to_string()
+                }
             }
         };
         if let Some(in_progress) = get!(task, InProgressCell { cell }) {
@@ -812,15 +818,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         None
     }
 
-    // TODO feature flag that for hanging detection only
     fn get_task_desc_fn(&self, task_id: TaskId) -> impl Fn() -> String + Send + Sync + 'static {
         let task_type = self.lookup_task_type(task_id);
-        move || {
+        Box::new(move || {
             task_type.as_ref().map_or_else(
                 || format!("{task_id:?} transient"),
                 |task_type| format!("{task_id:?} {task_type}"),
             )
-        }
+        })
     }
 
     fn snapshot(&self) -> Option<(Instant, bool)> {
@@ -2357,9 +2362,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             }
             task.add(CachedDataItem::new_scheduled(
                 TaskExecutionReason::Initial,
-                move || match root_type {
-                    RootType::RootTask => "Root Task".to_string(),
-                    RootType::OnceTask => "Once Task".to_string(),
+                move || {
+                    move || match root_type {
+                        RootType::RootTask => "Root Task".to_string(),
+                        RootType::OnceTask => "Once Task".to_string(),
+                    }
                 },
             ));
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1219,7 +1219,7 @@ impl AggregationUpdateQueue {
             None
         };
         if let Some(reason) = should_schedule {
-            let description = ctx.get_task_desc_fn(task_id);
+            let description = || ctx.get_task_desc_fn(task_id);
             if task.add(CachedDataItem::new_scheduled(reason, description)) {
                 ctx.schedule(task_id);
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -27,10 +27,9 @@ impl ConnectChildOperation {
         if !ctx.should_track_children() {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
             if !task.has_key(&CachedDataItemKey::Output {}) {
-                let description = ctx.get_task_desc_fn(child_task_id);
                 let should_schedule = task.add(CachedDataItem::new_scheduled(
                     TaskExecutionReason::Connect,
-                    description,
+                    || ctx.get_task_desc_fn(child_task_id),
                 ));
                 drop(task);
                 if should_schedule {
@@ -80,10 +79,9 @@ impl ConnectChildOperation {
             let mut task = ctx.task(child_task_id, TaskDataCategory::All);
 
             if !task.has_key(&CachedDataItemKey::Output {}) {
-                let description = ctx.get_task_desc_fn(child_task_id);
                 let should_schedule = task.add(CachedDataItem::new_scheduled(
                     TaskExecutionReason::Connect,
-                    description,
+                    || ctx.get_task_desc_fn(child_task_id),
                 ));
                 drop(task);
                 if should_schedule {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -296,7 +296,7 @@ pub fn make_task_dirty_internal(
     };
 
     if should_schedule {
-        let description = ctx.get_task_desc_fn(task_id);
+        let description = || ctx.get_task_desc_fn(task_id);
         if task.add(CachedDataItem::new_scheduled(
             TaskExecutionReason::Invalidated,
             description,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -735,8 +735,8 @@ impl CachedDataItem {
         InnerFnDescription: Fn() -> String + Sync + Send + 'static,
     {
         let done_event = Event::new(move || {
-            let inner = (description)();
-            move || format!("{} done_event", (inner)())
+            let inner = description();
+            move || format!("{} done_event", inner())
         });
         CachedDataItem::InProgress {
             value: InProgressState::Scheduled { done_event, reason },
@@ -753,8 +753,8 @@ impl CachedDataItem {
         InnerFnNote: Fn() -> String + Sync + Send + 'static,
     {
         let done_event = Event::new(move || {
-            let inner = (description)();
-            move || format!("{} done_event", (inner)())
+            let inner = description();
+            move || format!("{} done_event", inner())
         });
         let listener = done_event.listen_with_note(note);
         (

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -94,7 +94,9 @@ impl ActivenessState {
             active_counter: 0,
             root_ty: None,
             active_until_clean: false,
-            all_clean_event: Event::new(move || format!("ActivenessState::all_clean_event {id:?}")),
+            all_clean_event: Event::new(move || {
+                move || format!("ActivenessState::all_clean_event {id:?}")
+            }),
         }
     }
 
@@ -536,7 +538,9 @@ impl Eq for InProgressCellState {}
 impl InProgressCellState {
     pub fn new(task_id: TaskId, cell: CellId) -> Self {
         InProgressCellState {
-            event: Event::new(move || format!("InProgressCellState::event ({task_id} {cell:?})")),
+            event: Event::new(move || {
+                move || format!("InProgressCellState::event ({task_id} {cell:?})")
+            }),
         }
     }
 }
@@ -723,24 +727,35 @@ impl CachedDataItem {
         }
     }
 
-    pub fn new_scheduled(
+    pub fn new_scheduled<InnerFnDescription>(
         reason: TaskExecutionReason,
-        description: impl Fn() -> String + Sync + Send + 'static,
-    ) -> Self {
+        description: impl FnOnce() -> InnerFnDescription,
+    ) -> Self
+    where
+        InnerFnDescription: Fn() -> String + Sync + Send + 'static,
+    {
+        let done_event = Event::new(move || {
+            let inner = (description)();
+            move || format!("{} done_event", (inner)())
+        });
         CachedDataItem::InProgress {
-            value: InProgressState::Scheduled {
-                done_event: Event::new(move || format!("{} done_event", description())),
-                reason,
-            },
+            value: InProgressState::Scheduled { done_event, reason },
         }
     }
 
-    pub fn new_scheduled_with_listener(
+    pub fn new_scheduled_with_listener<InnerFnDescription, InnerFnNote>(
         reason: TaskExecutionReason,
-        description: impl Fn() -> String + Sync + Send + 'static,
-        note: impl Fn() -> String + Sync + Send + 'static,
-    ) -> (Self, EventListener) {
-        let done_event = Event::new(move || format!("{} done_event", description()));
+        description: impl FnOnce() -> InnerFnDescription,
+        note: impl FnOnce() -> InnerFnNote,
+    ) -> (Self, EventListener)
+    where
+        InnerFnDescription: Fn() -> String + Sync + Send + 'static,
+        InnerFnNote: Fn() -> String + Sync + Send + 'static,
+    {
+        let done_event = Event::new(move || {
+            let inner = (description)();
+            move || format!("{} done_event", (inner)())
+        });
         let listener = done_event.listen_with_note(note);
         (
             CachedDataItem::InProgress {

--- a/turbopack/crates/turbo-tasks-fs/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/benches/mod.rs
@@ -32,7 +32,7 @@ fn bench_file_watching(c: &mut Criterion) {
         BenchmarkId::new("bench_file_watching", "change file"),
         move |b| {
             let (tx, rx) = channel();
-            let event = Arc::new(Event::new(|| "test event".to_string()));
+            let event = Arc::new(Event::new(|| || "test event".to_string()));
 
             let mut watcher = RecommendedWatcher::new(tx, Config::default()).unwrap();
             watcher.watch(temp_path, RecursiveMode::Recursive).unwrap();

--- a/turbopack/crates/turbo-tasks-fs/src/mutex_map.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/mutex_map.rs
@@ -30,7 +30,7 @@ impl<'a, K: Eq + Hash + Clone> MutexMap<K> {
                             event.listen()
                         }
                         None => {
-                            let event = Event::new(|| "MutexMap".to_string());
+                            let event = Event::new(|| || "MutexMap".to_string());
                             let listener = event.listen();
                             *state = Some((event, 0));
                             listener

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -52,7 +52,7 @@ impl VcStorage {
             let mut tasks = self.tasks.lock().unwrap();
             let i = tasks.len();
             tasks.push(Task::Spawned(Event::new(move || {
-                format!("Task({i})::event")
+                move || format!("Task({i})::event")
             })));
             i
         };

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -85,7 +85,7 @@ impl EffectInstance {
                     EffectState::NotStarted(_) => {
                         let EffectState::NotStarted(inner) = std::mem::replace(
                             &mut *guard,
-                            EffectState::Started(Event::new(|| "Effect".to_string())),
+                            EffectState::Started(Event::new(|| || "Effect".to_string())),
                         ) else {
                             unreachable!();
                         };

--- a/turbopack/crates/turbo-tasks/src/event.rs
+++ b/turbopack/crates/turbo-tasks/src/event.rs
@@ -115,7 +115,7 @@ impl Event {
 }
 
 impl Event {
-    /// see [event_listener::Event]::notify
+    /// see [`event_listener::Event::notify`]
     pub fn notify(&self, n: usize) {
         self.event.notify(n);
     }
@@ -214,5 +214,47 @@ impl Future for EventListener {
         }
         // EventListener was awaited again after completion
         Poll::Ready(())
+    }
+}
+
+#[cfg(all(test, not(feature = "hanging_detection")))]
+mod tests {
+    use std::hint::black_box;
+
+    use tokio::time::{Duration, timeout};
+
+    use super::*;
+
+    // The closures used for descriptions/notes should be eliminated. This may only happen at higher
+    // optimization levels (that would be okay), but in practice it seems to work even for
+    // opt-level=0.
+    #[tokio::test]
+    async fn ensure_dead_code_elimination() {
+        fn dead_fn() {
+            // This code triggers a build error when it's not removed.
+            unsafe {
+                unsafe extern "C" {
+                    fn trigger_link_error() -> !;
+                }
+                trigger_link_error();
+            }
+        }
+
+        let event = black_box(Event::new(|| {
+            dead_fn();
+            || {
+                dead_fn();
+                String::new()
+            }
+        }));
+        let listener = black_box(event.listen_with_note(|| {
+            dead_fn();
+            || {
+                dead_fn();
+                String::new()
+            }
+        }));
+
+        let _ = black_box(timeout(Duration::from_millis(10), listener)).await;
     }
 }

--- a/turbopack/crates/turbo-tasks/src/event.rs
+++ b/turbopack/crates/turbo-tasks/src/event.rs
@@ -1,22 +1,18 @@
-#[cfg(feature = "hanging_detection")]
-use std::sync::Arc;
-#[cfg(feature = "hanging_detection")]
-use std::task::Poll;
-#[cfg(feature = "hanging_detection")]
-use std::task::ready;
-#[cfg(feature = "hanging_detection")]
-use std::time::Duration;
 use std::{
     fmt::{Debug, Formatter},
     future::Future,
     mem::replace,
     pin::Pin,
 };
+#[cfg(feature = "hanging_detection")]
+use std::{
+    sync::Arc,
+    task::{Poll, ready},
+    time::Duration,
+};
 
 #[cfg(feature = "hanging_detection")]
-use tokio::time::Timeout;
-#[cfg(feature = "hanging_detection")]
-use tokio::time::timeout;
+use tokio::time::{Timeout, timeout};
 
 pub struct Event {
     #[cfg(feature = "hanging_detection")]
@@ -24,87 +20,97 @@ pub struct Event {
     event: event_listener::Event,
 }
 
-#[cfg(not(feature = "hanging_detection"))]
 impl Event {
-    /// see [event_listener::Event]::new
+    /// See [`event_listener::Event::new`]. May attach a description that may optionally be read
+    /// later.
+    ///
+    /// This confusingly takes a closure ([`FnOnce`]) that returns a nested closure ([`Fn`]).
+    ///
+    /// When `hanging_detection` is disabled, `description` is never called.
+    ///
+    /// When `hanging_detection` is enabled, the outer closure is called immediately. The outer
+    /// closure can have an ephemeral lifetime. The inner closer must be `'static`, but is called
+    /// only when the `description` is actually read.
+    ///
+    /// The outer closure allow avoiding extra lookups (e.g. task type info) that may be needed to
+    /// capture information needed for constructing (moving into) the inner closure.
     #[inline(always)]
-    pub fn new(_description: impl Fn() -> String + Sync + Send + 'static) -> Self {
-        Self {
+    pub fn new<InnerFn>(_description: impl FnOnce() -> InnerFn) -> Self
+    where
+        InnerFn: Fn() -> String + Sync + Send + 'static,
+    {
+        #[cfg(not(feature = "hanging_detection"))]
+        return Self {
             event: event_listener::Event::new(),
-        }
-    }
-
-    /// see [event_listener::Event]::listen
-    pub fn listen(&self) -> EventListener {
-        EventListener {
-            listener: self.event.listen(),
-        }
-    }
-
-    /// see [event_listener::Event]::listen
-    pub fn listen_with_note(
-        &self,
-        _note: impl Fn() -> String + Sync + Send + 'static,
-    ) -> EventListener {
-        EventListener {
-            listener: self.event.listen(),
-        }
-    }
-
-    /// pulls out the event listener, leaving a new, empty event in its place.
-    pub fn take(&mut self) -> Self {
-        Self {
-            event: replace(&mut self.event, event_listener::Event::new()),
-        }
-    }
-}
-
-#[cfg(feature = "hanging_detection")]
-impl Event {
-    /// see [event_listener::Event]::new
-    #[inline(always)]
-    pub fn new(description: impl Fn() -> String + Sync + Send + 'static) -> Self {
-        Self {
-            description: Arc::new(description),
+        };
+        #[cfg(feature = "hanging_detection")]
+        return Self {
+            description: Arc::new((_description)()),
             event: event_listener::Event::new(),
-        }
+        };
     }
 
-    /// see [event_listener::Event]::listen
+    /// See [`event_listener::Event::listen`].
     pub fn listen(&self) -> EventListener {
-        EventListener {
+        #[cfg(not(feature = "hanging_detection"))]
+        return EventListener {
+            listener: self.event.listen(),
+        };
+        #[cfg(feature = "hanging_detection")]
+        return EventListener {
             description: self.description.clone(),
-            note: Arc::new(|| String::new()),
+            note: Arc::new(String::new),
             future: Some(Box::pin(timeout(
                 Duration::from_secs(10),
                 self.event.listen(),
             ))),
             duration: Duration::from_secs(10),
-        }
+        };
     }
 
-    /// see [event_listener::Event]::listen
-    pub fn listen_with_note(
-        &self,
-        note: impl Fn() -> String + Sync + Send + 'static,
-    ) -> EventListener {
-        EventListener {
+    /// See [`event_listener::Event::listen`]. May attach a note that may optionally be read later.
+    ///
+    /// This confusingly takes a closure ([`FnOnce`]) that returns a nested closure ([`Fn`]).
+    ///
+    /// When `hanging_detection` is disabled, `note` is never called.
+    ///
+    /// When `hanging_detection` is enabled, the outer closure is called immediately. The outer
+    /// closure can have an ephemeral lifetime. The inner closer must be `'static`, but is called
+    /// only when the `note` is actually read.
+    ///
+    /// The outer closure allow avoiding extra lookups (e.g. task type info) that may be needed to
+    /// capture information needed for constructing (moving into) the inner closure.
+    pub fn listen_with_note<InnerFn>(&self, _note: impl FnOnce() -> InnerFn) -> EventListener
+    where
+        InnerFn: Fn() -> String + Sync + Send + 'static,
+    {
+        #[cfg(not(feature = "hanging_detection"))]
+        return EventListener {
+            listener: self.event.listen(),
+        };
+        #[cfg(feature = "hanging_detection")]
+        return EventListener {
             description: self.description.clone(),
-            note: Arc::new(note),
+            note: Arc::new((_note)()),
             future: Some(Box::pin(timeout(
                 Duration::from_secs(10),
                 self.event.listen(),
             ))),
             duration: Duration::from_secs(10),
-        }
+        };
     }
 
     /// pulls out the event listener, leaving a new, empty event in its place.
     pub fn take(&mut self) -> Event {
-        Self {
+        #[cfg(not(feature = "hanging_detection"))]
+        return Self {
+            event: replace(&mut self.event, event_listener::Event::new()),
+        };
+        #[cfg(feature = "hanging_detection")]
+        return Self {
             description: self.description.clone(),
             event: replace(&mut self.event, event_listener::Event::new()),
-        }
+        };
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/event.rs
+++ b/turbopack/crates/turbo-tasks/src/event.rs
@@ -29,10 +29,10 @@ impl Event {
     /// When `hanging_detection` is disabled, `description` is never called.
     ///
     /// When `hanging_detection` is enabled, the outer closure is called immediately. The outer
-    /// closure can have an ephemeral lifetime. The inner closer must be `'static`, but is called
+    /// closure can have an ephemeral lifetime. The inner closure must be `'static`, but is called
     /// only when the `description` is actually read.
     ///
-    /// The outer closure allow avoiding extra lookups (e.g. task type info) that may be needed to
+    /// The outer closure allows avoiding extra lookups (e.g. task type info) that may be needed to
     /// capture information needed for constructing (moving into) the inner closure.
     #[inline(always)]
     pub fn new<InnerFn>(_description: impl FnOnce() -> InnerFn) -> Self


### PR DESCRIPTION
This is an alternate attempt at solving #81424 without macros.

The extra laziness desired can be accomplished with an outer wrapping `FnOnce`. It's a bit confusing, but I think it causes less problems than a macro does?

Checked compilation and lints with:

```
cargo clippy --all-targets
cargo clippy --all-targets --features turbo-tasks/hanging_detection
```

// TODO: Find somewhere else to insert a closure so that we can have a factory factory factory!

Closes PACK-5045