### PR TITLE
fix: always strip search params from prerenders

### DIFF
--- a/packages/next/src/lib/url.ts
+++ b/packages/next/src/lib/url.ts
@@ -52,3 +52,8 @@ export function stripNextRscUnionQuery(relativeUrl: string): string {
 
   return urlInstance.pathname + urlInstance.search
 }
+
+export function stripSearchParamsFromReqUrl(rawUrl: string): string {
+  const parsedUrl = parseReqUrl(rawUrl)!
+  return `${parsedUrl.pathname}${parsedUrl.hash}`
+}

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
@@ -33,6 +33,21 @@ export default function SearchParamsPage() {
             searchParam=d_full, prefetch=true
           </LinkAccordion>
         </li>
+        <li>
+          with route param
+          <ul>
+            <li>
+              <LinkAccordion href="/search-params/target-page/one?searchParam=e_PPR">
+                param=one, searchParam=e_PPR
+              </LinkAccordion>
+            </li>
+            <li>
+              <LinkAccordion href="/search-params/target-page/one?searchParam=f_PPR">
+                param=one, searchParam=f_PPR
+              </LinkAccordion>
+            </li>
+          </ul>
+        </li>
       </ul>
     </>
   )

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/[param]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/[param]/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+
+async function SearchParam({ searchParams }) {
+  const { searchParam } = await searchParams
+  return `Search param: ${searchParam}`
+}
+
+async function Param({ params }) {
+  const { param } = await params
+  return `Param: ${param}`
+}
+
+export default async function Target({ params, searchParams }) {
+  return (
+    <>
+      <Suspense fallback="Loading...">
+        <div id="target-page-with-param">
+          <Param params={params} />
+        </div>
+      </Suspense>
+      <Suspense fallback="Loading...">
+        <div id="target-page-with-search-param">
+          <SearchParam searchParams={searchParams} />
+        </div>
+      </Suspense>
+    </>
+  )
+}


### PR DESCRIPTION
if we're prerendering a page `/foo/[lang]` at runtime because of a request with search params `/foo/en?abc=123`, we need to make sure that the search params don't end up in the canonicalUrl and flight router state that we put in the, (and, by extension, any segment prefetch files generated based on them). this PR fixes this problem by stripping the query before going into `renderToHtmlOrFlight`

(this only seems to happen in `next start` and not on vercel, i'm assuming that prerender-related infra already handles the stripping)