### PR TITLE
docs: add missing `-D` flag upon installing React compiler

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/reactCompiler.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/reactCompiler.mdx
@@ -17,7 +17,7 @@ This avoids compiling everything and keeps the performance cost minimal. You may
 To use it, install the `babel-plugin-react-compiler`:
 
 ```bash filename="Terminal"
-npm install babel-plugin-react-compiler
+npm install -D babel-plugin-react-compiler
 ```
 
 Then, add `experimental.reactCompiler` option in `next.config.js`:


### PR DESCRIPTION
This simply adds a `-D` to make the React compiler a dev dependency in the guide to install it. In [React docs](https://react.dev/learn/react-compiler) it also uses  `-D`. I think it just went missing here.