### PR TITLE
Fail task if one of the parallel ones fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,7 +306,8 @@
       "webpack-sources@3.2.3": "patches/webpack-sources@3.2.3.patch",
       "stacktrace-parser@0.1.10": "patches/stacktrace-parser@0.1.10.patch",
       "@ampproject/toolbox-optimizer@2.8.3": "patches/@ampproject__toolbox-optimizer@2.8.3.patch",
-      "@types/node@20.17.6": "patches/@types__node@20.17.6.patch"
+      "@types/node@20.17.6": "patches/@types__node@20.17.6.patch",
+      "taskr@1.1.0": "patches/taskr@1.1.0.patch"
     }
   }
 }

--- a/patches/taskr@1.1.0.patch
+++ b/patches/taskr@1.1.0.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/taskr.js b/lib/taskr.js
+index c961a997bfb5791383173e3444d18aed4194b21b..3810e74562d17abda9603080fcdbf2d230dc7fe0 100644
+--- a/lib/taskr.js
++++ b/lib/taskr.js
+@@ -115,11 +115,7 @@ class Taskr extends Emitter {
+ 	}
+ 
+ 	*parallel(tasks, opts) {
+-		try {
+-			yield Promise.all(tasks.map(t => this.start(t, opts)));
+-		} catch (err) {
+-			//
+-		}
++		yield Promise.all(tasks.map(t => this.start(t, opts)));
+ 	}
+ 
+ 	*serial(tasks, opts) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ patchedDependencies:
   stacktrace-parser@0.1.10:
     hash: misknddihoqkqinipod62zbcj4
     path: patches/stacktrace-parser@0.1.10.patch
+  taskr@1.1.0:
+    hash: utitb3olraq7egc3hk7waltisu
+    path: patches/taskr@1.1.0.patch
   webpack-sources@3.2.3:
     hash: jbynf5dc46ambamq3wuyho6hkq
     path: patches/webpack-sources@3.2.3.patch
@@ -576,7 +579,7 @@ importers:
         version: 3.2.7(postcss@8.4.31)
       taskr:
         specifier: 1.1.0
-        version: 1.1.0
+        version: 1.1.0(patch_hash=utitb3olraq7egc3hk7waltisu)
       tree-kill:
         specifier: 1.2.2
         version: 1.2.2
@@ -1539,7 +1542,7 @@ importers:
         version: 6.1.15
       taskr:
         specifier: 1.1.0
-        version: 1.1.0
+        version: 1.1.0(patch_hash=utitb3olraq7egc3hk7waltisu)
       terser:
         specifier: 5.27.0
         version: 5.27.0
@@ -34150,7 +34153,7 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  taskr@1.1.0:
+  taskr@1.1.0(patch_hash=utitb3olraq7egc3hk7waltisu):
     dependencies:
       bluebird: 3.7.2
       clor: 5.2.0


### PR DESCRIPTION
I expect `await task.parallel` to work like `await Promise.all` but `task.parallel` actually resolved even if one of its task fails. 

This leads to bad results like https://github.com/vercel/next.js/actions/runs/16171524278/job/45646032904#step:7:717