### PR TITLE
[devtool] move font styling to global.css

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.css
@@ -5,7 +5,6 @@
 }
 
 .dev-tools-indicator-menu {
-  -webkit-font-smoothing: antialiased;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
@@ -92,7 +92,6 @@ export function NextLogo({
           }
 
           [data-next-badge] {
-            -webkit-font-smoothing: antialiased;
             width: var(--size);
             height: var(--size);
             display: flex;

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-info.tsx
@@ -91,7 +91,6 @@ export function DevToolsInfo({
 
 export const DEV_TOOLS_INFO_STYLES = css`
   [data-info-popover] {
-    -webkit-font-smoothing: antialiased;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dialog/dialog.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dialog/dialog.tsx
@@ -31,7 +31,6 @@ export function ErrorOverlayDialog({
 
 export const DIALOG_STYLES = `
   .error-overlay-dialog-container {
-    -webkit-font-smoothing: antialiased;
     display: flex;
     flex-direction: column;
     background: var(--color-background-100);

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/restart-server-button.tsx
@@ -86,7 +86,6 @@ export function usePersistentCacheErrorDetection({
 
 export const RESTART_SERVER_BUTTON_STYLES = `
   .restart-dev-server-button {
-    -webkit-font-smoothing: antialiased;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/packages/next/src/next-devtools/dev-overlay/components/version-staleness-info/version-staleness-info.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/version-staleness-info/version-staleness-info.tsx
@@ -52,7 +52,6 @@ export function VersionStalenessInfo({
 
 export const styles = `
   .nextjs-container-build-error-version-status {
-    -webkit-font-smoothing: antialiased;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/packages/next/src/next-devtools/global.css
+++ b/packages/next/src/next-devtools/global.css
@@ -1,4 +1,10 @@
 /* devtool global css variables */
 :host {
+  /* variables */
   --top-z-index: 2147483647;
+}
+
+/* global styles */
+* {
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Since we have global css reset, we can only need to reset the font style once, not everywhere

Closes NEXT-4628