### PR TITLE
Turbopack: remove `clone_value` again

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -454,7 +454,7 @@ pub async fn project_new(
     turbo_tasks.spawn_once_task({
         let tt = turbo_tasks.clone();
         async move {
-            benchmark_file_io(tt, container.project().node_root().await?.clone_value())
+            benchmark_file_io(tt, container.project().node_root().owned().await?)
                 .await
                 .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
         }
@@ -1501,12 +1501,8 @@ pub async fn project_trace_source_operation(
         }
     };
 
-    let project_root_uri = uri_from_file(
-        container.project().project_root_path().await?.clone_value(),
-        None,
-    )
-    .await?
-        + "/";
+    let project_root_uri =
+        uri_from_file(container.project().project_root_path().owned().await?, None).await? + "/";
     let (file, original_file, is_internal) =
         if let Some(source_file) = original_file.strip_prefix(&project_root_uri) {
             // Client code uses file://

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -204,7 +204,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_client_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
             self.client_ty().owned().await?,
@@ -217,7 +217,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.client_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -234,7 +234,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
@@ -248,7 +248,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
@@ -262,7 +262,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.route_ty().owned().await?,
             self.project().next_mode(),
@@ -276,7 +276,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.route_ty().owned().await?,
             self.project().next_mode(),
@@ -290,7 +290,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -301,7 +301,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.rsc_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -312,7 +312,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -325,7 +325,7 @@ impl AppProject {
         self: Vc<Self>,
     ) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.route_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -594,7 +594,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
@@ -608,7 +608,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
@@ -622,7 +622,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -633,7 +633,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.ssr_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -797,7 +797,7 @@ impl AppProject {
     #[turbo_tasks::function]
     async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         Ok(get_client_runtime_entries(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.client_ty().owned().await?,
             self.project().next_mode(),
             self.project().next_config(),
@@ -1076,11 +1076,7 @@ impl AppEndpoint {
             self.app_project.edge_rsc_module_context(),
             loader_tree,
             self.page.clone(),
-            self.app_project
-                .project()
-                .project_path()
-                .await?
-                .clone_value(),
+            self.app_project.project().project_path().owned().await?,
             self.app_project.project().next_config(),
         ))
     }
@@ -1112,11 +1108,7 @@ impl AppEndpoint {
             self.app_project.edge_route_module_context(),
             Vc::upcast(FileSource::new(path)),
             self.page.clone(),
-            self.app_project
-                .project()
-                .project_path()
-                .await?
-                .clone_value(),
+            self.app_project.project().project_path().owned().await?,
             config,
             next_config,
         ))
@@ -1131,11 +1123,7 @@ impl AppEndpoint {
         Ok(get_app_metadata_route_entry(
             self.app_project.rsc_module_context(),
             self.app_project.edge_rsc_module_context(),
-            self.app_project
-                .project()
-                .project_path()
-                .await?
-                .clone_value(),
+            self.app_project.project().project_path().owned().await?,
             self.page.clone(),
             *self.app_project.project().next_mode().await?,
             metadata,
@@ -1199,8 +1187,8 @@ impl AppEndpoint {
             ),
         };
 
-        let node_root = project.node_root().await?.clone_value();
-        let client_relative_path = project.client_relative_path().await?.clone_value();
+        let node_root = project.node_root().owned().await?;
+        let client_relative_path = project.client_relative_path().owned().await?;
         let server_path = node_root.join("server")?;
 
         let mut server_assets = fxindexset![];
@@ -1240,7 +1228,7 @@ impl AppEndpoint {
         };
 
         let client_shared_chunk_group = get_app_client_shared_chunk_group(
-            AssetIdent::from_path(project.project_path().await?.clone_value())
+            AssetIdent::from_path(project.project_path().owned().await?)
                 .with_modifier(rcstr!("client-shared-chunks")),
             this.app_project.client_runtime_entries(),
             *module_graphs.full,
@@ -1340,9 +1328,9 @@ impl AppEndpoint {
 
         // polyfill-nomodule.js is a pre-compiled asset distributed as part of next,
         // load it as a RawModule.
-        let next_package = get_next_package(project.project_path().await?.clone_value())
-            .await?
-            .clone_value();
+        let next_package = get_next_package(project.project_path().owned().await?)
+            .owned()
+            .await?;
         let polyfill_source =
             FileSource::new(next_package.join("dist/build/polyfills/polyfill-nomodule.js")?);
         let polyfill_output_path = client_chunking_context
@@ -1351,8 +1339,8 @@ impl AppEndpoint {
                 polyfill_source.ident(),
                 rcstr!(".js"),
             )
-            .await?
-            .clone_value();
+            .owned()
+            .await?;
         let polyfill_output_asset = ResolvedVc::upcast(
             RawOutput::new(polyfill_output_path, Vc::upcast(polyfill_source))
                 .to_resolved()
@@ -1431,7 +1419,7 @@ impl AppEndpoint {
 
         let server_action_manifest = create_server_actions_manifest(
             actions,
-            project.project_path().await?.clone_value(),
+            project.project_path().owned().await?,
             node_root.clone(),
             app_entry.original_name.clone(),
             runtime,
@@ -1495,9 +1483,9 @@ impl AppEndpoint {
             client_reference_manifest = Some(entry_manifest);
 
             let next_font_manifest_output = create_font_manifest(
-                project.client_root().await?.clone_value(),
+                project.client_root().owned().await?,
                 node_root.clone(),
-                this.app_project.app_dir().await?.clone_value(),
+                this.app_project.app_dir().owned().await?,
                 &app_entry.original_name,
                 &app_entry.original_name,
                 &app_entry.original_name,
@@ -1800,11 +1788,7 @@ impl AppEndpoint {
                         let chunk_group = chunking_context
                             .chunk_group(
                                 AssetIdent::from_path(
-                                    this.app_project
-                                        .project()
-                                        .project_path()
-                                        .await?
-                                        .clone_value(),
+                                    this.app_project.project().project_path().owned().await?,
                                 )
                                 .with_modifier(rcstr!("server-utils")),
                                 // TODO this should be ChunkGroup::Shared
@@ -1954,15 +1938,15 @@ impl Endpoint for AppEndpoint {
                 .await?
                 .is_development()
             {
-                let node_root = this.app_project.project().node_root().await?.clone_value();
+                let node_root = this.app_project.project().node_root().owned().await?;
                 let server_paths = all_server_paths(output_assets, node_root).owned().await?;
 
                 let client_relative_root = this
                     .app_project
                     .project()
                     .client_relative_path()
-                    .await?
-                    .clone_value();
+                    .owned()
+                    .await?;
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
                     .owned()
                     .instrument(tracing::info_span!("client_paths"))
@@ -2060,11 +2044,7 @@ impl Endpoint for AppEndpoint {
 
         let server_actions_loader = ResolvedVc::upcast(
             build_server_actions_loader(
-                this.app_project
-                    .project()
-                    .project_path()
-                    .await?
-                    .clone_value(),
+                this.app_project.project().project_path().owned().await?,
                 app_entry.original_name.clone(),
                 actions,
                 match runtime {

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -83,7 +83,7 @@ impl InstrumentationEndpoint {
 
         let edge_entry_module = wrap_edge_entry(
             *self.asset_context,
-            self.project.project_path().await?.clone_value(),
+            self.project.project_path().owned().await?,
             *userland_module,
             rcstr!("instrumentation"),
         )
@@ -177,7 +177,7 @@ impl InstrumentationEndpoint {
             let edge_files = self.edge_files();
             let mut output_assets = edge_files.owned().await?;
 
-            let node_root = this.project.node_root().await?.clone_value();
+            let node_root = this.project.node_root().owned().await?;
             let node_root_value = node_root.clone();
 
             let file_paths_from_root =
@@ -243,7 +243,7 @@ impl Endpoint for InstrumentationEndpoint {
             let output_assets = self.output_assets();
 
             let server_paths = if this.project.next_mode().await?.is_development() {
-                let node_root = this.project.node_root().await?.clone_value();
+                let node_root = this.project.node_root().owned().await?;
                 all_server_paths(output_assets, node_root).owned().await?
             } else {
                 vec![]

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -82,7 +82,7 @@ impl MiddlewareEndpoint {
 
         let module = get_middleware_module(
             *self.asset_context,
-            self.project.project_path().await?.clone_value(),
+            self.project.project_path().owned().await?,
             userland_module,
         );
 
@@ -94,7 +94,7 @@ impl MiddlewareEndpoint {
         }
         Ok(wrap_edge_entry(
             *self.asset_context,
-            self.project.project_path().await?.clone_value(),
+            self.project.project_path().owned().await?,
             module,
             rcstr!("middleware"),
         ))
@@ -282,7 +282,7 @@ impl MiddlewareEndpoint {
             let edge_files = self.edge_files();
             let mut output_assets = edge_files.owned().await?;
 
-            let node_root = this.project.node_root().await?.clone_value();
+            let node_root = this.project.node_root().owned().await?;
             let node_root_value = node_root.clone();
 
             let file_paths_from_root =
@@ -362,11 +362,11 @@ impl Endpoint for MiddlewareEndpoint {
             let output_assets = self.output_assets();
 
             let (server_paths, client_paths) = if this.project.next_mode().await?.is_development() {
-                let node_root = this.project.node_root().await?.clone_value();
+                let node_root = this.project.node_root().owned().await?;
                 let server_paths = all_server_paths(output_assets, node_root).owned().await?;
 
                 // Middleware could in theory have a client path (e.g. `new URL`).
-                let client_relative_root = this.project.client_relative_path().await?.clone_value();
+                let client_relative_root = this.project.client_relative_path().owned().await?;
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
                     .into_future()
                     .owned()

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -408,8 +408,8 @@ impl Issue for CssGlobalImportIssue {
 
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        let parent_path = self.parent_module.ident().path().await?.clone_value();
-        let module_path = self.module.ident().path().await?.clone_value();
+        let parent_path = self.parent_module.ident().path().owned().await?;
+        let module_path = self.module.ident().path().owned().await?;
         let relative_import_location = parent_path.parent();
 
         let import_path = match relative_import_location.get_relative_path_to(&module_path) {

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -234,7 +234,7 @@ impl Asset for NftJsonAsset {
         // Apply outputFileTracingIncludes and outputFileTracingExcludes
         // Extract route from chunk path for pattern matching
         if let Some(route) = &this.page_name {
-            let project_path = this.project.project_path().await?.clone_value();
+            let project_path = this.project.project_path().owned().await?;
             let mut combined_includes = BTreeSet::new();
 
             // Process includes

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -264,9 +264,9 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn pages_structure(&self) -> Result<Vc<PagesStructure>> {
         let next_router_fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new());
-        let next_router_root = next_router_fs.root().await?.clone_value();
+        let next_router_root = next_router_fs.root().owned().await?;
         Ok(find_pages_structure(
-            self.project.project_path().await?.clone_value(),
+            self.project.project_path().owned().await?,
             next_router_root,
             self.project.next_config().page_extensions(),
         ))
@@ -333,11 +333,11 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_client_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
             ClientContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -348,9 +348,9 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             ClientContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -440,10 +440,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -456,10 +456,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -472,10 +472,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             ServerContextType::PagesApi {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -488,10 +488,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn edge_api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             ServerContextType::PagesApi {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -504,10 +504,10 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             ServerContextType::PagesData {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -522,10 +522,10 @@ impl PagesProject {
         self: Vc<Self>,
     ) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             self.project().execution_context(),
             ServerContextType::PagesData {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -538,12 +538,12 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -554,12 +554,12 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
             // differentiate between the two.
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -570,9 +570,9 @@ impl PagesProject {
     #[turbo_tasks::function]
     async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         let client_runtime_entries = get_client_runtime_entries(
-            self.project().project_path().await?.clone_value(),
+            self.project().project_path().owned().await?,
             ClientContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
             self.project().next_config(),
@@ -585,7 +585,7 @@ impl PagesProject {
     async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
             ServerContextType::Pages {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
         ))
@@ -595,7 +595,7 @@ impl PagesProject {
     async fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
             ServerContextType::PagesData {
-                pages_dir: self.pages_dir().await?.clone_value(),
+                pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
         ))
@@ -727,7 +727,7 @@ impl PageEndpoint {
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
         Ok(Vc::upcast(FileSource::new(
-            self.page.file_path().await?.clone_value(),
+            self.page.file_path().owned().await?,
         )))
     }
 
@@ -864,7 +864,7 @@ impl PageEndpoint {
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         let this = self.await?;
         let project = this.pages_project.project();
-        let node_root = project.client_root().await?.clone_value();
+        let node_root = project.client_root().owned().await?;
         let client_relative_path = self.client_relative_path();
         let page_loader = PageLoaderAsset::new(
             node_root,
@@ -882,31 +882,19 @@ impl PageEndpoint {
         let (reference_type, project_root, module_context, edge_module_context) = match this.ty {
             PageEndpointType::Html | PageEndpointType::SsrOnly => (
                 ReferenceType::Entry(EntryReferenceSubType::Page),
-                this.pages_project
-                    .project()
-                    .project_path()
-                    .await?
-                    .clone_value(),
+                this.pages_project.project().project_path().owned().await?,
                 this.pages_project.ssr_module_context(),
                 this.pages_project.edge_ssr_module_context(),
             ),
             PageEndpointType::Data => (
                 ReferenceType::Entry(EntryReferenceSubType::Page),
-                this.pages_project
-                    .project()
-                    .project_path()
-                    .await?
-                    .clone_value(),
+                this.pages_project.project().project_path().owned().await?,
                 this.pages_project.ssr_data_module_context(),
                 this.pages_project.edge_ssr_data_module_context(),
             ),
             PageEndpointType::Api => (
                 ReferenceType::Entry(EntryReferenceSubType::PagesApi),
-                this.pages_project
-                    .project()
-                    .project_path()
-                    .await?
-                    .clone_value(),
+                this.pages_project.project().project_path().owned().await?,
                 this.pages_project.api_module_context(),
                 this.pages_project.edge_api_module_context(),
             ),
@@ -1029,12 +1017,7 @@ impl PageEndpoint {
                         .client_module_context()
                         .process(
                             Vc::upcast(FileSource::new(
-                                this.pages_structure
-                                    .await?
-                                    .app
-                                    .file_path()
-                                    .await?
-                                    .clone_value(),
+                                this.pages_structure.await?.app.file_path().owned().await?,
                             )),
                             ReferenceType::Entry(EntryReferenceSubType::Page),
                         )
@@ -1276,18 +1259,13 @@ impl PageEndpoint {
         dynamic_import_entries: Vc<DynamicImportedChunks>,
         runtime: NextRuntime,
     ) -> Result<Vc<OutputAssets>> {
-        let node_root = self
-            .pages_project
-            .project()
-            .node_root()
-            .await?
-            .clone_value();
+        let node_root = self.pages_project.project().node_root().owned().await?;
         let client_relative_path = self
             .pages_project
             .project()
             .client_relative_path()
-            .await?
-            .clone_value();
+            .owned()
+            .await?;
         let loadable_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
         Ok(create_react_loadable_manifest(
             dynamic_import_entries,
@@ -1304,18 +1282,13 @@ impl PageEndpoint {
         &self,
         client_chunks: ResolvedVc<OutputAssets>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let node_root = self
-            .pages_project
-            .project()
-            .node_root()
-            .await?
-            .clone_value();
+        let node_root = self.pages_project.project().node_root().owned().await?;
         let client_relative_path = self
             .pages_project
             .project()
             .client_relative_path()
-            .await?
-            .clone_value();
+            .owned()
+            .await?;
         let build_manifest = BuildManifest {
             pages: fxindexmap!(self.pathname.clone() => client_chunks),
             ..Default::default()
@@ -1362,20 +1335,11 @@ impl PageEndpoint {
         let client_assets = OutputAssets::new(client_assets).to_resolved().await?;
 
         let manifest_path_prefix = get_asset_prefix_from_pathname(pathname);
-        let node_root = this
-            .pages_project
-            .project()
-            .node_root()
-            .await?
-            .clone_value();
+        let node_root = this.pages_project.project().node_root().owned().await?;
         let next_font_manifest_output = create_font_manifest(
-            this.pages_project
-                .project()
-                .client_root()
-                .await?
-                .clone_value(),
+            this.pages_project.project().client_root().owned().await?,
             node_root.clone(),
-            this.pages_project.pages_dir().await?.clone_value(),
+            this.pages_project.pages_dir().owned().await?,
             original_name,
             &manifest_path_prefix,
             pathname,
@@ -1441,12 +1405,7 @@ impl PageEndpoint {
                 dynamic_import_entries,
                 ref regions,
             } => {
-                let node_root = this
-                    .pages_project
-                    .project()
-                    .node_root()
-                    .await?
-                    .clone_value();
+                let node_root = this.pages_project.project().node_root().owned().await?;
                 if emit_manifests {
                     let files_value = files.await?;
                     if let Some(&file) = files_value.first() {
@@ -1558,8 +1517,8 @@ impl PageEndpoint {
             self.pages_project
                 .project()
                 .client_relative_path()
-                .await?
-                .clone_value(),
+                .owned()
+                .await?,
         )))
     }
 }
@@ -1599,12 +1558,7 @@ impl Endpoint for PageEndpoint {
             let output = self.output().await?;
             let output_assets = self.output().output_assets();
 
-            let node_root = this
-                .pages_project
-                .project()
-                .node_root()
-                .await?
-                .clone_value();
+            let node_root = this.pages_project.project().node_root().owned().await?;
 
             let (server_paths, client_paths) = if this
                 .pages_project
@@ -1621,8 +1575,8 @@ impl Endpoint for PageEndpoint {
                     .pages_project
                     .project()
                     .client_relative_path()
-                    .await?
-                    .clone_value();
+                    .owned()
+                    .await?;
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
                     .owned()
                     .instrument(tracing::info_span!("client_paths"))

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -264,7 +264,7 @@ async fn get_entries(assets: OperationVc<OutputAssets>) -> Result<Vc<GetEntriesR
     let entries = assets_ref
         .iter()
         .map(|&asset| async move {
-            let path = asset.path().await?.clone_value();
+            let path = asset.path().owned().await?;
             Ok((path, asset))
         })
         .try_join()

--- a/crates/next-core/src/embed_js.rs
+++ b/crates/next-core/src/embed_js.rs
@@ -25,6 +25,6 @@ pub(crate) async fn next_js_file_path(path: RcStr) -> Result<Vc<FileSystemPath>>
 #[turbo_tasks::function]
 pub(crate) async fn next_asset(path: RcStr) -> Result<Vc<Box<dyn Source>>> {
     Ok(Vc::upcast(FileSource::new(
-        next_js_file_path(path).await?.clone_value(),
+        next_js_file_path(path).owned().await?,
     )))
 }

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -55,7 +55,7 @@ pub async fn emit_assets(
             let client_output_path = client_output_path.clone();
 
             async move {
-                let path = asset.path().await?.clone_value();
+                let path = asset.path().owned().await?;
                 let span = tracing::info_span!("emit asset", name = %path.value_to_string().await?);
                 async move {
                     Ok(if path.is_inside_ref(&node_root) {
@@ -88,7 +88,7 @@ async fn emit(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
         .content()
         .resolve()
         .await?
-        .write(asset.path().await?.clone_value())
+        .write(asset.path().owned().await?)
         .as_side_effect()
         .await?;
     Ok(())
@@ -100,9 +100,9 @@ async fn emit_rebase(
     from: FileSystemPath,
     to: FileSystemPath,
 ) -> Result<()> {
-    let path = rebase(asset.path().await?.clone_value(), from, to)
-        .await?
-        .clone_value();
+    let path = rebase(asset.path().owned().await?, from, to)
+        .owned()
+        .await?;
     let content = asset.content();
     content
         .resolve()

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -179,7 +179,7 @@ pub async fn get_app_client_references_chunks(
 
                 let base_ident = server_component.ident();
 
-                let server_path = server_component.server_path().await?.clone_value();
+                let server_path = server_component.server_path().owned().await?;
                 let is_layout = server_path.file_stem() == Some("layout");
                 let server_component_path = server_path.value_to_string().await?;
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -55,7 +55,7 @@ pub async fn get_app_route_entry(
     let original_name: RcStr = page.to_string().into();
     let pathname: RcStr = AppPath::from(page.clone()).to_string().into();
 
-    let path = source.ident().path().await?.clone_value();
+    let path = source.ident().path().owned().await?;
 
     const INNER: &str = "INNER_APP_ROUTE";
 

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -16,7 +16,7 @@ pub async fn get_postcss_package_mapping(
             .resolved_cell(),
         ImportMapping::PrimaryAlternative(
             "postcss".into(),
-            Some(get_next_package(project_path.clone()).await?.clone_value()),
+            Some(get_next_package(project_path.clone()).owned().await?),
         )
         .resolved_cell(),
     ])

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -149,7 +149,7 @@ pub async fn get_client_resolve_options_context(
             .await?;
     let custom_conditions = vec![mode.await?.condition().into()];
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().await?.clone_value()),
+        enable_node_modules: Some(project_path.root().owned().await?),
         custom_conditions,
         import_map: Some(next_client_import_map),
         fallback_import_map: Some(next_client_fallback_import_map),
@@ -431,9 +431,7 @@ pub async fn get_client_chunking_context(
         client_root_to_root_path,
         client_root.clone(),
         client_root.join("static/chunks")?,
-        get_client_assets_path(client_root.clone())
-            .await?
-            .clone_value(),
+        get_client_assets_path(client_root.clone()).owned().await?,
         environment.to_resolved().await?,
         next_mode.runtime_type(),
     )

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -154,7 +154,7 @@ pub async fn get_edge_resolve_options_context(
     };
 
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().await?.clone_value()),
+        enable_node_modules: Some(project_path.root().owned().await?),
         enable_edge_node_externals: true,
         custom_conditions,
         import_map: Some(next_edge_import_map),

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -50,7 +50,7 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
             // Call out to separate `unsupported_module_source` to only have a single Source cell
             // for requests with different subpaths: `fs` and `fs/promises`.
             let source =
-                unsupported_module_source(lookup_path.root().await?.clone_value(), module.clone())
+                unsupported_module_source(lookup_path.root().owned().await?, module.clone())
                     .to_resolved()
                     .await?;
             Ok(ImportMapResult::Result(ResolveResult::source(ResolvedVc::upcast(source))).cell())

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -730,7 +730,7 @@ async fn get_mock_stylesheet(
         )
         .module();
 
-    let root = mock_fs.root().await?.clone_value();
+    let root = mock_fs.root().owned().await?;
     let val = evaluate(
         mocked_response_asset,
         root,

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -624,7 +624,7 @@ async fn insert_next_server_special_aliases(
         ServerContextType::AppSSR { app_dir }
         | ServerContextType::AppRSC { app_dir, .. }
         | ServerContextType::AppRoute { app_dir, .. } => {
-            let next_package = get_next_package(app_dir.clone()).await?.clone_value();
+            let next_package = get_next_package(app_dir.clone()).owned().await?;
             import_map.insert_exact_alias(
                 "styled-jsx",
                 request_to_import_mapping(next_package.clone(), "styled-jsx"),
@@ -966,7 +966,7 @@ async fn insert_next_shared_aliases(
     next_mode: Vc<NextMode>,
     is_runtime_edge: bool,
 ) -> Result<()> {
-    let package_root = next_js_fs().root().await?.clone_value();
+    let package_root = next_js_fs().root().owned().await?;
 
     insert_alias_to_alternatives(
         import_map,
@@ -1033,7 +1033,7 @@ async fn insert_next_shared_aliases(
         .resolved_cell(),
     );
 
-    let next_package = get_next_package(project_path.clone()).await?.clone_value();
+    let next_package = get_next_package(project_path.clone()).owned().await?;
     import_map.insert_singleton_alias("@swc/helpers", next_package.clone());
     import_map.insert_singleton_alias("styled-jsx", next_package.clone());
     import_map.insert_singleton_alias("next", project_path.clone());
@@ -1108,10 +1108,7 @@ async fn insert_next_shared_aliases(
     insert_package_alias(
         import_map,
         "@vercel/turbopack-node/",
-        turbopack_node::embed_js::embed_fs()
-            .root()
-            .await?
-            .clone_value(),
+        turbopack_node::embed_js::embed_fs().root().owned().await?,
     );
 
     let image_config = next_config.image_config().await?;
@@ -1138,7 +1135,7 @@ pub async fn get_next_package(context_directory: FileSystemPath) -> Result<Vc<Fi
         context_directory.clone(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
-        node_cjs_resolve_options(context_directory.root().await?.clone_value()),
+        node_cjs_resolve_options(context_directory.root().owned().await?),
     );
     let source = result
         .first_source()
@@ -1248,8 +1245,8 @@ async fn insert_turbopack_dev_alias(import_map: &mut ImportMap) -> Result<()> {
         "@vercel/turbopack-ecmascript-runtime/",
         turbopack_ecmascript_runtime::embed_fs()
             .root()
-            .await?
-            .clone_value(),
+            .owned()
+            .await?,
     );
     Ok(())
 }

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -139,7 +139,7 @@ impl ClientReferenceManifest {
                         Ok(if let Some(path) = path {
                             (chunk, Either::Left(path))
                         } else {
-                            (chunk, Either::Right(chunk.path().await?.clone_value()))
+                            (chunk, Either::Right(chunk.path().owned().await?))
                         })
                     })
                     .try_join()

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -111,7 +111,7 @@ pub async fn create_page_ssr_entry_module(
         let file = File::from(result.build());
 
         source = Vc::upcast(VirtualSource::new(
-            source.ident().path().await?.clone_value(),
+            source.ident().path().owned().await?,
             AssetContent::file(file.into()),
         ));
     }
@@ -188,7 +188,7 @@ async fn process_global_item(
     reference_type: ReferenceType,
     module_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<Box<dyn Module>>> {
-    let source = Vc::upcast(FileSource::new(item.file_path().await?.clone_value()));
+    let source = Vc::upcast(FileSource::new(item.file_path().owned().await?));
     Ok(module_context.process(source, reference_type).module())
 }
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -141,7 +141,7 @@ pub async fn get_server_resolve_options_context(
     .await?;
     let foreign_code_context_condition =
         foreign_code_context_condition(next_config, project_path.clone()).await?;
-    let root_dir = project_path.root().await?.clone_value();
+    let root_dir = project_path.root().owned().await?;
     let module_feature_report_resolve_plugin =
         ModuleFeatureReportResolvePlugin::new(project_path.clone())
             .to_resolved()
@@ -194,7 +194,7 @@ pub async fn get_server_resolve_options_context(
 
     let server_external_packages_plugin = ExternalCjsModulesResolvePlugin::new(
         project_path.clone(),
-        project_path.root().await?.clone_value(),
+        project_path.root().owned().await?,
         ExternalPredicate::Only(ResolvedVc::cell(external_packages)).cell(),
         *next_config.import_externals().await?,
     )
@@ -219,7 +219,7 @@ pub async fn get_server_resolve_options_context(
     } else {
         ExternalCjsModulesResolvePlugin::new(
             project_path.clone(),
-            project_path.root().await?.clone_value(),
+            project_path.root().owned().await?,
             ExternalPredicate::AllExcept(ResolvedVc::cell(transpiled_packages)).cell(),
             *next_config.import_externals().await?,
         )

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -215,9 +215,9 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         let mut request_str = request_str.to_string();
 
         let node_resolve_options = if is_esm {
-            node_esm_resolve_options(lookup_path.root().await?.clone_value())
+            node_esm_resolve_options(lookup_path.root().owned().await?)
         } else {
-            node_cjs_resolve_options(lookup_path.root().await?.clone_value())
+            node_cjs_resolve_options(lookup_path.root().owned().await?)
         };
         let result_from_original_location = loop {
             let node_resolved_from_original_location = resolve(
@@ -348,7 +348,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 )]);
             }
         }
-        let path = result.ident().path().await?.clone_value();
+        let path = result.ident().path().owned().await?;
         let file_type = get_file_type(path.clone(), &path).await?;
 
         let external_type = match (file_type, is_esm) {
@@ -370,7 +370,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 // It would be more efficient to use an CJS external instead of an ESM external,
                 // but we need to verify if that would be correct (as in resolves to the same file).
                 let node_resolve_options =
-                    node_cjs_resolve_options(lookup_path.root().await?.clone_value());
+                    node_cjs_resolve_options(lookup_path.root().owned().await?);
                 let node_resolved = resolve(
                     self.project_path.clone(),
                     reference_type.clone(),
@@ -378,7 +378,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     node_resolve_options,
                 );
                 let resolves_equal = if let Some(result) = *node_resolved.first_source().await? {
-                    let cjs_path = result.ident().path().await?.clone_value();
+                    let cjs_path = result.ident().path().owned().await?;
                     cjs_path == path
                 } else {
                     false

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -221,7 +221,7 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
         Ok(AfterResolvePluginCondition::new(
-            self.project_path.root().await?.clone_value(),
+            self.project_path.root().owned().await?,
             Glob::new("**/next/dist/**/*.{external,runtime.dev,runtime.prod}.js".into()),
         ))
     }
@@ -275,7 +275,7 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
         Ok(AfterResolvePluginCondition::new(
-            self.root.root().await?.clone_value(),
+            self.root.root().owned().await?,
             Glob::new("**/next/dist/**/*.shared-runtime.js".into()),
         ))
     }
@@ -400,7 +400,7 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
         Ok(AfterResolvePluginCondition::new(
-            self.root.root().await?.clone_value(),
+            self.root.root().owned().await?,
             Glob::new("**/next/dist/esm/**/*.shared-runtime.js".into()),
         ))
     }

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -65,7 +65,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
                 let resolve_options = resolve_options(
                     project_path.clone(),
                     ResolveOptionsContext {
-                        enable_node_modules: Some(project_path.root().await?.clone_value()),
+                        enable_node_modules: Some(project_path.root().owned().await?),
                         enable_node_native_modules: true,
                         ..Default::default()
                     }

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -31,8 +31,8 @@ pub async fn create_page_loader_entry_module(
     writeln!(result, "const PAGE_PATH = {};\n", StringifyJs(&pathname))?;
 
     let page_loader_path = next_js_file_path(rcstr!("entry/page-loader.ts"))
-        .await?
-        .clone_value();
+        .owned()
+        .await?;
     let base_code = page_loader_path.read();
     if let FileContent::Content(base_file) = &*base_code.await? {
         result += base_file.content()
@@ -103,7 +103,7 @@ impl PageLoaderAsset {
         // If we are provided a prefix path, we need to rewrite our chunk paths to
         // remove that prefix.
         if let Some(rebase_path) = &*rebase_prefix_path.await? {
-            let root_path = rebase_path.root().await?.clone_value();
+            let root_path = rebase_path.root().owned().await?;
             let rebased = chunks
                 .await?
                 .iter()
@@ -114,12 +114,12 @@ impl PageLoaderAsset {
                         Vc::upcast::<Box<dyn OutputAsset>>(ProxiedAsset::new(
                             *chunk,
                             FileSystemPath::rebase(
-                                chunk.path().await?.clone_value(),
+                                chunk.path().owned().await?,
                                 rebase_path.clone(),
                                 root_path.clone(),
                             )
-                            .await?
-                            .clone_value(),
+                            .owned()
+                            .await?,
                         ))
                         .to_resolved()
                         .await

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -103,15 +103,11 @@ pub async fn find_pages_structure(
     next_router_root: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesStructure>> {
-    let pages_root = project_root.join("pages")?.realpath().await?.clone_value();
+    let pages_root = project_root.join("pages")?.realpath().owned().await?;
     let pages_root = if *pages_root.get_type().await? == FileSystemEntryType::Directory {
         Some(pages_root)
     } else {
-        let src_pages_root = project_root
-            .join("src/pages")?
-            .realpath()
-            .await?
-            .clone_value();
+        let src_pages_root = project_root.join("src/pages")?.realpath().owned().await?;
         if *src_pages_root.get_type().await? == FileSystemEntryType::Directory {
             Some(src_pages_root)
         } else {

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -25,7 +25,7 @@ async fn get_typescript_options(
         Some(FindContextFileResult::Found(path, _)) => read_tsconfigs(
             path.read(),
             ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
-            node_cjs_resolve_options(path.root().await?.clone_value()),
+            node_cjs_resolve_options(path.root().owned().await?),
         )
         .await
         .ok(),

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -187,19 +187,14 @@ pub async fn foreign_code_context_condition(
 // subject to Next.js's configuration even if it's embedded assets.
 pub async fn internal_assets_conditions() -> Result<ContextCondition> {
     Ok(ContextCondition::any(vec![
-        ContextCondition::InPath(next_js_fs().root().await?.clone_value()),
+        ContextCondition::InPath(next_js_fs().root().owned().await?),
         ContextCondition::InPath(
             turbopack_ecmascript_runtime::embed_fs()
                 .root()
-                .await?
-                .clone_value(),
+                .owned()
+                .await?,
         ),
-        ContextCondition::InPath(
-            turbopack_node::embed_js::embed_fs()
-                .root()
-                .await?
-                .clone_value(),
-        ),
+        ContextCondition::InPath(turbopack_node::embed_js::embed_fs().root().owned().await?),
     ]))
 }
 

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -125,10 +125,7 @@ async fn errors_on_failed_connection() {
         assert_eq!(*err.kind.await?, FetchErrorKind::Connect);
         assert_eq!(*err.url.await?, url);
 
-        let issue = err_vc.to_issue(
-            IssueSeverity::Error,
-            get_issue_context().await?.clone_value(),
-        );
+        let issue = err_vc.to_issue(IssueSeverity::Error, get_issue_context().owned().await?);
         assert_eq!(issue.await?.severity(), IssueSeverity::Error);
         assert_eq!(
             *issue.description().await?.unwrap().await?,
@@ -162,10 +159,7 @@ async fn errors_on_404() {
         assert!(matches!(*err.kind.await?, FetchErrorKind::Status(404)));
         assert_eq!(*err.url.await?, url);
 
-        let issue = err_vc.to_issue(
-            IssueSeverity::Error,
-            get_issue_context().await?.clone_value(),
-        );
+        let issue = err_vc.to_issue(IssueSeverity::Error, get_issue_context().owned().await?);
         assert_eq!(issue.await?.severity(), IssueSeverity::Error);
         assert_eq!(
             *issue.description().await?.unwrap().await?,

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -42,15 +42,6 @@ where
     }
 }
 
-impl<T> ReadRef<T>
-where
-    T: VcValueType + Clone,
-{
-    pub fn clone_value(&self) -> VcReadTarget<T> {
-        T::Read::value_to_target((*self.0).clone())
-    }
-}
-
 impl<T> Display for ReadRef<T>
 where
     T: VcValueType,

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -62,8 +62,8 @@ impl EcmascriptBrowserChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBrowserChunkVersion>> {
         Ok(EcmascriptBrowserChunkVersion::new(
-            self.chunking_context.output_root().await?.clone_value(),
-            self.chunk.path().await?.clone_value(),
+            self.chunking_context.output_root().owned().await?,
+            self.chunk.path().owned().await?,
             *self.content,
         ))
     }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -70,7 +70,7 @@ impl EcmascriptBrowserEvaluateChunk {
     #[turbo_tasks::function]
     async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         Ok(ChunkData::from_assets(
-            self.chunking_context.output_root().await?.clone_value(),
+            self.chunking_context.output_root().owned().await?,
             *self.other_chunks,
         ))
     }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -210,7 +210,7 @@ async fn build_internal(
         .unwrap_or(project_relative)
         .replace(MAIN_SEPARATOR, "/")
         .into();
-    let root_path = project_fs.root().await?.clone_value();
+    let root_path = project_fs.root().owned().await?;
     let project_path = root_path.join(&project_relative)?;
     let build_output_root = output_fs.root().await?.join("dist")?;
 
@@ -502,7 +502,7 @@ async fn build_internal(
 
     chunks
         .iter()
-        .map(|c| async move { c.content().write(c.path().await?.clone_value()).await })
+        .map(|c| async move { c.content().write(c.path().owned().await?).await })
         .try_join()
         .await?;
 

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -64,8 +64,8 @@ pub async fn get_client_import_map(project_path: FileSystemPath) -> Result<Vc<Im
             Some(
                 turbopack_ecmascript_runtime::embed_fs()
                     .root()
-                    .await?
-                    .clone_value(),
+                    .owned()
+                    .await?,
             ),
         )
         .resolved_cell(),
@@ -83,7 +83,7 @@ pub async fn get_client_resolve_options_context(
         .to_resolved()
         .await?;
     let module_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().await?.clone_value()),
+        enable_node_modules: Some(project_path.root().owned().await?),
         custom_conditions: vec![node_env.await?.to_string().into(), "browser".into()],
         import_map: Some(next_client_import_map),
         browser: true,

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -266,7 +266,7 @@ async fn source(
 
     let output_fs = output_fs(project_dir);
     let fs: Vc<Box<dyn FileSystem>> = project_fs(root_dir, /* watch= */ true);
-    let root_path = fs.root().await?.clone_value();
+    let root_path = fs.root().owned().await?;
     let project_path = root_path.join(&project_relative)?;
 
     let env = load_env(root_path.clone());
@@ -294,7 +294,7 @@ async fn source(
         ExecutionContext::new(root_path.clone(), Vc::upcast(build_chunking_context), env);
 
     let server_fs = Vc::upcast::<Box<dyn FileSystem>>(ServerFileSystem::new());
-    let server_root = server_fs.root().await?.clone_value();
+    let server_root = server_fs.root().owned().await?;
     let entry_requests = entry_requests
         .iter()
         .map(|r| match r {

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -84,8 +84,8 @@ pub async fn get_client_runtime_entries(
         RuntimeEntry::Source(ResolvedVc::upcast(
             FileSource::new(
                 embed_file_path(rcstr!("entry/bootstrap.ts"))
-                    .await?
-                    .clone_value(),
+                    .owned()
+                    .await?,
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -910,7 +910,7 @@ impl PlainIssue {
                     into_plain_trace(
                         tracer
                             .await?
-                            .get_traces(issue.file_path().await?.clone_value())
+                            .get_traces(issue.file_path().owned().await?)
                             .await?,
                     )
                     .await?

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -42,7 +42,7 @@ impl OutputAsset for RebasedAsset {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(FileSystemPath::rebase(
-            self.module.ident().path().await?.clone_value(),
+            self.module.ident().path().owned().await?,
             self.input_dir.clone(),
             self.output_dir.clone(),
         ))

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1133,20 +1133,20 @@ async fn type_exists(
     ty: FileSystemEntryType,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<Option<FileSystemPath>> {
-    let result = fs_path.realpath_with_links().await?;
+    let result = fs_path.realpath_with_links().owned().await?;
     refs.extend(
         result
             .symlinks
-            .iter()
+            .into_iter()
             .map(|path| async move {
                 Ok(ResolvedVc::upcast(
-                    FileSource::new(path.clone()).to_resolved().await?,
+                    FileSource::new(path).to_resolved().await?,
                 ))
             })
             .try_join()
             .await?,
     );
-    let path = result.clone_value().path;
+    let path = result.path;
     Ok(if *path.get_type().await? == ty {
         Some(path)
     } else {
@@ -1158,20 +1158,20 @@ async fn any_exists(
     fs_path: FileSystemPath,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<Option<(FileSystemEntryType, FileSystemPath)>> {
-    let result = fs_path.realpath_with_links().await?;
+    let result = fs_path.realpath_with_links().owned().await?;
     refs.extend(
         result
             .symlinks
-            .iter()
+            .into_iter()
             .map(|path| async move {
                 Ok(ResolvedVc::upcast(
-                    FileSource::new(path.clone()).to_resolved().await?,
+                    FileSource::new(path).to_resolved().await?,
                 ))
             })
             .try_join()
             .await?,
     );
-    let path = result.clone_value().path;
+    let path = result.path;
     let ty = *path.get_type().await?;
     Ok(
         if matches!(
@@ -1508,7 +1508,7 @@ pub async fn resolve_raw(
     {
         let path = Pattern::new(pat);
         let matches = read_matches(
-            lookup_dir.root().await?.clone_value(),
+            lookup_dir.root().owned().await?,
             rcstr!("/ROOT/"),
             true,
             path,
@@ -1644,7 +1644,7 @@ pub async fn url_resolve(
     handle_resolve_error(
         result,
         reference_type,
-        origin.origin_path().await?.clone_value(),
+        origin.origin_path().owned().await?,
         request,
         resolve_options,
         is_optional,
@@ -1717,7 +1717,7 @@ async fn handle_after_resolve_plugins(
 
     for (key, primary) in result_value.primary.iter() {
         if let &ResolveResultItem::Source(source) = primary {
-            let path = source.ident().path().await?.clone_value();
+            let path = source.ident().path().owned().await?;
             if let Some(new_result) = apply_plugins_to_path(
                 path.clone(),
                 lookup_path.clone(),
@@ -1944,7 +1944,7 @@ async fn resolve_internal_inline(
                 }
 
                 Box::pin(resolve_internal_inline(
-                    lookup_path.root().await?.clone_value(),
+                    lookup_path.root().owned().await?,
                     relative,
                     options,
                 ))
@@ -2768,10 +2768,10 @@ async fn resolve_import_map_result(
                     match ty {
                         // TODO is that root correct?
                         ExternalType::CommonJs => {
-                            node_cjs_resolve_options(alias_lookup_path.root().await?.clone_value())
+                            node_cjs_resolve_options(alias_lookup_path.root().owned().await?)
                         }
                         ExternalType::EcmaScriptModule => {
-                            node_esm_resolve_options(alias_lookup_path.root().await?.clone_value())
+                            node_esm_resolve_options(alias_lookup_path.root().owned().await?)
                         }
                         ExternalType::Script | ExternalType::Url | ExternalType::Global => options,
                     },

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -75,7 +75,7 @@ where
     ) -> Result<Vc<ResolveOptions>> {
         Ok(self
             .asset_context()
-            .resolve_options(self.origin_path().await?.clone_value(), reference_type))
+            .resolve_options(self.origin_path().owned().await?, reference_type))
     }
 
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>> {
@@ -103,7 +103,7 @@ async fn resolve_asset(
         .resolve()
         .await?
         .resolve_asset(
-            resolve_origin.origin_path().await?.clone_value(),
+            resolve_origin.origin_path().owned().await?,
             request.resolve().await?,
             options.resolve().await?,
             reference_type,

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -102,7 +102,7 @@ impl CssChunk {
             {
                 fileify_source_map(
                     content.source_map.as_ref(),
-                    self.chunking_context().root_path().await?.clone_value(),
+                    self.chunking_context().root_path().owned().await?,
                 )
                 .await?
             } else {
@@ -154,7 +154,7 @@ impl CssChunk {
     async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
         let CssChunkContent { chunk_items, .. } = &*self.content.await?;
         let mut common_path = if let Some(chunk_item) = chunk_items.first() {
-            let path = chunk_item.asset_ident().path().await?.clone_value();
+            let path = chunk_item.asset_ident().path().owned().await?;
             Some((path.clone(), path))
         } else {
             None
@@ -191,7 +191,7 @@ impl CssChunk {
             path: if let Some((common_path, _)) = common_path {
                 common_path
             } else {
-                ServerFileSystem::new().root().await?.clone_value()
+                ServerFileSystem::new().root().owned().await?
             },
             query: RcStr::default(),
             fragment: RcStr::default(),
@@ -243,7 +243,7 @@ pub struct CssChunkContent {
 impl Chunk for CssChunk {
     #[turbo_tasks::function]
     async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
-        Ok(AssetIdent::from_path(self.path().await?.clone_value()))
+        Ok(AssetIdent::from_path(self.path().owned().await?))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -85,7 +85,7 @@ impl Chunk for SingleItemCssChunk {
     async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
         let self_as_output_asset: Vc<Box<dyn OutputAsset>> = Vc::upcast(self);
         Ok(AssetIdent::from_path(
-            self_as_output_asset.path().await?.clone_value(),
+            self_as_output_asset.path().owned().await?,
         ))
     }
 

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
@@ -28,7 +28,7 @@ pub async fn embed_static_code(
 ) -> Result<Vc<Code>> {
     Ok(StaticEcmascriptCode::new(
         asset_context,
-        embed_file_path(path).await?.clone_value(),
+        embed_file_path(path).owned().await?,
         generate_source_map,
     )
     .code())

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -62,7 +62,7 @@ impl AsyncLoaderChunkItem {
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root().await?.clone_value(),
+            this.chunking_context.output_root().owned().await?,
             self.chunks(),
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -55,7 +55,7 @@ impl EcmascriptChunkItemContent {
 
         Ok(EcmascriptChunkItemContent {
             rewrite_source_path: if *chunking_context.should_use_file_source_map_uris().await? {
-                Some(chunking_context.root_path().await?.clone_value())
+                Some(chunking_context.root_path().owned().await?)
             } else {
                 None
             },
@@ -279,7 +279,7 @@ async fn module_factory_with_code_generation_issue(
                 let js_error_message = serde_json::to_string(&error_message)?;
                 CodeGenerationIssue {
                     severity: IssueSeverity::Error,
-                    path: chunk_item.asset_ident().path().await?.clone_value(),
+                    path: chunk_item.asset_ident().path().owned().await?,
                     title: StyledString::Text(rcstr!("Code generation for chunk item errored"))
                         .resolved_cell(),
                     message: StyledString::Text(error_message).resolved_cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -72,7 +72,7 @@ impl Chunk for EcmascriptChunk {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let chunk_items = &*self.content.included_chunk_items().await?;
         let mut common_path = if let Some(chunk_item) = chunk_items.first() {
-            let path = chunk_item.asset_ident().path().await?.clone_value();
+            let path = chunk_item.asset_ident().path().owned().await?;
             Some(path)
         } else {
             None
@@ -108,7 +108,7 @@ impl Chunk for EcmascriptChunk {
             path: if let Some(common_path) = common_path {
                 common_path
             } else {
-                ServerFileSystem::new().root().await?.clone_value()
+                ServerFileSystem::new().root().owned().await?
             },
             query: RcStr::default(),
             fragment: RcStr::default(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -34,7 +34,7 @@ pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
         side_effect_free_packages: Vc<Glob>,
     ) -> Result<Vc<bool>> {
         Ok(is_marked_as_side_effect_free(
-            self.ident().path().await?.clone_value(),
+            self.ident().path().owned().await?,
             side_effect_free_packages,
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -694,7 +694,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleAsset {
     ) -> Result<Vc<bool>> {
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
         let pkg_side_effect_free = is_marked_as_side_effect_free(
-            self.ident().path().await?.clone_value(),
+            self.ident().path().owned().await?,
             side_effect_free_packages,
         );
         Ok(if *pkg_side_effect_free.await? {

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -32,7 +32,7 @@ impl ManifestChunkItem {
     #[turbo_tasks::function]
     async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         Ok(ChunkData::from_assets(
-            self.chunking_context.output_root().await?.clone_value(),
+            self.chunking_context.output_root().owned().await?,
             self.manifest.chunks(),
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -69,7 +69,7 @@ impl ManifestLoaderChunkItem {
     pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         let chunks = self.manifest.manifest_chunks();
         Ok(ChunkData::from_assets(
-            self.chunking_context.output_root().await?.clone_value(),
+            self.chunking_context.output_root().owned().await?,
             chunks,
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -218,7 +218,7 @@ async fn parse_internal(
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
     let content = source.content();
-    let fs_path_vc = source.ident().path().await?.clone_value();
+    let fs_path_vc = source.ident().path().owned().await?;
     let fs_path = fs_path_vc.clone();
     let ident = &*source.ident().to_string().await?;
     let file_path_hash = hash_xxh3_hash64(&*source.ident().to_string().await?) as u128;

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -80,7 +80,7 @@ async fn resolve_reference_from_dir(
     let matches = match (abs_path, rel_path) {
         (Some(abs_path), Some(rel_path)) => Either::Right(
             read_matches(
-                parent_path.root().await?.clone_value(),
+                parent_path.root().owned().await?,
                 rcstr!("/ROOT/"),
                 true,
                 Pattern::new(abs_path.or_any_nested_file()),
@@ -101,7 +101,7 @@ async fn resolve_reference_from_dir(
         (Some(abs_path), None) => Either::Left(
             // absolute path only
             read_matches(
-                parent_path.root().await?.clone_value(),
+                parent_path.root().owned().await?,
                 rcstr!("/ROOT/"),
                 true,
                 Pattern::new(abs_path.or_any_nested_file()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -354,7 +354,7 @@ async fn to_single_pattern_mapping(
                     .into(),
                 )
                 .resolved_cell(),
-                path: origin.origin_path().await?.clone_value(),
+                path: origin.origin_path().owned().await?,
             }
             .resolved_cell()
             .emit();
@@ -380,7 +380,7 @@ async fn to_single_pattern_mapping(
             "asset is not placeable in ESM chunks, so it doesn't have a module id".into(),
         )
         .resolved_cell(),
-        path: origin.origin_path().await?.clone_value(),
+        path: origin.origin_path().owned().await?,
     }
     .resolved_cell()
     .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -73,7 +73,7 @@ impl WorkerAssetReference {
                 title: StyledString::Text(rcstr!("non-ecmascript placeable asset")).resolved_cell(),
                 message: StyledString::Text(rcstr!("asset is not placeable in ESM chunks"))
                     .resolved_cell(),
-                path: self.origin.origin_path().await?.clone_value(),
+                path: self.origin.origin_path().owned().await?,
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -48,7 +48,7 @@ impl WorkerLoaderChunkItem {
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root().await?.clone_value(),
+            this.chunking_context.output_root().owned().await?,
             self.chunks(),
         ))
     }

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -120,10 +120,7 @@ impl Asset for MdxTransformedAsset {
     async fn content(self: ResolvedVc<Self>) -> Result<Vc<AssetContent>> {
         let this = self.await?;
         Ok(*transform_process_operation(self)
-            .issue_file_path(
-                this.source.ident().path().await?.clone_value(),
-                "MDX processing",
-            )
+            .issue_file_path(this.source.ident().path().owned().await?, "MDX processing")
             .await?
             .connect()
             .await?

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -100,9 +100,7 @@ async fn emit_evaluate_pool_assets_operation(
     let runtime_asset = asset_context
         .process(
             Vc::upcast(FileSource::new(
-                embed_file_path(rcstr!("ipc/evaluate.ts"))
-                    .await?
-                    .clone_value(),
+                embed_file_path(rcstr!("ipc/evaluate.ts")).owned().await?,
             )),
             ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
         )
@@ -141,7 +139,7 @@ async fn emit_evaluate_pool_assets_operation(
         let globals_module = asset_context
             .process(
                 Vc::upcast(FileSource::new(
-                    embed_file_path(rcstr!("globals.ts")).await?.clone_value(),
+                    embed_file_path(rcstr!("globals.ts")).owned().await?,
                 )),
                 ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
             )
@@ -179,7 +177,7 @@ async fn emit_evaluate_pool_assets_operation(
         OutputAssets::empty(),
     );
 
-    let output_root = chunking_context.output_root().await?.clone_value();
+    let output_root = chunking_context.output_root().owned().await?;
     emit_package_json(output_root.clone())?
         .as_side_effect()
         .await?;
@@ -289,7 +287,7 @@ pub async fn get_evaluate_pool(
         env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
         assets_for_source_mapping,
         output_root.clone(),
-        chunking_context.root_path().await?.clone_value(),
+        chunking_context.root_path().owned().await?,
         available_parallelism().map_or(1, |v| v.get()),
         debug,
     );
@@ -664,7 +662,7 @@ impl EvaluateContext for BasicEvaluateContext {
             source: IssueSource::from_source_only(self.context_source_for_issue),
             assets_for_source_mapping: pool.assets_for_source_mapping,
             assets_root: pool.assets_root.clone(),
-            root_path: self.chunking_context.root_path().await?.clone_value(),
+            root_path: self.chunking_context.root_path().owned().await?,
         }
         .resolved_cell()
         .emit();
@@ -711,7 +709,7 @@ async fn print_error(
         .print(
             *pool.assets_for_source_mapping,
             pool.assets_root.clone(),
-            evaluate_context.cwd().await?.clone_value(),
+            evaluate_context.cwd().owned().await?,
             FormattingMode::Plain,
         )
         .await

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -46,7 +46,7 @@ async fn emit(
     for asset in internal_assets(intermediate_asset, intermediate_output_path).await? {
         let _ = asset
             .content()
-            .write(asset.path().await?.clone_value())
+            .write(asset.path().owned().await?)
             .resolve()
             .await?;
     }
@@ -222,7 +222,7 @@ pub async fn get_renderer_pool_operation(
     let assets_for_source_mapping =
         internal_assets_for_source_mapping(*intermediate_asset, output_root.clone());
 
-    let entrypoint = intermediate_asset.path().await?.clone_value();
+    let entrypoint = intermediate_asset.path().owned().await?;
 
     let Some(cwd) = to_sys_path(cwd.clone()).await? else {
         bail!(
@@ -267,8 +267,8 @@ pub async fn get_intermediate_asset(
         chunking_context.root_entry_chunk_group_asset(
             chunking_context
                 .chunk_path(None, main_entry.ident(), rcstr!(".js"))
-                .await?
-                .clone_value(),
+                .owned()
+                .await?,
             other_entries.with_entry(*main_entry),
             ModuleGraph::from_modules(
                 Vc::cell(vec![ChunkGroupEntry::Entry(

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -207,7 +207,7 @@ impl GetContentSourceContent for NodeRenderContentSource {
             self.debug,
         )
         .issue_file_path(
-            entry.module.ident().path().await?.clone_value(),
+            entry.module.ident().path().owned().await?,
             format!("server-side rendering {pathname}"),
         )
         .await?;

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -65,7 +65,7 @@ pub async fn apply_source_mapping(
         let resolved = resolve_source_mapping(
             assets_for_source_mapping,
             root.clone(),
-            project_dir.root().await?.clone_value(),
+            project_dir.root().owned().await?,
             &frame,
         )
         .await;

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -169,7 +169,7 @@ impl Asset for PostCssTransformedAsset {
         let this = self.await?;
         Ok(*transform_process_operation(self)
             .issue_file_path(
-                this.source.ident().path().await?.clone_value(),
+                this.source.ident().path().owned().await?,
                 "PostCSS processing",
             )
             .await?
@@ -403,8 +403,8 @@ async fn postcss_executor(
     Ok(asset_context.process(
         Vc::upcast(FileSource::new(
             embed_file_path(rcstr!("transforms/postcss.ts"))
-                .await?
-                .clone_value(),
+                .owned()
+                .await?,
         )),
         ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
             rcstr!("CONFIG") => config_asset

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -192,8 +192,8 @@ async fn webpack_loaders_executor(
     Ok(evaluate_context.process(
         Vc::upcast(FileSource::new(
             embed_file_path(rcstr!("transforms/webpack-loaders.ts"))
-                .await?
-                .clone_value(),
+                .owned()
+                .await?,
         )),
         ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),
     ))
@@ -243,7 +243,7 @@ impl WebpackLoadersProcessedAsset {
             .to_resolved()
             .await?;
 
-        let resource_fs_path = this.source.ident().path().await?.clone_value();
+        let resource_fs_path = this.source.ident().path().owned().await?;
         let resource_fs_path_ref = resource_fs_path.clone();
         let Some(resource_path) = project_path.get_relative_path_to(&resource_fs_path_ref) else {
             bail!(format!(
@@ -472,7 +472,7 @@ impl EvaluateContext for WebpackLoaderContext {
             source: IssueSource::from_source_only(self.context_source_for_issue),
             assets_for_source_mapping: pool.assets_for_source_mapping,
             assets_root: pool.assets_root.clone(),
-            root_path: self.chunking_context.root_path().await?.clone_value(),
+            root_path: self.chunking_context.root_path().owned().await?,
         }
         .resolved_cell()
         .emit();
@@ -543,7 +543,7 @@ impl EvaluateContext for WebpackLoaderContext {
                     severity,
                     assets_for_source_mapping: pool.assets_for_source_mapping,
                     assets_root: pool.assets_root.clone(),
-                    project_dir: self.chunking_context.root_path().await?.clone_value(),
+                    project_dir: self.chunking_context.root_path().owned().await?,
                 }
                 .resolved_cell()
                 .emit();
@@ -635,7 +635,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 },
                 assets_for_source_mapping: pool.assets_for_source_mapping,
                 assets_root: pool.assets_root.clone(),
-                project_dir: self.chunking_context.root_path().await?.clone_value(),
+                project_dir: self.chunking_context.root_path().owned().await?,
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -87,8 +87,8 @@ impl EcmascriptBuildNodeChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
         Ok(EcmascriptBuildNodeChunkVersion::new(
-            self.chunking_context.output_root().await?.clone_value(),
-            self.chunk.path().await?.clone_value(),
+            self.chunking_context.output_root().owned().await?,
+            self.chunk.path().owned().await?,
             *self.content,
             *self.chunking_context.minify_type().await?,
         ))

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -57,10 +57,10 @@ impl EcmascriptBuildNodeEntryChunk {
     async fn code(self: Vc<Self>) -> Result<Vc<Code>> {
         let this = self.await?;
 
-        let output_root = this.chunking_context.output_root().await?.clone_value();
-        let chunk_path = self.path().await?.clone_value();
+        let output_root = this.chunking_context.output_root().owned().await?;
+        let chunk_path = self.path().owned().await?;
         let chunk_directory = self.path().await?.parent();
-        let runtime_path = self.runtime_chunk().path().await?.clone_value();
+        let runtime_path = self.runtime_chunk().path().owned().await?;
         let runtime_relative_path =
             if let Some(path) = chunk_directory.get_relative_path_to(&runtime_path) {
                 path

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -137,7 +137,7 @@ pub async fn cjs_resolve_source(
     handle_resolve_source_error(
         result,
         ty,
-        origin.origin_path().await?.clone_value(),
+        origin.origin_path().owned().await?,
         *request,
         options,
         is_optional,
@@ -161,7 +161,7 @@ async fn specific_resolve(
     handle_resolve_error(
         result,
         reference_type,
-        origin.origin_path().await?.clone_value(),
+        origin.origin_path().owned().await?,
         request,
         options,
         is_optional,

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -105,7 +105,7 @@ pub async fn resolve_node_pre_gyp_files(
         && let AssetContent::File(file) = &*config_asset.content().await?
         && let FileContent::Content(config_file) = &*file.await?
     {
-        let config_file_path = config_asset.ident().path().await?.clone_value();
+        let config_file_path = config_asset.ident().path().owned().await?;
         let mut affecting_paths = vec![config_file_path.clone()];
         let config_file_dir = config_file_path.parent();
         let node_pre_gyp_config: NodePreGypConfigJson =

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -91,7 +91,7 @@ async fn base_resolve_options(
 ) -> Result<Vc<ResolveOptions>> {
     let opt = options_context.await?;
     let emulating = opt.emulate_environment;
-    let root = fs.root().await?.clone_value();
+    let root = fs.root().owned().await?;
     let mut direct_mappings = AliasMap::new();
     let node_externals = if let Some(environment) = emulating {
         environment.node_externals().owned().await?

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -267,7 +267,7 @@ pub async fn tsconfig_resolve_options(
     let configs = read_tsconfigs(
         tsconfig.read(),
         ResolvedVc::upcast(FileSource::new(tsconfig.clone()).to_resolved().await?),
-        node_cjs_resolve_options(tsconfig.root().await?.clone_value()),
+        node_cjs_resolve_options(tsconfig.root().owned().await?),
     )
     .await?;
 
@@ -473,7 +473,7 @@ pub async fn type_resolve(
     handle_resolve_error(
         result,
         ty,
-        origin.origin_path().await?.clone_value(),
+        origin.origin_path().owned().await?,
         request,
         options,
         false,

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -137,7 +137,7 @@ impl EcmascriptChunkItem for StaticUrlJsChunkItem {
                 path = StringifyJs(
                     &self
                         .chunking_context
-                        .asset_url(self.static_asset.path().await?.clone_value())
+                        .asset_url(self.static_asset.path().owned().await?)
                         .await?
                 )
             )

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -283,7 +283,7 @@ async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
 
     let root_fs = DiskFileSystem::new(rcstr!("workspace"), REPO_ROOT.clone(), vec![]);
     let project_fs = DiskFileSystem::new(rcstr!("project"), REPO_ROOT.clone(), vec![]);
-    let project_root = project_fs.root().await?.clone_value();
+    let project_root = project_fs.root().owned().await?;
 
     let relative_path = resource_path.strip_prefix(&*REPO_ROOT).context(format!(
         "stripping repo root {:?} from resource path {:?}",

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -84,7 +84,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
 
                 let input_dir = input.parent().parent();
                 let output_fs: Vc<NullFileSystem> = NullFileSystem.into();
-                let output_dir = output_fs.root().await?.clone_value();
+                let output_dir = output_fs.root().owned().await?;
 
                 let source = FileSource::new(input);
                 let compile_time_info = CompileTimeInfo::builder(

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
                 ResolveOptionsContext {
                     enable_typescript: true,
                     enable_react: true,
-                    enable_node_modules: Some(fs.root().await?.clone_value()),
+                    enable_node_modules: Some(fs.root().owned().await?),
                     custom_conditions: vec![rcstr!("development")],
                     ..Default::default()
                 }

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -46,12 +46,7 @@ pub async fn node_evaluate_asset_context(
         "@vercel/turbopack-node/",
         ImportMapping::PrimaryAlternative(
             rcstr!("./*"),
-            Some(
-                turbopack_node::embed_js::embed_fs()
-                    .root()
-                    .await?
-                    .clone_value(),
-            ),
+            Some(turbopack_node::embed_js::embed_fs().root().owned().await?),
         )
         .resolved_cell(),
     );
@@ -71,8 +66,8 @@ pub async fn node_evaluate_asset_context(
                 .project_path()
                 .await?
                 .root()
-                .await?
-                .clone_value(),
+                .owned()
+                .await?,
         ),
         enable_node_externals: true,
         enable_node_native_modules: true,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -935,7 +935,7 @@ async fn emit_aggregated_assets(
 pub async fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
     asset
         .content()
-        .write(asset.path().await?.clone_value())
+        .write(asset.path().owned().await?)
         .as_side_effect()
         .await?;
 

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -650,7 +650,7 @@ impl ModuleOptions {
 
                             match &condition.path {
                                 ConditionPath::Glob(glob) => RuleCondition::ResourcePathGlob {
-                                    base: execution_context.project_path().await?.clone_value(),
+                                    base: execution_context.project_path().owned().await?,
                                     glob: Glob::new(glob.clone()).await?,
                                 },
                                 ConditionPath::Regex(regex) => {
@@ -659,7 +659,7 @@ impl ModuleOptions {
                             }
                         } else if key.contains('/') {
                             RuleCondition::ResourcePathGlob {
-                                base: execution_context.project_path().await?.clone_value(),
+                                base: execution_context.project_path().owned().await?,
                                 glob: Glob::new(key.clone()).await?,
                             }
                         } else {

--- a/turbopack/crates/turbopack/src/unsupported_sass.rs
+++ b/turbopack/crates/turbopack/src/unsupported_sass.rs
@@ -33,7 +33,7 @@ impl AfterResolvePlugin for UnsupportedSassResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
         Ok(AfterResolvePluginCondition::new(
-            self.root.root().await?.clone_value(),
+            self.root.root().owned().await?,
             Glob::new("**/*.{sass,scss}".into()),
         ))
     }

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -339,11 +339,11 @@ async fn node_file_trace_operation(
         package_root.clone(),
         vec![],
     ));
-    let input_dir = workspace_fs.root().await?.clone_value();
+    let input_dir = workspace_fs.root().owned().await?;
     let input = input_dir.join(&format!("tests/{input}"))?;
 
     let output_fs = DiskFileSystem::new(rcstr!("output"), directory.clone(), vec![]);
-    let output_dir = output_fs.root().await?.clone_value();
+    let output_dir = output_fs.root().owned().await?;
 
     let source = FileSource::new(input);
     let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(


### PR DESCRIPTION
```
ast-grep run --pattern '$$$X.await?.clone_value()' --rewrite '$$$X.owned().await?' --lang rust -U
```

This was originally removed in #75852, but added again in #80634 for no apparent reason.

Closes PACK-5060