### PR TITLE
Turbopack: Support string without options for @next/mdx

### DIFF
--- a/docs/01-app/02-guides/mdx.mdx
+++ b/docs/01-app/02-guides/mdx.mdx
@@ -727,8 +727,18 @@ const nextConfig = {
 
 const withMDX = createMDX({
   options: {
-    remarkPlugins: [],
-    rehypePlugins: [['rehype-katex', { strict: true, throwOnError: true }]],
+    remarkPlugins: [
+      // Without options
+      'remark-gfm',
+      // With options
+      ['remark-toc', { heading: 'The Table' }],
+    ],
+    rehypePlugins: [
+      // Without options
+      'rehype-slug',
+      // With options
+      ['rehype-katex', { strict: true, throwOnError: true }],
+    ],
   },
 })
 
@@ -737,7 +747,7 @@ export default withMDX(nextConfig)
 
 > **Good to know**:
 >
-> remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/app/api-reference/turbopack), due to [inability to pass JavaScript functions to Rust](https://github.com/vercel/next.js/issues/71819#issuecomment-2461802968)
+> remark and rehype plugins without serializable options cannot be used yet with [Turbopack](/docs/app/api-reference/turbopack), because JavaScript functions can't be passed to Rust.
 
 ## Remote MDX
 

--- a/packages/next-mdx/index.d.ts
+++ b/packages/next-mdx/index.d.ts
@@ -21,7 +21,22 @@ declare namespace nextMDX {
      *
      * @see https://mdxjs.com/packages/mdx/#api
      */
-    options?: Options
+    options?: Options & {
+      remarkPlugins?:
+        | (
+            | string
+            | [name: string, options: any]
+            | NonNullable<Options['remarkPlugins']>[number]
+          )[]
+        | Options['remarkPlugins']
+      rehypePlugins?:
+        | (
+            | string
+            | [name: string, options: any]
+            | NonNullable<Options['rehypePlugins']>[number]
+          )[]
+        | Options['rehypePlugins']
+    }
   }
 }
 

--- a/test/e2e/app-dir/mdx/app/remark-plugin/page.mdx
+++ b/test/e2e/app-dir/mdx/app/remark-plugin/page.mdx
@@ -1,0 +1,10 @@
+# The Table
+
+# Remark plugin
+
+Testing emoji: :dog: :+1:
+
+## Todo List
+
+- [ ] Implement
+- [x] Implemented

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -9,6 +9,9 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
         '@mdx-js/loader': '^2.2.1',
         '@mdx-js/react': '^2.2.1',
         'rehype-katex': '7.0.1',
+        'rehype-slug': '6.0.0',
+        'remark-gfm': '4.0.1',
+        'remark-toc': '9.0.0',
       },
       env: {
         WITH_MDX_RS: type === 'with-mdx-rs' ? 'true' : 'false',
@@ -62,10 +65,22 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
       })
 
       if (type === 'without-mdx-rs') {
-        it('should run plugins', async () => {
-          const html = await next.render('/rehype-plugin')
+        it('should run rehype plugins', async () => {
+          const $ = await next.render$('/rehype-plugin')
+          const html = $('html').html()
           expect(html.includes('<mi>C</mi>')).toBe(true)
           expect(html.includes('<mi>L</mi>')).toBe(true)
+          expect($('#rehype-plugin').text()).toBe('Rehype plugin')
+        })
+
+        it('should run remark plugins', async () => {
+          const $ = await next.render$('/remark-plugin')
+          const html = $('html').html()
+          expect(html.includes('The Table')).toBe(true)
+          expect($('a[href="#todo-list"]').text()).toBe('Todo List')
+
+          expect($('input[type="checkbox"]').length).toBe(2)
+          expect($('input[type="checkbox"][checked]').length).toBe(1)
         })
       }
     })

--- a/test/e2e/app-dir/mdx/next.config.ts
+++ b/test/e2e/app-dir/mdx/next.config.ts
@@ -2,8 +2,11 @@ import nextMDX from '@next/mdx'
 const withMDX = nextMDX({
   extension: /\.mdx?$/,
   options: {
-    remarkPlugins: [],
-    rehypePlugins: [['rehype-katex', { strict: true, throwOnError: true }]],
+    remarkPlugins: ['remark-gfm', ['remark-toc', { heading: 'The Table' }]],
+    rehypePlugins: [
+      'rehype-slug',
+      ['rehype-katex', { strict: true, throwOnError: true }],
+    ],
   },
 })
 


### PR DESCRIPTION
## What?

Adds support for `remarkPlugins: ['remark-gfm']` and `rehypePlugins: ['rehype-slug']`.

Previously you had to nest an array like `remarkPlugins: [['remark-gfm']]` but that's a bug, that case is only for passing options. Directly passing the string without options should be allowed. This PR implements that.

Closes PACK-5080