### PR TITLE
Add VSCode tasks to show TypeScript compilation errors in problems view

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "types",
+      "command": "pnpm",
+      "args": ["typescript", "--watch"],
+      "isBackground": true,
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": ["$tsc-watch"]
+    },
+    {
+      "label": "types-next",
+      "command": "pnpm",
+      "args": ["types", "--watch"],
+      "options": {
+        "cwd": "${workspaceFolder}/packages/next"
+      },
+      "isBackground": true,
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": {
+        "base": "$tsc-watch",
+        "fileLocation": ["relative", "${workspaceFolder}/packages/next"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Showing compilation errors for files that aren't currently open is very useful during refactorings.

https://github.com/user-attachments/assets/629f8f2a-37ba-44c1-be6d-9a2e0f93e4f1

