### PR TITLE
Turbopack: improve named spans in tracing

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -309,7 +309,7 @@ impl DiskFileSystemInner {
     }
 
     fn invalidate(&self) {
-        let _span = tracing::info_span!("invalidate filesystem", path = &*self.root).entered();
+        let _span = tracing::info_span!("invalidate filesystem", name = &*self.root).entered();
         let span = tracing::Span::current();
         let handle = tokio::runtime::Handle::current();
         let invalidator_map = take(&mut *self.invalidator_map.lock().unwrap());
@@ -332,7 +332,7 @@ impl DiskFileSystemInner {
         &self,
         reason: impl Fn(String) -> R + Sync,
     ) {
-        let _span = tracing::info_span!("invalidate filesystem", path = &*self.root).entered();
+        let _span = tracing::info_span!("invalidate filesystem", name = &*self.root).entered();
         let span = tracing::Span::current();
         let handle = tokio::runtime::Handle::current();
         let invalidator_map = take(&mut *self.invalidator_map.lock().unwrap());
@@ -388,7 +388,7 @@ impl DiskFileSystemInner {
         // create the directory for the filesystem on disk, if it doesn't exist
         retry_blocking(root_path.clone(), move |path| {
             let _tracing =
-                tracing::info_span!("create root directory", path = display(path.display()))
+                tracing::info_span!("create root directory", name = display(path.display()))
                     .entered();
 
             std::fs::create_dir_all(path)
@@ -413,7 +413,7 @@ impl DiskFileSystemInner {
                 .concurrency_limited(&self.semaphore)
                 .instrument(tracing::info_span!(
                     "create directory",
-                    path = display(directory.display())
+                    name = display(directory.display())
                 ))
                 .await?;
             ApplyEffectsContext::with(|fs_context: &mut DiskFileSystemApplyContext| {
@@ -558,7 +558,7 @@ impl FileSystem for DiskFileSystem {
             .concurrency_limited(&self.inner.semaphore)
             .instrument(tracing::info_span!(
                 "read file",
-                path = display(full_path.display())
+                name = display(full_path.display())
             ))
             .await
         {
@@ -583,7 +583,7 @@ impl FileSystem for DiskFileSystem {
         // node-file-trace
         let read_dir = match retry_blocking(full_path.clone(), |path| {
             let _span =
-                tracing::info_span!("read directory", path = display(path.display())).entered();
+                tracing::info_span!("read directory", name = display(path.display())).entered();
             std::fs::read_dir(path)
         })
         .concurrency_limited(&self.inner.semaphore)
@@ -640,7 +640,7 @@ impl FileSystem for DiskFileSystem {
                 .concurrency_limited(&self.inner.semaphore)
                 .instrument(tracing::info_span!(
                     "read symlink",
-                    path = display(full_path.display())
+                    name = display(full_path.display())
                 ))
                 .await
             {
@@ -745,7 +745,7 @@ impl FileSystem for DiskFileSystem {
                 .concurrency_limited(&inner.semaphore)
                 .instrument(tracing::info_span!(
                     "read file before write",
-                    path = display(full_path.display())
+                    name = display(full_path.display())
                 ))
                 .await?;
             if compare == FileComparison::Equal {
@@ -812,7 +812,7 @@ impl FileSystem for DiskFileSystem {
                     .concurrency_limited(&inner.semaphore)
                     .instrument(tracing::info_span!(
                         "write file",
-                        path = display(full_path.display())
+                        name = display(full_path.display())
                     ))
                     .await
                     .with_context(|| format!("failed to write to {}", full_path.display()))?;
@@ -824,7 +824,7 @@ impl FileSystem for DiskFileSystem {
                     .concurrency_limited(&inner.semaphore)
                     .instrument(tracing::info_span!(
                         "remove file",
-                        path = display(full_path.display())
+                        name = display(full_path.display())
                     ))
                     .await
                     .or_else(|err| {
@@ -873,7 +873,7 @@ impl FileSystem for DiskFileSystem {
             .concurrency_limited(&inner.semaphore)
             .instrument(tracing::info_span!(
                 "read symlink before write",
-                path = display(full_path.display())
+                name = display(full_path.display())
             ))
             .await
             {
@@ -923,7 +923,7 @@ impl FileSystem for DiskFileSystem {
                     retry_blocking(target_path, move |target_path| {
                         let _span = tracing::info_span!(
                             "write symlink",
-                            path = display(target_path.display())
+                            name = display(target_path.display())
                         )
                         .entered();
                         // we use the sync std method here because `symlink` is fast
@@ -980,7 +980,7 @@ impl FileSystem for DiskFileSystem {
             .concurrency_limited(&self.inner.semaphore)
             .instrument(tracing::info_span!(
                 "read metadata",
-                path = display(full_path.display())
+                name = display(full_path.display())
             ))
             .await
             .with_context(|| format!("reading metadata for {}", full_path.display()))?;

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -571,7 +571,7 @@ impl ChunkingContext for BrowserChunkingContext {
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = tracing::info_span!("chunking", ident = ident.to_string().await?.to_string());
+        let span = tracing::info_span!("chunking", name = ident.to_string().await?.to_string());
         async move {
             let this = self.await?;
             let modules = chunk_group.entries();

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1573,7 +1573,7 @@ pub async fn resolve_inline(
         tracing::info_span!(
             "resolving",
             lookup_path = lookup_path,
-            request = request,
+            name = request,
             reference_type = display(&reference_type),
         )
     };
@@ -1778,7 +1778,7 @@ async fn resolve_internal_inline(
         tracing::info_span!(
             "internal resolving",
             lookup_path = lookup_path,
-            request = request
+            name = request
         )
     };
     async move {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -810,7 +810,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let span = tracing::info_span!(
             "code generation",
-            module = self.asset_ident().to_string().await?.to_string()
+            name = self.asset_ident().to_string().await?.to_string()
         );
         async {
             let this = self.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -495,7 +495,7 @@ pub(crate) async fn analyse_ecmascript_module(
 ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
     let span = {
         let module = module.ident().to_string().await?.to_string();
-        tracing::info_span!("analyse ecmascript module", module = module)
+        tracing::info_span!("analyse ecmascript module", name = module)
     };
     let result = analyse_ecmascript_module_internal(module, part)
         .instrument(span)

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -384,7 +384,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = tracing::info_span!("chunking", module = ident.to_string().await?.to_string());
+        let span = tracing::info_span!("chunking", name = ident.to_string().await?.to_string());
         async move {
             let modules = chunk_group.entries();
             let MakeChunkGroupResult {

--- a/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
+++ b/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
@@ -1,6 +1,6 @@
 use std::{env, sync::Arc};
 
-use hashbrown::HashMap;
+use hashbrown::{Equivalent, HashMap};
 
 use crate::{
     span::{SpanBottomUp, SpanIndex},
@@ -10,7 +10,7 @@ use crate::{
 pub struct SpanBottomUpBuilder {
     // These values won't change after creation:
     pub self_spans: Vec<SpanIndex>,
-    pub children: HashMap<String, SpanBottomUpBuilder>,
+    pub children: HashMap<(String, String), SpanBottomUpBuilder>,
     pub example_span: SpanIndex,
 }
 
@@ -35,6 +35,33 @@ impl SpanBottomUpBuilder {
     }
 }
 
+#[derive(Hash)]
+struct StringTupleRef<'a>(&'a str, &'a str);
+
+impl<'a> Equivalent<(String, String)> for StringTupleRef<'a> {
+    fn equivalent(&self, other: &(String, String)) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+#[cfg(test)]
+mod string_tuple_ref_tests {
+    use std::hash::RandomState;
+
+    use super::*;
+
+    #[test]
+    fn test_string_tuple_ref_hash() {
+        use std::hash::BuildHasher;
+
+        let s = RandomState::new();
+        assert_eq!(
+            s.hash_one(&StringTupleRef("abc", "def")),
+            s.hash_one(&("abc".to_string(), "def".to_string()))
+        );
+    }
+}
+
 pub fn build_bottom_up_graph<'a>(
     spans: impl Iterator<Item = SpanRef<'a>>,
 ) -> Vec<Arc<SpanBottomUp>> {
@@ -42,7 +69,7 @@ pub fn build_bottom_up_graph<'a>(
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(usize::MAX);
-    let mut roots: HashMap<String, SpanBottomUpBuilder> = HashMap::default();
+    let mut roots: HashMap<(String, String), SpanBottomUpBuilder> = HashMap::default();
 
     // unfortunately there is a rustc bug that fails the typechecking here
     // when using Either<impl Iterator, impl Iterator>. This error appears
@@ -52,30 +79,40 @@ pub fn build_bottom_up_graph<'a>(
     let mut current_iterators: Vec<Box<dyn Iterator<Item = SpanRef<'_>>>> =
         vec![Box::new(spans.flat_map(|span| span.children()))];
 
-    let mut current_path: Vec<(&'_ str, SpanIndex)> = vec![];
+    let mut current_path: Vec<((&'_ str, &'_ str), SpanIndex)> = vec![];
     while let Some(mut iter) = current_iterators.pop() {
         if let Some(child) = iter.next() {
             current_iterators.push(iter);
 
-            let name = child.group_name();
+            let (category, name) = child.group_name();
             let (_, mut bottom_up) = roots
                 .raw_entry_mut()
-                .from_key(name)
-                .or_insert_with(|| (name.to_string(), SpanBottomUpBuilder::new(child.index())));
+                .from_key(&StringTupleRef(category, name))
+                .or_insert_with(|| {
+                    (
+                        (category.to_string(), name.to_string()),
+                        SpanBottomUpBuilder::new(child.index()),
+                    )
+                });
             bottom_up.self_spans.push(child.index());
             let mut prev = None;
-            for &(name, example_span) in current_path.iter().rev().take(max_depth) {
-                if prev == Some(name) {
+            for &((category, title), example_span) in current_path.iter().rev().take(max_depth) {
+                if prev == Some((category, title)) {
                     continue;
                 }
                 let (_, child_bottom_up) = bottom_up
                     .children
                     .raw_entry_mut()
-                    .from_key(name)
-                    .or_insert_with(|| (name.to_string(), SpanBottomUpBuilder::new(example_span)));
+                    .from_key(&StringTupleRef(category, title))
+                    .or_insert_with(|| {
+                        (
+                            (category.to_string(), title.to_string()),
+                            SpanBottomUpBuilder::new(example_span),
+                        )
+                    });
                 child_bottom_up.self_spans.push(child.index());
                 bottom_up = child_bottom_up;
-                prev = Some(name);
+                prev = Some((category, title));
             }
 
             current_path.push((child.group_name(), child.index()));

--- a/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
+++ b/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
@@ -1,10 +1,11 @@
 use std::{env, sync::Arc};
 
-use hashbrown::{Equivalent, HashMap};
+use hashbrown::HashMap;
 
 use crate::{
     span::{SpanBottomUp, SpanIndex},
     span_ref::SpanRef,
+    string_tuple_ref::StringTupleRef,
 };
 
 pub struct SpanBottomUpBuilder {
@@ -32,33 +33,6 @@ impl SpanBottomUpBuilder {
                 .map(|child| Arc::new(child.build()))
                 .collect(),
         )
-    }
-}
-
-#[derive(Hash)]
-struct StringTupleRef<'a>(&'a str, &'a str);
-
-impl<'a> Equivalent<(String, String)> for StringTupleRef<'a> {
-    fn equivalent(&self, other: &(String, String)) -> bool {
-        self.0 == other.0 && self.1 == other.1
-    }
-}
-
-#[cfg(test)]
-mod string_tuple_ref_tests {
-    use std::hash::RandomState;
-
-    use super::*;
-
-    #[test]
-    fn test_string_tuple_ref_hash() {
-        use std::hash::BuildHasher;
-
-        let s = RandomState::new();
-        assert_eq!(
-            s.hash_one(&StringTupleRef("abc", "def")),
-            s.hash_one(&("abc".to_string(), "def".to_string()))
-        );
     }
 }
 

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -17,6 +17,7 @@ mod span_graph_ref;
 mod span_ref;
 mod store;
 mod store_container;
+mod string_tuple_ref;
 mod timestamp;
 mod u64_empty_string;
 mod u64_string;

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -18,6 +18,7 @@ mod span_graph_ref;
 mod span_ref;
 mod store;
 mod store_container;
+mod string_tuple_ref;
 mod timestamp;
 mod u64_empty_string;
 mod u64_string;

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -71,7 +71,7 @@ pub struct SpanExtra {
 pub struct SpanNames {
     // These values are computed when accessed (and maybe deleted during writing):
     pub nice_name: OnceLock<(String, String)>,
-    pub group_name: OnceLock<String>,
+    pub group_name: OnceLock<(String, String)>,
 }
 
 impl Span {

--- a/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
@@ -54,7 +54,7 @@ impl<'a> SpanBottomUpRef<'a> {
         self.bottom_up.self_spans.len()
     }
 
-    pub fn group_name(&self) -> &'a str {
+    pub fn group_name(&self) -> (&'a str, &'a str) {
         self.first_span().group_name()
     }
 
@@ -62,7 +62,7 @@ impl<'a> SpanBottomUpRef<'a> {
         if self.count() == 1 {
             self.example_span().nice_name()
         } else {
-            ("", self.example_span().group_name())
+            self.example_span().group_name()
         }
     }
 
@@ -85,7 +85,7 @@ impl<'a> SpanBottomUpRef<'a> {
                     let _ = self.first_span().graph();
                     self.first_span().extra().graph.get().unwrap().clone()
                 } else {
-                    let mut map: FxIndexMap<&str, (Vec<SpanIndex>, Vec<SpanIndex>)> =
+                    let mut map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)> =
                         FxIndexMap::default();
                     let mut queue = VecDeque::with_capacity(8);
                     for child in self.spans() {

--- a/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
@@ -6,9 +6,9 @@ use std::{
 
 use crate::{
     FxIndexMap,
-    span::{SpanBottomUp, SpanGraphEvent, SpanIndex},
+    span::{SpanBottomUp, SpanGraphEvent},
     span_graph_ref::{SpanGraphEventRef, SpanGraphRef, event_map_to_list},
-    span_ref::SpanRef,
+    span_ref::{GroupNameToDirectAndRecusiveSpans, SpanRef},
     store::{SpanId, Store},
     timestamp::Timestamp,
 };
@@ -85,8 +85,7 @@ impl<'a> SpanBottomUpRef<'a> {
                     let _ = self.first_span().graph();
                     self.first_span().extra().graph.get().unwrap().clone()
                 } else {
-                    let mut map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)> =
-                        FxIndexMap::default();
+                    let mut map: GroupNameToDirectAndRecusiveSpans = FxIndexMap::default();
                     let mut queue = VecDeque::with_capacity(8);
                     for child in self.spans() {
                         let name = child.group_name();

--- a/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
@@ -9,9 +9,9 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use crate::{
     FxIndexMap,
     bottom_up::build_bottom_up_graph,
-    span::{SpanGraph, SpanGraphEvent, SpanIndex},
+    span::{SpanGraph, SpanGraphEvent},
     span_bottom_up_ref::SpanBottomUpRef,
-    span_ref::SpanRef,
+    span_ref::{GroupNameToDirectAndRecusiveSpans, SpanRef},
     store::{SpanId, Store},
     timestamp::Timestamp,
 };
@@ -87,8 +87,7 @@ impl<'a> SpanGraphRef<'a> {
                 self.first_span().extra().graph.get().unwrap().clone()
             } else {
                 let self_group = self.first_span().group_name();
-                let mut map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)> =
-                    FxIndexMap::default();
+                let mut map: GroupNameToDirectAndRecusiveSpans = FxIndexMap::default();
                 let mut queue = VecDeque::with_capacity(8);
                 for span in self.recursive_spans() {
                     for span in span.children() {
@@ -303,9 +302,7 @@ impl<'a> SpanGraphRef<'a> {
     }
 }
 
-pub fn event_map_to_list(
-    map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)>,
-) -> Vec<SpanGraphEvent> {
+pub fn event_map_to_list(map: GroupNameToDirectAndRecusiveSpans) -> Vec<SpanGraphEvent> {
     map.into_iter()
         .map(|(_, (root_spans, recursive_spans))| {
             let graph = SpanGraph {

--- a/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
@@ -40,7 +40,7 @@ impl<'a> SpanGraphRef<'a> {
         if self.count() == 1 {
             self.first_span().nice_name()
         } else {
-            ("", self.first_span().group_name())
+            self.first_span().group_name()
         }
     }
 
@@ -87,7 +87,7 @@ impl<'a> SpanGraphRef<'a> {
                 self.first_span().extra().graph.get().unwrap().clone()
             } else {
                 let self_group = self.first_span().group_name();
-                let mut map: FxIndexMap<&str, (Vec<SpanIndex>, Vec<SpanIndex>)> =
+                let mut map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)> =
                     FxIndexMap::default();
                 let mut queue = VecDeque::with_capacity(8);
                 for span in self.recursive_spans() {
@@ -304,7 +304,7 @@ impl<'a> SpanGraphRef<'a> {
 }
 
 pub fn event_map_to_list(
-    map: FxIndexMap<&str, (Vec<SpanIndex>, Vec<SpanIndex>)>,
+    map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)>,
 ) -> Vec<SpanGraphEvent> {
     map.into_iter()
         .map(|(_, (root_spans, recursive_spans))| {

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -89,18 +89,17 @@ impl<'a> SpanRef<'a> {
                 .find(|&(k, _)| k == "name")
                 .map(|(_, v)| v.as_str())
             {
-                if matches!(
+                if matches!(self.span.name.as_str(), "turbo_tasks::function") {
+                    (self.span.name.clone(), name.to_string())
+                } else if matches!(
                     self.span.name.as_str(),
                     "turbo_tasks::resolve_call" | "turbo_tasks::resolve_trait_call"
                 ) {
-                    (
-                        format!("{} {}", self.span.name, self.span.category),
-                        format!("*{name}"),
-                    )
+                    (self.span.name.clone(), format!("*{name}"))
                 } else {
                     (
-                        format!("{} {}", self.span.name, self.span.category),
-                        name.to_string(),
+                        self.span.category.clone(),
+                        format!("{} {name}", self.span.name),
                     )
                 }
             } else {
@@ -110,29 +109,37 @@ impl<'a> SpanRef<'a> {
         (category, title)
     }
 
-    pub fn group_name(&self) -> &'a str {
-        self.names().group_name.get_or_init(|| {
+    pub fn group_name(&self) -> (&'a str, &'a str) {
+        let (category, title) = self.names().group_name.get_or_init(|| {
             if matches!(self.span.name.as_str(), "turbo_tasks::function") {
-                self.span
+                let name = self
+                    .span
                     .args
                     .iter()
                     .find(|&(k, _)| k == "name")
                     .map(|(_, v)| v.to_string())
-                    .unwrap_or_else(|| self.span.name.to_string())
+                    .unwrap_or_else(|| self.span.name.to_string());
+                (self.span.name.clone(), name)
             } else if matches!(
                 self.span.name.as_str(),
                 "turbo_tasks::resolve_call" | "turbo_tasks::resolve_trait_call"
             ) {
-                self.span
+                let name = self
+                    .span
                     .args
                     .iter()
                     .find(|&(k, _)| k == "name")
                     .map(|(_, v)| format!("*{v}"))
-                    .unwrap_or_else(|| self.span.name.to_string())
+                    .unwrap_or_else(|| self.span.name.to_string());
+                (
+                    self.span.category.clone(),
+                    format!("{} {name}", self.span.name),
+                )
             } else {
-                self.span.name.to_string()
+                (self.span.category.clone(), self.span.name.clone())
             }
-        })
+        });
+        (category.as_str(), title.as_str())
     }
 
     pub fn args(&self) -> impl Iterator<Item = (&str, &str)> {
@@ -349,7 +356,7 @@ impl<'a> SpanRef<'a> {
                         Entry { span, recursive }
                     })
                     .collect_vec_list();
-                let mut map: FxIndexMap<&str, (Vec<SpanIndex>, Vec<SpanIndex>)> =
+                let mut map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)> =
                     FxIndexMap::default();
                 for Entry {
                     span,

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -19,6 +19,9 @@ use crate::{
     timestamp::Timestamp,
 };
 
+pub type GroupNameToDirectAndRecusiveSpans<'l> =
+    FxIndexMap<(&'l str, &'l str), (Vec<SpanIndex>, Vec<SpanIndex>)>;
+
 #[derive(Copy, Clone)]
 pub struct SpanRef<'a> {
     pub(crate) span: &'a Span,
@@ -356,8 +359,7 @@ impl<'a> SpanRef<'a> {
                         Entry { span, recursive }
                     })
                     .collect_vec_list();
-                let mut map: FxIndexMap<(&str, &str), (Vec<SpanIndex>, Vec<SpanIndex>)> =
-                    FxIndexMap::default();
+                let mut map: GroupNameToDirectAndRecusiveSpans = FxIndexMap::default();
                 for Entry {
                     span,
                     mut recursive,

--- a/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
@@ -1,0 +1,28 @@
+use hashbrown::Equivalent;
+
+#[derive(Hash)]
+pub struct StringTupleRef<'a>(pub &'a str, pub &'a str);
+
+impl<'a> Equivalent<(String, String)> for StringTupleRef<'a> {
+    fn equivalent(&self, other: &(String, String)) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+#[cfg(test)]
+mod string_tuple_ref_tests {
+    use std::hash::RandomState;
+
+    use super::*;
+
+    #[test]
+    fn test_string_tuple_ref_hash() {
+        use std::hash::BuildHasher;
+
+        let s = RandomState::new();
+        assert_eq!(
+            s.hash_one(StringTupleRef("abc", "def")),
+            s.hash_one(&("abc".to_string(), "def".to_string()))
+        );
+    }
+}


### PR DESCRIPTION
### What?

Show span name before attribute `name` in tracing when using custom named spans.

Include category and original span name when grouping spans.

Use more custom named spans.

Closes PACK-5125