### PR TITLE
Explicit need of "use client" in instrumentation-client.mdx

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation-client.mdx
@@ -12,6 +12,7 @@ To use it, place the file in the **root** of your application or inside a `src` 
 Unlike [server-side instrumentation](/docs/app/guides/instrumentation), you do not need to export any specific functions. You can write your monitoring code directly in the file:
 
 ```ts filename="instrumentation-client.ts" switcher
+"use client";
 // Set up performance monitoring
 performance.mark('app-init')
 
@@ -26,6 +27,7 @@ window.addEventListener('error', (event) => {
 ```
 
 ```js filename="instrumentation-client.js" switcher
+"use client";
 // Set up performance monitoring
 performance.mark('app-init')
 


### PR DESCRIPTION
### Improving Documentation

Explicit the need of "use client"; in the `instrumentation-client.ts|js` file. If not set it throws an error.