### PR TITLE
fix: preprocess windows files correctly

### DIFF
--- a/packages/next/src/server/dev/browser-logs/receive-logs.test.ts
+++ b/packages/next/src/server/dev/browser-logs/receive-logs.test.ts
@@ -1,4 +1,5 @@
 import { stripFormatSpecifiers } from './receive-logs'
+import { preprocessStackTrace } from './source-map'
 
 describe('stripFormatSpecifiers', () => {
   it('should only process when first arg is string containing %', () => {
@@ -70,5 +71,28 @@ describe('stripFormatSpecifiers', () => {
 
   it('should handle % at end of string', () => {
     expect(stripFormatSpecifiers(['ends with %'])).toEqual(['ends with %'])
+  })
+})
+
+describe('preprocessStackTrace', () => {
+  it('should convert _next/static paths to file URLs (posix)', () => {
+    const input = '    at myFunc (_next/static/chunks/app/page.js:1:1)'
+    const distDir = '/project/.next'
+    const output = preprocessStackTrace(input, distDir)
+
+    expect(output).toContain('file://')
+    expect(output).toContain('/project/.next/static/chunks/app/page.js:1:1')
+  })
+
+  it('should convert _next static paths with backslashes (windows) to file URLs', () => {
+    const input = '    at myFunc (_next\\static\\chunks\\app\\page.js:1:1)'
+    const distDir = '/project/.next'
+    const output = preprocessStackTrace(input, distDir)
+
+    expect(output).toContain('file://')
+    expect(output).toContain('/project/.next/static/chunks/app/page.js:1:1')
+
+    expect(output).not.toContain('_next/static')
+    expect(output).not.toContain('\\')
   })
 })


### PR DESCRIPTION
Previously we hardcoded a special case with forward slashes when preprocessing stack traces before source mapping. This caused source locations to show .next\static\chunks instead of their correct source mapped names

Before:

After:
<img width="719" height="175" alt="image" src="https://github.com/user-attachments/assets/38794cf5-6f2c-4dfb-be32-aa4607b15c3b" />


Closes NEXT-4609
Closes #81498