### PR TITLE
Turbopack: make invalidation from chunking context more granular

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -282,36 +282,6 @@ impl BrowserChunkingContext {
     }
 }
 
-impl BrowserChunkingContext {
-    /// Returns the kind of runtime to include in output chunks.
-    ///
-    /// This is defined directly on `BrowserChunkingContext` so it is zero-cost
-    /// when `RuntimeType` has a single variant.
-    pub fn runtime_type(&self) -> RuntimeType {
-        self.runtime_type
-    }
-
-    /// Returns the asset base path.
-    pub fn chunk_base_path(&self) -> Option<RcStr> {
-        self.chunk_base_path.clone()
-    }
-
-    /// Returns the asset suffix path.
-    pub fn chunk_suffix_path(&self) -> Option<RcStr> {
-        self.chunk_suffix_path.clone()
-    }
-
-    /// Returns the source map type.
-    pub fn source_maps_type(&self) -> SourceMapsType {
-        self.source_maps_type
-    }
-
-    /// Returns the minify type.
-    pub fn minify_type(&self) -> MinifyType {
-        self.minify_type
-    }
-}
-
 #[turbo_tasks::value_impl]
 impl BrowserChunkingContext {
     #[turbo_tasks::function]
@@ -372,6 +342,39 @@ impl BrowserChunkingContext {
     #[turbo_tasks::function]
     pub fn current_chunk_method(&self) -> Vc<CurrentChunkMethod> {
         self.current_chunk_method.cell()
+    }
+
+    /// Returns the kind of runtime to include in output chunks.
+    ///
+    /// This is defined directly on `BrowserChunkingContext` so it is zero-cost
+    /// when `RuntimeType` has a single variant.
+    #[turbo_tasks::function]
+    pub fn runtime_type(&self) -> Vc<RuntimeType> {
+        self.runtime_type.cell()
+    }
+
+    /// Returns the asset base path.
+    #[turbo_tasks::function]
+    pub fn chunk_base_path(&self) -> Vc<Option<RcStr>> {
+        Vc::cell(self.chunk_base_path.clone())
+    }
+
+    /// Returns the asset suffix path.
+    #[turbo_tasks::function]
+    pub fn chunk_suffix_path(&self) -> Vc<Option<RcStr>> {
+        Vc::cell(self.chunk_suffix_path.clone())
+    }
+
+    /// Returns the source map type.
+    #[turbo_tasks::function]
+    pub fn source_maps_type(&self) -> Vc<SourceMapsType> {
+        self.source_maps_type.cell()
+    }
+
+    /// Returns the minify type.
+    #[turbo_tasks::function]
+    pub fn minify_type(&self) -> Vc<MinifyType> {
+        self.minify_type.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -127,7 +127,7 @@ impl EcmascriptBrowserChunkContent {
 
         let mut code = code.build();
 
-        if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
+        if let MinifyType::Minify { mangle } = *this.chunking_context.minify_type().await? {
             code = minify(code, source_maps, mangle)?;
         }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -172,8 +172,8 @@ impl EcmascriptBrowserEvaluateChunk {
             RuntimeType::Production | RuntimeType::Development => {
                 let runtime_code = turbopack_ecmascript_runtime::get_browser_runtime_code(
                     environment,
-                    this.chunking_context.chunk_base_path().owned().await?,
-                    this.chunking_context.chunk_suffix_path().owned().await?,
+                    this.chunking_context.chunk_base_path(),
+                    this.chunking_context.chunk_suffix_path(),
                     *this.chunking_context.runtime_type().await?,
                     output_root_to_root_path,
                     source_maps,

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -174,7 +174,7 @@ impl EcmascriptBrowserEvaluateChunk {
                     environment,
                     this.chunking_context.chunk_base_path(),
                     this.chunking_context.chunk_suffix_path(),
-                    *this.chunking_context.runtime_type().await?,
+                    runtime_type,
                     output_root_to_root_path,
                     source_maps,
                 );

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -78,7 +78,6 @@ impl EcmascriptBrowserEvaluateChunk {
     #[turbo_tasks::function]
     async fn code(self: Vc<Self>) -> Result<Vc<Code>> {
         let this = self.await?;
-        let chunking_context = this.chunking_context.await?;
         let environment = this.chunking_context.environment();
 
         let output_root_to_root_path = this
@@ -168,13 +167,14 @@ impl EcmascriptBrowserEvaluateChunk {
             StringifyJs(&params),
         )?;
 
-        match chunking_context.runtime_type() {
+        let runtime_type = *this.chunking_context.runtime_type().await?;
+        match runtime_type {
             RuntimeType::Production | RuntimeType::Development => {
                 let runtime_code = turbopack_ecmascript_runtime::get_browser_runtime_code(
                     environment,
-                    chunking_context.chunk_base_path(),
-                    chunking_context.chunk_suffix_path(),
-                    chunking_context.runtime_type(),
+                    this.chunking_context.chunk_base_path().owned().await?,
+                    this.chunking_context.chunk_suffix_path().owned().await?,
+                    *this.chunking_context.runtime_type().await?,
                     output_root_to_root_path,
                     source_maps,
                 );
@@ -189,7 +189,7 @@ impl EcmascriptBrowserEvaluateChunk {
 
         let mut code = code.build();
 
-        if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
+        if let MinifyType::Minify { mangle } = *this.chunking_context.minify_type().await? {
             code = minify(code, source_maps, mangle)?;
         }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -57,21 +57,8 @@ impl Default for MinifyType {
     }
 }
 
-#[derive(
-    Debug,
-    Default,
-    TaskInput,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    TraceRawVcs,
-    DeterministicHash,
-    NonLocalValue,
-)]
+#[turbo_tasks::value(shared)]
+#[derive(Debug, Default, TaskInput, Clone, Copy, Hash, DeterministicHash)]
 pub enum SourceMapsType {
     /// Extracts source maps from input files and writes source maps for output files.
     #[default]

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/asset_context.rs
@@ -11,6 +11,7 @@ use turbopack_core::{
 use turbopack_ecmascript::TreeShakingMode;
 
 /// Returns the runtime asset context to use to process runtime code assets.
+#[turbo_tasks::function]
 pub async fn get_runtime_asset_context(
     environment: ResolvedVc<Environment>,
 ) -> Result<Vc<Box<dyn AssetContext>>> {

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -17,13 +17,13 @@ use crate::{RuntimeType, asset_context::get_runtime_asset_context, embed_js::emb
 #[turbo_tasks::function]
 pub async fn get_browser_runtime_code(
     environment: ResolvedVc<Environment>,
-    chunk_base_path: Option<RcStr>,
-    chunk_suffix_path: Option<RcStr>,
+    chunk_base_path: Vc<Option<RcStr>>,
+    chunk_suffix_path: Vc<Option<RcStr>>,
     runtime_type: RuntimeType,
     output_root_to_root_path: RcStr,
     generate_source_map: bool,
 ) -> Result<Vc<Code>> {
-    let asset_context = get_runtime_asset_context(environment).await?;
+    let asset_context = get_runtime_asset_context(*environment).resolve().await?;
 
     let shared_runtime_utils_code = embed_static_code(
         asset_context,
@@ -79,7 +79,9 @@ pub async fn get_browser_runtime_code(
 
     let mut code: CodeBuilder = CodeBuilder::default();
     let relative_root_path = output_root_to_root_path;
+    let chunk_base_path = chunk_base_path.await?;
     let chunk_base_path = chunk_base_path.as_ref().map_or_else(|| "", |f| f.as_str());
+    let chunk_suffix_path = chunk_suffix_path.await?;
     let chunk_suffix_path = chunk_suffix_path
         .as_ref()
         .map_or_else(|| "", |f| f.as_str());

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
@@ -13,7 +13,7 @@ pub async fn get_nodejs_runtime_code(
     environment: ResolvedVc<Environment>,
     generate_source_map: bool,
 ) -> Result<Vc<Code>> {
-    let asset_context = get_runtime_asset_context(environment).await?;
+    let asset_context = get_runtime_asset_context(*environment).resolve().await?;
 
     let shared_runtime_utils_code = embed_static_code(
         asset_context,

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/runtime_type.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/runtime_type.rs
@@ -1,19 +1,7 @@
-use serde::{Deserialize, Serialize};
-use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
+use turbo_tasks::TaskInput;
 
-#[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Copy,
-    Hash,
-    PartialEq,
-    Eq,
-    TraceRawVcs,
-    NonLocalValue,
-    TaskInput,
-)]
+#[turbo_tasks::value(shared)]
+#[derive(Debug, Clone, Copy, Hash, TaskInput)]
 pub enum RuntimeType {
     Development,
     Production,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -188,27 +188,6 @@ impl NodeJsChunkingContext {
     }
 }
 
-impl NodeJsChunkingContext {
-    /// Returns the kind of runtime to include in output chunks.
-    ///
-    /// This is defined directly on `NodeJsChunkingContext` so it is zero-cost
-    /// when `RuntimeType` has a single variant.
-    pub fn runtime_type(&self) -> RuntimeType {
-        self.runtime_type
-    }
-
-    /// Returns the minify type.
-    pub fn minify_type(&self) -> MinifyType {
-        self.minify_type
-    }
-}
-
-impl NodeJsChunkingContext {
-    pub async fn asset_prefix(self: Vc<Self>) -> Result<Option<RcStr>> {
-        Ok(self.await?.asset_prefix.clone())
-    }
-}
-
 #[turbo_tasks::value_impl]
 impl NodeJsChunkingContext {
     #[turbo_tasks::function]
@@ -229,6 +208,26 @@ impl NodeJsChunkingContext {
                 bail!("Unable to generate output asset for chunk");
             },
         )
+    }
+
+    /// Returns the kind of runtime to include in output chunks.
+    ///
+    /// This is defined directly on `NodeJsChunkingContext` so it is zero-cost
+    /// when `RuntimeType` has a single variant.
+    #[turbo_tasks::function]
+    pub fn runtime_type(&self) -> Vc<RuntimeType> {
+        self.runtime_type.cell()
+    }
+
+    /// Returns the minify type.
+    #[turbo_tasks::function]
+    pub fn minify_type(&self) -> Vc<MinifyType> {
+        self.minify_type.cell()
+    }
+
+    #[turbo_tasks::function]
+    pub fn asset_prefix(&self) -> Vc<Option<RcStr>> {
+        Vc::cell(self.asset_prefix.clone())
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -77,7 +77,7 @@ impl EcmascriptBuildNodeChunkContent {
 
         let mut code = code.build();
 
-        if let MinifyType::Minify { mangle } = this.chunking_context.await?.minify_type() {
+        if let MinifyType::Minify { mangle } = *this.chunking_context.minify_type().await? {
             code = minify(code, source_maps, mangle)?;
         }
 
@@ -90,7 +90,7 @@ impl EcmascriptBuildNodeChunkContent {
             self.chunking_context.output_root().await?.clone_value(),
             self.chunk.path().await?.clone_value(),
             *self.content,
-            self.chunking_context.await?.minify_type(),
+            *self.chunking_context.minify_type().await?,
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -69,7 +69,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
             StringifyJs(asset_prefix),
         )?;
 
-        match this.chunking_context.await?.runtime_type() {
+        match *this.chunking_context.runtime_type().await? {
             RuntimeType::Development => {
                 let runtime_code = turbopack_ecmascript_runtime::get_nodejs_runtime_code(
                     this.chunking_context.environment(),


### PR DESCRIPTION
### What?

More granular invalidation to improve incremental builds with Skew Protections (modifies chunking context as it includes `chunk_suffix_path`).

Closes PACK-5048