### PR TITLE
[sourcemaps] Properly devirtualize `rsc:` URLs

### DIFF
--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -16,6 +16,7 @@ import {
 import type { Project, TurbopackStackFrame } from '../../build/swc/types'
 import {
   type ModernSourceMapPayload,
+  devirtualizeReactServerURL,
   findApplicableSourceMapPayload,
 } from '../lib/source-maps'
 import { getSourceMapFromFile } from './get-source-map-from-file'
@@ -121,13 +122,13 @@ async function batchedTraceSource(
     source,
   }
 }
+
 function parseFile(fileParam: string | null): string | undefined {
   if (!fileParam) {
     return undefined
   }
 
-  // rsc://React/Server/file://<filename>?42 => file://<filename>
-  return fileParam.replace(/^rsc:\/\/React\/[^/]+\//, '').replace(/\?\d+$/, '')
+  return devirtualizeReactServerURL(fileParam)
 }
 
 function createStackFrames(
@@ -178,8 +179,7 @@ function createStackFrame(
 async function nativeTraceSource(
   frame: TurbopackStackFrame
 ): Promise<{ frame: IgnorableStackFrame; source: string | null } | undefined> {
-  const sourceURL = // TODO(veil): Why are the frames sent encoded?
-    decodeURIComponent(frame.file)
+  const sourceURL = frame.file
   let sourceMapPayload: ModernSourceMapPayload | undefined
   try {
     sourceMapPayload = findSourceMap(sourceURL)?.payload

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -156,3 +156,15 @@ export function filterStackFrameDEV(
     return true
   }
 }
+
+export function devirtualizeReactServerURL(sourceURL: string): string {
+  if (sourceURL.startsWith('rsc://React/')) {
+    // rsc://React/Server/file://<filename>?42 => file://<filename>
+    const envIdx = sourceURL.indexOf('/', 'rsc://React/'.length)
+    const suffixIdx = sourceURL.lastIndexOf('?')
+    if (envIdx > -1 && suffixIdx > -1) {
+      return decodeURI(sourceURL.slice(envIdx + 1, suffixIdx))
+    }
+  }
+  return sourceURL
+}

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -90,6 +90,8 @@ describe('Dynamic IO Dev Errors', () => {
         next.cliOutput.slice(outputIndex)
       ).replaceAll(`file:` + next.testDir, '<FIXME-file-protocol>')
 
+      // TODO(veil): Source mapping breaks due to double-encoding of the square
+      // brackets.
       expect(normalizedCliOutput).toContain(
         `\nError: Route "/no-accessed-data": ` +
           `A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. ` +
@@ -101,21 +103,6 @@ describe('Dynamic IO Dev Errors', () => {
           '\n  3 |   return <p>Page</p>' +
           '\n  4 | }'
       )
-
-      // TODO(veil): Source mapping breaks due to double-encoding of the square
-      // brackets.
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
-         "environmentLabel": "Server",
-         "label": "Console Error",
-         "source": null,
-         "stack": [
-           "<FIXME-file-protocol>",
-           "LogSafely <anonymous>",
-         ],
-       }
-      `)
     } else {
       expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
         `\nError: Route "/no-accessed-data": ` +
@@ -128,22 +115,22 @@ describe('Dynamic IO Dev Errors', () => {
           '\n  3 |   return <p>Page</p>' +
           '\n  4 | }'
       )
-
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
-         "environmentLabel": "Server",
-         "label": "Console Error",
-         "source": "app/no-accessed-data/page.js (1:31) @ Page
-       > 1 | export default async function Page() {
-           |                               ^",
-         "stack": [
-           "Page app/no-accessed-data/page.js (1:31)",
-           "LogSafely <anonymous>",
-         ],
-       }
-      `)
     }
+
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+       "environmentLabel": "Server",
+       "label": "Console Error",
+       "source": "app/no-accessed-data/page.js (1:31) @ Page
+     > 1 | export default async function Page() {
+         |                               ^",
+       "stack": [
+         "Page app/no-accessed-data/page.js (1:31)",
+         "LogSafely <anonymous>",
+       ],
+     }
+    `)
   })
 
   it('should clear segment errors after correcting them', async () => {

--- a/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
+++ b/test/development/app-dir/use-cache-errors/use-cache-errors.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { assertNoRedbox } from '../../../lib/next-test-utils'
 
 describe('use-cache-errors', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { isTurbopack, next } = nextTestSetup({
     files: __dirname,
   })
   const isRspack = Boolean(process.env.NEXT_RSPACK)
@@ -20,18 +20,18 @@ describe('use-cache-errors', () => {
     await browser.elementById('action-button').click()
 
     if (isTurbopack) {
-      // TODO(veil): The wrong stack frame is used for the source snippet.
+      // TODO(veil): Inconsistent cursor position
       await expect(browser).toDisplayRedbox(`
        {
          "description": "Attempted to call useStuff() from the server but useStuff is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.",
          "environmentLabel": "Cache",
          "label": "Runtime Error",
-         "source": "app/page.tsx (22:10) @ Page
-       > 22 |   return <OtherClientComponent getCachedStuff={useCachedStuff} />
-            |          ^",
+         "source": "app/module-with-use-cache.ts (16:17) @ useCachedStuff
+       > 16 |   return useStuff()
+            |                 ^",
          "stack": [
            "<FIXME-file-protocol>",
-           "<FIXME-file-protocol>",
+           "useCachedStuff app/module-with-use-cache.ts (16:17)",
            "Page app/page.tsx (22:10)",
          ],
        }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -153,39 +153,21 @@ describe('Dynamic IO Errors', () => {
         it('should show a collapsed redbox error', async () => {
           const browser = await next.browser(pathname)
 
-          if (isTurbopack) {
-            // TODO(veil): Source mapping breaks due to double-encoding of the
-            // square brackets.
-            await expect(browser).toDisplayCollapsedRedbox(`
-             {
-               "description": "Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
-               "environmentLabel": "Server",
-               "label": "Console Error",
-               "source": null,
-               "stack": [
-                 "<FIXME-file-protocol>",
-                 "<FIXME-file-protocol>",
-                 "LogSafely <anonymous>",
-               ],
-             }
-            `)
-          } else {
-            await expect(browser).toDisplayCollapsedRedbox(`
-             {
-               "description": "Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
-               "environmentLabel": "Server",
-               "label": "Console Error",
-               "source": "app/dynamic-metadata-error-route/page.tsx (21:9) @ Dynamic
-             > 21 |   await new Promise((r) => setTimeout(r))
-                  |         ^",
-               "stack": [
-                 "Dynamic app/dynamic-metadata-error-route/page.tsx (21:9)",
-                 "Page app/dynamic-metadata-error-route/page.tsx (15:7)",
-                 "LogSafely <anonymous>",
-               ],
-             }
-            `)
-          }
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "description": "Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/dynamic-metadata-error-route/page.tsx (21:9) @ Dynamic
+           > 21 |   await new Promise((r) => setTimeout(r))
+                |         ^",
+             "stack": [
+               "Dynamic app/dynamic-metadata-error-route/page.tsx (21:9)",
+               "Page app/dynamic-metadata-error-route/page.tsx (15:7)",
+               "LogSafely <anonymous>",
+             ],
+           }
+          `)
         })
       } else {
         // This test is just here because there was a bug when dynamic metadata was used alongside another dynamic IO violation which caused the validation to be skipped.
@@ -566,18 +548,18 @@ describe('Dynamic IO Errors', () => {
           const browser = await next.browser(pathname)
 
           if (isTurbopack) {
-            // TODO(veil): Source mapping breaks due to double-encoding of the
-            // square brackets.
             await expect(browser).toDisplayCollapsedRedbox(`
              [
                {
                  "description": "Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
                  "environmentLabel": "Server",
                  "label": "Console Error",
-                 "source": null,
+                 "source": "app/dynamic-root/page.tsx (45:56) @ FetchingComponent
+             > 45 |       {cached ? await fetchRandomCached(nonce) : await fetchRandom(nonce)}
+                  |                                                        ^",
                  "stack": [
-                   "<FIXME-file-protocol>",
-                   "<FIXME-file-protocol>",
+                   "FetchingComponent app/dynamic-root/page.tsx (45:56)",
+                   "Page app/dynamic-root/page.tsx (22:9)",
                    "LogSafely <anonymous>",
                  ],
                },
@@ -585,10 +567,12 @@ describe('Dynamic IO Errors', () => {
                  "description": "Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
                  "environmentLabel": "Server",
                  "label": "Console Error",
-                 "source": null,
+                 "source": "app/dynamic-root/page.tsx (45:56) @ FetchingComponent
+             > 45 |       {cached ? await fetchRandomCached(nonce) : await fetchRandom(nonce)}
+                  |                                                        ^",
                  "stack": [
-                   "<FIXME-file-protocol>",
-                   "<FIXME-file-protocol>",
+                   "FetchingComponent app/dynamic-root/page.tsx (45:56)",
+                   "Page app/dynamic-root/page.tsx (27:7)",
                    "LogSafely <anonymous>",
                  ],
                },
@@ -1574,37 +1558,20 @@ describe('Dynamic IO Errors', () => {
           it('should show a collapsed redbox with a sync access error', async () => {
             const browser = await next.browser(`${pathname}/test`)
 
-            if (isTurbopack) {
-              await expect(browser).toDisplayCollapsedRedbox(`
-                            {
-                              "description": "Route "/sync-server-params/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                              "environmentLabel": "Prerender",
-                              "label": "Console Error",
-                              "source": "app/sync-server-params/[slug]/page.tsx (24:39) @ ParamsReadingComponent
-                            > 24 |       <span id="param">{String(params.slug)}</span>
-                                 |                                       ^",
-                              "stack": [
-                                "ParamsReadingComponent app/sync-server-params/[slug]/page.tsx (24:39)",
-                                "Page app/sync-server-params/[slug]/page.tsx (12:7)",
-                              ],
-                            }
-                          `)
-            } else {
-              // TODO(veil): Source mapping breaks due to double-encoding of the
-              // square brackets.
-              await expect(browser).toDisplayCollapsedRedbox(`
-                            {
-                              "description": "Route "/sync-server-params/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                              "environmentLabel": "Prerender",
-                              "label": "Console Error",
-                              "source": null,
-                              "stack": [
-                                "ParamsReadingComponent rsc:/Prerender/webpack-internal:///(rsc)/app/sync-server-params/%5Bslug%5D/page.tsx (51:41)",
-                                "Page rsc:/Prerender/webpack-internal:///(rsc)/app/sync-server-params/%5Bslug%5D/page.tsx (23:88)",
-                              ],
-                            }
-                          `)
-            }
+            await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "description": "Route "/sync-server-params/[slug]" used \`params.slug\`. \`params\` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+               "environmentLabel": "Prerender",
+               "label": "Console Error",
+               "source": "app/sync-server-params/[slug]/page.tsx (24:39) @ ParamsReadingComponent
+             > 24 |       <span id="param">{String(params.slug)}</span>
+                  |                                       ^",
+               "stack": [
+                 "ParamsReadingComponent app/sync-server-params/[slug]/page.tsx (24:39)",
+                 "Page app/sync-server-params/[slug]/page.tsx (12:7)",
+               ],
+             }
+            `)
           })
         } else {
           it('should not error the build when synchronously reading `params.slug`', async () => {
@@ -1660,39 +1627,21 @@ describe('Dynamic IO Errors', () => {
           it('should show a collapsed redbox error', async () => {
             const browser = await next.browser(pathname)
 
-            if (isTurbopack) {
-              await expect(browser).toDisplayCollapsedRedbox(`
-                            {
-                              "description": "Route "/sync-attribution/guarded-async-unguarded-clientsync" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
-                              "environmentLabel": "Server",
-                              "label": "Console Error",
-                              "source": "app/sync-attribution/guarded-async-unguarded-clientsync/client.tsx (5:16) @ SyncIO
-                            > 5 |   const data = new Date().toISOString()
-                                |                ^",
-                              "stack": [
-                                "SyncIO app/sync-attribution/guarded-async-unguarded-clientsync/client.tsx (5:16)",
-                                "<FIXME-file-protocol>",
-                                "LogSafely <anonymous>",
-                              ],
-                            }
-                          `)
-            } else {
-              await expect(browser).toDisplayCollapsedRedbox(`
-                            {
-                              "description": "Route "/sync-attribution/guarded-async-unguarded-clientsync" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
-                              "environmentLabel": "Server",
-                              "label": "Console Error",
-                              "source": "app/sync-attribution/guarded-async-unguarded-clientsync/client.tsx (5:16) @ SyncIO
-                            > 5 |   const data = new Date().toISOString()
-                                |                ^",
-                              "stack": [
-                                "SyncIO app/sync-attribution/guarded-async-unguarded-clientsync/client.tsx (5:16)",
-                                "Page app/sync-attribution/guarded-async-unguarded-clientsync/page.tsx (22:9)",
-                                "LogSafely <anonymous>",
-                              ],
-                            }
-                          `)
-            }
+            await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "description": "Route "/sync-attribution/guarded-async-unguarded-clientsync" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/sync-attribution/guarded-async-unguarded-clientsync/client.tsx (5:16) @ SyncIO
+             > 5 |   const data = new Date().toISOString()
+                 |                ^",
+               "stack": [
+                 "SyncIO app/sync-attribution/guarded-async-unguarded-clientsync/client.tsx (5:16)",
+                 "Page app/sync-attribution/guarded-async-unguarded-clientsync/page.tsx (22:9)",
+                 "LogSafely <anonymous>",
+               ],
+             }
+            `)
           })
         } else {
           it('should error the build with a reason related to sync IO access', async () => {
@@ -1788,22 +1737,22 @@ describe('Dynamic IO Errors', () => {
           it('should show a collapsed redbox error', async () => {
             const browser = await next.browser(pathname)
 
-            // TODO(veil): Source mapping breaks due to double-encoding of the
-            // square brackets.
             if (isTurbopack) {
               await expect(browser).toDisplayCollapsedRedbox(`
-                            {
-                              "description": "Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
-                              "environmentLabel": "Server",
-                              "label": "Console Error",
-                              "source": null,
-                              "stack": [
-                                "<FIXME-file-protocol>",
-                                "<FIXME-file-protocol>",
-                                "LogSafely <anonymous>",
-                              ],
-                            }
-                          `)
+               {
+                 "description": "Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+                 "environmentLabel": "Server",
+                 "label": "Console Error",
+                 "source": "app/sync-attribution/unguarded-async-guarded-clientsync/page.tsx (34:17) @ RequestData
+               > 34 |   ;(await cookies()).get('foo')
+                    |                 ^",
+                 "stack": [
+                   "RequestData app/sync-attribution/unguarded-async-guarded-clientsync/page.tsx (34:17)",
+                   "Page app/sync-attribution/unguarded-async-guarded-clientsync/page.tsx (27:9)",
+                   "LogSafely <anonymous>",
+                 ],
+               }
+              `)
             } else {
               await expect(browser).toDisplayCollapsedRedbox(`
                             {
@@ -1987,39 +1936,21 @@ describe('Dynamic IO Errors', () => {
           it('should show a collapsed redbox error', async () => {
             const browser = await next.browser(pathname)
 
-            if (isTurbopack) {
-              await expect(browser).toDisplayCollapsedRedbox(`
-                            {
-                              "description": "Route "/sync-attribution/unguarded-async-unguarded-clientsync" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
-                              "environmentLabel": "Server",
-                              "label": "Console Error",
-                              "source": "app/sync-attribution/unguarded-async-unguarded-clientsync/client.tsx (5:16) @ SyncIO
-                            > 5 |   const data = new Date().toISOString()
-                                |                ^",
-                              "stack": [
-                                "SyncIO app/sync-attribution/unguarded-async-unguarded-clientsync/client.tsx (5:16)",
-                                "<FIXME-file-protocol>",
-                                "LogSafely <anonymous>",
-                              ],
-                            }
-                          `)
-            } else {
-              await expect(browser).toDisplayCollapsedRedbox(`
-                            {
-                              "description": "Route "/sync-attribution/unguarded-async-unguarded-clientsync" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
-                              "environmentLabel": "Server",
-                              "label": "Console Error",
-                              "source": "app/sync-attribution/unguarded-async-unguarded-clientsync/client.tsx (5:16) @ SyncIO
-                            > 5 |   const data = new Date().toISOString()
-                                |                ^",
-                              "stack": [
-                                "SyncIO app/sync-attribution/unguarded-async-unguarded-clientsync/client.tsx (5:16)",
-                                "Page app/sync-attribution/unguarded-async-unguarded-clientsync/page.tsx (22:9)",
-                                "LogSafely <anonymous>",
-                              ],
-                            }
-                          `)
-            }
+            await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "description": "Route "/sync-attribution/unguarded-async-unguarded-clientsync" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/sync-attribution/unguarded-async-unguarded-clientsync/client.tsx (5:16) @ SyncIO
+             > 5 |   const data = new Date().toISOString()
+                 |                ^",
+               "stack": [
+                 "SyncIO app/sync-attribution/unguarded-async-unguarded-clientsync/client.tsx (5:16)",
+                 "Page app/sync-attribution/unguarded-async-unguarded-clientsync/page.tsx (22:9)",
+                 "LogSafely <anonymous>",
+               ],
+             }
+            `)
           })
         } else {
           it('should error the build with a reason related to sync IO access', async () => {


### PR DESCRIPTION
We've been devirtualizing the RSC URLs at various steps throughout the sourcemapping implementation and sometimes missed some steps. This PR puts that logic into a single place fixing a bunch of sourcemapping bugs in the error overlay.