### PR TITLE
[metadata] treat google bots as html limited bots

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -1172,15 +1172,13 @@ There are two default `meta` tags that are always added even if a route doesn't 
 
 ### Streaming metadata
 
-Metadata returned by `generateMetadata` is streamed to the client. This allows Next.js to inject metadata into the HTML as soon as it's resolved.
+Metadata returned by `generateMetadata` is streamed to the client, allowing Next.js to inject it into the HTML as soon as it's resolved.
 
-Streamed metadata is appended to the `<body>` tag. Since metadata mainly targets bots and crawlers, Next.js streams metadata for bots that can execute JavaScript and inspect the full DOM (e.g. `Googlebot`). We have verified that these bots interpret the metadata correctly.
+Streamed metadata is appended to the `<body>` tag. For **HTML-limited** bots that can't run JavaScript (e.g. `Twitterbot`), metadata continues to block page rendering and is placed in the `<head>` tag.
 
-For **HTML-limited** bots that can’t run JavaScript (e.g. `Twitterbot`), metadata continues to block page rendering and is placed in the `<head>` tag.
+Next.js maintains a list of [**HTML-limited** bot user agents](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/bots.ts) that receive blocking metadata.
 
-Next.js automatically detects the user agent of incoming requests to determine whether to serve streaming metadata or fallback to blocking metadata.
-
-If you need to customize this list, you can define them manually using the `htmlLimitedBots` option in `next.config.js`. Next.js will ensure user agents matching this regex receive blocking metadata when requesting your web page.
+To customize this behavior, use the `htmlLimitedBots` option in `next.config.js`. Matching user agents will be served blocking metadata.
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/htmlLimitedBots.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/htmlLimitedBots.mdx
@@ -23,7 +23,7 @@ module.exports = {
 
 ## Default list
 
-Next.js identifies certain user agent patterns as [bots](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/user-agent.ts).
+Next.js identifies certain user agent patterns as [bots](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/bots.ts).
 They're all classified them as HTML-limited bots and served with blocking metadata in the HTML.
 
 Specifying a `htmlLimitedBots` config will override the Next.js' default list, allowing you full control over what user agents should opt into this behavior. However, this is advanced behavior, and the default should be sufficient for most cases.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/htmlLimitedBots.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/htmlLimitedBots.mdx
@@ -23,7 +23,8 @@ module.exports = {
 
 ## Default list
 
-Next.js includes [a default list of HTML limited bots](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/html-bots.ts).
+Next.js identifies certain user agent patterns as [bots](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/user-agent.ts).
+They're all classified them as HTML-limited bots and served with blocking metadata in the HTML.
 
 Specifying a `htmlLimitedBots` config will override the Next.js' default list, allowing you full control over what user agents should opt into this behavior. However, this is advanced behavior, and the default should be sufficient for most cases.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/htmlLimitedBots.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/htmlLimitedBots.mdx
@@ -23,8 +23,7 @@ module.exports = {
 
 ## Default list
 
-Next.js identifies certain user agent patterns as [bots](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/bots.ts).
-They're all classified them as HTML-limited bots and served with blocking metadata in the HTML.
+Next.js identifies certain user agent patterns as [bots](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/bots.ts). These are classified as **HTML-limited** bots and are served blocking metadata.
 
 Specifying a `htmlLimitedBots` config will override the Next.js' default list, allowing you full control over what user agents should opt into this behavior. However, this is advanced behavior, and the default should be sufficient for most cases.
 

--- a/packages/next/src/server/web/spec-extension/user-agent.ts
+++ b/packages/next/src/server/web/spec-extension/user-agent.ts
@@ -1,7 +1,6 @@
 import parseua from 'next/dist/compiled/ua-parser-js'
+import { BOT_UA_RE } from '../../../shared/lib/router/utils/bots'
 
-export const BOT_UA_RE =
-  /Googlebot|GoogleOther|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Chrome-Lighthouse|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|Yeti/i
 interface UserAgent {
   isBot: boolean
   ua: string

--- a/packages/next/src/server/web/spec-extension/user-agent.ts
+++ b/packages/next/src/server/web/spec-extension/user-agent.ts
@@ -1,5 +1,7 @@
 import parseua from 'next/dist/compiled/ua-parser-js'
 
+export const BOT_UA_RE =
+  /Googlebot|GoogleOther|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Chrome-Lighthouse|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|Yeti/i
 interface UserAgent {
   isBot: boolean
   ua: string
@@ -27,9 +29,7 @@ interface UserAgent {
 }
 
 export function isBot(input: string): boolean {
-  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver/i.test(
-    input
-  )
+  return BOT_UA_RE.test(input)
 }
 
 export function userAgentFromString(input: string | undefined): UserAgent {

--- a/packages/next/src/shared/lib/router/utils/bots.ts
+++ b/packages/next/src/shared/lib/router/utils/bots.ts
@@ -1,0 +1,2 @@
+export const BOT_UA_RE =
+  /Googlebot|GoogleOther|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Chrome-Lighthouse|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|Yeti/i

--- a/packages/next/src/shared/lib/router/utils/html-bots.ts
+++ b/packages/next/src/shared/lib/router/utils/html-bots.ts
@@ -1,4 +1,2 @@
-// This regex contains the bots that we need to do a blocking render for and can't safely stream the response
-// due to how they parse the DOM. For example, they might explicitly check for metadata in the `head` tag, so we can't stream metadata tags after the `head` was sent.
-export const HTML_LIMITED_BOT_UA_RE =
-  /Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti/i
+// Treat all bots as html-limited bots
+export { BOT_UA_RE as HTML_LIMITED_BOT_UA_RE } from '../../../../server/web/spec-extension/user-agent'

--- a/packages/next/src/shared/lib/router/utils/html-bots.ts
+++ b/packages/next/src/shared/lib/router/utils/html-bots.ts
@@ -1,2 +1,0 @@
-// Treat all bots as html-limited bots
-export { BOT_UA_RE as HTML_LIMITED_BOT_UA_RE } from '../../../../server/web/spec-extension/user-agent'

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -1,30 +1,16 @@
 import { HTML_LIMITED_BOT_UA_RE } from './html-bots'
 
-// Bot crawler that will spin up a headless browser and execute JS.
-// By default, only googlebots are considered as DOM bots. Blow is where the regex is computed from:
-// x-ref: https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers
-const HEADLESS_BROWSER_BOT_UA_RE = /google/i
-
 export const HTML_LIMITED_BOT_UA_RE_STRING = HTML_LIMITED_BOT_UA_RE.source
 
 export { HTML_LIMITED_BOT_UA_RE }
-
-function isDomBotUA(userAgent: string) {
-  return HEADLESS_BROWSER_BOT_UA_RE.test(userAgent)
-}
 
 function isHtmlLimitedBotUA(userAgent: string) {
   return HTML_LIMITED_BOT_UA_RE.test(userAgent)
 }
 
-export function isBot(userAgent: string): boolean {
-  return isDomBotUA(userAgent) || isHtmlLimitedBotUA(userAgent)
-}
+export { isBot } from '../../../../server/web/spec-extension/user-agent'
 
-export function getBotType(userAgent: string): 'dom' | 'html' | undefined {
-  if (isDomBotUA(userAgent)) {
-    return 'dom'
-  }
+export function getBotType(userAgent: string): 'html' | undefined {
   if (isHtmlLimitedBotUA(userAgent)) {
     return 'html'
   }

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -1,17 +1,16 @@
-import { HTML_LIMITED_BOT_UA_RE } from './html-bots'
+import { BOT_UA_RE } from './bots'
 
-export const HTML_LIMITED_BOT_UA_RE_STRING = HTML_LIMITED_BOT_UA_RE.source
+export const HTML_LIMITED_BOT_UA_RE_STRING = BOT_UA_RE.source
 
-export { HTML_LIMITED_BOT_UA_RE }
+// Treat all bots as html-limited bots
+export { BOT_UA_RE as HTML_LIMITED_BOT_UA_RE }
 
-function isHtmlLimitedBotUA(userAgent: string) {
-  return HTML_LIMITED_BOT_UA_RE.test(userAgent)
+export function isBot(userAgent: string) {
+  return BOT_UA_RE.test(userAgent)
 }
 
-export { isBot } from '../../../../server/web/spec-extension/user-agent'
-
 export function getBotType(userAgent: string): 'html' | undefined {
-  if (isHtmlLimitedBotUA(userAgent)) {
+  if (isBot(userAgent)) {
     return 'html'
   }
   return undefined

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -100,7 +100,7 @@ const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
       it('should contain async generated metadata in head for simple dynamic page', async () => {
         const $ = await next.render$('/slow/dynamic', undefined, {
           headers: {
-            'User-Agent': 'Discordbot/2.0;',
+            'User-Agent': 'Googlebot',
           },
         })
         expect($('head title').text()).toBe('slow page - dynamic')

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config.test.ts
@@ -11,7 +11,7 @@ describe('app-dir - metadata-streaming-config', () => {
     )
 
     expect(requiredServerFiles.config.htmlLimitedBots).toMatchInlineSnapshot(
-      `"Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti"`
+      `"Googlebot|GoogleOther|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Chrome-Lighthouse|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|Yeti"`
     )
 
     const prerenderManifest = JSON.parse(
@@ -38,7 +38,7 @@ describe('app-dir - metadata-streaming-config', () => {
        "/ppr": {
          "key": "user-agent",
          "type": "header",
-         "value": "Mediapartners-Google|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti",
+         "value": "Googlebot|GoogleOther|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Chrome-Lighthouse|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|Yeti",
        },
      }
     `)


### PR DESCRIPTION
Google crawlers were the ones that we were treating these bots as streaming metadata friendly bots, since they able to handle the streaming response and also work like headless browsers.
However we're seeing a few frictions of Google crawlers handling streaming metadata, where the metadata is delayed to insert into `<body>` tag but then Google crawlers are failed to recogonize them, which leads to the metadata is missing.

Google had [some documentations](https://developers.google.com/search/docs/crawling-indexing/special-tags) on meta tags handling saying meta tags which are not under `<head>` could become risky for SEO.

This PR merges the regex of bot detection from `next/server` with the regex of html limited bots, and we'll treat all bots as html limited bots now. Then when google crawling the page, Next.js will still serve the blocking metadata that everything is ended in `<head>` tag to ensure crawler can handle it.

For reviewer, the changes are added to the final regex are:
* Add `Chrome-Lighthouse`, previously we added for lighthouse in html limited regex
* Yeti, in html limited regex
* Ensure Google related cralwers are all covered (x-ref: https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers)

Closes NEXT-4611