### PR TITLE
Docs: Document `global-not-found`

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -5,8 +5,8 @@ description: API reference for the not-found.js file.
 
 Next.js provides two conventions to handle not found cases:
 
-- **`global-not-found.js`**: For your entire application.
-- **`not-found.js`**: For nested route segments.
+- **`not-found.js`**: Used when you call the [`notFound`](/docs/app/api-reference/functions/not-found) function in a route segment.
+- **`global-not-found.js`**: Used to define a global 404 page for unmatched routes across your entire app. This is handled at the routing level and doesn't depend on rendering a layout or page.
 
 ## `not-found.js`
 
@@ -42,12 +42,12 @@ export default function NotFound() {
 
 ## `global-not-found.js` (experimental)
 
-The `global-not-found.js` file lets you define a custom 404 page for your entire app, including its layout.
+The `global-not-found.js` file lets you define a 404 page for your entire application. Unlike `not-found.js`, which works at the route level, this is used when a requested URL doesn't match any route at all. Next.js **skips rendering** and directly returns this global page.
 
-This is useful for:
+This is useful when you can't build a 404 page using a combination of `layout.js` and `not-found.js`. This can happen in two cases:
 
-- Apps with multiple root layouts.
-- Projects where composing a 404 page from `layout.js` and `not-found.js` is not possible.
+- Your app has multiple root layouts (e.g. `app/(admin)/layout.tsx` and `app/(shop)/layout.tsx`), so there's no single layout to compose a global 404 from.
+- Your root layout is defined using top-level dynamic segments (e.g. `app/[country]/layout.tsx`), which makes composing a consistent 404 page harder.
 
 To enable it, add the `globalNotFound` flag in `next.config.ts`:
 
@@ -138,7 +138,7 @@ If you need to use Client Component hooks like `usePathname` to display content 
 
 ### Metadata
 
-You can export a `metadata` object or a [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) function to customize the `<title>`, `<meta>`, and other head tags for your 404 page:
+For `global-not-found.js`, you can export a `metadata` object or a [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) function to customize the `<title>`, `<meta>`, and other head tags for your 404 page:
 
 ```tsx filename="app/not-found.tsx" switcher
 export const metadata = {
@@ -160,6 +160,6 @@ export default function NotFound() {
 
 | Version   | Changes                                             |
 | --------- | --------------------------------------------------- |
-| `v15.4.0`   | `global-not-found.js` introduced (experimental).    |
+| `v15.4.0` | `global-not-found.js` introduced (experimental).    |
 | `v13.3.0` | Root `app/not-found` handles global unmatched URLs. |
 | `v13.0.0` | `not-found` introduced.                             |

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -140,7 +140,7 @@ If you need to use Client Component hooks like `usePathname` to display content 
 
 For `global-not-found.js`, you can export a `metadata` object or a [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) function to customize the `<title>`, `<meta>`, and other head tags for your 404 page:
 
-```tsx filename="app/not-found.tsx" switcher
+```tsx filename="app/global-not-found.tsx" switcher
 export const metadata = {
   title: 'Not Found',
   description: 'The page you are looking for does not exist.',

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -86,7 +86,7 @@ Unlike `not-found.js`, this file must return a full HTML document, including `<h
 
 `not-found.js` or `global-not-found.js` components do not accept any props.
 
-> **Good to know**: In addition to catching expected `notFound()` errors, the root `app/not-found.js` file handles any unmatched URLs for your whole application by default. This means users that visit a URL that is not handled by your app will be shown the UI exported by the `app/not-found.js` file. When the experimental `globalNotFound` flag is enabled, this behavior changes and the `app/global-not-found.js` file will handle unmatched URLs instead.
+> **Good to know**: In addition to catching expected `notFound()` errors, the root `app/not-found.js` and `app/global-not-found.js` files handle any unmatched URLs for your whole application. This means users that visit a URL that is not handled by your app will be shown the exported UI.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -160,6 +160,6 @@ export default function NotFound() {
 
 | Version   | Changes                                             |
 | --------- | --------------------------------------------------- |
-| `v15.x`   | `global-not-found.js` introduced (experimental).    |
+| `v15.4.0`   | `global-not-found.js` introduced (experimental).    |
 | `v13.3.0` | Root `app/not-found` handles global unmatched URLs. |
 | `v13.0.0` | `not-found` introduced.                             |

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -146,7 +146,7 @@ export const metadata = {
   description: 'The page you are looking for does not exist.',
 }
 
-export default function NotFound() {
+export default function GlobalNotFound() {
   return (
     <div>
       <h1>Not Found</h1>

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -86,7 +86,7 @@ Unlike `not-found.js`, this file must return a full HTML document, including `<h
 
 `not-found.js` or `global-not-found.js` components do not accept any props.
 
-> **Good to know**: In addition to catching expected `notFound()` errors, the root `app/global-not-found.js` file also handles any unmatched URLs for your whole application. This means users that visit a URL that is not handled by your app will be shown the UI exported by the `app/global-not-found.js` file.
+> **Good to know**: In addition to catching expected `notFound()` errors, the root `app/not-found.js` file handles any unmatched URLs for your whole application by default. This means users that visit a URL that is not handled by your app will be shown the UI exported by the `app/not-found.js` file. When the experimental `globalNotFound` flag is enabled, this behavior changes and the `app/global-not-found.js` file will handle unmatched URLs instead.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -3,6 +3,13 @@ title: not-found.js
 description: API reference for the not-found.js file.
 ---
 
+Next.js provides two conventions to handle not found cases:
+
+- **`global-not-found.js`**: For your entire application.
+- **`not-found.js`**: For nested route segments.
+
+## `not-found.js`
+
 The **not-found** file is used to render UI when the [`notFound`](/docs/app/api-reference/functions/not-found) function is thrown within a route segment. Along with serving a custom UI, Next.js will return a `200` HTTP status code for streamed responses, and `404` for non-streamed responses.
 
 ```tsx filename="app/not-found.tsx" switcher
@@ -33,13 +40,53 @@ export default function NotFound() {
 }
 ```
 
+## `global-not-found.js` (experimental)
+
+The `global-not-found.js` file lets you define a custom 404 page for your entire app, including its layout.
+
+This is useful for:
+
+- Apps with multiple root layouts.
+- Projects where composing a 404 page from `layout.js` and `not-found.js` is not possible.
+
+To enable it, add the `globalNotFound` flag in `next.config.ts`:
+
+```tsx filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    globalNotFound: true,
+  },
+}
+
+export default nextConfig
+```
+
+Then, create a file in the root of the `app` directory: `app/global-not-found.js`:
+
+```tsx filename="app/global-not-found.tsx" switcher
+export default function GlobalNotFound() {
+  return (
+    <html>
+      <body>
+        <h1>404 - Page Not Found</h1>
+        <p>This page does not exist.</p>
+      </body>
+    </html>
+  )
+}
+```
+
+Unlike `not-found.js`, this file must return a full HTML document, including `<html>` and `<body>` tags.
+
 ## Reference
 
 ### Props
 
-`not-found.js` components do not accept any props.
+`not-found.js` or `global-not-found.js` components do not accept any props.
 
-> **Good to know**: In addition to catching expected `notFound()` errors, the root `app/not-found.js` file also handles any unmatched URLs for your whole application. This means users that visit a URL that is not handled by your app will be shown the UI exported by the `app/not-found.js` file.
+> **Good to know**: In addition to catching expected `notFound()` errors, the root `app/global-not-found.js` file also handles any unmatched URLs for your whole application. This means users that visit a URL that is not handled by your app will be shown the UI exported by the `app/global-not-found.js` file.
 
 ## Examples
 
@@ -89,9 +136,30 @@ export default async function NotFound() {
 
 If you need to use Client Component hooks like `usePathname` to display content based on the path, you must fetch data on the client-side instead.
 
+### Metadata
+
+You can export a `metadata` object or a [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) function to customize the `<title>`, `<meta>`, and other head tags for your 404 page:
+
+```tsx filename="app/not-found.tsx" switcher
+export const metadata = {
+  title: 'Not Found',
+  description: 'The page you are looking for does not exist.',
+}
+
+export default function NotFound() {
+  return (
+    <div>
+      <h1>Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  )
+}
+```
+
 ## Version History
 
 | Version   | Changes                                             |
 | --------- | --------------------------------------------------- |
+| `v15.x`   | `global-not-found.js` introduced (experimental).    |
 | `v13.3.0` | Root `app/not-found` handles global unmatched URLs. |
 | `v13.0.0` | `not-found` introduced.                             |


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4873/document-global-not-found