### PR TITLE
[sourcemaps] Don't check for vendor chunks when Node.js 18 is used

### DIFF
--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -1,7 +1,13 @@
+import type { SourceMap } from 'module'
+
+function noSourceMap(): SourceMap | undefined {
+  return undefined
+}
+
 // Edge runtime does not implement `module`
-const findSourceMap =
+const nativeFindSourceMap =
   process.env.NEXT_RUNTIME === 'edge'
-    ? () => undefined
+    ? noSourceMap
     : (require('module') as typeof import('module')).findSourceMap
 
 /**
@@ -94,6 +100,13 @@ export function findApplicableSourceMapPayload(
 }
 
 const didWarnAboutInvalidSourceMapDEV = new Set<string>()
+
+const findSourceMap: (scriptNameOrSourceURL: string) => SourceMap | undefined =
+  process.env.NEXT_RUNTIME === 'nodejs' &&
+  process.versions.node?.startsWith('18')
+    ? // Node.js 18 has a horribly slow `findSourceMap` implementation
+      noSourceMap
+    : nativeFindSourceMap
 
 export function filterStackFrameDEV(
   sourceURL: string,


### PR DESCRIPTION
`module.findSourceMap` is horribly slow in Node.js 18 (EOL) when it parses the source map. 

We still officially support it so I just disabled the check for Node.js. Lower fidelity in naming React Performance track and more bandwidth used in dev is preferable over waiting 10s+ for a page request.

I didn't add a warning because that's unactionable for people stuck on Node.js 18. With Next.js 16, we can revisit if we want to drop Node.js 18