### PR TITLE
Turbopack: fix hanging problem with reexport cycles

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/issues/unexpected export __star__-32fbe8.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/issues/unexpected export __star__-32fbe8.txt
@@ -1,0 +1,5 @@
+warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-star/not-executed.js  unexpected export *
+  
+  export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-star/not-executed.js [test] (ecmascript) which has no exports
+  Typescript only: Did you want to export only types with `export type * from "..."`?
+  Note: Using `export type` is more efficient than `export *` as it won't emit any runtime code.

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/input/a.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/input/a.js
@@ -1,0 +1,5 @@
+export * from './b.js'
+
+export const value = 42
+
+export { value as reexported } from './b.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/input/b.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/input/b.js
@@ -1,0 +1,1 @@
+export * from './a.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/input/index.js
@@ -1,0 +1,5 @@
+it('should allow reexport cycles', async () => {
+  const module = await import('./a.js')
+  expect(module.value).toBe(42)
+  expect(module.reexported).toBe(42)
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/cycle/options.json
@@ -1,0 +1,3 @@
+{
+  "scopeHoisting": false
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/basic/issues/unexpected export __star__-32fbe8.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/basic/issues/unexpected export __star__-32fbe8.txt
@@ -1,0 +1,5 @@
+warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-star/not-executed.js  unexpected export *
+  
+  export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/basic/input/node_modules/package-star/not-executed.js [test] (ecmascript) which has no exports
+  Typescript only: Did you want to export only types with `export type * from "..."`?
+  Note: Using `export type` is more efficient than `export *` as it won't emit any runtime code.


### PR DESCRIPTION
### What?

Fix a hanging compilation in a specific case when reexports modules in a cycle.

Fix reported issues for tree shaken modules

Closes PACK-5066