### PR TITLE
Allow `beforePageLoad` to be async

### DIFF
--- a/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+++ b/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
@@ -81,16 +81,17 @@ describe('segment cache (staleness)', () => {
 
   it('reuses dynamic data up to the staleTimes.dynamic threshold', async () => {
     let page: Playwright.Page
+    const startDate = Date.now()
+
     const browser = await next.browser('/', {
-      beforePageLoad(p: Playwright.Page) {
+      async beforePageLoad(p: Playwright.Page) {
         page = p
+        await page.clock.install()
+        await page.clock.setFixedTime(startDate)
       },
     })
-    const act = createRouterAct(page)
 
-    await page.clock.install()
-    const startDate = Date.now()
-    await page.clock.setFixedTime(startDate)
+    const act = createRouterAct(page)
 
     // Navigate to the dynamic page
     await act(

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -228,7 +228,7 @@ export class Playwright<TCurrent = undefined> {
       disableCache?: boolean
       cpuThrottleRate?: number
       pushErrorAsConsoleLog?: boolean
-      beforePageLoad?: (page: Page) => void
+      beforePageLoad?: (page: Page) => void | Promise<void>
     }
   ) {
     await this.close()
@@ -310,7 +310,7 @@ export class Playwright<TCurrent = undefined> {
       })
     })
 
-    opts?.beforePageLoad?.(page)
+    await opts?.beforePageLoad?.(page)
 
     await page.goto(url, { waitUntil: 'load' })
   }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -703,8 +703,8 @@ export class NextInstance {
     const [browser, response] = await Promise.all([
       webdriver(this.url, url, {
         ...options,
-        beforePageLoad(page: Page) {
-          options.beforePageLoad?.(page)
+        async beforePageLoad(page: Page) {
+          await options.beforePageLoad?.(page)
 
           page.on('response', async (response) => {
             if (response.url() === absoluteUrl) {

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -62,7 +62,7 @@ export interface WebdriverOptions {
    * @param page
    * @returns
    */
-  beforePageLoad?: (page: Page) => void
+  beforePageLoad?: (page: Page) => void | Promise<void>
   /**
    * browser locale
    */


### PR DESCRIPTION
This is useful when working with `Playwright.Clock`.