### PR TITLE
Initial MCP implementation

### DIFF
--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -4,16 +4,22 @@ use anyhow::Result;
 use futures_util::TryFutureExt;
 use napi::{JsFunction, bindgen_prelude::External};
 use next_api::{
+    module_graph_snapshot::{
+        ModuleGraphSnapshot, ModuleInfo, ModuleReference, get_module_graph_snapshot,
+    },
     operation::OptionEndpoint,
     paths::ServerPath,
     route::{
-        EndpointOutputPaths, endpoint_client_changed_operation, endpoint_server_changed_operation,
-        endpoint_write_to_disk_operation,
+        Endpoint, EndpointOutputPaths, endpoint_client_changed_operation,
+        endpoint_server_changed_operation, endpoint_write_to_disk_operation,
     },
 };
 use tracing::Instrument;
-use turbo_tasks::{Completion, Effects, OperationVc, ReadRef, Vc};
-use turbopack_core::{diagnostics::PlainDiagnostic, issue::PlainIssue};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{
+    Completion, Effects, OperationVc, ReadRef, TryFlatJoinIterExt, TryJoinIterExt, Vc,
+};
+use turbopack_core::{diagnostics::PlainDiagnostic, error::PrettyPrintError, issue::PlainIssue};
 
 use super::utils::{
     DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult,
@@ -79,6 +85,80 @@ impl From<Option<EndpointOutputPaths>> for NapiWrittenEndpoint {
             },
         }
     }
+}
+
+#[napi(object)]
+pub struct NapiModuleReference {
+    /// The index of the referenced/referencing module in the modules list.
+    pub i: u32,
+}
+
+impl From<&ModuleReference> for NapiModuleReference {
+    fn from(reference: &ModuleReference) -> Self {
+        Self {
+            i: reference.index as u32,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NapiModuleInfo {
+    pub ident: RcStr,
+    pub path: RcStr,
+    pub depth: u32,
+    pub references: Vec<NapiModuleReference>,
+    pub incoming_references: Vec<NapiModuleReference>,
+}
+
+impl From<&ModuleInfo> for NapiModuleInfo {
+    fn from(info: &ModuleInfo) -> Self {
+        Self {
+            ident: info.ident.clone(),
+            path: info.path.clone(),
+            depth: info.depth,
+            references: info
+                .references
+                .iter()
+                .map(|r| NapiModuleReference::from(r))
+                .collect(),
+            incoming_references: info
+                .incoming_references
+                .iter()
+                .map(|r| NapiModuleReference::from(r))
+                .collect(),
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NapiModuleGraphSnapshot {
+    pub modules: Vec<NapiModuleInfo>,
+    pub entries: Vec<u32>,
+}
+
+impl From<&ModuleGraphSnapshot> for NapiModuleGraphSnapshot {
+    fn from(snapshot: &ModuleGraphSnapshot) -> Self {
+        Self {
+            modules: snapshot
+                .modules
+                .iter()
+                .map(|info| NapiModuleInfo::from(info))
+                .collect(),
+            entries: snapshot
+                .entries
+                .iter()
+                .map(|&i| {
+                    // If you have more that 4294967295 entries, you probably have other problems...
+                    i.try_into().unwrap()
+                })
+                .collect(),
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NapiModuleGraphSnapshots {
+    pub module_graphs: Vec<NapiModuleGraphSnapshot>,
 }
 
 // NOTE(alexkirsz) We go through an extra layer of indirection here because of
@@ -152,6 +232,103 @@ pub async fn endpoint_write_to_disk(
         result: NapiWrittenEndpoint::from(written.map(ReadRef::into_owned)),
         issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
         diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
+    })
+}
+
+#[turbo_tasks::value(serialization = "none")]
+struct ModuleGraphsWithIssues {
+    module_graphs: Option<ReadRef<ModuleGraphSnapshots>>,
+    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    diagnostics: Arc<Vec<ReadRef<PlainDiagnostic>>>,
+    effects: Arc<Effects>,
+}
+
+#[turbo_tasks::function(operation)]
+async fn get_module_graphs_with_issues_operation(
+    endpoint_op: OperationVc<OptionEndpoint>,
+) -> Result<Vc<ModuleGraphsWithIssues>> {
+    let module_graphs_op = get_module_graphs_operation(endpoint_op);
+    let (module_graphs, issues, diagnostics, effects) =
+        strongly_consistent_catch_collectables(module_graphs_op).await?;
+    Ok(ModuleGraphsWithIssues {
+        module_graphs,
+        issues,
+        diagnostics,
+        effects,
+    }
+    .cell())
+}
+
+#[turbo_tasks::value(transparent)]
+struct ModuleGraphSnapshots(Vec<ReadRef<ModuleGraphSnapshot>>);
+
+#[turbo_tasks::function(operation)]
+async fn get_module_graphs_operation(
+    endpoint_op: OperationVc<OptionEndpoint>,
+) -> Result<Vc<ModuleGraphSnapshots>> {
+    let Some(endpoint) = *endpoint_op.connect().await? else {
+        return Ok(Vc::cell(vec![]));
+    };
+    let graphs = endpoint.module_graphs().await?;
+    let entries = endpoint.entries().await?;
+    let entry_modules = entries.iter().flat_map(|e| e.entries()).collect::<Vec<_>>();
+    let snapshots = graphs
+        .iter()
+        .map(async |&graph| {
+            let module_graph = graph.await?;
+            let entry_modules = entry_modules
+                .iter()
+                .map(async |&m| Ok(module_graph.has_entry(m).await?.then_some(m)))
+                .try_flat_join()
+                .await?;
+            Ok((*graph, entry_modules))
+        })
+        .try_join()
+        .await?
+        .into_iter()
+        .map(|(graph, entry_modules)| (graph, Vc::cell(entry_modules)))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(async |(graph, entry_modules)| get_module_graph_snapshot(graph, entry_modules).await)
+        .try_join()
+        .await?;
+    Ok(Vc::cell(snapshots))
+}
+
+#[napi]
+pub async fn endpoint_module_graphs(
+    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
+) -> napi::Result<TurbopackResult<NapiModuleGraphSnapshots>> {
+    let endpoint_op: OperationVc<OptionEndpoint> = ***endpoint;
+    let (module_graphs, issues, diagnostics) = endpoint
+        .turbopack_ctx()
+        .turbo_tasks()
+        .run_once(async move {
+            let module_graphs_op = get_module_graphs_with_issues_operation(endpoint_op);
+            let ModuleGraphsWithIssues {
+                module_graphs,
+                issues,
+                diagnostics,
+                effects: _,
+            } = &*module_graphs_op.connect().await?;
+            Ok((module_graphs.clone(), issues.clone(), diagnostics.clone()))
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+
+    Ok(TurbopackResult {
+        result: NapiModuleGraphSnapshots {
+            module_graphs: module_graphs
+                .into_iter()
+                .flat_map(|m| m.into_iter())
+                .map(|m| NapiModuleGraphSnapshot::from(&**m))
+                .collect(),
+        },
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+        diagnostics: diagnostics
+            .iter()
+            .map(|d| NapiDiagnostic::from(d))
+            .collect(),
     })
 }
 

--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -4,9 +4,7 @@ use anyhow::Result;
 use futures_util::TryFutureExt;
 use napi::{JsFunction, bindgen_prelude::External};
 use next_api::{
-    module_graph_snapshot::{
-        ModuleGraphSnapshot, ModuleInfo, ModuleReference, get_module_graph_snapshot,
-    },
+    module_graph_snapshot::{ModuleGraphSnapshot, get_module_graph_snapshot},
     operation::OptionEndpoint,
     paths::ServerPath,
     route::{
@@ -15,7 +13,6 @@ use next_api::{
     },
 };
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{
     Completion, Effects, OperationVc, ReadRef, TryFlatJoinIterExt, TryJoinIterExt, Vc,
 };
@@ -25,6 +22,7 @@ use super::utils::{
     DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult,
     strongly_consistent_catch_collectables, subscribe,
 };
+use crate::next_api::module_graph::NapiModuleGraphSnapshot;
 
 #[napi(object)]
 #[derive(Default)]
@@ -83,75 +81,6 @@ impl From<Option<EndpointOutputPaths>> for NapiWrittenEndpoint {
                 r#type: "none".to_string(),
                 ..Default::default()
             },
-        }
-    }
-}
-
-#[napi(object)]
-pub struct NapiModuleReference {
-    /// The index of the referenced/referencing module in the modules list.
-    pub i: u32,
-}
-
-impl From<&ModuleReference> for NapiModuleReference {
-    fn from(reference: &ModuleReference) -> Self {
-        Self {
-            i: reference.index as u32,
-        }
-    }
-}
-
-#[napi(object)]
-pub struct NapiModuleInfo {
-    pub ident: RcStr,
-    pub path: RcStr,
-    pub depth: u32,
-    pub references: Vec<NapiModuleReference>,
-    pub incoming_references: Vec<NapiModuleReference>,
-}
-
-impl From<&ModuleInfo> for NapiModuleInfo {
-    fn from(info: &ModuleInfo) -> Self {
-        Self {
-            ident: info.ident.clone(),
-            path: info.path.clone(),
-            depth: info.depth,
-            references: info
-                .references
-                .iter()
-                .map(|r| NapiModuleReference::from(r))
-                .collect(),
-            incoming_references: info
-                .incoming_references
-                .iter()
-                .map(|r| NapiModuleReference::from(r))
-                .collect(),
-        }
-    }
-}
-
-#[napi(object)]
-pub struct NapiModuleGraphSnapshot {
-    pub modules: Vec<NapiModuleInfo>,
-    pub entries: Vec<u32>,
-}
-
-impl From<&ModuleGraphSnapshot> for NapiModuleGraphSnapshot {
-    fn from(snapshot: &ModuleGraphSnapshot) -> Self {
-        Self {
-            modules: snapshot
-                .modules
-                .iter()
-                .map(|info| NapiModuleInfo::from(info))
-                .collect(),
-            entries: snapshot
-                .entries
-                .iter()
-                .map(|&i| {
-                    // If you have more that 4294967295 entries, you probably have other problems...
-                    i.try_into().unwrap()
-                })
-                .collect(),
         }
     }
 }
@@ -289,7 +218,9 @@ async fn get_module_graphs_operation(
         .map(|(graph, entry_modules)| (graph, Vc::cell(entry_modules)))
         .collect::<Vec<_>>()
         .into_iter()
-        .map(async |(graph, entry_modules)| get_module_graph_snapshot(graph, entry_modules).await)
+        .map(async |(graph, entry_modules)| {
+            get_module_graph_snapshot(graph, Some(entry_modules)).await
+        })
         .try_join()
         .await?;
     Ok(Vc::cell(snapshots))

--- a/crates/napi/src/next_api/mod.rs
+++ b/crates/napi/src/next_api/mod.rs
@@ -1,4 +1,5 @@
 pub mod endpoint;
+pub mod module_graph;
 pub mod project;
 pub mod turbopack_ctx;
 pub mod utils;

--- a/crates/napi/src/next_api/module_graph.rs
+++ b/crates/napi/src/next_api/module_graph.rs
@@ -1,16 +1,42 @@
 use next_api::module_graph_snapshot::{ModuleGraphSnapshot, ModuleInfo, ModuleReference};
 use turbo_rcstr::RcStr;
+use turbopack_core::chunk::ChunkingType;
 
 #[napi(object)]
 pub struct NapiModuleReference {
     /// The index of the referenced/referencing module in the modules list.
-    pub i: u32,
+    pub index: u32,
+    /// The export used in the module reference.
+    pub export: String,
+    /// The type of chunking for the module reference.
+    pub chunking_type: String,
 }
 
 impl From<&ModuleReference> for NapiModuleReference {
     fn from(reference: &ModuleReference) -> Self {
         Self {
-            i: reference.index as u32,
+            index: reference.index as u32,
+            export: reference.export.to_string(),
+            chunking_type: match &reference.chunking_type {
+                ChunkingType::Parallel { hoisted: true, .. } => "hoisted".to_string(),
+                ChunkingType::Parallel { hoisted: false, .. } => "sync".to_string(),
+                ChunkingType::Async => "async".to_string(),
+                ChunkingType::Isolated {
+                    merge_tag: None, ..
+                } => "isolated".to_string(),
+                ChunkingType::Isolated {
+                    merge_tag: Some(name),
+                    ..
+                } => format!("isolated {name}"),
+                ChunkingType::Shared {
+                    merge_tag: None, ..
+                } => "shared".to_string(),
+                ChunkingType::Shared {
+                    merge_tag: Some(name),
+                    ..
+                } => format!("shared {name}"),
+                ChunkingType::Traced => "traced".to_string(),
+            },
         }
     }
 }

--- a/crates/napi/src/next_api/module_graph.rs
+++ b/crates/napi/src/next_api/module_graph.rs
@@ -1,0 +1,72 @@
+use next_api::module_graph_snapshot::{ModuleGraphSnapshot, ModuleInfo, ModuleReference};
+use turbo_rcstr::RcStr;
+
+#[napi(object)]
+pub struct NapiModuleReference {
+    /// The index of the referenced/referencing module in the modules list.
+    pub i: u32,
+}
+
+impl From<&ModuleReference> for NapiModuleReference {
+    fn from(reference: &ModuleReference) -> Self {
+        Self {
+            i: reference.index as u32,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NapiModuleInfo {
+    pub ident: RcStr,
+    pub path: RcStr,
+    pub depth: u32,
+    pub references: Vec<NapiModuleReference>,
+    pub incoming_references: Vec<NapiModuleReference>,
+}
+
+impl From<&ModuleInfo> for NapiModuleInfo {
+    fn from(info: &ModuleInfo) -> Self {
+        Self {
+            ident: info.ident.clone(),
+            path: info.path.clone(),
+            depth: info.depth,
+            references: info
+                .references
+                .iter()
+                .map(|r| NapiModuleReference::from(r))
+                .collect(),
+            incoming_references: info
+                .incoming_references
+                .iter()
+                .map(|r| NapiModuleReference::from(r))
+                .collect(),
+        }
+    }
+}
+
+#[napi(object)]
+#[derive(Default)]
+pub struct NapiModuleGraphSnapshot {
+    pub modules: Vec<NapiModuleInfo>,
+    pub entries: Vec<u32>,
+}
+
+impl From<&ModuleGraphSnapshot> for NapiModuleGraphSnapshot {
+    fn from(snapshot: &ModuleGraphSnapshot) -> Self {
+        Self {
+            modules: snapshot
+                .modules
+                .iter()
+                .map(|info| NapiModuleInfo::from(info))
+                .collect(),
+            entries: snapshot
+                .entries
+                .iter()
+                .map(|&i| {
+                    // If you have more that 4294967295 entries, you probably have other problems...
+                    i.try_into().unwrap()
+                })
+                .collect(),
+        }
+    }
+}

--- a/crates/napi/src/next_api/module_graph.rs
+++ b/crates/napi/src/next_api/module_graph.rs
@@ -46,6 +46,8 @@ pub struct NapiModuleInfo {
     pub ident: RcStr,
     pub path: RcStr,
     pub depth: u32,
+    pub size: u32,
+    pub retained_size: u32,
     pub references: Vec<NapiModuleReference>,
     pub incoming_references: Vec<NapiModuleReference>,
 }
@@ -56,6 +58,8 @@ impl From<&ModuleInfo> for NapiModuleInfo {
             ident: info.ident.clone(),
             path: info.path.clone(),
             depth: info.depth,
+            size: info.size,
+            retained_size: info.retained_size,
             references: info
                 .references
                 .iter()

--- a/crates/napi/src/next_api/module_graph.rs
+++ b/crates/napi/src/next_api/module_graph.rs
@@ -63,12 +63,12 @@ impl From<&ModuleInfo> for NapiModuleInfo {
             references: info
                 .references
                 .iter()
-                .map(|r| NapiModuleReference::from(r))
+                .map(NapiModuleReference::from)
                 .collect(),
             incoming_references: info
                 .incoming_references
                 .iter()
-                .map(|r| NapiModuleReference::from(r))
+                .map(NapiModuleReference::from)
                 .collect(),
         }
     }
@@ -84,11 +84,7 @@ pub struct NapiModuleGraphSnapshot {
 impl From<&ModuleGraphSnapshot> for NapiModuleGraphSnapshot {
     fn from(snapshot: &ModuleGraphSnapshot) -> Self {
         Self {
-            modules: snapshot
-                .modules
-                .iter()
-                .map(|info| NapiModuleInfo::from(info))
-                .collect(),
+            modules: snapshot.modules.iter().map(NapiModuleInfo::from).collect(),
             entries: snapshot
                 .entries
                 .iter()

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -9,6 +9,7 @@ use napi::{
 };
 use next_api::{
     entrypoints::Entrypoints,
+    module_graph_snapshot::{ModuleGraphSnapshot, get_module_graph_snapshot},
     operation::{
         EntrypointsOperation, InstrumentationOperation, MiddlewareOperation, OptionEndpoint,
         RouteOperation,
@@ -63,13 +64,14 @@ use url::Url;
 use crate::{
     next_api::{
         endpoint::ExternalEndpoint,
+        module_graph::NapiModuleGraphSnapshot,
         turbopack_ctx::{
             NapiNextTurbopackCallbacks, NapiNextTurbopackCallbacksJsObject, NextTurboTasks,
             NextTurbopackContext, create_turbo_tasks,
         },
         utils::{
             DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult, get_diagnostics,
-            get_issues, subscribe,
+            get_issues, strongly_consistent_catch_collectables, subscribe,
         },
     },
     register,
@@ -1683,4 +1685,71 @@ pub fn project_get_source_map_sync(
     within_runtime_if_available(|| {
         tokio::runtime::Handle::current().block_on(project_get_source_map(project, file_path))
     })
+}
+
+#[napi]
+pub async fn project_module_graph(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+) -> napi::Result<TurbopackResult<NapiModuleGraphSnapshot>> {
+    let container = project.container;
+    let (module_graph, issues, diagnostics) = project
+        .turbopack_ctx
+        .turbo_tasks()
+        .run_once(async move {
+            let module_graph_op = get_module_graph_with_issues_operation(container);
+            let ModuleGraphWithIssues {
+                module_graph,
+                issues,
+                diagnostics,
+                effects: _,
+            } = &*module_graph_op.connect().await?;
+            Ok((module_graph.clone(), issues.clone(), diagnostics.clone()))
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+
+    Ok(TurbopackResult {
+        result: module_graph.map_or_else(NapiModuleGraphSnapshot::default, |m| {
+            NapiModuleGraphSnapshot::from(&*m)
+        }),
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+        diagnostics: diagnostics
+            .iter()
+            .map(|d| NapiDiagnostic::from(d))
+            .collect(),
+    })
+}
+
+#[turbo_tasks::value(serialization = "none")]
+struct ModuleGraphWithIssues {
+    module_graph: Option<ReadRef<ModuleGraphSnapshot>>,
+    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    diagnostics: Arc<Vec<ReadRef<PlainDiagnostic>>>,
+    effects: Arc<Effects>,
+}
+
+#[turbo_tasks::function(operation)]
+async fn get_module_graph_with_issues_operation(
+    project: ResolvedVc<ProjectContainer>,
+) -> Result<Vc<ModuleGraphWithIssues>> {
+    let module_graph_op = get_module_graph_operation(project);
+    let (module_graph, issues, diagnostics, effects) =
+        strongly_consistent_catch_collectables(module_graph_op).await?;
+    Ok(ModuleGraphWithIssues {
+        module_graph,
+        issues,
+        diagnostics,
+        effects,
+    }
+    .cell())
+}
+
+#[turbo_tasks::function(operation)]
+async fn get_module_graph_operation(
+    project: ResolvedVc<ProjectContainer>,
+) -> Result<Vc<ModuleGraphSnapshot>> {
+    let project = project.project();
+    let graph = project.whole_app_module_graphs().await?.full;
+    let snapshot = get_module_graph_snapshot(*graph, None).resolve().await?;
+    Ok(snapshot)
 }

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -987,6 +987,40 @@ async fn output_assets_operation(
     Ok(Vc::cell(output_assets.into_iter().collect()))
 }
 
+#[napi]
+pub async fn project_entrypoints(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+) -> napi::Result<TurbopackResult<NapiEntrypoints>> {
+    let container = project.container;
+
+    let (entrypoints, issues, diags) = project
+        .turbopack_ctx
+        .turbo_tasks()
+        .run_once(async move {
+            let entrypoints_with_issues_op = get_entrypoints_with_issues_operation(container);
+
+            // Read and compile the files
+            let EntrypointsWithIssues {
+                entrypoints,
+                issues,
+                diagnostics,
+                effects: _,
+            } = &*entrypoints_with_issues_op
+                .read_strongly_consistent()
+                .await?;
+
+            Ok((entrypoints.clone(), issues.clone(), diagnostics.clone()))
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+
+    Ok(TurbopackResult {
+        result: NapiEntrypoints::from_entrypoints_op(&entrypoints, &project.turbopack_ctx)?,
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+        diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
+    })
+}
+
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_entrypoints_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,

--- a/crates/next-api/src/empty.rs
+++ b/crates/next-api/src/empty.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, bail};
 use turbo_tasks::{Completion, Vc};
 use turbopack_core::module_graph::GraphEntries;
 
-use crate::route::{Endpoint, EndpointOutput};
+use crate::route::{Endpoint, EndpointOutput, ModuleGraphs};
 
 #[turbo_tasks::value]
 pub struct EmptyEndpoint;
@@ -35,5 +35,10 @@ impl Endpoint for EmptyEndpoint {
     #[turbo_tasks::function]
     fn entries(self: Vc<Self>) -> Vc<GraphEntries> {
         GraphEntries::empty()
+    }
+
+    #[turbo_tasks::function]
+    fn module_graphs(self: Vc<Self>) -> Vc<ModuleGraphs> {
+        Vc::cell(vec![])
     }
 }

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -13,6 +13,7 @@ mod instrumentation;
 mod loadable_manifest;
 mod middleware;
 mod module_graph;
+pub mod module_graph_snapshot;
 mod nft_json;
 pub mod operation;
 mod pages;

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -38,7 +38,7 @@ use crate::{
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
-    route::{Endpoint, EndpointOutput, EndpointOutputPaths},
+    route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs},
 };
 
 #[turbo_tasks::value]
@@ -407,5 +407,16 @@ impl Endpoint for MiddlewareEndpoint {
         Ok(Vc::cell(vec![ChunkGroupEntry::Entry(vec![
             self.entry_module().to_resolved().await?,
         ])]))
+    }
+
+    #[turbo_tasks::function]
+    async fn module_graphs(self: Vc<Self>) -> Result<Vc<ModuleGraphs>> {
+        let this = self.await?;
+        let module_graph = this
+            .project
+            .module_graph(self.entry_module())
+            .to_resolved()
+            .await?;
+        Ok(Vc::cell(vec![module_graph]))
     }
 }

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -156,7 +156,9 @@ pub async fn get_module_graph_snapshot(
                     .content()
                     .len()
                     .owned()
-                    .await?
+                    .await
+                    // TODO all modules should report some content and should not crash
+                    .unwrap_or_default()
                     .unwrap_or_default()
                     .try_into()
                     .unwrap_or(u32::MAX),

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_map::Entry;
 
 use anyhow::Result;
+use either::Either;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
@@ -39,7 +40,7 @@ pub struct ModuleGraphSnapshot {
 #[turbo_tasks::function]
 pub async fn get_module_graph_snapshot(
     module_graph: Vc<ModuleGraph>,
-    entry_modules: Vc<Modules>,
+    entry_modules: Option<Vc<Modules>>,
 ) -> Result<Vc<ModuleGraphSnapshot>> {
     let module_graph = module_graph.await?;
 
@@ -75,43 +76,42 @@ pub async fn get_module_graph_snapshot(
         }
     }
 
+    let entry_modules = if let Some(entry_modules) = entry_modules {
+        Either::Left(entry_modules.await?)
+    } else {
+        Either::Right(module_graph.entries().await?)
+    };
     module_graph
-        .traverse_edges_from_entries_bfs(
-            entry_modules.await?.iter().copied(),
-            |parent_info, node| {
-                let module = node.module;
-                let module_index = get_or_create_module(&mut modules, &mut module_to_index, module);
+        .traverse_edges_from_entries_bfs(entry_modules.iter().copied(), |parent_info, node| {
+            let module = node.module;
+            let module_index = get_or_create_module(&mut modules, &mut module_to_index, module);
 
-                if let Some((parent_module, ty)) = parent_info {
-                    let parent_index = get_or_create_module(
-                        &mut modules,
-                        &mut module_to_index,
-                        parent_module.module,
-                    );
-                    let parent_module = &mut modules[parent_index];
-                    let parent_depth = parent_module.depth;
-                    debug_assert!(parent_depth < u32::MAX);
-                    parent_module.references.push(ModuleReference {
-                        index: module_index,
-                        chunking_type: ty.chunking_type.clone(),
-                        export: ty.export.clone(),
-                    });
-                    let module = &mut modules[module_index];
-                    module.depth = module.depth.min(parent_depth + 1);
-                    module.incoming_references.push(ModuleReference {
-                        index: parent_index,
-                        chunking_type: ty.chunking_type.clone(),
-                        export: ty.export.clone(),
-                    });
-                } else {
-                    entries.push(module_index);
-                    let module = &mut modules[module_index];
-                    module.depth = 0;
-                }
+            if let Some((parent_module, ty)) = parent_info {
+                let parent_index =
+                    get_or_create_module(&mut modules, &mut module_to_index, parent_module.module);
+                let parent_module = &mut modules[parent_index];
+                let parent_depth = parent_module.depth;
+                debug_assert!(parent_depth < u32::MAX);
+                parent_module.references.push(ModuleReference {
+                    index: module_index,
+                    chunking_type: ty.chunking_type.clone(),
+                    export: ty.export.clone(),
+                });
+                let module = &mut modules[module_index];
+                module.depth = module.depth.min(parent_depth + 1);
+                module.incoming_references.push(ModuleReference {
+                    index: parent_index,
+                    chunking_type: ty.chunking_type.clone(),
+                    export: ty.export.clone(),
+                });
+            } else {
+                entries.push(module_index);
+                let module = &mut modules[module_index];
+                module.depth = 0;
+            }
 
-                Ok(GraphTraversalAction::Continue)
-            },
-        )
+            Ok(GraphTraversalAction::Continue)
+        })
         .await?;
 
     let modules = modules

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -134,9 +134,9 @@ pub async fn get_module_graph_snapshot(
             for ref_info in &module.incoming_references {
                 let ref_module = &modules[ref_info.index];
                 if ref_module.depth < depth {
-                    let mut retained_modules = modules[module_index].retained_modules.borrow_mut();
+                    let mut retained_modules = ref_module.retained_modules.borrow_mut();
                     retained_modules.insert(module_index as u32);
-                    for retained in ref_module.retained_modules.borrow().iter() {
+                    for retained in module.retained_modules.borrow().iter() {
                         retained_modules.insert(*retained);
                     }
                 }
@@ -181,7 +181,7 @@ pub async fn get_module_graph_snapshot(
             })
             .reduce(|a, b| a.saturating_add(b))
             .unwrap_or_default();
-        final_modules[index].retained_size = retained_size;
+        final_modules[index].retained_size = retained_size + final_modules[index].size;
     }
 
     Ok(ModuleGraphSnapshot {

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, cmp::Reverse, collections::hash_map::Entry, mem::take, u32};
+use std::{cell::RefCell, cmp::Reverse, collections::hash_map::Entry, mem::take};
 
 use anyhow::Result;
 use either::Either;
@@ -66,7 +66,7 @@ pub async fn get_module_graph_snapshot(
         module: ResolvedVc<Box<dyn Module>>,
     ) -> usize {
         match module_to_index.entry(module) {
-            Entry::Occupied(entry) => return *entry.get(),
+            Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
                 let index = modules.len();
                 modules.push(RawModuleInfo {
@@ -77,7 +77,7 @@ pub async fn get_module_graph_snapshot(
                     retained_modules: Default::default(),
                 });
                 entry.insert(index);
-                return index;
+                index
             }
         }
     }

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -1,0 +1,132 @@
+use std::collections::hash_map::Entry;
+
+use anyhow::Result;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{
+    NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
+};
+use turbopack_core::{
+    chunk::ChunkingType,
+    module::{Module, Modules},
+    module_graph::{GraphTraversalAction, ModuleGraph},
+    resolve::ExportUsage,
+};
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, Debug)]
+pub struct ModuleReference {
+    pub index: usize,
+    pub chunking_type: ChunkingType,
+    pub export: ExportUsage,
+}
+
+#[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, Debug)]
+pub struct ModuleInfo {
+    pub ident: RcStr,
+    pub path: RcStr,
+    pub depth: u32,
+    pub references: Vec<ModuleReference>,
+    pub incoming_references: Vec<ModuleReference>,
+}
+
+#[turbo_tasks::value]
+pub struct ModuleGraphSnapshot {
+    pub modules: Vec<ModuleInfo>,
+    pub entries: Vec<usize>,
+}
+
+#[turbo_tasks::function]
+pub async fn get_module_graph_snapshot(
+    module_graph: Vc<ModuleGraph>,
+    entry_modules: Vc<Modules>,
+) -> Result<Vc<ModuleGraphSnapshot>> {
+    let module_graph = module_graph.await?;
+
+    struct RawModuleInfo {
+        module: ResolvedVc<Box<dyn Module>>,
+        depth: u32,
+        references: Vec<ModuleReference>,
+        incoming_references: Vec<ModuleReference>,
+    }
+
+    let mut entries = Vec::new();
+    let mut modules = Vec::new();
+    let mut module_to_index = FxHashMap::default();
+
+    fn get_or_create_module(
+        modules: &mut Vec<RawModuleInfo>,
+        module_to_index: &mut FxHashMap<ResolvedVc<Box<dyn Module>>, usize>,
+        module: ResolvedVc<Box<dyn Module>>,
+    ) -> usize {
+        match module_to_index.entry(module) {
+            Entry::Occupied(entry) => return *entry.get(),
+            Entry::Vacant(entry) => {
+                let index = modules.len();
+                modules.push(RawModuleInfo {
+                    module,
+                    depth: u32::MAX,
+                    references: Vec::new(),
+                    incoming_references: Vec::new(),
+                });
+                entry.insert(index);
+                return index;
+            }
+        }
+    }
+
+    module_graph
+        .traverse_edges_from_entries_bfs(
+            entry_modules.await?.iter().copied(),
+            |parent_info, node| {
+                let module = node.module;
+                let module_index = get_or_create_module(&mut modules, &mut module_to_index, module);
+
+                if let Some((parent_module, ty)) = parent_info {
+                    let parent_index = get_or_create_module(
+                        &mut modules,
+                        &mut module_to_index,
+                        parent_module.module,
+                    );
+                    let parent_module = &mut modules[parent_index];
+                    let parent_depth = parent_module.depth;
+                    debug_assert!(parent_depth < u32::MAX);
+                    parent_module.incoming_references.push(ModuleReference {
+                        index: module_index,
+                        chunking_type: ty.chunking_type.clone(),
+                        export: ty.export.clone(),
+                    });
+                    let module = &mut modules[module_index];
+                    module.depth = module.depth.min(parent_depth + 1);
+                    module.references.push(ModuleReference {
+                        index: parent_index,
+                        chunking_type: ty.chunking_type.clone(),
+                        export: ty.export.clone(),
+                    });
+                } else {
+                    entries.push(module_index);
+                    let module = &mut modules[module_index];
+                    module.depth = 0;
+                }
+
+                Ok(GraphTraversalAction::Continue)
+            },
+        )
+        .await?;
+
+    let modules = modules
+        .into_iter()
+        .map(async |info| {
+            Ok(ModuleInfo {
+                ident: info.module.ident().to_string().owned().await?,
+                path: info.module.ident().path().to_string().owned().await?,
+                depth: info.depth,
+                references: info.references,
+                incoming_references: info.incoming_references,
+            })
+        })
+        .try_join()
+        .await?;
+
+    Ok(ModuleGraphSnapshot { modules, entries }.cell())
+}

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -29,6 +29,7 @@ pub struct ModuleInfo {
     pub path: RcStr,
     pub depth: u32,
     pub size: u32,
+    // TODO this should be per layer
     pub retained_size: u32,
     pub references: Vec<ModuleReference>,
     pub incoming_references: Vec<ModuleReference>,

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -1,14 +1,15 @@
-use std::collections::hash_map::Entry;
+use std::{cell::RefCell, cmp::Reverse, collections::hash_map::Entry, mem::take, u32};
 
 use anyhow::Result;
 use either::Either;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbopack_core::{
+    asset::Asset,
     chunk::ChunkingType,
     module::{Module, Modules},
     module_graph::{GraphTraversalAction, ModuleGraph},
@@ -27,6 +28,8 @@ pub struct ModuleInfo {
     pub ident: RcStr,
     pub path: RcStr,
     pub depth: u32,
+    pub size: u32,
+    pub retained_size: u32,
     pub references: Vec<ModuleReference>,
     pub incoming_references: Vec<ModuleReference>,
 }
@@ -47,6 +50,7 @@ pub async fn get_module_graph_snapshot(
     struct RawModuleInfo {
         module: ResolvedVc<Box<dyn Module>>,
         depth: u32,
+        retained_modules: RefCell<FxHashSet<u32>>,
         references: Vec<ModuleReference>,
         incoming_references: Vec<ModuleReference>,
     }
@@ -69,6 +73,7 @@ pub async fn get_module_graph_snapshot(
                     depth: u32::MAX,
                     references: Vec::new(),
                     incoming_references: Vec::new(),
+                    retained_modules: Default::default(),
                 });
                 entry.insert(index);
                 return index;
@@ -114,19 +119,72 @@ pub async fn get_module_graph_snapshot(
         })
         .await?;
 
-    let modules = modules
-        .into_iter()
+    let mut modules_by_depth = FxHashMap::default();
+    for (index, info) in modules.iter().enumerate() {
+        modules_by_depth
+            .entry(info.depth)
+            .or_insert_with(Vec::new)
+            .push(index);
+    }
+    let mut modules_by_depth = modules_by_depth.into_iter().collect::<Vec<_>>();
+    modules_by_depth.sort_by_key(|(depth, _)| Reverse(*depth));
+    for (depth, module_indicies) in modules_by_depth {
+        for module_index in module_indicies {
+            let module = &modules[module_index];
+            for ref_info in &module.incoming_references {
+                let ref_module = &modules[ref_info.index];
+                if ref_module.depth < depth {
+                    let mut retained_modules = modules[module_index].retained_modules.borrow_mut();
+                    retained_modules.insert(module_index as u32);
+                    for retained in ref_module.retained_modules.borrow().iter() {
+                        retained_modules.insert(*retained);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut final_modules = modules
+        .iter_mut()
         .map(async |info| {
             Ok(ModuleInfo {
                 ident: info.module.ident().to_string().owned().await?,
                 path: info.module.ident().path().to_string().owned().await?,
                 depth: info.depth,
-                references: info.references,
-                incoming_references: info.incoming_references,
+                size: info
+                    .module
+                    .content()
+                    .len()
+                    .owned()
+                    .await?
+                    .unwrap_or_default()
+                    .try_into()
+                    .unwrap_or(u32::MAX),
+                retained_size: 0,
+                references: take(&mut info.references),
+                incoming_references: take(&mut info.incoming_references),
             })
         })
         .try_join()
         .await?;
 
-    Ok(ModuleGraphSnapshot { modules, entries }.cell())
+    for (index, info) in modules.into_iter().enumerate() {
+        let retained_size = info
+            .retained_modules
+            .into_inner()
+            .iter()
+            .map(|&retained_index| {
+                let retained_info = &final_modules[retained_index as usize];
+                retained_info.size
+            })
+            .reduce(|a, b| a.saturating_add(b))
+            .unwrap_or_default();
+        final_modules[index].retained_size = retained_size;
+    }
+
+    Ok(ModuleGraphSnapshot {
+        modules: final_modules,
+        entries,
+    }
+    .cell())
 }

--- a/crates/next-api/src/module_graph_snapshot.rs
+++ b/crates/next-api/src/module_graph_snapshot.rs
@@ -91,14 +91,14 @@ pub async fn get_module_graph_snapshot(
                     let parent_module = &mut modules[parent_index];
                     let parent_depth = parent_module.depth;
                     debug_assert!(parent_depth < u32::MAX);
-                    parent_module.incoming_references.push(ModuleReference {
+                    parent_module.references.push(ModuleReference {
                         index: module_index,
                         chunking_type: ty.chunking_type.clone(),
                         export: ty.export.clone(),
                     });
                     let module = &mut modules[module_index];
                     module.depth = module.depth.min(parent_depth + 1);
-                    module.references.push(ModuleReference {
+                    module.incoming_references.push(ModuleReference {
                         index: parent_index,
                         chunking_type: ty.chunking_type.clone(),
                         export: ty.export.clone(),

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -77,7 +77,7 @@ use crate::{
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
-    route::{Endpoint, EndpointOutput, EndpointOutputPaths, Route, Routes},
+    route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs, Route, Routes},
     webpack_stats::generate_webpack_stats,
 };
 
@@ -1726,6 +1726,13 @@ impl Endpoint for PageEndpoint {
             .collect::<Vec<_>>();
 
         Ok(Vc::cell(modules))
+    }
+
+    #[turbo_tasks::function]
+    async fn module_graphs(self: Vc<Self>) -> Result<Vc<ModuleGraphs>> {
+        let client_module_graph = self.client_module_graph().to_resolved().await?;
+        let ssr_module_graph = self.ssr_module_graph().to_resolved().await?;
+        Ok(Vc::cell(vec![client_module_graph, ssr_module_graph]))
     }
 }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -973,7 +973,9 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub async fn whole_app_module_graphs(self: ResolvedVc<Self>) -> Result<Vc<ModuleGraphs>> {
+    pub async fn whole_app_module_graphs(
+        self: ResolvedVc<Self>,
+    ) -> Result<Vc<BaseAndFullModuleGraph>> {
         async move {
             let module_graphs_op = whole_app_module_graph_operation(self);
             let module_graphs_vc = module_graphs_op.resolve_strongly_consistent().await?;
@@ -1813,7 +1815,7 @@ impl Project {
 #[turbo_tasks::function(operation)]
 async fn whole_app_module_graph_operation(
     project: ResolvedVc<Project>,
-) -> Result<Vc<ModuleGraphs>> {
+) -> Result<Vc<BaseAndFullModuleGraph>> {
     mark_root();
 
     let should_trace = project.next_mode().await?.is_production();
@@ -1831,7 +1833,7 @@ async fn whole_app_module_graph_operation(
     );
 
     let full = ModuleGraph::from_graphs(vec![base_single_module_graph, additional_module_graph]);
-    Ok(ModuleGraphs {
+    Ok(BaseAndFullModuleGraph {
         base: base.to_resolved().await?,
         full: full.to_resolved().await?,
     }
@@ -1839,7 +1841,7 @@ async fn whole_app_module_graph_operation(
 }
 
 #[turbo_tasks::value(shared)]
-pub struct ModuleGraphs {
+pub struct BaseAndFullModuleGraph {
     pub base: ResolvedVc<ModuleGraph>,
     pub full: ResolvedVc<ModuleGraph>,
 }

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -47,6 +47,9 @@ pub enum Route {
     Conflict,
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct ModuleGraphs(Vec<ResolvedVc<ModuleGraph>>);
+
 #[turbo_tasks::value_trait]
 pub trait Endpoint {
     #[turbo_tasks::function]
@@ -65,6 +68,8 @@ pub trait Endpoint {
     fn additional_entries(self: Vc<Self>, _graph: Vc<ModuleGraph>) -> Vc<GraphEntries> {
         GraphEntries::empty()
     }
+    #[turbo_tasks::function]
+    fn module_graphs(self: Vc<Self>) -> Vc<ModuleGraphs>;
 }
 
 #[turbo_tasks::value(transparent)]

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -752,5 +752,8 @@
   "751": "%s cannot not be used outside of a request context.",
   "752": "Route %s used \"connection\" inside \"use cache\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
   "753": "Route %s used \"connection\" inside \"use cache: private\". The \\`connection()\\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
-  "754": "%s cannot be used outside of a request context."
+  "754": "%s cannot be used outside of a request context.",
+  "755": "Route must be a string",
+  "756": "Route %s not found",
+  "757": "Unknown styled string type: %s"
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -100,15 +100,14 @@
     ]
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.15.1",
     "@next/env": "15.4.2-canary.14",
     "@swc/helpers": "0.5.15",
     "caniuse-lite": "^1.0.30001579",
     "postcss": "8.4.31",
-    "styled-jsx": "5.1.6",
-    "zod": "3.25.76"
+    "styled-jsx": "5.1.6"
   },
   "peerDependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.1",
     "@opentelemetry/api": "^1.1.0",
     "@playwright/test": "^1.51.1",
     "babel-plugin-react-compiler": "*",
@@ -121,6 +120,9 @@
       "optional": true
     },
     "sass": {
+      "optional": true
+    },
+    "@modelcontextprotocol/sdk": {
       "optional": true
     },
     "@opentelemetry/api": {
@@ -163,6 +165,7 @@
     "@hapi/accept": "5.0.2",
     "@jest/transform": "29.5.0",
     "@jest/types": "29.5.0",
+    "@modelcontextprotocol/sdk": "1.15.1",
     "@mswjs/interceptors": "0.23.0",
     "@napi-rs/triples": "1.2.0",
     "@next/font": "15.4.2-canary.14",
@@ -351,7 +354,8 @@
     "webpack-sources1": "npm:webpack-sources@1.4.3",
     "webpack-sources3": "npm:webpack-sources@3.2.3",
     "ws": "8.2.3",
-    "zod-validation-error": "3.4.0"
+    "zod-validation-error": "3.4.0",
+    "zod": "3.25.76"
   },
   "keywords": [
     "react",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -354,8 +354,8 @@
     "webpack-sources1": "npm:webpack-sources@1.4.3",
     "webpack-sources3": "npm:webpack-sources@3.2.3",
     "ws": "8.2.3",
-    "zod-validation-error": "3.4.0",
-    "zod": "3.25.76"
+    "zod": "3.25.76",
+    "zod-validation-error": "3.4.0"
   },
   "keywords": [
     "react",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -100,11 +100,13 @@
     ]
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.15.1",
     "@next/env": "15.4.2-canary.14",
     "@swc/helpers": "0.5.15",
     "caniuse-lite": "^1.0.30001579",
     "postcss": "8.4.31",
-    "styled-jsx": "5.1.6"
+    "styled-jsx": "5.1.6",
+    "zod": "3.25.76"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.1.0",
@@ -349,7 +351,6 @@
     "webpack-sources1": "npm:webpack-sources@1.4.3",
     "webpack-sources3": "npm:webpack-sources@3.2.3",
     "ws": "8.2.3",
-    "zod": "3.25.76",
     "zod-validation-error": "3.4.0"
   },
   "keywords": [

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -64,7 +64,28 @@ export interface NapiWrittenEndpoint {
   serverPaths: Array<NapiServerPath>
   config: NapiEndpointConfig
 }
+export interface NapiModuleReference {
+  /** The index of the referenced/referencing module in the modules list. */
+  i: number
+}
+export interface NapiModuleInfo {
+  ident: RcStr
+  path: RcStr
+  depth: number
+  references: Array<NapiModuleReference>
+  incomingReferences: Array<NapiModuleReference>
+}
+export interface NapiModuleGraphSnapshot {
+  modules: Array<NapiModuleInfo>
+  entries: Array<number>
+}
+export interface NapiModuleGraphSnapshots {
+  moduleGraphs: Array<NapiModuleGraphSnapshot>
+}
 export declare function endpointWriteToDisk(endpoint: {
+  __napiType: 'Endpoint'
+}): Promise<TurbopackResult>
+export declare function endpointModuleGraphs(endpoint: {
   __napiType: 'Endpoint'
 }): Promise<TurbopackResult>
 export declare function endpointServerChangedSubscribe(
@@ -286,6 +307,9 @@ export declare function projectWriteAllEntrypointsToDisk(
   project: { __napiType: 'Project' },
   appDirOnly: boolean
 ): Promise<TurbopackResult>
+export declare function projectEntrypoints(project: {
+  __napiType: 'Project'
+}): Promise<TurbopackResult>
 export declare function projectEntrypointsSubscribe(
   project: { __napiType: 'Project' },
   func: (...args: any[]) => any

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -84,7 +84,11 @@ export declare function endpointClientChangedSubscribe(
 ): { __napiType: 'RootTask' }
 export interface NapiModuleReference {
   /** The index of the referenced/referencing module in the modules list. */
-  i: number
+  index: number
+  /** The export used in the module reference. */
+  export: string
+  /** The type of chunking for the module reference. */
+  chunkingType: string
 }
 export interface NapiModuleInfo {
   ident: RcStr

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -94,6 +94,8 @@ export interface NapiModuleInfo {
   ident: RcStr
   path: RcStr
   depth: number
+  size: number
+  retainedSize: number
   references: Array<NapiModuleReference>
   incomingReferences: Array<NapiModuleReference>
 }

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -64,21 +64,6 @@ export interface NapiWrittenEndpoint {
   serverPaths: Array<NapiServerPath>
   config: NapiEndpointConfig
 }
-export interface NapiModuleReference {
-  /** The index of the referenced/referencing module in the modules list. */
-  i: number
-}
-export interface NapiModuleInfo {
-  ident: RcStr
-  path: RcStr
-  depth: number
-  references: Array<NapiModuleReference>
-  incomingReferences: Array<NapiModuleReference>
-}
-export interface NapiModuleGraphSnapshot {
-  modules: Array<NapiModuleInfo>
-  entries: Array<number>
-}
 export interface NapiModuleGraphSnapshots {
   moduleGraphs: Array<NapiModuleGraphSnapshot>
 }
@@ -97,6 +82,21 @@ export declare function endpointClientChangedSubscribe(
   endpoint: { __napiType: 'Endpoint' },
   func: (...args: any[]) => any
 ): { __napiType: 'RootTask' }
+export interface NapiModuleReference {
+  /** The index of the referenced/referencing module in the modules list. */
+  i: number
+}
+export interface NapiModuleInfo {
+  ident: RcStr
+  path: RcStr
+  depth: number
+  references: Array<NapiModuleReference>
+  incomingReferences: Array<NapiModuleReference>
+}
+export interface NapiModuleGraphSnapshot {
+  modules: Array<NapiModuleInfo>
+  entries: Array<number>
+}
 export interface NapiEnvVar {
   name: RcStr
   value: RcStr
@@ -386,6 +386,9 @@ export declare function projectGetSourceMapSync(
   project: { __napiType: 'Project' },
   filePath: RcStr
 ): string | null
+export declare function projectModuleGraph(project: {
+  __napiType: 'Project'
+}): Promise<TurbopackResult>
 /**
  * A version of [`NapiNextTurbopackCallbacks`] that can accepted as an argument to a napi function.
  *

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -19,6 +19,7 @@ import { isDeepStrictEqual } from 'util'
 import { type DefineEnvOptions, getDefineEnv } from '../define-env'
 import { getReactCompilerLoader } from '../get-babel-loader-config'
 import type {
+  NapiModuleGraphSnapshot,
   NapiModuleGraphSnapshots,
   NapiPartialProjectOptions,
   NapiProjectOptions,
@@ -750,6 +751,15 @@ function bindingToApi(
             eventTypes
           )
         }
+      )
+    }
+
+    async moduleGraph(): Promise<TurbopackResult<NapiModuleGraphSnapshot>> {
+      return await withErrorCause(
+        () =>
+          binding.projectModuleGraph(this._nativeProject) as Promise<
+            TurbopackResult<NapiModuleGraphSnapshot>
+          >
       )
     }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -672,13 +672,11 @@ function bindingToApi(
     }
 
     async getEntrypoints() {
-      return await withErrorCause(async () => {
-        const napiEndpoints = (await binding.projectEntrypoints(
-          this._nativeProject
-        )) as TurbopackResult<NapiEntrypoints>
+      const napiEndpoints = (await binding.projectEntrypoints(
+        this._nativeProject
+      )) as TurbopackResult<NapiEntrypoints>
 
-        return napiEntrypointsToRawEntrypoints(napiEndpoints)
-      })
+      return napiEntrypointsToRawEntrypoints(napiEndpoints)
     }
 
     entrypointsSubscribe() {
@@ -754,13 +752,10 @@ function bindingToApi(
       )
     }
 
-    async moduleGraph(): Promise<TurbopackResult<NapiModuleGraphSnapshot>> {
-      return await withErrorCause(
-        () =>
-          binding.projectModuleGraph(this._nativeProject) as Promise<
-            TurbopackResult<NapiModuleGraphSnapshot>
-          >
-      )
+    moduleGraph(): Promise<TurbopackResult<NapiModuleGraphSnapshot>> {
+      return binding.projectModuleGraph(this._nativeProject) as Promise<
+        TurbopackResult<NapiModuleGraphSnapshot>
+      >
     }
 
     invalidatePersistentCache(): Promise<void> {
@@ -816,12 +811,9 @@ function bindingToApi(
     }
 
     async moduleGraphs(): Promise<TurbopackResult<NapiModuleGraphSnapshots>> {
-      return await withErrorCause(
-        () =>
-          binding.endpointModuleGraphs(this._nativeEndpoint) as Promise<
-            TurbopackResult<NapiModuleGraphSnapshots>
-          >
-      )
+      return binding.endpointModuleGraphs(this._nativeEndpoint) as Promise<
+        TurbopackResult<NapiModuleGraphSnapshots>
+      >
     }
   }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -19,6 +19,7 @@ import { isDeepStrictEqual } from 'util'
 import { type DefineEnvOptions, getDefineEnv } from '../define-env'
 import { getReactCompilerLoader } from '../get-babel-loader-config'
 import type {
+  NapiModuleGraphSnapshots,
   NapiPartialProjectOptions,
   NapiProjectOptions,
   NapiSourceDiagnostic,
@@ -669,6 +670,16 @@ function bindingToApi(
       return napiEntrypointsToRawEntrypoints(napiEndpoints)
     }
 
+    async getEntrypoints() {
+      return await withErrorCause(async () => {
+        const napiEndpoints = (await binding.projectEntrypoints(
+          this._nativeProject
+        )) as TurbopackResult<NapiEntrypoints>
+
+        return napiEntrypointsToRawEntrypoints(napiEndpoints)
+      })
+    }
+
     entrypointsSubscribe() {
       const subscription = subscribe<TurbopackResult<NapiEntrypoints>>(
         false,
@@ -792,6 +803,15 @@ function bindingToApi(
       )
       await serverSubscription.next()
       return serverSubscription
+    }
+
+    async moduleGraphs(): Promise<TurbopackResult<NapiModuleGraphSnapshots>> {
+      return await withErrorCause(
+        () =>
+          binding.endpointModuleGraphs(this._nativeEndpoint) as Promise<
+            TurbopackResult<NapiModuleGraphSnapshots>
+          >
+      )
     }
   }
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -5,6 +5,7 @@ import type {
   RefCell,
   NapiTurboEngineOptions,
   NapiSourceDiagnostic,
+  NapiModuleGraphSnapshots,
 } from './generated-native'
 
 export type { NapiTurboEngineOptions as TurboEngineOptions }
@@ -216,6 +217,7 @@ export interface Project {
     appDirOnly: boolean
   ): Promise<TurbopackResult<RawEntrypoints>>
 
+  getEntrypoints(): Promise<TurbopackResult<RawEntrypoints>>
   entrypointsSubscribe(): AsyncIterableIterator<TurbopackResult<RawEntrypoints>>
 
   hmrEvents(identifier: string): AsyncIterableIterator<TurbopackResult<Update>>
@@ -295,6 +297,11 @@ export interface Endpoint {
   serverChanged(
     includeIssues: boolean
   ): Promise<AsyncIterableIterator<TurbopackResult>>
+
+  /**
+   * Gets a snapshot of the module graphs for the endpoint.
+   */
+  moduleGraphs(): Promise<TurbopackResult<NapiModuleGraphSnapshots>>
 }
 
 interface EndpointConfig {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -6,6 +6,7 @@ import type {
   NapiTurboEngineOptions,
   NapiSourceDiagnostic,
   NapiModuleGraphSnapshots,
+  NapiModuleGraphSnapshot,
 } from './generated-native'
 
 export type { NapiTurboEngineOptions as TurboEngineOptions }
@@ -245,6 +246,8 @@ export interface Project {
   ): AsyncIterableIterator<TurbopackResult<CompilationEvent>>
 
   invalidatePersistentCache(): Promise<void>
+
+  moduleGraph(): Promise<TurbopackResult<NapiModuleGraphSnapshot>>
 
   shutdown(): Promise<void>
 

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -18,6 +18,8 @@ import * as Log from '../../../build/output/log'
 import { formatImportTraces } from '../../../shared/lib/turbopack/utils'
 import { inspect } from 'node:util'
 
+export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+
 const QUERY_DESCRIPTION = `A piece of JavaScript code that will be executed.
 It can access the module graph and extract information it finds useful.
 The \`console.log\` function can be used to log messages, which will also be returned in the response.

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -23,6 +23,8 @@ It can access the module graph and extract information it finds useful.
 The value of all newly created global variables will be returned in the response and can be used to report results.
 The \`console.log\` function can be used to log messages, which will also be returned in the response.
 No Node.js or browser APIs are available, but JavaScript language features are available.
+When the user is interested in used exports of modules, you can use the \`export\` property of ModuleReferences (\`incomingReferences\`).
+When the user is interested in the import path of a module, follow one of the \`incomingReferences\` with a smaller \`depth\` value than the current module until you hit the root.
 See the following TypeScript typings for reference:
 
 \`\`\` typescript
@@ -50,14 +52,28 @@ interface Module {
   /// Example: 0 for the entrypoint, 1 for the first layer of modules, etc.
   depth: number,
   /// The modules that are referenced by this module.
-  /// Modules could be references by \`import\`, \`require\`, \`new URL\`, etc.
+  /// Modules could be referenced by \`import\`, \`require\`, \`new URL\`, etc.
   references: ModuleReference[],
   /// The modules that reference this module.
   incomingReferences: ModuleReference[],
 }
 
 interface ModuleReference {
+  /// The referenced/referencing module.
   module: Module
+  /// The thing that is used from the module.
+  /// export {name}: The named export that is used.
+  /// evaluation: Imported for side effects only.
+  /// all: All exports and the side effects.
+  export: "evaluation" | "all" | \`export \${string}\`
+  /// How this reference affects chunking of the module.
+  /// hoisted | sync: The module is placed in the same chunk group as the referencing module.
+  /// hoisted: The module is loaded before all "sync" modules.
+  /// async: The module forms a separate chunk group which is loaded asynchronously.
+  /// isolated: The module forms a separate chunk group which is loaded as separate entry. When it has a name, all modules imported with this name are placed in the same chunk group.
+  /// shared: The module forms a separate chunk group which is loaded before the current chunk group. When it has a name, all modules imported with this name are placed in the same chunk group.
+  /// traced: The module is not bundled, but the graph is still traced and all modules are included unbundled.
+  chunkingType: "hoisted" | "sync" | "async" | "isolated" | \`isolated \${string}\` | "shared" | \`shared \${string}\` | "traced"
 }
 
 // The following global variables are available in the query:
@@ -237,6 +253,8 @@ function arrayOrSingle<T>(value: T | T[]): T[] {
 
 interface ModuleReference {
   module: Module
+  export: string
+  chunkingType: string
 }
 interface Module {
   /// The identifier of the module, which is a unique string.
@@ -273,12 +291,16 @@ function processModuleGraphSnapshot(
 
     queryModule.references = rawModule.references.map(
       (ref: NapiModuleReference) => ({
-        module: queryModules[ref.i],
+        module: queryModules[ref.index],
+        export: ref.export,
+        chunkingType: ref.chunkingType,
       })
     )
     queryModule.incomingReferences = rawModule.incomingReferences.map(
       (ref: NapiModuleReference) => ({
-        module: queryModules[ref.i],
+        module: queryModules[ref.index],
+        export: ref.export,
+        chunkingType: ref.chunkingType,
       })
     )
     modules.push(queryModule)
@@ -350,7 +372,7 @@ You can use the Model Context Protocol to query information about pages and modu
     {
       title: 'Entrypoints',
       description:
-        'Get all entrypoints of a Turbopack project, which are all pages, routes and the middleware. Also reports issues found while accumulating the entrypoints.',
+        'Get all entrypoints of a Turbopack project, which are all pages, routes and the middleware.',
     },
     async () =>
       measureAndHandleErrors('entrypoints', async () => {

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -65,35 +65,29 @@ You can use the Model Context Protocol to query information about pages and modu
     return `${indentStr}${str.replace(/\n/g, `\n${indentStr}`)}`
   }
 
-  function issueToString(issue: Issue): string {
-    return (
-      `${issue.severity} in ${issue.stage} {` +
-      indent(
-        [
-          `File Path: ${issue.filePath}`,
-          issue.source &&
-            `Source:
+  function issueToString(issue: Issue & { route: string }): string {
+    return [
+      `${issue.severity} in ${issue.stage} on ${issue.route}`,
+      `File Path: ${issue.filePath}`,
+      issue.source &&
+        `Source:
   ${issue.source.source.ident}
   ${issue.source.range ? `Range: ${issue.source.range?.start.line}:${issue.source.range?.start.column} - ${issue.source.range?.end.line}:${issue.source.range?.end.column}` : 'Unknown range'}
 `,
-          `Title: ${issue.title}`,
-          issue.description &&
-            `Description:
+      `Title: ${styledStringToMarkdown(issue.title)}`,
+      issue.description &&
+        `Description:
 ${indent(styledStringToMarkdown(issue.description))}`,
-          issue.detail &&
-            `Details:
+      issue.detail &&
+        `Details:
 ${indent(styledStringToMarkdown(issue.detail))}`,
-          issue.documentationLink &&
-            `Documentation: ${issue.documentationLink}`,
-          issue.importTraces &&
-            issue.importTraces.length > 0 &&
-            formatImportTraces(issue.importTraces),
-        ]
-          .filter(Boolean)
-          .join('\n')
-      ) +
-      '\n}'
-    )
+      issue.documentationLink && `Documentation: ${issue.documentationLink}`,
+      issue.importTraces &&
+        issue.importTraces.length > 0 &&
+        formatImportTraces(issue.importTraces),
+    ]
+      .filter(Boolean)
+      .join('\n')
   }
 
   function issuesReference(issues: Issue[]): { type: 'text'; text: string } {
@@ -118,31 +112,6 @@ ${indent(styledStringToMarkdown(issue.detail))}`,
         .map(([severity, count]) => `${count} x ${severity}`)
         .join(', ')}.`,
     ]
-
-    const reportedSeverities = ['bug', 'fatal', 'error', 'warning']
-
-    const reportedServerity = reportedSeverities.find(
-      (severity) => countBySeverity.get(severity) > 0
-    )
-
-    if (reportedServerity) {
-      const count = countBySeverity.get(reportedServerity) || 0
-      const visibleCount = Math.min(count, 5)
-      text.push(
-        `Showing the first ${visibleCount} of ${count} issues of severity \`${reportedServerity}\`:`
-      )
-      let remainingCount = visibleCount
-      for (const issue of issues) {
-        if (issue.severity !== reportedServerity) {
-          continue
-        }
-        text.push(`- ${issueToString(issue)}`)
-        remainingCount--
-        if (remainingCount <= 0) {
-          break
-        }
-      }
-    }
 
     return {
       type: 'text',
@@ -182,6 +151,10 @@ ${indent(styledStringToMarkdown(issue.detail))}`,
       default:
         invariant(route, (r) => `Unknown route type: ${r.type}`)
     }
+  }
+
+  function arrayOrSingle<T>(value: T | T[]): T[] {
+    return Array.isArray(value) ? value : [value]
   }
 
   server.registerTool(
@@ -234,12 +207,13 @@ ${list.map((e) => `- ${e}`).join('\n')}`,
     'query-module-graph',
     {
       title: 'Query module graph',
-      description:
-        'Query details about the module graph of a route. Also reports issues found in that route.',
+      description: 'Query details about the module graph of routes.',
       inputSchema: {
-        route: z
-          .string()
-          .describe('The route from which to query the module graph.'),
+        routes: z
+          .union([z.string(), z.array(z.string())])
+          .describe(
+            'The routes from which to query the module graph. Can be a single string or an array of strings.'
+          ),
         query: z.string().describe(
           `A piece of JavaScript code that will be executed.
 It can access the module graph and log out information it finds useful.
@@ -267,6 +241,7 @@ interface Module {
   /// Example: "[project]/pages/folder/index.js",
   path: string,
   /// The distance to the entries of the module graph. Use this to traverse the graph in the right direction.
+  /// This is useful when trying to find the path from a module to the root of the module graph.
   /// Example: 0 for the entrypoint, 1 for the first layer of modules, etc.
   depth: number,
   /// The modules that are referenced by this module.
@@ -299,24 +274,22 @@ const modules: Module[]
 /// Prints the gives data as JSON to the tool response.
 /// It might be useful to use a string as first argument to identify the result in the response when using multiple different log calls.
 declare function log(...data: any[]): void
-
-/// Finds a path to the root of the module graph, starting from the given module.
-/// The return value is an array of modules, starting with the given module and ending with the root module.
-/// When the user asks to find a module, they are often interested to know the path of the module too.
-declare function findPathToRoot(module: Module): Module[];
 \`\`\`
 `
         ),
       },
     },
-    async ({ route, query }) => {
+    async ({ routes, query }) => {
       const start = performance.now()
       const entrypoints = await turbopack.getEntrypoints()
-      const routeInfo = entrypoints.routes.get(route)
-      if (!routeInfo) {
-        throw new Error(`Route ${route} not found`)
+      const endpoints = []
+      for (const route of arrayOrSingle(routes)) {
+        const routeInfo = entrypoints.routes.get(route)
+        if (!routeInfo) {
+          throw new Error(`Route ${route} not found`)
+        }
+        endpoints.push(...routeToEndpoints(routeInfo))
       }
-      const endpoints = routeToEndpoints(routeInfo)
       const issues = []
       const modules = []
       const entries = []
@@ -380,7 +353,99 @@ declare function findPathToRoot(module: Module): Module[];
         duration > 2000
           ? `${Math.round(duration / 100) / 10}s`
           : `${Math.round(duration)}ms`
-      Log.event(`MCP query on ${route} in ${formatDurationText}`)
+      Log.event(
+        `MCP query on ${arrayOrSingle(routes).join(', ')} in ${formatDurationText}`
+      )
+      return {
+        content,
+      }
+    }
+  )
+
+  server.registerTool(
+    'query-issues',
+    {
+      title: 'Query issues of routes',
+      description:
+        'Query issues (errors, warnings, lints, etc.) that are reported on routes.',
+      inputSchema: {
+        routes: z
+          .union([z.string(), z.array(z.string())])
+          .describe(
+            'The routes from which to query the module graph. Can be a single string or an array of strings.'
+          ),
+        page: z
+          .optional(z.number())
+          .describe(
+            'Issues are paginated when there are more than 50 issues. The first page is number 0.'
+          ),
+      },
+    },
+    async ({ routes, page }) => {
+      const start = performance.now()
+      const entrypoints = await turbopack.getEntrypoints()
+      const issues = []
+      for (const route of arrayOrSingle(routes)) {
+        const routeInfo = entrypoints.routes.get(route)
+        if (!routeInfo) {
+          throw new Error(`Route ${route} not found`)
+        }
+        for (const endpoint of routeToEndpoints(routeInfo)) {
+          const result = await endpoint.moduleGraphs()
+          for (const issue of result.issues) {
+            const issuesWithRoute = issue as Issue & { route: string }
+            issuesWithRoute.route = route
+            issues.push(issuesWithRoute)
+          }
+        }
+      }
+      const severitiesArray = [
+        'bug',
+        'fatal',
+        'error',
+        'warning',
+        'hint',
+        'note',
+        'suggestion',
+        'info',
+      ]
+      const severities = new Map(
+        severitiesArray.map((severity, index) => [severity, index])
+      )
+      issues.sort((a, b) => {
+        const severityA = severities.get(a.severity)
+        const severityB = severities.get(b.severity)
+        if (severityA !== undefined && severityB !== undefined) {
+          return severityA - severityB
+        }
+        return 0
+      })
+
+      const content: CallToolResult['content'] = []
+      content.push(issuesReference(issues))
+      page = page ?? 0
+      const currentPage = issues.slice(page * 50, (page + 1) * 50)
+      for (const issue of currentPage) {
+        content.push({
+          type: 'text',
+          text: issueToString(issue),
+        })
+      }
+      if (issues.length >= (page + 1) * 50) {
+        content.push({
+          type: 'text',
+          text: `Note: There are more issues available. Use the \`page\` parameter to query the next page.`,
+        })
+      }
+
+      const duration = performance.now() - start
+      const formatDurationText =
+        duration > 2000
+          ? `${Math.round(duration / 100) / 10}s`
+          : `${Math.round(duration)}ms`
+      Log.event(
+        `MCP query on ${arrayOrSingle(routes).join(', ')} in ${formatDurationText}`
+      )
       return {
         content,
       }
@@ -420,18 +485,6 @@ function runQuery(
         type: 'text',
         text: `Log: ${data.map((d) => JSON.stringify(d, null, 2)).join('\n')}`,
       })
-    },
-    findPathToRoot: (module: Module): Module[] => {
-      const path: Module[] = []
-      let current: Module | undefined = module
-      while (current) {
-        path.push(current)
-        const depth: number = current.depth
-        const reference: ModuleReference | undefined =
-          current.incomingReferences.find((ref) => ref.module.depth < depth)
-        current = reference?.module
-      }
-      return path.reverse()
     },
     global: undefined,
     self: undefined,

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -1,5 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { z } from 'zod'
+import { z } from 'next/dist/compiled/zod'
 import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
 import type {
   Endpoint,
@@ -352,14 +352,11 @@ function runQuery(
         })
       },
     },
-    global: undefined,
-    self: undefined,
-    globalThis: undefined,
   }
   const contextObject = Object.create(proto)
-  proto.global = contextObject
-  proto.self = contextObject
-  proto.globalThis = contextObject
+  contextObject.global = contextObject
+  contextObject.self = contextObject
+  contextObject.globalThis = contextObject
   runInNewContext(query, contextObject, {
     displayErrors: true,
     filename: 'query.js',

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -16,10 +16,13 @@ import type {
 import { runInNewContext } from 'node:vm'
 import * as Log from '../../../build/output/log'
 import { formatImportTraces } from '../../../shared/lib/turbopack/utils'
+import { inspect } from 'node:util'
 
 const QUERY_DESCRIPTION = `A piece of JavaScript code that will be executed.
 It can access the module graph and extract information it finds useful.
 The value of all newly created global variables will be returned in the response and can be used to report results.
+The \`console.log\` function can be used to log messages, which will also be returned in the response.
+No Node.js or browser APIs are available, but JavaScript language features are available.
 See the following TypeScript typings for reference:
 
 \`\`\` typescript
@@ -70,6 +73,13 @@ const entries: Module[]
 /// Make sure to iterate over this array and not only consider the first one.
 /// Prefer to use \`modules\` over \`entries\` as it contains all modules, not only the entrypoints.
 const modules: Module[]
+
+const console: {
+  /// Logs a message to the console.
+  /// The message will be returned in the response.
+  /// The message can be a string or any other value that can be inspected.
+  log: (...data: any[]) => void
+}
 \`\`\`
 `
 
@@ -288,6 +298,14 @@ function runQuery(
   const proto = {
     modules,
     entries,
+    console: {
+      log: (...data: any[]) => {
+        response.push({
+          type: 'text',
+          text: data.map((item) => inspect(item, false, 2, false)).join(' '),
+        })
+      },
+    },
     global: undefined,
     self: undefined,
     globalThis: undefined,

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -1,0 +1,451 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
+import type {
+  Endpoint,
+  Issue,
+  Route,
+  StyledString,
+} from '../../../build/swc/types'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
+import type {
+  NapiModuleInfo,
+  NapiModuleReference,
+} from '../../../build/swc/generated-native'
+import { runInNewContext } from 'node:vm'
+import * as Log from '../../../build/output/log'
+import { formatImportTraces } from '../../../shared/lib/turbopack/utils'
+
+export function createMcpServer(
+  hotReloader: NextJsHotReloaderInterface
+): McpServer | undefined {
+  const turbopack = hotReloader.turbopackProject
+  if (!turbopack) return undefined
+  const server = new McpServer({
+    name: 'next.js',
+    version: '1.0.0',
+    instructions: `This is a running next.js dev server with Turbopack.
+You can use the Model Context Protocol to query information about pages and modules and their relations.
+
+
+`,
+  })
+
+  function invariant(
+    value: never,
+    errorMessage: (value: any) => string
+  ): never {
+    throw new Error(errorMessage(value))
+  }
+
+  function styledStringToMarkdown(
+    styledString: StyledString | undefined
+  ): string {
+    if (!styledString) {
+      return ''
+    }
+    switch (styledString.type) {
+      case 'text':
+        return styledString.value
+      case 'strong':
+        return `*${styledString.value}*`
+      case 'code':
+        return `\`${styledString.value}\``
+      case 'line':
+        return styledString.value.map(styledStringToMarkdown).join('')
+      case 'stack':
+        return styledString.value.map(styledStringToMarkdown).join('\n\n')
+      default:
+        invariant(styledString, (s) => `Unknown styled string type: ${s.type}`)
+    }
+  }
+
+  function indent(str: string, spaces: number = 2): string {
+    const indentStr = ' '.repeat(spaces)
+    return `${indentStr}${str.replace(/\n/g, `\n${indentStr}`)}`
+  }
+
+  function issueToString(issue: Issue): string {
+    return (
+      `${issue.severity} in ${issue.stage} {` +
+      indent(
+        [
+          `File Path: ${issue.filePath}`,
+          issue.source &&
+            `Source:
+  ${issue.source.source.ident}
+  ${issue.source.range ? `Range: ${issue.source.range?.start.line}:${issue.source.range?.start.column} - ${issue.source.range?.end.line}:${issue.source.range?.end.column}` : 'Unknown range'}
+`,
+          `Title: ${issue.title}`,
+          issue.description &&
+            `Description:
+${indent(styledStringToMarkdown(issue.description))}`,
+          issue.detail &&
+            `Details:
+${indent(styledStringToMarkdown(issue.detail))}`,
+          issue.documentationLink &&
+            `Documentation: ${issue.documentationLink}`,
+          issue.importTraces &&
+            issue.importTraces.length > 0 &&
+            formatImportTraces(issue.importTraces),
+        ]
+          .filter(Boolean)
+          .join('\n')
+      ) +
+      '\n}'
+    )
+  }
+
+  function issuesReference(issues: Issue[]): { type: 'text'; text: string } {
+    if (issues.length === 0) {
+      return {
+        type: 'text',
+        text: 'Note: There are no issues.',
+      }
+    }
+
+    const countBySeverity = new Map()
+
+    for (const issue of issues) {
+      const count = countBySeverity.get(issue.severity) || 0
+      countBySeverity.set(issue.severity, count + 1)
+    }
+
+    const text = [
+      `Note: There are ${issues.length} issues in total, with the following severities: ${Array.from(
+        countBySeverity.entries()
+      )
+        .map(([severity, count]) => `${count} x ${severity}`)
+        .join(', ')}.`,
+    ]
+
+    const reportedSeverities = ['bug', 'fatal', 'error', 'warning']
+
+    const reportedServerity = reportedSeverities.find(
+      (severity) => countBySeverity.get(severity) > 0
+    )
+
+    if (reportedServerity) {
+      const count = countBySeverity.get(reportedServerity) || 0
+      const visibleCount = Math.min(count, 5)
+      text.push(
+        `Showing the first ${visibleCount} of ${count} issues of severity \`${reportedServerity}\`:`
+      )
+      let remainingCount = visibleCount
+      for (const issue of issues) {
+        if (issue.severity !== reportedServerity) {
+          continue
+        }
+        text.push(`- ${issueToString(issue)}`)
+        remainingCount--
+        if (remainingCount <= 0) {
+          break
+        }
+      }
+    }
+
+    return {
+      type: 'text',
+      text: text.join('\n'),
+    }
+  }
+
+  function routeToTitle(route: Route): string {
+    switch (route.type) {
+      case 'page':
+        return 'A page using Pages Router.'
+      case 'app-page':
+        return `A page using App Router. Original names: ${route.pages.map((page) => page.originalName).join(', ')}.`
+      case 'page-api':
+        return 'An API route using Pages Router.'
+      case 'app-route':
+        return `A route using App Router. Original name: ${route.originalName}.`
+      case 'conflict':
+        return 'Multiple routes conflict on this path. This is an error in the folder structure.'
+      default:
+        invariant(route, (r) => `Unknown route type: ${r.type}`)
+    }
+  }
+
+  function routeToEndpoints(route: Route): Endpoint[] {
+    switch (route.type) {
+      case 'page':
+        return [route.htmlEndpoint]
+      case 'app-page':
+        return route.pages.map((p) => p.htmlEndpoint)
+      case 'page-api':
+        return [route.endpoint]
+      case 'app-route':
+        return [route.endpoint]
+      case 'conflict':
+        return []
+      default:
+        invariant(route, (r) => `Unknown route type: ${r.type}`)
+    }
+  }
+
+  server.registerTool(
+    'entrypoints',
+    {
+      title: 'Entrypoints',
+      description:
+        'Get all entrypoints of a Turbopack project, which are all pages, routes and the middleware. Also reports issues found while accumulating the entrypoints.',
+    },
+    async () => {
+      const start = performance.now()
+      let entrypoints = await turbopack.getEntrypoints()
+
+      const list = []
+
+      for (const [key, route] of entrypoints.routes.entries()) {
+        list.push(`\`${key}\` (${routeToTitle(route)})`)
+      }
+
+      if (entrypoints.middleware) {
+        list.push('Middleware')
+      }
+
+      if (entrypoints.instrumentation) {
+        list.push('Instrumentation')
+      }
+
+      const content: CallToolResult['content'] = [
+        issuesReference(entrypoints.issues),
+        {
+          type: 'text',
+          text: `These are the routes of the application:
+
+${list.map((e) => `- ${e}`).join('\n')}`,
+        },
+      ]
+      const duration = performance.now() - start
+      const formatDurationText =
+        duration > 2000
+          ? `${Math.round(duration / 100) / 10}s`
+          : `${Math.round(duration)}ms`
+      Log.event(`MCP entrypoints in ${formatDurationText}`)
+      return {
+        content,
+      }
+    }
+  )
+
+  server.registerTool(
+    'query-module-graph',
+    {
+      title: 'Query module graph',
+      description:
+        'Query details about the module graph of a route. Also reports issues found in that route.',
+      inputSchema: {
+        route: z
+          .string()
+          .describe('The route from which to query the module graph.'),
+        query: z.string().describe(
+          `A piece of JavaScript code that will be executed.
+It can access the module graph and log out information it finds useful.
+The value of all newly created global variables will be returned in the response and can be used to report results.
+See the following TypeScript typings for reference:
+
+\`\`\` typescript
+interface Module {
+  /// The identifier of the module, which is a unique string.
+  /// Example: "[project]/packages/next-app/src/app/folder/page.tsx [app-rsc] (ecmascript, Next.js Server Component) <locals>"
+  /// These layers exist in App Router:
+  /// * Server Components: [app-rsc], [app-edge-rsc]
+  /// * API routes: [app-route], [app-edge-route]
+  /// * Client Components: [app-client]
+  /// * Server Side Rendering of Client Components: [app-ssr], [app-edge-ssr]
+  /// These layers exist in Pages Router:
+  /// * Client-side rendering: [client]
+  /// * Server-side rendering: [ssr], [edge-ssr]
+  /// * API routes: [api], [edge-api]
+  /// And these layers also exist:
+  /// * Middleware: [middleware], [middleware-edge]
+  /// * Instrumentation: [instrumentation], [instrumentation-edge]
+  ident: string,
+  /// The path of the module. It's not unique as multiple modules can have the same path.
+  /// Example: "[project]/pages/folder/index.js",
+  path: string,
+  /// The distance to the entries of the module graph. Use this to traverse the graph in the right direction.
+  /// Example: 0 for the entrypoint, 1 for the first layer of modules, etc.
+  depth: number,
+  /// The modules that are referenced by this module.
+  /// Modules could be references by \`import\`, \`require\`, \`new URL\`, etc.
+  references: ModuleReference[],
+  /// The modules that reference this module.
+  incomingReferences: ModuleReference[],
+}
+
+interface ModuleReference {
+  module: Module
+}
+
+// The following global variables are available in the query:
+
+/// The entries of the module graph.
+/// Note that this only includes the entrypoints of the module graph and not all modules.
+/// You need to traverse it recursively to find not only children, but also grandchildren (resp, grandparents).
+/// Prefer to use \`modules\` over \`entries\` as it contains all modules, not only the entrypoints.
+const entries: Module[]
+
+/// All modules in the module graph.
+/// Note that this array already contains all the modules as flat list.
+/// Make sure to iterate over this array and not only consider the first one.
+/// Prefer to use \`modules\` over \`entries\` as it contains all modules, not only the entrypoints.
+const modules: Module[]
+
+// Helper methods available in scope:
+
+/// Prints the gives data as JSON to the tool response.
+/// It might be useful to use a string as first argument to identify the result in the response when using multiple different log calls.
+declare function log(...data: any[]): void
+
+/// Finds a path to the root of the module graph, starting from the given module.
+/// The return value is an array of modules, starting with the given module and ending with the root module.
+/// When the user asks to find a module, they are often interested to know the path of the module too.
+declare function findPathToRoot(module: Module): Module[];
+\`\`\`
+`
+        ),
+      },
+    },
+    async ({ route, query }) => {
+      const start = performance.now()
+      const entrypoints = await turbopack.getEntrypoints()
+      const routeInfo = entrypoints.routes.get(route)
+      if (!routeInfo) {
+        throw new Error(`Route ${route} not found`)
+      }
+      const endpoints = routeToEndpoints(routeInfo)
+      const issues = []
+      const modules = []
+      const entries = []
+
+      function createModuleObject(rawModule: NapiModuleInfo): Module {
+        return {
+          ident: rawModule.ident,
+          path: rawModule.path,
+          depth: rawModule.depth,
+          references: [],
+          incomingReferences: [],
+        }
+      }
+      for (const endpoint of endpoints) {
+        const result = await endpoint.moduleGraphs()
+        issues.push(...result.issues)
+        const moduleGraphs = result.moduleGraphs
+        for (const moduleGraph of moduleGraphs) {
+          const queryModules = moduleGraph.modules.map(createModuleObject)
+          for (let i = 0; i < queryModules.length; i++) {
+            const rawModule = moduleGraph.modules[i]
+            const queryModule = queryModules[i]
+
+            queryModule.references = rawModule.references.map(
+              (ref: NapiModuleReference) => ({
+                module: queryModules[ref.i],
+              })
+            )
+            queryModule.incomingReferences = rawModule.incomingReferences.map(
+              (ref: NapiModuleReference) => ({
+                module: queryModules[ref.i],
+              })
+            )
+            modules.push(queryModule)
+          }
+          for (const entry of moduleGraph.entries) {
+            const queryModule = queryModules[entry]
+            entries.push(queryModule)
+          }
+        }
+      }
+      const content: CallToolResult['content'] = []
+      content.push(issuesReference(issues))
+      try {
+        const response = runQuery(query, modules, entries)
+        content.push(...response)
+      } catch (error) {
+        content.push({
+          type: 'text',
+          text: `Error while running query: ${
+            error instanceof Error ? error.stack : String(error)
+          }`,
+        })
+        content.push({
+          type: 'text',
+          text: 'Fix the query and try again.',
+        })
+      }
+      const duration = performance.now() - start
+      const formatDurationText =
+        duration > 2000
+          ? `${Math.round(duration / 100) / 10}s`
+          : `${Math.round(duration)}ms`
+      Log.event(`MCP query on ${route} in ${formatDurationText}`)
+      return {
+        content,
+      }
+    }
+  )
+
+  return server
+}
+
+interface ModuleReference {
+  module: Module
+}
+interface Module {
+  /// The identifier of the module, which is a unique string.
+  ident: string
+  /// The path of the module. It's not unique as multiple modules can have the same path.
+  path: string
+  /// The distance to the entries of the module graph. Use this to traverse the graph in the right direction.
+  depth: number
+  /// The modules that are referenced by this module.
+  references: ModuleReference[]
+  /// The modules that reference this module.
+  incomingReferences: ModuleReference[]
+}
+
+function runQuery(
+  query: string,
+  modules: Module[],
+  entries: Module[]
+): CallToolResult['content'] {
+  const response: CallToolResult['content'] = []
+  const contextObject = Object.create({
+    modules,
+    entries,
+    log: (...data: any[]) => {
+      response.push({
+        type: 'text',
+        text: `Log: ${data.map((d) => JSON.stringify(d, null, 2)).join('\n')}`,
+      })
+    },
+    findPathToRoot: (module: Module): Module[] => {
+      const path: Module[] = []
+      let current: Module | undefined = module
+      while (current) {
+        path.push(current)
+        const depth: number = current.depth
+        const reference: ModuleReference | undefined =
+          current.incomingReferences.find((ref) => ref.module.depth < depth)
+        current = reference?.module
+      }
+      return path.reverse()
+    },
+  })
+  runInNewContext(query, contextObject, {
+    displayErrors: true,
+    filename: 'query.js',
+    timeout: 5000,
+    contextName: 'Query Context',
+  })
+  for (const [key, value] of Object.entries(contextObject)) {
+    if (typeof value === 'function') continue
+    response.push({
+      type: 'text',
+      text: `Global variable \`${key}\` = ${JSON.stringify(value, null, 2)}`,
+    })
+  }
+  return response
+}

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -339,7 +339,7 @@ function runQuery(
   runInNewContext(query, contextObject, {
     displayErrors: true,
     filename: 'query.js',
-    timeout: 5000,
+    timeout: 20000,
     contextName: 'Query Context',
   })
   for (const [key, value] of Object.entries(contextObject)) {

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -51,6 +51,13 @@ interface Module {
   /// This is useful when trying to find the path from a module to the root of the module graph.
   /// Example: 0 for the entrypoint, 1 for the first layer of modules, etc.
   depth: number,
+  /// The size of the source code of the module in bytes.
+  /// Note that it's not the final size of the generated code, but can be a good indicator of that.
+  /// It's only the size of this single module, not the size of the whole subgraph behind it (see retainedSize instead).
+  size: number,
+  /// The size of the whole subgraph behind this module in bytes.
+  /// Note that it's not the final size of the generated code, but can be a good indicator of that.
+  retainedSize: number,
   /// The modules that are referenced by this module.
   /// Modules could be referenced by \`import\`, \`require\`, \`new URL\`, etc.
   references: ModuleReference[],
@@ -263,6 +270,10 @@ interface Module {
   path: string
   /// The distance to the entries of the module graph. Use this to traverse the graph in the right direction.
   depth: number
+  /// The size of the source code of the module in bytes.
+  size: number
+  /// The size of the whole subgraph behind this module in bytes.
+  retainedSize: number
   /// The modules that are referenced by this module.
   references: ModuleReference[]
   /// The modules that reference this module.
@@ -274,6 +285,8 @@ function createModuleObject(rawModule: NapiModuleInfo): Module {
     ident: rawModule.ident,
     path: rawModule.path,
     depth: rawModule.depth,
+    size: rawModule.size,
+    retainedSize: rawModule.retainedSize,
     references: [],
     incomingReferences: [],
   }

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -20,17 +20,17 @@ import { inspect } from 'node:util'
 
 const QUERY_DESCRIPTION = `A piece of JavaScript code that will be executed.
 It can access the module graph and extract information it finds useful.
-The value of all newly created global variables will be returned in the response and can be used to report results.
 The \`console.log\` function can be used to log messages, which will also be returned in the response.
 No Node.js or browser APIs are available, but JavaScript language features are available.
 When the user is interested in used exports of modules, you can use the \`export\` property of ModuleReferences (\`incomingReferences\`).
 When the user is interested in the import path of a module, follow one of the \`incomingReferences\` with a smaller \`depth\` value than the current module until you hit the root.
+Do not try to make any assumptions or estimations. See the typings to see which data you have available. If you don't have the data, tell the user that this data is not available and list alternatives that are available.
 See the following TypeScript typings for reference:
 
 \`\`\` typescript
 interface Module {
   /// The identifier of the module, which is a unique string.
-  /// Example: "[project]/packages/next-app/src/app/folder/page.tsx [app-rsc] (ecmascript, Next.js Server Component) <locals>"
+  /// Example: "[project]/packages/next-app/src/app/folder/page.tsx [app-rsc] (ecmascript, Next.js Server Component)"
   /// These layers exist in App Router:
   /// * Server Components: [app-rsc], [app-edge-rsc]
   /// * API routes: [app-route], [app-edge-route]
@@ -45,7 +45,10 @@ interface Module {
   /// * Instrumentation: [instrumentation], [instrumentation-edge]
   ident: string,
   /// The path of the module. It's not unique as multiple modules can have the same path.
+  /// Separate between application code and node_modules (npm packages, vendor code).
   /// Example: "[project]/pages/folder/index.js",
+  /// Example: "[project]/node_modules/.pnpm/next@file+..+next.js+packages+next_@babel+core@7.27.4_@opentelemetry+api@1.7.0_@playwright+te_5kenhtwdm6lrgjpao5hc34lkgy/node_modules/next/dist/compiled/fresh/index.js",
+  /// Example: "[project]/apps/site/node_modules/@opentelemtry/api/build/src/trace/instrumentation.js",
   path: string,
   /// The distance to the entries of the module graph. Use this to traverse the graph in the right direction.
   /// This is useful when trying to find the path from a module to the root of the module graph.
@@ -56,12 +59,16 @@ interface Module {
   /// It's only the size of this single module, not the size of the whole subgraph behind it (see retainedSize instead).
   size: number,
   /// The size of the whole subgraph behind this module in bytes.
-  /// Note that it's not the final size of the generated code, but can be a good indicator of that.
+  /// Use this value if the user is interested in sizes of modules (except when they are interested in the size of the module itself).
+  /// Never try to compute the retained size yourself, but use this value instead.
   retainedSize: number,
   /// The modules that are referenced by this module.
   /// Modules could be referenced by \`import\`, \`require\`, \`new URL\`, etc.
+  /// Beware cycles in the module graph. You can avoid that by only walking edges with a bigger \`depth\` value than the current module.
   references: ModuleReference[],
   /// The modules that reference this module.
+  /// Beware cycles in the module graph. 
+  /// You can use this to walk up the graph up to the root. When doing this only walk edges with a smaller \`depth\` value than the current module.
   incomingReferences: ModuleReference[],
 }
 
@@ -337,7 +344,11 @@ function runQuery(
       log: (...data: any[]) => {
         response.push({
           type: 'text',
-          text: data.map((item) => inspect(item, false, 2, false)).join(' '),
+          text: data
+            .map((item) =>
+              typeof item === 'string' ? item : inspect(item, false, 2, false)
+            )
+            .join(' '),
         })
       },
     },
@@ -360,7 +371,7 @@ function runQuery(
     if (key === 'global' || key === 'self' || key === 'globalThis') continue
     response.push({
       type: 'text',
-      text: `Global variable \`${key}\` = ${JSON.stringify(value, null, 2)}`,
+      text: `Global variable \`${key}\` = ${inspect(value, false, 2, false)}`,
     })
   }
   return response

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -412,7 +412,7 @@ function runQuery(
   entries: Module[]
 ): CallToolResult['content'] {
   const response: CallToolResult['content'] = []
-  const contextObject = Object.create({
+  const proto = {
     modules,
     entries,
     log: (...data: any[]) => {
@@ -433,7 +433,14 @@ function runQuery(
       }
       return path.reverse()
     },
-  })
+    global: undefined,
+    self: undefined,
+    globalThis: undefined,
+  }
+  const contextObject = Object.create(proto)
+  proto.global = contextObject
+  proto.self = contextObject
+  proto.globalThis = contextObject
   runInNewContext(query, contextObject, {
     displayErrors: true,
     filename: 'query.js',
@@ -442,6 +449,7 @@ function runQuery(
   })
   for (const [key, value] of Object.entries(contextObject)) {
     if (typeof value === 'function') continue
+    if (key === 'global' || key === 'self' || key === 'globalThis') continue
     response.push({
       type: 'text',
       text: `Global variable \`${key}\` = ${JSON.stringify(value, null, 2)}`,

--- a/packages/next/src/server/lib/router-utils/mcp.ts
+++ b/packages/next/src/server/lib/router-utils/mcp.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../../build/swc/types'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
 import type {
+  NapiModuleGraphSnapshot,
   NapiModuleInfo,
   NapiModuleReference,
 } from '../../../build/swc/generated-native'
@@ -16,207 +17,8 @@ import { runInNewContext } from 'node:vm'
 import * as Log from '../../../build/output/log'
 import { formatImportTraces } from '../../../shared/lib/turbopack/utils'
 
-export function createMcpServer(
-  hotReloader: NextJsHotReloaderInterface
-): McpServer | undefined {
-  const turbopack = hotReloader.turbopackProject
-  if (!turbopack) return undefined
-  const server = new McpServer({
-    name: 'next.js',
-    version: '1.0.0',
-    instructions: `This is a running next.js dev server with Turbopack.
-You can use the Model Context Protocol to query information about pages and modules and their relations.
-
-
-`,
-  })
-
-  function invariant(
-    value: never,
-    errorMessage: (value: any) => string
-  ): never {
-    throw new Error(errorMessage(value))
-  }
-
-  function styledStringToMarkdown(
-    styledString: StyledString | undefined
-  ): string {
-    if (!styledString) {
-      return ''
-    }
-    switch (styledString.type) {
-      case 'text':
-        return styledString.value
-      case 'strong':
-        return `*${styledString.value}*`
-      case 'code':
-        return `\`${styledString.value}\``
-      case 'line':
-        return styledString.value.map(styledStringToMarkdown).join('')
-      case 'stack':
-        return styledString.value.map(styledStringToMarkdown).join('\n\n')
-      default:
-        invariant(styledString, (s) => `Unknown styled string type: ${s.type}`)
-    }
-  }
-
-  function indent(str: string, spaces: number = 2): string {
-    const indentStr = ' '.repeat(spaces)
-    return `${indentStr}${str.replace(/\n/g, `\n${indentStr}`)}`
-  }
-
-  function issueToString(issue: Issue & { route: string }): string {
-    return [
-      `${issue.severity} in ${issue.stage} on ${issue.route}`,
-      `File Path: ${issue.filePath}`,
-      issue.source &&
-        `Source:
-  ${issue.source.source.ident}
-  ${issue.source.range ? `Range: ${issue.source.range?.start.line}:${issue.source.range?.start.column} - ${issue.source.range?.end.line}:${issue.source.range?.end.column}` : 'Unknown range'}
-`,
-      `Title: ${styledStringToMarkdown(issue.title)}`,
-      issue.description &&
-        `Description:
-${indent(styledStringToMarkdown(issue.description))}`,
-      issue.detail &&
-        `Details:
-${indent(styledStringToMarkdown(issue.detail))}`,
-      issue.documentationLink && `Documentation: ${issue.documentationLink}`,
-      issue.importTraces &&
-        issue.importTraces.length > 0 &&
-        formatImportTraces(issue.importTraces),
-    ]
-      .filter(Boolean)
-      .join('\n')
-  }
-
-  function issuesReference(issues: Issue[]): { type: 'text'; text: string } {
-    if (issues.length === 0) {
-      return {
-        type: 'text',
-        text: 'Note: There are no issues.',
-      }
-    }
-
-    const countBySeverity = new Map()
-
-    for (const issue of issues) {
-      const count = countBySeverity.get(issue.severity) || 0
-      countBySeverity.set(issue.severity, count + 1)
-    }
-
-    const text = [
-      `Note: There are ${issues.length} issues in total, with the following severities: ${Array.from(
-        countBySeverity.entries()
-      )
-        .map(([severity, count]) => `${count} x ${severity}`)
-        .join(', ')}.`,
-    ]
-
-    return {
-      type: 'text',
-      text: text.join('\n'),
-    }
-  }
-
-  function routeToTitle(route: Route): string {
-    switch (route.type) {
-      case 'page':
-        return 'A page using Pages Router.'
-      case 'app-page':
-        return `A page using App Router. Original names: ${route.pages.map((page) => page.originalName).join(', ')}.`
-      case 'page-api':
-        return 'An API route using Pages Router.'
-      case 'app-route':
-        return `A route using App Router. Original name: ${route.originalName}.`
-      case 'conflict':
-        return 'Multiple routes conflict on this path. This is an error in the folder structure.'
-      default:
-        invariant(route, (r) => `Unknown route type: ${r.type}`)
-    }
-  }
-
-  function routeToEndpoints(route: Route): Endpoint[] {
-    switch (route.type) {
-      case 'page':
-        return [route.htmlEndpoint]
-      case 'app-page':
-        return route.pages.map((p) => p.htmlEndpoint)
-      case 'page-api':
-        return [route.endpoint]
-      case 'app-route':
-        return [route.endpoint]
-      case 'conflict':
-        return []
-      default:
-        invariant(route, (r) => `Unknown route type: ${r.type}`)
-    }
-  }
-
-  function arrayOrSingle<T>(value: T | T[]): T[] {
-    return Array.isArray(value) ? value : [value]
-  }
-
-  server.registerTool(
-    'entrypoints',
-    {
-      title: 'Entrypoints',
-      description:
-        'Get all entrypoints of a Turbopack project, which are all pages, routes and the middleware. Also reports issues found while accumulating the entrypoints.',
-    },
-    async () => {
-      const start = performance.now()
-      let entrypoints = await turbopack.getEntrypoints()
-
-      const list = []
-
-      for (const [key, route] of entrypoints.routes.entries()) {
-        list.push(`\`${key}\` (${routeToTitle(route)})`)
-      }
-
-      if (entrypoints.middleware) {
-        list.push('Middleware')
-      }
-
-      if (entrypoints.instrumentation) {
-        list.push('Instrumentation')
-      }
-
-      const content: CallToolResult['content'] = [
-        issuesReference(entrypoints.issues),
-        {
-          type: 'text',
-          text: `These are the routes of the application:
-
-${list.map((e) => `- ${e}`).join('\n')}`,
-        },
-      ]
-      const duration = performance.now() - start
-      const formatDurationText =
-        duration > 2000
-          ? `${Math.round(duration / 100) / 10}s`
-          : `${Math.round(duration)}ms`
-      Log.event(`MCP entrypoints in ${formatDurationText}`)
-      return {
-        content,
-      }
-    }
-  )
-
-  server.registerTool(
-    'query-module-graph',
-    {
-      title: 'Query module graph',
-      description: 'Query details about the module graph of routes.',
-      inputSchema: {
-        routes: z
-          .union([z.string(), z.array(z.string())])
-          .describe(
-            'The routes from which to query the module graph. Can be a single string or an array of strings.'
-          ),
-        query: z.string().describe(
-          `A piece of JavaScript code that will be executed.
-It can access the module graph and log out information it finds useful.
+const QUERY_DESCRIPTION = `A piece of JavaScript code that will be executed.
+It can access the module graph and extract information it finds useful.
 The value of all newly created global variables will be returned in the response and can be used to report results.
 See the following TypeScript typings for reference:
 
@@ -268,191 +70,159 @@ const entries: Module[]
 /// Make sure to iterate over this array and not only consider the first one.
 /// Prefer to use \`modules\` over \`entries\` as it contains all modules, not only the entrypoints.
 const modules: Module[]
-
-// Helper methods available in scope:
-
-/// Prints the gives data as JSON to the tool response.
-/// It might be useful to use a string as first argument to identify the result in the response when using multiple different log calls.
-declare function log(...data: any[]): void
 \`\`\`
 `
-        ),
-      },
-    },
-    async ({ routes, query }) => {
-      const start = performance.now()
-      const entrypoints = await turbopack.getEntrypoints()
-      const endpoints = []
-      for (const route of arrayOrSingle(routes)) {
-        const routeInfo = entrypoints.routes.get(route)
-        if (!routeInfo) {
-          throw new Error(`Route ${route} not found`)
-        }
-        endpoints.push(...routeToEndpoints(routeInfo))
-      }
-      const issues = []
-      const modules = []
-      const entries = []
 
-      function createModuleObject(rawModule: NapiModuleInfo): Module {
-        return {
-          ident: rawModule.ident,
-          path: rawModule.path,
-          depth: rawModule.depth,
-          references: [],
-          incomingReferences: [],
-        }
-      }
-      for (const endpoint of endpoints) {
-        const result = await endpoint.moduleGraphs()
-        issues.push(...result.issues)
-        const moduleGraphs = result.moduleGraphs
-        for (const moduleGraph of moduleGraphs) {
-          const queryModules = moduleGraph.modules.map(createModuleObject)
-          for (let i = 0; i < queryModules.length; i++) {
-            const rawModule = moduleGraph.modules[i]
-            const queryModule = queryModules[i]
+async function measureAndHandleErrors(
+  name: string,
+  fn: () => Promise<CallToolResult['content']>
+): Promise<CallToolResult> {
+  const start = performance.now()
+  let content: CallToolResult['content'] = []
+  try {
+    content = await fn()
+  } catch (error) {
+    content.push({
+      type: 'text',
+      text: `Error: ${error instanceof Error ? error.stack : String(error)}`,
+    })
+    content.push({
+      type: 'text',
+      text: 'Fix the error and try again.',
+    })
+  }
+  const duration = performance.now() - start
+  const formatDurationText =
+    duration > 2000
+      ? `${Math.round(duration / 100) / 10}s`
+      : `${Math.round(duration)}ms`
+  Log.event(`MCP ${name} in ${formatDurationText}`)
+  return {
+    content,
+  }
+}
 
-            queryModule.references = rawModule.references.map(
-              (ref: NapiModuleReference) => ({
-                module: queryModules[ref.i],
-              })
-            )
-            queryModule.incomingReferences = rawModule.incomingReferences.map(
-              (ref: NapiModuleReference) => ({
-                module: queryModules[ref.i],
-              })
-            )
-            modules.push(queryModule)
-          }
-          for (const entry of moduleGraph.entries) {
-            const queryModule = queryModules[entry]
-            entries.push(queryModule)
-          }
-        }
-      }
-      const content: CallToolResult['content'] = []
-      content.push(issuesReference(issues))
-      try {
-        const response = runQuery(query, modules, entries)
-        content.push(...response)
-      } catch (error) {
-        content.push({
-          type: 'text',
-          text: `Error while running query: ${
-            error instanceof Error ? error.stack : String(error)
-          }`,
-        })
-        content.push({
-          type: 'text',
-          text: 'Fix the query and try again.',
-        })
-      }
-      const duration = performance.now() - start
-      const formatDurationText =
-        duration > 2000
-          ? `${Math.round(duration / 100) / 10}s`
-          : `${Math.round(duration)}ms`
-      Log.event(
-        `MCP query on ${arrayOrSingle(routes).join(', ')} in ${formatDurationText}`
-      )
-      return {
-        content,
-      }
+function invariant(value: never, errorMessage: (value: any) => string): never {
+  throw new Error(errorMessage(value))
+}
+
+function styledStringToMarkdown(
+  styledString: StyledString | undefined
+): string {
+  if (!styledString) {
+    return ''
+  }
+  switch (styledString.type) {
+    case 'text':
+      return styledString.value
+    case 'strong':
+      return `*${styledString.value}*`
+    case 'code':
+      return `\`${styledString.value}\``
+    case 'line':
+      return styledString.value.map(styledStringToMarkdown).join('')
+    case 'stack':
+      return styledString.value.map(styledStringToMarkdown).join('\n\n')
+    default:
+      invariant(styledString, (s) => `Unknown styled string type: ${s.type}`)
+  }
+}
+
+function indent(str: string, spaces: number = 2): string {
+  const indentStr = ' '.repeat(spaces)
+  return `${indentStr}${str.replace(/\n/g, `\n${indentStr}`)}`
+}
+
+function issueToString(issue: Issue & { route: string }): string {
+  return [
+    `${issue.severity} in ${issue.stage} on ${issue.route}`,
+    `File Path: ${issue.filePath}`,
+    issue.source &&
+      `Source:
+  ${issue.source.source.ident}
+  ${issue.source.range ? `Range: ${issue.source.range?.start.line}:${issue.source.range?.start.column} - ${issue.source.range?.end.line}:${issue.source.range?.end.column}` : 'Unknown range'}
+`,
+    `Title: ${styledStringToMarkdown(issue.title)}`,
+    issue.description &&
+      `Description:
+${indent(styledStringToMarkdown(issue.description))}`,
+    issue.detail &&
+      `Details:
+${indent(styledStringToMarkdown(issue.detail))}`,
+    issue.documentationLink && `Documentation: ${issue.documentationLink}`,
+    issue.importTraces &&
+      issue.importTraces.length > 0 &&
+      formatImportTraces(issue.importTraces),
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function issuesReference(issues: Issue[]): { type: 'text'; text: string } {
+  if (issues.length === 0) {
+    return {
+      type: 'text',
+      text: 'Note: There are no issues.',
     }
-  )
+  }
 
-  server.registerTool(
-    'query-issues',
-    {
-      title: 'Query issues of routes',
-      description:
-        'Query issues (errors, warnings, lints, etc.) that are reported on routes.',
-      inputSchema: {
-        routes: z
-          .union([z.string(), z.array(z.string())])
-          .describe(
-            'The routes from which to query the module graph. Can be a single string or an array of strings.'
-          ),
-        page: z
-          .optional(z.number())
-          .describe(
-            'Issues are paginated when there are more than 50 issues. The first page is number 0.'
-          ),
-      },
-    },
-    async ({ routes, page }) => {
-      const start = performance.now()
-      const entrypoints = await turbopack.getEntrypoints()
-      const issues = []
-      for (const route of arrayOrSingle(routes)) {
-        const routeInfo = entrypoints.routes.get(route)
-        if (!routeInfo) {
-          throw new Error(`Route ${route} not found`)
-        }
-        for (const endpoint of routeToEndpoints(routeInfo)) {
-          const result = await endpoint.moduleGraphs()
-          for (const issue of result.issues) {
-            const issuesWithRoute = issue as Issue & { route: string }
-            issuesWithRoute.route = route
-            issues.push(issuesWithRoute)
-          }
-        }
-      }
-      const severitiesArray = [
-        'bug',
-        'fatal',
-        'error',
-        'warning',
-        'hint',
-        'note',
-        'suggestion',
-        'info',
-      ]
-      const severities = new Map(
-        severitiesArray.map((severity, index) => [severity, index])
-      )
-      issues.sort((a, b) => {
-        const severityA = severities.get(a.severity)
-        const severityB = severities.get(b.severity)
-        if (severityA !== undefined && severityB !== undefined) {
-          return severityA - severityB
-        }
-        return 0
-      })
+  const countBySeverity = new Map()
 
-      const content: CallToolResult['content'] = []
-      content.push(issuesReference(issues))
-      page = page ?? 0
-      const currentPage = issues.slice(page * 50, (page + 1) * 50)
-      for (const issue of currentPage) {
-        content.push({
-          type: 'text',
-          text: issueToString(issue),
-        })
-      }
-      if (issues.length >= (page + 1) * 50) {
-        content.push({
-          type: 'text',
-          text: `Note: There are more issues available. Use the \`page\` parameter to query the next page.`,
-        })
-      }
+  for (const issue of issues) {
+    const count = countBySeverity.get(issue.severity) || 0
+    countBySeverity.set(issue.severity, count + 1)
+  }
 
-      const duration = performance.now() - start
-      const formatDurationText =
-        duration > 2000
-          ? `${Math.round(duration / 100) / 10}s`
-          : `${Math.round(duration)}ms`
-      Log.event(
-        `MCP query on ${arrayOrSingle(routes).join(', ')} in ${formatDurationText}`
-      )
-      return {
-        content,
-      }
-    }
-  )
+  const text = [
+    `Note: There are ${issues.length} issues in total, with the following severities: ${Array.from(
+      countBySeverity.entries()
+    )
+      .map(([severity, count]) => `${count} x ${severity}`)
+      .join(', ')}.`,
+  ]
 
-  return server
+  return {
+    type: 'text',
+    text: text.join('\n'),
+  }
+}
+
+function routeToTitle(route: Route): string {
+  switch (route.type) {
+    case 'page':
+      return 'A page using Pages Router.'
+    case 'app-page':
+      return `A page using App Router. Original names: ${route.pages.map((page) => page.originalName).join(', ')}.`
+    case 'page-api':
+      return 'An API route using Pages Router.'
+    case 'app-route':
+      return `A route using App Router. Original name: ${route.originalName}.`
+    case 'conflict':
+      return 'Multiple routes conflict on this path. This is an error in the folder structure.'
+    default:
+      invariant(route, (r) => `Unknown route type: ${r.type}`)
+  }
+}
+
+function routeToEndpoints(route: Route): Endpoint[] {
+  switch (route.type) {
+    case 'page':
+      return [route.htmlEndpoint]
+    case 'app-page':
+      return route.pages.map((p) => p.htmlEndpoint)
+    case 'page-api':
+      return [route.endpoint]
+    case 'app-route':
+      return [route.endpoint]
+    case 'conflict':
+      return []
+    default:
+      invariant(route, (r) => `Unknown route type: ${r.type}`)
+  }
+}
+
+function arrayOrSingle<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
 }
 
 interface ModuleReference {
@@ -471,6 +241,44 @@ interface Module {
   incomingReferences: ModuleReference[]
 }
 
+function createModuleObject(rawModule: NapiModuleInfo): Module {
+  return {
+    ident: rawModule.ident,
+    path: rawModule.path,
+    depth: rawModule.depth,
+    references: [],
+    incomingReferences: [],
+  }
+}
+
+function processModuleGraphSnapshot(
+  moduleGraph: NapiModuleGraphSnapshot,
+  modules: Module[],
+  entries: Module[]
+) {
+  const queryModules = moduleGraph.modules.map(createModuleObject)
+  for (let i = 0; i < queryModules.length; i++) {
+    const rawModule = moduleGraph.modules[i]
+    const queryModule = queryModules[i]
+
+    queryModule.references = rawModule.references.map(
+      (ref: NapiModuleReference) => ({
+        module: queryModules[ref.i],
+      })
+    )
+    queryModule.incomingReferences = rawModule.incomingReferences.map(
+      (ref: NapiModuleReference) => ({
+        module: queryModules[ref.i],
+      })
+    )
+    modules.push(queryModule)
+  }
+  for (const entry of moduleGraph.entries) {
+    const queryModule = queryModules[entry]
+    entries.push(queryModule)
+  }
+}
+
 function runQuery(
   query: string,
   modules: Module[],
@@ -480,12 +288,6 @@ function runQuery(
   const proto = {
     modules,
     entries,
-    log: (...data: any[]) => {
-      response.push({
-        type: 'text',
-        text: `Log: ${data.map((d) => JSON.stringify(d, null, 2)).join('\n')}`,
-      })
-    },
     global: undefined,
     self: undefined,
     globalThis: undefined,
@@ -509,4 +311,211 @@ function runQuery(
     })
   }
   return response
+}
+
+const ROUTES_DESCRIPTION =
+  'The routes from which to query the module graph. Can be a single string or an array of strings.'
+export function createMcpServer(
+  hotReloader: NextJsHotReloaderInterface
+): McpServer | undefined {
+  const turbopack = hotReloader.turbopackProject
+  if (!turbopack) return undefined
+  const server = new McpServer({
+    name: 'next.js',
+    version: '1.0.0',
+    instructions: `This is a running next.js dev server with Turbopack.
+You can use the Model Context Protocol to query information about pages and modules and their relations.`,
+  })
+
+  server.registerTool(
+    'entrypoints',
+    {
+      title: 'Entrypoints',
+      description:
+        'Get all entrypoints of a Turbopack project, which are all pages, routes and the middleware. Also reports issues found while accumulating the entrypoints.',
+    },
+    async () =>
+      measureAndHandleErrors('entrypoints', async () => {
+        let entrypoints = await turbopack.getEntrypoints()
+
+        const list = []
+
+        for (const [key, route] of entrypoints.routes.entries()) {
+          list.push(`\`${key}\` (${routeToTitle(route)})`)
+        }
+
+        if (entrypoints.middleware) {
+          list.push('Middleware')
+        }
+
+        if (entrypoints.instrumentation) {
+          list.push('Instrumentation')
+        }
+
+        const content: CallToolResult['content'] = [
+          issuesReference(entrypoints.issues),
+          {
+            type: 'text',
+            text: `These are the routes of the application:
+
+${list.map((e) => `- ${e}`).join('\n')}`,
+          },
+        ]
+        return content
+      })
+  )
+
+  server.registerTool(
+    'query-routes-module-graph',
+    {
+      title: 'Query module graph of routes',
+      description: 'Query details about the module graph of routes.',
+      inputSchema: {
+        routes: z
+          .union([z.string(), z.array(z.string())])
+          .describe(ROUTES_DESCRIPTION),
+        query: z.string().describe(QUERY_DESCRIPTION),
+      },
+    },
+    async ({ routes, query }) =>
+      measureAndHandleErrors(
+        `module graph query on ${arrayOrSingle(routes).join(', ')}`,
+        async () => {
+          const entrypoints = await turbopack.getEntrypoints()
+          const endpoints = []
+          for (const route of arrayOrSingle(routes)) {
+            const routeInfo = entrypoints.routes.get(route)
+            if (!routeInfo) {
+              throw new Error(`Route ${route} not found`)
+            }
+            endpoints.push(...routeToEndpoints(routeInfo))
+          }
+          const issues = []
+          const modules: Module[] = []
+          const entries: Module[] = []
+
+          for (const endpoint of endpoints) {
+            const result = await endpoint.moduleGraphs()
+            issues.push(...result.issues)
+            const moduleGraphs = result.moduleGraphs
+            for (const moduleGraph of moduleGraphs) {
+              processModuleGraphSnapshot(moduleGraph, modules, entries)
+            }
+          }
+          const content: CallToolResult['content'] = []
+          content.push(issuesReference(issues))
+          const response = runQuery(query, modules, entries)
+          content.push(...response)
+          return content
+        }
+      )
+  )
+
+  server.registerTool(
+    'query-module-graph',
+    {
+      title: 'Query whole app module graph',
+      description:
+        'Query details about the module graph the whole application. This is a expensive operation and should only be used when module graph of the whole application is needed.',
+      inputSchema: {
+        query: z.string().describe(QUERY_DESCRIPTION),
+      },
+    },
+    async ({ query }) =>
+      measureAndHandleErrors(`whole app module graph query`, async () => {
+        const moduleGraph = await turbopack.moduleGraph()
+        const issues = moduleGraph.issues
+        const modules: Module[] = []
+        const entries: Module[] = []
+        processModuleGraphSnapshot(moduleGraph, modules, entries)
+        const content: CallToolResult['content'] = []
+        content.push(issuesReference(issues))
+        const response = runQuery(query, modules, entries)
+        content.push(...response)
+        return content
+      })
+  )
+
+  server.registerTool(
+    'query-issues',
+    {
+      title: 'Query issues of routes',
+      description:
+        'Query issues (errors, warnings, lints, etc.) that are reported on routes.',
+      inputSchema: {
+        routes: z
+          .union([z.string(), z.array(z.string())])
+          .describe(ROUTES_DESCRIPTION),
+        page: z
+          .optional(z.number())
+          .describe(
+            'Issues are paginated when there are more than 50 issues. The first page is number 0.'
+          ),
+      },
+    },
+    async ({ routes, page }) =>
+      measureAndHandleErrors(
+        `issues on ${arrayOrSingle(routes).join(', ')}`,
+        async () => {
+          const entrypoints = await turbopack.getEntrypoints()
+          const issues = []
+          for (const route of arrayOrSingle(routes)) {
+            const routeInfo = entrypoints.routes.get(route)
+            if (!routeInfo) {
+              throw new Error(`Route ${route} not found`)
+            }
+            for (const endpoint of routeToEndpoints(routeInfo)) {
+              const result = await endpoint.moduleGraphs()
+              for (const issue of result.issues) {
+                const issuesWithRoute = issue as Issue & { route: string }
+                issuesWithRoute.route = route
+                issues.push(issuesWithRoute)
+              }
+            }
+          }
+          const severitiesArray = [
+            'bug',
+            'fatal',
+            'error',
+            'warning',
+            'hint',
+            'note',
+            'suggestion',
+            'info',
+          ]
+          const severities = new Map(
+            severitiesArray.map((severity, index) => [severity, index])
+          )
+          issues.sort((a, b) => {
+            const severityA = severities.get(a.severity)
+            const severityB = severities.get(b.severity)
+            if (severityA !== undefined && severityB !== undefined) {
+              return severityA - severityB
+            }
+            return 0
+          })
+
+          const content: CallToolResult['content'] = []
+          content.push(issuesReference(issues))
+          page = page ?? 0
+          const currentPage = issues.slice(page * 50, (page + 1) * 50)
+          for (const issue of currentPage) {
+            content.push({
+              type: 'text',
+              text: issueToString(issue),
+            })
+          }
+          if (issues.length >= (page + 1) * 50) {
+            content.push({
+              type: 'text',
+              text: `Note: There are more issues available. Use the \`page\` parameter to query the next page.`,
+            })
+          }
+
+          return content
+        }
+      )
+  )
+
+  return server
 }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -86,7 +86,6 @@ import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-e
 import { normalizePath } from '../../../lib/normalize-path'
 import { JSON_CONTENT_TYPE_HEADER } from '../../../lib/constants'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import { createMcpServer } from './mcp'
 import { parseBody } from '../../api-utils/node/parse-body'
 import { timingSafeEqual } from 'crypto'
 
@@ -976,11 +975,24 @@ async function startWatcher(
   const mcpPath = `/_next/mcp`
   opts.fsChecker.devVirtualFsItems.add(mcpPath)
 
-  const mcpSecret = process.env.NEXT_MCP_SECRET
+  let mcpSecret = process.env.NEXT_MCP_SECRET
     ? Buffer.from(process.env.NEXT_MCP_SECRET)
     : undefined
 
   if (mcpSecret) {
+    try {
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      require('@modelcontextprotocol/sdk/package.json')
+    } catch (error) {
+      Log.error(
+        'The use the MCP server, please install the `@modelcontextprotocol/sdk` package.'
+      )
+      mcpSecret = undefined
+    }
+  }
+  let createMcpServer: typeof import('./mcp').createMcpServer | undefined
+  if (mcpSecret) {
+    ;({ createMcpServer } = await import('./mcp'))
     Log.info(`MCP server is available at: /_next/mcp?${mcpSecret.toString()}`)
   }
 
@@ -988,43 +1000,42 @@ async function startWatcher(
     const parsedUrl = url.parse(req.url || '/')
 
     if (parsedUrl.pathname?.includes(mcpPath)) {
-      if (!mcpSecret) {
-        Log.error('Next.js MCP server is not enabled')
-        Log.info(
-          'To enable it, set the NEXT_MCP_SECRET environment variable to a secret value. This will make the MCP server available at /_next/mcp?{NEXT_MCP_SECRET}'
-        )
+      function sendMcpInternalError(message: string) {
         res.statusCode = 500
         res.setHeader('Content-Type', 'application/json; charset=utf-8')
         res.end(
           JSON.stringify({
             jsonrpc: '2.0',
             error: {
+              // "Internal error" see https://www.jsonrpc.org/specification
               code: -32603,
-              message: 'Missing NEXT_MCP_SECRET environment variable',
+              message,
             },
             id: null,
           })
         )
         return { finished: true }
       }
+      if (!mcpSecret) {
+        Log.error('Next.js MCP server is not enabled')
+        Log.info(
+          'To enable it, set the NEXT_MCP_SECRET environment variable to a secret value. This will make the MCP server available at /_next/mcp?{NEXT_MCP_SECRET}'
+        )
+        return sendMcpInternalError(
+          'Missing NEXT_MCP_SECRET environment variable'
+        )
+      }
+      if (!createMcpServer) {
+        return sendMcpInternalError(
+          'Model Context Protocol (MCP) server is not available'
+        )
+      }
       if (!parsedUrl.query) {
         Log.error('No MCP secret provided in request query')
         Log.info(
           `MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
         )
-        res.statusCode = 500
-        res.setHeader('Content-Type', 'application/json; charset=utf-8')
-        res.end(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'No MCP secret provided in request query',
-            },
-            id: null,
-          })
-        )
-        return { finished: true }
+        return sendMcpInternalError('No MCP secret provided in request query')
       }
       let mcpSecretQuery = Buffer.from(parsedUrl.query)
       if (
@@ -1035,20 +1046,11 @@ async function startWatcher(
         Log.info(
           `MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
         )
-        res.statusCode = 500
-        res.setHeader('Content-Type', 'application/json; charset=utf-8')
-        res.end(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'Invalid MCP secret provided in request query',
-            },
-            id: null,
-          })
+        return sendMcpInternalError(
+          'Invalid MCP secret provided in request query'
         )
-        return { finished: true }
       }
+
       const server = createMcpServer(hotReloader)
       if (server) {
         try {
@@ -1064,20 +1066,9 @@ async function startWatcher(
           const parsedBody = await parseBody(req, 1024 * 1024 * 1024)
           await transport.handleRequest(req, res, parsedBody)
         } catch (error) {
-          console.error('Error handling MCP request:', error)
+          Log.error('Error handling MCP request:', error)
           if (!res.headersSent) {
-            res.statusCode = 500
-            res.setHeader('Content-Type', 'application/json; charset=utf-8')
-            res.end(
-              JSON.stringify({
-                jsonrpc: '2.0',
-                error: {
-                  code: -32603,
-                  message: 'Internal server error',
-                },
-                id: null,
-              })
-            )
+            return sendMcpInternalError('Internal server error')
           }
         }
         return { finished: true }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -88,6 +88,7 @@ import { JSON_CONTENT_TYPE_HEADER } from '../../../lib/constants'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { createMcpServer } from './mcp'
 import { parseBody } from '../../api-utils/node/parse-body'
+import { timingSafeEqual } from 'crypto'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -975,10 +976,79 @@ async function startWatcher(
   const mcpPath = `/_next/mcp`
   opts.fsChecker.devVirtualFsItems.add(mcpPath)
 
+  const mcpSecret = process.env.NEXT_MCP_SECRET
+    ? Buffer.from(process.env.NEXT_MCP_SECRET)
+    : undefined
+
+  if (mcpSecret) {
+    Log.info(`MCP server is available at: /_next/mcp?${mcpSecret.toString()}`)
+  }
+
   async function requestHandler(req: IncomingMessage, res: ServerResponse) {
     const parsedUrl = url.parse(req.url || '/')
 
     if (parsedUrl.pathname?.includes(mcpPath)) {
+      if (!mcpSecret) {
+        Log.error('Next.js MCP server is not enabled')
+        Log.info(
+          'To enable it, set the NEXT_MCP_SECRET environment variable to a secret value. This will make the MCP server available at /_next/mcp?{NEXT_MCP_SECRET}'
+        )
+        res.statusCode = 500
+        res.setHeader('Content-Type', 'application/json; charset=utf-8')
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Missing NEXT_MCP_SECRET environment variable',
+            },
+            id: null,
+          })
+        )
+        return { finished: true }
+      }
+      if (!parsedUrl.query) {
+        Log.error('No MCP secret provided in request query')
+        Log.info(
+          `MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
+        )
+        res.statusCode = 500
+        res.setHeader('Content-Type', 'application/json; charset=utf-8')
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'No MCP secret provided in request query',
+            },
+            id: null,
+          })
+        )
+        return { finished: true }
+      }
+      let mcpSecretQuery = Buffer.from(parsedUrl.query)
+      if (
+        mcpSecretQuery.length !== mcpSecret.length ||
+        !timingSafeEqual(mcpSecretQuery, mcpSecret)
+      ) {
+        Log.error('Invalid MCP secret provided in request query')
+        Log.info(
+          `MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
+        )
+        res.statusCode = 500
+        res.setHeader('Content-Type', 'application/json; charset=utf-8')
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Invalid MCP secret provided in request query',
+            },
+            id: null,
+          })
+        )
+        return { finished: true }
+      }
       const server = createMcpServer(hotReloader)
       if (server) {
         try {

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -992,7 +992,7 @@ async function startWatcher(
   }
   let createMcpServer: typeof import('./mcp').createMcpServer | undefined
   if (mcpSecret) {
-    ;({ createMcpServer } = await import('./mcp'))
+    ;({ createMcpServer } = require('./mcp') as typeof import('./mcp'))
     Log.info(`MCP server is available at: /_next/mcp?${mcpSecret.toString()}`)
   }
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -984,7 +984,7 @@ async function startWatcher(
       require('@modelcontextprotocol/sdk/package.json')
     } catch (error) {
       Log.error(
-        'The use the MCP server, please install the `@modelcontextprotocol/sdk` package.'
+        'To use the MCP server, please install the `@modelcontextprotocol/sdk` package.'
       )
       mcpSecret = undefined
     }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -85,6 +85,9 @@ import { getDefineEnv } from '../../../build/define-env'
 import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-error'
 import { normalizePath } from '../../../lib/normalize-path'
 import { JSON_CONTENT_TYPE_HEADER } from '../../../lib/constants'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { createMcpServer } from './mcp'
+import { parseBody } from '../../api-utils/node/parse-body'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -969,8 +972,47 @@ async function startWatcher(
   const devTurbopackMiddlewareManifestPath = `/_next/${CLIENT_STATIC_FILES_PATH}/development/${TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST}`
   opts.fsChecker.devVirtualFsItems.add(devTurbopackMiddlewareManifestPath)
 
+  const mcpPath = `/_next/mcp`
+  opts.fsChecker.devVirtualFsItems.add(mcpPath)
+
   async function requestHandler(req: IncomingMessage, res: ServerResponse) {
     const parsedUrl = url.parse(req.url || '/')
+
+    if (parsedUrl.pathname?.includes(mcpPath)) {
+      const server = createMcpServer(hotReloader)
+      if (server) {
+        try {
+          const transport: StreamableHTTPServerTransport =
+            new StreamableHTTPServerTransport({
+              sessionIdGenerator: undefined,
+            })
+          res.on('close', () => {
+            transport.close()
+            server.close()
+          })
+          await server.connect(transport)
+          const parsedBody = await parseBody(req, 1024 * 1024 * 1024)
+          await transport.handleRequest(req, res, parsedBody)
+        } catch (error) {
+          console.error('Error handling MCP request:', error)
+          if (!res.headersSent) {
+            res.statusCode = 500
+            res.setHeader('Content-Type', 'application/json; charset=utf-8')
+            res.end(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32603,
+                  message: 'Internal server error',
+                },
+                id: null,
+              })
+            )
+          }
+        }
+        return { finished: true }
+      }
+    }
 
     if (parsedUrl.pathname?.includes(clientPagesManifestPath)) {
       res.statusCode = 200

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -85,7 +85,6 @@ import { getDefineEnv } from '../../../build/define-env'
 import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-error'
 import { normalizePath } from '../../../lib/normalize-path'
 import { JSON_CONTENT_TYPE_HEADER } from '../../../lib/constants'
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { parseBody } from '../../api-utils/node/parse-body'
 import { timingSafeEqual } from 'crypto'
 
@@ -991,8 +990,12 @@ async function startWatcher(
     }
   }
   let createMcpServer: typeof import('./mcp').createMcpServer | undefined
+  let StreamableHTTPServerTransport:
+    | typeof import('./mcp').StreamableHTTPServerTransport
+    | undefined
   if (mcpSecret) {
-    ;({ createMcpServer } = require('./mcp') as typeof import('./mcp'))
+    ;({ createMcpServer, StreamableHTTPServerTransport } =
+      require('./mcp') as typeof import('./mcp'))
     Log.info(
       `Experimental MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
     )
@@ -1027,7 +1030,7 @@ async function startWatcher(
           'Missing NEXT_EXPERIMENTAL_MCP_SECRET environment variable'
         )
       }
-      if (!createMcpServer) {
+      if (!createMcpServer || !StreamableHTTPServerTransport) {
         return sendMcpInternalError(
           'Model Context Protocol (MCP) server is not available'
         )
@@ -1056,10 +1059,9 @@ async function startWatcher(
       const server = createMcpServer(hotReloader)
       if (server) {
         try {
-          const transport: StreamableHTTPServerTransport =
-            new StreamableHTTPServerTransport({
-              sessionIdGenerator: undefined,
-            })
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+          })
           res.on('close', () => {
             transport.close()
             server.close()

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -975,8 +975,8 @@ async function startWatcher(
   const mcpPath = `/_next/mcp`
   opts.fsChecker.devVirtualFsItems.add(mcpPath)
 
-  let mcpSecret = process.env.NEXT_MCP_SECRET
-    ? Buffer.from(process.env.NEXT_MCP_SECRET)
+  let mcpSecret = process.env.NEXT_EXPERIMENTAL_MCP_SECRET
+    ? Buffer.from(process.env.NEXT_EXPERIMENTAL_MCP_SECRET)
     : undefined
 
   if (mcpSecret) {
@@ -993,7 +993,9 @@ async function startWatcher(
   let createMcpServer: typeof import('./mcp').createMcpServer | undefined
   if (mcpSecret) {
     ;({ createMcpServer } = require('./mcp') as typeof import('./mcp'))
-    Log.info(`MCP server is available at: /_next/mcp?${mcpSecret.toString()}`)
+    Log.info(
+      `Experimental MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
+    )
   }
 
   async function requestHandler(req: IncomingMessage, res: ServerResponse) {
@@ -1019,10 +1021,10 @@ async function startWatcher(
       if (!mcpSecret) {
         Log.error('Next.js MCP server is not enabled')
         Log.info(
-          'To enable it, set the NEXT_MCP_SECRET environment variable to a secret value. This will make the MCP server available at /_next/mcp?{NEXT_MCP_SECRET}'
+          'To enable it, set the NEXT_EXPERIMENTAL_MCP_SECRET environment variable to a secret value. This will make the MCP server available at /_next/mcp?{NEXT_EXPERIMENTAL_MCP_SECRET}'
         )
         return sendMcpInternalError(
-          'Missing NEXT_MCP_SECRET environment variable'
+          'Missing NEXT_EXPERIMENTAL_MCP_SECRET environment variable'
         )
       }
       if (!createMcpServer) {
@@ -1033,7 +1035,7 @@ async function startWatcher(
       if (!parsedUrl.query) {
         Log.error('No MCP secret provided in request query')
         Log.info(
-          `MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
+          `Experimental MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
         )
         return sendMcpInternalError('No MCP secret provided in request query')
       }
@@ -1044,7 +1046,7 @@ async function startWatcher(
       ) {
         Log.error('Invalid MCP secret provided in request query')
         Log.info(
-          `MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
+          `Experimental MCP server is available at: /_next/mcp?${mcpSecret.toString()}`
         )
         return sendMcpInternalError(
           'Invalid MCP secret provided in request query'

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -185,39 +185,44 @@ export function formatIssue(issue: Issue) {
 
   if (importTraces?.length) {
     // This is the same logic as in turbopack/crates/turbopack-cli-utils/src/issue.rs
-    // We end up with multiple traces when the file with the error is reachable from multiple
-    // different entry points (e.g. ssr, client)
-    message += `Import trace${importTraces.length > 1 ? 's' : ''}:\n`
-    const everyTraceHasADistinctRootLayer =
-      new Set(importTraces.map(leafLayerName).filter((l) => l != null)).size ===
-      importTraces.length
-    for (let i = 0; i < importTraces.length; i++) {
-      const trace = importTraces[i]
-      const layer = leafLayerName(trace)
-      let traceIndent = '    '
-      // If this is true, layer must be present
-      if (everyTraceHasADistinctRootLayer) {
-        message += `  ${layer}:\n`
-      } else {
-        if (importTraces.length > 1) {
-          // Otherwise use simple 1 based indices to disambiguate
-          message += `  #${i + 1}`
-          if (layer) {
-            message += ` [${layer}]`
-          }
-          message += ':\n'
-        } else if (layer) {
-          message += ` [${layer}]:\n`
-        } else {
-          // If there is a single trace and no layer name just don't indent it.
-          traceIndent = '  '
-        }
-      }
-      message += formatIssueTrace(trace, traceIndent, !identicalLayers(trace))
-    }
+    message += formatImportTraces(importTraces)
   }
   if (documentationLink) {
     message += documentationLink + '\n\n'
+  }
+  return message
+}
+
+export function formatImportTraces(importTraces: PlainTraceItem[][]) {
+  // We end up with multiple traces when the file with the error is reachable from multiple
+  // different entry points (e.g. ssr, client)
+  let message = `Import trace${importTraces.length > 1 ? 's' : ''}:\n`
+  const everyTraceHasADistinctRootLayer =
+    new Set(importTraces.map(leafLayerName).filter((l) => l != null)).size ===
+    importTraces.length
+  for (let i = 0; i < importTraces.length; i++) {
+    const trace = importTraces[i]
+    const layer = leafLayerName(trace)
+    let traceIndent = '    '
+    // If this is true, layer must be present
+    if (everyTraceHasADistinctRootLayer) {
+      message += `  ${layer}:\n`
+    } else {
+      if (importTraces.length > 1) {
+        // Otherwise use simple 1 based indices to disambiguate
+        message += `  #${i + 1}`
+        if (layer) {
+          message += ` [${layer}]`
+        }
+        message += ':\n'
+      } else if (layer) {
+        message += ` [${layer}]:\n`
+      } else {
+        // If there is a single trace and no layer name just don't indent it.
+        traceIndent = '  '
+      }
+    }
+    message += formatIssueTrace(trace, traceIndent, !identicalLayers(trace))
   }
   return message
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -923,9 +923,6 @@ importers:
 
   packages/next:
     dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: 1.15.1
-        version: 1.15.1
       '@next/env':
         specifier: 15.4.2-canary.14
         version: link:../next-env
@@ -950,9 +947,6 @@ importers:
       styled-jsx:
         specifier: 5.1.6
         version: 5.1.6(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react@19.2.0-canary-7513996f-20250722)
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     optionalDependencies:
       sharp:
         specifier: ^0.34.3
@@ -1045,6 +1039,9 @@ importers:
       '@jest/types':
         specifier: 29.5.0
         version: 29.5.0
+      '@modelcontextprotocol/sdk':
+        specifier: 1.15.1
+        version: 1.15.1
       '@mswjs/interceptors':
         specifier: 0.23.0
         version: 0.23.0
@@ -1609,6 +1606,9 @@ importers:
       ws:
         specifier: 8.2.3
         version: 8.2.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
       zod-validation-error:
         specifier: 3.4.0
         version: 3.4.0(zod@3.25.76)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -923,6 +923,9 @@ importers:
 
   packages/next:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.15.1
+        version: 1.15.1
       '@next/env':
         specifier: 15.4.2-canary.14
         version: link:../next-env
@@ -947,6 +950,9 @@ importers:
       styled-jsx:
         specifier: 5.1.6
         version: 5.1.6(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react@19.2.0-canary-7513996f-20250722)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
     optionalDependencies:
       sharp:
         specifier: ^0.34.3
@@ -1603,9 +1609,6 @@ importers:
       ws:
         specifier: 8.2.3
         version: 8.2.3
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
       zod-validation-error:
         specifier: 3.4.0
         version: 3.4.0(zod@3.25.76)
@@ -4424,6 +4427,10 @@ packages:
       '@types/react': 19.1.8
       react: 19.2.0-canary-7513996f-20250722
 
+  '@modelcontextprotocol/sdk@1.15.1':
+    resolution: {integrity: sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==}
+    engines: {node: '>=18'}
+
   '@module-federation/error-codes@0.15.0':
     resolution: {integrity: sha512-CFJSF+XKwTcy0PFZ2l/fSUpR4z247+Uwzp1sXVkdIfJ/ATsnqf0Q01f51qqSEA6MYdQi6FKos9FIcu3dCpQNdg==}
 
@@ -6188,6 +6195,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
 
@@ -6791,6 +6802,10 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
+
   bonjour-service@1.3.0:
     resolution: {integrity: sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==}
 
@@ -6942,11 +6957,19 @@ packages:
     resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
 
   call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   caller-callsite@2.0.0:
@@ -7446,6 +7469,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
   content-type@1.0.4:
     resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
     engines: {node: '>= 0.6'}
@@ -7497,6 +7524,10 @@ packages:
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.4.0:
     resolution: {integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==}
@@ -8506,6 +8537,10 @@ packages:
   downsample-lttb@0.0.1:
     resolution: {integrity: sha512-Olebo5gyh44OAXTd2BKdcbN5VaZOIKFzoeo9JUFwxDlGt6Sd8fUo6SKaLcafy8aP2UrsKmWDpsscsFEghMjeZA==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   duplexer3@0.1.4:
     resolution: {integrity: sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==}
 
@@ -8653,6 +8688,10 @@ packages:
     resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
     engines: {node: '>= 0.4'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
@@ -8669,6 +8708,10 @@ packages:
 
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.0.3:
@@ -9057,6 +9100,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.3:
+    resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
+    engines: {node: '>=20.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -9110,6 +9161,12 @@ packages:
     resolution: {integrity: sha512-WVi2V4iHKw/vHEyye00Q9CSZz7KHDbJkJyteUI8kTih9jiyMl3bIk7wLYFcY9D1Blnadlyb5w5NBuNjQBow99g==}
     engines: {node: ^16.10.0 || ^18.12.0 || >=20.0.0}
 
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.17.0:
     resolution: {integrity: sha512-1Z7/t3Z5ZnBG252gKUPyItc4xdeaA0X934ca2ewckAsVsw9EG71i++ZHZPYnus8g/s5Bty8IMpSVEuRkmwwPRQ==}
     engines: {node: '>= 0.10.0'}
@@ -9117,6 +9174,10 @@ packages:
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
 
   ext@1.6.0:
     resolution: {integrity: sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==}
@@ -9251,6 +9312,10 @@ packages:
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
 
   find-cache-dir@2.1.0:
@@ -9402,6 +9467,10 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   from@0.1.7:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
@@ -9504,6 +9573,10 @@ packages:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -9522,6 +9595,10 @@ packages:
   get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stdin@4.0.1:
     resolution: {integrity: sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==}
@@ -9705,6 +9782,10 @@ packages:
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   got@7.1.0:
     resolution: {integrity: sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==}
     engines: {node: '>=4'}
@@ -9802,6 +9883,10 @@ packages:
 
   has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
   has-to-string-tag-x@1.4.1:
@@ -10563,6 +10648,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -11605,6 +11693,10 @@ packages:
     resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
     engines: {node: '>=0.10.0'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   maximatch@0.1.0:
     resolution: {integrity: sha512-9ORVtDUFk4u/NFfo0vG/ND/z7UQCVZBL539YW0+U1I7H1BkZwizcPx5foFv7LCPcBnm2U6RjFnQOsIvN4/Vm2A==}
     engines: {node: '>=0.10.0'}
@@ -11710,6 +11802,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -11742,6 +11838,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -11978,12 +12078,20 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.18:
     resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -12238,6 +12346,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.1:
@@ -12501,6 +12613,10 @@ packages:
 
   object-inspect@1.13.2:
     resolution: {integrity: sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==}
+    engines: {node: '>= 0.4'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
   object-is@1.0.2:
@@ -12941,6 +13057,10 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
   path-type@1.1.0:
     resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
     engines: {node: '>=0.10.0'}
@@ -13045,6 +13165,10 @@ packages:
   pixrem@5.0.0:
     resolution: {integrity: sha512-ugJ4Imy92u55zeznaN/5d7iqOBIZjZ7q10/T+dcd0IuFtbLlsGDvAUabFu1cafER+G9f0T1WtTqvzm4KAdcDgQ==}
     engines: {node: '>=4.0.0', npm: '>=1.2.10'}
+
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
@@ -13993,6 +14117,10 @@ packages:
     resolution: {integrity: sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==}
     engines: {node: '>=0.6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   qs@6.5.2:
     resolution: {integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==}
     engines: {node: '>=0.6'}
@@ -14065,6 +14193,10 @@ packages:
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
   rc@1.2.8:
@@ -14667,6 +14799,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -14853,6 +14989,10 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
   sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
 
@@ -14879,6 +15019,10 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -14946,8 +15090,24 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -15989,6 +16149,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   type@1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
 
@@ -16975,6 +17139,11 @@ packages:
 
   yoga-wasm-web@0.3.3:
     resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
+
+  zod-to-json-schema@3.24.6:
+    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
+    peerDependencies:
+      zod: ^3.24.1
 
   zod-validation-error@3.4.0:
     resolution: {integrity: sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==}
@@ -20118,6 +20287,23 @@ snapshots:
       '@types/react': 19.1.8
       react: 19.2.0-canary-7513996f-20250722
 
+  '@modelcontextprotocol/sdk@1.15.1':
+    dependencies:
+      ajv: 6.12.6
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.3
+      express: 5.1.0
+      express-rate-limit: 7.5.1(express@5.1.0)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@module-federation/error-codes@0.15.0': {}
 
   '@module-federation/runtime-core@0.15.0':
@@ -22359,6 +22545,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
+
   acorn-globals@7.0.1:
     dependencies:
       acorn: 8.14.0
@@ -23030,6 +23221,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.0
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.0
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   bonjour-service@1.3.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -23224,6 +23429,11 @@ snapshots:
       package-hash: 4.0.0
       write-file-atomic: 3.0.3
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   call-bind@1.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -23236,6 +23446,11 @@ snapshots:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caller-callsite@2.0.0:
     dependencies:
@@ -23781,6 +23996,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-type@1.0.4: {}
 
   content-type@1.0.5: {}
@@ -23856,6 +24075,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.6: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.4.0: {}
 
@@ -24985,6 +25206,12 @@ snapshots:
 
   downsample-lttb@0.0.1: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   duplexer3@0.1.4: {}
 
   duplexer@0.1.1: {}
@@ -25187,6 +25414,8 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
 
   es-get-iterator@1.1.3:
@@ -25221,6 +25450,10 @@ snapshots:
   es-module-lexer@1.6.0: {}
 
   es-object-atoms@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
@@ -25973,6 +26206,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.3: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.3
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -26073,6 +26312,10 @@ snapshots:
       jest-mock: 30.0.0-alpha.6
       jest-util: 30.0.0-alpha.6
 
+  express-rate-limit@7.5.1(express@5.1.0):
+    dependencies:
+      express: 5.1.0
+
   express@4.17.0:
     dependencies:
       accepts: 1.3.7
@@ -26140,6 +26383,38 @@ snapshots:
       statuses: 2.0.1
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.1
+      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -26308,6 +26583,17 @@ snapshots:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -26492,6 +26778,8 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fresh@2.0.0: {}
+
   from@0.1.7: {}
 
   fromentries@1.3.2: {}
@@ -26606,6 +26894,19 @@ snapshots:
       has-symbols: 1.0.3
       hasown: 2.0.2
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
@@ -26621,6 +26922,11 @@ snapshots:
   get-port-please@3.1.1: {}
 
   get-port@5.1.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stdin@4.0.1: {}
 
@@ -26874,6 +27180,8 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
+  gopd@1.2.0: {}
+
   got@7.1.0:
     dependencies:
       '@types/keyv': 3.1.1
@@ -26977,6 +27285,8 @@ snapshots:
   has-symbols@1.0.2: {}
 
   has-symbols@1.0.3: {}
+
+  has-symbols@1.1.0: {}
 
   has-to-string-tag-x@1.4.1:
     dependencies:
@@ -27793,6 +28103,8 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -29202,6 +29514,8 @@ snapshots:
 
   markdown-extensions@1.1.1: {}
 
+  math-intrinsics@1.1.0: {}
+
   maximatch@0.1.0:
     dependencies:
       array-differ: 1.0.0
@@ -29469,6 +29783,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.0.6
@@ -29530,6 +29846,8 @@ snapshots:
   merge-descriptors@1.0.1: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -30102,6 +30420,8 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.18:
     dependencies:
       mime-db: 1.33.0
@@ -30109,6 +30429,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -30331,6 +30655,8 @@ snapshots:
   negotiator@0.6.2: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.1: {}
 
@@ -30661,6 +30987,8 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.2: {}
+
+  object-inspect@1.13.4: {}
 
   object-is@1.0.2: {}
 
@@ -31174,6 +31502,8 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  path-to-regexp@8.2.0: {}
+
   path-type@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -31259,6 +31589,8 @@ snapshots:
       browserslist: 4.25.1
       postcss: 7.0.32
       reduce-css-calc: 2.1.7
+
+  pkce-challenge@5.0.0: {}
 
   pkg-dir@3.0.0:
     dependencies:
@@ -32256,6 +32588,10 @@ snapshots:
     dependencies:
       side-channel: 1.0.6
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   qs@6.5.2: {}
 
   qs@6.7.0: {}
@@ -32318,6 +32654,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -33153,6 +33496,16 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.0
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.0.0: {}
 
   run-async@2.4.1: {}
@@ -33361,6 +33714,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
@@ -33416,6 +33785,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -33508,12 +33886,40 @@ snapshots:
       interpret: 1.4.0
       rechoir: 0.6.2
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
   side-channel@1.0.6:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       object-inspect: 1.13.2
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0:
     optional: true
@@ -34637,6 +35043,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
 
   type@1.2.0: {}
 
@@ -35890,6 +36302,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoga-wasm-web@0.3.3: {}
+
+  zod-to-json-schema@3.24.6(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-validation-error@3.4.0(zod@3.25.76):
     dependencies:

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1221,6 +1221,13 @@ impl ModuleGraph {
         Ok(idx)
     }
 
+    pub async fn has_entry(&self, entry: ResolvedVc<Box<dyn Module>>) -> Result<bool> {
+        let graphs = self.get_graphs().await?;
+        Ok(graphs
+            .iter()
+            .any(|graph| graph.modules.contains_key(&entry)))
+    }
+
     /// Traverses all reachable edges exactly once and calls the visitor with the edge source and
     /// target.
     ///

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1221,6 +1221,16 @@ impl ModuleGraph {
         Ok(idx)
     }
 
+    pub async fn entries(&self) -> Result<Vec<ResolvedVc<Box<dyn Module>>>> {
+        Ok(self
+            .get_graphs()
+            .await?
+            .iter()
+            .flat_map(|g| g.entries.iter())
+            .flat_map(|e| e.entries())
+            .collect())
+    }
+
     pub async fn has_entry(&self, entry: ResolvedVc<Box<dyn Module>>) -> Result<bool> {
         let graphs = self.get_graphs().await?;
         Ok(graphs


### PR DESCRIPTION
### What?

Add MCP for next dev exposing entrypoints, module graph and issues.

Can be enabled via `NEXT_EXPERIMENTAL_MCP_SECRET=<random>` and makes the MCP available on `/_next/mcp?<random>`.

Interesting change is in: packages/next/src/server/lib/router-utils/mcp.ts

Closes PACK-5124