### PR TITLE
[metadata] replace for initial body icon case

### DIFF
--- a/test/e2e/app-dir/metadata-icons/app/custom-icon/delay-icons/page.tsx
+++ b/test/e2e/app-dir/metadata-icons/app/custom-icon/delay-icons/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { connection } from 'next/server'
+
+export default async function Page() {
+  return (
+    <div>
+      <h1>Delay Icons</h1>
+      <Link id="custom-icon-sub-link" href="/custom-icon/sub">
+        Go to another page with custom icon
+      </Link>
+      <br />
+      <Link id="custom-icon-sub-link" href="/custom-icon">
+        Go to root page with custom icon
+      </Link>
+    </div>
+  )
+}
+
+export async function generateMetadata() {
+  await connection()
+  return {
+    // This long text description will lead to the metadata being inserted after the head tag.
+    description: 'long text description'.repeat(1000),
+    icons: {
+      icon: `/heart.png`,
+    },
+  }
+}


### PR DESCRIPTION
Follow up on #76915, when there's icon showing up in the initial chunk during streaming, and they're located after the `<head>` tag, we need to insert the icon hoist script to ensure they're hoisted in the `<head>` in browser.

Closes NEXT-4619