### PR TITLE
15.4 Docs: Minor feature updates

### DIFF
--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -299,7 +299,7 @@ Prefetching happens when a `<Link />` component enters the user's viewport (init
 
 The following values can be passed to the `prefetch` prop:
 
-- **`auto` or `null` (default)**: Prefetch behavior depends on whether the route is static or dynamic. For static routes, the full route will be prefetched (including all its data). For dynamic routes, the partial route down to the nearest segment with a [`loading.js`](/docs/app/api-reference/file-conventions/loading#instant-loading-states) boundary will be prefetched.
+- **`"auto"` or `null` (default)**: Prefetch behavior depends on whether the route is static or dynamic. For static routes, the full route will be prefetched (including all its data). For dynamic routes, the partial route down to the nearest segment with a [`loading.js`](/docs/app/api-reference/file-conventions/loading#instant-loading-states) boundary will be prefetched.
 - `true`: The full route will be prefetched for both static and dynamic routes.
 - `false`: Prefetching will never happen both on entering the viewport and on hover.
 

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -299,7 +299,7 @@ Prefetching happens when a `<Link />` component enters the user's viewport (init
 
 The following values can be passed to the `prefetch` prop:
 
-- **`null` (default)**: Prefetch behavior depends on whether the route is static or dynamic. For static routes, the full route will be prefetched (including all its data). For dynamic routes, the partial route down to the nearest segment with a [`loading.js`](/docs/app/api-reference/file-conventions/loading#instant-loading-states) boundary will be prefetched.
+- **`auto` or `null` (default)**: Prefetch behavior depends on whether the route is static or dynamic. For static routes, the full route will be prefetched (including all its data). For dynamic routes, the partial route down to the nearest segment with a [`loading.js`](/docs/app/api-reference/file-conventions/loading#instant-loading-states) boundary will be prefetched.
 - `true`: The full route will be prefetched for both static and dynamic routes.
 - `false`: Prefetching will never happen both on entering the viewport and on hover.
 
@@ -1480,6 +1480,7 @@ When a user tries to navigate away using `CustomLink` while the form has unsaved
 
 | Version   | Changes                                                                                                                                                                      |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v15.4.0` | Add `auto` as an alias to the default `prefetch` behavior.                                                                                                                   |
 | `v15.3.0` | Add `onNavigate` API                                                                                                                                                         |
 | `v13.0.0` | No longer requires a child `<a>` tag. A [codemod](/docs/app/guides/upgrading/codemods#remove-a-tags-from-link-components) is provided to automatically update your codebase. |
 | `v10.0.0` | `href` props pointing to a dynamic route are automatically resolved and no longer require an `as` prop.                                                                      |

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -85,6 +85,7 @@ The following options are available for the `next build` command:
 | `--no-mangling`                    | Disables [mangling](https://en.wikipedia.org/wiki/Name_mangling). This may affect performance and should only be used for debugging purposes. |
 | `--experimental-app-only`          | Builds only App Router routes.                                                                                                                |
 | `--experimental-build-mode [mode]` | Uses an experimental build mode. (choices: "compile", "generate", default: "default")                                                         |
+| `--debug-prerender`                | Builds only App Router routes.                                                                                                                |
 
 ### `next start` options
 
@@ -183,6 +184,30 @@ Learn more about [Telemetry](/telemetry).
 
 ## Examples
 
+### Debugging prerender errors
+
+If you encounter prerendering errors during next build, you can pass the --debug-prerender flag to get more detailed output:
+
+```bash filename="Terminal"
+next build --debug-prerender
+```
+
+This enables several experimental options to make debugging easier:
+
+- Disables server code minification:
+  - `experimental.serverMinification = false`
+  - `experimental.turbopackMinify = false`
+- Generates source maps for server bundles:
+  - `experimental.serverSourceMaps = true`
+- Enables source map consumption in child processes used for prerendering:
+  - `experimental.enablePrerenderSourceMaps = true`
+- Continues building even after the first prerender error, so you can see all issues at once:
+  - `experimental.prerenderEarlyExit = false`
+
+This helps surface more readable stack traces and code frames in the build output.
+
+> **Warning**: `--debug-prerender` is for debugging in development only. Do not deploy builds generated with `--debug-prerender` to production, as it may impact performance.
+
 ### Changing the default port
 
 By default, Next.js uses `http://localhost:3000` during development and with `next start`. The default port can be changed with the `-p` option, like so:
@@ -236,3 +261,7 @@ NODE_OPTIONS='--throw-deprecation' next
 NODE_OPTIONS='-r esm' next
 NODE_OPTIONS='--inspect' next
 ```
+
+| Version   | Changes                                                                         |
+| --------- | ------------------------------------------------------------------------------- |
+| `v15.4.0` | Add `--debug-prerender` option for `next build` to help debug prerender errors. |

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -186,7 +186,7 @@ Learn more about [Telemetry](/telemetry).
 
 ### Debugging prerender errors
 
-If you encounter prerendering errors during next build, you can pass the --debug-prerender flag to get more detailed output:
+If you encounter prerendering errors during `next build`, you can pass the --debug-prerender flag to get more detailed output:
 
 ```bash filename="Terminal"
 next build --debug-prerender

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -186,7 +186,7 @@ Learn more about [Telemetry](/telemetry).
 
 ### Debugging prerender errors
 
-If you encounter prerendering errors during `next build`, you can pass the --debug-prerender flag to get more detailed output:
+If you encounter prerendering errors during `next build`, you can pass the `--debug-prerender` flag to get more detailed output:
 
 ```bash filename="Terminal"
 next build --debug-prerender

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -85,7 +85,7 @@ The following options are available for the `next build` command:
 | `--no-mangling`                    | Disables [mangling](https://en.wikipedia.org/wiki/Name_mangling). This may affect performance and should only be used for debugging purposes. |
 | `--experimental-app-only`          | Builds only App Router routes.                                                                                                                |
 | `--experimental-build-mode [mode]` | Uses an experimental build mode. (choices: "compile", "generate", default: "default")                                                         |
-| `--debug-prerender`                | Builds only App Router routes.                                                                                                                |
+| `--debug-prerender`                | Debug prerender errors in development.                                                                                                        |
 
 ### `next start` options
 


### PR DESCRIPTION
Updates the docs to include the new options in 15.4. 

- `prefetch="auto"` option: https://github.com/vercel/next.js/pull/78689
-  `next build` new `--debug-prerender option`: https://github.com/vercel/next.js/pull/80667