### PR TITLE
[Segment Cache] Support dynamic head prefetching

### DIFF
--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/page.tsx
@@ -43,6 +43,14 @@ export default function Page() {
             </li>
           </ul>
         </li>
+        <li>
+          <LinkAccordion
+            prefetch={true}
+            href="/ppr-disabled-dynamic-head?foo=yay"
+          >
+            Page with PPR disabled and a dynamic head, prefetch=true
+          </LinkAccordion>
+        </li>
       </ul>
     </>
   )

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-dynamic-head/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-dynamic-head/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { Metadata } from 'next'
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ foo: string }>
+}): Promise<Metadata> {
+  const { foo } = await searchParams
+  return {
+    title: 'Dynamic Title: ' + (foo ?? '(empty)'),
+  }
+}
+
+async function Content() {
+  await connection()
+  return <div id="page-content">Page content</div>
+}
+
+export default function PPRDisabledDynamicHead() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
Fixes an issue where opting into dynamic prefetching with prefetch={true} would not apply to head data (like the title), only the page data. Although the head was being sent by the server as part of the prefetch response, it wasn't being transferred correctly to the prefetch cache.

The net result is that you can now fully prefetch a page with a dynamic title without any additional network requests on navigation.