### PR TITLE
Turbopack: add module cost benchmark

### DIFF
--- a/bench/module-cost/.gitignore
+++ b/bench/module-cost/.gitignore
@@ -1,0 +1,3 @@
+commonjs/*
+esm/*
+CPU*

--- a/bench/module-cost/app/app/commonjs/route.js
+++ b/bench/module-cost/app/app/commonjs/route.js
@@ -3,7 +3,10 @@
 import { measure } from '../../../lib/measure'
 
 export async function GET() {
-  const result = await measure(() => import('../../../lib/commonjs.js'))
+  const result = await measure(
+    'app route commonjs',
+    () => import('../../../lib/commonjs.js')
+  )
 
   return Response.json(result)
 }

--- a/bench/module-cost/app/app/commonjs/route.js
+++ b/bench/module-cost/app/app/commonjs/route.js
@@ -1,0 +1,9 @@
+// Next.js route.js
+
+import { measure } from '../../../lib/measure'
+
+export async function GET() {
+  const result = await measure(() => import('../../../lib/commonjs.js'))
+
+  return Response.json(result)
+}

--- a/bench/module-cost/app/app/esm/route.js
+++ b/bench/module-cost/app/app/esm/route.js
@@ -3,7 +3,10 @@
 import { measure } from '../../../lib/measure'
 
 export async function GET() {
-  const result = await measure(() => import('../../../lib/esm.js'))
+  const result = await measure(
+    'app route esm',
+    () => import('../../../lib/esm.js')
+  )
 
   return Response.json(result)
 }

--- a/bench/module-cost/app/app/esm/route.js
+++ b/bench/module-cost/app/app/esm/route.js
@@ -1,0 +1,9 @@
+// Next.js route.js
+
+import { measure } from '../../../lib/measure'
+
+export async function GET() {
+  const result = await measure(() => import('../../../lib/esm.js'))
+
+  return Response.json(result)
+}

--- a/bench/module-cost/app/app/page.js
+++ b/bench/module-cost/app/app/page.js
@@ -1,0 +1,17 @@
+import { Client } from '../../components/client'
+
+import { format, measure } from '../../lib/measure.js'
+
+const COMMONJS = await measure(() => import('../../lib/commonjs.js'))
+const ESM = await measure(() => import('../../lib/esm.js'))
+
+export default function Page() {
+  return (
+    <>
+      <h1>Measures the loading time of modules (app router)</h1>
+      <p>CommonJs RSC ({format(COMMONJS)})</p>
+      <p>ESM RSC ({format(ESM)})</p>
+      <Client prefix="/app" />
+    </>
+  )
+}

--- a/bench/module-cost/app/app/page.js
+++ b/bench/module-cost/app/app/page.js
@@ -1,17 +1,29 @@
 import { Client } from '../../components/client'
 
-import { format, measure } from '../../lib/measure.js'
+import { measure } from '../../lib/measure.js'
 
-const COMMONJS = await measure(() => import('../../lib/commonjs.js'))
-const ESM = await measure(() => import('../../lib/esm.js'))
+const commonjsAction = async () => {
+  'use server'
+  return await measure(
+    'app rsc commonjs',
+    () => import('../../lib/commonjs.js')
+  )
+}
+
+const esmAction = async () => {
+  'use server'
+  return await measure('app rsc esm', () => import('../../lib/esm.js'))
+}
 
 export default function Page() {
   return (
     <>
       <h1>Measures the loading time of modules (app router)</h1>
-      <p>CommonJs RSC ({format(COMMONJS)})</p>
-      <p>ESM RSC ({format(ESM)})</p>
-      <Client prefix="/app" />
+      <Client
+        prefix="/app"
+        commonjsAction={commonjsAction}
+        esmAction={esmAction}
+      />
     </>
   )
 }

--- a/bench/module-cost/app/layout.js
+++ b/bench/module-cost/app/layout.js
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <head></head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/bench/module-cost/components/client.js
+++ b/bench/module-cost/components/client.js
@@ -2,17 +2,27 @@
 
 import { format, measure } from '../lib/measure'
 
-async function measureClientButton(element, fn) {
+async function measureClientButton(element, name, fn) {
   if (element.textContent.includes('Loading time')) {
     return
   }
 
-  const result = await measure(fn)
+  const result = await measure(name, fn)
 
   element.textContent += ` (${format(result)})`
 }
 
-async function measureServerButton(element, url) {
+async function measureActionButton(element, action) {
+  if (element.textContent.includes('Loading time')) {
+    return
+  }
+
+  const result = await action()
+
+  element.textContent += ` (${format(result)})`
+}
+
+async function measureApiButton(element, url) {
   if (element.textContent.includes('Loading time')) {
     return
   }
@@ -22,13 +32,17 @@ async function measureServerButton(element, url) {
   element.textContent += ` (${format(result)})`
 }
 
-export function Client({ prefix }) {
+export function Client({ prefix, commonjsAction, esmAction }) {
   return (
     <>
       <p>
         <button
           onClick={(e) =>
-            measureClientButton(e.target, () => import('../lib/commonjs.js'))
+            measureClientButton(
+              e.target,
+              'client commonjs',
+              () => import('../lib/commonjs.js')
+            )
           }
         >
           CommonJs client
@@ -37,21 +51,41 @@ export function Client({ prefix }) {
       <p>
         <button
           onClick={(e) =>
-            measureClientButton(e.target, () => import('../lib/esm.js'))
+            measureClientButton(
+              e.target,
+              'client esm',
+              () => import('../lib/esm.js')
+            )
           }
         >
           ESM client
         </button>
       </p>
+      {commonjsAction && (
+        <p>
+          <button
+            onClick={(e) => measureActionButton(e.target, commonjsAction)}
+          >
+            CommonJs server action
+          </button>
+        </p>
+      )}
+      {esmAction && (
+        <p>
+          <button onClick={(e) => measureActionButton(e.target, esmAction)}>
+            ESM server action
+          </button>
+        </p>
+      )}
       <p>
         <button
-          onClick={(e) => measureServerButton(e.target, `${prefix}/commonjs`)}
+          onClick={(e) => measureApiButton(e.target, `${prefix}/commonjs`)}
         >
           CommonJs API
         </button>
       </p>
       <p>
-        <button onClick={(e) => measureServerButton(e.target, `${prefix}/esm`)}>
+        <button onClick={(e) => measureApiButton(e.target, `${prefix}/esm`)}>
           ESM API
         </button>
       </p>

--- a/bench/module-cost/components/client.js
+++ b/bench/module-cost/components/client.js
@@ -1,0 +1,60 @@
+'use client'
+
+import { format, measure } from '../lib/measure'
+
+async function measureClientButton(element, fn) {
+  if (element.textContent.includes('Loading time')) {
+    return
+  }
+
+  const result = await measure(fn)
+
+  element.textContent += ` (${format(result)})`
+}
+
+async function measureServerButton(element, url) {
+  if (element.textContent.includes('Loading time')) {
+    return
+  }
+
+  const result = await fetch(url).then((res) => res.json())
+
+  element.textContent += ` (${format(result)})`
+}
+
+export function Client({ prefix }) {
+  return (
+    <>
+      <p>
+        <button
+          onClick={(e) =>
+            measureClientButton(e.target, () => import('../lib/commonjs.js'))
+          }
+        >
+          CommonJs client
+        </button>
+      </p>
+      <p>
+        <button
+          onClick={(e) =>
+            measureClientButton(e.target, () => import('../lib/esm.js'))
+          }
+        >
+          ESM client
+        </button>
+      </p>
+      <p>
+        <button
+          onClick={(e) => measureServerButton(e.target, `${prefix}/commonjs`)}
+        >
+          CommonJs API
+        </button>
+      </p>
+      <p>
+        <button onClick={(e) => measureServerButton(e.target, `${prefix}/esm`)}>
+          ESM API
+        </button>
+      </p>
+    </>
+  )
+}

--- a/bench/module-cost/lib/commonjs.js
+++ b/bench/module-cost/lib/commonjs.js
@@ -1,0 +1,3 @@
+export function execute() {
+  return require('../commonjs/index.js') + 1
+}

--- a/bench/module-cost/lib/esm.js
+++ b/bench/module-cost/lib/esm.js
@@ -1,0 +1,3 @@
+export function execute() {
+  return require('../esm/index.js').default + 1
+}

--- a/bench/module-cost/lib/measure.js
+++ b/bench/module-cost/lib/measure.js
@@ -1,4 +1,4 @@
-export async function measure(fn) {
+export async function measure(name, fn) {
   let module
   let loadDuration
   {
@@ -18,7 +18,10 @@ export async function measure(fn) {
     executeDuration = end - start
   }
 
-  return { loadDuration, executeDuration, files }
+  const result = { loadDuration, executeDuration, files }
+  console.log(`${name} Measurement: ${format(result)}`)
+
+  return result
 }
 
 export function format(result) {

--- a/bench/module-cost/lib/measure.js
+++ b/bench/module-cost/lib/measure.js
@@ -1,0 +1,26 @@
+export async function measure(fn) {
+  let module
+  let loadDuration
+  {
+    const start = performance.now()
+    module = await fn()
+    const end = performance.now()
+    loadDuration = end - start
+  }
+
+  let files
+  let executeDuration
+  {
+    const execute = module.execute
+    const start = performance.now()
+    files = execute()
+    const end = performance.now()
+    executeDuration = end - start
+  }
+
+  return { loadDuration, executeDuration, files }
+}
+
+export function format(result) {
+  return `Load duration: ${result.loadDuration.toFixed(2)}ms, Execution duration: ${result.executeDuration.toFixed(2)}ms, Files: ${result.files}`
+}

--- a/bench/module-cost/next.config.js
+++ b/bench/module-cost/next.config.js
@@ -1,0 +1,18 @@
+const idx = process.execArgv.indexOf('--cpu-prof')
+if (idx >= 0) process.execArgv.splice(idx, 1)
+
+/** @type {import("next").NextConfig} */
+module.exports = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  experimental: {
+    // With Scope Hoisting ESM require cost is 0 and that's not what we want to test
+    turbopackScopeHoisting: false,
+  },
+  webpack: (config) => {
+    // With Scope Hoisting ESM require cost is 0 and that's not what we want to test
+    config.optimization.concatenateModules = false
+    return config
+  },
+}

--- a/bench/module-cost/package.json
+++ b/bench/module-cost/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "module-cost",
+  "scripts": {
+    "prepare-bench": "node scripts/prepare-bench.mjs",
+    "dev-webpack": "next dev",
+    "dev-turbopack": "next dev --turbo",
+    "build-webpack": "next build",
+    "build-turbopack": "next build --turbo",
+    "start": "next start"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "next": "workspace:*"
+  }
+}

--- a/bench/module-cost/pages/api/commonjs.js
+++ b/bench/module-cost/pages/api/commonjs.js
@@ -1,0 +1,7 @@
+import { measure } from '../../lib/measure'
+
+export default async function handler(req, res) {
+  const result = await measure(() => import('../../lib/commonjs.js'))
+
+  res.status(200).json(result)
+}

--- a/bench/module-cost/pages/api/commonjs.js
+++ b/bench/module-cost/pages/api/commonjs.js
@@ -1,7 +1,10 @@
 import { measure } from '../../lib/measure'
 
 export default async function handler(req, res) {
-  const result = await measure(() => import('../../lib/commonjs.js'))
+  const result = await measure(
+    'pages api commonjs',
+    () => import('../../lib/commonjs.js')
+  )
 
   res.status(200).json(result)
 }

--- a/bench/module-cost/pages/api/esm.js
+++ b/bench/module-cost/pages/api/esm.js
@@ -1,0 +1,7 @@
+import { measure } from '../../lib/measure'
+
+export default async function handler(req, res) {
+  const result = await measure(() => import('../../lib/esm.js'))
+
+  res.status(200).json(result)
+}

--- a/bench/module-cost/pages/api/esm.js
+++ b/bench/module-cost/pages/api/esm.js
@@ -1,7 +1,10 @@
 import { measure } from '../../lib/measure'
 
 export default async function handler(req, res) {
-  const result = await measure(() => import('../../lib/esm.js'))
+  const result = await measure(
+    'pages api esm',
+    () => import('../../lib/esm.js')
+  )
 
   res.status(200).json(result)
 }

--- a/bench/module-cost/pages/index.jsx
+++ b/bench/module-cost/pages/index.jsx
@@ -1,0 +1,10 @@
+import { Client } from '../components/client.js'
+
+export default function Home() {
+  return (
+    <>
+      <h1>Measures the loading time of modules (pages router)</h1>
+      <Client prefix="/api" />
+    </>
+  )
+}

--- a/bench/module-cost/scripts/prepare-bench.mjs
+++ b/bench/module-cost/scripts/prepare-bench.mjs
@@ -1,0 +1,74 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const commonjsDir = path.join(__dirname, '../commonjs')
+const esmDir = path.join(__dirname, '../esm')
+
+async function main() {
+  await fs.rm(commonjsDir, { recursive: true, force: true })
+  await fs.rm(esmDir, { recursive: true, force: true })
+
+  // Ensure directories exist
+  await fs.mkdir(commonjsDir, { recursive: true })
+  await fs.mkdir(esmDir, { recursive: true })
+
+  async function createFiles(dir, prefix, depth, type) {
+    const fileName = `${prefix}.js`
+
+    let content
+    if (depth === 0) {
+      switch (type) {
+        case 'commonjs':
+          content = `module.exports = 1;`
+          break
+        case 'esm':
+          content = `export default 1;`
+          break
+        default:
+          throw new Error(`Unknown type: ${type}`)
+      }
+    } else {
+      const inner = []
+      content = ''
+      for (let i = 0; i < 6; i++) {
+        const subPrefix = `${prefix}_${i}`
+        await createFiles(dir, subPrefix, depth - 1, type)
+
+        const subFileName = `${subPrefix}.js`
+        switch (type) {
+          case 'commonjs':
+            content += `const ${subPrefix} = require('./${subFileName}');\n`
+            break
+          case 'esm':
+            content += `import ${subPrefix} from './${subFileName}';\n`
+            break
+          default:
+            throw new Error(`Unknown type: ${type}`)
+        }
+        inner.push(subPrefix)
+      }
+      switch (type) {
+        case 'commonjs':
+          content += `\nmodule.exports = 1 + ${inner.join(' + ')};`
+          break
+        case 'esm':
+          content += `\nexport default 1 + ${inner.join(' + ')};`
+          break
+        default:
+          throw new Error(`Unknown type: ${type}`)
+      }
+    }
+
+    const filePath = path.join(dir, fileName)
+    await fs.writeFile(filePath, content, 'utf8')
+  }
+  await createFiles(commonjsDir, 'index', 5, 'commonjs')
+  await createFiles(esmDir, 'index', 5, 'esm')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,6 +674,15 @@ importers:
         specifier: 3.2.7
         version: 3.2.7(postcss@8.5.3)
 
+  bench/module-cost:
+    devDependencies:
+      next:
+        specifier: workspace:*
+        version: link:../../packages/next
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+
   bench/nested-deps:
     devDependencies:
       cross-env:
@@ -3853,6 +3862,14 @@ packages:
   '@inquirer/type@1.3.2':
     resolution: {integrity: sha512-5Frickan9c89QbPkSu6I6y8p+9eR6hZkdPahGmNDsTFX8FHLPAozyzCZMKUeW8FyYwnlCKUjqIEqxY+UctARiw==}
     engines: {node: '>=18'}
+
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -9329,8 +9346,8 @@ packages:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
     engines: {node: '>=8.0.0'}
 
-  foreground-child@3.3.0:
-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
   forever-agent@0.6.1:
@@ -9613,6 +9630,11 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   glob@7.1.6:
@@ -10740,6 +10762,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
+
   jake@10.8.5:
     resolution: {integrity: sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==}
     engines: {node: '>=10'}
@@ -11493,12 +11519,12 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
-  lru-cache@10.0.0:
-    resolution: {integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==}
-    engines: {node: 14 || >=16.14}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
@@ -11998,6 +12024,10 @@ packages:
 
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
@@ -12887,6 +12917,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -14575,6 +14609,11 @@ packages:
   rimraf@5.0.9:
     resolution: {integrity: sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==}
     engines: {node: 14 >=14.20 || 16 >=16.20 || >=18}
+    hasBin: true
+
+  rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   ripemd160@2.0.2:
@@ -19084,6 +19123,12 @@ snapshots:
 
   '@inquirer/type@1.3.2': {}
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -20245,7 +20290,7 @@ snapshots:
       '@octokit/request-error': 5.0.0
       '@octokit/types': 11.1.0
       deprecation: 2.3.1
-      lru-cache: 10.0.0
+      lru-cache: 10.4.3
       universal-github-app-jwt: 1.1.1
       universal-user-agent: 6.0.0
 
@@ -26353,9 +26398,9 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 3.0.7
 
-  foreground-child@3.3.0:
+  foreground-child@3.3.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
@@ -26680,12 +26725,21 @@ snapshots:
 
   glob@10.4.5:
     dependencies:
-      foreground-child: 3.3.0
+      foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
       minipass: 7.1.2
       package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
+
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.0
+      path-scurry: 2.0.0
 
   glob@7.1.6:
     dependencies:
@@ -27930,6 +27984,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   jake@10.8.5:
     dependencies:
       async: 3.2.4
@@ -29023,9 +29081,9 @@ snapshots:
 
   lowercase-keys@2.0.0: {}
 
-  lru-cache@10.0.0: {}
-
   lru-cache@10.4.3: {}
+
+  lru-cache@11.1.0: {}
 
   lru-cache@4.1.5:
     dependencies:
@@ -30040,6 +30098,10 @@ snapshots:
   minimalistic-assert@1.0.1: {}
 
   minimalistic-crypto-utils@1.0.1: {}
+
+  minimatch@10.0.3:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.0.4:
     dependencies:
@@ -31061,6 +31123,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
       minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}
@@ -32954,6 +33021,11 @@ snapshots:
   rimraf@5.0.9:
     dependencies:
       glob: 10.4.5
+
+  rimraf@6.0.1:
+    dependencies:
+      glob: 11.0.3
+      package-json-from-dist: 1.0.0
 
   ripemd160@2.0.2:
     dependencies:


### PR DESCRIPTION
### What?

Add a benchmark that requires/imports nearly 10k of empty modules.

Measures load and execution time for these modules.

Might also be useful to measure the compile overhead of modules.

Closes PACK-5061