### PR TITLE
[segment explorer] fix route url is missing cases

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -40,6 +40,7 @@ import { createRouterCacheKey } from './router-reducer/create-router-cache-key'
 import { hasInterceptionRouteInCurrentTree } from './router-reducer/reducers/has-interception-route-in-current-tree'
 import { dispatchAppRouterAction } from './use-action-queue'
 import { useRouterBFCache, type RouterBFCacheEntry } from './bfcache'
+import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 
 const Activity = process.env.__NEXT_ROUTER_BF_CACHE
   ? (require('react') as typeof import('react')).unstable_Activity
@@ -616,12 +617,18 @@ export default function OuterLayoutRouter({
       : ErrorBoundary
 
     let segmentBoundaryTriggerNode: React.ReactNode = null
+    let segmentViewStateNode: React.ReactNode = null
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER
     ) {
-      const { SegmentBoundaryTriggerNode } =
+      const { SegmentBoundaryTriggerNode, SegmentViewStateNode } =
         require('../../next-devtools/userspace/app/segment-explorer-node') as typeof import('../../next-devtools/userspace/app/segment-explorer-node')
+
+      const pagePrefix = normalizeAppPath(url)
+      segmentViewStateNode = (
+        <SegmentViewStateNode key={pagePrefix} page={pagePrefix} />
+      )
 
       segmentBoundaryTriggerNode = (
         <>
@@ -667,6 +674,7 @@ export default function OuterLayoutRouter({
                 </HTTPAccessFallbackBoundary>
               </LoadingBoundary>
             </ErrorBoundaryComponent>
+            {segmentViewStateNode}
           </ScrollAndFocusHandler>
         }
       >

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -105,7 +105,6 @@ async function createComponentTreeInternal({
     workStore,
     componentMod: {
       SegmentViewNode,
-      SegmentViewStateNode,
       HTTPAccessFallbackBoundary,
       LayoutRouter,
       RenderFromTemplateContext,
@@ -800,7 +799,6 @@ async function createComponentTreeInternal({
         pageElement
       )
 
-    const pagePrefix = ctx.renderOpts.page.replace(/\/page$/, '')
     return [
       actualSegment,
       <React.Fragment key={cacheNodeKey}>
@@ -810,7 +808,6 @@ async function createComponentTreeInternal({
           <MetadataOutlet ready={getViewportReady} />
           {metadataOutlet}
         </OutletBoundary>
-        <SegmentViewStateNode page={pagePrefix} />
       </React.Fragment>,
       parallelRouteCacheNodeSeedData,
       loadingData,

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -1,5 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
-import { getSegmentExplorerContent, retry } from 'next-test-utils'
+import {
+  getSegmentExplorerContent,
+  getSegmentExplorerRoute,
+  retry,
+} from 'next-test-utils'
 
 describe('segment-explorer', () => {
   const { next } = nextTestSetup({
@@ -14,6 +18,7 @@ describe('segment-explorer', () => {
      @bar/ [layout.tsx, page.tsx]
      @foo/ [layout.tsx, page.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe('/parallel-routes')
   })
 
   it('should render the segment explorer for parallel routes in edge runtime', async () => {
@@ -24,6 +29,7 @@ describe('segment-explorer', () => {
      @bar/ [layout.tsx, page.tsx]
      @foo/ [layout.tsx, page.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe('/parallel-routes-edge')
   })
 
   it('should render the segment explorer for nested routes', async () => {
@@ -35,6 +41,7 @@ describe('segment-explorer', () => {
      ~ / (overview)/ [layout.tsx]
      grid/ [page.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe('/blog/~/grid')
   })
 
   it('should cleanup on soft navigation', async () => {
@@ -43,6 +50,7 @@ describe('segment-explorer', () => {
      "app/ [layout.tsx]
      soft-navigation / a/ [page.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe('/soft-navigation/a')
 
     await browser.elementByCss('[href="/soft-navigation/b"]').click()
     await retry(async () => {
@@ -53,6 +61,7 @@ describe('segment-explorer', () => {
      "app/ [layout.tsx]
      soft-navigation / b/ [page.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe('/soft-navigation/b')
   })
 
   it('should handle show file segments in order', async () => {
@@ -61,6 +70,7 @@ describe('segment-explorer', () => {
      "app/ [layout.tsx]
      (all) / file-segments/ [layout.tsx, template.tsx, page.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe('/file-segments')
   })
 
   it('should indicate segment explorer is not available for pages router', async () => {
@@ -73,6 +83,7 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(
       `"app/ [layout.tsx, not-found.js]"`
     )
+    expect(await getSegmentExplorerRoute(browser)).toBe('/404')
   })
 
   it('should show global-error segment', async () => {
@@ -80,6 +91,8 @@ describe('segment-explorer', () => {
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(
       `"app/ [global-error.js]"`
     )
+    // FIXME: handle preserve the url when hitting global-error
+    expect(await getSegmentExplorerRoute(browser)).toBe('')
   })
 
   it('should show navigation boundaries of the segment', async () => {
@@ -88,6 +101,9 @@ describe('segment-explorer', () => {
      "app/ [layout.tsx]
      boundary/ [layout.tsx, not-found.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe(
+      '/boundary?name=not-found'
+    )
 
     await browser.loadPage(`${next.url}/boundary?name=forbidden`)
     expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(`
@@ -116,6 +132,7 @@ describe('segment-explorer', () => {
      "app/ [layout.tsx]
      search/ [layout.tsx, loading.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe('/search?q=abc')
   })
 
   it('should show the custom error boundary when present', async () => {
@@ -124,6 +141,9 @@ describe('segment-explorer', () => {
      "app/ [layout.tsx]
      runtime-error / boundary/ [error.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe(
+      '/runtime-error/boundary'
+    )
   })
 
   it('should display parallel routes default page when present', async () => {
@@ -135,6 +155,9 @@ describe('segment-explorer', () => {
      subroute/ [page.tsx]
      @foo/ [default.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe(
+      '/parallel-default/subroute'
+    )
   })
 
   it('should display boundary selector when a segment has only boundary files', async () => {
@@ -145,5 +168,16 @@ describe('segment-explorer', () => {
      framework/ [layout.tsx]
      blog/ [layout.tsx, page.tsx]"
     `)
+    expect(await getSegmentExplorerRoute(browser)).toBe(
+      '/no-layout/framework/blog'
+    )
+  })
+
+  it('should render route for index page', async () => {
+    const browser = await next.browser('/')
+    expect(await getSegmentExplorerContent(browser)).toMatchInlineSnapshot(
+      `"app/ [layout.tsx, page.tsx]"`
+    )
+    expect(await getSegmentExplorerRoute(browser)).toBe('/')
   })
 })

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -237,13 +237,13 @@ describe('Dynamic IO Errors', () => {
                    at ScrollAndFocusHandler (webpack://<next-src>)
                    at RenderFromTemplateContext (webpack://<next-src>)
                    at OuterLayoutRouter (webpack://<next-src>)
-                 332 |  */
-                 333 | function InnerLayoutRouter({
-               > 334 |   tree,
+                 333 |  */
+                 334 | function InnerLayoutRouter({
+               > 335 |   tree,
                      |  ^
-                 335 |   segmentPath,
-                 336 |   cacheNode,
-                 337 |   url,
+                 336 |   segmentPath,
+                 337 |   cacheNode,
+                 338 |   url,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -739,13 +739,13 @@ describe('Dynamic IO Errors', () => {
                    at ScrollAndFocusHandler (webpack://<next-src>)
                    at RenderFromTemplateContext (webpack://<next-src>)
                    at OuterLayoutRouter (webpack://<next-src>)
-                 332 |  */
-                 333 | function InnerLayoutRouter({
-               > 334 |   tree,
+                 333 |  */
+                 334 | function InnerLayoutRouter({
+               > 335 |   tree,
                      |  ^
-                 335 |   segmentPath,
-                 336 |   cacheNode,
-                 337 |   url,
+                 336 |   segmentPath,
+                 337 |   cacheNode,
+                 338 |   url,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -1860,13 +1860,13 @@ describe('Dynamic IO Errors', () => {
                      at ScrollAndFocusHandler (webpack://<next-src>)
                      at RenderFromTemplateContext (<anonymous>)
                      at OuterLayoutRouter (webpack://<next-src>)
-                   332 |  */
-                   333 | function InnerLayoutRouter({
-                 > 334 |   tree,
+                   333 |  */
+                   334 | function InnerLayoutRouter({
+                 > 335 |   tree,
                        |  ^
-                   335 |   segmentPath,
-                   336 |   cacheNode,
-                   337 |   url,
+                   336 |   segmentPath,
+                   337 |   cacheNode,
+                   338 |   url,
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -13,7 +13,7 @@ const EXTERNAL = {
 const COLLECTOR_PORT = 9001
 
 describe('opentelemetry', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
@@ -170,7 +170,7 @@ describe('opentelemetry', () => {
                       },
                       {
                         attributes: {
-                          'next.clientComponentLoadCount': isNextDev ? 8 : 7,
+                          'next.clientComponentLoadCount': 7,
                           'next.span_type':
                             'NextNodeServer.clientComponentLoading',
                         },

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -962,6 +962,12 @@ export async function openDevToolsIndicatorPopover(
   }
 }
 
+export async function getSegmentExplorerRoute(browser: Playwright) {
+  return await browser
+    .elementByCss('.segment-explorer-page-route-bar-path')
+    .text()
+}
+
 export async function getSegmentExplorerContent(browser: Playwright) {
   // open the devtool button
   await openDevToolsIndicatorPopover(browser)


### PR DESCRIPTION
* Use the normalizer to normalize url to the route
* Move the state node outside of the error boundary to ensure it won't be lost when it's hitting error boundary. 

Closes NEXT-4615