### PR TITLE
fix: update useEffect closure when menu is truly mounted

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -163,8 +163,8 @@ function DevToolsPopover({
   )
 
   // Features to make the menu accessible
-  useFocusTrap(menuRef, triggerRef, isMenuOpen)
-  useClickOutside(menuRef, triggerRef, isMenuOpen, closeMenu)
+  useFocusTrap(menuRef, triggerRef, menuMounted)
+  useClickOutside(menuRef, triggerRef, menuMounted, closeMenu)
   useShortcuts(hideShortcut ? { [hideShortcut]: hideDevTools } : {}, triggerRef)
 
   useEffect(() => {

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -33,11 +33,11 @@ export function DevToolsInfo({
     exitDelay: MENU_DURATION_MS,
   })
 
-  useFocusTrap(ref, triggerRef, isOpen, () => {
+  useFocusTrap(ref, triggerRef, mounted, () => {
     // Bring focus to close button, so the user can easily close the overlay
     closeButtonRef.current?.focus()
   })
-  useClickOutside(ref, triggerRef, isOpen, close)
+  useClickOutside(ref, triggerRef, mounted, close)
 
   if (!mounted) {
     return null


### PR DESCRIPTION
Previously we mounted event handlers on the the menu's [`ownerDocument`](https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument) to listen for clicks outside the menu. This causes a bug where the ref the useEffect captures is not set yet, and when it is set the effect does not try to run again. The fix is to derive active state from the true state tracking if the menu is mounted, not if the menu __will be open__

### Before
https://github.com/user-attachments/assets/d88f9b46-2203-45f3-a184-46db39584679

### After

https://github.com/user-attachments/assets/57a0f68f-8d46-41ea-b761-222c82e4b6bc


