### PR TITLE
Turbopack: Add cache for reqwest clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5460,9 +5460,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick_cache"
-version = "0.6.11"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af25b4e960ffdf0dead61cf0cec0c2e44c76927bf933ab4f02e2858fb449397"
+checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -9338,7 +9338,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "mockito",
+ "quick_cache",
  "reqwest 0.12.20",
+ "serde",
  "tokio",
  "turbo-rcstr",
  "turbo-tasks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,6 +390,7 @@ pin-project-lite = "0.2.9"
 postcard = "1.0.4"
 proc-macro2 = "1.0.79"
 qstring = "0.7.2"
+quick_cache = { version = "0.6.14" }
 quote = "1.0.23"
 rand = "0.9.0"
 rayon = "1.10.0"

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -9,7 +9,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, FxIndexMap, ResolvedVc, Vc};
 use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::{CommandLineProcessEnv, ProcessEnv};
-use turbo_tasks_fetch::{HttpResponseBody, fetch};
+use turbo_tasks_fetch::{HttpResponseBody, ReqwestClientConfig, fetch};
 use turbo_tasks_fs::{
     DiskFileSystem, File, FileContent, FileSystem, FileSystemPath,
     json::parse_json_with_source_context,
@@ -663,7 +663,7 @@ async fn fetch_from_google_fonts(
     let result = fetch(
         url,
         Some(rcstr!(USER_AGENT_FOR_GOOGLE_FONTS)),
-        Vc::cell(None),
+        ReqwestClientConfig { proxy: None }.cell(),
     )
     .await?;
 

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -21,7 +21,7 @@ lzzzz = "1.1.0"
 memmap2 = "0.9.5"
 parking_lot = { workspace = true }
 qfilter = { version = "0.2.4", features = ["serde"] }
-quick_cache = { version = "0.6.9" }
+quick_cache = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true}

--- a/turbopack/crates/turbo-tasks-fetch/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fetch/Cargo.toml
@@ -25,7 +25,9 @@ reqwest = { workspace = true, features = ["rustls-tls"] }
 
 [dependencies]
 anyhow = { workspace = true }
+quick_cache = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fetch/src/reqwest_client_cache.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/reqwest_client_cache.rs
@@ -1,0 +1,74 @@
+use std::{hash::Hash, sync::LazyLock};
+
+use quick_cache::sync::Cache;
+use serde::{Deserialize, Serialize};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{NonLocalValue, ReadRef, trace::TraceRawVcs};
+
+const MAX_CLIENTS: usize = 16;
+static CLIENT_CACHE: LazyLock<Cache<ReadRef<ReqwestClientConfig>, reqwest::Client>> =
+    LazyLock::new(|| Cache::new(MAX_CLIENTS));
+
+#[derive(Hash, PartialEq, Eq, Serialize, Deserialize, NonLocalValue, Debug, TraceRawVcs)]
+pub enum ProxyConfig {
+    Http(RcStr),
+    Https(RcStr),
+}
+
+/// Represents the configuration needed to construct a [`reqwest::Client`].
+///
+/// This is used to cache clients keyed by their configuration, so the configuration should contain
+/// as few fields as possible and change infrequently.
+///
+/// This is needed because [`reqwest::ClientBuilder`] does not implement the required traits. This
+/// factory cannot be a closure because closures do not implement `Eq` or `Hash`.
+#[turbo_tasks::value(shared)]
+#[derive(Hash)]
+pub struct ReqwestClientConfig {
+    pub proxy: Option<ProxyConfig>,
+}
+
+impl ReqwestClientConfig {
+    fn try_build(&self) -> reqwest::Result<reqwest::Client> {
+        let mut client_builder = reqwest::Client::builder();
+        match &self.proxy {
+            Some(ProxyConfig::Http(proxy)) => {
+                client_builder = client_builder.proxy(reqwest::Proxy::http(proxy.as_str())?)
+            }
+            Some(ProxyConfig::Https(proxy)) => {
+                client_builder = client_builder.proxy(reqwest::Proxy::https(proxy.as_str())?)
+            }
+            None => {}
+        };
+        client_builder.build()
+    }
+}
+
+/// Given a config, returns a cached instance if it exists, otherwise constructs a new one.
+///
+/// The cache is bound in size to prevent accidental blowups or leaks. However, in practice, very
+/// few clients should be created, likely only when the bundler configuration changes.
+///
+/// Client construction is largely deterministic, aside from changes to system TLS configuration.
+///
+/// The reqwest client fails to construct if the TLS backend cannot be initialized, or the resolver
+/// cannot load the system configuration. These failures should be treated as cached for some amount
+/// of time, but ultimately transient (e.g. using [`turbo_tasks::mark_session_dependent`]).
+pub fn try_get_cached_reqwest_client(
+    config: ReadRef<ReqwestClientConfig>,
+) -> reqwest::Result<reqwest::Client> {
+    CLIENT_CACHE.get_or_insert_with(&config, {
+        let config = ReadRef::clone(&config);
+        move || config.try_build()
+    })
+}
+
+#[doc(hidden)]
+pub fn __test_only_reqwest_client_cache_clear() {
+    CLIENT_CACHE.clear()
+}
+
+#[doc(hidden)]
+pub fn __test_only_reqwest_client_cache_len() -> usize {
+    CLIENT_CACHE.len()
+}


### PR DESCRIPTION
We need a cache because:
- This will allow us to enable HTTP keep-alive in a subsequent PR which would allow connection-reuse.
- Using `rustls-tls-native` may make client construction far more expensive: #79060

Clients don't fit turbo-task's caching architecture and are not serializable, so the cache lives outside of turbo-tasks. I'm re-using the https://docs.rs/quick_cache/latest/quick_cache/ crate for this, which we already pull in for turbo-persistence.

Closes PACK-5103