### PR TITLE
[devtool] fix scrollbar styling

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
@@ -87,6 +87,7 @@ const Dialog: React.FC<DialogProps> = function Dialog({
       ref={dialogRef}
       tabIndex={-1}
       data-nextjs-dialog
+      data-nextjs-scrollable-content
       role={role}
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}

--- a/packages/next/src/next-devtools/dev-overlay/components/dialog/styles.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/dialog/styles.ts
@@ -41,36 +41,6 @@ export const styles = css`
     outline: 0;
   }
 
-  [data-nextjs-dialog],
-  [data-nextjs-dialog] * {
-    &::-webkit-scrollbar {
-      width: 6px;
-      height: 6px;
-      border-radius: 0 0 1rem 1rem;
-      margin-bottom: 1rem;
-    }
-
-    &::-webkit-scrollbar-button {
-      display: none;
-    }
-
-    &::-webkit-scrollbar-track {
-      border-radius: 0 0 1rem 1rem;
-      background-color: var(--color-background-100);
-    }
-
-    &::-webkit-scrollbar-thumb {
-      border-radius: 1rem;
-      background-color: var(--color-gray-500);
-    }
-  }
-
-  /* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */
-  [data-nextjs-dialog-sizer] {
-    overflow: hidden;
-    border-radius: inherit;
-  }
-
   [data-nextjs-dialog-backdrop] {
     opacity: 0;
     transition: opacity var(--transition-duration) var(--timing-overlay);

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.css
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.css
@@ -1,0 +1,19 @@
+/* Panel content padding styles */
+.panel-content {
+  padding: 16px;
+  padding-top: 8px;
+  overflow: hidden;
+}
+
+/* User preferences wrapper styles */
+.user-preferences-wrapper {
+  padding: 20px;
+  padding-top: 8px;
+  overflow: hidden;
+}
+
+/* Panel route base styles */
+.panel-route {
+  opacity: var(--panel-opacity);
+  transition: var(--panel-transition);
+}

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -29,6 +29,7 @@ import { UserPreferencesBody } from '../components/errors/dev-tools-indicator/de
 import { useHideShortcutStorage } from '../components/errors/dev-tools-indicator/dev-tools-info/preferences'
 import { useShortcuts } from '../hooks/use-shortcuts'
 import { useUpdateAllPanelPositions } from '../components/devtools-indicator/devtools-indicator'
+import './panel-router.css'
 
 const MenuPanel = () => {
   const { setPanel, setSelectedIndex } = usePanelRouterContext()
@@ -189,12 +190,7 @@ export const PanelRouter = () => {
             />
           }
         >
-          <div
-            style={{
-              padding: '16px',
-              paddingTop: '8px',
-            }}
-          >
+          <div className="panel-content">
             <RouteInfoBody
               routerType={state.routerType}
               isStaticRoute={state.staticIndicator}
@@ -246,12 +242,7 @@ export const PanelRouter = () => {
           closeOnClickOutside
           header={<DevToolsHeader title="Try Turbopack" />}
         >
-          <div
-            style={{
-              padding: '16px',
-              paddingTop: '8px',
-            }}
-          >
+          <div className="panel-content">
             <TurbopackInfoBody />
             <InfoFooter href="https://nextjs.org/docs/app/api-reference/turbopack" />
           </div>
@@ -288,12 +279,7 @@ const UserPreferencesWrapper = ({
   const updateAllPanelPositions = useUpdateAllPanelPositions()
 
   return (
-    <div
-      style={{
-        padding: '20px',
-        paddingTop: '8px',
-      }}
-    >
+    <div className="user-preferences-wrapper">
       <UserPreferencesBody
         position={state.devToolsPosition}
         scale={state.scale}
@@ -358,10 +344,13 @@ function PanelRoute({
     >
       <div
         id="panel-route"
-        style={{
-          opacity: rendered ? 1 : 0,
-          transition: `opacity ${MENU_DURATION_MS}ms ${MENU_CURVE}`,
-        }}
+        className="panel-route"
+        style={
+          {
+            '--panel-opacity': rendered ? 1 : 0,
+            '--panel-transition': `opacity ${MENU_DURATION_MS}ms ${MENU_CURVE}`,
+          } as React.CSSProperties
+        }
       >
         {children}
       </div>

--- a/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.css
@@ -1,0 +1,34 @@
+/* Panel container base styles with dynamic positioning and sizing */
+.dynamic-panel-container {
+  position: fixed;
+  z-index: 2147483646;
+  outline: none;
+  top: var(--panel-top, auto);
+  bottom: var(--panel-bottom, auto);
+  left: var(--panel-left, auto);
+  right: var(--panel-right, auto);
+  width: var(--panel-width);
+  height: var(--panel-height);
+  min-width: var(--panel-min-width);
+  min-height: var(--panel-min-height);
+  max-width: var(--panel-max-width);
+  max-height: var(--panel-max-height);
+}
+
+/* Panel content container styles */
+.panel-content-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border: 1px solid var(--color-gray-alpha-400);
+  border-radius: var(--rounded-xl);
+  background: var(--color-background-100);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Draggable content area styles */
+.draggable-content {
+  flex: 1;
+  overflow: auto;
+}

--- a/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/panel/dynamic-panel.tsx
@@ -19,6 +19,7 @@ import {
   STORE_KEY_SHARED_PANEL_SIZE,
 } from '../shared'
 import { getIndicatorOffset } from '../utils/indicator-metrics'
+import './dynamic-panel.css'
 
 function resolveCSSValue(
   value: string | number,
@@ -235,23 +236,30 @@ export function DynamicPanel({
       <div
         tabIndex={-1}
         ref={resizeContainerRef}
-        style={{
-          position: 'fixed',
-          zIndex: 2147483646,
-          outline: 'none',
-          ...positionStyle,
-          ...(isResizable
-            ? {
-                minWidth,
-                minHeight,
-                maxWidth,
-                maxHeight,
-              }
-            : {
-                height: panelSize ? panelSize.height : sizeConfig.height,
-                width: panelSize ? panelSize.width : sizeConfig.width,
-              }),
-        }}
+        className="dynamic-panel-container"
+        style={
+          {
+            '--panel-top': positionStyle.top,
+            '--panel-bottom': positionStyle.bottom,
+            '--panel-left': positionStyle.left,
+            '--panel-right': positionStyle.right,
+            ...(isResizable
+              ? {
+                  '--panel-min-width': minWidth ? `${minWidth}px` : undefined,
+                  '--panel-min-height': minHeight
+                    ? `${minHeight}px`
+                    : undefined,
+                  '--panel-max-width': maxWidth ? `${maxWidth}px` : undefined,
+                  '--panel-max-height': maxHeight
+                    ? `${maxHeight}px`
+                    : undefined,
+                }
+              : {
+                  '--panel-height': `${panelSize ? panelSize.height : sizeConfig.height}px`,
+                  '--panel-width': `${panelSize ? panelSize.width : sizeConfig.width}px`,
+                }),
+          } as React.CSSProperties & Record<string, string | number | undefined>
+        }
       >
         <DragProvider disabled={!draggable}>
           <Draggable
@@ -283,20 +291,18 @@ export function DynamicPanel({
             <>
               <div
                 {...containerProps}
+                className={`panel-content-container ${containerProps?.className || ''}`}
                 style={{
-                  position: 'relative',
-                  width: '100%',
-                  height: '100%',
-                  border: '1px solid var(--color-gray-alpha-400)',
-                  borderRadius: 'var(--rounded-xl)',
-                  background: 'var(--color-background-100)',
-                  display: 'flex',
-                  flexDirection: 'column',
                   ...containerProps?.style,
                 }}
               >
                 <DragHandle>{header}</DragHandle>
-                <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+                <div
+                  data-nextjs-scrollable-content
+                  className="draggable-content"
+                >
+                  {children}
+                </div>
               </div>
               {isResizable && (
                 <>

--- a/packages/next/src/next-devtools/global.css
+++ b/packages/next/src/next-devtools/global.css
@@ -10,3 +10,34 @@
 * {
   -webkit-font-smoothing: antialiased;
 }
+
+/* global reset for draggable content scrollbar styles */
+[data-nextjs-scrollable-content],
+[data-nextjs-scrollable-content] * {
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+    border-radius: 0 0 1rem 1rem;
+    margin-bottom: 1rem;
+  }
+
+  &::-webkit-scrollbar-button {
+    display: none;
+  }
+
+  &::-webkit-scrollbar-track {
+    border-radius: 0 0 1rem 1rem;
+    background-color: var(--color-background-100);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 1rem;
+    background-color: var(--color-gray-500);
+  }
+}
+
+/* Place overflow: hidden on this so we can break out from [data-nextjs-dialog] */
+[data-nextjs-scrollable-content] {
+  overflow: hidden;
+  border-radius: inherit;
+}


### PR DESCRIPTION
* The scrollbar styling was lost before while we enabling the draggable panel. Share that styles between all scrollable content
* Migrate the inline style to css and dynamic css into css variables, so we'll create less dynamic object during rendering.

<video src="https://github.com/user-attachments/assets/df63169f-4846-4c53-91b4-3ca0585dd76d" width="400">


