### PR TITLE
fix: revert focus trap dependency change

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-indicator.tsx
@@ -163,7 +163,7 @@ function DevToolsPopover({
   )
 
   // Features to make the menu accessible
-  useFocusTrap(menuRef, triggerRef, menuMounted)
+  useFocusTrap(menuRef, triggerRef, isMenuOpen)
   useClickOutside(menuRef, triggerRef, menuMounted, closeMenu)
   useShortcuts(hideShortcut ? { [hideShortcut]: hideDevTools } : {}, triggerRef)
 

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -33,7 +33,7 @@ export function DevToolsInfo({
     exitDelay: MENU_DURATION_MS,
   })
 
-  useFocusTrap(ref, triggerRef, mounted, () => {
+  useFocusTrap(ref, triggerRef, isOpen, () => {
     // Bring focus to close button, so the user can easily close the overlay
     closeButtonRef.current?.focus()
   })


### PR DESCRIPTION
Reverts a change in #81531 which updated how `useFocusTrap` behaved- which caused some accessibility features to break