### PR TITLE
[turbopack] Fix an issue in how css references are collected under `next build --turbopack`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4262,6 +4262,7 @@ dependencies = [
  "indexmap 2.9.0",
  "next-core",
  "regex",
+ "roaring",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,6 +395,7 @@ regex = "1.10.6"
 regress = "0.10.3"
 reqwest = { version = "0.12.20", default-features = false }
 ringmap = "0.1.3"
+roaring = "0.10.10"
 rstest = "0.16.0"
 rustc-hash = "2.1.1"
 semver = "1.0.16"

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 indexmap = { workspace = true }
 next-core = { workspace = true }
 regex = { workspace = true }
+roaring = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -146,15 +146,14 @@ pub async fn map_client_references(
                     // self cycle. They don't introduce new bits anyway.
                     && module != *parent_module
                     {
-                        // copy parent bits down.  visit_preorder always visits parents before
-                        // children so we can assert that the parent it set.
+                        // copy parent bits down.  `traverse_edges_from_entries_fixed_point`` always visits parents before
+                        // children so we can simply assert that the parent it set.
                         let [Some(current), Some(parent)] =
                             parent_modules.get_disjoint_mut([&module, parent_module])
                         else {
                             unreachable!()
                         };
-                        // inherit the server components from the newly observed parent.
-                        // check if we are adding new bits and thus need to revisit children unless we are already planning to because this is a new node.
+                        // Check if we are adding new bits and thus need to revisit children unless we are already planning to because this is a new node.
                         if !should_visit_children {
                             let len = current.len();
                             *current |= &*parent;

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -1,16 +1,23 @@
 use anyhow::Result;
 use next_core::{
-    self,
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
     next_server_component::server_component_module::NextServerComponentModule,
 };
+use roaring::RoaringBitmap;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use tracing::Instrument;
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    FxIndexSet, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc, debug::ValueDebugFormat,
+    trace::TraceRawVcs,
 };
 use turbopack::css::chunk::CssChunkPlaceable;
-use turbopack_core::{module::Module, module_graph::SingleModuleGraph};
+use turbopack_core::{
+    module::Module,
+    module_graph::{
+        GraphTraversalAction, SingleModuleGraph, chunk_group_info::RoaringBitmapWrapper,
+    },
+};
 
 #[derive(
     Copy, Clone, Serialize, Deserialize, Eq, PartialEq, TraceRawVcs, ValueDebugFormat, NonLocalValue,
@@ -24,50 +31,174 @@ pub enum ClientReferenceMapType {
     ServerComponent(ResolvedVc<NextServerComponentModule>),
 }
 
-#[turbo_tasks::value(transparent)]
-pub struct ClientReferencesSet(FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>);
+#[turbo_tasks::value]
+pub struct ClientReferencesSet {
+    pub client_references: FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>,
+    // All the server components in the graph.
+    server_components: FxIndexSet<ResolvedVc<NextServerComponentModule>>,
+    // All the server components that depend on each module
+    // This only includes mappings for modules with client references and the bitmaps reference
+    // indices into `[server_components]`
+    server_components_for_client_references:
+        FxHashMap<ResolvedVc<Box<dyn Module>>, RoaringBitmapWrapper>,
+}
+
+impl ClientReferencesSet {
+    fn new(client_references: ClientReferencesSet) -> Vc<Self> {
+        Self::cell(client_references)
+    }
+
+    /// Returns all the server components that depend on the given client reference
+    pub fn server_components_for_client_reference(
+        &self,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> impl Iterator<Item = ResolvedVc<NextServerComponentModule>> {
+        let bitmap = &self
+            .server_components_for_client_references
+            .get(&module)
+            .expect("the passed module should be a client reference module")
+            .0;
+
+        bitmap
+            .iter()
+            .map(|index| *self.server_components.get_index(index as usize).unwrap())
+    }
+}
 
 #[turbo_tasks::function]
 pub async fn map_client_references(
     graph: Vc<SingleModuleGraph>,
 ) -> Result<Vc<ClientReferencesSet>> {
-    let client_references = graph
-        .await?
-        .iter_nodes()
-        .map(|node| async move {
-            let module = node.module;
+    let span = tracing::info_span!("mapping client references");
+    async move {
+        let graph = graph.await?;
+        let client_references = graph
+            .iter_nodes()
+            .map(|node| async move {
+                let module = node.module;
 
-            if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
-            {
-                Ok(Some((
-                    module,
-                    ClientReferenceMapType::EcmascriptClientReference {
-                        module: client_reference_module,
-                        ssr_module: ResolvedVc::upcast(client_reference_module.await?.ssr_module),
-                    },
-                )))
-            } else if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<CssClientReferenceModule>(module)
-            {
-                Ok(Some((
-                    module,
-                    ClientReferenceMapType::CssClientReference(
-                        client_reference_module.await?.client_module,
-                    ),
-                )))
-            } else if let Some(server_component) =
-                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
-            {
-                Ok(Some((
-                    module,
-                    ClientReferenceMapType::ServerComponent(server_component),
-                )))
-            } else {
-                Ok(None)
-            }
-        })
-        .try_flat_join()
-        .await?;
-    Ok(Vc::cell(client_references.into_iter().collect()))
+                if let Some(client_reference_module) =
+                    ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
+                {
+                    Ok(Some((
+                        module,
+                        ClientReferenceMapType::EcmascriptClientReference {
+                            module: client_reference_module,
+                            ssr_module: ResolvedVc::upcast(
+                                client_reference_module.await?.ssr_module,
+                            ),
+                        },
+                    )))
+                } else if let Some(client_reference_module) =
+                    ResolvedVc::try_downcast_type::<CssClientReferenceModule>(module)
+                {
+                    Ok(Some((
+                        module,
+                        ClientReferenceMapType::CssClientReference(
+                            client_reference_module.await?.client_module,
+                        ),
+                    )))
+                } else if let Some(server_component) =
+                    ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
+                {
+                    Ok(Some((
+                        module,
+                        ClientReferenceMapType::ServerComponent(server_component),
+                    )))
+                } else {
+                    Ok(None)
+                }
+            })
+            .try_flat_join()
+            .await?
+            .into_iter()
+            .collect::<FxHashMap<_, _>>();
+
+        let mut server_components = FxIndexSet::default();
+        let mut parent_modules = FxHashMap::default();
+        if !client_references.is_empty() {
+            graph.traverse_edges_from_entries_fixed_point(
+                graph.entry_modules(),
+                |parent_info, node| {
+                    let module = node.module();
+                    let module_type = client_references.get(&module);
+                    let mut should_visit_children = match parent_modules.entry(module) {
+                        std::collections::hash_map::Entry::Occupied(_) => false,
+                        std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                            // only do this the first time we visit the node.
+                            let bits = vacant_entry.insert(RoaringBitmap::new());
+                            if let Some(ClientReferenceMapType::ServerComponent(
+                                server_component_module,
+                            )) = module_type
+                            {
+                                let index =
+                                    server_components.insert_full(*server_component_module).0;
+
+                                bits.insert(index.try_into().unwrap());
+                            }
+                            true
+                        }
+                    };
+                    if let Some((parent_module, _)) = parent_info {
+                        // copy parent bits down.  visit_preorder always visits parents before
+                        // children so we can assert that the parent it set.
+                        let [Some(current), Some(parent)] =
+                            parent_modules.get_disjoint_mut([&module, &parent_module.module])
+                        else {
+                            unreachable!()
+                        };
+                        // inherit the server components from the newly observed parent.
+                        // check if we are adding new bits and thus need to revisit children
+                        if !should_visit_children {
+                            let len = current.len();
+                            *current |= &*parent;
+                            should_visit_children |= len != current.len(); // did we find new bits
+                        } else {
+                            *current |= &*parent;
+                        }
+                    }
+
+                    Ok(match module_type {
+                        Some(
+                            ClientReferenceMapType::EcmascriptClientReference { .. }
+                            | ClientReferenceMapType::CssClientReference { .. },
+                        ) => {
+                            // No need to explore these subgraphs ever, these are the leaves in the
+                            // server component graph
+                            GraphTraversalAction::Skip
+                        }
+                        // Continue on server components and through graphs of non-ClientReference
+                        // modules, but only if our set of parent components has changed.
+                        _ => {
+                            if should_visit_children {
+                                GraphTraversalAction::Continue
+                            } else {
+                                GraphTraversalAction::Skip
+                            }
+                        }
+                    })
+                },
+            )?;
+        }
+
+        // Filter down to just the client reference modules to reduce datastructure size
+        let server_components_for_client_references = parent_modules
+            .into_iter()
+            .filter_map(|(k, v)| match client_references.get(&k) {
+                Some(
+                    ClientReferenceMapType::CssClientReference(_)
+                    | ClientReferenceMapType::EcmascriptClientReference { .. },
+                ) => Some((k, RoaringBitmapWrapper(v))),
+                _ => None,
+            })
+            .collect();
+
+        Ok(ClientReferencesSet::new(ClientReferencesSet {
+            client_references,
+            server_components,
+            server_components_for_client_references,
+        }))
+    }
+    .instrument(span)
+    .await
 }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
     debug::ValueDebugFormat,
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
     trace::TraceRawVcs,
@@ -75,10 +75,6 @@ pub enum ClientReferenceType {
 #[derive(Clone, Debug, Default)]
 pub struct ClientReferenceGraphResult {
     pub client_references: Vec<ClientReference>,
-    /// Only the [`ClientReferenceType::EcmascriptClientReference`]s are listed in this map.
-    #[allow(clippy::type_complexity)]
-    pub client_references_by_server_component:
-        FxIndexMap<Option<ResolvedVc<NextServerComponentModule>>, Vec<ResolvedVc<Box<dyn Module>>>>,
     pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
     pub server_utils: Vec<ResolvedVc<NextServerUtilityModule>>,
 }
@@ -115,12 +111,6 @@ impl ClientReferenceGraphResult {
     pub fn extend(&mut self, other: &Self) {
         self.client_references
             .extend(other.client_references.iter().copied());
-        for (k, v) in other.client_references_by_server_component.iter() {
-            self.client_references_by_server_component
-                .entry(*k)
-                .or_insert_with(Vec::new)
-                .extend(v);
-        }
         self.server_component_entries
             .extend(other.server_component_entries.iter().copied());
         self.server_utils.extend(other.server_utils.iter().copied());

--- a/test/e2e/app-dir/initial-css-not-found/app/(default)/layout.tsx
+++ b/test/e2e/app-dir/initial-css-not-found/app/(default)/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+import styles from '@/app/styles.module.css'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body className={styles.foo}>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/initial-css-not-found/app/(default)/page.tsx
+++ b/test/e2e/app-dir/initial-css-not-found/app/(default)/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/initial-css-not-found/app/fonts.ts
+++ b/test/e2e/app-dir/initial-css-not-found/app/fonts.ts
@@ -1,0 +1,11 @@
+import { Geist, Geist_Mono } from 'next/font/google'
+
+export const geistSans = Geist({
+  variable: '--font-geist-sans',
+  subsets: ['latin'],
+})
+
+export const geistMono = Geist_Mono({
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
+})

--- a/test/e2e/app-dir/initial-css-not-found/app/layout.tsx
+++ b/test/e2e/app-dir/initial-css-not-found/app/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/test/e2e/app-dir/initial-css-not-found/app/not-found.tsx
+++ b/test/e2e/app-dir/initial-css-not-found/app/not-found.tsx
@@ -1,0 +1,16 @@
+import styles from '@/app/styles.module.css'
+
+/**
+ * The mere existence of a not found page importing the same css as a layout used to prevent it frombeing served.
+ */
+export default function NotFoundPage() {
+  return (
+    <html>
+      <body className={styles.foo}>
+        <main>
+          <h1>Page not found</h1>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/initial-css-not-found/app/styles.module.css
+++ b/test/e2e/app-dir/initial-css-not-found/app/styles.module.css
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
+++ b/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
@@ -9,6 +9,7 @@ describe('initial-css-not-found', () => {
   it('should serve styles', async () => {
     const browser = await next.browser('/')
 
+    // Simply check that our css was served and applied.
     expect(
       await browser.eval(
         `window.getComputedStyle(document.querySelector('body')).color`

--- a/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
+++ b/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
@@ -1,0 +1,18 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('initial-css-not-found', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Regression test for a bug where the existence of a not-found page would prevent the css from being discovered.
+  it('should serve styles', async () => {
+    const browser = await next.browser('/')
+
+    expect(
+      await browser.eval(
+        `window.getComputedStyle(document.querySelector('body')).color`
+      )
+    ).toBe('rgb(255, 0, 0)')
+  })
+})

--- a/test/e2e/app-dir/initial-css-not-found/next.config.js
+++ b/test/e2e/app-dir/initial-css-not-found/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { workspace = true }
 once_cell = { workspace = true }
 patricia_tree = "0.5.5"
 petgraph = { workspace = true, features = ["serde-1"] }
-roaring = { version = "0.10.10", features = ["serde"] }
+roaring = { workspace = true, features = ["serde"] }
 ref-cast = "1.0.20"
 rustc-hash = { workspace = true }
 regex = { workspace = true }

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -25,6 +25,7 @@ use crate::{
 #[derive(
     Clone, Debug, Default, PartialEq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat,
 )]
+#[repr(transparent)]
 pub struct RoaringBitmapWrapper(#[turbo_tasks(trace_ignore)] pub RoaringBitmap);
 
 impl TaskInput for RoaringBitmapWrapper {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -568,19 +568,18 @@ impl SingleModuleGraph {
     /// eventual termination of the traversal. This corresponds to computing a fixed point state for
     /// the graph.
     ///
-    /// Nodes are (re)visited according to the returned priority of the node, prioritizing high
-    /// values. This priority is intended to be used a heuristic to reduce the number of
-    /// retraversals.
+    /// It is guaranteed that the parent node passed to the `visit` function, if any, has
+    /// already been passed to `visit`.
     ///
     /// * `entries` - The entry modules to start the traversal from
     /// * `state` - The state to be passed to the callbacks
     /// * `visit` - Called for a specific edge
-    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///    - Receives: Option(originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode
     ///    - Return [GraphTraversalAction]s to control the traversal
     ///
-    /// Returns the number of node visits (i.e. higher than the node count if there are
-    /// retraversals).
+    /// Returns the number of node visits (i.e. higher than the node
+    /// count if there are retraversals).
     pub fn traverse_edges_from_entries_fixed_point<'a>(
         &'a self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
@@ -2001,7 +2000,7 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn traverse_edges_from_entries_fixed_point_diamond() {
+    async fn traverse_edges_from_entries_fixed_point_cycle() {
         run_graph_test(
             vec![rcstr!("a.js")],
             {
@@ -2040,6 +2039,7 @@ pub mod tests {
                         (Some(rcstr!("a.js")), rcstr!("b.js")),
                         (Some(rcstr!("b.js")), rcstr!("c.js")),
                         (Some(rcstr!("c.js")), rcstr!("a.js")),
+                        // we start following the cycle again
                         (Some(rcstr!("a.js")), rcstr!("b.js")),
                         (Some(rcstr!("b.js")), rcstr!("c.js")),
                     ],


### PR DESCRIPTION
## Fix how client references are discovered during `next build --turbopack`

To correctly serve js and css resources during server side rendering we construct a client manifest that lists all the server components and their requires resources.  Prior to this PR there was a bug where we would sometimes fail to serve css resources.  The major cases we have seen this is when a `not-found.js` file references css that is also referenced by a layout.

When present all pages pages implicitly depend on this module and depend on it as an early implicit dependency of the generated `app-page.js` file.  This means if a `not-found.js` file (or a global error file) would happen to depend on the same css as a normal component we would associate it as a client-reference of that component instead of any other.  Then on a server side render we would simply omit it.

This PR address this by ensuring we always associate client resources with every server component that depends on them, not just the first one.  To do this we precompute the full set of server components that depend on each client resource in the module graph and then after our dfs traversal we can collect all server components for a given entry point and then perform the association.

The downside of this approach is simply the additional 'fixed point' traversal (shared across all routes) and the slightly more complex bookkeeping during each route computation.


Fixes #77861
Fixes #79535

Closes PACK-5097