### PR TITLE
Name patched `fetch` function `fetch`

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -151,12 +151,11 @@ export function createPatchedFetcher(
   originFetch: Fetcher,
   { workAsyncStorage, workUnitAsyncStorage }: PatchableModule
 ): PatchedFetcher {
-  // Create the patched fetch function. We don't set the type here, as it's
-  // verified as the return value of this function.
-  const patched = async (
+  // Create the patched fetch function.
+  const patched = async function fetch(
     input: RequestInfo | URL,
     init: RequestInit | undefined
-  ) => {
+  ): Promise<Response> {
     let url: URL | undefined
     try {
       url = new URL(input instanceof Request ? input.url : input)

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -1051,6 +1051,10 @@ export function createPatchedFetcher(
   patched._nextOriginalFetch = originFetch
   ;(globalThis as Record<symbol, unknown>)[NEXT_PATCH_SYMBOL] = true
 
+  // Assign the function name also as a name property, so that it's preserved
+  // even when mangling is enabled.
+  Object.defineProperty(patched, 'name', { value: 'fetch', writable: false })
+
   return patched
 }
 // we patch fetch to collect cache information used for

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -24,12 +24,8 @@ describe('react-performance-track', () => {
     expect(track).toEqual([
       {
         // TODO(veil): Should always be `fetch (random)`
-        name: isTurbopack ? 'fetch (random)' : 'patched',
-        properties: expect.arrayContaining([
-          ['status', '200'],
-          // Not sure if this is useful to assert on. Feel free to remove is this breaks often
-          ['body', isTurbopack ? 'ReadableStream' : 'TeeReadableStream'],
-        ]),
+        name: isTurbopack ? 'fetch (random)' : 'fetch',
+        properties: expect.arrayContaining([['status', '200']]),
       },
     ])
   })


### PR DESCRIPTION
This ensures that `fetch` is shown in stack traces (in collapsed ignore-listed frames), instead of `patched`.