### PR TITLE
perf: memorize exclude function in webpack config

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -447,8 +447,9 @@ export default async function getBaseWebpackConfig(
 
   const excludeCache: Record<string, boolean> = {}
   function exclude(excludePath: string): boolean {
-    if (excludeCache[excludePath] !== undefined) {
-      return excludeCache[excludePath]
+    const cached = excludeCache[excludePath]
+    if (cached !== undefined) {
+      return cached
     }
 
     const shouldExclude =

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -445,6 +445,21 @@ export default async function getBaseWebpackConfig(
     loggedIgnoredCompilerOptions = true
   }
 
+  const excludeCache: Record<string, boolean> = {}
+  function exclude(excludePath: string): boolean {
+    if (excludeCache[excludePath] !== undefined) {
+      return excludeCache[excludePath]
+    }
+
+    const shouldExclude =
+      !babelIncludeRegexes.some((r) => r.test(excludePath)) &&
+      !isResourceInPackages(excludePath, finalTranspilePackages) &&
+      excludePath.includes('node_modules')
+
+    excludeCache[excludePath] = shouldExclude
+    return shouldExclude
+  }
+
   const shouldIncludeExternalDirs =
     config.experimental.externalDir || !!config.transpilePackages
   const codeCondition = {
@@ -453,19 +468,7 @@ export default async function getBaseWebpackConfig(
       ? // Allowing importing TS/TSX files from outside of the root dir.
         {}
       : { include: [dir, ...babelIncludeRegexes] }),
-    exclude: (excludePath: string) => {
-      if (babelIncludeRegexes.some((r) => r.test(excludePath))) {
-        return false
-      }
-
-      const shouldBeBundled = isResourceInPackages(
-        excludePath,
-        finalTranspilePackages
-      )
-      if (shouldBeBundled) return false
-
-      return excludePath.includes('node_modules')
-    },
+    exclude,
   }
 
   const babelLoader = getBabelLoader(

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -452,9 +452,9 @@ export default async function getBaseWebpackConfig(
     }
 
     const shouldExclude =
+      excludePath.includes('node_modules') &&
       !babelIncludeRegexes.some((r) => r.test(excludePath)) &&
-      !isResourceInPackages(excludePath, finalTranspilePackages) &&
-      excludePath.includes('node_modules')
+      !isResourceInPackages(excludePath, finalTranspilePackages)
 
     excludeCache[excludePath] = shouldExclude
     return shouldExclude


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

During JavaScript profiling, I identified repeated calls to the exclude function in the webpack configuration and implemented caching to optimize it.

<img width="2248" height="772" alt="image" src="https://github.com/user-attachments/assets/1fdb03f3-2904-4195-a538-7b1f4646f0f2" />

I tested the performance using the [chakra-ui-docs](https://github.com/SyMind/chakra-ui-docs) repository with the following steps:
  1. Execute `pnpm run dev`
  2. Wait for the server to be ready (indicated by the 'Ready' message)
  3. Run `curl` on the root endpoint (`/`)

| | Webpack | Rspack |
|-|-|-|
|After| Compiled / in 8.3s (2682 modules) | Compiled / in 2.3s (2650 modules) |
|Before| Compiled / in 7.8s (2682 modules) | Compiled / in 1983ms (2650 modules) |