### PR TITLE
[segment explorer] missing file suggestion

### DIFF
--- a/packages/next/src/next-devtools/components/tooltip.css
+++ b/packages/next/src/next-devtools/components/tooltip.css
@@ -11,6 +11,8 @@
   font-size: 14px;
   line-height: 1.4;
   pointer-events: none;
+  color: var(--color-gray-100);
+  background-color: var(--color-gray-1000);
 }
 
 .tooltip-arrow {
@@ -25,7 +27,7 @@
 .tooltip-arrow--top {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px) 0
     var(--arrow-size, 6px);
-  border-top-color: var(--tooltip-bg-color);
+  border-top-color: var(--color-gray-1000);
   bottom: 0;
   transform: translateY(100%);
 }
@@ -33,7 +35,7 @@
 .tooltip-arrow--bottom {
   border-width: 0 var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-bottom-color: var(--tooltip-bg-color);
+  border-bottom-color: var(--color-gray-1000);
   top: 0;
   transform: translateY(-100%);
 }
@@ -41,7 +43,7 @@
 .tooltip-arrow--left {
   border-width: var(--arrow-size, 6px) 0 var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-left-color: var(--tooltip-bg-color);
+  border-left-color: var(--color-gray-1000);
   right: 0;
   transform: translateX(100%);
 }
@@ -49,7 +51,7 @@
 .tooltip-arrow--right {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px) 0;
-  border-right-color: var(--tooltip-bg-color);
+  border-right-color: var(--color-gray-1000);
   left: 0;
   transform: translateX(-100%);
 }

--- a/packages/next/src/next-devtools/components/tooltip.stories.tsx
+++ b/packages/next/src/next-devtools/components/tooltip.stories.tsx
@@ -31,14 +31,6 @@ const meta: Meta<typeof Tooltip> = {
       control: { type: 'range', min: 0, max: 20, step: 1 },
       description: 'Distance between tooltip and trigger element',
     },
-    bgcolor: {
-      control: { type: 'color' },
-      description: 'Background color of the tooltip',
-    },
-    color: {
-      control: { type: 'color' },
-      description: 'Text color of the tooltip',
-    },
   },
 }
 
@@ -52,8 +44,6 @@ export const Default: Story = {
     direction: 'top',
     arrowSize: 6,
     offset: 8,
-    bgcolor: 'var(--color-gray-1000)',
-    color: 'var(--color-gray-100)',
   },
   render: (args) => (
     <div>

--- a/packages/next/src/next-devtools/components/tooltip.tsx
+++ b/packages/next/src/next-devtools/components/tooltip.tsx
@@ -11,8 +11,6 @@ interface TooltipProps {
   direction?: TooltipDirection
   arrowSize?: number
   offset?: number
-  bgcolor?: string
-  color?: string
   className?: string
 }
 
@@ -25,8 +23,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       direction = 'top',
       arrowSize = 6,
       offset = 8,
-      bgcolor = '#000',
-      color = '#fff',
     },
     ref
   ) {
@@ -67,9 +63,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                 className={cx('tooltip', className)}
                 style={
                   {
-                    backgroundColor: bgcolor,
-                    color: color,
-                    '--tooltip-bg-color': bgcolor,
                     '--arrow-size': `${arrowSize}px`,
                   } as React.CSSProperties
                 }
@@ -80,7 +73,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                   style={
                     {
                       '--arrow-size': `${arrowSize}px`,
-                      '--tooltip-bg-color': bgcolor,
                     } as React.CSSProperties
                   }
                 />

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -1,7 +1,10 @@
 import './segment-boundary-trigger.css'
 import { useCallback, useState, useRef, useMemo } from 'react'
 import { Menu } from '@base-ui-components/react/menu'
-import type { SegmentNodeState } from '../../../userspace/app/segment-explorer-node'
+import type {
+  SegmentBoundaryType,
+  SegmentNodeState,
+} from '../../../userspace/app/segment-explorer-node'
 import { normalizeBoundaryFilename } from '../../../../server/app-render/segment-explorer-path'
 import { useClickOutsideAndEscape } from '../errors/dev-tools-indicator/utils'
 
@@ -22,7 +25,7 @@ export function SegmentBoundaryTrigger({
   boundaries,
 }: {
   nodeState: SegmentNodeState
-  boundaries: Record<'not-found' | 'loading' | 'error', string | null>
+  boundaries: Record<SegmentBoundaryType, string | null>
 }) {
   const currNode = nodeState
   const { pagePath, boundaryType, setBoundaryType: onSelectBoundary } = currNode
@@ -50,9 +53,8 @@ export function SegmentBoundaryTrigger({
   )
 
   const firstDefinedBoundary = Object.values(boundaries).find((v) => v !== null)
-  const possibleExtension = firstDefinedBoundary
-    ? firstDefinedBoundary.split('.')?.pop()
-    : 'js'
+  const possibleExtension =
+    (firstDefinedBoundary || '').split('.').pop() || 'js'
 
   const fileNames = useMemo(() => {
     return Object.fromEntries(

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
@@ -31,13 +31,16 @@
 .segment-explorer-item:nth-child(even) {
   background-color: var(--color-background-200);
 }
-
 .segment-explorer-item-row {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   padding-top: 10px;
   padding-bottom: 10px;
   padding-right: 4px;
+}
+.segment-explorer-item-row-main {
+  display: flex;
+  align-items: center;
   white-space: pre;
   cursor: default;
   color: var(--color-gray-1000);
@@ -83,7 +86,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 6px;
+  padding: 0 6px;
+  height: 20px;
   border-radius: 16px;
   line-height: 16px;
   font-size: var(--size-12);
@@ -92,6 +96,10 @@
   cursor: pointer;
   background-color: var(--color-gray-300);
   color: var(--color-gray-1000);
+}
+.segment-explorer-file-label-text {
+  display: inline-flex;
+  align-items: center;
 }
 
 .segment-explorer-file-label--overridden {
@@ -184,4 +192,31 @@
 
 .segment-explorer-file-label-tooltip--lg {
   min-width: 200px;
+}
+
+.segment-explorer-suggestions-toggler {
+  margin-right: 8px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.segment-explorer-suggestions-toggler svg {
+  width: 12px;
+  height: 12px;
+  transform: rotate(-90deg);
+}
+.segment-explorer-suggestions-toggler--expanded svg {
+  transform: rotate(0deg);
+}
+
+.segment-explorer-suggestions p {
+  font-size: var(--size-13);
+  line-height: 1;
+  margin: 0;
+  margin-top: 14px;
+}
+
+.segment-explorer-suggestions .segment-explorer-file-label {
+  margin: 0 8px;
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
@@ -3,7 +3,6 @@
   padding: 0 8px;
   width: 100%;
   height: 100%;
-  overflow-y: hidden;
 }
 
 .segment-explorer-page-route-bar {
@@ -59,9 +58,8 @@
 .segment-explorer-filename select {
   margin-left: auto;
 }
-
 .segment-explorer-filename--path {
-  margin-right: auto;
+  margin-right: 8px;
 }
 .segment-explorer-filename--path small {
   display: inline-block;
@@ -194,29 +192,11 @@
   min-width: 200px;
 }
 
-.segment-explorer-suggestions-toggler {
-  margin-right: 8px;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-.segment-explorer-suggestions-toggler svg {
-  width: 12px;
-  height: 12px;
-  transform: rotate(-90deg);
-}
-.segment-explorer-suggestions-toggler--expanded svg {
-  transform: rotate(0deg);
+.segment-explorer-suggestions {
+  display: inline-flex;
+  gap: 8px;
 }
 
-.segment-explorer-suggestions p {
-  font-size: var(--size-13);
-  line-height: 1;
-  margin: 0;
-  margin-top: 14px;
-}
-
-.segment-explorer-suggestions .segment-explorer-file-label {
-  margin: 0 8px;
+.segment-explorer-suggestions-tooltip {
+  width: 200px;
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -6,13 +6,15 @@ import {
 import { cx } from '../../utils/cx'
 import { SegmentBoundaryTrigger } from './segment-boundary-trigger'
 import { Tooltip } from '../../../components/tooltip'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   BUILTIN_PREFIX,
   getBoundaryOriginFileType,
   isBoundaryFile,
   normalizeBoundaryFilename,
 } from '../../../../server/app-render/segment-explorer-path'
+import { ChevronDownIcon } from '../../icons/chevron-down'
+import { SegmentSuggestion } from './segment-suggestion'
 
 const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
@@ -96,6 +98,37 @@ function SegmentExplorerFooter({
   )
 }
 
+export function FilePill({
+  type,
+  isBuiltin,
+  isOverridden,
+  filePath,
+  fileName,
+}: {
+  type: string
+  isBuiltin: boolean
+  isOverridden: boolean
+  filePath: string
+  fileName: string
+}) {
+  return (
+    <span
+      className={cx(
+        'segment-explorer-file-label',
+        `segment-explorer-file-label--${type}`,
+        isBuiltin && 'segment-explorer-file-label--builtin',
+        isOverridden && 'segment-explorer-file-label--overridden'
+      )}
+      onClick={() => {
+        openInEditor({ filePath })
+      }}
+    >
+      <span className="segment-explorer-file-label-text">{fileName}</span>
+      {isBuiltin ? <InfoIcon /> : <CodeIcon className="code-icon" />}
+    </span>
+  )
+}
+
 export function PageSegmentTree({ page }: { page: string }) {
   const tree = useSegmentTree()
 
@@ -146,7 +179,11 @@ function PageSegmentTreeLayerPresentation({
   node: SegmentTrieNode
   level: number
 }) {
-  const childrenKeys = Object.keys(node.children)
+  const [isSuggestionsExpanded, setIsSuggestionsExpanded] = useState(false)
+  const childrenKeys = useMemo(
+    () => Object.keys(node.children),
+    [node.children]
+  )
 
   const sortedChildrenKeys = childrenKeys.sort((a, b) => {
     // Prioritize files with extensions over directories
@@ -207,6 +244,11 @@ function PageSegmentTreeLayerPresentation({
     // Otherwise, it's a folder node, add it to folderChildrenKeys
     folderChildrenKeys.push(childKey)
   }
+
+  const possibleExtension =
+    filesChildrenKeys.length > 0
+      ? filesChildrenKeys[0].split('.').pop() || 'js'
+      : 'js'
 
   let firstChild = null
 
@@ -269,94 +311,101 @@ function PageSegmentTreeLayerPresentation({
               ...{ paddingLeft: `${(level + 1) * 8}px` },
             }}
           >
-            <div className="segment-explorer-filename">
-              {folderName && (
-                <span className="segment-explorer-filename--path">
-                  {folderName}
-                  {/* hidden slashes for testing snapshots */}
-                  <small>{'/'}</small>
-                </span>
-              )}
-              {/* display all the file segments in this level */}
-              {filesChildrenKeysBesidesSelectedBoundary.length > 0 && (
-                <span className="segment-explorer-files">
-                  {filesChildrenKeysBesidesSelectedBoundary.map(
-                    (fileChildSegment) => {
-                      const childNode = node.children[fileChildSegment]
-                      if (!childNode || !childNode.value) {
-                        return null
-                      }
-                      // If it's boundary node, which marks the existence of the boundary not the rendered status,
-                      // we don't need to present in the rendered files.
-                      if (isBoundaryFile(childNode.value.type)) {
-                        return null
-                      }
-                      // If it's a page/default file, don't show it as a separate label since it's represented by the dropdown button
-                      // if (
-                      //   childNode.value.type === 'page' ||
-                      //   childNode.value.type === 'default'
-                      // ) {
-                      //   return null
-                      // }
-                      const filePath = childNode.value.pagePath
-                      const lastSegment = filePath.split('/').pop() || ''
-                      const isBuiltin = filePath.startsWith(BUILTIN_PREFIX)
-                      const fileName = normalizeBoundaryFilename(lastSegment)
+            <div className="segment-explorer-item-row-main">
+              {/* add a chevron icon to toggle a new div below filename */}
+              <button
+                className={cx(
+                  'segment-explorer-suggestions-toggler',
+                  isSuggestionsExpanded &&
+                    'segment-explorer-suggestions-toggler--expanded'
+                )}
+                onClick={() => setIsSuggestionsExpanded(!isSuggestionsExpanded)}
+              >
+                <ChevronDownIcon />
+              </button>
 
-                      const tooltipMessage = isBuiltin
-                        ? `The default Next.js ${childNode.value.type} is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`
-                        : null
+              <div className="segment-explorer-filename">
+                {folderName && (
+                  <span className="segment-explorer-filename--path">
+                    {folderName}
+                    {/* hidden slashes for testing snapshots */}
+                    <small>{'/'}</small>
+                  </span>
+                )}
+                {/* display all the file segments in this level */}
+                {filesChildrenKeysBesidesSelectedBoundary.length > 0 && (
+                  <span className="segment-explorer-files">
+                    {filesChildrenKeysBesidesSelectedBoundary.map(
+                      (fileChildSegment) => {
+                        const childNode = node.children[fileChildSegment]
+                        if (!childNode || !childNode.value) {
+                          return null
+                        }
+                        // If it's boundary node, which marks the existence of the boundary not the rendered status,
+                        // we don't need to present in the rendered files.
+                        if (isBoundaryFile(childNode.value.type)) {
+                          return null
+                        }
+                        // If it's a page/default file, don't show it as a separate label since it's represented by the dropdown button
+                        // if (
+                        //   childNode.value.type === 'page' ||
+                        //   childNode.value.type === 'default'
+                        // ) {
+                        //   return null
+                        // }
+                        const filePath = childNode.value.pagePath
+                        const lastSegment = filePath.split('/').pop() || ''
+                        const isBuiltin = filePath.startsWith(BUILTIN_PREFIX)
+                        const fileName = normalizeBoundaryFilename(lastSegment)
 
-                      const isOverridden = childNode.value.boundaryType !== null
+                        const tooltipMessage = isBuiltin
+                          ? `The default Next.js ${childNode.value.type} is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`
+                          : null
 
-                      return (
-                        <Tooltip
-                          key={fileChildSegment}
-                          className={
-                            'segment-explorer-file-label-tooltip--' +
-                            (isBuiltin ? 'lg' : 'sm')
-                          }
-                          direction={isBuiltin ? 'right' : 'top'}
-                          title={tooltipMessage}
-                          offset={12}
-                          bgcolor="var(--color-gray-1000)"
-                          color="var(--color-gray-100)"
-                        >
-                          <span
-                            className={cx(
-                              'segment-explorer-file-label',
-                              `segment-explorer-file-label--${childNode.value.type}`,
-                              isBuiltin &&
-                                'segment-explorer-file-label--builtin',
-                              isOverridden &&
-                                'segment-explorer-file-label--overridden'
-                            )}
-                            onClick={() => {
-                              openInEditor({ filePath })
-                            }}
+                        const isOverridden =
+                          childNode.value.boundaryType !== null
+
+                        return (
+                          <Tooltip
+                            key={fileChildSegment}
+                            className={
+                              'segment-explorer-file-label-tooltip--' +
+                              (isBuiltin ? 'lg' : 'sm')
+                            }
+                            direction={isBuiltin ? 'right' : 'top'}
+                            title={tooltipMessage}
+                            offset={12}
+                            bgcolor="var(--color-gray-1000)"
+                            color="var(--color-gray-100)"
                           >
-                            <span className="segment-explorer-file-label-text">
-                              {fileName}
-                            </span>
-                            {isBuiltin ? (
-                              <InfoIcon />
-                            ) : (
-                              <CodeIcon className="code-icon" />
-                            )}
-                          </span>
-                        </Tooltip>
-                      )
-                    }
-                  )}
-                </span>
-              )}
-              {firstChild && firstChild.value && (
-                <SegmentBoundaryTrigger
-                  nodeState={firstChild.value}
-                  boundaries={boundaries}
-                />
-              )}
+                            <FilePill
+                              type={childNode.value.type}
+                              isBuiltin={isBuiltin}
+                              isOverridden={isOverridden}
+                              filePath={filePath}
+                              fileName={fileName}
+                            />
+                          </Tooltip>
+                        )
+                      }
+                    )}
+                  </span>
+                )}
+                {firstChild && firstChild.value && (
+                  <SegmentBoundaryTrigger
+                    nodeState={firstChild.value}
+                    boundaries={boundaries}
+                  />
+                )}
+              </div>
             </div>
+            {isSuggestionsExpanded && (
+              <SegmentSuggestion
+                segment={segment}
+                node={node}
+                possibleExtension={possibleExtension}
+              />
+            )}
           </div>
         </div>
       )}
@@ -385,7 +434,7 @@ function PageSegmentTreeLayerPresentation({
   )
 }
 
-function openInEditor({ filePath }: { filePath: string }) {
+export function openInEditor({ filePath }: { filePath: string }) {
   const params = new URLSearchParams({
     file: filePath,
     // Mark the file path is relative to the app directory,
@@ -399,7 +448,7 @@ function openInEditor({ filePath }: { filePath: string }) {
   )
 }
 
-function InfoIcon(props: React.SVGProps<SVGSVGElement>) {
+export function InfoIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       width="16"
@@ -435,7 +484,7 @@ function BackArrowIcon() {
   )
 }
 
-function CodeIcon(props: React.SVGProps<SVGSVGElement>) {
+export function CodeIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       width="12"

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -392,8 +392,6 @@ function PageSegmentTreeLayerPresentation({
                           direction={isBuiltin ? 'right' : 'top'}
                           title={tooltipMessage}
                           offset={12}
-                          bgcolor="var(--color-gray-1000)"
-                          color="var(--color-gray-100)"
                         >
                           <FilePill
                             type={childNode.value.type}

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -6,15 +6,16 @@ import {
 import { cx } from '../../utils/cx'
 import { SegmentBoundaryTrigger } from './segment-boundary-trigger'
 import { Tooltip } from '../../../components/tooltip'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import {
   BUILTIN_PREFIX,
   getBoundaryOriginFileType,
   isBoundaryFile,
+  isBuiltinBoundaryFile,
   normalizeBoundaryFilename,
 } from '../../../../server/app-render/segment-explorer-path'
-import { ChevronDownIcon } from '../../icons/chevron-down'
 import { SegmentSuggestion } from './segment-suggestion'
+import type { SegmentBoundaryType } from '../../../userspace/app/segment-explorer-node'
 
 const isFileNode = (node: SegmentTrieNode) => {
   return !!node.value?.type && !!node.value?.pagePath
@@ -170,6 +171,8 @@ export function PageSegmentTree({ page }: { page: string }) {
   )
 }
 
+const GLOBAL_BOUNDARY_TYPES = ['global-error']
+
 function PageSegmentTreeLayerPresentation({
   segment,
   node,
@@ -179,11 +182,34 @@ function PageSegmentTreeLayerPresentation({
   node: SegmentTrieNode
   level: number
 }) {
-  const [isSuggestionsExpanded, setIsSuggestionsExpanded] = useState(false)
   const childrenKeys = useMemo(
     () => Object.keys(node.children),
     [node.children]
   )
+
+  const missingBoundaryTypes = useMemo(() => {
+    const boundaryTypes = level === 0 ? GLOBAL_BOUNDARY_TYPES : []
+
+    const existingBoundaries: string[] = []
+    childrenKeys.forEach((key) => {
+      const childNode = node.children[key]
+      if (!childNode || !childNode.value) return
+      const boundaryType = getBoundaryOriginFileType(childNode.value.type)
+      const isGlobalConvention = GLOBAL_BOUNDARY_TYPES.includes(boundaryType)
+      if (
+        // If global-* convention is not built-in, it's existed
+        (isGlobalConvention &&
+          !isBuiltinBoundaryFile(childNode.value.pagePath)) ||
+        (!isGlobalConvention &&
+          // If it's non global boundary, we check if file is boundary type
+          isBoundaryFile(childNode.value.type))
+      ) {
+        existingBoundaries.push(boundaryType)
+      }
+    })
+
+    return boundaryTypes.filter((type) => !existingBoundaries.includes(type))
+  }, [node.children, childrenKeys, level])
 
   const sortedChildrenKeys = childrenKeys.sort((a, b) => {
     // Prioritize files with extensions over directories
@@ -246,9 +272,9 @@ function PageSegmentTreeLayerPresentation({
   }
 
   const possibleExtension =
-    filesChildrenKeys.length > 0
-      ? filesChildrenKeys[0].split('.').pop() || 'js'
-      : 'js'
+    normalizeBoundaryFilename(filesChildrenKeys[0] || '')
+      .split('.')
+      .pop() || 'js'
 
   let firstChild = null
 
@@ -275,10 +301,11 @@ function PageSegmentTreeLayerPresentation({
   firstChild = firstChild || firstBoundaryChild
 
   const hasFilesChildren = filesChildrenKeys.length > 0
-  const boundaries: Record<'not-found' | 'loading' | 'error', string | null> = {
+  const boundaries: Record<SegmentBoundaryType, string | null> = {
     'not-found': null,
     loading: null,
     error: null,
+    'global-error': null,
   }
 
   filesChildrenKeys.forEach((childKey) => {
@@ -293,8 +320,6 @@ function PageSegmentTreeLayerPresentation({
       }
     }
   })
-
-  const filesChildrenKeysBesidesSelectedBoundary = filesChildrenKeys
 
   return (
     <>
@@ -312,18 +337,6 @@ function PageSegmentTreeLayerPresentation({
             }}
           >
             <div className="segment-explorer-item-row-main">
-              {/* add a chevron icon to toggle a new div below filename */}
-              <button
-                className={cx(
-                  'segment-explorer-suggestions-toggler',
-                  isSuggestionsExpanded &&
-                    'segment-explorer-suggestions-toggler--expanded'
-                )}
-                onClick={() => setIsSuggestionsExpanded(!isSuggestionsExpanded)}
-              >
-                <ChevronDownIcon />
-              </button>
-
               <div className="segment-explorer-filename">
                 {folderName && (
                   <span className="segment-explorer-filename--path">
@@ -332,63 +345,66 @@ function PageSegmentTreeLayerPresentation({
                     <small>{'/'}</small>
                   </span>
                 )}
+                {missingBoundaryTypes.length > 0 && (
+                  <SegmentSuggestion
+                    possibleExtension={possibleExtension}
+                    missingBoundaryTypes={missingBoundaryTypes}
+                  />
+                )}
                 {/* display all the file segments in this level */}
-                {filesChildrenKeysBesidesSelectedBoundary.length > 0 && (
+                {filesChildrenKeys.length > 0 && (
                   <span className="segment-explorer-files">
-                    {filesChildrenKeysBesidesSelectedBoundary.map(
-                      (fileChildSegment) => {
-                        const childNode = node.children[fileChildSegment]
-                        if (!childNode || !childNode.value) {
-                          return null
-                        }
-                        // If it's boundary node, which marks the existence of the boundary not the rendered status,
-                        // we don't need to present in the rendered files.
-                        if (isBoundaryFile(childNode.value.type)) {
-                          return null
-                        }
-                        // If it's a page/default file, don't show it as a separate label since it's represented by the dropdown button
-                        // if (
-                        //   childNode.value.type === 'page' ||
-                        //   childNode.value.type === 'default'
-                        // ) {
-                        //   return null
-                        // }
-                        const filePath = childNode.value.pagePath
-                        const lastSegment = filePath.split('/').pop() || ''
-                        const isBuiltin = filePath.startsWith(BUILTIN_PREFIX)
-                        const fileName = normalizeBoundaryFilename(lastSegment)
-
-                        const tooltipMessage = isBuiltin
-                          ? `The default Next.js ${childNode.value.type} is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`
-                          : null
-
-                        const isOverridden =
-                          childNode.value.boundaryType !== null
-
-                        return (
-                          <Tooltip
-                            key={fileChildSegment}
-                            className={
-                              'segment-explorer-file-label-tooltip--' +
-                              (isBuiltin ? 'lg' : 'sm')
-                            }
-                            direction={isBuiltin ? 'right' : 'top'}
-                            title={tooltipMessage}
-                            offset={12}
-                            bgcolor="var(--color-gray-1000)"
-                            color="var(--color-gray-100)"
-                          >
-                            <FilePill
-                              type={childNode.value.type}
-                              isBuiltin={isBuiltin}
-                              isOverridden={isOverridden}
-                              filePath={filePath}
-                              fileName={fileName}
-                            />
-                          </Tooltip>
-                        )
+                    {filesChildrenKeys.map((fileChildSegment) => {
+                      const childNode = node.children[fileChildSegment]
+                      if (!childNode || !childNode.value) {
+                        return null
                       }
-                    )}
+                      // If it's boundary node, which marks the existence of the boundary not the rendered status,
+                      // we don't need to present in the rendered files.
+                      if (isBoundaryFile(childNode.value.type)) {
+                        return null
+                      }
+                      // If it's a page/default file, don't show it as a separate label since it's represented by the dropdown button
+                      // if (
+                      //   childNode.value.type === 'page' ||
+                      //   childNode.value.type === 'default'
+                      // ) {
+                      //   return null
+                      // }
+                      const filePath = childNode.value.pagePath
+                      const lastSegment = filePath.split('/').pop() || ''
+                      const isBuiltin = filePath.startsWith(BUILTIN_PREFIX)
+                      const fileName = normalizeBoundaryFilename(lastSegment)
+
+                      const tooltipMessage = isBuiltin
+                        ? `The default Next.js ${childNode.value.type} is being shown. You can customize this page by adding your own ${fileName} file to the app/ directory.`
+                        : null
+
+                      const isOverridden = childNode.value.boundaryType !== null
+
+                      return (
+                        <Tooltip
+                          key={fileChildSegment}
+                          className={
+                            'segment-explorer-file-label-tooltip--' +
+                            (isBuiltin ? 'lg' : 'sm')
+                          }
+                          direction={isBuiltin ? 'right' : 'top'}
+                          title={tooltipMessage}
+                          offset={12}
+                          bgcolor="var(--color-gray-1000)"
+                          color="var(--color-gray-100)"
+                        >
+                          <FilePill
+                            type={childNode.value.type}
+                            isBuiltin={isBuiltin}
+                            isOverridden={isOverridden}
+                            filePath={filePath}
+                            fileName={fileName}
+                          />
+                        </Tooltip>
+                      )
+                    })}
                   </span>
                 )}
                 {firstChild && firstChild.value && (
@@ -399,13 +415,6 @@ function PageSegmentTreeLayerPresentation({
                 )}
               </div>
             </div>
-            {isSuggestionsExpanded && (
-              <SegmentSuggestion
-                segment={segment}
-                node={node}
-                possibleExtension={possibleExtension}
-              />
-            )}
           </div>
         </div>
       )}

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -171,7 +171,7 @@ export function PageSegmentTree({ page }: { page: string }) {
   )
 }
 
-const GLOBAL_BOUNDARY_TYPES = ['global-error']
+const GLOBAL_ERROR_BOUNDARY_TYPE = 'global-error'
 
 function PageSegmentTreeLayerPresentation({
   segment,
@@ -187,15 +187,13 @@ function PageSegmentTreeLayerPresentation({
     [node.children]
   )
 
-  const missingBoundaryTypes = useMemo(() => {
-    const boundaryTypes = level === 0 ? GLOBAL_BOUNDARY_TYPES : []
-
+  const missingGlobalError = useMemo(() => {
     const existingBoundaries: string[] = []
     childrenKeys.forEach((key) => {
       const childNode = node.children[key]
       if (!childNode || !childNode.value) return
       const boundaryType = getBoundaryOriginFileType(childNode.value.type)
-      const isGlobalConvention = GLOBAL_BOUNDARY_TYPES.includes(boundaryType)
+      const isGlobalConvention = boundaryType === GLOBAL_ERROR_BOUNDARY_TYPE
       if (
         // If global-* convention is not built-in, it's existed
         (isGlobalConvention &&
@@ -208,7 +206,9 @@ function PageSegmentTreeLayerPresentation({
       }
     })
 
-    return boundaryTypes.filter((type) => !existingBoundaries.includes(type))
+    return (
+      level === 0 && !existingBoundaries.includes(GLOBAL_ERROR_BOUNDARY_TYPE)
+    )
   }, [node.children, childrenKeys, level])
 
   const sortedChildrenKeys = childrenKeys.sort((a, b) => {
@@ -345,10 +345,10 @@ function PageSegmentTreeLayerPresentation({
                     <small>{'/'}</small>
                   </span>
                 )}
-                {missingBoundaryTypes.length > 0 && (
+                {missingGlobalError && (
                   <SegmentSuggestion
                     possibleExtension={possibleExtension}
-                    missingBoundaryTypes={missingBoundaryTypes}
+                    missingGlobalError={missingGlobalError}
                   />
                 )}
                 {/* display all the file segments in this level */}

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-suggestion.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-suggestion.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react'
+import { FilePill } from './segment-explorer'
+import {
+  isBoundaryFile,
+  getBoundaryOriginFileType,
+} from '../../../../server/app-render/segment-explorer-path'
+import type { SegmentTrieNode } from '../../segment-explorer-trie'
+
+export function SegmentSuggestion({
+  segment,
+  node,
+  possibleExtension,
+}: {
+  segment: string
+  node: SegmentTrieNode
+  possibleExtension: string
+}) {
+  const isDynamicSegment =
+    segment && segment.startsWith('[') && segment.endsWith(']')
+  const boundaryTypes = ['not-found', 'error'].concat(
+    isDynamicSegment ? ['loading'] : []
+  )
+  const childrenKeys = useMemo(
+    () => Object.keys(node.children),
+    [node.children]
+  )
+  const missingBoundaryTypes = useMemo(() => {
+    const existingBoundaries: string[] = []
+    childrenKeys.forEach((key) => {
+      const childNode = node.children[key]
+      if (!childNode || !childNode.value) return false
+      if (isBoundaryFile(childNode.value.type)) {
+        const boundaryType = getBoundaryOriginFileType(childNode.value.type)
+        existingBoundaries.push(boundaryType)
+      }
+    })
+    return boundaryTypes.filter((type) => !existingBoundaries.includes(type))
+  }, [node.children, childrenKeys, boundaryTypes])
+
+  return (
+    <div className="segment-explorer-suggestions">
+      <p>
+        This segment may be missing the following special files:
+        {missingBoundaryTypes.map((type) => {
+          return (
+            <FilePill
+              key={type}
+              type={type}
+              isBuiltin={true}
+              isOverridden={false}
+              filePath={type + '.' + possibleExtension}
+              fileName={type + '.' + possibleExtension}
+            />
+          )
+        })}
+      </p>
+    </div>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-suggestion.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-suggestion.tsx
@@ -1,59 +1,21 @@
-import { useMemo } from 'react'
-import { FilePill } from './segment-explorer'
-import {
-  isBoundaryFile,
-  getBoundaryOriginFileType,
-} from '../../../../server/app-render/segment-explorer-path'
-import type { SegmentTrieNode } from '../../segment-explorer-trie'
+import { Tooltip } from '../../../components/tooltip'
+import { InfoIcon } from './segment-explorer'
 
 export function SegmentSuggestion({
-  segment,
-  node,
   possibleExtension,
+  missingBoundaryTypes,
 }: {
-  segment: string
-  node: SegmentTrieNode
   possibleExtension: string
+  missingBoundaryTypes: string[]
 }) {
-  const isDynamicSegment =
-    segment && segment.startsWith('[') && segment.endsWith(']')
-  const boundaryTypes = ['not-found', 'error'].concat(
-    isDynamicSegment ? ['loading'] : []
-  )
-  const childrenKeys = useMemo(
-    () => Object.keys(node.children),
-    [node.children]
-  )
-  const missingBoundaryTypes = useMemo(() => {
-    const existingBoundaries: string[] = []
-    childrenKeys.forEach((key) => {
-      const childNode = node.children[key]
-      if (!childNode || !childNode.value) return false
-      if (isBoundaryFile(childNode.value.type)) {
-        const boundaryType = getBoundaryOriginFileType(childNode.value.type)
-        existingBoundaries.push(boundaryType)
-      }
-    })
-    return boundaryTypes.filter((type) => !existingBoundaries.includes(type))
-  }, [node.children, childrenKeys, boundaryTypes])
-
+  const tooltip = `This segment may be missing the following files: ${missingBoundaryTypes
+    .map((type) => `${type}.${possibleExtension}`)
+    .join(', ')}`
   return (
-    <div className="segment-explorer-suggestions">
-      <p>
-        This segment may be missing the following special files:
-        {missingBoundaryTypes.map((type) => {
-          return (
-            <FilePill
-              key={type}
-              type={type}
-              isBuiltin={true}
-              isOverridden={false}
-              filePath={type + '.' + possibleExtension}
-              fileName={type + '.' + possibleExtension}
-            />
-          )
-        })}
-      </p>
-    </div>
+    <span className="segment-explorer-suggestions">
+      <Tooltip className="segment-explorer-suggestions-tooltip" title={tooltip}>
+        <InfoIcon />
+      </Tooltip>
+    </span>
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-suggestion.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-suggestion.tsx
@@ -3,14 +3,14 @@ import { InfoIcon } from './segment-explorer'
 
 export function SegmentSuggestion({
   possibleExtension,
-  missingBoundaryTypes,
+  missingGlobalError,
 }: {
   possibleExtension: string
-  missingBoundaryTypes: string[]
+  missingGlobalError: boolean
 }) {
-  const tooltip = `This segment may be missing the following files: ${missingBoundaryTypes
-    .map((type) => `${type}.${possibleExtension}`)
-    .join(', ')}`
+  const tooltip = missingGlobalError
+    ? `No global-error.${possibleExtension} found: Add one to ensure users see a helpful message when an unexpected error occurs.`
+    : null
   return (
     <span className="segment-explorer-suggestions">
       <Tooltip className="segment-explorer-suggestions-tooltip" title={tooltip}>

--- a/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
+++ b/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
@@ -13,6 +13,12 @@ import { useLayoutEffect } from 'react'
 import { dispatcher } from 'next/dist/compiled/next-devtools'
 import { notFound } from '../../../client/components/not-found'
 
+export type SegmentBoundaryType =
+  | 'not-found'
+  | 'error'
+  | 'loading'
+  | 'global-error'
+
 export const SEGMENT_EXPLORER_SIMULATED_ERROR_MESSAGE =
   'NEXT_DEVTOOLS_SIMULATED_ERROR'
 
@@ -20,7 +26,7 @@ export type SegmentNodeState = {
   type: string
   pagePath: string
   boundaryType: string | null
-  setBoundaryType: (type: 'error' | 'not-found' | 'loading' | null) => void
+  setBoundaryType: (type: SegmentBoundaryType | null) => void
 }
 
 function SegmentTrieNode({
@@ -111,17 +117,17 @@ export function SegmentViewNode({
 }
 
 const SegmentStateContext = createContext<{
-  boundaryType: 'not-found' | 'error' | 'loading' | null
-  setBoundaryType: (type: 'not-found' | 'error' | 'loading' | null) => void
+  boundaryType: SegmentBoundaryType | null
+  setBoundaryType: (type: SegmentBoundaryType | null) => void
 }>({
   boundaryType: null,
   setBoundaryType: () => {},
 })
 
 export function SegmentStateProvider({ children }: { children: ReactNode }) {
-  const [boundaryType, setBoundaryType] = useState<
-    'not-found' | 'error' | 'loading' | null
-  >(null)
+  const [boundaryType, setBoundaryType] = useState<SegmentBoundaryType | null>(
+    null
+  )
 
   const [errorBoundaryKey, setErrorBoundaryKey] = useState(0)
   const reloadBoundary = useCallback(
@@ -130,7 +136,7 @@ export function SegmentStateProvider({ children }: { children: ReactNode }) {
   )
 
   const setBoundaryTypeAndReload = useCallback(
-    (type: 'not-found' | 'error' | 'loading' | null) => {
+    (type: SegmentBoundaryType | null) => {
       if (type === null) {
         reloadBoundary()
       }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -29,7 +29,9 @@ import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
 import {
   BOUNDARY_PREFIX,
   BOUNDARY_SUFFIX,
+  BUILTIN_PREFIX,
   getConventionPathByType,
+  isNextjsBuiltinFilePath,
 } from './segment-explorer-path'
 
 /**
@@ -55,7 +57,7 @@ export function createComponentTree(props: {
     {
       spanName: 'build component tree',
     },
-    () => createComponentTreeInternal(props)
+    () => createComponentTreeInternal(props, true)
   )
 }
 
@@ -71,35 +73,38 @@ function errorMissingDefaultExport(
 
 const cacheNodeKey = 'c'
 
-async function createComponentTreeInternal({
-  loaderTree: tree,
-  parentParams,
-  rootLayoutIncluded,
-  injectedCSS,
-  injectedJS,
-  injectedFontPreloadTags,
-  getViewportReady,
-  getMetadataReady,
-  ctx,
-  missingSlots,
-  preloadCallbacks,
-  authInterrupts,
-  StreamingMetadataOutlet,
-}: {
-  loaderTree: LoaderTree
-  parentParams: Params
-  rootLayoutIncluded: boolean
-  injectedCSS: Set<string>
-  injectedJS: Set<string>
-  injectedFontPreloadTags: Set<string>
-  getViewportReady: () => Promise<void>
-  getMetadataReady: () => Promise<void>
-  ctx: AppRenderContext
-  missingSlots?: Set<string>
-  preloadCallbacks: PreloadCallbacks
-  authInterrupts: boolean
-  StreamingMetadataOutlet: React.ComponentType | null
-}): Promise<CacheNodeSeedData> {
+async function createComponentTreeInternal(
+  {
+    loaderTree: tree,
+    parentParams,
+    rootLayoutIncluded,
+    injectedCSS,
+    injectedJS,
+    injectedFontPreloadTags,
+    getViewportReady,
+    getMetadataReady,
+    ctx,
+    missingSlots,
+    preloadCallbacks,
+    authInterrupts,
+    StreamingMetadataOutlet,
+  }: {
+    loaderTree: LoaderTree
+    parentParams: Params
+    rootLayoutIncluded: boolean
+    injectedCSS: Set<string>
+    injectedJS: Set<string>
+    injectedFontPreloadTags: Set<string>
+    getViewportReady: () => Promise<void>
+    getMetadataReady: () => Promise<void>
+    ctx: AppRenderContext
+    missingSlots?: Set<string>
+    preloadCallbacks: PreloadCallbacks
+    authInterrupts: boolean
+    StreamingMetadataOutlet: React.ComponentType | null
+  },
+  isRoot: boolean
+): Promise<CacheNodeSeedData> {
   const {
     renderOpts: { nextConfigOutput, experimental },
     workStore,
@@ -520,31 +525,34 @@ async function createComponentTreeInternal({
             }
           }
 
-          const seedData = await createComponentTreeInternal({
-            loaderTree: parallelRoute,
-            parentParams: currentParams,
-            rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
-            injectedCSS: injectedCSSWithCurrentLayout,
-            injectedJS: injectedJSWithCurrentLayout,
-            injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
-            // `getMetadataReady` and `getViewportReady` are used to conditionally throw. In the case of parallel routes we will have more than one page
-            // but we only want to throw on the first one.
-            getMetadataReady: isChildrenRouteKey
-              ? getMetadataReady
-              : () => Promise.resolve(),
-            getViewportReady: isChildrenRouteKey
-              ? getViewportReady
-              : () => Promise.resolve(),
-            ctx,
-            missingSlots,
-            preloadCallbacks,
-            authInterrupts,
-            // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
-            // but we only want to throw on the first one.
-            StreamingMetadataOutlet: isChildrenRouteKey
-              ? StreamingMetadataOutlet
-              : null,
-          })
+          const seedData = await createComponentTreeInternal(
+            {
+              loaderTree: parallelRoute,
+              parentParams: currentParams,
+              rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
+              injectedCSS: injectedCSSWithCurrentLayout,
+              injectedJS: injectedJSWithCurrentLayout,
+              injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
+              // `getMetadataReady` and `getViewportReady` are used to conditionally throw. In the case of parallel routes we will have more than one page
+              // but we only want to throw on the first one.
+              getMetadataReady: isChildrenRouteKey
+                ? getMetadataReady
+                : () => Promise.resolve(),
+              getViewportReady: isChildrenRouteKey
+                ? getViewportReady
+                : () => Promise.resolve(),
+              ctx,
+              missingSlots,
+              preloadCallbacks,
+              authInterrupts,
+              // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
+              // but we only want to throw on the first one.
+              StreamingMetadataOutlet: isChildrenRouteKey
+                ? StreamingMetadataOutlet
+                : null,
+            },
+            false
+          )
 
           childCacheNodeSeedData = seedData
         }
@@ -558,6 +566,9 @@ async function createComponentTreeInternal({
         const templateFilePath = getConventionPathByType(tree, dir, 'template')
         const errorFilePath = getConventionPathByType(tree, dir, 'error')
         const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
+        const globalErrorFilePath = isRoot
+          ? getConventionPathByType(tree, dir, 'global-error')
+          : undefined
 
         const wrappedErrorStyles =
           isSegmentViewEnabled && errorFilePath ? (
@@ -590,6 +601,17 @@ async function createComponentTreeInternal({
               <SegmentViewNode
                 type={`${BOUNDARY_PREFIX}error`}
                 pagePath={errorFilePath + fileNameSuffix}
+              />
+            )}
+            {/* Only show global-error when it's the builtin one */}
+            {globalErrorFilePath && (
+              <SegmentViewNode
+                type={`${BOUNDARY_PREFIX}global-error`}
+                pagePath={
+                  isNextjsBuiltinFilePath(globalErrorFilePath)
+                    ? `${BUILTIN_PREFIX}global-error.js${fileNameSuffix}`
+                    : globalErrorFilePath
+                }
               />
             )}
             {/* do not surface forbidden and unauthorized boundaries yet as they're unstable */}

--- a/packages/next/src/server/app-render/segment-explorer-path.ts
+++ b/packages/next/src/server/app-render/segment-explorer-path.ts
@@ -2,13 +2,14 @@ import type { LoaderTree } from '../lib/app-dir-module'
 
 export const BUILTIN_PREFIX = '__next_builtin__'
 
+const nextInternalPrefixRegex =
+  /^(.*[\\/])?next[\\/]dist[\\/]client[\\/]components[\\/]builtin[\\/]/
+
 export function normalizeConventionFilePath(
   projectDir: string,
   conventionPath: string | undefined
 ) {
   const cwd = process.env.NEXT_RUNTIME === 'edge' ? '' : process.cwd()
-  const nextInternalPrefixRegex =
-    /^(.*[\\/])?next[\\/]dist[\\/]client[\\/]components[\\/]builtin[\\/]/
 
   let relativePath = (conventionPath || '')
     // remove turbopack [project] prefix
@@ -30,6 +31,13 @@ export function normalizeConventionFilePath(
   return relativePath
 }
 
+// if a filepath is a builtin file. e.g.
+// .../project/node_modules/next/dist/client/components/builtin/global-error.js -> true
+// .../project/app/global-error.js -> false
+export const isNextjsBuiltinFilePath = (filePath: string) => {
+  return nextInternalPrefixRegex.test(filePath)
+}
+
 export const BOUNDARY_SUFFIX = '@boundary'
 export function normalizeBoundaryFilename(filename: string) {
   return filename
@@ -40,6 +48,13 @@ export function normalizeBoundaryFilename(filename: string) {
 export const BOUNDARY_PREFIX = 'boundary:'
 export function isBoundaryFile(fileType: string) {
   return fileType.startsWith(BOUNDARY_PREFIX)
+}
+
+// if a filename is a builtin file.
+// __next_builtin__global-error.js -> true
+// page.js -> false
+export function isBuiltinBoundaryFile(fileType: string) {
+  return fileType.startsWith(BUILTIN_PREFIX)
 }
 
 export function getBoundaryOriginFileType(fileType: string) {
@@ -59,6 +74,7 @@ export function getConventionPathByType(
     | 'forbidden'
     | 'unauthorized'
     | 'defaultPage'
+    | 'global-error'
 ) {
   const modules = tree[2]
   const conventionPath = modules[conventionType]

--- a/test/development/app-dir/segment-explorer/app/dynamic/blog/[slug]/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/dynamic/blog/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Blog Slug</div>
+}

--- a/test/development/app-dir/segment-explorer/app/dynamic/blog/error.tsx
+++ b/test/development/app-dir/segment-explorer/app/dynamic/blog/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <div>Error</div>
+}

--- a/test/development/app-dir/segment-explorer/app/dynamic/full/error.tsx
+++ b/test/development/app-dir/segment-explorer/app/dynamic/full/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <div>Error</div>
+}

--- a/test/development/app-dir/segment-explorer/app/dynamic/full/not-found.tsx
+++ b/test/development/app-dir/segment-explorer/app/dynamic/full/not-found.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function NotFound() {
+  return <div>Not Found</div>
+}

--- a/test/development/app-dir/segment-explorer/app/dynamic/full/page.tsx
+++ b/test/development/app-dir/segment-explorer/app/dynamic/full/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Full</div>
+}


### PR DESCRIPTION
Show a info icon right next to the root segment when there're `global-error` convention is missing.

<img width="589" height="270" alt="image" src="https://github.com/user-attachments/assets/684545f8-31fc-4124-adc6-7a95e4f4fe3d" />

Closes NEXT-4600

