### PR TITLE
Turbopack: RawEcmascriptModule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,6 +4291,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "swc_core",
+ "swc_sourcemap",
  "thiserror 1.0.69",
  "tracing",
  "turbo-esregex",

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -35,6 +35,7 @@ remove_console = { workspace = true }
 itertools = { workspace = true }
 percent-encoding = "2.3.1"
 serde_path_to_error = { workspace = true }
+swc_sourcemap = { workspace = true }
 
 swc_core = { workspace = true, features = [
   "base",

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -35,6 +35,7 @@ mod next_shared;
 pub mod next_telemetry;
 mod page_loader;
 pub mod pages_structure;
+pub mod raw_ecmascript_module;
 pub mod segment_config;
 pub mod tracing_presets;
 mod transform_options;

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -45,6 +45,11 @@ pub async fn get_next_client_transforms_rules(
         ));
     }
 
+    // This is purely a performance optimization:
+    // - The next-devtools file is very large and rather slow to analyze (unforatunately, at least
+    //   with our current implementation)
+    // - It's used by every single application in dev, even tiny (CNA) apps
+    // - It's prebundled already and doesn't contain any imports/requires
     rules.push(ModuleRule::new(
         RuleCondition::ResourcePathEndsWith(
             "next/dist/compiled/next-devtools/index.js".to_string(),

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use next_custom_transforms::transforms::strip_page_exports::ExportFilter;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbopack::module_options::ModuleRule;
+use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
 
 use crate::{
     mode::NextMode,
@@ -17,6 +17,7 @@ use crate::{
         next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
         next_pure::get_next_pure_rule, server_actions::ActionsTransform,
     },
+    raw_ecmascript_module::RawEcmascriptModuleType,
 };
 
 /// Returns a list of module rules which apply client-side, Next.js-specific
@@ -43,6 +44,15 @@ pub async fn get_next_client_transforms_rules(
             enable_mdx_rs,
         ));
     }
+
+    rules.push(ModuleRule::new(
+        RuleCondition::ResourcePathEndsWith(
+            "next/dist/compiled/next-devtools/index.js".to_string(),
+        ),
+        vec![ModuleRuleEffect::ModuleType(ModuleType::Custom(
+            ResolvedVc::upcast(RawEcmascriptModuleType {}.resolved_cell()),
+        ))],
+    ));
 
     rules.push(get_next_font_transform_rule(enable_mdx_rs));
 

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, fxindexmap, trace::TraceRawVcs};
@@ -7,6 +7,7 @@ use turbopack_core::{
     context::AssetContext, module::Module, reference_type::ReferenceType, resolve::ModulePart,
     source::Source,
 };
+use turbopack_ecmascript::EcmascriptInputTransforms;
 use turbopack_static::ecma::StaticUrlJsModule;
 
 use super::source_asset::StructuredImageFileSource;
@@ -94,5 +95,15 @@ impl CustomModuleType for StructuredImageModuleType {
             self.blur_placeholder_mode,
             module_asset_context,
         )
+    }
+
+    #[turbo_tasks::function]
+    fn extend_ecmascript_transforms(
+        self: Vc<Self>,
+        _preprocess: Vc<EcmascriptInputTransforms>,
+        _main: Vc<EcmascriptInputTransforms>,
+        _postprocess: Vc<EcmascriptInputTransforms>,
+    ) -> Result<Vc<Box<dyn CustomModuleType>>> {
+        bail!("StructuredImageModuleType does not support adding Ecmascript transforms");
     }
 }

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -185,10 +185,15 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
                                 name,
                                 if let Some(value) =
                                     replacements.get(&DefinableNameSegment::Name(name.into()))
-                                    && let Some(value) = value.get(&vec![
-                                        DefinableNameSegment::Name("process".into()),
-                                        DefinableNameSegment::Name("env".into()),
-                                    ])
+                                    && let Some((_, value)) = value.iter().find(|(path, _)| {
+                                        matches!(
+                                            path.as_slice(),
+                                            [
+                                                DefinableNameSegment::Name(a),
+                                                DefinableNameSegment::Name(b)
+                                            ] if a == "process" && b == "env"
+                                        )
+                                    })
                                 {
                                     let value = value.await?;
                                     let value = match &*value {

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -1,20 +1,31 @@
+use std::io::Write;
+
 use anyhow::{Result, bail};
+use once_cell::sync::Lazy;
+use regex::Regex;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{FileContent, glob::Glob, rope::RopeBuilder};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
+    compile_time_info::{
+        CompileTimeDefineValue, CompileTimeInfo, DefinableNameSegment, FreeVarReference,
+    },
+    context::AssetContext,
     ident::AssetIdent,
     module::Module,
     module_graph::ModuleGraph,
     resolve::ModulePart,
     source::Source,
 };
-use turbopack_ecmascript::chunk::{
-    EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptChunkType,
-    EcmascriptExports,
+use turbopack_ecmascript::{
+    chunk::{
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
+        EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports,
+    },
+    utils::StringifyJs,
 };
 
 #[turbo_tasks::value(shared)]
@@ -26,23 +37,34 @@ impl CustomModuleType for RawEcmascriptModuleType {
     fn create_module(
         &self,
         source: Vc<Box<dyn Source>>,
-        _module_asset_context: Vc<ModuleAssetContext>,
+        module_asset_context: Vc<ModuleAssetContext>,
         _part: Option<ModulePart>,
     ) -> Vc<Box<dyn Module>> {
-        Vc::upcast(RawEcmascriptModule::new(source))
+        Vc::upcast(RawEcmascriptModule::new(
+            source,
+            module_asset_context.compile_time_info(),
+        ))
     }
 }
 
 #[turbo_tasks::value]
 pub struct RawEcmascriptModule {
     source: ResolvedVc<Box<dyn Source>>,
+    compile_time_info: ResolvedVc<CompileTimeInfo>,
 }
 
 #[turbo_tasks::value_impl]
 impl RawEcmascriptModule {
     #[turbo_tasks::function]
-    pub fn new(source: ResolvedVc<Box<dyn Source>>) -> Vc<Self> {
-        Self::cell(RawEcmascriptModule { source })
+    pub fn new(
+        source: ResolvedVc<Box<dyn Source>>,
+        compile_time_info: ResolvedVc<CompileTimeInfo>,
+    ) -> Vc<Self> {
+        RawEcmascriptModule {
+            source,
+            compile_time_info,
+        }
+        .cell()
     }
 }
 
@@ -130,12 +152,83 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
             FileContent::Content(file) => file.content(),
             FileContent::NotFound => bail!("RawEcmascriptModule content not found"),
         };
+
+        static ENV_REGEX: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"process\.env\.([a-zA-Z0-9_]+)").unwrap());
+
+        let content_str = content.to_str()?;
+
+        let mut env_vars = FxIndexSet::default();
+        for (_, [name]) in ENV_REGEX.captures_iter(&content_str).map(|c| c.extract()) {
+            env_vars.insert(name);
+        }
+
         let mut inner_code = RopeBuilder::default();
+        if !env_vars.is_empty() {
+            let replacements = self
+                .module
+                .await?
+                .compile_time_info
+                .await?
+                .free_var_references
+                .individual()
+                .await?;
+            inner_code += "var process = {env:\n";
+            writeln!(
+                inner_code,
+                "{}",
+                StringifyJs(
+                    &env_vars
+                        .into_iter()
+                        .map(async |name| {
+                            Ok((
+                                name,
+                                if let Some(value) =
+                                    replacements.get(&DefinableNameSegment::Name(name.into()))
+                                    && let Some(value) = value.get(&vec![
+                                        DefinableNameSegment::Name("process".into()),
+                                        DefinableNameSegment::Name("env".into()),
+                                    ])
+                                {
+                                    let value = value.await?;
+                                    let value = match &*value {
+                                        FreeVarReference::Value(
+                                            CompileTimeDefineValue::String(value),
+                                        ) => serde_json::Value::String(value.to_string()),
+                                        FreeVarReference::Value(CompileTimeDefineValue::Bool(
+                                            value,
+                                        )) => serde_json::Value::Bool(*value),
+                                        _ => {
+                                            bail!(
+                                                "Unexpected replacement for process.env.{name} in \
+                                                 RawEcmascriptModule: {value:?}"
+                                            );
+                                        }
+                                    };
+                                    Some(value)
+                                } else {
+                                    None
+                                },
+                            ))
+                        })
+                        .try_join()
+                        .await?
+                        .into_iter()
+                        .collect::<FxIndexMap<_, _>>()
+                )
+            )?;
+            inner_code += "};\n";
+        }
+        inner_code += "{\n";
         inner_code.concat(content);
         // Add newline in case the raw code had a comment as the last line and no final newline.
-        inner_code += "\n";
+        inner_code += "\n}\n";
         Ok(EcmascriptChunkItemContent {
             inner_code: inner_code.build(),
+            options: EcmascriptChunkItemOptions {
+                module_and_exports: true,
+                ..Default::default()
+            },
             ..Default::default()
         }
         .into())

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -243,8 +243,8 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
             )?;
             code += "};\n";
         }
-        code += "{\n";
 
+        code += "(function(){\n";
         let source_map = if let Some((source_map, _)) = parse_source_map_comment(
             source,
             Either::Right(&content_str),
@@ -259,7 +259,7 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
         code.push_source(content, source_map);
 
         // Add newline in case the raw code had a comment as the last line and no final newline.
-        code += "\n}\n";
+        code += "\n})();\n";
 
         let code = code.build();
         let source_map = if code.has_source_map() {

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -92,10 +92,13 @@ impl ChunkableModule for RawEcmascriptModule {
         _module_graph: Vc<ModuleGraph>,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
-        Vc::upcast(RawEcmascriptChunkItem::cell(RawEcmascriptChunkItem {
-            module: self,
-            chunking_context,
-        }))
+        Vc::upcast(
+            RawEcmascriptChunkItem {
+                module: self,
+                chunking_context,
+            }
+            .cell(),
+        )
     }
 }
 

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -1,15 +1,17 @@
 use std::io::Write;
 
 use anyhow::{Result, bail};
+use either::Either;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
-use turbo_tasks_fs::{FileContent, glob::Glob, rope::RopeBuilder};
+use turbo_tasks_fs::{FileContent, glob::Glob, rope::Rope};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
+    code_builder::CodeBuilder,
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeInfo, DefinableNameSegment, FreeVarReference,
     },
@@ -19,12 +21,14 @@ use turbopack_core::{
     module_graph::ModuleGraph,
     resolve::ModulePart,
     source::Source,
+    source_map::GenerateSourceMap,
 };
 use turbopack_ecmascript::{
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
         EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports,
     },
+    source_map::parse_source_map_comment,
     utils::StringifyJs,
 };
 
@@ -150,7 +154,9 @@ impl ChunkItem for RawEcmascriptChunkItem {
 impl EcmascriptChunkItem for RawEcmascriptChunkItem {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let content = self.module.content().file_content().await?;
+        let module = self.module.await?;
+        let source = module.source;
+        let content = source.content().file_content().await?;
         let content = match &*content {
             FileContent::Content(file) => file.content(),
             FileContent::NotFound => bail!("RawEcmascriptModule content not found"),
@@ -166,19 +172,17 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
             env_vars.insert(name);
         }
 
-        let mut inner_code = RopeBuilder::default();
+        let mut code = CodeBuilder::default();
         if !env_vars.is_empty() {
-            let replacements = self
-                .module
-                .await?
+            let replacements = module
                 .compile_time_info
                 .await?
                 .free_var_references
                 .individual()
                 .await?;
-            inner_code += "var process = {env:\n";
+            code += "var process = {env:\n";
             writeln!(
-                inner_code,
+                code,
                 "{}",
                 StringifyJs(
                     &env_vars
@@ -225,14 +229,54 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
                         .collect::<FxIndexMap<_, _>>()
                 )
             )?;
-            inner_code += "};\n";
+            code += "};\n";
         }
-        inner_code += "{\n";
-        inner_code.concat(content);
+        code += "{\n";
+
+        let source_map = if let Some((source_map, _)) = parse_source_map_comment(
+            source,
+            Either::Right(&content_str),
+            &*self.module.ident().path().await?,
+        )
+        .await?
+        {
+            source_map.generate_source_map().owned().await?
+        } else {
+            None
+        };
+        code.push_source(content, source_map);
+
         // Add newline in case the raw code had a comment as the last line and no final newline.
-        inner_code += "\n}\n";
+        code += "\n}\n";
+
+        let code = code.build();
+        let source_map = if code.has_source_map() {
+            let source_map = code.generate_source_map_ref()?;
+
+            static SECTIONS_REGEX: Lazy<Regex> =
+                Lazy::new(|| Regex::new(r#"sections"[\s\n]*:"#).unwrap());
+            Some(if !SECTIONS_REGEX.is_match(&source_map.to_str()?) {
+                // This is definitely not an index source map
+                source_map
+            } else {
+                match swc_sourcemap::lazy::decode(&source_map.to_bytes())? {
+                    swc_sourcemap::lazy::DecodedMap::Regular(_) => source_map,
+                    // without flattening the index map, we would get nested index source maps in
+                    // the output chunks, which are apparently not supported
+                    swc_sourcemap::lazy::DecodedMap::Index(source_map) => {
+                        let source_map = source_map.flatten()?.into_raw_sourcemap();
+                        let result = serde_json::to_vec(&source_map)?;
+                        Rope::from(result)
+                    }
+                }
+            })
+        } else {
+            None
+        };
+
         Ok(EcmascriptChunkItemContent {
-            inner_code: inner_code.build(),
+            source_map,
+            inner_code: code.into_source_code(),
             options: EcmascriptChunkItemOptions {
                 module_and_exports: true,
                 ..Default::default()

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -24,6 +24,7 @@ use turbopack_core::{
     source_map::GenerateSourceMap,
 };
 use turbopack_ecmascript::{
+    EcmascriptInputTransforms,
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
         EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports,
@@ -48,6 +49,17 @@ impl CustomModuleType for RawEcmascriptModuleType {
             source,
             module_asset_context.compile_time_info(),
         ))
+    }
+
+    #[turbo_tasks::function]
+    fn extend_ecmascript_transforms(
+        self: Vc<Self>,
+        _preprocess: Vc<EcmascriptInputTransforms>,
+        _main: Vc<EcmascriptInputTransforms>,
+        _postprocess: Vc<EcmascriptInputTransforms>,
+    ) -> Vc<Box<dyn CustomModuleType>> {
+        // Just ignore them
+        Vc::upcast(self)
     }
 }
 

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -1,0 +1,143 @@
+use anyhow::{Result, bail};
+use turbo_rcstr::rcstr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::{FileContent, glob::Glob, rope::RopeBuilder};
+use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
+    ident::AssetIdent,
+    module::Module,
+    module_graph::ModuleGraph,
+    resolve::ModulePart,
+    source::Source,
+};
+use turbopack_ecmascript::chunk::{
+    EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptChunkType,
+    EcmascriptExports,
+};
+
+#[turbo_tasks::value(shared)]
+pub struct RawEcmascriptModuleType {}
+
+#[turbo_tasks::value_impl]
+impl CustomModuleType for RawEcmascriptModuleType {
+    #[turbo_tasks::function]
+    fn create_module(
+        &self,
+        source: Vc<Box<dyn Source>>,
+        _module_asset_context: Vc<ModuleAssetContext>,
+        _part: Option<ModulePart>,
+    ) -> Vc<Box<dyn Module>> {
+        Vc::upcast(RawEcmascriptModule::new(source))
+    }
+}
+
+#[turbo_tasks::value]
+pub struct RawEcmascriptModule {
+    source: ResolvedVc<Box<dyn Source>>,
+}
+
+#[turbo_tasks::value_impl]
+impl RawEcmascriptModule {
+    #[turbo_tasks::function]
+    pub fn new(source: ResolvedVc<Box<dyn Source>>) -> Vc<Self> {
+        Self::cell(RawEcmascriptModule { source })
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Module for RawEcmascriptModule {
+    #[turbo_tasks::function]
+    fn ident(&self) -> Vc<AssetIdent> {
+        self.source.ident().with_modifier(rcstr!("raw"))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for RawEcmascriptModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModule for RawEcmascriptModule {
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: ResolvedVc<Self>,
+        _module_graph: Vc<ModuleGraph>,
+        chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(RawEcmascriptChunkItem::cell(RawEcmascriptChunkItem {
+            module: self,
+            chunking_context,
+        }))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for RawEcmascriptModule {
+    #[turbo_tasks::function]
+    fn get_exports(&self) -> Vc<EcmascriptExports> {
+        EcmascriptExports::CommonJs.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn is_marked_as_side_effect_free(&self, _side_effect_free_packages: Vc<Glob>) -> Vc<bool> {
+        Vc::cell(false)
+    }
+}
+
+#[turbo_tasks::value]
+struct RawEcmascriptChunkItem {
+    module: ResolvedVc<RawEcmascriptModule>,
+    chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for RawEcmascriptChunkItem {
+    #[turbo_tasks::function]
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        *self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    async fn ty(&self) -> Result<Vc<Box<dyn ChunkType>>> {
+        Ok(Vc::upcast(
+            Vc::<EcmascriptChunkType>::default().resolve().await?,
+        ))
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(*self.module)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for RawEcmascriptChunkItem {
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let content = self.module.content().file_content().await?;
+        let content = match &*content {
+            FileContent::Content(file) => file.content(),
+            FileContent::NotFound => bail!("RawEcmascriptModule content not found"),
+        };
+        let mut inner_code = RopeBuilder::default();
+        inner_code.concat(content);
+        // Add newline in case the raw code had a comment as the last line and no final newline.
+        inner_code += "\n";
+        Ok(EcmascriptChunkItemContent {
+            inner_code: inner_code.build(),
+            ..Default::default()
+        }
+        .into())
+    }
+}

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -4,8 +4,9 @@ use anyhow::{Result, bail};
 use either::Either;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use tracing::Instrument;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, glob::Glob, rope::Rope};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
@@ -166,135 +167,151 @@ impl ChunkItem for RawEcmascriptChunkItem {
 impl EcmascriptChunkItem for RawEcmascriptChunkItem {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let module = self.module.await?;
-        let source = module.source;
-        let content = source.content().file_content().await?;
-        let content = match &*content {
-            FileContent::Content(file) => file.content(),
-            FileContent::NotFound => bail!("RawEcmascriptModule content not found"),
-        };
+        let span = tracing::info_span!(
+            "code generation raw module",
+            name = display(self.module.ident().to_string().await?)
+        );
 
-        static ENV_REGEX: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"process\.env\.([a-zA-Z0-9_]+)").unwrap());
+        async {
+            let module = self.module.await?;
+            let source = module.source;
+            let content = source.content().file_content().await?;
+            let content = match &*content {
+                FileContent::Content(file) => file.content(),
+                FileContent::NotFound => bail!("RawEcmascriptModule content not found"),
+            };
 
-        let content_str = content.to_str()?;
+            static ENV_REGEX: Lazy<Regex> =
+                Lazy::new(|| Regex::new(r"process\.env\.([a-zA-Z0-9_]+)").unwrap());
 
-        let mut env_vars = FxIndexSet::default();
-        for (_, [name]) in ENV_REGEX.captures_iter(&content_str).map(|c| c.extract()) {
-            env_vars.insert(name);
-        }
+            let content_str = content.to_str()?;
 
-        let mut code = CodeBuilder::default();
-        if !env_vars.is_empty() {
-            let replacements = module
-                .compile_time_info
-                .await?
-                .free_var_references
-                .individual()
-                .await?;
-            code += "var process = {env:\n";
-            writeln!(
-                code,
-                "{}",
-                StringifyJs(
-                    &env_vars
-                        .into_iter()
-                        .map(async |name| {
-                            Ok((
-                                name,
-                                if let Some(value) =
-                                    replacements.get(&DefinableNameSegment::Name(name.into()))
-                                    && let Some((_, value)) = value.iter().find(|(path, _)| {
-                                        matches!(
-                                            path.as_slice(),
-                                            [
-                                                DefinableNameSegment::Name(a),
-                                                DefinableNameSegment::Name(b)
-                                            ] if a == "process" && b == "env"
-                                        )
-                                    })
-                                {
-                                    let value = value.await?;
-                                    let value = match &*value {
-                                        FreeVarReference::Value(
-                                            CompileTimeDefineValue::String(value),
-                                        ) => serde_json::Value::String(value.to_string()),
-                                        FreeVarReference::Value(CompileTimeDefineValue::Bool(
-                                            value,
-                                        )) => serde_json::Value::Bool(*value),
-                                        _ => {
-                                            bail!(
-                                                "Unexpected replacement for process.env.{name} in \
-                                                 RawEcmascriptModule: {value:?}"
-                                            );
-                                        }
-                                    };
-                                    Some(value)
-                                } else {
-                                    None
-                                },
-                            ))
-                        })
-                        .try_join()
-                        .await?
-                        .into_iter()
-                        .collect::<FxIndexMap<_, _>>()
-                )
-            )?;
-            code += "};\n";
-        }
+            let mut env_vars = FxIndexSet::default();
+            for (_, [name]) in ENV_REGEX.captures_iter(&content_str).map(|c| c.extract()) {
+                env_vars.insert(name);
+            }
 
-        code += "(function(){\n";
-        let source_map = if let Some((source_map, _)) = parse_source_map_comment(
-            source,
-            Either::Right(&content_str),
-            &*self.module.ident().path().await?,
-        )
-        .await?
-        {
-            source_map.generate_source_map().owned().await?
-        } else {
-            None
-        };
-        code.push_source(content, source_map);
+            let mut code = CodeBuilder::default();
+            if !env_vars.is_empty() {
+                let replacements = module
+                    .compile_time_info
+                    .await?
+                    .free_var_references
+                    .individual()
+                    .await?;
+                code += "var process = {env:\n";
+                writeln!(
+                    code,
+                    "{}",
+                    StringifyJs(
+                        &env_vars
+                            .into_iter()
+                            .map(async |name| {
+                                Ok((
+                                    name,
+                                    if let Some(value) =
+                                        replacements.get(&DefinableNameSegment::Name(name.into()))
+                                        && let Some((_, value)) = value.iter().find(|(path, _)| {
+                                            matches!(
+                                                path.as_slice(),
+                                                [
+                                                    DefinableNameSegment::Name(a),
+                                                    DefinableNameSegment::Name(b)
+                                                ] if a == "process" && b == "env"
+                                            )
+                                        })
+                                    {
+                                        let value = value.await?;
+                                        let value = match &*value {
+                                            FreeVarReference::Value(
+                                                CompileTimeDefineValue::String(value),
+                                            ) => serde_json::Value::String(value.to_string()),
+                                            FreeVarReference::Value(
+                                                CompileTimeDefineValue::Bool(value),
+                                            ) => serde_json::Value::Bool(*value),
+                                            _ => {
+                                                bail!(
+                                                    "Unexpected replacement for \
+                                                     process.env.{name} in RawEcmascriptModule: \
+                                                     {value:?}"
+                                                );
+                                            }
+                                        };
+                                        Some(value)
+                                    } else {
+                                        None
+                                    },
+                                ))
+                            })
+                            .try_join()
+                            .await?
+                            .into_iter()
+                            .collect::<FxIndexMap<_, _>>()
+                    )
+                )?;
+                code += "};\n";
+            }
 
-        // Add newline in case the raw code had a comment as the last line and no final newline.
-        code += "\n})();\n";
-
-        let code = code.build();
-        let source_map = if code.has_source_map() {
-            let source_map = code.generate_source_map_ref()?;
-
-            static SECTIONS_REGEX: Lazy<Regex> =
-                Lazy::new(|| Regex::new(r#"sections"[\s\n]*:"#).unwrap());
-            Some(if !SECTIONS_REGEX.is_match(&source_map.to_str()?) {
-                // This is definitely not an index source map
-                source_map
+            code += "(function(){\n";
+            let source_map = if let Some((source_map, _)) = parse_source_map_comment(
+                source,
+                Either::Right(&content_str),
+                &*self.module.ident().path().await?,
+            )
+            .await?
+            {
+                source_map.generate_source_map().owned().await?
             } else {
-                match swc_sourcemap::lazy::decode(&source_map.to_bytes())? {
-                    swc_sourcemap::lazy::DecodedMap::Regular(_) => source_map,
-                    // without flattening the index map, we would get nested index source maps in
-                    // the output chunks, which are apparently not supported
-                    swc_sourcemap::lazy::DecodedMap::Index(source_map) => {
-                        let source_map = source_map.flatten()?.into_raw_sourcemap();
-                        let result = serde_json::to_vec(&source_map)?;
-                        Rope::from(result)
-                    }
-                }
-            })
-        } else {
-            None
-        };
+                None
+            };
+            code.push_source(content, source_map);
 
-        Ok(EcmascriptChunkItemContent {
-            source_map,
-            inner_code: code.into_source_code(),
-            options: EcmascriptChunkItemOptions {
-                module_and_exports: true,
+            // Add newline in case the raw code had a comment as the last line and no final newline.
+            code += "\n})();\n";
+
+            let code = code.build();
+            let source_map = if code.has_source_map() {
+                let source_map = code.generate_source_map_ref()?;
+
+                static SECTIONS_REGEX: Lazy<Regex> =
+                    Lazy::new(|| Regex::new(r#"sections"[\s\n]*:"#).unwrap());
+                Some(if !SECTIONS_REGEX.is_match(&source_map.to_str()?) {
+                    // This is definitely not an index source map
+                    source_map
+                } else {
+                    let _span = tracing::span!(
+                        tracing::Level::WARN,
+                        "flattening index source map in RawEcmascriptModule"
+                    )
+                    .entered();
+                    match swc_sourcemap::lazy::decode(&source_map.to_bytes())? {
+                        swc_sourcemap::lazy::DecodedMap::Regular(_) => source_map,
+                        // without flattening the index map, we would get nested index source maps
+                        // in the output chunks, which are apparently not
+                        // supported
+                        swc_sourcemap::lazy::DecodedMap::Index(source_map) => {
+                            let source_map = source_map.flatten()?.into_raw_sourcemap();
+                            let result = serde_json::to_vec(&source_map)?;
+                            Rope::from(result)
+                        }
+                    }
+                })
+            } else {
+                None
+            };
+
+            Ok(EcmascriptChunkItemContent {
+                source_map,
+                inner_code: code.into_source_code(),
+                options: EcmascriptChunkItemOptions {
+                    module_and_exports: true,
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
-            ..Default::default()
+            }
+            .into())
         }
-        .into())
+        .instrument(span)
+        .await
     }
 }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -622,6 +622,10 @@ async fn process_default_internal(
                                 analyze_types,
                                 options,
                             }),
+                            Some(ModuleType::Custom(_)) => {
+                                // TODO
+                                current_module_type
+                            }
                             Some(module_type) => {
                                 ModuleIssue::new(
                                     *ident,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -622,9 +622,37 @@ async fn process_default_internal(
                                 analyze_types,
                                 options,
                             }),
-                            Some(ModuleType::Custom(_)) => {
-                                // TODO
-                                current_module_type
+                            Some(ModuleType::Custom(custom_module_type)) => {
+                                match custom_module_type
+                                    .extend_ecmascript_transforms(
+                                        **extend_preprocess,
+                                        **extend_main,
+                                        **extend_postprocess,
+                                    )
+                                    .to_resolved()
+                                    .await
+                                {
+                                    Ok(custom_module_type) => {
+                                        Some(ModuleType::Custom(custom_module_type))
+                                    }
+                                    // TODO ideally this would print the actual error message
+                                    // returned by the CustomModuleType
+                                    Err(_) => {
+                                        ModuleIssue::new(
+                                            *ident,
+                                            rcstr!("Invalid module type"),
+                                            rcstr!(
+                                                "The custom module type didn't accept the \
+                                                 additional Ecmascript transforms"
+                                            ),
+                                            Some(IssueSource::from_source_only(current_source)),
+                                        )
+                                        .to_resolved()
+                                        .await?
+                                        .emit();
+                                        Some(ModuleType::Custom(custom_module_type))
+                                    }
+                                }
                             }
                             Some(module_type) => {
                                 ModuleIssue::new(

--- a/turbopack/crates/turbopack/src/module_options/custom_module_type.rs
+++ b/turbopack/crates/turbopack/src/module_options/custom_module_type.rs
@@ -1,5 +1,6 @@
 use turbo_tasks::Vc;
 use turbopack_core::{module::Module, resolve::ModulePart, source::Source};
+use turbopack_ecmascript::EcmascriptInputTransforms;
 
 use crate::ModuleAssetContext;
 
@@ -12,4 +13,12 @@ pub trait CustomModuleType {
         module_asset_context: Vc<ModuleAssetContext>,
         part: Option<ModulePart>,
     ) -> Vc<Box<dyn Module>>;
+
+    #[turbo_tasks::function]
+    fn extend_ecmascript_transforms(
+        self: Vc<Self>,
+        preprocess: Vc<EcmascriptInputTransforms>,
+        main: Vc<EcmascriptInputTransforms>,
+        postprocess: Vc<EcmascriptInputTransforms>,
+    ) -> Vc<Box<dyn CustomModuleType>>;
 }


### PR DESCRIPTION
Add a JS module type that does no analysis, and just concatenates the source file into the output file.
As a consequence however, the input module cannot have
- `import`s/`require`s/`new Worker`/...
- ~~`process.env.*` that should be replaced~~
- JSX/any new syntax, since the module won't be transpiled using the user's browserslist

```
before:

 ✓ Starting...
 ✓ Ready in 335ms
 ○ Compiling / ...
 ✓ Compiled / in 980ms
 GET / 200 in 1258ms

after:

 ✓ Starting...
 ✓ Ready in 406ms
 ✓ Compiled / in 406ms
 GET / 200 in 692ms
```

<img width="1358" height="959" alt="Bildschirmfoto 2025-09-16 um 12 09 47" src="https://github.com/user-attachments/assets/87bb3161-8749-475b-9a84-bf62324735e4" />

<img width="1352" height="939" alt="Bildschirmfoto 2025-09-16 um 12 12 48" src="https://github.com/user-attachments/assets/4a42e724-7090-4ca7-bad9-41e5cf1af80b" />


Closes PACK-5555