### PR TITLE
Discard prerendered route handler data from FS cache after revalidation

### DIFF
--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -28,10 +28,7 @@
       ]
     },
     "test/e2e/app-dir/use-cache/use-cache.test.ts": {
-      "failed": [
-        "use-cache should revalidate before redirecting in a route handler",
-        "use-cache should update after unstable_expireTag correctly"
-      ]
+      "failed": ["use-cache should update after unstable_expireTag correctly"]
     },
     "test/production/app-dir/browser-chunks/browser-chunks.test.ts": {
       "failed": [


### PR DESCRIPTION
After having revalidated a prerendered route handler, on the subsequent request we must discard the prerendered data from the file system cache, as we already do for pages and fetch caches as well.

> [!NOTE]  
> This PR is best reviewed with hidden whitespace changes.