### PR TITLE
[turbopack] Always print trace labels in headers

### DIFF
--- a/packages/next/src/shared/lib/turbopack/utils.test.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.test.ts
@@ -40,9 +40,10 @@ describe('formatIssue', () => {
     expect(output).toBe(`\
 ./src/app/page.ts
 Module not found
-Import trace [client]:
-  ./src/app/page.ts
-  ./src/lib/foo.ts
+Import trace:
+  client:
+    ./src/app/page.ts
+    ./src/lib/foo.ts
 
 https://nextjs.org/docs/messages/module-not-found
 

--- a/packages/next/src/shared/lib/turbopack/utils.test.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.test.ts
@@ -23,7 +23,7 @@ describe('formatIssue', () => {
     filePath: '[project]/src/app/page.ts',
     title: styledText('Module not found'),
     source: undefined,
-    documentationLink: 'http:://nextjs.org/docs',
+    documentationLink: 'https://nextjs.org/docs',
     stage: 'resolve',
   }
 

--- a/packages/next/src/shared/lib/turbopack/utils.test.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.test.ts
@@ -1,0 +1,128 @@
+import type {
+  Issue,
+  PlainTraceItem,
+  StyledString,
+} from '../../../build/swc/types'
+import { formatIssue } from './utils'
+
+function styledText(value: string): StyledString {
+  return { type: 'text', value }
+}
+
+function traceItem(path: string, layer?: string): PlainTraceItem {
+  return {
+    fsName: 'project',
+    path,
+    layer,
+    rootPath: '',
+  }
+}
+describe('formatIssue', () => {
+  const baseIssue: Omit<Issue, 'importTraces'> = {
+    severity: 'error',
+    filePath: '[project]/src/app/page.ts',
+    title: styledText('Module not found'),
+    source: undefined,
+    documentationLink: 'http:://nextjs.org/docs',
+    stage: 'resolve',
+  }
+
+  it('formats a single import trace', () => {
+    const trace: PlainTraceItem[] = [
+      traceItem('src/app/page.ts', 'client'),
+      traceItem('src/lib/foo.ts', 'client'),
+    ]
+    const issue: Issue = {
+      ...baseIssue,
+      importTraces: [trace],
+    }
+    const output = formatIssue(issue)
+    expect(output).toBe(`\
+./src/app/page.ts
+Module not found
+Import trace [client]:
+  ./src/app/page.ts
+  ./src/lib/foo.ts
+
+https://nextjs.org/docs/messages/module-not-found
+
+`)
+  })
+
+  it('formats multiple import traces with distinct layers', () => {
+    const trace1: PlainTraceItem[] = [
+      traceItem('src/app/page.ts', 'client'),
+      traceItem('src/lib/foo.ts', 'client'),
+    ]
+    const trace2: PlainTraceItem[] = [
+      traceItem('src/app/page.ts', 'server'),
+      traceItem('src/lib/foo.ts', 'server'),
+    ]
+    const issue: Issue = {
+      ...baseIssue,
+      importTraces: [trace1, trace2],
+    }
+    const output = formatIssue(issue)
+    expect(output).toBe(`\
+./src/app/page.ts
+Module not found
+Import traces:
+  client:
+    ./src/app/page.ts
+    ./src/lib/foo.ts
+
+  server:
+    ./src/app/page.ts
+    ./src/lib/foo.ts
+
+https://nextjs.org/docs/messages/module-not-found
+
+`)
+  })
+
+  it('formats multiple import traces with identical layers', () => {
+    const trace1: PlainTraceItem[] = [
+      traceItem('src/app/page.ts', 'client'),
+      traceItem('src/lib/foo.ts', 'client'),
+    ]
+    const trace2: PlainTraceItem[] = [
+      traceItem('src/app/other.ts', 'client'),
+      traceItem('src/lib/bar.ts', 'client'),
+    ]
+    const issue: Issue = {
+      ...baseIssue,
+      importTraces: [trace1, trace2],
+    }
+    const output = formatIssue(issue)
+    expect(output).toBe(`\
+./src/app/page.ts
+Module not found
+Import traces:
+  #1 [client]:
+    ./src/app/page.ts
+    ./src/lib/foo.ts
+
+  #2 [client]:
+    ./src/app/other.ts
+    ./src/lib/bar.ts
+
+https://nextjs.org/docs/messages/module-not-found
+
+`)
+  })
+
+  it('handles missing layers in traces', () => {
+    const trace: PlainTraceItem[] = [
+      traceItem('src/app/page.ts'),
+      traceItem('src/lib/foo.ts'),
+    ]
+    const issue: Issue = {
+      ...baseIssue,
+      importTraces: [trace],
+    }
+    const output = formatIssue(issue)
+    expect(output).toContain('Import trace:')
+    expect(output).toContain('./src/app/page.ts')
+    expect(output).toContain('./src/lib/foo.ts')
+  })
+})

--- a/packages/next/src/shared/lib/turbopack/utils.test.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.test.ts
@@ -121,8 +121,15 @@ https://nextjs.org/docs/messages/module-not-found
       importTraces: [trace],
     }
     const output = formatIssue(issue)
-    expect(output).toContain('Import trace:')
-    expect(output).toContain('./src/app/page.ts')
-    expect(output).toContain('./src/lib/foo.ts')
+    expect(output).toBe(`\
+./src/app/page.ts
+Module not found
+Import trace:
+  ./src/app/page.ts
+  ./src/lib/foo.ts
+
+https://nextjs.org/docs/messages/module-not-found
+
+`)
   })
 })

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -185,34 +185,37 @@ export function formatIssue(issue: Issue) {
 
   if (importTraces?.length) {
     // This is the same logic as in turbopack/crates/turbopack-cli-utils/src/issue.rs
-    if (importTraces.length === 1) {
-      const trace = importTraces[0]
-      // We only display the layer if there is more than one for the trace
+    // We end up with multiple traces when the file with the error is reachable from multiple
+    // different entry points (e.g. ssr, client)
+    message += `Import trace${importTraces.length > 1 ? 's' : ''}:\n`
+    const everyTraceHasADistinctRootLayer =
+      new Set(importTraces.map(leafLayerName).filter((l) => l != null)).size ===
+      importTraces.length
+    for (let i = 0; i < importTraces.length; i++) {
+      const trace = importTraces[i]
       const layer = leafLayerName(trace)
-      message += `Import trace${layer != null ? ` [${layer}]` : ''}:\n${formatIssueTrace(trace, '  ', !identicalLayers(trace))}`
-    } else {
-      // We end up with multiple traces when the file with the error is reachable from multiple
-      // different entry points (e.g. ssr, client)
-      message += 'Import traces:\n'
-      const everyTraceHasADistinctRootLayer =
-        new Set(importTraces.map(leafLayerName).filter((l) => l != null))
-          .size === importTraces.length
-      for (let i = 0; i < importTraces.length; i++) {
-        const trace = importTraces[i]
-        const layer = leafLayerName(trace)
-        // If this is true, layer must be present
-        if (everyTraceHasADistinctRootLayer) {
-          message += `  ${layer}:\n`
-        } else {
+      let traceIndent = '    '
+      // If this is true, layer must be present
+      if (everyTraceHasADistinctRootLayer) {
+        message += `  ${layer}:\n`
+      } else {
+        if (importTraces.length > 1) {
           // Otherwise use simple 1 based indices to disambiguate
           message += `  #${i + 1}`
           if (layer) {
             message += ` [${layer}]`
           }
           message += ':\n'
+        } else {
+          if (layer) {
+            message += ` [${layer}]:\n`
+          } else {
+            // If there is a single trace and no layer name just don't indent it.
+            traceIndent = '  '
+          }
         }
-        message += formatIssueTrace(trace, '    ', !identicalLayers(trace))
       }
+      message += formatIssueTrace(trace, traceIndent, !identicalLayers(trace))
     }
   }
   if (documentationLink) {

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -200,7 +200,7 @@ export function formatIssue(issue: Issue) {
       for (let i = 0; i < importTraces.length; i++) {
         const trace = importTraces[i]
         const layer = leafLayerName(trace)
-        // If this is true, layer must be be present
+        // If this is true, layer must be present
         if (everyTraceHasADistinctRootLayer) {
           message += `  ${layer}:\n`
         } else {

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -188,7 +188,8 @@ export function formatIssue(issue: Issue) {
     if (importTraces.length === 1) {
       const trace = importTraces[0]
       // We only display the layer if there is more than one for the trace
-      message += `Import trace:\n${formatIssueTrace(trace, '  ', !identicalLayers(trace))}`
+      const layer = leafLayerName(trace)
+      message += `Import trace${layer != null ? ` [${layer}]` : ''}:\n${formatIssueTrace(trace, '  ', !identicalLayers(trace))}`
     } else {
       // We end up with multiple traces when the file with the error is reachable from multiple
       // different entry points (e.g. ssr, client)
@@ -199,9 +200,11 @@ export function formatIssue(issue: Issue) {
       for (let i = 0; i < importTraces.length; i++) {
         const trace = importTraces[i]
         const layer = leafLayerName(trace)
+        // If this is true, layer must be be present
         if (everyTraceHasADistinctRootLayer) {
           message += `  ${layer}:\n`
         } else {
+          // Otherwise use simple 1 based indices to disambiguate
           message += `  #${i + 1}`
           if (layer) {
             message += ` [${layer}]`
@@ -249,24 +252,22 @@ function formatIssueTrace(
   indent: string,
   printLayers: boolean
 ): string {
-  return (
-    items
-      .map((item) => {
-        let r = indent
-        if (item.fsName !== 'project') {
-          r += `[${item.fsName}]/`
-        } else {
-          // This is consistent with webpack's output
-          r += './'
-        }
-        r += item.path
-        if (printLayers && item.layer) {
-          r += ` [${item.layer}]`
-        }
-        return r
-      })
-      .join('\n') + '\n\n'
-  )
+  return `${items
+    .map((item) => {
+      let r = indent
+      if (item.fsName !== 'project') {
+        r += `[${item.fsName}]/`
+      } else {
+        // This is consistent with webpack's output
+        r += './'
+      }
+      r += item.path
+      if (printLayers && item.layer) {
+        r += ` [${item.layer}]`
+      }
+      return r
+    })
+    .join('\n')}\n\n`
 }
 
 export function isRelevantWarning(issue: Issue): boolean {

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -206,13 +206,11 @@ export function formatIssue(issue: Issue) {
             message += ` [${layer}]`
           }
           message += ':\n'
+        } else if (layer) {
+          message += ` [${layer}]:\n`
         } else {
-          if (layer) {
-            message += ` [${layer}]:\n`
-          } else {
-            // If there is a single trace and no layer name just don't indent it.
-            traceIndent = '  '
-          }
+          // If there is a single trace and no layer name just don't indent it.
+          traceIndent = '  '
         }
       }
       message += formatIssueTrace(trace, traceIndent, !identicalLayers(trace))

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -186,9 +186,10 @@ describe('Error overlay - RSC build errors', () => {
        You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
        Learn more: https://nextjs.org/docs/app/building-your-application/rendering
 
-       Import trace [Server Component]:
-         ./app/server-with-errors/client-only-in-server/client-only-lib.js
-         ./app/server-with-errors/client-only-in-server/page.js"
+       Import trace:
+         Server Component:
+           ./app/server-with-errors/client-only-in-server/client-only-lib.js
+           ./app/server-with-errors/client-only-in-server/page.js"
       `)
     } else {
       expect(await session.getRedboxSource()).toInclude(

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -186,7 +186,7 @@ describe('Error overlay - RSC build errors', () => {
        You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
        Learn more: https://nextjs.org/docs/app/building-your-application/rendering
 
-       Import trace:
+       Import trace [Server Component]:
          ./app/server-with-errors/client-only-in-server/client-only-lib.js
          ./app/server-with-errors/client-only-in-server/page.js"
       `)

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -38,7 +38,7 @@ describe('app dir - css', () => {
 
            Pseudo-elements like '::before' or '::after' can't be followed by selectors like 'Ident("path")' at [project]/app/global.scss.css:0:884
 
-           Import trace:
+           Import trace [Client Component Browser]:
              ./app/global.scss.css [Client Component Browser]
              ./app/layout.js [Client Component Browser]
              ./app/layout.js [Server Component]"

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -38,10 +38,11 @@ describe('app dir - css', () => {
 
            Pseudo-elements like '::before' or '::after' can't be followed by selectors like 'Ident("path")' at [project]/app/global.scss.css:0:884
 
-           Import trace [Client Component Browser]:
-             ./app/global.scss.css [Client Component Browser]
-             ./app/layout.js [Client Component Browser]
-             ./app/layout.js [Server Component]"
+           Import trace:
+             Client Component Browser:
+               ./app/global.scss.css [Client Component Browser]
+               ./app/layout.js [Client Component Browser]
+               ./app/layout.js [Server Component]"
           `)
         })
       }

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -247,20 +247,19 @@ pub fn format_issue(
             let mut trace_indent = "    ";
             if every_trace_has_a_distinct_root_layer {
                 writeln!(styled_issue, "  {}:", layer.unwrap()).unwrap();
-            } else {
-                if traces.len() > 1 {
-                    write!(styled_issue, "  #{}", index + 1).unwrap();
-                    if let Some(layer) = layer {
-                        write!(styled_issue, " [{layer}]").unwrap();
-                    }
-                    writeln!(styled_issue, ":").unwrap();
-                } else if let Some(layer) = layer {
+            } else if traces.len() > 1 {
+                write!(styled_issue, "  #{}", index + 1).unwrap();
+                if let Some(layer) = layer {
                     write!(styled_issue, " [{layer}]").unwrap();
-                } else {
-                    // There is one trace and no layer (!?) just indent once
-                    trace_indent = "  ";
                 }
+                writeln!(styled_issue, ":").unwrap();
+            } else if let Some(layer) = layer {
+                write!(styled_issue, " [{layer}]").unwrap();
+            } else {
+                // There is one trace and no layer (!?) just indent once
+                trace_indent = "  ";
             }
+
             format_trace_items(
                 &mut styled_issue,
                 trace_indent,

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -254,12 +254,10 @@ pub fn format_issue(
                         write!(styled_issue, " [{layer}]").unwrap();
                     }
                     writeln!(styled_issue, ":").unwrap();
+                } else if let Some(layer) = layer {
+                    write!(styled_issue, " [{layer}]").unwrap();
                 } else {
-                    if let Some(layer) = layer {
-                        write!(styled_issue, " [{layer}]").unwrap();
-                    } else {
-                        trace_indent = "  ";
-                    }
+                    trace_indent = "  ";
                 }
                 format_trace_items(
                     &mut styled_issue,

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -257,7 +257,7 @@ pub fn format_issue(
                 } else if let Some(layer) = layer {
                     write!(styled_issue, " [{layer}]").unwrap();
                 } else {
-                    // There is one trace and no layer (!?)
+                    // There is one trace and no layer (!?) just indent once
                     trace_indent = "  ";
                 }
             }

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -257,15 +257,16 @@ pub fn format_issue(
                 } else if let Some(layer) = layer {
                     write!(styled_issue, " [{layer}]").unwrap();
                 } else {
+                    // There is one trace and no layer (!?)
                     trace_indent = "  ";
                 }
-                format_trace_items(
-                    &mut styled_issue,
-                    trace_indent,
-                    !are_layers_identical(trace),
-                    trace,
-                );
             }
+            format_trace_items(
+                &mut styled_issue,
+                trace_indent,
+                !are_layers_identical(trace),
+                trace,
+            );
         }
     }
 

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -226,52 +226,47 @@ pub fn format_issue(
                 out.push('\n');
             }
         }
-        if traces.len() == 1 {
-            let trace = &traces[0];
-            match leaf_layer_name(trace) {
-                Some(layer) => {
-                    writeln!(styled_issue, "Import trace [{layer}]:").unwrap();
-                }
-                None => {
-                    writeln!(styled_issue, "Import trace:").unwrap();
-                }
-            }
-            format_trace_items(&mut styled_issue, "  ", !are_layers_identical(trace), trace);
-        } else {
-            // When there are multiple traces we:
-            // * display the layer in the header if the trace has a consistent layer
-            // * label the traces with their index, unless the layer is sufficiently unique.
-            styled_issue.push_str("Import traces:\n");
-            let every_trace_has_a_distinct_root_layer = traces
-                .iter()
-                .filter_map(|t| leaf_layer_name(t))
-                .collect::<FxHashSet<RcStr>>()
-                .len()
-                == traces.len();
+
+        // For each trace we:
+        // * display the layer in the header if the trace has a consistent layer
+        // * label the traces with their index, unless the layer is sufficiently unique.
+        writeln!(
+            styled_issue,
+            "Import trace{}:",
+            if traces.len() > 1 { "s" } else { "" }
+        )
+        .unwrap();
+        let every_trace_has_a_distinct_root_layer = traces
+            .iter()
+            .filter_map(|t| leaf_layer_name(t))
+            .collect::<FxHashSet<RcStr>>()
+            .len()
+            == traces.len();
+        for (index, trace) in traces.iter().enumerate() {
+            let layer = leaf_layer_name(trace);
+            let mut trace_indent = "    ";
             if every_trace_has_a_distinct_root_layer {
-                for trace in traces {
-                    writeln!(styled_issue, "  {}:", leaf_layer_name(trace).unwrap()).unwrap();
-                    format_trace_items(&mut styled_issue, "    ", false, trace);
-                }
+                writeln!(styled_issue, "  {}:", layer.unwrap()).unwrap();
             } else {
-                for (index, trace) in traces.iter().enumerate() {
-                    let printed_layer = match leaf_layer_name(trace) {
-                        Some(layer) => {
-                            writeln!(styled_issue, "  #{} [{layer}]:", index + 1).unwrap();
-                            false
-                        }
-                        None => {
-                            writeln!(styled_issue, "  #{}:", index + 1).unwrap();
-                            true
-                        }
-                    };
-                    format_trace_items(
-                        &mut styled_issue,
-                        "    ",
-                        !printed_layer || !are_layers_identical(trace),
-                        trace,
-                    );
+                if traces.len() > 1 {
+                    write!(styled_issue, "  #{}", index + 1).unwrap();
+                    if let Some(layer) = layer {
+                        write!(styled_issue, " [{layer}]").unwrap();
+                    }
+                    writeln!(styled_issue, ":").unwrap();
+                } else {
+                    if let Some(layer) = layer {
+                        write!(styled_issue, " [{layer}]").unwrap();
+                    } else {
+                        trace_indent = "  ";
+                    }
                 }
+                format_trace_items(
+                    &mut styled_issue,
+                    trace_indent,
+                    !are_layers_identical(trace),
+                    trace,
+                );
             }
         }
     }

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -228,10 +228,14 @@ pub fn format_issue(
         }
         if traces.len() == 1 {
             let trace = &traces[0];
-            // We don't put the layer in the header for the single case. Either they are all the
-            // same in which case it should be clear from the filename or they are different and we
-            // need to print them on the items anyway.
-            writeln!(styled_issue, "Import trace:").unwrap();
+            match leaf_layer_name(trace) {
+                Some(layer) => {
+                    writeln!(styled_issue, "Import trace [{layer}:").unwrap();
+                }
+                None => {
+                    writeln!(styled_issue, "Import trace:").unwrap();
+                }
+            }
             format_trace_items(&mut styled_issue, "  ", !are_layers_identical(trace), trace);
         } else {
             // When there are multiple traces we:

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -230,7 +230,7 @@ pub fn format_issue(
             let trace = &traces[0];
             match leaf_layer_name(trace) {
                 Some(layer) => {
-                    writeln!(styled_issue, "Import trace [{layer}:").unwrap();
+                    writeln!(styled_issue, "Import trace [{layer}]:").unwrap();
                 }
                 None => {
                     writeln!(styled_issue, "Import trace:").unwrap();

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/tla.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/tla.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
@@ -5,3 +5,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/tla.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-118256.txt
@@ -3,7 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/tla.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
@@ -5,6 +5,6 @@ error - [load] /turbopack/crates/turbopack-tests/tests/execution/turbopack/basic
   Caused by:
   - invalid utf-8 sequence of 1 bytes from index 1
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
@@ -5,6 +5,5 @@ error - [load] /turbopack/crates/turbopack-tests/tests/execution/turbopack/basic
   Caused by:
   - invalid utf-8 sequence of 1 bytes from index 1
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
@@ -7,3 +7,5 @@ error - [load] /turbopack/crates/turbopack-tests/tests/execution/turbopack/basic
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-18c792.txt
@@ -5,6 +5,6 @@ error - [load] /turbopack/crates/turbopack-tests/tests/execution/turbopack/basic
   Caused by:
   - invalid utf-8 sequence of 1 bytes from index 1
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
@@ -4,7 +4,7 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/b
   The module was automatically converted to an EcmaScript module, but that is in conflict with the specified module format. Either change the "type" field in the package.json or replace EcmaScript import/export syntax with CommonJs syntas in the source file.
   In some cases EcmaScript import/export syntax is added by an transform and isn't actually part of the source code. In these cases revisit transformation options to inject the correct syntax.
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.cjs
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
@@ -4,7 +4,5 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/b
   The module was automatically converted to an EcmaScript module, but that is in conflict with the specified module format. Either change the "type" field in the package.json or replace EcmaScript import/export syntax with CommonJs syntas in the source file.
   In some cases EcmaScript import/export syntax is added by an transform and isn't actually part of the source code. In these cases revisit transformation options to inject the correct syntax.
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.cjs
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
@@ -4,7 +4,7 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/b
   The module was automatically converted to an EcmaScript module, but that is in conflict with the specified module format. Either change the "type" field in the package.json or replace EcmaScript import/export syntax with CommonJs syntas in the source file.
   In some cases EcmaScript import/export syntax is added by an transform and isn't actually part of the source code. In these cases revisit transformation options to inject the correct syntax.
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.cjs
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-267718.txt
@@ -6,3 +6,6 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/b
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.cjs
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.
   Exports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the "type" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.
   Exports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the "type" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
@@ -5,3 +5,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-1a0fe8.txt
@@ -3,7 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.
   Exports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the "type" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/index.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
@@ -11,6 +11,6 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
@@ -13,3 +13,5 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
@@ -11,6 +11,6 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-01c974.txt
@@ -11,6 +11,5 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
@@ -11,7 +11,7 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/b.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
@@ -11,7 +11,7 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/b.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
@@ -11,7 +11,5 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/b.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/issues/__l_Export __c_a__ is a circular re-export__-1122f4.txt
@@ -13,3 +13,6 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/c
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/b.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/a.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/cycle/reexport-cycle/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
@@ -9,3 +9,6 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/broken.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/index.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
@@ -7,7 +7,7 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   
   Unexpected eof
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/broken.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
@@ -7,7 +7,7 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   
   Unexpected eof
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/broken.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Parsing ecmascript source code failed-2cef13.txt
@@ -7,7 +7,5 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   
   Unexpected eof
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/broken.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/index.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
@@ -18,6 +18,6 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   | These are the exports of the module:
   | Abd, Eef, a, b, c
   | 
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/invalid-export/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
@@ -18,6 +18,6 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   | These are the exports of the module:
   | Abd, Eef, a, b, c
   | 
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/invalid-export/index.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
@@ -20,3 +20,5 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   | 
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/invalid-export/index.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-2cf4be.txt
@@ -18,6 +18,5 @@ error - [bindings] /turbopack/crates/turbopack-tests/tests/execution/turbopack/e
   | These are the exports of the module:
   | Abd, Eef, a, b, c
   | 
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/invalid-export/index.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/a.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/a.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
@@ -3,7 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/a.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/a.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-bffb6d.txt
@@ -5,3 +5,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/a.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/b.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/b.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
@@ -5,3 +5,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/b.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/b.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/b.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
     ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/issues/unexpected export __star__-e62f85.txt
@@ -3,7 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/b.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/b.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/reexport.js
-    ./turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reexport-dynamic-cjs/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
@@ -3,7 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/webpack/s
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/a.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/a.js
-    ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/c.js
-    ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
@@ -5,3 +5,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/webpack/s
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/a.js
+      ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/c.js
+      ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/webpack/s
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/a.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/c.js
     ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/issues/unexpected export __star__-6bd305.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/webpack/s
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/a.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/a.js
     ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/c.js
     ./turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/reexport-star-external-cjs/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
@@ -3,6 +3,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/comptime/t
   The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.
   Exports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the "type" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs
     ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
@@ -5,3 +5,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/comptime/t
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs
+      ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
@@ -3,6 +3,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/comptime/t
   The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.
   Exports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the "type" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs
     ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/issues/Specified module format (EcmaScript Modules) is no-729334.txt
@@ -3,6 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/comptime/t
   The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.
   Exports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the "type" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/esm-specified.mjs
-    ./turbopack/crates/turbopack-tests/tests/snapshot/comptime/typeof/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
@@ -5,3 +5,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js
+      ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js
+      ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js
+      ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
@@ -3,8 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js
-    ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js
-    ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js
-    ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-2d66af.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/b.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
@@ -5,3 +5,6 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs
+      ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js
+      ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
@@ -3,7 +3,5 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs
-    ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js
-    ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-feb633.txt
@@ -3,7 +3,7 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/export-all
   export * used with module [project]/turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs [test] (ecmascript) which is a CommonJS module with exports only available at runtime
   List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/mod.js
     ./turbopack/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
@@ -19,6 +19,5 @@ error - [code gen] /turbopack/crates/turbopack-tests/tests/snapshot/imports/json
          4 |   }
          5 | }
   
-  Import trace [test]:
-    ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json
-    ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js
+  Import trace:
+    test:

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
@@ -19,6 +19,6 @@ error - [code gen] /turbopack/crates/turbopack-tests/tests/snapshot/imports/json
          4 |   }
          5 | }
   
-  Import trace [test:
+  Import trace [test]:
     ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json
     ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
@@ -19,6 +19,6 @@ error - [code gen] /turbopack/crates/turbopack-tests/tests/snapshot/imports/json
          4 |   }
          5 | }
   
-  Import trace:
+  Import trace [test:
     ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json
     ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-fc1795.txt
@@ -21,3 +21,5 @@ error - [code gen] /turbopack/crates/turbopack-tests/tests/snapshot/imports/json
   
   Import trace:
     test:
+      ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json
+      ./turbopack/crates/turbopack-tests/tests/snapshot/imports/json/input/index.js


### PR DESCRIPTION
## Always format layer names in import trace headers

Previously if there was a single import trace where all items were in a single layer we wouldn't display the layer.  With this we always put the layer in the trace 'header' for a single trace just like we do when there are multiple traces (unless there are no layers which is really just a theoretical possibility).

### Why?

The concern was really about consistency

Tim was [confused](https://vercel.slack.com/archives/C03KAR5DCKC/p1752584756904199?thread_ts=1749510128.195809&cid=C03KAR5DCKC) why the layer headers showed up sometimes but not others.  Obviously when there are multiple traces, the layers are a critical distinguishing factor, when there is a single one we might suspect it is obvious, but inferring the layer of a file isn't always and by consistently formatting traces the same way we can ease readability.

Also add some unit tests to speed up iteration on this formatting.

Closes PACK-5112