### PR TITLE
fix(ppr): ensure fallback route params trigger dynamic resume

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1075,6 +1075,16 @@ export async function handler(
       // should also be the case for a resume request because it's completed
       // as a server render (rather than a static render).
       if (!didPostpone || minimalMode) {
+        // If we're in test mode, we should add a sentinel chunk to the response
+        // that's between the static and dynamic parts so we can compare the
+        // chunks and add assertions.
+        if (process.env.__NEXT_TEST_MODE && minimalMode && isRoutePPREnabled) {
+          // As we're in minimal mode, the static part would have already been
+          // streamed first. The only part that this streams is the dynamic part
+          // so we should FIRST stream the sentinel and THEN the dynamic part.
+          body.unshift(createPPRBoundarySentinel())
+        }
+
         return sendRenderResult({
           req,
           res,
@@ -1093,7 +1103,7 @@ export async function handler(
       if (isDebugStaticShell || isDebugDynamicAccesses) {
         // Since we're not resuming the render, we need to at least add the
         // closing body and html tags to create valid HTML.
-        body.chain(
+        body.push(
           new ReadableStream({
             start(controller) {
               controller.enqueue(ENCODED_TAGS.CLOSED.BODY_AND_HTML)
@@ -1113,11 +1123,18 @@ export async function handler(
         })
       }
 
+      // If we're in test mode, we should add a sentinel chunk to the response
+      // that's between the static and dynamic parts so we can compare the
+      // chunks and add assertions.
+      if (process.env.__NEXT_TEST_MODE) {
+        body.push(createPPRBoundarySentinel())
+      }
+
       // This request has postponed, so let's create a new transformer that the
       // dynamic data can pipe to that will attach the dynamic data to the end
       // of the response.
       const transformer = new TransformStream<Uint8Array, Uint8Array>()
-      body.chain(transformer.readable)
+      body.push(transformer.readable)
 
       // Perform the render again, but this time, provide the postponed state.
       // We don't await because we want the result to start streaming now, and
@@ -1207,4 +1224,21 @@ export async function handler(
     // rethrow so that we can handle serving error page
     throw err
   }
+}
+
+// TODO: omit this from production builds, only test builds should include it
+/**
+ * Creates a readable stream that emits a PPR boundary sentinel.
+ *
+ * @returns A readable stream that emits a PPR boundary sentinel.
+ */
+function createPPRBoundarySentinel() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode('<!-- PPR_BOUNDARY_SENTINEL -->')
+      )
+      controller.close()
+    },
+  })
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3491,7 +3491,14 @@ async function prerenderToStream(
         fallbackRouteParams
       )
 
-      if (serverIsDynamic) {
+      // If there are fallback route params, the RSC data is inherently dynamic
+      // today because it's encoded into the flight router state. Until we can
+      // move the fallback route params out of the flight router state, we need
+      // to always perform a dynamic resume after the static prerender.
+      const hasFallbackRouteParams =
+        workStore.fallbackRouteParams && workStore.fallbackRouteParams.size > 0
+
+      if (serverIsDynamic || hasFallbackRouteParams) {
         // Dynamic case
         // We will always need to perform a "resume" render of some kind when this route is accessed
         // because the RSC data itself is dynamic. We determine if there are any HTML holes or not

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3586,7 +3586,7 @@ export default abstract class Server<
       if (isDebugStaticShell || isDebugDynamicAccesses) {
         // Since we're not resuming the render, we need to at least add the
         // closing body and html tags to create valid HTML.
-        body.chain(
+        body.push(
           new ReadableStream({
             start(controller) {
               controller.enqueue(ENCODED_TAGS.CLOSED.BODY_AND_HTML)
@@ -3606,7 +3606,7 @@ export default abstract class Server<
       // dynamic data can pipe to that will attach the dynamic data to the end
       // of the response.
       const transformer = new TransformStream<Uint8Array, Uint8Array>()
-      body.chain(transformer.readable)
+      body.push(transformer.readable)
 
       // Perform the render again, but this time, provide the postponed state.
       // We don't await because we want the result to start streaming now, and

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/params/[...slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/params/[...slug]/page.jsx
@@ -1,8 +1,8 @@
-import { setTimeout } from 'timers/promises'
+// import { setTimeout } from 'timers/promises'
 
 export default async function Page(props) {
   const params = await props.params
-  await setTimeout(1000)
+  // await setTimeout(1000)
 
   return <div data-slug={params.slug.join('/')}>{params.slug.join('/')}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/use-params/[...slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/use-params/[...slug]/page.jsx
@@ -1,12 +1,9 @@
 'use client'
 
 import { useParams } from 'next/navigation'
-import { use } from 'react'
 
 export default function Page() {
   const params = useParams()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={params.slug.join('/')}>{params.slug.join('/')}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/use-pathname/[...slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/use-pathname/[...slug]/page.jsx
@@ -1,12 +1,9 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { use } from 'react'
 
 export default function Page() {
   const pathname = usePathname()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={pathname}>{pathname}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/use-selected-layout-segment/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/use-selected-layout-segment/layout.jsx
@@ -1,11 +1,9 @@
 'use client'
 import { useSelectedLayoutSegment } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { Suspense } from 'react'
 
 function Dynamic() {
   const segment = useSelectedLayoutSegment()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={segment}>{segment}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/use-selected-layout-segments/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/use-selected-layout-segments/layout.jsx
@@ -1,11 +1,9 @@
 'use client'
 import { useSelectedLayoutSegments } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { Suspense } from 'react'
 
 function Dynamic() {
   const segments = useSelectedLayoutSegments()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={segments.join('/')}>{segments.join('/')}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/use-params/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/use-params/[slug]/page.jsx
@@ -1,12 +1,9 @@
 'use client'
 
 import { useParams } from 'next/navigation'
-import { use } from 'react'
 
 export default function Page() {
   const params = useParams()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={params.slug}>{params.slug}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/use-pathname/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/use-pathname/[slug]/page.jsx
@@ -1,12 +1,9 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { use } from 'react'
 
 export default function Page() {
   const pathname = usePathname()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={pathname}>{pathname}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/use-selected-layout-segment/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/use-selected-layout-segment/layout.jsx
@@ -1,11 +1,9 @@
 'use client'
 import { useSelectedLayoutSegment } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { Suspense } from 'react'
 
 function Dynamic() {
   const segment = useSelectedLayoutSegment()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={segment}>{segment}</div>
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/use-selected-layout-segments/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/use-selected-layout-segments/layout.jsx
@@ -1,11 +1,9 @@
 'use client'
 import { useSelectedLayoutSegments } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { Suspense } from 'react'
 
 function Dynamic() {
   const segments = useSelectedLayoutSegments()
-
-  use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={segments.join('/')}>{segments.join('/')}</div>
 }

--- a/test/e2e/app-dir/ppr-full/components/dynamic.jsx
+++ b/test/e2e/app-dir/ppr-full/components/dynamic.jsx
@@ -1,4 +1,4 @@
-import React, { use } from 'react'
+import React from 'react'
 import * as next from 'next/headers'
 
 export const Dynamic = ({ pathname, fallback = null, params = null }) => {
@@ -10,11 +10,6 @@ export const Dynamic = ({ pathname, fallback = null, params = null }) => {
   const messages = []
   for (const name of ['x-test-input', 'user-agent']) {
     messages.push({ name, value: headers.get(name) })
-  }
-
-  const delay = headers.get('x-delay')
-  if (delay) {
-    use(new Promise((resolve) => setTimeout(resolve, parseInt(delay, 10))))
   }
 
   return (

--- a/test/lib/e2e-utils/ppr.ts
+++ b/test/lib/e2e-utils/ppr.ts
@@ -1,62 +1,42 @@
-export async function measurePPRTimings(
-  fn: () => Promise<NodeJS.ReadableStream>,
-  delay: number
-) {
-  const start = Date.now()
-
-  // Create the stream so we can measure it.
+/**
+ * Measures and separates static and dynamic content in a response stream
+ * by splitting on PPR boundary sentinel markers.
+ *
+ * This function is used in Partial Prerendering (PPR) tests to analyze the output
+ * of Next.js pages and verify that static and dynamic content are properly separated.
+ *
+ * @param fn - A function that returns a Promise resolving to a readable stream
+ *             containing HTML with PPR boundary markers
+ * @returns An object containing the separated static and dynamic chunks
+ *
+ * @example
+ * const [staticPart, dynamicPart] = await splitResponseWithPPRSentinel(async () => {
+ *   return fetch('/some-ppr-page').then(res => res.body)
+ * })
+ * console.log(staticPart)  // Content before the boundary
+ * console.log(dynamicPart) // Content after the boundary
+ */
+export async function splitResponseWithPPRSentinel(
+  fn: () => Promise<NodeJS.ReadableStream>
+): Promise<[staticPart: string, dynamicPart: string]> {
   const stream = await fn()
-
-  let streamFirstChunk = 0
-  let streamEnd = 0
-
-  const chunks: {
-    chunk: string
-    emittedAt: number
-  }[] = []
+  const chunks: string[] = []
 
   await new Promise<void>((resolve, reject) => {
     stream.on('data', (chunk: Buffer | string) => {
-      if (!streamFirstChunk) {
-        streamFirstChunk = Date.now()
-      }
-
       if (typeof chunk !== 'string') {
-        chunk = chunk.toString()
+        chunk = chunk.toString('utf8')
       }
 
-      chunks.push({ chunk, emittedAt: Date.now() })
+      chunks.push(chunk)
     })
 
-    stream.on('end', () => {
-      streamEnd = Date.now()
-      resolve()
-    })
-
+    stream.on('end', resolve)
     stream.on('error', reject)
   })
 
-  return {
-    // Find all the chunks that arrived before the delay, and split
-    // it into the static and dynamic parts.
-    chunks: chunks.reduce<{
-      static: string
-      dynamic: string
-    }>(
-      (acc, { chunk, emittedAt }) => {
-        if (emittedAt < start + delay) {
-          acc.static += chunk
-        } else {
-          acc.dynamic += chunk
-        }
-        return acc
-      },
-      { static: '', dynamic: '' }
-    ),
-    timings: {
-      start,
-      streamFirstChunk,
-      streamEnd,
-    },
-  }
+  // Combine all chunks and split on the PPR boundary sentinel
+  // The sentinel marks the boundary between static and dynamic content
+  const parts = chunks.join('').split('<!-- PPR_BOUNDARY_SENTINEL -->', 2)
+  return [parts[0] ?? '', parts[1] ?? '']
 }


### PR DESCRIPTION
### What?

This PR fixes an issue where pages with fallback route params weren't triggering dynamic resume behavior in PPR (Partial Pre-Rendering).

### Why?

When fallback route params exist, the RSC (React Server Components) data is inherently dynamic because the params are encoded into the flight router state. Without this fix, pages with fallback route params would incorrectly be treated as fully static, leading to incorrect behavior.

### How?

- Added a check in `app-render.tsx` to ensure that pages with fallback route params (`workStore.fallbackRouteParams.size > 0`) always perform a dynamic resume after the static prerender
- Refactored PPR tests to use deterministic sentinel markers (`<\!-- PPR_BOUNDARY_SENTINEL -->`) instead of time-based measurements for more reliable testing
- Updated the test utilities to split responses based on the sentinel marker rather than timing delays

This ensures that:
1. Pages with fallback route params correctly trigger dynamic behavior
2. PPR tests are more reliable and deterministic
3. The boundary between static and dynamic content is clearly marked in test mode

Fixes #