### PR TITLE
Simplify running test apps locally with `ppr` or `dynamicIO` enabled

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1397,19 +1397,7 @@ export const defaultConfig = Object.freeze({
     serverSourceMaps: false,
     linkNoTouchStart: false,
     caseSensitiveRoutes: false,
-    clientSegmentCache:
-      // TODO: Remove once we've made clientSegmentCache the default. We're
-      // piggybacking on the PPR test flag, instead of introducing a separate
-      // CI run.
-      //
-      // If we're testing, and the `__NEXT_EXPERIMENTAL_PPR` environment
-      // variable has been set to `true`, enable the experimental
-      // clientSegmentCache feature so long as it wasn't explicitly disabled in
-      // the config.
-      !!(
-        process.env.__NEXT_TEST_MODE &&
-        process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-      ),
+    clientSegmentCache: false,
     dynamicOnHover: false,
     appDocumentPreloading: undefined,
     preloadEntriesOnStart: true,
@@ -1454,15 +1442,7 @@ export const defaultConfig = Object.freeze({
     clientTraceMetadata: undefined,
     parallelServerCompiles: false,
     parallelServerBuildTraces: false,
-    ppr:
-      // TODO: remove once we've made PPR default
-      // If we're testing, and the `__NEXT_EXPERIMENTAL_PPR` environment variable
-      // has been set to `true`, enable the experimental PPR feature so long as it
-      // wasn't explicitly disabled in the config.
-      !!(
-        process.env.__NEXT_TEST_MODE &&
-        process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-      ),
+    ppr: false,
     authInterrupts: false,
     webpackBuildWorker: undefined,
     webpackMemoryOptimizations: false,
@@ -1483,15 +1463,7 @@ export const defaultConfig = Object.freeze({
     serverComponentsHmrCache: true,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
-    dynamicIO:
-      // TODO: remove once we've made dynamicIO the default
-      // If we're testing, and the `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS` environment
-      // variable has been set to `true`, enable the experimental dynamicIO feature so long as it
-      // wasn't explicitly disabled in the config.
-      !!(
-        process.env.__NEXT_TEST_MODE &&
-        process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
-      ),
+    dynamicIO: false,
     inlineCss: false,
     useCache: undefined,
     slowModuleDetection: undefined,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1501,23 +1501,6 @@ function enforceExperimentalFeatures(
     phase,
   } = options
 
-  if (
-    config.experimental &&
-    config.experimental.enablePrerenderSourceMaps === undefined &&
-    config.experimental.dynamicIO === true
-  ) {
-    config.experimental.enablePrerenderSourceMaps = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'enablePrerenderSourceMaps',
-        true,
-        'enabled by `experimental.dynamicIO`'
-      )
-    }
-  }
-
   config.experimental ??= {}
 
   if (
@@ -1555,9 +1538,29 @@ function enforceExperimentalFeatures(
 
   // TODO: Remove this once we've made Cache Components the default.
   if (
+    process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.ppr === undefined ||
+      (isDefaultConfig && !config.experimental.ppr))
+  ) {
+    config.experimental.ppr = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'ppr',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS`'
+      )
+    }
+  }
+
+  // TODO: Remove this once we've made Cache Components the default.
+  if (
     process.env.__NEXT_EXPERIMENTAL_PPR === 'true' &&
     // We do respect an explicit value in the user config.
-    (config.experimental.ppr === undefined || isDefaultConfig)
+    (config.experimental.ppr === undefined ||
+      (isDefaultConfig && !config.experimental.ppr))
   ) {
     config.experimental.ppr = true
 
@@ -1575,7 +1578,8 @@ function enforceExperimentalFeatures(
   if (
     process.env.__NEXT_EXPERIMENTAL_PPR === 'true' &&
     // We do respect an explicit value in the user config.
-    (config.experimental.clientSegmentCache === undefined || isDefaultConfig)
+    (config.experimental.clientSegmentCache === undefined ||
+      (isDefaultConfig && !config.experimental.clientSegmentCache))
   ) {
     config.experimental.clientSegmentCache = true
 
@@ -1593,7 +1597,8 @@ function enforceExperimentalFeatures(
   if (
     process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true' &&
     // We do respect an explicit value in the user config.
-    (config.experimental.dynamicIO === undefined || isDefaultConfig)
+    (config.experimental.dynamicIO === undefined ||
+      (isDefaultConfig && !config.experimental.dynamicIO))
   ) {
     config.experimental.dynamicIO = true
 
@@ -1603,6 +1608,22 @@ function enforceExperimentalFeatures(
         'dynamicIO',
         true,
         'enabled by `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS`'
+      )
+    }
+  }
+
+  if (
+    config.experimental.enablePrerenderSourceMaps === undefined &&
+    config.experimental.dynamicIO === true
+  ) {
+    config.experimental.enablePrerenderSourceMaps = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'enablePrerenderSourceMaps',
+        true,
+        'enabled by `experimental.dynamicIO`'
       )
     }
   }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -240,21 +240,6 @@ function assignDefaults(
     {}
   ) as NextConfig & { configFileName: string }
 
-  // TODO: remove these once we've made PPR default
-  // If this was defaulted to true, it implies that the configuration was
-  // overridden for testing to be defaulted on.
-  if (defaultConfig.experimental?.ppr) {
-    Log.warn(
-      `\`experimental.ppr\` has been defaulted to \`true\` because \`__NEXT_EXPERIMENTAL_PPR\` was set to \`true\` during testing.`
-    )
-  }
-
-  if (defaultConfig.experimental?.dynamicIO) {
-    Log.warn(
-      `\`experimental.dynamicIO\` has been defaulted to \`true\` because \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\` was set to \`true\` during testing.`
-    )
-  }
-
   const result = {
     ...defaultConfig,
     ...config,
@@ -1420,6 +1405,7 @@ export default async function loadConfig(
     }
 
     enforceExperimentalFeatures(userConfig, {
+      isDefaultConfig: false,
       configuredExperimentalFeatures: reportExperimentalFeatures
         ? configuredExperimentalFeatures
         : undefined,
@@ -1468,6 +1454,7 @@ export default async function loadConfig(
   const clonedDefaultConfig = cloneObject(defaultConfig) as NextConfig
 
   enforceExperimentalFeatures(clonedDefaultConfig, {
+    isDefaultConfig: true,
     configuredExperimentalFeatures: reportExperimentalFeatures
       ? configuredExperimentalFeatures
       : undefined,
@@ -1501,12 +1488,18 @@ export type ConfiguredExperimentalFeature = {
 function enforceExperimentalFeatures(
   config: NextConfig,
   options: {
+    isDefaultConfig: boolean
     configuredExperimentalFeatures: ConfiguredExperimentalFeature[] | undefined
     debugPrerender: boolean | undefined
     phase: string
   }
 ) {
-  const { configuredExperimentalFeatures, debugPrerender, phase } = options
+  const {
+    configuredExperimentalFeatures,
+    debugPrerender,
+    isDefaultConfig,
+    phase,
+  } = options
 
   if (
     config.experimental &&
@@ -1558,6 +1551,60 @@ function enforceExperimentalFeatures(
       false,
       configuredExperimentalFeatures
     )
+  }
+
+  // TODO: Remove this once we've made Cache Components the default.
+  if (
+    process.env.__NEXT_EXPERIMENTAL_PPR === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.ppr === undefined || isDefaultConfig)
+  ) {
+    config.experimental.ppr = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'ppr',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_PPR`'
+      )
+    }
+  }
+
+  // TODO: Remove this once we've made Client Segment Cache the default.
+  if (
+    process.env.__NEXT_EXPERIMENTAL_PPR === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.clientSegmentCache === undefined || isDefaultConfig)
+  ) {
+    config.experimental.clientSegmentCache = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'clientSegmentCache',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_PPR`'
+      )
+    }
+  }
+
+  // TODO: Remove this once we've made Cache Components the default.
+  if (
+    process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.dynamicIO === undefined || isDefaultConfig)
+  ) {
+    config.experimental.dynamicIO = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'dynamicIO',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS`'
+      )
+    }
   }
 }
 

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -250,6 +250,7 @@
       "test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts",
       "test/e2e/app-dir/segment-cache/client-only-opt-in/client-only-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts",
+      "test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts",
       "test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts",
       "test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts",

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -334,7 +334,6 @@
       "test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts",
       "test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions-edge.test.ts",
       "test/production/app-dir/app-fetch-build-cache/app-fetch-build-cache.test.ts",
-      "test/production/app-dir/build-output-prerender/build-output-prerender.test.ts",
       "test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts",
       "test/production/app-dir/build-output/index.test.ts",
       "test/production/app-dir/client-components-tree-shaking/index.test.ts",

--- a/test/e2e/app-dir/node-extensions/fixtures/random/legacy/next.config.js
+++ b/test/e2e/app-dir/node-extensions/fixtures/random/legacy/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    ppr: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-standalone-search-params/next.config.js
+++ b/test/e2e/app-dir/use-cache-standalone-search-params/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   experimental: {
     useCache: true,
     prerenderEarlyExit: false,
-    ppr: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
   },
 }
 

--- a/test/e2e/app-dir/use-cache/next.config.js
+++ b/test/e2e/app-dir/use-cache/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    ppr: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
     useCache: true,
     cacheLife: {
       frequent: {

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -2,6 +2,11 @@ import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 const { version: nextVersion } = require('next/package.json')
 
+const cacheComponentsEnabled =
+  process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
+
+const pprEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('build-output-prerender', () => {
   describe('with a next config file', () => {
     describe('without --debug-prerender', () => {
@@ -12,21 +17,63 @@ describe('build-output-prerender', () => {
 
       beforeAll(() => next.build())
 
-      it('prints only the user-selected experimental flags', async () => {
-        if (isTurbopack) {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-           "▲ Next.js x.y.z (Turbopack)
-              - Experiments (use with caution):
-                ✓ dynamicIO
-                ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
-          `)
+      it('prints only the user-selected experimental flags (and the ones enabled via env variable)', async () => {
+        if (cacheComponentsEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ dynamicIO
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ dynamicIO
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          }
         } else {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-           "▲ Next.js x.y.z
-              - Experiments (use with caution):
-                ✓ dynamicIO
-                ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
-          `)
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ dynamicIO
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ dynamicIO
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          }
         }
       })
 
@@ -70,28 +117,86 @@ describe('build-output-prerender', () => {
       beforeAll(() => next.build())
 
       it('prints a warning and the customized experimental flags', async () => {
-        if (isTurbopack) {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-           "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-              ▲ Next.js x.y.z (Turbopack)
-              - Experiments (use with caution):
-                ✓ dynamicIO
-                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
-                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
-          `)
+        if (cacheComponentsEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ dynamicIO
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ dynamicIO
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
         } else {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-           "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-              ▲ Next.js x.y.z
-              - Experiments (use with caution):
-                ✓ dynamicIO
-                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
-          `)
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ dynamicIO
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ dynamicIO
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
         }
       })
 
@@ -164,15 +269,53 @@ describe('build-output-prerender', () => {
 
       beforeAll(() => next.build())
 
-      it('prints no experimental flags', async () => {
-        if (isTurbopack) {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(
-            `"▲ Next.js x.y.z (Turbopack)"`
-          )
+      it('prints no experimental flags (unless enabled via env variable)', async () => {
+        if (cacheComponentsEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.dynamicIO\`)"
+            `)
+          }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+            `)
+          }
         } else {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(
-            `"▲ Next.js x.y.z"`
-          )
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(
+              `"▲ Next.js x.y.z (Turbopack)"`
+            )
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(
+              `"▲ Next.js x.y.z"`
+            )
+          }
         }
       })
     })
@@ -187,26 +330,82 @@ describe('build-output-prerender', () => {
       beforeAll(() => next.build())
 
       it('prints a warning and the customized experimental flags', async () => {
-        if (isTurbopack) {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-           "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-              ▲ Next.js x.y.z (Turbopack)
-              - Experiments (use with caution):
-                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
-                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
-          `)
+        if (cacheComponentsEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ dynamicIO (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
         } else {
-          expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-           "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-              ▲ Next.js x.y.z
-              - Experiments (use with caution):
-                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
-          `)
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z
+                - Experiments (use with caution):
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
         }
       })
     })
@@ -219,12 +418,6 @@ function getPreambleOutput(cliOutput: string): string {
   for (const line of cliOutput.split('\n')) {
     if (line.includes('Creating an optimized production build')) {
       break
-    }
-
-    // Ignore the test-only warning that `experimental.ppr` has been defaulted
-    // to `true` when `__NEXT_EXPERIMENTAL_PPR` is set to `true`.
-    if (line.includes('__NEXT_EXPERIMENTAL_PPR')) {
-      continue
     }
 
     lines.push(line.replace(nextVersion, 'x.y.z'))


### PR DESCRIPTION
We want to respect the `__NEXT_EXPERIMENTAL_PPR` and `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS` environment variables in the test apps, so that we can run them locally with these features enabled without needing to modify the config files.

So we're removing the requirement that `__NEXT_TEST_MODE` needs to be set at the same time. Usually you don't want to set this variable locally because it also changes other behavior in a few places.

This really has no downside, because it was already possible for users to set both variables and affect the flags, and now this can be done with a single variable. It allows us to keep the noise out of the test app's next config files.

We're also moving the assignments from the default config into `enforceExperimentalFeatures` to get the nice output when printing the experimental features in the CLI.