### PR TITLE
[lint] keep lint-stage use faster linting

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   '*.{js,jsx,mjs,ts,tsx,mts,mdx}': [
     'prettier --with-node-modules --ignore-path .prettierignore --write',
-    'cross-env ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.cli.json --no-eslintrc --fix',
+    'cross-env ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.json --no-eslintrc --fix',
   ],
   '*.{json,md,css,html,yml,yaml,scss}': [
     'prettier --with-node-modules --ignore-path .prettierignore --write',


### PR DESCRIPTION
Using the eslint config with rules that need type information (`.eslintrc.cli.json`) takes too long when committing. This PR restores the previous commit speed by using the `.eslintrc.json` config instead, which does not require type information. Eslint rule violations for type-checked rules will now only be shown in CI, or when running `pnpm lint-eslint` locally.