### PR TITLE
[build-sourcemaps] Default `experimental.enablePrerenderSourceMaps` to `experimental.dynamicIO`

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1360,7 +1360,8 @@ export const defaultConfig = {
     appNavFailHandling: false,
     prerenderEarlyExit: true,
     serverMinification: true,
-    enablePrerenderSourceMaps: false,
+    // Will default to dynamicIO value.
+    enablePrerenderSourceMaps: undefined,
     serverSourceMaps: false,
     linkNoTouchStart: false,
     caseSensitiveRoutes: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1415,6 +1415,20 @@ export default async function loadConfig(
     }
 
     if (
+      userConfig.experimental &&
+      userConfig.experimental.enablePrerenderSourceMaps === undefined &&
+      userConfig.experimental.dynamicIO === true
+    ) {
+      userConfig.experimental.enablePrerenderSourceMaps = true
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'enablePrerenderSourceMaps',
+        true,
+        'enabled by `experimental.dynamicIO`'
+      )
+    }
+
+    if (
       debugPrerender &&
       (phase === PHASE_PRODUCTION_BUILD || phase === PHASE_EXPORT)
     ) {

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -120,7 +120,14 @@ describe.each(
           } else {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`Math.random()\` outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                 at a (<next-dist-dir>)
+                 at f (turbopack:///[project]/app/page.tsx:32:14)
+               30 |
+               31 | function getRandomNumber() {
+             > 32 |   return Math.random()
+                  |              ^
+               33 | }
+               34 |
+               35 | function RandomReadingComponent() {
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
                - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-attribution.test.ts
@@ -137,7 +137,14 @@ describe.each(
           } else {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
-                 at a (<next-dist-dir>)
+                 at c (turbopack:///[project]/app/client.tsx:9:6)
+                7 |   return (
+                8 |     <main>
+             >  9 |       <h1>Sync IO Access</h1>
+                  |      ^
+               10 |       <p suppressHydrationWarning>Current date and time: {data}</p>
+               11 |     </main>
+               12 |   )
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
                - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
@@ -264,17 +271,7 @@ describe.each(
              "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
                  at a (<anonymous>)
                  at main (<anonymous>)
-                 at b (<next-dist-dir>)
-                 at c (<next-dist-dir>)
-                 at d (<next-dist-dir>)
-                 at e (<next-dist-dir>)
-                 at f (<next-dist-dir>)
-                 at g (<next-dist-dir>)
-                 at h (<next-dist-dir>)
-                 at i (<next-dist-dir>)
-                 at j (<next-dist-dir>)
-                 at k (<anonymous>)
-                 at l (<next-dist-dir>)
+                 at b (<anonymous>)
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
@@ -434,7 +431,14 @@ describe.each(
           } else {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
-                 at a (<next-dist-dir>)
+                 at c (turbopack:///[project]/app/client.tsx:9:6)
+                7 |   return (
+                8 |     <main>
+             >  9 |       <h1>Sync IO Access</h1>
+                  |      ^
+               10 |       <p suppressHydrationWarning>Current date and time: {data}</p>
+               11 |     </main>
+               12 |   )
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
                - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -234,8 +234,15 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              TypeError: <module-function>().get is not a function
-                 at a (<next-dist-dir>)
-                 at b (<anonymous>) {
+                 at e (turbopack:///[project]/app/page.tsx:17:66)
+                 at a (<anonymous>)
+               15 |
+               16 | async function CookiesReadingComponent() {
+             > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                  |                                                                  ^
+               18 |   return <div>this component reads the \`token\` cookie synchronously</div>
+               19 | }
+               20 | {
                digest: '<error-digest>'
              }
              Export encountered an error on /page: /, exiting the build."
@@ -456,8 +463,15 @@ describe.each(
             expect(output).toMatchInlineSnapshot(`
              "Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
              TypeError: <module-function>().get is not a function
-                 at a (<next-dist-dir>)
-                 at b (<anonymous>) {
+                 at e (turbopack:///[project]/app/page.tsx:17:69)
+                 at a (<anonymous>)
+               15 |
+               16 | async function HeadersReadingComponent() {
+             > 17 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                  |                                                                     ^
+               18 |     'user-agent'
+               19 |   )
+               20 |   return ( {
                digest: '<error-digest>'
              }
              Export encountered an error on /page: /, exiting the build."

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -181,17 +181,6 @@ describe.each(
           } else {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
-                 at a (<next-dist-dir>)
-                 at b (<next-dist-dir>)
-                 at c (<next-dist-dir>)
-                 at d (<next-dist-dir>)
-                 at e (<next-dist-dir>)
-                 at f (<next-dist-dir>)
-                 at g (<next-dist-dir>)
-                 at h (<next-dist-dir>)
-                 at i (<next-dist-dir>)
-                 at j (<next-dist-dir>)
-                 at k (<next-dist-dir>)
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
@@ -673,36 +662,18 @@ describe.each(
           } else {
             expect(output).toMatchInlineSnapshot(`
              "Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
-                 at a (<next-dist-dir>)
-                 at b (<next-dist-dir>)
-                 at c (<next-dist-dir>)
-                 at d (<next-dist-dir>)
-                 at e (<next-dist-dir>)
-                 at f (<next-dist-dir>)
-                 at g (<next-dist-dir>)
-                 at h (<next-dist-dir>)
-                 at i (<next-dist-dir>)
-                 at j (<next-dist-dir>)
-                 at k (<next-dist-dir>)
-                 at l (<next-dist-dir>)
+                 at c (turbopack:///[project]/app/indirection.tsx:9:0)
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)
+                7 | export function IndirectionTwo({ children }) {
+                8 |   return children
+             >  9 | }
+               10 |
              To get a more detailed stack trace and pinpoint the issue, try one of the following:
                - Start the app in development mode by running \`next dev\`, then open "/" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
-                 at m (<next-dist-dir>)
-                 at n (<next-dist-dir>)
-                 at o (<next-dist-dir>)
-                 at p (<next-dist-dir>)
-                 at q (<next-dist-dir>)
-                 at r (<next-dist-dir>)
-                 at s (<next-dist-dir>)
-                 at t (<next-dist-dir>)
-                 at u (<next-dist-dir>)
-                 at v (<next-dist-dir>)
-                 at w (<next-dist-dir>)
                  at main (<anonymous>)
                  at body (<anonymous>)
                  at html (<anonymous>)

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   experimental: {
     cpus: 1,
     dynamicIO: true,
-    enablePrerenderSourceMaps: true,
     serverSourceMaps: true,
   },
   serverExternalPackages: ['external-pkg'],

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -15,22 +15,29 @@ describe('build-output-prerender', () => {
         expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
          "▲ Next.js x.y.z (Turbopack)
             - Experiments (use with caution):
-              ✓ dynamicIO"
+              ✓ dynamicIO
+              ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
         `)
       } else {
         expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
          "▲ Next.js x.y.z
             - Experiments (use with caution):
-              ✓ dynamicIO"
+              ✓ dynamicIO
+              ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
         `)
       }
     })
 
     it('shows only a single prerender error with a mangled stack', async () => {
       if (isTurbopack) {
+        // TODO(veil): Why is the location incomplete unless we enable --no-mangling?
         expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
          "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
-             at x (<next-dist-dir>)
+             at c (turbopack:///[project]/app/client/page.tsx:5:0)
+           3 | export default function Page() {
+           4 |   return <p>Current time: {new Date().toISOString()}</p>
+         > 5 | }
+           6 |
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
            - Start the app in development mode by running \`next dev\`, then open "/client" in your browser to investigate the error.
            - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
@@ -70,7 +77,7 @@ describe('build-output-prerender', () => {
               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-              ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+              ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
         `)
       } else {
         expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
@@ -81,7 +88,7 @@ describe('build-output-prerender', () => {
               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
               ⨯ serverMinification (disabled by \`--debug-prerender\`)
               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-              ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+              ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
         `)
       }
     })


### PR DESCRIPTION
We'll land this instead of https://github.com/vercel/next.js/pull/80317 (scheduled for after 15.4).

The idea is that you'll likely encounter dynamic I/O errors for the first time during `next build` so that experience shouldn't be too horrible.