### PR TITLE
fix: Add log for image optimizer failure

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -694,7 +694,6 @@ export async function imageOptimizer(
   maxAge: number
   etag: string
   upstreamEtag: string
-  error?: unknown
 }> {
   const { href, quality, width, mimeType } = paramsResult
   const { buffer: upstreamBuffer, etag: upstreamEtag } = imageUpstream
@@ -821,6 +820,10 @@ export async function imageOptimizer(
     }
   } catch (error) {
     if (upstreamType) {
+      Log.error(
+        `The requested image "${href}" could not be optimized, falling back to original image`,
+        error
+      )
       // If we fail to optimize, fallback to the original image
       return {
         buffer: upstreamBuffer,
@@ -828,7 +831,6 @@ export async function imageOptimizer(
         maxAge: nextConfig.images.minimumCacheTTL,
         etag: upstreamEtag,
         upstreamEtag,
-        error,
       }
     } else {
       throw new ImageError(


### PR DESCRIPTION
## What?

Add a log to image optimization failures (exceptions raised by Sharp) that end up returning the original - unoptimized - image.

Linked to #67623.

Does not fix it since it seems there's a lack of information to track it down.

## Why?

Currently, when an exception is raised by Sharp, the image is returned unoptimized to the user and put into the cache as is.
This behavior prevent developpers to track the reason of the failure since the raised error isn't used at all.

## How?

- Add a server log on raised exception
- Remove error from function signature since it's not used
