### PR TITLE
[turbopack] Correctly associate client references with parent server componenents

### DIFF
--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, sync::Arc};
+use std::rc::Rc;
 
 use anyhow::Result;
 use next_core::{
@@ -191,11 +191,10 @@ pub async fn map_client_references(
                 continue;
             };
             let refs = memo
-                .remove(&module)
+                .remove(module)
                 .expect("everything was already computed");
             // In the most common case each server component should be the only thing retaining the
-            // Rc
-
+            // Rc, if not, then at least the next one will get to avoid the copy.
             let refs: Box<[_]> = match Rc::try_unwrap(refs) {
                 Ok(owned) => owned.into_boxed_slice(),
                 Err(shared) => shared.to_vec().into_boxed_slice(),

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -1,3 +1,5 @@
+use std::{rc::Rc, sync::Arc};
+
 use anyhow::Result;
 use next_core::{
     self,
@@ -38,8 +40,13 @@ pub enum ClientReferenceMapType {
 #[turbo_tasks::value]
 pub struct ClientReferencesSet {
     pub client_references: FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>,
+    /// Every value in this map will have an associated `ClientReferenceMapType` in
+    /// [client_references].
+    /// This is a shallow map so the values will include other server components.  So to collect
+    /// everything requires a recursive walk.
+    #[allow(clippy::type_complexity)]
     pub client_references_per_server_component:
-        FxHashMap<ResolvedVc<Box<dyn Module>>, Vec<ResolvedVc<Box<dyn Module>>>>,
+        FxHashMap<ResolvedVc<Box<dyn Module>>, Box<[ResolvedVc<Box<dyn Module>>]>>,
 }
 
 impl ClientReferencesSet {
@@ -96,23 +103,25 @@ pub async fn map_client_references(
             .await?
             .into_iter()
             .collect::<FxHashMap<_, _>>();
-
+        #[allow(clippy::type_complexity)]
         fn dfs_collect_shallow_client_references(
             u: ResolvedVc<Box<dyn Module>>,
             graph: &SingleModuleGraph,
             client_references: &FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>,
-            memo: &mut FxHashMap<ResolvedVc<Box<dyn Module>>, Vec<ResolvedVc<Box<dyn Module>>>>,
+            memo: &mut FxHashMap<ResolvedVc<Box<dyn Module>>, Rc<Vec<ResolvedVc<Box<dyn Module>>>>>,
             visiting_stack: &mut FxHashSet<ResolvedVc<Box<dyn Module>>>, /* For cycle detection
                                                                           * in
                                                                           * current DFS path */
-        ) -> Vec<ResolvedVc<Box<dyn Module>>> {
-            if client_references.get(&u).is_some() {
-                return vec![u];
+        ) -> Option<Rc<Vec<ResolvedVc<Box<dyn Module>>>>> {
+            // Because we are only collecting shallowly discoverable references, short circuit on
+            // each client reference
+            if client_references.contains_key(&u) {
+                return Some(Rc::from(vec![u]));
             }
 
             // 1. Memoization check: If already computed, return cached result.
             if let Some(cached_result) = memo.get(&u) {
-                return cached_result.clone();
+                return Some(cached_result.clone());
             }
 
             // 2. Cycle detection: If 'u' is currently in recursion stack, it's a cycle.
@@ -120,7 +129,7 @@ pub async fn map_client_references(
             // until the cycle is naturally broken or handled by memoization from another path.
             // We return an empty list for this path to avoid infinite recursion.
             if visiting_stack.contains(&u) {
-                return Vec::new();
+                return None;
             }
 
             visiting_stack.insert(u); // Mark 'u' as currently visiting
@@ -130,26 +139,28 @@ pub async fn map_client_references(
             let mut reachable_green_from_u = FxIndexSet::default();
 
             for v in graph.neighbors(u) {
-                let green_nodes_from_v = dfs_collect_shallow_client_references(
+                if let Some(green_nodes_from_v) = dfs_collect_shallow_client_references(
                     v,
                     graph,
                     client_references,
                     memo,
                     visiting_stack,
-                );
-                // Merge results from sub-paths
-                reachable_green_from_u.extend(green_nodes_from_v);
+                ) {
+                    // Merge results from sub-paths
+                    reachable_green_from_u.extend(green_nodes_from_v.iter());
+                }
             }
 
             // 4. Flatten to a Vec
-            let reachable_green_from_u: Vec<_> = reachable_green_from_u.into_iter().collect();
+            let reachable_green_from_u: Rc<Vec<_>> =
+                Rc::from(reachable_green_from_u.into_iter().collect::<Vec<_>>());
 
             // 5. Save the result for 'u'
             memo.insert(u, reachable_green_from_u.clone());
 
             visiting_stack.remove(&u); // Unmark 'u' as visiting
 
-            reachable_green_from_u // Return the computed list
+            Some(reachable_green_from_u) // Return the computed list
         }
 
         let mut memo = FxHashMap::default();
@@ -158,16 +169,40 @@ pub async fn map_client_references(
             let ClientReferenceMapType::ServerComponent(_) = client_reference_type else {
                 continue;
             };
-
-            let refs = dfs_collect_shallow_client_references(
+            dfs_collect_shallow_client_references(
                 *module,
-                &graph,
+                graph,
                 &client_references,
                 &mut memo,
                 &mut FxHashSet::default(),
-            );
+            )
+            .expect("entry points cannot be in the middle of a cycle");
+        }
+        // Drop everything from the map except server components, this frees memory and decrements
+        // ref counts so we can avoid copies later.
+        memo.retain(|k, _| {
+            matches!(
+                client_references.get(k),
+                Some(ClientReferenceMapType::ServerComponent(_))
+            )
+        });
+        for (module, client_reference_type) in &client_references {
+            let ClientReferenceMapType::ServerComponent(_) = client_reference_type else {
+                continue;
+            };
+            let refs = memo
+                .remove(&module)
+                .expect("everything was already computed");
+            // In the most common case each server component should be the only thing retaining the
+            // Rc
+
+            let refs: Box<[_]> = match Rc::try_unwrap(refs) {
+                Ok(owned) => owned.into_boxed_slice(),
+                Err(shared) => shared.to_vec().into_boxed_slice(),
+            };
             client_references_per_server_component.insert(*module, refs);
         }
+        debug_assert!(memo.is_empty());
 
         Ok(ClientReferencesSet::new(ClientReferencesSet {
             client_references,

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -340,10 +340,10 @@ impl ClientReferencesGraph {
                     }
                     ClientReferenceMapType::ServerComponent(sc) => {
                         if server_components.insert(module)
-                            && let Some(client_referencces) =
+                            && let Some(component_references) =
                                 data.client_references_per_server_component.get(&module)
                         {
-                            for client_reference in client_referencces {
+                            for client_reference in component_references {
                                 collect_client_references(
                                     *client_reference,
                                     Some(*sc),

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
     debug::ValueDebugFormat,
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
     trace::TraceRawVcs,
@@ -75,10 +75,6 @@ pub enum ClientReferenceType {
 #[derive(Clone, Debug, Default)]
 pub struct ClientReferenceGraphResult {
     pub client_references: Vec<ClientReference>,
-    /// Only the [`ClientReferenceType::EcmascriptClientReference`]s are listed in this map.
-    #[allow(clippy::type_complexity)]
-    pub client_references_by_server_component:
-        FxIndexMap<Option<ResolvedVc<NextServerComponentModule>>, Vec<ResolvedVc<Box<dyn Module>>>>,
     pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
     pub server_utils: Vec<ResolvedVc<NextServerUtilityModule>>,
 }
@@ -115,12 +111,6 @@ impl ClientReferenceGraphResult {
     pub fn extend(&mut self, other: &Self) {
         self.client_references
             .extend(other.client_references.iter().copied());
-        for (k, v) in other.client_references_by_server_component.iter() {
-            self.client_references_by_server_component
-                .entry(*k)
-                .or_insert_with(Vec::new)
-                .extend(v);
-        }
         self.server_component_entries
             .extend(other.server_component_entries.iter().copied());
         self.server_utils.extend(other.server_utils.iter().copied());

--- a/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
+++ b/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
@@ -13,11 +13,6 @@ describe('initial-css-not-found', () => {
       await browser.eval(
         `window.getComputedStyle(document.querySelector('body')).color`
       )
-    ).toBe(
-      // This only fails in production turbopack builds
-      process.env.IS_TURBOPACK_TEST && !process.env.TURBOPACK_DEV
-        ? 'rgb(0, 0, 0)'
-        : 'rgb(255, 0, 0)'
-    )
+    ).toBe('rgb(255, 0, 0)')
   })
 })


### PR DESCRIPTION
## Fix how client references are discovered during `next build --turbopack`

To correctly serve js and css resources during server side rendering we construct a client manifest that lists all the server components and their requires resources.  Prior to this PR there was a bug where we would sometimes fail to serve css resources.  The major cases we have seen this is when a `not-found.js` file references css that is also referenced by a layout.

When present all pages pages implicitly depend on this module and depend on it as an early implicit dependency of the generated `app-page.js` file.  This means if a `not-found.js` file (or a global error file) would happen to depend on the same css as a normal component we would associate it as a client-reference of that component instead of any other.  Then on a server side render we would simply omit it.

This PR address this by ensuring we always associate client resources with every server component that depends on them, not just the first one.  To do this we precompute the set of client references for each server component in the whole module graph. The for each page we can aggregate these precomputed traversals, taking care to omit redundant references and maintain DFS post order (aka evaluation order).

The downside of this approach is simply the additional traversal (shared across all routes) and memory usage.  Computing each page should be roughly the same and possibly even faster.

Fixes #77861
Fixes #79535

Closes PACK-5078