### PR TITLE
[turbopack] fix styled-jsx import message

### DIFF
--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -192,7 +192,7 @@ pub(crate) fn get_invalid_styled_jsx_resolve_plugin(
         root,
         "styled-jsx".into(),
         vec![
-            "'client-only' cannot be imported from a Server Component module. It should only be \
+            "'styled-jsx' cannot be imported from a Server Component module. It should only be \
              used from a Client Component."
                 .into(),
             "The error was caused by using 'styled-jsx'. It only works in a Client Component but \

--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -66,10 +66,10 @@ describe('Error Overlay invalid imports', () => {
     await session.assertHasRedbox()
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./app
-        Invalid import
-        'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.
-        The error was caused by using 'styled-jsx'. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default."
+       "./app
+       Invalid import
+       'styled-jsx' cannot be imported from a Server Component module. It should only be used from a Client Component.
+       The error was caused by using 'styled-jsx'. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default."
       `)
     } else {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`


### PR DESCRIPTION
seems weird that that message is inconsistent with all the other aliases we have there