### PR TITLE
Turbopack: Fix turbopack-swc-ast-explorer with multi-line inputs

### DIFF
--- a/turbopack/crates/turbopack-swc-ast-explorer/src/main.rs
+++ b/turbopack/crates/turbopack-swc-ast-explorer/src/main.rs
@@ -1,4 +1,7 @@
-use std::{io::stdin, sync::Arc};
+use std::{
+    io::{Read, stdin},
+    sync::Arc,
+};
 
 use anyhow::Result;
 use clap::Parser;
@@ -25,7 +28,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     let mut contents = String::new();
-    stdin().read_line(&mut contents)?;
+    stdin().read_to_string(&mut contents)?;
 
     let sm = Arc::new(SourceMap::default());
     let file = sm.new_source_file(FileName::Anon.into(), contents);


### PR DESCRIPTION
Previously this was only parsing the first line of input

```
cargo run -p swc-ast-explorer <turbopack/crates/turbopack-tests/tests/snapshot/comptime/assignment/input/index.js | less
```

Closes PACK-5067