### PR TITLE
Refactor: Use enums for work unit types and phases

### DIFF
--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -1,6 +1,9 @@
 import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { workAsyncStorage } from '../../server/app-render/work-async-storage.external'
-import { workUnitAsyncStorage } from '../../server/app-render/work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitType,
+} from '../../server/app-render/work-unit-async-storage.external'
 
 export function bailoutToClientRendering(reason: string): void | never {
   const workStore = workAsyncStorage.getStore()
@@ -11,14 +14,14 @@ export function bailoutToClientRendering(reason: string): void | never {
 
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
         throw new BailoutToCSRError(reason)
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never

--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -2,7 +2,10 @@ import { DetachedPromise } from '../../lib/detached-promise'
 import { AsyncLocalStorage } from 'async_hooks'
 
 import type { WorkStore } from '../app-render/work-async-storage.external'
-import type { WorkUnitStore } from '../app-render/work-unit-async-storage.external'
+import {
+  WorkUnitPhase,
+  type WorkUnitStore,
+} from '../app-render/work-unit-async-storage.external'
 import type { AfterContext } from './after-context'
 
 describe('AfterContext', () => {
@@ -561,5 +564,5 @@ const createMockWorkStore = (afterContext: AfterContext): WorkStore => {
 }
 
 const createMockWorkUnitStore = () => {
-  return { phase: 'render' } as WorkUnitStore
+  return { phase: WorkUnitPhase.Render } as WorkUnitStore
 }

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -8,6 +8,7 @@ import { withExecuteRevalidates } from '../revalidation-utils'
 import { bindSnapshot } from '../app-render/async-local-storage'
 import {
   workUnitAsyncStorage,
+  WorkUnitPhase,
   type WorkUnitStore,
 } from '../app-render/work-unit-async-storage.external'
 import { afterTaskAsyncStorage } from '../app-render/after-task-async-storage.external'
@@ -106,7 +107,7 @@ export class AfterContext {
     if (this.callbackQueue.size === 0) return
 
     for (const workUnitStore of this.workUnitStores) {
-      workUnitStore.phase = 'after'
+      workUnitStore.phase = WorkUnitPhase.After
     }
 
     const workStore = workAsyncStorage.getStore()

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -53,7 +53,10 @@ import { isNodeNextRequest, isWebNextRequest } from '../base-http/helpers'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { synchronizeMutableCookies } from '../async-storage/request-store'
 import type { TemporaryReferenceSet } from 'react-server-dom-webpack/server'
-import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitPhase,
+} from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { executeRevalidates } from '../revalidation-utils'
 import { getRequestMeta } from '../request-meta'
@@ -1137,13 +1140,13 @@ async function executeActionAndPrepareForRender<
   workStore: WorkStore,
   requestStore: RequestStore
 ): Promise<Awaited<ReturnType<TFn>>> {
-  requestStore.phase = 'action'
+  requestStore.phase = WorkUnitPhase.Action
   try {
     return await workUnitAsyncStorage.run(requestStore, () =>
       action.apply(null, args)
     )
   } finally {
-    requestStore.phase = 'render'
+    requestStore.phase = WorkUnitPhase.Render
 
     // When we switch to the render phase, cookies() will return
     // `workUnitStore.cookies` instead of `workUnitStore.userspaceMutableCookies`.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -167,6 +167,8 @@ import { scheduleInSequentialTasks } from './app-render-render-utils'
 import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
 import {
   workUnitAsyncStorage,
+  WorkUnitPhase,
+  WorkUnitType,
   type PrerenderStore,
 } from './work-unit-async-storage.external'
 import { CacheSignal } from './cache-signal'
@@ -715,8 +717,8 @@ async function warmupDevRender(
   const cacheSignal = new CacheSignal()
 
   const prerenderStore: PrerenderStore = {
-    type: 'prerender',
-    phase: 'render',
+    type: WorkUnitType.Prerender,
+    phase: WorkUnitPhase.Render,
     rootParams,
     implicitTags,
     renderSignal: renderController.signal,
@@ -1239,14 +1241,14 @@ async function renderToHTMLOrFlightImpl(
       }
 
       switch (workUnitStore.type) {
-        case 'prerender':
-        case 'prerender-client':
-        case 'cache':
+        case WorkUnitType.Prerender:
+        case WorkUnitType.PrerenderClient:
+        case WorkUnitType.Cache:
           return true
-        case 'prerender-ppr':
-        case 'prerender-legacy':
-        case 'request':
-        case 'unstable-cache':
+        case WorkUnitType.PrerenderPPR:
+        case WorkUnitType.PrerenderLegacy:
+        case WorkUnitType.Request:
+        case WorkUnitType.UnstableCache:
           return false
         default:
           workUnitStore satisfies never
@@ -2351,8 +2353,8 @@ async function spawnDynamicValidationInDev(
   // resume data cache instead.
   const prerenderResumeDataCache = createPrerenderResumeDataCache()
   const initialServerPrerenderStore: PrerenderStore = {
-    type: 'prerender',
-    phase: 'render',
+    type: WorkUnitType.Prerender,
+    phase: WorkUnitPhase.Render,
     rootParams,
     implicitTags,
     renderSignal: initialServerRenderController.signal,
@@ -2481,8 +2483,8 @@ async function spawnDynamicValidationInDev(
     const initialClientRenderController = new AbortController()
 
     const initialClientPrerenderStore: PrerenderStore = {
-      type: 'prerender-client',
-      phase: 'render',
+      type: WorkUnitType.PrerenderClient,
+      phase: WorkUnitPhase.Render,
       rootParams,
       implicitTags,
       renderSignal: initialClientRenderController.signal,
@@ -2589,8 +2591,8 @@ async function spawnDynamicValidationInDev(
   )
 
   const finalServerPrerenderStore: PrerenderStore = {
-    type: 'prerender',
-    phase: 'render',
+    type: WorkUnitType.Prerender,
+    phase: WorkUnitPhase.Render,
     rootParams,
     implicitTags,
     renderSignal: finalServerRenderController.signal,
@@ -2676,8 +2678,8 @@ async function spawnDynamicValidationInDev(
   const finalClientRenderController = new AbortController()
 
   const finalClientPrerenderStore: PrerenderStore = {
-    type: 'prerender-client',
-    phase: 'render',
+    type: WorkUnitType.PrerenderClient,
+    phase: WorkUnitPhase.Render,
     rootParams,
     implicitTags,
     renderSignal: finalClientRenderController.signal,
@@ -3044,8 +3046,8 @@ async function prerenderToStream(
       }
 
       const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
-        type: 'prerender',
-        phase: 'render',
+        type: WorkUnitType.Prerender,
+        phase: WorkUnitPhase.Render,
         rootParams,
         implicitTags,
         renderSignal: initialServerRenderController.signal,
@@ -3168,8 +3170,8 @@ async function prerenderToStream(
         const initialClientRenderController = new AbortController()
 
         const initialClientPrerenderStore: PrerenderStore = {
-          type: 'prerender-client',
-          phase: 'render',
+          type: WorkUnitType.PrerenderClient,
+          phase: WorkUnitPhase.Render,
           rootParams,
           implicitTags,
           renderSignal: initialClientRenderController.signal,
@@ -3276,8 +3278,8 @@ async function prerenderToStream(
       )
 
       const finalServerPrerenderStore: PrerenderStore = (prerenderStore = {
-        type: 'prerender',
-        phase: 'render',
+        type: WorkUnitType.Prerender,
+        phase: WorkUnitPhase.Render,
         rootParams,
         implicitTags,
         renderSignal: finalServerRenderController.signal,
@@ -3368,8 +3370,8 @@ async function prerenderToStream(
       const finalClientRenderController = new AbortController()
 
       const finalClientPrerenderStore: PrerenderStore = {
-        type: 'prerender-client',
-        phase: 'render',
+        type: WorkUnitType.PrerenderClient,
+        phase: WorkUnitPhase.Render,
         rootParams,
         implicitTags,
         renderSignal: finalClientRenderController.signal,
@@ -3604,8 +3606,8 @@ async function prerenderToStream(
 
       const prerenderResumeDataCache = createPrerenderResumeDataCache()
       const reactServerPrerenderStore: PrerenderStore = (prerenderStore = {
-        type: 'prerender-ppr',
-        phase: 'render',
+        type: WorkUnitType.PrerenderPPR,
+        phase: WorkUnitPhase.Render,
         rootParams,
         implicitTags,
         dynamicTracking,
@@ -3638,8 +3640,8 @@ async function prerenderToStream(
         ))
 
       const ssrPrerenderStore: PrerenderStore = {
-        type: 'prerender-ppr',
-        phase: 'render',
+        type: WorkUnitType.PrerenderPPR,
+        phase: WorkUnitPhase.Render,
         rootParams,
         implicitTags,
         dynamicTracking,
@@ -3833,8 +3835,8 @@ async function prerenderToStream(
       }
     } else {
       const prerenderLegacyStore: PrerenderStore = (prerenderStore = {
-        type: 'prerender-legacy',
-        phase: 'render',
+        type: WorkUnitType.PrerenderLegacy,
+        phase: WorkUnitPhase.Render,
         rootParams,
         implicitTags,
         revalidate: INFINITE_CACHE,
@@ -3998,8 +4000,8 @@ async function prerenderToStream(
     )
 
     const prerenderLegacyStore: PrerenderStore = (prerenderStore = {
-      type: 'prerender-legacy',
-      phase: 'render',
+      type: WorkUnitType.PrerenderLegacy,
+      phase: WorkUnitPhase.Render,
       rootParams,
       implicitTags: implicitTags,
       revalidate:

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -19,7 +19,10 @@ import { NextNodeServerSpan } from '../lib/trace/constants'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import type { LoadingModuleData } from '../../shared/lib/app-router-context.shared-runtime'
 import type { Params } from '../request/params'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitType,
+} from './work-unit-async-storage.external'
 import { OUTLET_BOUNDARY_NAME } from '../../lib/metadata/metadata-constants'
 import type {
   UseCacheLayoutComponentProps,
@@ -294,17 +297,17 @@ async function createComponentTreeInternal({
 
     if (workUnitStore) {
       switch (workUnitStore.type) {
-        case 'prerender':
-        case 'prerender-legacy':
-        case 'prerender-ppr':
-        case 'cache':
+        case WorkUnitType.Prerender:
+        case WorkUnitType.PrerenderLegacy:
+        case WorkUnitType.PrerenderPPR:
+        case WorkUnitType.Cache:
           if (workUnitStore.revalidate > defaultRevalidate) {
             workUnitStore.revalidate = defaultRevalidate
           }
           break
-        case 'prerender-client':
-        case 'request':
-        case 'unstable-cache':
+        case WorkUnitType.PrerenderClient:
+        case WorkUnitType.Request:
+        case WorkUnitType.UnstableCache:
           break
         default:
           workUnitStore satisfies never

--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -21,6 +21,7 @@ import {
   getPrerenderResumeDataCache,
   getRenderResumeDataCache,
   workUnitAsyncStorage,
+  WorkUnitType,
 } from './work-unit-async-storage.external'
 import { createHangingInputAbortSignal } from './dynamic-rendering'
 import React from 'react'
@@ -254,7 +255,7 @@ export async function decryptActionBoundArgs(
         controller.enqueue(textEncoder.encode(decrypted))
 
         switch (workUnitStore?.type) {
-          case 'prerender':
+          case WorkUnitType.Prerender:
             // Explicitly don't close the stream here (until prerendering is
             // complete) so that hanging promises are not rejected.
             if (workUnitStore.renderSignal.aborted) {
@@ -267,12 +268,12 @@ export async function decryptActionBoundArgs(
               )
             }
             break
-          case 'prerender-client':
-          case 'prerender-ppr':
-          case 'prerender-legacy':
-          case 'request':
-          case 'cache':
-          case 'unstable-cache':
+          case WorkUnitType.PrerenderClient:
+          case WorkUnitType.PrerenderPPR:
+          case WorkUnitType.PrerenderLegacy:
+          case WorkUnitType.Request:
+          case WorkUnitType.Cache:
+          case WorkUnitType.UnstableCache:
           case undefined:
             return controller.close()
           default:

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -3,7 +3,10 @@ import type { BinaryStreamOf } from './app-render'
 
 import { htmlEscapeJsonString } from '../htmlescape'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitType,
+} from './work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
@@ -57,18 +60,18 @@ export function useFlightStream<T>(
     }
 
     switch (workUnitStore.type) {
-      case 'prerender-client':
+      case WorkUnitType.PrerenderClient:
         const responseOnNextTick = new Promise<T>((resolve) => {
           process.nextTick(() => resolve(newResponse))
         })
         flightResponses.set(flightStream, responseOnNextTick)
         return responseOnNextTick
-      case 'prerender':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -1,6 +1,10 @@
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import type { IncomingHttpHeaders } from 'http'
-import type { RequestStore } from '../app-render/work-unit-async-storage.external'
+import {
+  WorkUnitPhase,
+  WorkUnitType,
+  type RequestStore,
+} from '../app-render/work-unit-async-storage.external'
 import type { RenderOpts } from '../app-render/types'
 import type { NextRequest } from '../web/spec-extension/request'
 import type { __ApiPreviewProps } from '../api-utils'
@@ -118,7 +122,7 @@ export function createRequestStoreForRender(
 ): RequestStore {
   return createRequestStoreImpl(
     // Pages start in render phase by default
-    'render',
+    WorkUnitPhase.Render,
     req,
     res,
     url,
@@ -141,7 +145,7 @@ export function createRequestStoreForAPI(
 ): RequestStore {
   return createRequestStoreImpl(
     // API routes start in action phase by default
-    'action',
+    WorkUnitPhase.Action,
     req,
     undefined,
     url,
@@ -183,7 +187,7 @@ function createRequestStoreImpl(
   } = {}
 
   return {
-    type: 'request',
+    type: WorkUnitType.Request,
     phase,
     implicitTags,
     // Rather than just using the whole `url` here, we pull the parts we want

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -17,6 +17,7 @@ import type { FetchMetric } from '../base-http'
 import { createDedupeFetch } from './dedupe-fetch'
 import {
   getCacheSignal,
+  WorkUnitType,
   type WorkUnitAsyncStorage,
   type WorkUnitStore,
 } from '../app-render/work-unit-async-storage.external'
@@ -369,16 +370,16 @@ export function createPatchedFetcher(
 
         if (workUnitStore) {
           switch (workUnitStore.type) {
-            case 'prerender':
+            case WorkUnitType.Prerender:
             // TODO: Stop accumulating tags in client prerender. (fallthrough)
-            case 'prerender-client':
-            case 'prerender-ppr':
-            case 'prerender-legacy':
-            case 'cache':
+            case WorkUnitType.PrerenderClient:
+            case WorkUnitType.PrerenderPPR:
+            case WorkUnitType.PrerenderLegacy:
+            case WorkUnitType.Cache:
               revalidateStore = workUnitStore
               break
-            case 'request':
-            case 'unstable-cache':
+            case WorkUnitType.Request:
+            case WorkUnitType.UnstableCache:
               break
             default:
               workUnitStore satisfies never
@@ -404,17 +405,17 @@ export function createPatchedFetcher(
 
         if (workUnitStore) {
           switch (workUnitStore.type) {
-            case 'unstable-cache':
+            case WorkUnitType.UnstableCache:
               // Inside unstable-cache we treat it the same as force-no-store on
               // the page.
               pageFetchCacheMode = 'force-no-store'
               break
-            case 'prerender':
-            case 'prerender-client':
-            case 'prerender-ppr':
-            case 'prerender-legacy':
-            case 'request':
-            case 'cache':
+            case WorkUnitType.Prerender:
+            case WorkUnitType.PrerenderClient:
+            case WorkUnitType.PrerenderPPR:
+            case WorkUnitType.PrerenderLegacy:
+            case WorkUnitType.Request:
+            case WorkUnitType.Cache:
               break
             default:
               workUnitStore satisfies never
@@ -549,11 +550,11 @@ export function createPatchedFetcher(
         // it'll be a dynamic call. We don't have to issue that dynamic call.
         if (hasNoExplicitCacheConfig && workUnitStore !== undefined) {
           switch (workUnitStore.type) {
-            case 'prerender':
+            case WorkUnitType.Prerender:
             // While we don't want to do caching in the client scope we know the
             // fetch will be dynamic for cacheComponents so we may as well avoid the
             // call here. (fallthrough)
-            case 'prerender-client':
+            case WorkUnitType.PrerenderClient:
               if (cacheSignal) {
                 cacheSignal.endRead()
                 cacheSignal = null
@@ -563,11 +564,11 @@ export function createPatchedFetcher(
                 workUnitStore.renderSignal,
                 'fetch()'
               )
-            case 'prerender-ppr':
-            case 'prerender-legacy':
-            case 'request':
-            case 'cache':
-            case 'unstable-cache':
+            case WorkUnitType.PrerenderPPR:
+            case WorkUnitType.PrerenderLegacy:
+            case WorkUnitType.Request:
+            case WorkUnitType.Cache:
+            case WorkUnitType.UnstableCache:
               break
             default:
               workUnitStore satisfies never
@@ -663,8 +664,8 @@ export function createPatchedFetcher(
           if (finalRevalidate === 0) {
             if (workUnitStore) {
               switch (workUnitStore.type) {
-                case 'prerender':
-                case 'prerender-client':
+                case WorkUnitType.Prerender:
+                case WorkUnitType.PrerenderClient:
                   if (cacheSignal) {
                     cacheSignal.endRead()
                     cacheSignal = null
@@ -673,11 +674,11 @@ export function createPatchedFetcher(
                     workUnitStore.renderSignal,
                     'fetch()'
                   )
-                case 'prerender-ppr':
-                case 'prerender-legacy':
-                case 'request':
-                case 'cache':
-                case 'unstable-cache':
+                case WorkUnitType.PrerenderPPR:
+                case WorkUnitType.PrerenderLegacy:
+                case WorkUnitType.Request:
+                case WorkUnitType.Cache:
+                case WorkUnitType.UnstableCache:
                   break
                 default:
                   workUnitStore satisfies never
@@ -709,16 +710,16 @@ export function createPatchedFetcher(
 
         if (workUnitStore) {
           switch (workUnitStore.type) {
-            case 'request':
-            case 'cache':
+            case WorkUnitType.Request:
+            case WorkUnitType.Cache:
               isHmrRefresh = workUnitStore.isHmrRefresh ?? false
               serverComponentsHmrCache = workUnitStore.serverComponentsHmrCache
               break
-            case 'prerender':
-            case 'prerender-client':
-            case 'prerender-ppr':
-            case 'prerender-legacy':
-            case 'unstable-cache':
+            case WorkUnitType.Prerender:
+            case WorkUnitType.PrerenderClient:
+            case WorkUnitType.PrerenderPPR:
+            case WorkUnitType.PrerenderLegacy:
+            case WorkUnitType.UnstableCache:
               break
             default:
               workUnitStore satisfies never
@@ -833,8 +834,8 @@ export function createPatchedFetcher(
                   : undefined
 
                 switch (workUnitStore?.type) {
-                  case 'prerender':
-                  case 'prerender-client':
+                  case WorkUnitType.Prerender:
+                  case WorkUnitType.PrerenderClient:
                     return createCachedPrerenderResponse(
                       res,
                       cacheKey,
@@ -843,11 +844,11 @@ export function createPatchedFetcher(
                       normalizedRevalidate,
                       handleUnlock
                     )
-                  case 'prerender-ppr':
-                  case 'prerender-legacy':
-                  case 'request':
-                  case 'cache':
-                  case 'unstable-cache':
+                  case WorkUnitType.PrerenderPPR:
+                  case WorkUnitType.PrerenderLegacy:
+                  case WorkUnitType.Request:
+                  case WorkUnitType.Cache:
+                  case WorkUnitType.UnstableCache:
                   case undefined:
                     return createCachedDynamicResponse(
                       workStore,
@@ -904,8 +905,8 @@ export function createPatchedFetcher(
 
             if (hasNoExplicitCacheConfig && workUnitStore) {
               switch (workUnitStore.type) {
-                case 'prerender':
-                case 'prerender-client':
+                case WorkUnitType.Prerender:
+                case WorkUnitType.PrerenderClient:
                   // We sometimes use the cache to dedupe fetches that do not
                   // specify a cache configuration. In these cases we want to
                   // make sure we still exclude them from prerenders if
@@ -913,11 +914,11 @@ export function createPatchedFetcher(
                   // here.
                   await waitAtLeastOneReactRenderTask()
                   break
-                case 'prerender-ppr':
-                case 'prerender-legacy':
-                case 'request':
-                case 'cache':
-                case 'unstable-cache':
+                case WorkUnitType.PrerenderPPR:
+                case WorkUnitType.PrerenderLegacy:
+                case WorkUnitType.Request:
+                case WorkUnitType.Cache:
+                case WorkUnitType.UnstableCache:
                   break
                 default:
                   workUnitStore satisfies never
@@ -1004,8 +1005,8 @@ export function createPatchedFetcher(
             // If enabled, we should bail out of static generation.
             if (workUnitStore) {
               switch (workUnitStore.type) {
-                case 'prerender':
-                case 'prerender-client':
+                case WorkUnitType.Prerender:
+                case WorkUnitType.PrerenderClient:
                   if (cacheSignal) {
                     cacheSignal.endRead()
                     cacheSignal = null
@@ -1014,11 +1015,11 @@ export function createPatchedFetcher(
                     workUnitStore.renderSignal,
                     'fetch()'
                   )
-                case 'prerender-ppr':
-                case 'prerender-legacy':
-                case 'request':
-                case 'cache':
-                case 'unstable-cache':
+                case WorkUnitType.PrerenderPPR:
+                case WorkUnitType.PrerenderLegacy:
+                case WorkUnitType.Request:
+                case WorkUnitType.Cache:
+                case WorkUnitType.UnstableCache:
                   break
                 default:
                   workUnitStore satisfies never
@@ -1042,17 +1043,17 @@ export function createPatchedFetcher(
               // If enabled, we should bail out of static generation.
               if (workUnitStore) {
                 switch (workUnitStore.type) {
-                  case 'prerender':
-                  case 'prerender-client':
+                  case WorkUnitType.Prerender:
+                  case WorkUnitType.PrerenderClient:
                     return makeHangingPromise<Response>(
                       workUnitStore.renderSignal,
                       'fetch()'
                     )
-                  case 'request':
-                  case 'cache':
-                  case 'unstable-cache':
-                  case 'prerender-legacy':
-                  case 'prerender-ppr':
+                  case WorkUnitType.Request:
+                  case WorkUnitType.Cache:
+                  case WorkUnitType.UnstableCache:
+                  case WorkUnitType.PrerenderLegacy:
+                  case WorkUnitType.PrerenderPPR:
                     break
                   default:
                     workUnitStore satisfies never

--- a/packages/next/src/server/node-environment-extensions/console-dev.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dev.tsx
@@ -1,5 +1,8 @@
 import { dim } from '../../lib/picocolors'
-import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitType,
+} from '../app-render/work-unit-async-storage.external'
 
 type InterceptableConsoleMethod =
   | 'error'
@@ -139,15 +142,15 @@ function patchConsoleMethodDEV(methodName: InterceptableConsoleMethod): void {
       const workUnitStore = workUnitAsyncStorage.getStore()
 
       switch (workUnitStore?.type) {
-        case 'prerender':
-        case 'prerender-client':
+        case WorkUnitType.Prerender:
+        case WorkUnitType.PrerenderClient:
           originalMethod.apply(this, dimConsoleCall(methodName, args))
           break
-        case 'prerender-ppr':
-        case 'prerender-legacy':
-        case 'request':
-        case 'cache':
-        case 'unstable-cache':
+        case WorkUnitType.PrerenderPPR:
+        case WorkUnitType.PrerenderLegacy:
+        case WorkUnitType.Request:
+        case WorkUnitType.Cache:
+        case WorkUnitType.UnstableCache:
         case undefined:
           originalMethod.apply(this, args)
           break

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -1,6 +1,7 @@
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import {
   workUnitAsyncStorage,
+  WorkUnitType,
   type PrerenderStoreModern,
 } from '../app-render/work-unit-async-storage.external'
 import {
@@ -20,7 +21,7 @@ export function io(expression: string, type: ApiType) {
   }
 
   switch (workUnitStore.type) {
-    case 'prerender': {
+    case WorkUnitType.Prerender: {
       const prerenderSignal = workUnitStore.controller.signal
 
       if (prerenderSignal.aborted === false) {
@@ -52,7 +53,7 @@ export function io(expression: string, type: ApiType) {
       }
       break
     }
-    case 'prerender-client': {
+    case WorkUnitType.PrerenderClient: {
       const prerenderSignal = workUnitStore.controller.signal
 
       if (prerenderSignal.aborted === false) {
@@ -84,15 +85,15 @@ export function io(expression: string, type: ApiType) {
       }
       break
     }
-    case 'request':
+    case WorkUnitType.Request:
       if (workUnitStore.prerenderPhase === true) {
         trackSynchronousPlatformIOAccessInDev(workUnitStore)
       }
       break
-    case 'prerender-ppr':
-    case 'prerender-legacy':
-    case 'cache':
-    case 'unstable-cache':
+    case WorkUnitType.PrerenderPPR:
+    case WorkUnitType.PrerenderLegacy:
+    case WorkUnitType.Cache:
+    case WorkUnitType.UnstableCache:
       break
     default:
       workUnitStore satisfies never

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -14,6 +14,7 @@ import {
   type PrerenderStorePPR,
   type PrerenderStoreLegacy,
   type PrerenderStoreModern,
+  WorkUnitType,
 } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
@@ -63,14 +64,14 @@ export function createParamsFromClient(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
         return createPrerenderParams(underlyingParams, workStore, workUnitStore)
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -91,14 +92,14 @@ export function createServerParamsForRoute(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
         return createPrerenderParams(underlyingParams, workStore, workUnitStore)
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -114,14 +115,14 @@ export function createServerParamsForServerSegment(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
         return createPrerenderParams(underlyingParams, workStore, workUnitStore)
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -137,8 +138,8 @@ export function createPrerenderParamsForClientSegment(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
         const fallbackParams = workStore.fallbackRouteParams
         if (fallbackParams) {
           for (let key in underlyingParams) {
@@ -152,11 +153,11 @@ export function createPrerenderParamsForClientSegment(
           }
         }
         break
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -186,12 +187,12 @@ function createPrerenderParams(
     if (hasSomeFallbackParams) {
       // params need to be treated as dynamic because we have at least one fallback param
       switch (prerenderStore.type) {
-        case 'prerender':
-        case 'prerender-client':
+        case WorkUnitType.Prerender:
+        case WorkUnitType.PrerenderClient:
           // We are in a cacheComponents prerender
           return makeHangingParams(underlyingParams, prerenderStore)
-        case 'prerender-ppr':
-        case 'prerender-legacy':
+        case WorkUnitType.PrerenderPPR:
+        case WorkUnitType.PrerenderLegacy:
           return makeErroringExoticParams(
             underlyingParams,
             fallbackParams,
@@ -316,7 +317,7 @@ function makeErroringExoticParams(
             // fallback shells
             // TODO remove this comment when cacheComponents is the default since there
             // will be no `dynamic = "error"`
-            if (prerenderStore.type === 'prerender-ppr') {
+            if (prerenderStore.type === WorkUnitType.PrerenderPPR) {
               // PPR Prerender (no cacheComponents)
               postponeWithTracking(
                 workStore.route,
@@ -343,7 +344,7 @@ function makeErroringExoticParams(
             // fallback shells
             // TODO remove this comment when cacheComponents is the default since there
             // will be no `dynamic = "error"`
-            if (prerenderStore.type === 'prerender-ppr') {
+            if (prerenderStore.type === WorkUnitType.PrerenderPPR) {
               // PPR Prerender (no cacheComponents)
               postponeWithTracking(
                 workStore.route,
@@ -543,19 +544,19 @@ function syncIODev(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'request':
+      case WorkUnitType.Request:
         if (workUnitStore.prerenderPhase === true) {
           // When we're rendering dynamically in dev, we need to advance out of
           // the Prerender environment when we read Request data synchronously.
           trackSynchronousRequestDataAccessInDev(workUnitStore)
         }
         break
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   workUnitAsyncStorage,
+  WorkUnitType,
   type PrerenderStore,
 } from '../app-render/work-unit-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
@@ -19,19 +20,19 @@ export function createServerPathnameForMetadata(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy': {
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy: {
         return createPrerenderPathname(
           underlyingPathname,
           workStore,
           workUnitStore
         )
       }
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -48,18 +49,18 @@ function createPrerenderPathname(
   const fallbackParams = workStore.fallbackRouteParams
   if (fallbackParams && fallbackParams.size > 0) {
     switch (prerenderStore.type) {
-      case 'prerender':
+      case WorkUnitType.Prerender:
         return makeHangingPromise<string>(
           prerenderStore.renderSignal,
           '`pathname`'
         )
-      case 'prerender-client':
+      case WorkUnitType.PrerenderClient:
         throw new InvariantError(
           'createPrerenderPathname was called inside a client component scope.'
         )
-      case 'prerender-ppr':
+      case WorkUnitType.PrerenderPPR:
         return makeErroringPathname(workStore, prerenderStore.dynamicTracking)
-      case 'prerender-legacy':
+      case WorkUnitType.PrerenderLegacy:
         return makeErroringPathname(workStore, null)
       default:
         prerenderStore satisfies never

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -15,6 +15,7 @@ import {
   type PrerenderStoreLegacy,
   type PrerenderStorePPR,
   type PrerenderStoreModern,
+  WorkUnitType,
 } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
@@ -67,14 +68,14 @@ export function createSearchParamsFromClient(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
         return createPrerenderSearchParams(workStore, workUnitStore)
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -94,14 +95,14 @@ export function createServerSearchParamsForServerPage(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
         return createPrerenderSearchParams(workStore, workUnitStore)
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -122,16 +123,16 @@ export function createPrerenderSearchParamsForClientPage(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender':
-      case 'prerender-client':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
         // We're prerendering in a mode that aborts (cacheComponents) and should stall
         // the promise to ensure the RSC side is considered dynamic
         return makeHangingPromise(workUnitStore.renderSignal, '`searchParams`')
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'request':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
+      case WorkUnitType.Request:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never
@@ -154,12 +155,12 @@ function createPrerenderSearchParams(
   }
 
   switch (prerenderStore.type) {
-    case 'prerender':
-    case 'prerender-client':
+    case WorkUnitType.Prerender:
+    case WorkUnitType.PrerenderClient:
       // We are in a cacheComponents (PPR or otherwise) prerender
       return makeHangingSearchParams(prerenderStore)
-    case 'prerender-ppr':
-    case 'prerender-legacy':
+    case WorkUnitType.PrerenderPPR:
+    case WorkUnitType.PrerenderLegacy:
       // We are in a legacy static generation and need to interrupt the
       // prerender when search params are accessed.
       return makeErroringExoticSearchParams(workStore, prerenderStore)
@@ -290,7 +291,7 @@ function makeErroringExoticSearchParams(
               workStore.route,
               expression
             )
-          } else if (prerenderStore.type === 'prerender-ppr') {
+          } else if (prerenderStore.type === WorkUnitType.PrerenderPPR) {
             // PPR Prerender (no cacheComponents)
             postponeWithTracking(
               workStore.route,
@@ -315,7 +316,7 @@ function makeErroringExoticSearchParams(
               workStore.route,
               expression
             )
-          } else if (prerenderStore.type === 'prerender-ppr') {
+          } else if (prerenderStore.type === WorkUnitType.PrerenderPPR) {
             // PPR Prerender (no cacheComponents)
             postponeWithTracking(
               workStore.route,
@@ -343,7 +344,7 @@ function makeErroringExoticSearchParams(
                 workStore.route,
                 expression
               )
-            } else if (prerenderStore.type === 'prerender-ppr') {
+            } else if (prerenderStore.type === WorkUnitType.PrerenderPPR) {
               // PPR Prerender (no cacheComponents)
               postponeWithTracking(
                 workStore.route,
@@ -378,7 +379,7 @@ function makeErroringExoticSearchParams(
             workStore.route,
             expression
           )
-        } else if (prerenderStore.type === 'prerender-ppr') {
+        } else if (prerenderStore.type === WorkUnitType.PrerenderPPR) {
           // PPR Prerender (no cacheComponents)
           postponeWithTracking(
             workStore.route,
@@ -405,7 +406,7 @@ function makeErroringExoticSearchParams(
           workStore.route,
           expression
         )
-      } else if (prerenderStore.type === 'prerender-ppr') {
+      } else if (prerenderStore.type === WorkUnitType.PrerenderPPR) {
         // PPR Prerender (no cacheComponents)
         postponeWithTracking(
           workStore.route,
@@ -782,19 +783,19 @@ function syncIODev(
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'request':
+      case WorkUnitType.Request:
         if (workUnitStore.prerenderPhase === true) {
           // When we're rendering dynamically in dev, we need to advance out of
           // the Prerender environment when we read Request data synchronously.
           trackSynchronousRequestDataAccessInDev(workUnitStore)
         }
         break
-      case 'prerender':
-      case 'prerender-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'cache':
-      case 'unstable-cache':
+      case WorkUnitType.Prerender:
+      case WorkUnitType.PrerenderClient:
+      case WorkUnitType.PrerenderPPR:
+      case WorkUnitType.PrerenderLegacy:
+      case WorkUnitType.Cache:
+      case WorkUnitType.UnstableCache:
         break
       default:
         workUnitStore satisfies never

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -1,6 +1,7 @@
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { afterTaskAsyncStorage } from '../app-render/after-task-async-storage.external'
 import type { WorkStore } from '../app-render/work-async-storage.external'
+import { WorkUnitPhase } from '../app-render/work-unit-async-storage.external'
 
 export function throwWithStaticGenerationBailoutError(
   route: string,
@@ -36,5 +37,5 @@ export function throwForSearchParamsAccessInUseCache(
 
 export function isRequestAPICallableInsideAfter() {
   const afterTaskStore = afterTaskAsyncStorage.getStore()
-  return afterTaskStore?.rootTaskSpawnPhase === 'action'
+  return afterTaskStore?.rootTaskSpawnPhase === WorkUnitPhase.After
 }

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -37,5 +37,5 @@ export function throwForSearchParamsAccessInUseCache(
 
 export function isRequestAPICallableInsideAfter() {
   const afterTaskStore = afterTaskAsyncStorage.getStore()
-  return afterTaskStore?.rootTaskSpawnPhase === WorkUnitPhase.After
+  return afterTaskStore?.rootTaskSpawnPhase === WorkUnitPhase.Action
 }

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -1,5 +1,8 @@
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
-import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitType,
+} from '../app-render/work-unit-async-storage.external'
 
 export type CacheLife = {
   // How long the client can cache a value without checking with the server.
@@ -94,17 +97,17 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
   const workUnitStore = workUnitAsyncStorage.getStore()
 
   switch (workUnitStore?.type) {
-    case 'prerender':
-    case 'prerender-client':
-    case 'prerender-ppr':
-    case 'prerender-legacy':
-    case 'request':
-    case 'unstable-cache':
+    case WorkUnitType.Prerender:
+    case WorkUnitType.PrerenderClient:
+    case WorkUnitType.PrerenderPPR:
+    case WorkUnitType.PrerenderLegacy:
+    case WorkUnitType.Request:
+    case WorkUnitType.UnstableCache:
     case undefined:
       throw new Error(
         'cacheLife() can only be called inside a "use cache" function.'
       )
-    case 'cache':
+    case WorkUnitType.Cache:
       break
     default:
       workUnitStore satisfies never

--- a/packages/next/src/server/use-cache/cache-tag.ts
+++ b/packages/next/src/server/use-cache/cache-tag.ts
@@ -1,4 +1,7 @@
-import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitType,
+} from '../app-render/work-unit-async-storage.external'
 import { validateTags } from '../lib/patch-fetch'
 
 export function cacheTag(...tags: string[]): void {
@@ -11,17 +14,17 @@ export function cacheTag(...tags: string[]): void {
   const workUnitStore = workUnitAsyncStorage.getStore()
 
   switch (workUnitStore?.type) {
-    case 'prerender':
-    case 'prerender-client':
-    case 'prerender-ppr':
-    case 'prerender-legacy':
-    case 'request':
-    case 'unstable-cache':
+    case WorkUnitType.Prerender:
+    case WorkUnitType.PrerenderClient:
+    case WorkUnitType.PrerenderPPR:
+    case WorkUnitType.PrerenderLegacy:
+    case WorkUnitType.Request:
+    case WorkUnitType.UnstableCache:
     case undefined:
       throw new Error(
         'cacheTag() can only be called inside a "use cache" function.'
       )
-    case 'cache':
+    case WorkUnitType.Cache:
       break
     default:
       workUnitStore satisfies never

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
@@ -1,5 +1,7 @@
 import {
   workUnitAsyncStorage,
+  WorkUnitPhase,
+  WorkUnitType,
   type RequestStore,
 } from '../../../app-render/work-unit-async-storage.external'
 import { RequestCookies, ResponseCookies } from '../cookies'
@@ -112,19 +114,19 @@ describe('wrapWithMutableAccessCheck', () => {
     const underlyingCookies = new ResponseCookies(headers)
 
     return {
-      type: 'request',
+      type: WorkUnitType.Request,
       phase,
       mutableCookies: underlyingCookies,
     } as RequestStore
   }
 
   it('prevents setting cookies in the render phase', () => {
-    const requestStore = createMockRequestStore('action')
+    const requestStore = createMockRequestStore(WorkUnitPhase.Action)
     workUnitAsyncStorage.run(requestStore, () => {
       const cookies = createCookiesWithMutableAccessCheck(requestStore)
 
       // simulate changing phases
-      requestStore.phase = 'render'
+      requestStore.phase = WorkUnitPhase.Render
 
       const EXPECTED_ERROR =
         /Cookies can only be modified in a Server Action or Route Handler\./
@@ -138,13 +140,13 @@ describe('wrapWithMutableAccessCheck', () => {
   })
 
   it('prevents deleting cookies in the render phase', () => {
-    const requestStore = createMockRequestStore('action')
+    const requestStore = createMockRequestStore(WorkUnitPhase.Action)
     workUnitAsyncStorage.run(requestStore, () => {
       const cookies = createCookiesWithMutableAccessCheck(requestStore)
       cookies.set('foo', '1')
 
       // simulate changing phases
-      requestStore.phase = 'render'
+      requestStore.phase = WorkUnitPhase.Render
 
       const EXPECTED_ERROR =
         /Cookies can only be modified in a Server Action or Route Handler\./

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -3,7 +3,10 @@ import { RequestCookies } from '../cookies'
 import { ResponseCookies } from '../cookies'
 import { ReflectAdapter } from './reflect'
 import { workAsyncStorage } from '../../../app-render/work-async-storage.external'
-import type { RequestStore } from '../../../app-render/work-unit-async-storage.external'
+import {
+  WorkUnitPhase,
+  type RequestStore,
+} from '../../../app-render/work-unit-async-storage.external'
 
 /**
  * @internal
@@ -205,7 +208,7 @@ export function createCookiesWithMutableAccessCheck(
 }
 
 export function areCookiesMutableInCurrentPhase(requestStore: RequestStore) {
-  return requestStore.phase === 'action'
+  return requestStore.phase === WorkUnitPhase.Action
 }
 
 /** Ensure that cookies() starts throwing on mutation

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -10,6 +10,8 @@ import {
   getCacheSignal,
   getDraftModeProviderForCacheScope,
   workUnitAsyncStorage,
+  WorkUnitPhase,
+  WorkUnitType,
 } from '../../app-render/work-unit-async-storage.external'
 import {
   CachedRouteKind,
@@ -140,8 +142,8 @@ export function unstable_cache<T extends Callback>(
       const implicitTags = workUnitStore?.implicitTags
 
       const innerCacheStore: UnstableCacheStore = {
-        type: 'unstable-cache',
-        phase: 'render',
+        type: WorkUnitType.UnstableCache,
+        phase: WorkUnitPhase.Render,
         implicitTags,
         draftMode:
           workUnitStore &&
@@ -160,10 +162,10 @@ export function unstable_cache<T extends Callback>(
 
         if (workUnitStore) {
           switch (workUnitStore.type) {
-            case 'cache':
-            case 'prerender':
-            case 'prerender-ppr':
-            case 'prerender-legacy':
+            case WorkUnitType.Cache:
+            case WorkUnitType.Prerender:
+            case WorkUnitType.PrerenderPPR:
+            case WorkUnitType.PrerenderLegacy:
               // We update the store's revalidate property if the option.revalidate is a higher precedence
               // options.revalidate === undefined doesn't affect timing.
               // options.revalidate === false doesn't shrink timing. it stays at the maximum.
@@ -188,11 +190,11 @@ export function unstable_cache<T extends Callback>(
                 }
               }
               break
-            case 'unstable-cache':
+            case WorkUnitType.UnstableCache:
               isNestedUnstableCache = true
               break
-            case 'prerender-client':
-            case 'request':
+            case WorkUnitType.PrerenderClient:
+            case WorkUnitType.Request:
               break
             default:
               workUnitStore satisfies never
@@ -371,7 +373,7 @@ function getFetchUrlPrefix(
   workUnitStore: WorkUnitStore
 ): string {
   switch (workUnitStore.type) {
-    case 'request':
+    case WorkUnitType.Request:
       const pathname = workUnitStore.url.pathname
       const searchParams = new URLSearchParams(workUnitStore.url.search)
 
@@ -381,12 +383,12 @@ function getFetchUrlPrefix(
         .join('&')
 
       return `${pathname}${sortedSearch.length ? '?' : ''}${sortedSearch}`
-    case 'prerender':
-    case 'prerender-client':
-    case 'prerender-ppr':
-    case 'prerender-legacy':
-    case 'cache':
-    case 'unstable-cache':
+    case WorkUnitType.Prerender:
+    case WorkUnitType.PrerenderClient:
+    case WorkUnitType.PrerenderPPR:
+    case WorkUnitType.PrerenderLegacy:
+    case WorkUnitType.Cache:
+    case WorkUnitType.UnstableCache:
       return workStore.route
     default:
       return workUnitStore satisfies never

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -1,5 +1,8 @@
 import { workAsyncStorage } from '../../app-render/work-async-storage.external'
-import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  WorkUnitType,
+} from '../../app-render/work-unit-async-storage.external'
 import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
 
 /**
@@ -32,15 +35,15 @@ export function unstable_noStore() {
     store.isUnstableNoStore = true
     if (workUnitStore) {
       switch (workUnitStore.type) {
-        case 'prerender':
-        case 'prerender-client':
+        case WorkUnitType.Prerender:
+        case WorkUnitType.PrerenderClient:
           // unstable_noStore() is a noop in Dynamic I/O.
           return
-        case 'prerender-ppr':
-        case 'prerender-legacy':
-        case 'request':
-        case 'cache':
-        case 'unstable-cache':
+        case WorkUnitType.PrerenderPPR:
+        case WorkUnitType.PrerenderLegacy:
+        case WorkUnitType.Request:
+        case WorkUnitType.Cache:
+        case WorkUnitType.UnstableCache:
           break
         default:
           workUnitStore satisfies never


### PR DESCRIPTION
This avoids repeating the strings many times throughout the codebase, as well as in the produced bundles. It also improves the DX of finding references of specific work unit types or phases.

Resolves https://github.com/vercel/next.js/pull/81577#discussion_r2205632688