### PR TITLE
Docs: fix 04-linking-and-navigating.mdx locale switcher example

### DIFF
--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -427,6 +427,8 @@ export function LocaleSwitcher() {
   const pathname = usePathname()
 
   function switchLocale(locale: string) {
+    // Remove existing locale prefix if present
+    const pathWithoutLocale = pathname.replace(/^\/(en|fr)/, '') || '/'
     // e.g. '/en/about' or '/fr/contact'
     const newPath = `/${locale}${pathname}`
     window.history.replaceState(null, '', newPath)
@@ -450,6 +452,8 @@ export function LocaleSwitcher() {
   const pathname = usePathname()
 
   function switchLocale(locale) {
+    // Remove existing locale prefix if present
+    const pathWithoutLocale = pathname.replace(/^\/(en|fr)/, '') || '/'
     // e.g. '/en/about' or '/fr/contact'
     const newPath = `/${locale}${pathname}`
     window.history.replaceState(null, '', newPath)


### PR DESCRIPTION
### What?

Fix locale switcher example to prevent infinite URL path accumulation when switching languages multiple times.

### Why?

The current example in the documentation has a bug where repeatedly clicking language switcher buttons causes infinite accumulation of locale prefixes in the URL path. For example:
- Initial: `/about`
- Click EN: `/en/about` 
- Click FR: `/fr/en/about`
- Click EN: `/en/fr/en/about`

This creates malformed URLs and poor user experience.

### How?

Added a regex pattern to remove existing locale prefixes before adding new ones:

```tsx
// Remove existing locale prefix if present
const pathWithoutLocale = pathname.replace(/^\/(en|fr)/, '') || '/'
const newPath = `/${locale}${pathWithoutLocale}`
