### PR TITLE
docs: update Page example to use Promise-based params in 05-server-and-client-components.mdx

### DIFF
--- a/docs/01-app/01-getting-started/05-server-and-client-components.mdx
+++ b/docs/01-app/01-getting-started/05-server-and-client-components.mdx
@@ -36,8 +36,13 @@ For example, the `<Page>` component is a Server Component that fetches data abou
 import LikeButton from '@/app/ui/like-button'
 import { getPost } from '@/lib/data'
 
-export default async function Page({ params }: { params: { id: string } }) {
-  const post = await getPost(params.id)
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const post = await getPost(id)
 
   return (
     <div>
@@ -240,8 +245,13 @@ You can pass data from Server Components to Client Components using props.
 import LikeButton from '@/app/ui/like-button'
 import { getPost } from '@/lib/data'
 
-export default async function Page({ params }: { params: { id: string } }) {
-  const post = await getPost(params.id)
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const post = await getPost(id)
 
   return <LikeButton likes={post.likes} />
 }


### PR DESCRIPTION
What?
This PR updates the Page component example in 05-server-and-client-components.mdx to use Promise-based params as recommended in the Next.js 15 documentation.

Why?
Next.js 15 introduced support for async props, allowing the params prop to be a Promise in Server Components. Updating the documentation ensures that users follow the latest recommended practices and avoid confusion when working with dynamic routes in Next.js 15.

How?
- Changed the Page component example to accept params as a Promise and use await params to destructure the id.
- Updated the type annotation accordingly.