### PR TITLE
Turbopack: fix export-all-as with name collision

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/index.js
@@ -1,0 +1,5 @@
+import { Sub } from 'package'
+
+it('should have the correct value', () => {
+  expect(Sub).toMatchObject({ Sub: 123 })
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/node_modules/package/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/node_modules/package/index.js
@@ -1,0 +1,1 @@
+export * as Sub from './sub.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/node_modules/package/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/node_modules/package/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/node_modules/package/sub.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/input/node_modules/package/sub.js
@@ -1,0 +1,1 @@
+export const Sub = 123

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-all-as/options.json
@@ -1,0 +1,3 @@
+{
+  "treeShakingMode": "reexports-only"
+}


### PR DESCRIPTION
`EcmascriptModulePartReference` is a pretty counterintuitive reference. The `part` declares which module should be synthesised on the other side. That doesn't have anything to do with which exports are actually being imported by reference.

This only triggered a bug when these exports here had the same name by coincidence
```js
// reexport.js
export * as Sub from './sub.js' // <--
// sub.js
export const Sub = 123 // <-- 
```

Closes PACK-5056