### PR TITLE
chore(bot): update comment

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -23,8 +23,8 @@ jobs:
           remove-issue-stale-when-updated: true
           stale-issue-label: 'stale'
           labels-to-add-when-unstale: 'not stale'
-          stale-issue-message: 'This issue has been automatically marked as stale due to two years of inactivity. It will be closed in 7 days unless there’s further input. If you believe this issue is still relevant, please leave a comment or provide updated details. Thank you.'
-          close-issue-message: 'This issue has been automatically closed due to two years of inactivity. If you’re still experiencing a similar problem or have additional details to share, please open a new issue following our current issue template. Your updated report helps us investigate and address concerns more efficiently. Thank you for your understanding!'
+          stale-issue-message: 'This issue has been automatically marked as stale due to inactivity. It will be closed in 7 days unless there’s further input. If you believe this issue is still relevant, please leave a comment or provide updated details. Thank you.'
+          close-issue-message: 'This issue has been automatically closed due to inactivity. If you’re still experiencing a similar problem or have additional details to share, please open a new issue following our current issue template. Your updated report helps us investigate and address concerns more efficiently. Thank you for your understanding!'
           operations-per-run: 300 # 1 operation per 100 issues, the rest is to label/comment/close
       - uses: actions/stale@v9
         id: stale-no-repro


### PR DESCRIPTION
The stale bot comment says 2 years even though its 1.5 years (or 545 days to be precise).

The exact amount of time is not as important in this message so we can remove it to avoid drift between the message and actual stale time.