### PR TITLE
Update NextAdapter type and re-export

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -51,10 +51,10 @@ export type AdapterOutputs = Array<{
 
 export interface NextAdapter {
   name: string
-  modifyConfig(
+  modifyConfig?: (
     config: NextConfigComplete
-  ): Promise<NextConfigComplete> | NextConfigComplete
-  onBuildComplete(ctx: {
+  ) => Promise<NextConfigComplete> | NextConfigComplete
+  onBuildComplete?: (ctx: {
     routes: {
       headers: Array<ManifestHeaderRoute>
       redirects: Array<ManifestRedirectRoute>
@@ -66,7 +66,7 @@ export interface NextAdapter {
       dynamicRoutes: Array<{}>
     }
     outputs: AdapterOutputs
-  }): Promise<void> | void
+  }) => Promise<void> | void
 }
 
 export type I18NDomains = readonly DomainLocale[]

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -29,6 +29,8 @@ export type ServerRuntime = 'nodejs' | 'experimental-edge' | 'edge' | undefined
 // @ts-ignore This path is generated at build time and conflicts otherwise
 export { NextConfig } from './server/config'
 
+export type { NextAdapter } from './server/config-shared'
+
 export type {
   Metadata,
   MetadataRoute,

--- a/test/production/adapter-config/my-adapter.mjs
+++ b/test/production/adapter-config/my-adapter.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /** @type {import('next').NextAdapter } */
 const myAdapter = {
   name: 'my-custom-adapter',


### PR DESCRIPTION
Just fixes up the type and re-exports it so it can be imported directly from `next`. Also fixes test file not being type checked which didn't catch missing optional fields.