### PR TITLE
fix: referencing unavailable __dirname

### DIFF
--- a/packages/next/.storybook/main.ts
+++ b/packages/next/.storybook/main.ts
@@ -1,5 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-webpack5'
 import { join, dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
@@ -65,7 +67,7 @@ const config: StorybookConfig = {
           options: {
             injectType: 'styleTag',
             insert: resolve(
-              __dirname,
+              dirname(fileURLToPath(import.meta.url)),
               '../src/build/webpack/loaders/devtool/devtool-style-inject.js'
             ),
           },


### PR DESCRIPTION
Patch missing __dirname usage for storybook css injection