### PR TITLE
Configure `url` for responses from patched fetch like the original `response.url`

### DIFF
--- a/packages/next/src/server/lib/clone-response.ts
+++ b/packages/next/src/server/lib/clone-response.ts
@@ -27,6 +27,10 @@ export function cloneResponse(original: Response): [Response, Response] {
 
   Object.defineProperty(cloned1, 'url', {
     value: original.url,
+    // How the original response.url behaves
+    configurable: true,
+    enumerable: true,
+    writable: false,
   })
 
   const cloned2 = new Response(body2, {
@@ -37,6 +41,10 @@ export function cloneResponse(original: Response): [Response, Response] {
 
   Object.defineProperty(cloned2, 'url', {
     value: original.url,
+    // How the original response.url behaves
+    configurable: true,
+    enumerable: true,
+    writable: false,
   })
 
   return [cloned1, cloned2]

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -29,9 +29,13 @@ describe('react-performance-track', () => {
     expect(track).toEqual(
       expect.arrayContaining([
         {
-          // TODO: Should include the URL.
-          name: 'fetch',
-          properties: expect.arrayContaining([['status', '200']]),
+          // React might decide to display the shorthand in round brackets differently.
+          // Double check with React changes if a shorthand change is intended.
+          name: 'fetch (random)',
+          properties: expect.arrayContaining([
+            ['status', '200'],
+            ['url', '"https://next-data-api-endpoint.vercel.app/api/random"'],
+          ]),
         },
       ])
     )


### PR DESCRIPTION
The main config that was missing is enumerability which is relevant for showing properties in the Chrome performance track and inferring shorthands.