### PR TITLE
chore: Reduce blocking time of router scrolling

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -117,10 +117,10 @@ function findDOMNode(
 }
 
 const hiddenProperties = {
-  'display': 'none',
-  'visibility': 'hidden',
+  display: 'none',
+  visibility: 'hidden',
   'content-visibility': 'hidden',
- } as const
+} as const
 /**
  * Check if a HTMLElement is hidden or fixed/sticky position
  */
@@ -149,10 +149,11 @@ function shouldSkipElement(element: HTMLElement) {
     return !element.checkVisibility()
   }
 
-  return Array.from(Object.entries(hiddenProperties)).some(
+  return (
+    Array.from(Object.entries(hiddenProperties)).some(
       ([property, value]) => computedStyle.getPropertyValue(property) === value
-    ) ||
-    parseFloat(computedStyle.opacity) === 0
+    ) || parseFloat(computedStyle.opacity) === 0
+  )
 }
 
 /**

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -120,6 +120,10 @@ function findDOMNode(
  * Check if a HTMLElement is hidden or fixed/sticky position
  */
 function shouldSkipElement(element: HTMLElement) {
+  if (element.tagName === 'HTML' || element.tagName === 'BODY') {
+    return false
+  }
+
   // we ignore fixed or sticky positioned elements since they'll likely pass the "in-viewport" check
   // and will result in a situation we bail on scroll because of something like a fixed nav,
   // even though the actual page content is offscreen
@@ -133,11 +137,7 @@ function shouldSkipElement(element: HTMLElement) {
     return true
   }
 
-  return (
-    element.offsetParent === null &&
-    element.tagName !== 'HTML' &&
-    element.tagName !== 'BODY'
-  )
+  return element.offsetParent === null
 }
 
 /**

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -144,7 +144,6 @@ function shouldSkipElement(element: HTMLElement) {
     return false
   }
 
-  // If checkVisibility is available, use it to check if the element is hidden
   if ('checkVisibility' in element) {
     return !element.checkVisibility()
   }

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -120,12 +120,10 @@ function findDOMNode(
  * Check if a HTMLElement is hidden or fixed/sticky position
  */
 function shouldSkipElement(element: HTMLElement) {
-  const computedStyle = getComputedStyle(element)
-
   // we ignore fixed or sticky positioned elements since they'll likely pass the "in-viewport" check
   // and will result in a situation we bail on scroll because of something like a fixed nav,
   // even though the actual page content is offscreen
-  if (['sticky', 'fixed'].includes(computedStyle.position)) {
+  if (['sticky', 'fixed'].includes(getComputedStyle(element).position)) {
     if (process.env.NODE_ENV === 'development') {
       console.warn(
         'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:',
@@ -135,7 +133,11 @@ function shouldSkipElement(element: HTMLElement) {
     return true
   }
 
-  return computedStyle.display === 'none'
+  return (
+    element.offsetParent === null &&
+    element.tagName !== 'HTML' &&
+    element.tagName !== 'BODY'
+  )
 }
 
 /**

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -116,11 +116,6 @@ function findDOMNode(
   return internal_reactDOMfindDOMNode(instance)
 }
 
-const hiddenProperties = {
-  display: 'none',
-  visibility: 'hidden',
-  'content-visibility': 'hidden',
-} as const
 /**
  * Check if a HTMLElement is hidden or fixed/sticky position
  */
@@ -140,19 +135,7 @@ function shouldSkipElement(element: HTMLElement) {
     return true
   }
 
-  if (element.offsetParent) {
-    return false
-  }
-
-  if ('checkVisibility' in element) {
-    return !element.checkVisibility()
-  }
-
-  return (
-    Array.from(Object.entries(hiddenProperties)).some(
-      ([property, value]) => computedStyle.getPropertyValue(property) === value
-    ) || parseFloat(computedStyle.opacity) === 0
-  )
+  return computedStyle.display === 'none'
 }
 
 /**


### PR DESCRIPTION
### What?

This improves the performance of the router's scrolling logic by removing an unnecessary `getBoundingClientRect()`. It also eliminates a `getComputedStyle()` call when the target element is the document element or body

### Why?

This should reduce the blocking time during soft navigations

### How?

We specifically want to skip elements that wouldn't have a bounding rect because they're `display: none` or that have `position: fixed` / `position: sticky`. This makes it safe to check whether `offsetParent === null` as long as we always treat the `<html>` and `<body>` tags as valid. If either of those elements are truly hidden, every element in the page is as well.

See #48874 for more context on why we need to check for hidden elements
