### PR TITLE
[devtool] dynamically import segment explorer when enabled

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/devtools-panel-tab/segments-explorer-tab.tsx
@@ -1,4 +1,8 @@
-import { PageSegmentTree } from '../../overview/segment-explorer'
+const PageSegmentTree = process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER
+  ? (
+      require('../../overview/segment-explorer') as typeof import('../../overview/segment-explorer')
+    ).PageSegmentTree
+  : () => null
 
 function SegmentsExplorer({
   routerType,

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -28,7 +28,6 @@ import {
 } from './dev-tools-info/preferences'
 import { Draggable } from './draggable'
 import { useShortcuts } from '../../../hooks/use-shortcuts'
-import { SegmentsExplorer } from './dev-tools-info/segments-explorer'
 
 // TODO: add E2E tests to cover different scenarios
 
@@ -96,6 +95,15 @@ const OVERLAYS = {
 export type Overlays = (typeof OVERLAYS)[keyof typeof OVERLAYS]
 
 const INDICATOR_PADDING = 20
+
+// Dynamic import for SegmentsExplorer which including base-ui that causing Edge browser crash
+// x-ref: https://github.com/vercel/next.js/pull/64602
+// TODO: remove this once the new base-ui version is released
+const SegmentsExplorer = process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER
+  ? (
+      require('./dev-tools-info/segments-explorer') as typeof import('./dev-tools-info/segments-explorer')
+    ).SegmentsExplorer
+  : () => null
 
 function DevToolsPopover({
   routerType,


### PR DESCRIPTION
Exclude segment explorer bundle when it's not enabled.

There's an issue in Edge browser on Windows platform, the browser check from mui will crash. It happens when the segment explorer is not enabled. More details described in #81467.
Hence we changed to only import the related modules when segment explorer is enabled to avoid mui being bundled. The proper fix would be bump mui to newer version once [their fix](https://github.com/mui/base-ui/pull/2273) is released.

Fixes #81467