### PR TITLE
[turbopack] Rename `traverse_edges_from_entries_topological` to `traverse_edges_from_entries_dfs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9639,10 +9639,12 @@ dependencies = [
  "turbo-prehash",
  "turbo-rcstr",
  "turbo-tasks",
+ "turbo-tasks-backend",
  "turbo-tasks-build",
  "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
+ "turbo-tasks-testing",
  "urlencoding",
 ]
 

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -13,7 +13,7 @@ use turbopack::css::chunk::CssChunkPlaceable;
 use turbopack_core::{module::Module, module_graph::SingleModuleGraph};
 
 #[derive(
-    Clone, Serialize, Deserialize, Eq, PartialEq, TraceRawVcs, ValueDebugFormat, NonLocalValue,
+    Copy, Clone, Serialize, Deserialize, Eq, PartialEq, TraceRawVcs, ValueDebugFormat, NonLocalValue,
 )]
 pub enum ClientReferenceMapType {
     EcmascriptClientReference {
@@ -31,7 +31,7 @@ pub struct ClientReferencesSet(FxHashMap<ResolvedVc<Box<dyn Module>>, ClientRefe
 pub async fn map_client_references(
     graph: Vc<SingleModuleGraph>,
 ) -> Result<Vc<ClientReferencesSet>> {
-    let actions = graph
+    let client_references = graph
         .await?
         .iter_nodes()
         .map(|node| async move {
@@ -52,9 +52,9 @@ pub async fn map_client_references(
             {
                 Ok(Some((
                     module,
-                    ClientReferenceMapType::CssClientReference(ResolvedVc::upcast(
+                    ClientReferenceMapType::CssClientReference(
                         client_reference_module.await?.client_module,
-                    )),
+                    ),
                 )))
             } else if let Some(server_component) =
                 ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
@@ -69,5 +69,5 @@ pub async fn map_client_references(
         })
         .try_flat_join()
         .await?;
-    Ok(Vc::cell(actions.into_iter().collect()))
+    Ok(Vc::cell(client_references.into_iter().collect()))
 }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -291,7 +291,7 @@ impl ClientReferencesGraph {
             let mut client_references_by_server_component =
                 FxIndexMap::from_iter([(None, Vec::new())]);
 
-            graph.traverse_edges_from_entries_topological(
+            graph.traverse_edges_from_entries_dfs(
                 entries,
                 // state_map is `module -> Option< the current so parent server component >`
                 &mut FxHashMap::default(),

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -961,18 +961,6 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub async fn module_graph_for_entries(
-        self: Vc<Self>,
-        entries: Vc<GraphEntries>,
-    ) -> Result<Vc<ModuleGraph>> {
-        Ok(if *self.per_page_module_graph().await? {
-            ModuleGraph::from_modules(entries, self.next_mode().await?.is_production())
-        } else {
-            *self.whole_app_module_graphs().await?.full
-        })
-    }
-
-    #[turbo_tasks::function]
     pub async fn whole_app_module_graphs(self: ResolvedVc<Self>) -> Result<Vc<ModuleGraphs>> {
         async move {
             let module_graphs_op = whole_app_module_graph_operation(self);

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -50,6 +50,8 @@ turbo-tasks-build = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 tokio = { workspace = true }
+turbo-tasks-testing = { workspace = true }
+turbo-tasks-backend = { workspace = true }
 
 [features]
 default = []

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -220,7 +220,7 @@ pub async fn chunk_group_content(
         entries.push(module_batches_graph.get_entry_index(entry).await?);
     }
 
-    module_batches_graph.traverse_edges_from_entries_topological(
+    module_batches_graph.traverse_edges_from_entries_dfs(
         entries,
         &mut state,
         |parent_info, &node, state| {

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -73,7 +73,7 @@ async fn compute_async_module_info_single(
     // modules in the SCC is async.
 
     let mut async_modules = self_async_modules;
-    graph.traverse_edges_from_entries_topological(
+    graph.traverse_edges_from_entries_dfs(
         graph.entry_modules(),
         &mut (),
         |_, _, _| Ok(GraphTraversalAction::Continue),

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -251,7 +251,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
             let mut visited = FxHashSet::default();
 
             module_graph
-                .traverse_edges_from_entries_topological(
+                .traverse_edges_from_entries_dfs(
                     chunk_group.entries(),
                     &mut (),
                     |parent_info, node, _| {
@@ -332,7 +332,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
             FxHashSet::with_capacity_and_hasher(module_merged_groups.len(), Default::default());
 
         module_graph
-            .traverse_edges_from_entries_topological(
+            .traverse_edges_from_entries_dfs(
                 entries,
                 &mut (),
                 |_, _, _| Ok(GraphTraversalAction::Continue),

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -571,7 +571,7 @@ impl SingleModuleGraph {
     /// Target nodes can be revisited (once per incoming edge).
     /// Edges are traversed in normal order, so should correspond to reference order.
     ///
-    /// * `entry` - The entry module to start the traversal from
+    /// * `entries` - The entry modules to start the traversal from
     /// * `state` - The state to be passed to the visitors
     /// * `visit_preorder` - Called before visiting the children of a node.
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -2008,7 +2008,6 @@ pub mod tests {
     ///     - `Vec<ResolvedVc<Box<dyn Module>>>`: The resolved entry modules.
     ///     - `FxHashMap<ResolvedVc<Box<dyn Module>>, RcStr>`: A mapping from module to its name for
     ///       easier analysis in tests.
-    ///   The function should return a `Result<()>`.
     async fn run_graph_test(
         entries: Vec<RcStr>,
         graph: FxHashMap<RcStr, Vec<RcStr>>,

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1995,8 +1995,20 @@ pub mod tests {
         }
     }
 
-    /// Constructs a graph based on the dependencies describes in the adjacency lists below and then
-    /// calls the [test_fn]
+    /// Constructs a graph based on the provided dependency adjacency lists and calls the given test
+    /// function.
+    ///
+    /// # Parameters
+    /// - `entries`: A vector of entry module names (as `RcStr`). These are the starting points for
+    ///   the graph.
+    /// - `graph`: A map from module name (`RcStr`) to a vector of its dependency module names
+    ///   (`RcStr`). Represents the adjacency list of the graph.
+    /// - `test_fn`: A function that is called with:
+    ///     - `ReadRef<SingleModuleGraph>`: The constructed module graph.
+    ///     - `Vec<ResolvedVc<Box<dyn Module>>>`: The resolved entry modules.
+    ///     - `FxHashMap<ResolvedVc<Box<dyn Module>>, RcStr>`: A mapping from module to its name for
+    ///       easier analysis in tests.
+    ///   The function should return a `Result<()>`.
     async fn run_graph_test(
         entries: Vec<RcStr>,
         graph: FxHashMap<RcStr, Vec<RcStr>>,
@@ -2046,6 +2058,10 @@ pub mod tests {
             )
             .await?;
 
+            // Create a simple name mapping to make analyzing the visitors easier.
+            // Technically they could always pull this name off of the
+            // `module.ident().await?.path.path` themselves but that `await` is trick in the
+            // visitors so precomputing this helps.
             let module_to_name = graph
                 .modules
                 .keys()

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1799,7 +1799,7 @@ pub mod tests {
     use anyhow::Result;
     use rustc_hash::FxHashMap;
     use turbo_rcstr::{RcStr, rcstr};
-    use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+    use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
     use turbo_tasks_fs::{FileSystem, FileSystemPath, VirtualFileSystem};
 
@@ -2001,7 +2001,7 @@ pub mod tests {
         entries: Vec<RcStr>,
         graph: FxHashMap<RcStr, Vec<RcStr>>,
         test_fn: impl FnOnce(
-            &SingleModuleGraph,
+            ReadRef<SingleModuleGraph>,
             Vec<ResolvedVc<Box<dyn Module>>>,
             FxHashMap<ResolvedVc<Box<dyn Module>>, RcStr>,
         ) -> Result<()>
@@ -2054,7 +2054,7 @@ pub mod tests {
                 .await?
                 .into_iter()
                 .collect();
-            test_fn(&*graph, entry_modules, module_to_name)
+            test_fn(graph, entry_modules, module_to_name)
         })
         .await
         .unwrap();

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -563,12 +563,13 @@ impl SingleModuleGraph {
         Ok(())
     }
 
-    /// Traverses all reachable edges in topological order. The preorder visitor can be used to
-    /// forward state down the graph, and to skip subgraphs
+    /// Traverses all reachable edges in dfs order. The preorder visitor can be used to
+    /// forward state down the graph, and to skip subgraphs.
     ///
     /// Use this to collect modules in evaluation order.
     ///
-    /// Target nodes can be revisited (once per incoming edge).
+    /// Target nodes can be revisited (once per incoming edge) in the preorder_visitor, in the post
+    /// order visitor they are visited exactly once with the first edge they were discovered with.
     /// Edges are traversed in normal order, so should correspond to reference order.
     ///
     /// * `entries` - The entry modules to start the traversal from
@@ -580,7 +581,7 @@ impl SingleModuleGraph {
     /// * `visit_postorder` - Called after visiting the children of a node. Return
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
-    pub fn traverse_edges_from_entries_topological<'a, S>(
+    pub fn traverse_edges_from_entries_dfs<'a, S>(
         &'a self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
@@ -1304,15 +1305,16 @@ impl ModuleGraph {
         Ok(())
     }
 
-    /// Traverses all reachable edges in topological order. The preorder visitor can be used to
+    /// Traverses all reachable edges in dfs order. The preorder visitor can be used to
     /// forward state down the graph, and to skip subgraphs
     ///
     /// Use this to collect modules in evaluation order.
     ///
-    /// Target nodes can be revisited (once per incoming edge).
+    /// Target nodes can be revisited (once per incoming edge) in the preorder_visitor, in the post
+    /// order visitor they are visited exactly once with the first edge they were discovered with.
     /// Edges are traversed in normal order, so should correspond to reference order.
     ///
-    /// * `entry` - The entry module to start the traversal from
+    /// * `entries` - The entry modules to start the traversal from
     /// * `state` - The state to be passed to the visitors
     /// * `visit_preorder` - Called before visiting the children of a node.
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
@@ -1322,7 +1324,7 @@ impl ModuleGraph {
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
     ///    - Can return [GraphTraversalAction]s to control the traversal
-    pub async fn traverse_edges_from_entries_topological<S>(
+    pub async fn traverse_edges_from_entries_dfs<S>(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -293,7 +293,7 @@ impl PreBatches {
         };
         let mut visited = FxHashSet::default();
         module_graph
-            .traverse_edges_from_entries_topological(
+            .traverse_edges_from_entries_dfs(
                 std::iter::once(ResolvedVc::upcast(entry)),
                 &mut state,
                 |parent_info, node, state| {

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -123,7 +123,7 @@ impl ModuleBatchesGraph {
 
     // Clippy complains but there's a type error without the bound
     #[allow(clippy::implied_bounds_in_impls)]
-    /// Traverses all reachable edges in topological order. The preorder visitor can be used to
+    /// Traverses all reachable edges in dfs order. The preorder visitor can be used to
     /// forward state down the graph, and to skip subgraphs
     ///
     /// Use this to collect batches/modules in evaluation order.
@@ -131,7 +131,7 @@ impl ModuleBatchesGraph {
     /// Target nodes can be revisited (once per incoming edge).
     /// Edges are traversed in normal order, so should correspond to reference order.
     ///
-    /// * `entry` - The entry module to start the traversal from
+    /// * `entries` - The entry modules to start the traversal from
     /// * `state` - The state to be passed to the visitors
     /// * `visit_preorder` - Called before visiting the children of a node.
     ///    - Receives: (originating &ModuleBatchesGraphNode, edge &ChunkingType), target
@@ -140,7 +140,7 @@ impl ModuleBatchesGraph {
     /// * `visit_postorder` - Called after visiting the children of a node. Return
     ///    - Receives: (originating &ModuleBatchesGraphNode, edge &ChunkingType), target
     ///      &ModuleBatchesGraphNode, state &S
-    pub fn traverse_edges_from_entries_topological<'a, S>(
+    pub fn traverse_edges_from_entries_dfs<'a, S>(
         &'a self,
         entries: impl IntoIterator<
             Item = NodeIndex,
@@ -160,20 +160,16 @@ impl ModuleBatchesGraph {
     ) -> Result<()> {
         let graph = &self.graph;
 
-        enum ReverseTopologicalPass {
+        enum ReverseDFSPass {
             Visit,
             ExpandAndVisit,
         }
 
         let entries = entries.into_iter();
         #[allow(clippy::type_complexity)] // This is a temporary internal structure
-        let mut stack: Vec<(
-            ReverseTopologicalPass,
-            Option<(NodeIndex, EdgeIndex)>,
-            NodeIndex,
-        )> = entries
+        let mut stack: Vec<(ReverseDFSPass, Option<(NodeIndex, EdgeIndex)>, NodeIndex)> = entries
             .rev()
-            .map(|e| (ReverseTopologicalPass::ExpandAndVisit, None, e))
+            .map(|e| (ReverseDFSPass::ExpandAndVisit, None, e))
             .collect();
         let mut expanded = FxHashSet::default();
         while let Some((pass, parent, current)) = stack.pop() {
@@ -184,24 +180,20 @@ impl ModuleBatchesGraph {
                 )
             });
             match pass {
-                ReverseTopologicalPass::Visit => {
+                ReverseDFSPass::Visit => {
                     let current_node = graph.node_weight(current).unwrap();
                     visit_postorder(parent_arg, current_node, state);
                 }
-                ReverseTopologicalPass::ExpandAndVisit => {
+                ReverseDFSPass::ExpandAndVisit => {
                     let current_node = graph.node_weight(current).unwrap();
                     let action = visit_preorder(parent_arg, current_node, state)?;
                     if action == GraphTraversalAction::Exclude {
                         continue;
                     }
-                    stack.push((ReverseTopologicalPass::Visit, parent, current));
+                    stack.push((ReverseDFSPass::Visit, parent, current));
                     if action == GraphTraversalAction::Continue && expanded.insert(current) {
                         stack.extend(iter_neighbors_rev(graph, current).map(|(edge, child)| {
-                            (
-                                ReverseTopologicalPass::ExpandAndVisit,
-                                Some((current, edge)),
-                                child,
-                            )
+                            (ReverseDFSPass::ExpandAndVisit, Some((current, edge)), child)
                         }));
                     }
                 }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -93,7 +93,7 @@ pub async fn compute_style_groups(
         }
         let mut visited = FxHashSet::default();
         let mut items_in_postorder = FxIndexSet::default();
-        batches_graph.traverse_edges_from_entries_topological(
+        batches_graph.traverse_edges_from_entries_dfs(
             entries.iter().copied(),
             &mut (),
             |parent_info, module, _| {


### PR DESCRIPTION
## Rename `traverse_edges_from_entries_topological` to `traverse_edges_from_entries_dfs`

This PR renames the `traverse_edges_from_entries_topological` method to `traverse_edges_from_entries_dfs` to better reflect its actual behavior. The method performs a depth-first search traversal rather than a topological sort.

The PR also:
- Updates the method documentation to clarify that it performs a DFS traversal
- Makes `ClientReferenceMapType` derive `Copy` for better ergonomics
- Removes unnecessary `ResolvedVc::upcast` call in client references mapping
- Renames some variables for clarity (`actions` → `client_references`)
- Removes unused `module_graph_for_entries` function
- Adds some tests for the traversal routine.  Not very interesting for this traversal but should make it easier to test future traversals.

These changes improve code clarity and correctness by ensuring the method name accurately describes its behavior.



Closes PACK-5069