### PR TITLE
Fix an issue in how css references are collected under `next build --turbopack`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4262,6 +4262,7 @@ dependencies = [
  "indexmap 2.9.0",
  "next-core",
  "regex",
+ "roaring",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,6 +398,7 @@ regex = "1.10.6"
 regress = "0.10.3"
 reqwest = { version = "0.12.20", default-features = false }
 ringmap = "0.1.3"
+roaring = "0.10.10"
 rstest = "0.16.0"
 rustc-hash = "2.1.1"
 semver = "1.0.16"

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -23,6 +23,7 @@ futures = { workspace = true }
 indexmap = { workspace = true }
 next-core = { workspace = true }
 regex = { workspace = true }
+roaring = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1937,10 +1937,10 @@ impl Endpoint for AppEndpoint {
         };
 
         async move {
-            let output = self.output().await?;
-            let output_assets = self.output().output_assets();
-            let node_root = this.app_project.project().node_root();
-            let node_root_ref = &node_root.await?;
+            let output = self.output();
+            let output_assets = output.output_assets();
+            let output = output.await?;
+            let node_root = &*this.app_project.project().node_root().await?;
 
             let (server_paths, client_paths) = if this
                 .app_project
@@ -1969,7 +1969,7 @@ impl Endpoint for AppEndpoint {
 
             let written_endpoint = match *output {
                 AppEndpointOutput::NodeJs { rsc_chunk, .. } => EndpointOutputPaths::NodeJs {
-                    server_entry_path: node_root_ref
+                    server_entry_path: node_root
                         .get_path_to(&*rsc_chunk.path().await?)
                         .context("Node.js chunk entry path must be inside the node root")?
                         .to_string(),

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -6,7 +6,6 @@ use next_core::{
 use roaring::RoaringBitmap;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use tracing::Instrument;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -66,141 +65,136 @@ impl ClientReferencesSet {
 pub async fn map_client_references(
     graph: Vc<SingleModuleGraph>,
 ) -> Result<Vc<ClientReferencesSet>> {
-    let span = tracing::info_span!("mapping client references");
-    async move {
-        let graph = graph.await?;
-        let client_references = graph
-            .iter_nodes()
-            .map(|node| async move {
-                let module = node.module;
+    let graph = graph.await?;
+    let client_references = graph
+        .iter_nodes()
+        .map(|node| async move {
+            let module = node.module;
 
-                if let Some(client_reference_module) =
-                    ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
-                {
-                    Ok(Some((
-                        module,
-                        ClientReferenceMapType::EcmascriptClientReference {
-                            module: client_reference_module,
-                            ssr_module: ResolvedVc::upcast(
-                                client_reference_module.await?.ssr_module,
-                            ),
-                        },
-                    )))
-                } else if let Some(client_reference_module) =
-                    ResolvedVc::try_downcast_type::<CssClientReferenceModule>(module)
-                {
-                    Ok(Some((
-                        module,
-                        ClientReferenceMapType::CssClientReference(
-                            client_reference_module.await?.client_module,
-                        ),
-                    )))
-                } else if let Some(server_component) =
-                    ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
-                {
-                    Ok(Some((
-                        module,
-                        ClientReferenceMapType::ServerComponent(server_component),
-                    )))
-                } else {
-                    Ok(None)
-                }
-            })
-            .try_flat_join()
-            .await?
-            .into_iter()
-            .collect::<FxHashMap<_, _>>();
+            if let Some(client_reference_module) =
+                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
+            {
+                Ok(Some((
+                    module,
+                    ClientReferenceMapType::EcmascriptClientReference {
+                        module: client_reference_module,
+                        ssr_module: ResolvedVc::upcast(client_reference_module.await?.ssr_module),
+                    },
+                )))
+            } else if let Some(client_reference_module) =
+                ResolvedVc::try_downcast_type::<CssClientReferenceModule>(module)
+            {
+                Ok(Some((
+                    module,
+                    ClientReferenceMapType::CssClientReference(
+                        client_reference_module.await?.client_module,
+                    ),
+                )))
+            } else if let Some(server_component) =
+                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
+            {
+                Ok(Some((
+                    module,
+                    ClientReferenceMapType::ServerComponent(server_component),
+                )))
+            } else {
+                Ok(None)
+            }
+        })
+        .try_flat_join()
+        .await?
+        .into_iter()
+        .collect::<FxHashMap<_, _>>();
 
-        let mut server_components = FxIndexSet::default();
-        let mut module_to_server_component_bits = FxHashMap::default();
-        if !client_references.is_empty() {
-            graph.traverse_edges_from_entries_fixed_point(
-                graph.entry_modules(),
-                |parent_info, node| {
-                    let module = node.module();
-                    let module_type = client_references.get(&module);
-                    let mut should_visit_children = match module_to_server_component_bits.entry(module) {
-                        std::collections::hash_map::Entry::Occupied(_) => false,
-                        std::collections::hash_map::Entry::Vacant(vacant_entry) => {
-                            // only do this the first time we visit the node.
-                            let bits = vacant_entry.insert(RoaringBitmap::new());
-                            if let Some(ClientReferenceMapType::ServerComponent(
-                                server_component_module,
-                            )) = module_type
-                            {
-                                let index =
-                                    server_components.insert_full(*server_component_module).0;
+    let mut server_components = FxIndexSet::default();
+    let mut module_to_server_component_bits = FxHashMap::default();
+    if !client_references.is_empty() {
+        graph.traverse_edges_from_entries_fixed_point(
+            graph.entry_modules(),
+            |parent_info, node| {
+                let module = node.module();
+                let module_type = client_references.get(&module);
+                let mut should_visit_children = match module_to_server_component_bits.entry(module)
+                {
+                    std::collections::hash_map::Entry::Occupied(_) => false,
+                    std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                        // only do this the first time we visit the node.
+                        let bits = vacant_entry.insert(RoaringBitmap::new());
+                        if let Some(ClientReferenceMapType::ServerComponent(
+                            server_component_module,
+                        )) = module_type
+                        {
+                            let index = server_components.insert_full(*server_component_module).0;
 
-                                bits.insert(index.try_into().unwrap());
-                            }
-                            true
+                            bits.insert(index.try_into().unwrap());
                         }
-                    };
-                    if let Some((SingleModuleGraphModuleNode{module: parent_module}, _)) = parent_info
+                        true
+                    }
+                };
+                if let Some((SingleModuleGraphModuleNode{module: parent_module}, _)) = parent_info
                     // Skip self cycles such as in
                     // test/e2e/app-dir/dynamic-import/app/page.tsx where a very-dynamic import induces a
                     // self cycle. They don't introduce new bits anyway.
                     && module != *parent_module
-                    {
-                        // Copy parent bits down.  `traverse_edges_from_entries_fixed_point` always visits parents before
-                        // children so we can simply assert that the parent it set.
-                        let [Some(current), Some(parent)] =
-                            module_to_server_component_bits.get_disjoint_mut([&module, parent_module])
-                        else {
-                            unreachable!()
-                        };
-                        // Check if we are adding new bits and thus need to revisit children unless we are already planning to because this is a new node.
-                        if !should_visit_children {
-                            let len = current.len();
-                            *current |= &*parent;
-                             // did we find new bits? If so visit the children again
-                            should_visit_children = len != current.len();
-                        } else {
-                            *current |= &*parent;
-                        }
+                {
+                    // Copy parent bits down.  `traverse_edges_from_entries_fixed_point` always
+                    // visits parents before children so we can simply assert
+                    // that the parent it set.
+                    let [Some(current), Some(parent)] =
+                        module_to_server_component_bits.get_disjoint_mut([&module, parent_module])
+                    else {
+                        unreachable!()
+                    };
+                    // Check if we are adding new bits and thus need to revisit children unless we
+                    // are already planning to because this is a new node.
+                    if !should_visit_children {
+                        let len = current.len();
+                        *current |= &*parent;
+                        // did we find new bits? If so visit the children again
+                        should_visit_children = len != current.len();
+                    } else {
+                        *current |= &*parent;
                     }
+                }
 
-                    Ok(match module_type {
-                        Some(
-                            ClientReferenceMapType::EcmascriptClientReference { .. }
-                            | ClientReferenceMapType::CssClientReference { .. },
-                        ) => {
-                            // No need to explore these subgraphs ever, these are the leaves in the
-                            // server component graph
+                Ok(match module_type {
+                    Some(
+                        ClientReferenceMapType::EcmascriptClientReference { .. }
+                        | ClientReferenceMapType::CssClientReference { .. },
+                    ) => {
+                        // No need to explore these subgraphs ever, these are the leaves in the
+                        // server component graph
+                        GraphTraversalAction::Skip
+                    }
+                    // Continue on server components and through graphs of non-ClientReference
+                    // modules, but only if our set of parent components has changed.
+                    _ => {
+                        if should_visit_children {
+                            GraphTraversalAction::Continue
+                        } else {
                             GraphTraversalAction::Skip
                         }
-                        // Continue on server components and through graphs of non-ClientReference
-                        // modules, but only if our set of parent components has changed.
-                        _ => {
-                            if should_visit_children {
-                                GraphTraversalAction::Continue
-                            } else {
-                                GraphTraversalAction::Skip
-                            }
-                        }
-                    })
-                },
-            )?;
-        }
-
-        // Filter down to just the client reference modules to reduce datastructure size
-        let server_components_for_client_references = module_to_server_component_bits
-            .into_iter()
-            .filter_map(|(k, v)| match client_references.get(&k) {
-                Some(
-                    ClientReferenceMapType::CssClientReference(_)
-                    | ClientReferenceMapType::EcmascriptClientReference { .. },
-                ) => Some((k, RoaringBitmapWrapper(v))),
-                _ => None,
-            })
-            .collect();
-
-        Ok(ClientReferencesSet::cell(ClientReferencesSet {
-            client_references,
-            server_components,
-            server_components_for_client_references,
-        }))
+                    }
+                })
+            },
+        )?;
     }
-    .instrument(span)
-    .await
+
+    // Filter down to just the client reference modules to reduce datastructure size
+    let server_components_for_client_references = module_to_server_component_bits
+        .into_iter()
+        .filter_map(|(k, v)| match client_references.get(&k) {
+            Some(
+                ClientReferenceMapType::CssClientReference(_)
+                | ClientReferenceMapType::EcmascriptClientReference { .. },
+            ) => Some((k, RoaringBitmapWrapper(v))),
+            _ => None,
+        })
+        .collect();
+
+    Ok(ClientReferencesSet::cell(ClientReferencesSet {
+        client_references,
+        server_components,
+        server_components_for_client_references,
+    }))
 }

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -45,10 +45,6 @@ pub struct ClientReferencesSet {
 }
 
 impl ClientReferencesSet {
-    fn new(client_references: ClientReferencesSet) -> Vc<Self> {
-        Self::cell(client_references)
-    }
-
     /// Returns all the server components that depend on the given client reference
     pub fn server_components_for_client_reference(
         &self,
@@ -146,7 +142,7 @@ pub async fn map_client_references(
                     // self cycle. They don't introduce new bits anyway.
                     && module != *parent_module
                     {
-                        // copy parent bits down.  `traverse_edges_from_entries_fixed_point`` always visits parents before
+                        // Copy parent bits down.  `traverse_edges_from_entries_fixed_point` always visits parents before
                         // children so we can simply assert that the parent it set.
                         let [Some(current), Some(parent)] =
                             module_to_server_component_bits.get_disjoint_mut([&module, parent_module])
@@ -158,7 +154,7 @@ pub async fn map_client_references(
                             let len = current.len();
                             *current |= &*parent;
                              // did we find new bits? If so visit the children again
-                            should_visit_children |= len != current.len();
+                            should_visit_children = len != current.len();
                         } else {
                             *current |= &*parent;
                         }
@@ -199,7 +195,7 @@ pub async fn map_client_references(
             })
             .collect();
 
-        Ok(ClientReferencesSet::new(ClientReferencesSet {
+        Ok(ClientReferencesSet::cell(ClientReferencesSet {
             client_references,
             server_components,
             server_components_for_client_references,

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -116,14 +116,14 @@ pub async fn map_client_references(
             .collect::<FxHashMap<_, _>>();
 
         let mut server_components = FxIndexSet::default();
-        let mut parent_modules = FxHashMap::default();
+        let mut module_to_server_component_bits = FxHashMap::default();
         if !client_references.is_empty() {
             graph.traverse_edges_from_entries_fixed_point(
                 graph.entry_modules(),
                 |parent_info, node| {
                     let module = node.module();
                     let module_type = client_references.get(&module);
-                    let mut should_visit_children = match parent_modules.entry(module) {
+                    let mut should_visit_children = match module_to_server_component_bits.entry(module) {
                         std::collections::hash_map::Entry::Occupied(_) => false,
                         std::collections::hash_map::Entry::Vacant(vacant_entry) => {
                             // only do this the first time we visit the node.
@@ -149,7 +149,7 @@ pub async fn map_client_references(
                         // copy parent bits down.  `traverse_edges_from_entries_fixed_point`` always visits parents before
                         // children so we can simply assert that the parent it set.
                         let [Some(current), Some(parent)] =
-                            parent_modules.get_disjoint_mut([&module, parent_module])
+                            module_to_server_component_bits.get_disjoint_mut([&module, parent_module])
                         else {
                             unreachable!()
                         };
@@ -188,7 +188,7 @@ pub async fn map_client_references(
         }
 
         // Filter down to just the client reference modules to reduce datastructure size
-        let server_components_for_client_references = parent_modules
+        let server_components_for_client_references = module_to_server_component_bits
             .into_iter()
             .filter_map(|(k, v)| match client_references.get(&k) {
                 Some(

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -1,16 +1,24 @@
 use anyhow::Result;
 use next_core::{
-    self,
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
     next_server_component::server_component_module::NextServerComponentModule,
 };
+use roaring::RoaringBitmap;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use tracing::Instrument;
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    FxIndexSet, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc, debug::ValueDebugFormat,
+    trace::TraceRawVcs,
 };
 use turbopack::css::chunk::CssChunkPlaceable;
-use turbopack_core::{module::Module, module_graph::SingleModuleGraph};
+use turbopack_core::{
+    module::Module,
+    module_graph::{
+        GraphTraversalAction, SingleModuleGraph, SingleModuleGraphModuleNode,
+        chunk_group_info::RoaringBitmapWrapper,
+    },
+};
 
 #[derive(
     Copy, Clone, Serialize, Deserialize, Eq, PartialEq, TraceRawVcs, ValueDebugFormat, NonLocalValue,
@@ -24,50 +32,179 @@ pub enum ClientReferenceMapType {
     ServerComponent(ResolvedVc<NextServerComponentModule>),
 }
 
-#[turbo_tasks::value(transparent)]
-pub struct ClientReferencesSet(FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>);
+#[turbo_tasks::value]
+pub struct ClientReferencesSet {
+    pub client_references: FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>,
+    // All the server components in the graph.
+    server_components: FxIndexSet<ResolvedVc<NextServerComponentModule>>,
+    // All the server components that depend on each module
+    // This only includes mappings for modules with client references and the bitmaps reference
+    // indices into `[server_components]`
+    server_components_for_client_references:
+        FxHashMap<ResolvedVc<Box<dyn Module>>, RoaringBitmapWrapper>,
+}
+
+impl ClientReferencesSet {
+    fn new(client_references: ClientReferencesSet) -> Vc<Self> {
+        Self::cell(client_references)
+    }
+
+    /// Returns all the server components that depend on the given client reference
+    pub fn server_components_for_client_reference(
+        &self,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> impl Iterator<Item = ResolvedVc<NextServerComponentModule>> {
+        let bitmap = &self
+            .server_components_for_client_references
+            .get(&module)
+            .expect("Module should be a client reference module")
+            .0;
+
+        bitmap
+            .iter()
+            .map(|index| *self.server_components.get_index(index as usize).unwrap())
+    }
+}
 
 #[turbo_tasks::function]
 pub async fn map_client_references(
     graph: Vc<SingleModuleGraph>,
 ) -> Result<Vc<ClientReferencesSet>> {
-    let client_references = graph
-        .await?
-        .iter_nodes()
-        .map(|node| async move {
-            let module = node.module;
+    let span = tracing::info_span!("mapping client references");
+    async move {
+        let graph = graph.await?;
+        let client_references = graph
+            .iter_nodes()
+            .map(|node| async move {
+                let module = node.module;
 
-            if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
-            {
-                Ok(Some((
-                    module,
-                    ClientReferenceMapType::EcmascriptClientReference {
-                        module: client_reference_module,
-                        ssr_module: ResolvedVc::upcast(client_reference_module.await?.ssr_module),
-                    },
-                )))
-            } else if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<CssClientReferenceModule>(module)
-            {
-                Ok(Some((
-                    module,
-                    ClientReferenceMapType::CssClientReference(
-                        client_reference_module.await?.client_module,
-                    ),
-                )))
-            } else if let Some(server_component) =
-                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
-            {
-                Ok(Some((
-                    module,
-                    ClientReferenceMapType::ServerComponent(server_component),
-                )))
-            } else {
-                Ok(None)
-            }
-        })
-        .try_flat_join()
-        .await?;
-    Ok(Vc::cell(client_references.into_iter().collect()))
+                if let Some(client_reference_module) =
+                    ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
+                {
+                    Ok(Some((
+                        module,
+                        ClientReferenceMapType::EcmascriptClientReference {
+                            module: client_reference_module,
+                            ssr_module: ResolvedVc::upcast(
+                                client_reference_module.await?.ssr_module,
+                            ),
+                        },
+                    )))
+                } else if let Some(client_reference_module) =
+                    ResolvedVc::try_downcast_type::<CssClientReferenceModule>(module)
+                {
+                    Ok(Some((
+                        module,
+                        ClientReferenceMapType::CssClientReference(
+                            client_reference_module.await?.client_module,
+                        ),
+                    )))
+                } else if let Some(server_component) =
+                    ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
+                {
+                    Ok(Some((
+                        module,
+                        ClientReferenceMapType::ServerComponent(server_component),
+                    )))
+                } else {
+                    Ok(None)
+                }
+            })
+            .try_flat_join()
+            .await?
+            .into_iter()
+            .collect::<FxHashMap<_, _>>();
+
+        let mut server_components = FxIndexSet::default();
+        let mut parent_modules = FxHashMap::default();
+        if !client_references.is_empty() {
+            graph.traverse_edges_from_entries_fixed_point(
+                graph.entry_modules(),
+                |parent_info, node| {
+                    let module = node.module();
+                    let module_type = client_references.get(&module);
+                    let mut should_visit_children = match parent_modules.entry(module) {
+                        std::collections::hash_map::Entry::Occupied(_) => false,
+                        std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                            // only do this the first time we visit the node.
+                            let bits = vacant_entry.insert(RoaringBitmap::new());
+                            if let Some(ClientReferenceMapType::ServerComponent(
+                                server_component_module,
+                            )) = module_type
+                            {
+                                let index =
+                                    server_components.insert_full(*server_component_module).0;
+
+                                bits.insert(index.try_into().unwrap());
+                            }
+                            true
+                        }
+                    };
+                    if let Some((SingleModuleGraphModuleNode{module: parent_module}, _)) = parent_info
+                    // Skip self cycles such as in
+                    // test/e2e/app-dir/dynamic-import/app/page.tsx where a very-dynamic import induces a
+                    // self cycle. They don't introduce new bits anyway.
+                    && module != *parent_module
+                    {
+                        // copy parent bits down.  `traverse_edges_from_entries_fixed_point`` always visits parents before
+                        // children so we can simply assert that the parent it set.
+                        let [Some(current), Some(parent)] =
+                            parent_modules.get_disjoint_mut([&module, parent_module])
+                        else {
+                            unreachable!()
+                        };
+                        // Check if we are adding new bits and thus need to revisit children unless we are already planning to because this is a new node.
+                        if !should_visit_children {
+                            let len = current.len();
+                            *current |= &*parent;
+                             // did we find new bits? If so visit the children again
+                            should_visit_children |= len != current.len();
+                        } else {
+                            *current |= &*parent;
+                        }
+                    }
+
+                    Ok(match module_type {
+                        Some(
+                            ClientReferenceMapType::EcmascriptClientReference { .. }
+                            | ClientReferenceMapType::CssClientReference { .. },
+                        ) => {
+                            // No need to explore these subgraphs ever, these are the leaves in the
+                            // server component graph
+                            GraphTraversalAction::Skip
+                        }
+                        // Continue on server components and through graphs of non-ClientReference
+                        // modules, but only if our set of parent components has changed.
+                        _ => {
+                            if should_visit_children {
+                                GraphTraversalAction::Continue
+                            } else {
+                                GraphTraversalAction::Skip
+                            }
+                        }
+                    })
+                },
+            )?;
+        }
+
+        // Filter down to just the client reference modules to reduce datastructure size
+        let server_components_for_client_references = parent_modules
+            .into_iter()
+            .filter_map(|(k, v)| match client_references.get(&k) {
+                Some(
+                    ClientReferenceMapType::CssClientReference(_)
+                    | ClientReferenceMapType::EcmascriptClientReference { .. },
+                ) => Some((k, RoaringBitmapWrapper(v))),
+                _ => None,
+            })
+            .collect();
+
+        Ok(ClientReferencesSet::new(ClientReferencesSet {
+            client_references,
+            server_components,
+            server_components_for_client_references,
+        }))
+    }
+    .instrument(span)
+    .await
 }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -14,8 +14,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    CollectiblesSource, FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueToString, Vc,
+    CollectiblesSource, FxIndexMap, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt,
+    ValueToString, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::css::{CssModuleAsset, ModuleCssAsset};

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -315,7 +315,8 @@ impl ClientReferencesGraph {
             // components for each module.
             graph.traverse_edges_from_entries_dfs(
                 entries,
-                // state_map is `module -> ParentType` for whether the parent is in a
+                // state_map is `module -> ParentType` to tracke whether the module is reachable
+                // directly from an entry point.
                 &mut FxHashMap::default(),
                 |parent_info, node, state_map| {
                     let module = node.module();
@@ -333,9 +334,10 @@ impl ClientReferencesGraph {
 
                     match state_map.entry(module) {
                         Entry::Occupied(mut occupied_entry) => {
-                            let merged = ParentType::merge(*occupied_entry.get(), parent_type);
+                            let current = occupied_entry.get_mut();
+                            let merged = ParentType::merge(*current, parent_type);
                             if merged != parent_type {
-                                occupied_entry.insert(merged);
+                                *current = merged;
                             }
                         }
                         Entry::Vacant(vacant_entry) => {
@@ -374,7 +376,8 @@ impl ClientReferencesGraph {
                     if *state_map.get(&module).unwrap() == ParentType::ServerComponent {
                         // This is only reachable through server components, we need to wait to
                         // compute the client references until we have seen all server components
-                        // reachable by this entrypoint so we can add it to all of them
+                        // reachable by this entrypoint, then we can intersect that with the set of
+                        // server components that depend on this client reference
                         client_reference_modules.push((module, ty));
                     } else {
                         // Otherwise there is some path from the root directly to the reference,
@@ -737,8 +740,10 @@ impl GlobalBuildInformation {
 
             // TODO(luke.sandberg): at least in the whole_app_module_graph case we should be able to
             // collect server components and server utilities during the above traversals in the
-            // correct order.  `find_server_entries returns them in reverse topological order but
-            // the above traversals find them in DFS post order which is similar but different.
+            // correct order.  `find_server_entries returns them in reverse topological order (root
+            // layout first, page last) but the above traversals find them in DFS post
+            // order which means we would need to reverse it.
+            // For server_utils the order is irrelevant.
             if has_layout_segments {
                 // Do this separately for now, because the graph traversal order messes up the order
                 // of the server_component_entries.

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::hash_map::Entry};
 
 use anyhow::{Ok, Result};
 use either::Either;
@@ -10,7 +10,7 @@ use next_core::{
     next_dynamic::NextDynamicEntryModule,
     next_manifests::ActionLayer,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -289,30 +289,59 @@ impl ClientReferencesGraph {
             // post_order callbacks which is the same as evaluation order
             let mut client_references = Vec::new();
             let mut client_reference_modules = Vec::new();
-            let mut server_components = FxIndexSet::default();
+            let mut server_components = FxHashSet::default();
 
+            // Track how we reached each client reference.  This way if a client reference is
+            // referenced by the root and by a server component we don't only associate it with the
+            // server component.
+            #[derive(PartialEq, Eq, Copy, Clone)]
+            enum ParentType {
+                ServerComponent,
+                Page,
+                Both,
+            }
+            impl ParentType {
+                fn merge(left: Self, right: Self) -> Self {
+                    if left == right {
+                        left
+                    } else {
+                        // One is Both or one is ServerComponent and the other is Page, which means
+                        // Both
+                        Self::Both
+                    }
+                }
+            }
             // Perform a DFS traversal to collect all client references and the set of server
-            // components for each module
-            // We collect in post order to respect 'evaluation order'
+            // components for each module.
             graph.traverse_edges_from_entries_dfs(
                 entries,
-                // state_map is `module -> boolean`
+                // state_map is `module -> ParentType` for whether the parent is in a
                 &mut FxHashMap::default(),
                 |parent_info, node, state_map| {
                     let module = node.module();
                     let module_type = data.client_references.get(&module);
 
-                    let current_server_component =
+                    let parent_type =
                         if let Some(ClientReferenceMapType::ServerComponent(_)) = module_type {
-                            true
+                            ParentType::ServerComponent
                         } else if let Some((parent_node, _)) = parent_info {
                             *state_map.get(&parent_node.module).unwrap()
                         } else {
                             // a root node
-                            false
+                            ParentType::Page
                         };
 
-                    state_map.insert(module, current_server_component);
+                    match state_map.entry(module) {
+                        Entry::Occupied(mut occupied_entry) => {
+                            let merged = ParentType::merge(*occupied_entry.get(), parent_type);
+                            if merged != parent_type {
+                                occupied_entry.insert(merged);
+                            }
+                        }
+                        Entry::Vacant(vacant_entry) => {
+                            vacant_entry.insert(parent_type);
+                        }
+                    }
 
                     Ok(match module_type {
                         Some(
@@ -327,10 +356,6 @@ impl ClientReferencesGraph {
                     let Some(module_type) = data.client_references.get(&module) else {
                         return Ok(());
                     };
-                    if let ClientReferenceMapType::ServerComponent(sc) = module_type {
-                        server_components.insert(*sc);
-                        return Ok(());
-                    }
 
                     let ty = match module_type {
                         ClientReferenceMapType::EcmascriptClientReference {
@@ -340,17 +365,20 @@ impl ClientReferencesGraph {
                         ClientReferenceMapType::CssClientReference(module) => {
                             ClientReferenceType::CssClientReference(*module)
                         }
-                        ClientReferenceMapType::ServerComponent(_) => {
-                            unreachable!()
+                        ClientReferenceMapType::ServerComponent(sc) => {
+                            server_components.insert(*sc);
+                            return Ok(());
                         }
                     };
 
-                    if *state_map.get(&module).unwrap() {
-                        // there is a parent component, we need to wait to compute the client
-                        // references until we have seen all server components reachable by this
-                        // entrypoint
+                    if *state_map.get(&module).unwrap() == ParentType::ServerComponent {
+                        // This is only reachable through server components, we need to wait to
+                        // compute the client references until we have seen all server components
+                        // reachable by this entrypoint so we can add it to all of them
                         client_reference_modules.push((module, ty));
                     } else {
+                        // Otherwise there is some path from the root directly to the reference,
+                        // just associate it with the root.
                         client_references.push(ClientReference {
                             server_component: None,
                             ty,
@@ -361,17 +389,18 @@ impl ClientReferencesGraph {
                 },
             )?;
 
-            for (module, ty) in client_reference_modules {
-                for sc in data
-                    .server_components_for_client_reference(module)
-                    .filter(|sc| server_components.contains(sc))
-                {
-                    client_references.push(ClientReference {
-                        server_component: Some(sc),
-                        ty,
-                    })
-                }
-            }
+            // Now compute all the parent components for each client reference module reachable from
+            // server components
+            client_references.extend(client_reference_modules.into_iter().flat_map(
+                |(module, ty)| {
+                    data.server_components_for_client_reference(module)
+                        .filter(|sc| server_components.contains(sc))
+                        .map(move |sc| ClientReference {
+                            server_component: Some(sc),
+                            ty,
+                        })
+                },
+            ));
 
             Ok(ClientReferenceGraphResult {
                 client_references: client_references.into_iter().collect(),

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -280,9 +280,9 @@ impl ClientReferencesGraph {
                     // the graph doesn't contain the entry, e.g. for the additional module graph
                     return Ok(ClientReferenceGraphResult::default().cell());
                 }
-                vec![entry]
+                Either::Left(std::iter::once(entry))
             } else {
-                graph.entry_modules().collect()
+                Either::Right(graph.entry_modules())
             };
 
             // Because we care about 'evaluation order' we need to collect client references in the

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
     debug::ValueDebugFormat,
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
     trace::TraceRawVcs,
@@ -75,10 +75,6 @@ pub enum ClientReferenceType {
 #[derive(Clone, Debug, Default)]
 pub struct ClientReferenceGraphResult {
     pub client_references: Vec<ClientReference>,
-    /// Only the [`ClientReferenceType::EcmascriptClientReference`]s are listed in this map.
-    #[allow(clippy::type_complexity)]
-    pub client_references_by_server_component:
-        FxIndexMap<Option<ResolvedVc<NextServerComponentModule>>, Vec<ResolvedVc<Box<dyn Module>>>>,
     pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
     pub server_utils: Vec<ResolvedVc<NextServerUtilityModule>>,
 }
@@ -115,12 +111,6 @@ impl ClientReferenceGraphResult {
     pub fn extend(&mut self, other: &Self) {
         self.client_references
             .extend(other.client_references.iter().copied());
-        for (k, v) in other.client_references_by_server_component.iter() {
-            self.client_references_by_server_component
-                .entry(*k)
-                .or_insert_with(Vec::new)
-                .extend(v);
-        }
         self.server_component_entries
             .extend(other.server_component_entries.iter().copied());
         self.server_utils.extend(other.server_utils.iter().copied());

--- a/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
+++ b/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
@@ -15,11 +15,7 @@ describe('initial-css-not-found', () => {
       await browser.eval(
         `window.getComputedStyle(document.querySelector('body')).color`
       )
-    ).toBe(
-      // This only fails in production turbopack builds
-      process.env.IS_TURBOPACK_TEST && process.env.NEXT_TEST_MODE !== 'dev'
-        ? 'rgb(0, 0, 0)'
-        : 'rgb(255, 0, 0)'
-    )
+
+    ).toBe('rgb(255, 0, 0)')
   })
 })

--- a/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
+++ b/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
@@ -10,6 +10,7 @@ describe('initial-css-not-found', () => {
   it('should serve styles', async () => {
     const browser = await next.browser('/')
 
+    // Simply check that our css was served and applied.
     expect(
       await browser.eval(
         `window.getComputedStyle(document.querySelector('body')).color`

--- a/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
+++ b/test/e2e/app-dir/initial-css-not-found/initial-css-not-found.test.ts
@@ -15,7 +15,6 @@ describe('initial-css-not-found', () => {
       await browser.eval(
         `window.getComputedStyle(document.querySelector('body')).color`
       )
-
     ).toBe('rgb(255, 0, 0)')
   })
 })

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { workspace = true }
 once_cell = { workspace = true }
 patricia_tree = "0.5.5"
 petgraph = { workspace = true, features = ["serde-1"] }
-roaring = { version = "0.10.10", features = ["serde"] }
+roaring = { workspace = true, features = ["serde"] }
 ref-cast = "1.0.20"
 rustc-hash = { workspace = true }
 regex = { workspace = true }

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -25,6 +25,7 @@ use crate::{
 #[derive(
     Clone, Debug, Default, PartialEq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat,
 )]
+#[repr(transparent)]
 pub struct RoaringBitmapWrapper(#[turbo_tasks(trace_ignore)] pub RoaringBitmap);
 
 impl TaskInput for RoaringBitmapWrapper {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -563,6 +563,71 @@ impl SingleModuleGraph {
         Ok(())
     }
 
+    /// Traverses all reachable nodes and also continue revisiting them as long the visitor returns
+    /// GraphTraversalAction::Continue. The visitor is responsible for the runtime complexity and
+    /// eventual termination of the traversal. This corresponds to computing a fixed point state for
+    /// the graph.
+    ///
+    /// It is guaranteed that the parent node passed to the `visit` function, if any, has
+    /// already been passed to `visit`.
+    ///
+    /// * `entries` - The entry modules to start the traversal from
+    /// * `state` - The state to be passed to the callbacks
+    /// * `visit` - Called for a specific edge
+    ///    - Receives: Option(originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///      &SingleModuleGraphNode
+    ///    - Return [GraphTraversalAction]s to control the traversal
+    ///
+    /// Returns the number of node visits (i.e. higher than the node
+    /// count if there are retraversals).
+    pub fn traverse_edges_from_entries_fixed_point<'a>(
+        &'a self,
+        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
+        mut visit: impl FnMut(
+            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
+            &'a SingleModuleGraphNode,
+        ) -> Result<GraphTraversalAction>,
+    ) -> Result<usize> {
+        let mut queue = VecDeque::default();
+        let mut queue_set = FxHashSet::default();
+
+        for module in entries {
+            let index = self.get_module(module).unwrap();
+            let action = visit(None, self.graph.node_weight(index).unwrap())?;
+            if action == GraphTraversalAction::Continue && queue_set.insert(index) {
+                queue.push_back(index);
+            }
+        }
+
+        let mut visit_count = 0;
+        while let Some(index) = queue.pop_front() {
+            queue_set.remove(&index);
+            let node = match self.graph.node_weight(index).unwrap() {
+                SingleModuleGraphNode::Module(single_module_graph_module_node) => {
+                    single_module_graph_module_node
+                }
+                _ => {
+                    continue; // we don't traverse into parent graphs
+                }
+            };
+            visit_count += 1;
+            for edge in self
+                .graph
+                .edges_directed(index, petgraph::Direction::Outgoing)
+            {
+                let refdata = edge.weight();
+                let target_index = edge.target();
+                let target = self.graph.node_weight(edge.target()).unwrap();
+                let action = visit(Some((node, refdata)), target)?;
+                if action == GraphTraversalAction::Continue && queue_set.insert(target_index) {
+                    queue.push_back(target_index);
+                }
+            }
+        }
+
+        Ok(visit_count)
+    }
+
     /// Traverses all reachable edges in dfs order. The preorder visitor can be used to
     /// forward state down the graph, and to skip subgraphs.
     ///
@@ -1937,6 +2002,58 @@ pub mod tests {
         .await;
     }
 
+    #[tokio::test]
+    async fn traverse_edges_from_entries_fixed_point_cycle() {
+        run_graph_test(
+            vec![rcstr!("a.js")],
+            {
+                let mut deps = FxHashMap::default();
+                // A cycle of length 3
+                deps.insert(rcstr!("a.js"), vec![rcstr!("b.js")]);
+                deps.insert(rcstr!("b.js"), vec![rcstr!("c.js")]);
+                deps.insert(rcstr!("c.js"), vec![rcstr!("a.js")]);
+                deps
+            },
+            |graph, entry_modules, module_to_name| {
+                let mut visits = Vec::new();
+                let mut count = 0;
+
+                graph.traverse_edges_from_entries_fixed_point(
+                    entry_modules,
+                    |parent, target| {
+                        visits.push((
+                            parent
+                                .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
+                            module_to_name.get(&target.module()).unwrap().clone(),
+                        ));
+                        count += 1;
+
+                        // We are a cycle so we need to break the loop eventually
+                        Ok(if count < 6 {
+                            GraphTraversalAction::Continue
+                        } else {
+                            GraphTraversalAction::Skip
+                        })
+                    },
+                )?;
+                assert_eq!(
+                    vec![
+                        (None, rcstr!("a.js")),
+                        (Some(rcstr!("a.js")), rcstr!("b.js")),
+                        (Some(rcstr!("b.js")), rcstr!("c.js")),
+                        (Some(rcstr!("c.js")), rcstr!("a.js")),
+                        // we start following the cycle again
+                        (Some(rcstr!("a.js")), rcstr!("b.js")),
+                        (Some(rcstr!("b.js")), rcstr!("c.js")),
+                    ],
+                    visits
+                );
+
+                Ok(())
+            },
+        )
+        .await;
+    }
     #[turbo_tasks::value(shared)]
     struct TestRepo {
         repo: FxHashMap<FileSystemPath, Vec<FileSystemPath>>,

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -572,7 +572,6 @@ impl SingleModuleGraph {
     /// already been passed to `visit`.
     ///
     /// * `entries` - The entry modules to start the traversal from
-    /// * `state` - The state to be passed to the callbacks
     /// * `visit` - Called for a specific edge
     ///    - Receives: Option(originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -30,7 +30,9 @@ fn main() {
     let args: FxIndexSet<String> = std::env::args().skip(1).collect();
 
     let mut iter = args.iter();
-    let arg = iter.next().expect("missing argument: trace file path");
+    let arg = iter
+        .next()
+        .expect("missing positional argument for the trace file path");
     let port = iter.next().map_or(5747, |s| s.parse().unwrap());
 
     let store = Arc::new(StoreContainer::new());


### PR DESCRIPTION
## Fix how client references are discovered during `next build --turbopack`

To correctly serve js and css resources during server side rendering we construct a client manifest that lists all the server components and their requires resources.  Prior to this PR there was a bug where we would sometimes fail to serve css resources.  The cases we have seen this is when a `not-found.js` file references css that is also referenced by a layout.

When present, all pages pages implicitly depend on this module and  crticically depend on it as an early implicit dependency of the generated `app-page.js` file.  This means if a `not-found.js` file (or another error file) would happen to depend on the same css as a normal component we would associate it as a client-reference of that component instead of any other.  Then on a server side render we would simply omit it.

This PR address this by ensuring we always associate client resources with _every_ server component that depends on them, not just the first one.  To do this we precompute the full set of server components that depend on each client resource in the module graph and then after our dfs traversal we can collect all server components for a given entry point and then perform the association.  Further more we ensure that if a resource is reachable 'directly' from the page it is associated as 'framework' dependency.  This wasn't know to be an issue but it seems possible that if a conditionally rendered server component depended on a core framework dependency we might see the same problem.

The downside of this approach is simply the additional 'fixed point' traversal (shared across all routes) and the slightly more complex bookkeeping during each route computation.  From looking at traces building vercel-site i see that `find_server_entries` dominates the collection of client-resources (by factor of ~20, so resolving the TODO added here is probably the best approach to resolving any potential production build regressions.   However, `find_server_entries` will likely still be needed in a development scenario.  In either case however this is a very small part of the build taking ~20us per entry point.

Fixes #77861
Fixes #79535
Fixes PACK-4282
Fixes PACK-4940