### PR TITLE
bugfix: static resources staleTime should be renewed once refetched

### DIFF
--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -404,22 +404,7 @@ function getPrefetchEntryCacheStatus({
   kind,
   prefetchTime,
   lastUsedTime,
-  staleTime,
 }: PrefetchCacheEntry): PrefetchCacheEntryStatus {
-  if (staleTime !== -1) {
-    // `staleTime` is the value sent by the server during static generation.
-    // When this is available, it takes precedence over any of the heuristics
-    // that follow.
-    //
-    // TODO: When PPR is enabled, the server will *always* return a stale time
-    // when prefetching. We should never use a prefetch entry that hasn't yet
-    // received data from the server. So the only two cases should be 1) we use
-    // the server-generated stale time 2) the unresolved entry is discarded.
-    return Date.now() < prefetchTime + staleTime
-      ? PrefetchCacheEntryStatus.fresh
-      : PrefetchCacheEntryStatus.stale
-  }
-
   // We will re-use the cache entry data for up to the `dynamic` staletime window.
   if (Date.now() < (lastUsedTime ?? prefetchTime) + DYNAMIC_STALETIME_MS) {
     return lastUsedTime


### PR DESCRIPTION
When the `x-nextjs-staletime` header is sent from the server, the client router was discarding all of its staleTime heuristics (such as lastUsedTime and "reusable" cache entries). This caused an issue where after the static staleTime window expired and the prefetch data was renewed, the static staleTime itself was not being renewed.

As a result, once the static staleTime expired, the client would continuously refetch the resource on every navigation, even though it had just been renewed.

This removes the `x-nextjs-staleTime` logic from this heuristic because it was only intended to be considered for the new `clientSegmentCache` & cache components work