### PR TITLE
fix: revert client segment route changes for sub shell generation

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3103,18 +3103,44 @@ export default async function build(
                 }
 
                 let prefetchDataRoute: string | undefined
+                let dynamicRoute = routesManifest.dynamicRoutes.find(
+                  (r) => r.page === route.pathname
+                )
                 if (!isAppRouteHandler && isAppPPREnabled) {
                   prefetchDataRoute = path.posix.join(
                     `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
                   )
+
+                  // If the dynamic route wasn't found, then we need to create
+                  // it. This ensures that for each fallback shell there's an
+                  // entry in the app routes manifest which enables routing for
+                  // this fallback shell.
+                  if (!dynamicRoute) {
+                    dynamicRoute = pageToRoute(route.pathname)
+
+                    // This route is not for the internal router, but instead
+                    // for external routers.
+                    dynamicRoute.skipInternalRouting = true
+
+                    // Push this to the end of the array. The dynamic routes are
+                    // sorted by page later.
+                    routesManifest.dynamicRoutes.push(dynamicRoute)
+                  }
                 }
 
                 if (!isAppRouteHandler && metadata?.segmentPaths) {
-                  const dynamicRoute = routesManifest.dynamicRoutes.find(
-                    (r) => r.page === page
-                  )
+                  // If PPR isn't enabled, then we might not find the dynamic
+                  // route by pathname. If that's the case, we need to find the
+                  // route by page.
                   if (!dynamicRoute) {
-                    throw new InvariantError('Dynamic route not found')
+                    dynamicRoute = routesManifest.dynamicRoutes.find(
+                      (r) => r.page === page
+                    )
+
+                    // If it can't be found by page, we must throw an error.
+                    if (!dynamicRoute) {
+                      throw new InvariantError('Dynamic route not found')
+                    }
                   }
 
                   dynamicRoute.prefetchSegmentDataRoutes ??= []

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -81,11 +81,7 @@ import {
   DYNAMIC_CSS_MANIFEST,
   TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST,
 } from '../shared/lib/constants'
-import {
-  getSortedRoutes,
-  isDynamicRoute,
-  getSortedRouteObjects,
-} from '../shared/lib/router/utils'
+import { isDynamicRoute } from '../shared/lib/router/utils'
 import type { __ApiPreviewProps } from '../server/api-utils'
 import loadConfig from '../server/config'
 import type { BuildManifest } from '../server/get-page-files'
@@ -210,6 +206,11 @@ import { extractNextErrorCode } from '../lib/error-telemetry-utils'
 import { runAfterProductionCompile } from './after-production-compile'
 import { generatePreviewKeys } from './preview-key-utils'
 import { handleBuildComplete } from './adapter/build-complete'
+import {
+  sortPageObjects,
+  sortPages,
+  sortSortableRouteObjects,
+} from '../shared/lib/router/utils/sortable-routes'
 
 type Fallback = null | boolean | string
 
@@ -430,7 +431,7 @@ export type RoutesManifest = {
   }
   headers: Array<ManifestHeaderRoute>
   staticRoutes: Array<ManifestRoute>
-  dynamicRoutes: Array<ManifestRoute>
+  dynamicRoutes: ReadonlyArray<ManifestRoute>
   dataRoutes: Array<ManifestDataRoute>
   i18n?: {
     domains?: ReadonlyArray<{
@@ -1328,14 +1329,20 @@ export default async function build(
       const isAppPPREnabled = checkIsAppPPREnabled(config.experimental.ppr)
 
       const routesManifestPath = path.join(distDir, ROUTES_MANIFEST)
+      const dynamicRoutes: Array<ManifestRoute> = []
+
+      /**
+       * A map of all the pages to their sourcePage value. This is only used for
+       * routes that have PPR enabled and clientSegmentEnabled is true.
+       */
+      const sourcePages = new Map<string, string>()
       const routesManifest: RoutesManifest = nextBuildSpan
         .traceChild('generate-routes-manifest')
         .traceFn(() => {
-          const sortedRoutes = getSortedRoutes([
+          const sortedRoutes = sortPages([
             ...pageKeys.pages,
             ...(pageKeys.app ?? []),
           ])
-          const dynamicRoutes: Array<ManifestRoute> = []
           const staticRoutes: Array<ManifestRoute> = []
 
           for (const route of sortedRoutes) {
@@ -2466,7 +2473,7 @@ export default async function build(
       if (serverPropsPages.size > 0 || ssgPages.size > 0) {
         // We update the routes manifest after the build with the
         // data routes since we can't determine these until after build
-        routesManifest.dataRoutes = getSortedRoutes([
+        routesManifest.dataRoutes = sortPages([
           ...serverPropsPages,
           ...ssgPages,
         ]).map((page) => {
@@ -2930,39 +2937,39 @@ export default async function build(
             // route), any routes that were generated with unknown route params
             // should be collected and included in the dynamic routes part
             // of the manifest instead.
-            const routes: PrerenderedRoute[] = []
-            const dynamicRoutes: PrerenderedRoute[] = []
+            const staticPrerenderedRoutes: PrerenderedRoute[] = []
+            const dynamicPrerenderedRoutes: PrerenderedRoute[] = []
 
             // Sort the outputted routes to ensure consistent output. Any route
             // though that has unknown route params will be pulled and sorted
             // independently. This is because the routes with unknown route
             // params will contain the dynamic path parameters, some of which
             // may conflict with the actual prerendered routes.
-            let unknownPrerenderRoutes: PrerenderedRoute[] = []
-            let knownPrerenderRoutes: PrerenderedRoute[] = []
+            const unsortedUnknownPrerenderRoutes: PrerenderedRoute[] = []
+            const unsortedKnownPrerenderRoutes: PrerenderedRoute[] = []
             for (const prerenderedRoute of prerenderedRoutes) {
               if (
                 prerenderedRoute.fallbackRouteParams &&
                 prerenderedRoute.fallbackRouteParams.length > 0
               ) {
-                unknownPrerenderRoutes.push(prerenderedRoute)
+                unsortedUnknownPrerenderRoutes.push(prerenderedRoute)
               } else {
-                knownPrerenderRoutes.push(prerenderedRoute)
+                unsortedKnownPrerenderRoutes.push(prerenderedRoute)
               }
             }
 
-            unknownPrerenderRoutes = getSortedRouteObjects(
-              unknownPrerenderRoutes,
+            const sortedUnknownPrerenderRoutes = sortPageObjects(
+              unsortedUnknownPrerenderRoutes,
               (prerenderedRoute) => prerenderedRoute.pathname
             )
-            knownPrerenderRoutes = getSortedRouteObjects(
-              knownPrerenderRoutes,
+            const sortedKnownPrerenderRoutes = sortPageObjects(
+              unsortedKnownPrerenderRoutes,
               (prerenderedRoute) => prerenderedRoute.pathname
             )
 
             prerenderedRoutes = [
-              ...knownPrerenderRoutes,
-              ...unknownPrerenderRoutes,
+              ...sortedKnownPrerenderRoutes,
+              ...sortedUnknownPrerenderRoutes,
             ]
 
             for (const prerenderedRoute of prerenderedRoutes) {
@@ -2979,16 +2986,16 @@ export default async function build(
               ) {
                 // If the route has unknown params, then we need to add it to
                 // the list of dynamic routes.
-                dynamicRoutes.push(prerenderedRoute)
+                dynamicPrerenderedRoutes.push(prerenderedRoute)
               } else {
                 // If the route doesn't have unknown params, then we need to
-                // add it to the list of routes.
-                routes.push(prerenderedRoute)
+                // add it to the list of static routes.
+                staticPrerenderedRoutes.push(prerenderedRoute)
               }
             }
 
             // Handle all the static routes.
-            for (const route of routes) {
+            for (const route of staticPrerenderedRoutes) {
               if (isDynamicRoute(page) && route.pathname === page) continue
               if (route.pathname === UNDERSCORE_NOT_FOUND_ROUTE) continue
 
@@ -3075,7 +3082,7 @@ export default async function build(
               // they are enabled, then it'll already be included in the
               // prerendered routes.
               if (!isRoutePPREnabled) {
-                dynamicRoutes.push({
+                dynamicPrerenderedRoutes.push({
                   params: {},
                   pathname: page,
                   encodedPathname: page,
@@ -3088,7 +3095,7 @@ export default async function build(
                 })
               }
 
-              for (const route of dynamicRoutes) {
+              for (const route of dynamicPrerenderedRoutes) {
                 const normalizedRoute = normalizePagePath(route.pathname)
 
                 const metadata = exportResult.byPath.get(
@@ -3117,6 +3124,7 @@ export default async function build(
                   // this fallback shell.
                   if (!dynamicRoute) {
                     dynamicRoute = pageToRoute(route.pathname)
+                    sourcePages.set(route.pathname, page)
 
                     // This route is not for the internal router, but instead
                     // for external routers.
@@ -3124,7 +3132,7 @@ export default async function build(
 
                     // Push this to the end of the array. The dynamic routes are
                     // sorted by page later.
-                    routesManifest.dynamicRoutes.push(dynamicRoute)
+                    dynamicRoutes.push(dynamicRoute)
                   }
                 }
 
@@ -3133,9 +3141,7 @@ export default async function build(
                   // route by pathname. If that's the case, we need to find the
                   // route by page.
                   if (!dynamicRoute) {
-                    dynamicRoute = routesManifest.dynamicRoutes.find(
-                      (r) => r.page === page
-                    )
+                    dynamicRoute = dynamicRoutes.find((r) => r.page === page)
 
                     // If it can't be found by page, we must throw an error.
                     if (!dynamicRoute) {
@@ -3599,11 +3605,16 @@ export default async function build(
           }
         })
 
-        // As we may have modified the routesManifest.dynamicRoutes, we need to
-        // sort the dynamic routes by page.
-        routesManifest.dynamicRoutes = getSortedRouteObjects(
-          routesManifest.dynamicRoutes,
-          (route) => route.page
+        // As we may have modified the dynamicRoutes, we need to sort the
+        // dynamic routes by page.
+        routesManifest.dynamicRoutes = sortSortableRouteObjects(
+          dynamicRoutes,
+          (route) => ({
+            // If the route is PPR enabled, and has an associated source page,
+            // use it. Otherwise fallback to the page which should be the same.
+            sourcePage: sourcePages.get(route.page) ?? route.page,
+            page: route.page,
+          })
         )
 
         // Now write the routes manifest out.

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -18,6 +18,7 @@ import type {
   ManifestHeaderRoute,
   ManifestRedirectRoute,
   RouteType,
+  ManifestRoute,
 } from '../build'
 import { isStableBuild } from '../shared/lib/canary-only'
 
@@ -63,7 +64,7 @@ export interface NextAdapter {
         afterFiles: Array<ManifestRewriteRoute>
         fallback: Array<ManifestRewriteRoute>
       }
-      dynamicRoutes: Array<{}>
+      dynamicRoutes: ReadonlyArray<ManifestRoute>
     }
     outputs: AdapterOutputs
   }) => Promise<void> | void

--- a/packages/next/src/shared/lib/router/utils/sortable-routes.test.ts
+++ b/packages/next/src/shared/lib/router/utils/sortable-routes.test.ts
@@ -1,0 +1,1014 @@
+import {
+  sortSortableRoutes,
+  sortSortableRouteObjects,
+  sortPageObjects,
+  sortPages,
+  getSegmentSpecificity,
+  compareRouteSegments,
+  type SortableRoute,
+} from './sortable-routes'
+
+describe('sortSortableRoutes', () => {
+  it('should sort routes by page', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+        page: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+      },
+      {
+        sourcePage: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+        page: '/en/[teamSlug]/[projectSlug]/monitoring',
+      },
+      {
+        sourcePage: '/[lang]/[teamSlug]/~/monitoring',
+        page: '/[lang]/[teamSlug]/~/monitoring',
+      },
+      {
+        sourcePage: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+        page: '/fr/[teamSlug]/[projectSlug]/monitoring',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/[lang]/[teamSlug]/~/monitoring',
+        page: '/[lang]/[teamSlug]/~/monitoring',
+      },
+      {
+        sourcePage: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+        page: '/en/[teamSlug]/[projectSlug]/monitoring',
+      },
+      {
+        sourcePage: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+        page: '/fr/[teamSlug]/[projectSlug]/monitoring',
+      },
+      {
+        sourcePage: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+        page: '/[lang]/[teamSlug]/[projectSlug]/monitoring',
+      },
+    ])
+  })
+
+  it('should sort routes by specificity with different parameter types', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/docs/[[...slug]]',
+        page: '/docs/[[...slug]]',
+      },
+      {
+        sourcePage: '/docs/[...slug]',
+        page: '/docs/[...slug]',
+      },
+      {
+        sourcePage: '/docs/[slug]',
+        page: '/docs/[slug]',
+      },
+      {
+        sourcePage: '/docs/api',
+        page: '/docs/api',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/docs/api',
+        page: '/docs/api',
+      },
+      {
+        sourcePage: '/docs/[slug]',
+        page: '/docs/[slug]',
+      },
+      {
+        sourcePage: '/docs/[...slug]',
+        page: '/docs/[...slug]',
+      },
+      {
+        sourcePage: '/docs/[[...slug]]',
+        page: '/docs/[[...slug]]',
+      },
+    ])
+  })
+
+  it('should prioritize source over page in sorting', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/[lang]/[...slug]',
+        page: '/en/docs/api',
+      },
+      {
+        sourcePage: '/en/docs',
+        page: '/[lang]/[...slug]',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/en/docs',
+        page: '/[lang]/[...slug]',
+      },
+      {
+        sourcePage: '/[lang]/[...slug]',
+        page: '/en/docs/api',
+      },
+    ])
+  })
+
+  it('should handle mixed route lengths correctly', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/api/[...path]',
+        page: '/api/[...path]',
+      },
+      {
+        sourcePage: '/api',
+        page: '/api',
+      },
+      {
+        sourcePage: '/api/users/[id]',
+        page: '/api/users/[id]',
+      },
+      {
+        sourcePage: '/api/users',
+        page: '/api/users',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/api',
+        page: '/api',
+      },
+      {
+        sourcePage: '/api/users',
+        page: '/api/users',
+      },
+      {
+        sourcePage: '/api/users/[id]',
+        page: '/api/users/[id]',
+      },
+      {
+        sourcePage: '/api/[...path]',
+        page: '/api/[...path]',
+      },
+    ])
+  })
+
+  it('should sort lexicographically when specificity is equal', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/[lang]/zebra',
+        page: '/[lang]/zebra',
+      },
+      {
+        sourcePage: '/[lang]/apple',
+        page: '/[lang]/apple',
+      },
+      {
+        sourcePage: '/[lang]/banana',
+        page: '/[lang]/banana',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/[lang]/apple',
+        page: '/[lang]/apple',
+      },
+      {
+        sourcePage: '/[lang]/banana',
+        page: '/[lang]/banana',
+      },
+      {
+        sourcePage: '/[lang]/zebra',
+        page: '/[lang]/zebra',
+      },
+    ])
+  })
+
+  it('should handle empty routes array', () => {
+    const routes: SortableRoute[] = []
+    const sorted = sortSortableRoutes(routes)
+    expect(sorted).toEqual([])
+  })
+
+  it('should handle single route', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/api/users/[id]',
+        page: '/api/users/[id]',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/api/users/[id]',
+        page: '/api/users/[id]',
+      },
+    ])
+  })
+
+  it('should handle identical routes', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/api/users',
+        page: '/api/users',
+      },
+      {
+        sourcePage: '/api/users',
+        page: '/api/users',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/api/users',
+        page: '/api/users',
+      },
+      {
+        sourcePage: '/api/users',
+        page: '/api/users',
+      },
+    ])
+  })
+
+  it('should handle complex nested routes with different parameter types', () => {
+    const routes: SortableRoute[] = [
+      {
+        sourcePage: '/[lang]/blog/[[...slug]]',
+        page: '/[lang]/blog/[[...slug]]',
+      },
+      {
+        sourcePage: '/[lang]/blog/[slug]',
+        page: '/[lang]/blog/[slug]',
+      },
+      {
+        sourcePage: '/en/blog/[slug]',
+        page: '/en/blog/[slug]',
+      },
+      {
+        sourcePage: '/en/blog',
+        page: '/en/blog',
+      },
+      {
+        sourcePage: '/[lang]/blog',
+        page: '/[lang]/blog',
+      },
+      {
+        sourcePage: '/[lang]/blog/[...slug]',
+        page: '/[lang]/blog/[...slug]',
+      },
+    ]
+
+    const sorted = sortSortableRoutes(routes)
+
+    expect(sorted).toEqual([
+      {
+        sourcePage: '/en/blog',
+        page: '/en/blog',
+      },
+      {
+        sourcePage: '/en/blog/[slug]',
+        page: '/en/blog/[slug]',
+      },
+      {
+        sourcePage: '/[lang]/blog',
+        page: '/[lang]/blog',
+      },
+      {
+        sourcePage: '/[lang]/blog/[slug]',
+        page: '/[lang]/blog/[slug]',
+      },
+      {
+        sourcePage: '/[lang]/blog/[...slug]',
+        page: '/[lang]/blog/[...slug]',
+      },
+      {
+        sourcePage: '/[lang]/blog/[[...slug]]',
+        page: '/[lang]/blog/[[...slug]]',
+      },
+    ])
+  })
+})
+
+describe('sortSortableRouteObjects', () => {
+  it('should sort objects by sourcePage and page while preserving object references', () => {
+    interface TestRoute {
+      id: string
+      sourcePage: string
+      page: string
+      data: string
+    }
+
+    const objects: TestRoute[] = [
+      {
+        id: '1',
+        sourcePage: '/[lang]/[slug]',
+        page: '/[lang]/[slug]',
+        data: 'dynamic',
+      },
+      {
+        id: '2',
+        sourcePage: '/api/users',
+        page: '/api/users',
+        data: 'static',
+      },
+      {
+        id: '3',
+        sourcePage: '/[lang]/blog',
+        page: '/[lang]/blog',
+        data: 'partial',
+      },
+      { id: '4', sourcePage: '/api', page: '/api', data: 'root' },
+    ]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.sourcePage,
+      page: obj.page,
+    }))
+
+    expect(sorted).toEqual([
+      { id: '4', sourcePage: '/api', page: '/api', data: 'root' },
+      {
+        id: '2',
+        sourcePage: '/api/users',
+        page: '/api/users',
+        data: 'static',
+      },
+      {
+        id: '3',
+        sourcePage: '/[lang]/blog',
+        page: '/[lang]/blog',
+        data: 'partial',
+      },
+      {
+        id: '1',
+        sourcePage: '/[lang]/[slug]',
+        page: '/[lang]/[slug]',
+        data: 'dynamic',
+      },
+    ])
+
+    // Verify object references are preserved
+    expect(sorted[0]).toBe(objects[3])
+    expect(sorted[1]).toBe(objects[1])
+    expect(sorted[2]).toBe(objects[2])
+    expect(sorted[3]).toBe(objects[0])
+  })
+
+  it('should handle objects with different source and page paths', () => {
+    interface PrerenderedRoute {
+      page: string
+      metadata: { type: string }
+    }
+
+    const routes: PrerenderedRoute[] = [
+      { page: '/blog/post-1', metadata: { type: 'static' } },
+      { page: '/blog/[slug]', metadata: { type: 'dynamic' } },
+      { page: '/api/[...path]', metadata: { type: 'catchall' } },
+      { page: '/api/users', metadata: { type: 'api' } },
+    ]
+
+    const sorted = sortSortableRouteObjects(routes, (route) => ({
+      sourcePage: route.page,
+      page: route.page,
+    }))
+
+    expect(sorted.map((r) => r.page)).toEqual([
+      '/api/users',
+      '/api/[...path]',
+      '/blog/post-1',
+      '/blog/[slug]',
+    ])
+
+    // Verify metadata is preserved
+    expect(sorted[0].metadata.type).toBe('api')
+    expect(sorted[1].metadata.type).toBe('catchall')
+    expect(sorted[2].metadata.type).toBe('static')
+    expect(sorted[3].metadata.type).toBe('dynamic')
+  })
+
+  it('should sort by sourcePage first, then page as tiebreaker', () => {
+    interface RouteWithDifferentPages {
+      name: string
+      source: string
+      rendered: string
+    }
+
+    const objects: RouteWithDifferentPages[] = [
+      { name: 'route-1', source: '/[lang]/docs', rendered: '/fr/docs' },
+      { name: 'route-2', source: '/[lang]/docs', rendered: '/en/docs' },
+      { name: 'route-3', source: '/en/docs', rendered: '/[lang]/docs' },
+      { name: 'route-4', source: '/[lang]/docs', rendered: '/[lang]/docs' },
+    ]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.source,
+      page: obj.rendered,
+    }))
+
+    expect(sorted.map((r) => r.name)).toEqual([
+      'route-3', // static source wins
+      'route-2', // same dynamic source, but '/en/docs' < '/fr/docs'
+      'route-1', // same dynamic source, but '/fr/docs' > '/en/docs'
+      'route-4', // same dynamic source, fully dynamic page last
+    ])
+  })
+
+  it('should handle complex route specificity ordering', () => {
+    const objects = [
+      { id: 'optional-catchall', path: '/docs/[[...slug]]' },
+      { id: 'catchall', path: '/docs/[...slug]' },
+      { id: 'dynamic', path: '/docs/[slug]' },
+      { id: 'static-nested', path: '/docs/api/auth' },
+      { id: 'static-mid', path: '/docs/api' },
+      { id: 'static-root', path: '/docs' },
+    ]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.path,
+      page: obj.path,
+    }))
+
+    expect(sorted.map((r) => r.id)).toEqual([
+      'static-root', // '/docs' - most specific (shortest + static)
+      'static-mid', // '/docs/api' - static segment
+      'static-nested', // '/docs/api/auth' - longer static path
+      'dynamic', // '/docs/[slug]' - dynamic segment
+      'catchall', // '/docs/[...slug]' - catch-all
+      'optional-catchall', // '/docs/[[...slug]]' - optional catch-all (least specific)
+    ])
+  })
+
+  it('should not mutate the input array', () => {
+    const objects = [
+      { id: 3, route: '/api/[id]' },
+      { id: 1, route: '/api' },
+      { id: 2, route: '/api/users' },
+    ]
+
+    const originalOrder = [...objects]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.route,
+      page: obj.route,
+    }))
+
+    // Original array should be unchanged
+    expect(objects).toEqual(originalOrder)
+
+    // Sorted array should be different
+    expect(sorted.map((r) => r.id)).toEqual([1, 2, 3])
+  })
+
+  it('should handle empty array', () => {
+    const objects: any[] = []
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.path,
+      page: obj.path,
+    }))
+
+    expect(sorted).toEqual([])
+  })
+
+  it('should handle single object', () => {
+    const objects = [{ name: 'only', path: '/api/users/[id]' }]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.path,
+      page: obj.path,
+    }))
+
+    expect(sorted).toEqual([{ name: 'only', path: '/api/users/[id]' }])
+    expect(sorted[0]).toBe(objects[0]) // Same reference
+  })
+
+  it('should handle duplicate route patterns with different objects', () => {
+    const objects = [
+      { type: 'layout', pattern: '/[lang]/blog' },
+      { type: 'page', pattern: '/[lang]/blog' },
+      { type: 'api', pattern: '/[lang]/blog' },
+    ]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.pattern,
+      page: obj.pattern,
+    }))
+
+    // All should have same route, so original order preserved (stable sort)
+    expect(sorted).toEqual(objects)
+    expect(sorted[0]).toBe(objects[0])
+    expect(sorted[1]).toBe(objects[1])
+    expect(sorted[2]).toBe(objects[2])
+  })
+
+  it('should work with getter function that creates new objects each time', () => {
+    // This test specifically covers the bug that was fixed in the WeakMap version
+    const objects = [
+      { page: '/blog/[slug]' },
+      { page: '/blog/post-1' },
+      { page: '/api/[...params]' },
+    ]
+
+    // Getter that creates new objects each time (like in the build process)
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.page, // New object created each call
+      page: obj.page,
+    }))
+
+    expect(sorted.map((r) => r.page)).toEqual([
+      '/api/[...params]', // Catch-all at root level comes first in this context
+      '/blog/post-1', // Static segment
+      '/blog/[slug]', // Dynamic segment
+    ])
+
+    // Verify original objects are returned, not new ones
+    expect(sorted[1]).toBe(objects[1]) // post-1 object reference preserved
+  })
+
+  it('should handle mixed route depths correctly', () => {
+    const objects = [
+      { name: 'deep-catchall', route: '/api/v1/[...path]' },
+      { name: 'root', route: '/' },
+      { name: 'shallow-dynamic', route: '/[slug]' },
+      { name: 'mid-static', route: '/api/users' },
+      { name: 'deep-static', route: '/api/v1/auth/login' },
+    ]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.route,
+      page: obj.route,
+    }))
+
+    expect(sorted.map((r) => r.name)).toEqual([
+      'root', // '/' - shortest and static
+      'mid-static', // '/api/users' - static segment before dynamic
+      'deep-static', // '/api/v1/auth/login' - longest static
+      'deep-catchall', // '/api/v1/[...path]' - catch-all
+      'shallow-dynamic', // '/[slug]' - dynamic comes after static
+    ])
+  })
+
+  it('should sort lexicographically when all other factors are equal', () => {
+    const objects = [
+      { letter: 'z', route: '/[lang]/zebra' },
+      { letter: 'a', route: '/[lang]/apple' },
+      { letter: 'm', route: '/[lang]/mango' },
+      { letter: 'b', route: '/[lang]/banana' },
+    ]
+
+    const sorted = sortSortableRouteObjects(objects, (obj) => ({
+      sourcePage: obj.route,
+      page: obj.route,
+    }))
+
+    expect(sorted.map((r) => r.letter)).toEqual(['a', 'b', 'm', 'z'])
+  })
+})
+
+describe('sortPageObjects', () => {
+  it('should handle duplicate pages correctly (bug fix)', () => {
+    // This test specifically covers the bug that was fixed where duplicate pages
+    // would overwrite each other in the indexes object
+    const objects = [
+      { id: 'first', type: 'layout', route: '/blog/[slug]' },
+      { id: 'second', type: 'page', route: '/blog/post-1' },
+      { id: 'third', type: 'page', route: '/blog/[slug]' }, // Same route as first
+      { id: 'fourth', type: 'api', route: '/api/users' },
+      { id: 'fifth', type: 'middleware', route: '/blog/[slug]' }, // Same route as first and third
+    ]
+
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+
+    // Should preserve all objects, even those with duplicate routes
+    expect(sorted.length).toBe(5)
+
+    // Should be sorted by route specificity
+    expect(sorted.map((r) => r.id)).toEqual([
+      'fourth', // '/api/users' - static, most specific
+      'second', // '/blog/post-1' - static
+      'first', // '/blog/[slug]' - dynamic (first occurrence)
+      'third', // '/blog/[slug]' - dynamic (second occurrence)
+      'fifth', // '/blog/[slug]' - dynamic (third occurrence)
+    ])
+
+    // Verify all objects are preserved with their original properties
+    expect(sorted[0]).toEqual({
+      id: 'fourth',
+      type: 'api',
+      route: '/api/users',
+    })
+    expect(sorted[1]).toEqual({
+      id: 'second',
+      type: 'page',
+      route: '/blog/post-1',
+    })
+    expect(sorted[2]).toEqual({
+      id: 'first',
+      type: 'layout',
+      route: '/blog/[slug]',
+    })
+    expect(sorted[3]).toEqual({
+      id: 'third',
+      type: 'page',
+      route: '/blog/[slug]',
+    })
+    expect(sorted[4]).toEqual({
+      id: 'fifth',
+      type: 'middleware',
+      route: '/blog/[slug]',
+    })
+  })
+
+  it('should sort pages by specificity', () => {
+    const objects = [
+      { name: 'catchall', path: '/docs/[...slug]' },
+      { name: 'static', path: '/docs/api' },
+      { name: 'dynamic', path: '/docs/[slug]' },
+      { name: 'optional', path: '/docs/[[...slug]]' },
+    ]
+
+    const sorted = sortPageObjects(objects, (obj) => obj.path)
+
+    expect(sorted.map((r) => r.name)).toEqual([
+      'static', // '/docs/api' - static segment
+      'dynamic', // '/docs/[slug]' - dynamic segment
+      'catchall', // '/docs/[...slug]' - catch-all
+      'optional', // '/docs/[[...slug]]' - optional catch-all
+    ])
+  })
+
+  it('should maintain original order for identical routes (stable sort)', () => {
+    const objects = [
+      { id: 'a', route: '/same' },
+      { id: 'b', route: '/same' },
+      { id: 'c', route: '/same' },
+    ]
+
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+
+    expect(sorted.map((r) => r.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should handle mixed route depths', () => {
+    const objects = [
+      { name: 'deep', route: '/api/v1/users/[id]' },
+      { name: 'shallow', route: '/[slug]' },
+      { name: 'root', route: '/' },
+      { name: 'mid', route: '/api/users' },
+    ]
+
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+
+    expect(sorted.map((r) => r.name)).toEqual([
+      'root', // '/' - shortest and static
+      'mid', // '/api/users' - static
+      'deep', // '/api/v1/users/[id]' - longer static path before dynamic
+      'shallow', // '/[slug]' - dynamic
+    ])
+  })
+
+  it('should sort lexicographically when specificity is equal', () => {
+    const objects = [
+      { letter: 'z', route: '/zebra' },
+      { letter: 'a', route: '/apple' },
+      { letter: 'm', route: '/mango' },
+    ]
+
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+
+    expect(sorted.map((r) => r.letter)).toEqual(['a', 'm', 'z'])
+  })
+
+  it('should handle empty array', () => {
+    const objects: any[] = []
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+    expect(sorted).toEqual([])
+  })
+
+  it('should handle single object', () => {
+    const objects = [{ name: 'only', route: '/single' }]
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+    expect(sorted).toEqual([{ name: 'only', route: '/single' }])
+  })
+
+  it('should not mutate the input array', () => {
+    const objects = [
+      { id: 2, route: '/dynamic/[id]' },
+      { id: 1, route: '/static' },
+    ]
+    const originalOrder = [...objects]
+
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+
+    // Original array should be unchanged
+    expect(objects).toEqual(originalOrder)
+
+    // Sorted array should be different - '/dynamic/[id]' comes before '/static' lexicographically
+    expect(sorted.map((r) => r.id)).toEqual([2, 1])
+  })
+
+  it('should handle many duplicate routes efficiently', () => {
+    // Test with many duplicates to ensure the fix handles large datasets
+    const objects = []
+    for (let i = 0; i < 100; i++) {
+      objects.push({ id: i, route: '/blog/[slug]' })
+    }
+    objects.push({ id: 'static', route: '/blog/about' })
+
+    const sorted = sortPageObjects(objects, (obj) => obj.route)
+
+    // Should preserve all objects
+    expect(sorted.length).toBe(101)
+
+    // Static route should come first
+    expect(sorted[0].id).toBe('static')
+
+    // All dynamic routes should follow in original order
+    for (let i = 1; i < 101; i++) {
+      expect(sorted[i].id).toBe(i - 1)
+    }
+  })
+})
+
+describe('sortPages', () => {
+  it('should sort pages by specificity', () => {
+    const pages = [
+      '/docs/[[...slug]]',
+      '/docs/[...slug]',
+      '/docs/[slug]',
+      '/docs/api',
+      '/docs',
+    ]
+
+    const sorted = sortPages(pages)
+
+    expect(sorted).toEqual([
+      '/docs',
+      '/docs/api',
+      '/docs/[slug]',
+      '/docs/[...slug]',
+      '/docs/[[...slug]]',
+    ])
+  })
+
+  it('should handle mixed route depths', () => {
+    const pages = [
+      '/api/v1/[...path]',
+      '/[slug]',
+      '/',
+      '/api/users/[id]',
+      '/api',
+    ]
+
+    const sorted = sortPages(pages)
+
+    expect(sorted).toEqual([
+      '/',
+      '/api',
+      '/api/users/[id]',
+      '/api/v1/[...path]',
+      '/[slug]',
+    ])
+  })
+
+  it('should sort lexicographically when specificity is equal', () => {
+    const pages = ['/zebra', '/apple', '/mango']
+
+    const sorted = sortPages(pages)
+
+    expect(sorted).toEqual(['/apple', '/mango', '/zebra'])
+  })
+
+  it('should handle empty array', () => {
+    const pages: string[] = []
+    const sorted = sortPages(pages)
+    expect(sorted).toEqual([])
+  })
+
+  it('should handle single page', () => {
+    const pages = ['/single']
+    const sorted = sortPages(pages)
+    expect(sorted).toEqual(['/single'])
+  })
+
+  it('should not mutate the input array', () => {
+    const pages = ['/static', '/dynamic/[id]']
+    const originalOrder = [...pages]
+
+    const sorted = sortPages(pages)
+
+    // Original array should be unchanged
+    expect(pages).toEqual(originalOrder)
+
+    // Sorted array should be different - '/dynamic/[id]' comes before '/static' lexicographically
+    expect(sorted).toEqual(['/dynamic/[id]', '/static'])
+  })
+
+  it('should handle duplicate pages', () => {
+    const pages = [
+      '/blog/[slug]',
+      '/blog/post-1',
+      '/blog/[slug]',
+      '/blog/[slug]',
+    ]
+
+    const sorted = sortPages(pages)
+
+    expect(sorted).toEqual([
+      '/blog/post-1',
+      '/blog/[slug]',
+      '/blog/[slug]',
+      '/blog/[slug]',
+    ])
+  })
+
+  it('should handle complex nested routes', () => {
+    const pages = [
+      '/[lang]/blog/[[...slug]]',
+      '/en/blog/[slug]',
+      '/[lang]/blog/[slug]',
+      '/en/blog',
+      '/[lang]/blog',
+      '/[lang]/blog/[...slug]',
+    ]
+
+    const sorted = sortPages(pages)
+
+    expect(sorted).toEqual([
+      '/en/blog',
+      '/en/blog/[slug]',
+      '/[lang]/blog',
+      '/[lang]/blog/[slug]',
+      '/[lang]/blog/[...slug]',
+      '/[lang]/blog/[[...slug]]',
+    ])
+  })
+})
+
+describe('getSegmentSpecificity', () => {
+  it('should return 0 for static segments', () => {
+    expect(getSegmentSpecificity('api')).toBe(0)
+    expect(getSegmentSpecificity('users')).toBe(0)
+    expect(getSegmentSpecificity('dashboard')).toBe(0)
+    expect(getSegmentSpecificity('123')).toBe(0)
+    expect(getSegmentSpecificity('about-us')).toBe(0)
+  })
+
+  it('should return 1 for dynamic segments', () => {
+    expect(getSegmentSpecificity('[id]')).toBe(1)
+    expect(getSegmentSpecificity('[slug]')).toBe(1)
+    expect(getSegmentSpecificity('[userId]')).toBe(1)
+    expect(getSegmentSpecificity('[post-id]')).toBe(1)
+  })
+
+  it('should return 2 for catch-all segments', () => {
+    expect(getSegmentSpecificity('[...slug]')).toBe(2)
+    expect(getSegmentSpecificity('[...path]')).toBe(2)
+    expect(getSegmentSpecificity('[...params]')).toBe(2)
+  })
+
+  it('should return 3 for optional catch-all segments', () => {
+    expect(getSegmentSpecificity('[[...slug]]')).toBe(3)
+    expect(getSegmentSpecificity('[[...path]]')).toBe(3)
+    expect(getSegmentSpecificity('[[...params]]')).toBe(3)
+  })
+
+  it('should handle edge cases', () => {
+    expect(getSegmentSpecificity('')).toBe(0)
+    expect(getSegmentSpecificity('[')).toBe(0) // Malformed bracket
+    expect(getSegmentSpecificity(']')).toBe(0) // Malformed bracket
+    expect(getSegmentSpecificity('[id')).toBe(0) // Missing closing bracket
+    expect(getSegmentSpecificity('id]')).toBe(0) // Missing opening bracket
+    expect(getSegmentSpecificity('[[...slug]')).toBe(1) // Malformed optional catch-all - treated as dynamic
+    expect(getSegmentSpecificity('[...slug]]')).toBe(2) // Malformed optional catch-all - treated as catch-all
+  })
+
+  it('should handle segments with brackets but not dynamic routes', () => {
+    expect(getSegmentSpecificity('api[version]')).toBe(0) // Contains brackets but not a dynamic route
+    expect(getSegmentSpecificity('users[admin]')).toBe(0)
+  })
+})
+
+describe('compareRouteSegments', () => {
+  it('should prioritize shorter routes', () => {
+    expect(compareRouteSegments('/api', '/api/users')).toBe(-1)
+    expect(compareRouteSegments('/api/users', '/api')).toBe(1)
+    expect(compareRouteSegments('/', '/about')).toBe(-1)
+    expect(compareRouteSegments('/about', '/')).toBe(1)
+  })
+
+  it('should prioritize static over dynamic segments', () => {
+    expect(compareRouteSegments('/api/users', '/api/[id]')).toBe(-1)
+    expect(compareRouteSegments('/api/[id]', '/api/users')).toBe(1)
+    expect(compareRouteSegments('/blog/about', '/blog/[slug]')).toBe(-1)
+  })
+
+  it('should prioritize dynamic over catch-all segments', () => {
+    expect(compareRouteSegments('/api/[id]', '/api/[...path]')).toBe(-1)
+    expect(compareRouteSegments('/api/[...path]', '/api/[id]')).toBe(1)
+    expect(compareRouteSegments('/docs/[slug]', '/docs/[...slug]')).toBe(-1)
+  })
+
+  it('should prioritize catch-all over optional catch-all segments', () => {
+    expect(compareRouteSegments('/docs/[...slug]', '/docs/[[...slug]]')).toBe(
+      -1
+    )
+    expect(compareRouteSegments('/docs/[[...slug]]', '/docs/[...slug]')).toBe(1)
+  })
+
+  it('should handle complete specificity hierarchy', () => {
+    const routes = [
+      '/docs/[[...slug]]',
+      '/docs/[...slug]',
+      '/docs/[slug]',
+      '/docs/api',
+    ]
+
+    const sorted = routes.sort(compareRouteSegments)
+    expect(sorted).toEqual([
+      '/docs/api', // Static - most specific
+      '/docs/[slug]', // Dynamic
+      '/docs/[...slug]', // Catch-all
+      '/docs/[[...slug]]', // Optional catch-all - least specific
+    ])
+  })
+
+  it('should sort lexicographically when specificity is equal', () => {
+    expect(compareRouteSegments('/api/zebra', '/api/apple')).toBe(1)
+    expect(compareRouteSegments('/api/apple', '/api/zebra')).toBe(-1)
+    expect(compareRouteSegments('/[lang]/zebra', '/[lang]/apple')).toBe(1)
+    expect(compareRouteSegments('/[lang]/apple', '/[lang]/zebra')).toBe(-1)
+  })
+
+  it('should handle identical routes', () => {
+    expect(compareRouteSegments('/api/users', '/api/users')).toBe(0)
+    expect(compareRouteSegments('/[lang]/[slug]', '/[lang]/[slug]')).toBe(0)
+    expect(compareRouteSegments('/docs/[...slug]', '/docs/[...slug]')).toBe(0)
+  })
+
+  it('should handle empty paths', () => {
+    expect(compareRouteSegments('', '')).toBe(0)
+    expect(compareRouteSegments('', '/api')).toBe(-1)
+    expect(compareRouteSegments('/api', '')).toBe(1)
+  })
+
+  it('should handle root path', () => {
+    expect(compareRouteSegments('/', '/api')).toBe(-1)
+    expect(compareRouteSegments('/api', '/')).toBe(1)
+    expect(compareRouteSegments('/', '/')).toBe(0)
+  })
+
+  it('should handle paths with leading/trailing slashes consistently', () => {
+    expect(compareRouteSegments('/api/users/', '/api/users')).toBe(0)
+    expect(compareRouteSegments('api/users', '/api/users')).toBe(0)
+    expect(compareRouteSegments('/api/users/', 'api/users')).toBe(0)
+  })
+
+  it('should handle complex nested comparisons', () => {
+    expect(compareRouteSegments('/[lang]/blog/[slug]', '/en/blog/[slug]')).toBe(
+      1
+    )
+    expect(compareRouteSegments('/en/blog/[slug]', '/[lang]/blog/[slug]')).toBe(
+      -1
+    )
+    expect(
+      compareRouteSegments('/[lang]/blog/[...slug]', '/[lang]/blog/[slug]')
+    ).toBe(1)
+  })
+
+  it('should handle mixed depths with different specificities', () => {
+    const routes = [
+      '/api/v1/users/[id]/posts/[...slug]',
+      '/api/v1/users/[id]/posts',
+      '/api/v1/users/[id]',
+      '/api/v1/users',
+      '/api/v1',
+      '/api',
+    ]
+
+    const sorted = routes.sort(compareRouteSegments)
+    expect(sorted).toEqual([
+      '/api',
+      '/api/v1',
+      '/api/v1/users',
+      '/api/v1/users/[id]',
+      '/api/v1/users/[id]/posts',
+      '/api/v1/users/[id]/posts/[...slug]',
+    ])
+  })
+})

--- a/packages/next/src/shared/lib/router/utils/sortable-routes.ts
+++ b/packages/next/src/shared/lib/router/utils/sortable-routes.ts
@@ -1,0 +1,242 @@
+/**
+ * A route that can be sorted by specificity.
+ */
+export type SortableRoute = {
+  /**
+   * The source page of the route. This represents the original page that's on
+   * disk. For example, the `app/[lang]/[...rest]/page.tsx` would have a source
+   * page of '/[lang]/[...rest]'.
+   */
+  readonly sourcePage: string
+
+  /**
+   * The page of the route. This represents the final rendered route. For
+   * example, the `app/[lang]/[...rest]/page.tsx` that was rendered with a lang
+   * value of `en` would have a page of '/en/[...rest]'.
+   */
+  readonly page: string
+}
+
+/**
+ * Determines the specificity of a route segment for sorting purposes.
+ *
+ * In Next.js routing, more specific routes should match before less specific ones.
+ * This function returns a numeric value where lower numbers indicate higher specificity.
+ *
+ * Specificity order (most to least specific):
+ * 1. Static segments (e.g., "about", "api") - return 0
+ * 2. Dynamic segments (e.g., "[id]", "[slug]") - return 1
+ * 3. Catch-all segments (e.g., "[...slug]") - return 2
+ * 4. Optional catch-all segments (e.g., "[[...slug]]") - return 3
+ *
+ * @param segment - A single path segment (e.g., "api", "[id]", "[...slug]")
+ * @returns A numeric specificity value (0-3, where 0 is most specific)
+ */
+export function getSegmentSpecificity(segment: string): number {
+  // Static segments are most specific - they match exactly one path
+  if (!segment.includes('[')) {
+    return 0
+  }
+
+  // Optional catch-all [[...param]] is least specific - matches zero or more segments
+  if (segment.startsWith('[[...') && segment.endsWith(']]')) {
+    return 3
+  }
+
+  // Catch-all [...param] is less specific - matches one or more segments
+  if (segment.startsWith('[...') && segment.endsWith(']')) {
+    return 2
+  }
+
+  // Regular dynamic [param] is more specific than catch-all - matches exactly one segment
+  if (segment.startsWith('[') && segment.endsWith(']')) {
+    return 1
+  }
+
+  // Default to static (fallback case)
+  return 0
+}
+
+/**
+ * Compares two route paths using a depth-first traversal approach.
+ *
+ * This function implements a deterministic comparison that sorts routes by specificity:
+ * 1. More specific routes come first (fewer dynamic segments)
+ * 2. Shorter routes are more specific than longer ones
+ * 3. Routes with same specificity are sorted lexicographically
+ *
+ * The comparison is done segment by segment, left to right, similar to how
+ * you would traverse a route tree in depth-first order.
+ *
+ * @param pathA - First route path to compare (e.g., "/api/users/[id]")
+ * @param pathB - Second route path to compare (e.g., "/api/[...slug]")
+ * @returns Negative if pathA is more specific, positive if pathB is more specific, 0 if equal
+ */
+export function compareRouteSegments(pathA: string, pathB: string): number {
+  // Split paths into segments, removing empty strings from leading/trailing slashes
+  const segmentsA = pathA.split('/').filter(Boolean)
+  const segmentsB = pathB.split('/').filter(Boolean)
+
+  // Compare segment by segment up to the length of the longer path
+  const maxLength = Math.max(segmentsA.length, segmentsB.length)
+
+  for (let i = 0; i < maxLength; i++) {
+    const segA = segmentsA[i] || ''
+    const segB = segmentsB[i] || ''
+
+    // Handle length differences: shorter routes are MORE specific
+    // Example: "/api" is more specific than "/api/users"
+    if (!segA && segB) return -1 // pathA is shorter, so more specific
+    if (segA && !segB) return 1 // pathB is shorter, so more specific
+    if (!segA && !segB) return 0 // Both paths ended, they're equal
+
+    // Compare segment specificity using our specificity scoring
+    const specificityA = getSegmentSpecificity(segA)
+    const specificityB = getSegmentSpecificity(segB)
+
+    // Lower specificity number = more specific route
+    // Example: "api" (0) vs "[slug]" (1) - "api" wins
+    if (specificityA !== specificityB) {
+      return specificityA - specificityB
+    }
+
+    // If segments have same specificity, compare lexicographically for determinism
+    // Example: "[id]" vs "[slug]" - "[id]" comes first alphabetically
+    if (segA !== segB) {
+      return segA.localeCompare(segB)
+    }
+
+    // Segments are identical, continue to next segment
+  }
+
+  // All segments compared equally
+  return 0
+}
+
+/**
+ * Compares two complete routes for sorting purposes.
+ *
+ * Routes are compared with a two-tier priority system:
+ * 1. Primary: Compare by source path specificity
+ * 2. Secondary: If sources are equal, compare by page path specificity
+ *
+ * This ensures that routes are primarily organized by their source patterns,
+ * with page-specific variations grouped together.
+ *
+ * @param a - First route to compare
+ * @param b - Second route to compare
+ * @returns Negative if route a should come first, positive if route b should come first, 0 if equal
+ */
+function compareSortableRoutes(a: SortableRoute, b: SortableRoute): number {
+  // First compare by source specificity - this is the primary sorting criterion
+  // Source represents the original route pattern and takes precedence
+  const sourceResult = compareRouteSegments(a.sourcePage, b.sourcePage)
+  if (sourceResult !== 0) return sourceResult
+
+  // If sources are identical, compare by page specificity as a tiebreaker
+  // Page represents the final rendered route and provides secondary ordering
+  return compareRouteSegments(a.page, b.page)
+}
+
+/**
+ * Sorts an array of routes by specificity using a deterministic depth-first traversal approach.
+ *
+ * This function implements Next.js route matching priority where more specific routes
+ * should be matched before less specific ones. The sorting is deterministic and stable,
+ * meaning identical inputs will always produce identical outputs.
+ *
+ * Sorting criteria (in order of priority):
+ * 1. Source path specificity (primary)
+ * 2. Page path specificity (secondary)
+ * 3. Lexicographic ordering (tertiary, for determinism)
+ *
+ * Examples of specificity order:
+ * - "/api/users" (static) comes before "/api/[slug]" (dynamic)
+ * - "/api/[id]" (dynamic) comes before "/api/[...slug]" (catch-all)
+ * - "/api/[...slug]" (catch-all) comes before "/api/[[...slug]]" (optional catch-all)
+ *
+ * @param routes - Array of routes to sort
+ * @returns New sorted array (does not mutate input)
+ */
+export function sortSortableRoutes(
+  routes: readonly SortableRoute[]
+): readonly SortableRoute[] {
+  // Because sort is always in-place, we need to create a shallow copy to avoid
+  // mutating the input array.
+  return [...routes].sort(compareSortableRoutes)
+}
+
+/**
+ * Sorts an array of pages by specificity using a deterministic depth-first
+ * traversal approach.
+ *
+ * @param pages - Array of pages to sort
+ * @returns New sorted array (does not mutate input)
+ */
+export function sortPages(pages: readonly string[]): readonly string[] {
+  // Because sort is always in-place, we need to create a shallow copy to avoid
+  // mutating the input array.
+  return [...pages].sort(compareRouteSegments)
+}
+
+/**
+ * Sorts an array of objects by sourcePage and page using a deterministic
+ * depth-first traversal approach.
+ *
+ * @param objects - Array of objects to sort
+ * @param getter - Function to get the sourcePage and page from an object
+ * @returns New sorted array (does not mutate input)
+ */
+export function sortSortableRouteObjects<T>(
+  objects: readonly T[],
+  getter: (object: T) => SortableRoute
+): readonly T[] {
+  // Create a SortableRoute for each object.
+  const routes: Array<SortableRoute & { object: T }> = []
+  for (const object of objects) {
+    const route = getter(object)
+    routes.push({ ...route, object })
+  }
+
+  // In-place sort the SortableRoutes.
+  routes.sort(compareSortableRoutes)
+
+  // Map the sorted SortableRoutes back to the original objects.
+  return routes.map(({ object }) => object)
+}
+
+/**
+ * Sorts an array of objects by page using a deterministic depth-first traversal
+ * approach.
+ *
+ * @param objects - Array of objects to sort
+ * @param getter - Function to get the page from an object
+ * @returns New sorted array (does not mutate input)
+ */
+export function sortPageObjects<T>(
+  objects: readonly T[],
+  getter: (object: T) => string
+): readonly T[] {
+  const indexes: Record<string, number[]> = {}
+  const pages: Set<string> = new Set()
+  for (let i = 0; i < objects.length; i++) {
+    const object = objects[i]
+    const page = getter(object)
+    indexes[page]?.push(i) || (indexes[page] = [i])
+    pages.add(page)
+  }
+
+  // Sort the unique pages.
+  const sortedPages = Array.from(pages).sort(compareRouteSegments)
+
+  // Map the sorted pages back to the original objects.
+  return sortedPages.reduce<T[]>((sortedObjects, page) => {
+    // Add all objects for this page to the sorted array.
+    for (const i of indexes[page]) {
+      sortedObjects.push(objects[i])
+    }
+
+    // Return the sorted array.
+    return sortedObjects
+  }, [])
+}

--- a/packages/next/src/shared/lib/router/utils/sorted-routes.ts
+++ b/packages/next/src/shared/lib/router/utils/sorted-routes.ts
@@ -201,6 +201,9 @@ class UrlNode {
   }
 }
 
+/**
+ * @deprecated Use `sortSortableRoutes` or `sortPages` instead.
+ */
 export function getSortedRoutes(
   normalizedPages: ReadonlyArray<string>
 ): string[] {
@@ -223,6 +226,9 @@ export function getSortedRoutes(
   return root.smoosh()
 }
 
+/**
+ * @deprecated Use `sortSortableRouteObjects` or `sortPageObjects` instead.
+ */
 export function getSortedRouteObjects<T>(
   objects: T[],
   getter: (obj: T) => string

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -4,8 +4,6 @@ import * as cheerio from 'cheerio'
 describe('sub-shell-generation', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // FIXME: re-enable once we've re-enabled the sub-shell generation in Vercel
-    skipDeployment: true,
   })
 
   if (isNextDev) {


### PR DESCRIPTION
### What?

Implements a new sortable routes system that distinguishes between source pages and rendered pages for sub-shell generation.

### Why?

The existing route sorting logic in Next.js doesn't account for the distinction between the original page definition (`sourcePage`) and the final rendered route (`page`). This is critical for sub-shell generation, given this example:

| Page | Source Page |
|--------|--------|
| `/en/[teamSlug]/[projectSlug]/monitoring` | `/[lang]/[teamSlug]/[projectSlug]/monitoring` |
| `/fr/[teamSlug]/[projectSlug]/monitoring` | `/[lang]/[teamSlug]/[projectSlug]/monitoring` |
| `/[lang]/[teamSlug]/~/monitoring` | `/[lang]/[teamSlug]/~/monitoring` |

And a request to `/en/vercel/~/monitoring` that it will hit the `/[lang]/[teamSlug]/~/monitoring` page instead of the `/en/[teamSlug]/[projectSlug]/monitoring`. This is because we first need to sort by the Source Page and then the Page to ensure that the correct route ordering is respected.

### How?

- Adds new `SortableRoute` type that tracks both `sourcePage` and `page`
- Implements depth-first route comparison algorithm that properly handles segment specificity
- Refactors build process to use the new sorting functions instead of legacy `getSortedRoutes`
- Adds source page tracking for PPR-enabled routes with `clientSegmentEnabled`
- Includes comprehensive test coverage for all route sorting scenarios

The new sorting algorithm ensures consistent route ordering across builds and proper sub-shell generation behavior.