### PR TITLE
chore: update username from 'nebrelbug' to 'bgub'

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -59,7 +59,7 @@
       { "type": "user", "pattern": "ijjk" },
       { "type": "user", "pattern": "lazarv" },
       { "type": "user", "pattern": "lubieowoce" },
-      { "type": "user", "pattern": "nebrelbug" },
+      { "type": "user", "pattern": "bgub" },
       { "type": "user", "pattern": "RobPruzan" },
       { "type": "user", "pattern": "samcx" },
       { "type": "user", "pattern": "sebmarkbage" },


### PR DESCRIPTION
## Update GitHub username in labeler configuration

I just changed my username from "nebrelbug" to "bgub"