### PR TITLE
Ignore pending revalidations during prerendering

### DIFF
--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -27,9 +27,6 @@
         "searchparams-reuse-loading should re-use loading from \"full\" prefetch for param-less URL when navigating to param-full route"
       ]
     },
-    "test/e2e/app-dir/use-cache/use-cache.test.ts": {
-      "failed": ["use-cache should update after unstable_expireTag correctly"]
-    },
     "test/production/app-dir/browser-chunks/browser-chunks.test.ts": {
       "failed": [
         "browser-chunks must not bundle any server modules into browser chunks"


### PR DESCRIPTION
When reading a cache entry, we usually check its tags against the recently revalidated tags, and dismiss it, if it has any of those tags. However, this is only needed during dynamic requests, specifically during the rendering that follows a revalidating server action.

During the prerender validation in dev mode, we should not discard the cache entries based on the pending revalidation. The concurrently running dynamic rendering will handle discarding and recreating those cache entries. During build-time prerendering, there will never be any pending revalidated tags.

This fixes a bug where a different value was rendered when revalidating with a server action and then reloading the page afterwards (or triggering another unrelated revalidating server action).