### PR TITLE
[test] Use same pnpm in temporary repo directory

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -81,7 +81,12 @@ async function createNextInstall({
         )
         require('console').log('Creating temp repo dir', tmpRepoDir)
 
-        for (const item of ['package.json', 'packages']) {
+        for (const item of [
+          'package.json',
+          'packages',
+          // Otherwise pnpm will not recognize workspaces
+          'pnpm-workspace.yaml',
+        ]) {
           await rootSpan
             .traceChild(`copy ${item} to temp dir`)
             .traceAsyncFn(() =>


### PR DESCRIPTION
During `node run-test`, we setup a temporary repository that will execute `pnpm` commands. However, that used the default pnpm version not the one configured in the monorepo root. The default pnpm version may not be compatible with the pnpm version we use normally in the monorepo (notably v10 has a different output format for `pnpm pack`)

Now we also copy the relevant files to signal to pnpm that the commands pnpm is running in are workspaces and where it should take the `packageManager` field from (the root package.json where the pnpm-workspaces.yml is located).