### PR TITLE
Add Facebook domain verification to metadata

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -710,6 +710,7 @@ export const metadata = {
 export const metadata = {
   verification: {
     google: 'google',
+    facebook: 'facebook',
     yandex: 'yandex',
     yahoo: 'yahoo',
     other: {

--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -234,6 +234,10 @@ export function VerificationMeta({
       namePrefix: 'google-site-verification',
       contents: verification.google,
     }),
+    MultiMeta({
+      namePrefix: 'facebook-domain-verification',
+      contents: verification.facebook,
+    }),
     MultiMeta({ namePrefix: 'y_key', contents: verification.yahoo }),
     MultiMeta({
       namePrefix: 'yandex-verification',

--- a/packages/next/src/lib/metadata/types/metadata-types.ts
+++ b/packages/next/src/lib/metadata/types/metadata-types.ts
@@ -125,6 +125,7 @@ export type Icons = {
 
 export type Verification = {
   google?: null | string | number | (string | number)[] | undefined
+  facebook?: null | string | number | (string | number)[] | undefined
   yahoo?: null | string | number | (string | number)[] | undefined
   yandex?: null | string | number | (string | number)[] | undefined
   me?: null | string | number | (string | number)[] | undefined
@@ -138,6 +139,7 @@ export type Verification = {
 
 export type ResolvedVerification = {
   google?: null | (string | number)[] | undefined
+  facebook?: null | (string | number)[] | undefined
   yahoo?: null | (string | number)[] | undefined
   yandex?: null | (string | number)[] | undefined
   me?: null | (string | number)[] | undefined

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -257,6 +257,7 @@ describe('app dir - metadata', () => {
       const matchMultiDom = createMultiHtmlMatcher($)
       matchMultiDom('meta', 'name', 'content', {
         'google-site-verification': 'google',
+        'facebook-domain-verification': 'facebook',
         y_key: 'yahoo',
         'yandex-verification': 'yandex',
         me: ['my-email', 'my-link'],


### PR DESCRIPTION
 ### What?
Introduces support for Facebook domain verification in the metadata generation system.

### Why?
Because it is missing.

### How?
Updates the Verification type definitions, documentation, and tests to include the new 'facebook' field and corresponding meta tag output. Similar to Google site verification. 

