### PR TITLE
[test] Fix `app-static` deploy test

### DIFF
--- a/test/e2e/app-dir/app-static/app/stale-cache-serving-edge/app-page/page.tsx
+++ b/test/e2e/app-dir/app-static/app/stale-cache-serving-edge/app-page/page.tsx
@@ -13,7 +13,7 @@ export default async function Page(props) {
   return (
     <>
       <p id="data">
-        {JSON.stringify({ fetchDuration, data, now: Date.now() })}
+        {JSON.stringify({ fetchDuration, data, now: Date.now(), start })}
       </p>
     </>
   )

--- a/test/e2e/app-dir/app-static/app/stale-cache-serving-edge/route-handler/route.ts
+++ b/test/e2e/app-dir/app-static/app/stale-cache-serving-edge/route-handler/route.ts
@@ -12,5 +12,5 @@ export async function GET(req: NextRequest) {
   ).then((res) => res.json())
   const fetchDuration = Date.now() - start
 
-  return NextResponse.json({ fetchDuration, data, now: Date.now() })
+  return NextResponse.json({ fetchDuration, data, now: Date.now(), start })
 }

--- a/test/e2e/app-dir/app-static/app/stale-cache-serving/app-page/page.tsx
+++ b/test/e2e/app-dir/app-static/app/stale-cache-serving/app-page/page.tsx
@@ -13,7 +13,7 @@ export default async function Page(props) {
   return (
     <>
       <p id="data">
-        {JSON.stringify({ fetchDuration, data, now: Date.now() })}
+        {JSON.stringify({ fetchDuration, data, now: Date.now(), start })}
       </p>
     </>
   )

--- a/test/e2e/app-dir/app-static/app/stale-cache-serving/route-handler/route.ts
+++ b/test/e2e/app-dir/app-static/app/stale-cache-serving/route-handler/route.ts
@@ -12,5 +12,5 @@ export async function GET(req: NextRequest) {
   ).then((res) => res.json())
   const fetchDuration = Date.now() - start
 
-  return NextResponse.json({ fetchDuration, data, now: Date.now() })
+  return NextResponse.json({ fetchDuration, data, now: Date.now(), start })
 }


### PR DESCRIPTION
The test previously included the time for the boot of the function. We're only interested in not blocking on revalidating though.

This introduces a different problem if clocks between Client and Server aren't synced though.  A proper fix would leverage `Server-Timing` headers where Next.js would include when the first chunk was sent. We don't have that yet though so we have to pray the clocks are close enough.