### PR TITLE
[turbopack] Improve internal error message when source map retrieval fails

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1411,7 +1411,7 @@ pub async fn get_source_map_rope(
                     },
                 )
             }
-            _ => bail!("Unknown url scheme"),
+            _ => bail!("Unknown url scheme '{}'", url.scheme()),
         },
         Err(_) => (file_path.to_string(), None),
     };

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -716,5 +716,6 @@
   "715": "Server Action \"%s\" was not found on the server. \\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "716": "NEXT_DEVTOOLS_SIMULATED_ERROR",
   "717": "Unsupported environment condition \"%s\" and react condition \"%s\". This is a bug in Next.js.",
-  "718": "Invariant: projectDir is required for node runtime"
+  "718": "Invariant: projectDir is required for node runtime",
+  "719": "Failed to get source map for '%s'. This is a bug in Next.js"
 }

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -7,7 +7,6 @@ import {
 } from '../../next-devtools/server/shared'
 import { middlewareResponse } from '../../next-devtools/server/middleware-response'
 import path from 'path'
-import url from 'url'
 import { openFileInEditor } from '../../next-devtools/server/launch-editor'
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import {
@@ -21,7 +20,7 @@ import {
 } from '../lib/source-maps'
 import { getSourceMapFromFile } from './get-source-map-from-file'
 import { findSourceMap } from 'node:module'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { inspect } from 'node:util'
 
 function shouldIgnorePath(modulePath: string): boolean {
@@ -302,7 +301,7 @@ async function createOriginalStackFrame(
   ) {
     normalizedStackFrameLocation = path.relative(
       projectPath,
-      url.fileURLToPath(normalizedStackFrameLocation)
+      fileURLToPath(normalizedStackFrameLocation)
     )
   }
 
@@ -437,7 +436,7 @@ export function getSourceMapMiddleware(project: Project) {
     }
 
     if (path.isAbsolute(filename)) {
-      filename = url.pathToFileURL(filename).href
+      filename = pathToFileURL(filename).href
     }
 
     try {

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -432,11 +432,15 @@ export function getSourceMapMiddleware(project: Project) {
     try {
       // Turbopack chunk filenames might be URL-encoded.
       filename = decodeURI(filename)
+    } catch {
+      return middlewareResponse.badRequest(res)
+    }
 
-      if (path.isAbsolute(filename)) {
-        filename = url.pathToFileURL(filename).href
-      }
+    if (path.isAbsolute(filename)) {
+      filename = url.pathToFileURL(filename).href
+    }
 
+    try {
       const sourceMapString = await project.getSourceMap(filename)
 
       if (sourceMapString) {
@@ -450,8 +454,16 @@ export function getSourceMapMiddleware(project: Project) {
           return middlewareResponse.json(res, sourceMap)
         }
       }
-    } catch (error) {
-      console.error('Failed to get source map:', error)
+    } catch (cause) {
+      return middlewareResponse.internalServerError(
+        res,
+        new Error(
+          `Failed to get source map for '${filename}'. This is a bug in Next.js`,
+          {
+            cause,
+          }
+        )
+      )
     }
 
     middlewareResponse.noContent(res)


### PR DESCRIPTION
Mostly so that I know which source URL slipped through.